### PR TITLE
Fixes an emp flash runtime

### DIFF
--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -76,11 +76,11 @@
 	times_used = max(0, times_used) //sanity
 
 
-/obj/item/flash/proc/try_use_flash(mob/user = null)
+/obj/item/flash/proc/try_use_flash(mob/user)
 	if(broken)
 		return FALSE
 
-	if(cooldown >= world.time)
+	if(cooldown >= world.time && user)
 		to_chat(user, "<span class='warning'>Your [name] is still too hot to use again!</span>")
 		return FALSE
 	cooldown = world.time + cooldown_duration


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Do note, that this returns the functionality back to flashes going off when EMP'd, even if theyre on cooldown, as that is how the logic *should* have worked without the runtime I believe. Currently, they do not go off if theyre on cooldown.

Fixes this runtime
```
[2023-04-22T13:15:15] Runtime in browserOutput.dm,299: DEBUG: to_chat called with invalid message/target. Message: '<span class='warning'>Your flash is still too hot to use again!</span>'. Target: ''.
[2023-04-22T13:15:15]   proc name: to chat (/proc/to_chat)
[2023-04-22T13:15:15]   usr: *REDACTED USER*
[2023-04-22T13:15:15]   usr.loc: The floor (75,57,2) (/turf/simulated/floor/plasteel)
[2023-04-22T13:15:15]   src: null
[2023-04-22T13:15:15]   call stack:
[2023-04-22T13:15:15]   to chat(null, "<span class=\'warning\'>Your f...", null)
[2023-04-22T13:15:15]   the flash (/obj/item/flash): try_use_flash
[2023-04-22T13:15:15]   the flash (/obj/item/flash): emp_act
[2023-04-22T13:15:15]   *HIDDEN* (/mob/living/carbon/human): emp_act
[2023-04-22T13:15:15]   *HIDDEN* (/mob/living/carbon/human): emp_act
[2023-04-22T13:15:15]   *HIDDEN* (/mob/living/carbon/human): emp_act
[2023-04-22T13:15:15]   empulse(the plating (80,58,2) (/turf/simulated/floor/plating), 4, 10, 1, null)
[2023-04-22T13:15:15]   the classic EMP grenade (/obj/item/grenade/empgrenade): prime
[2023-04-22T13:15:15]   the classic EMP grenade (/obj/item/grenade/empgrenade): attack_self
```

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Runtime bad

## Testing
<!-- How did you test the PR, if at all? -->
I looked at a lot of white screens and EMPd myself a lot

## Changelog
Nothing player facing

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
