### PR TITLE
Tones down Brand Intelligence a bit

### DIFF
--- a/code/game/machinery/vendors/vending.dm
+++ b/code/game/machinery/vendors/vending.dm
@@ -446,10 +446,10 @@
 			"<span class='danger'>[src] suddenly topples over onto [AM]!</span>",
 			"<span class='userdanger'>[src] topples over onto you without warning!</span>"
 		)
-		tilt(AM, FALSE, FALSE)
+		tilt(AM, prob(5), FALSE)
 		aggressive = FALSE
 		// NOTE: AFTER THE GREAT MASSACRE OF 4/22/23 IT HAS BECOME INCREDIBLY CLEAR THAT NOT SETTING AGGRESSIVE TO FALSE HERE IS A BAD BAD IDEA
-		// ALSO DEAR GOD DO NOT MAKE THEM CRIT
+		// ALSO DEAR GOD DO NOT MAKE IT MORE LIKELY FOR THEM TO CRIT OR NOT
 
 /obj/machinery/economy/vending/crowbar_act(mob/user, obj/item/I)
 	if(!component_parts)

--- a/code/game/machinery/vendors/vending.dm
+++ b/code/game/machinery/vendors/vending.dm
@@ -152,6 +152,7 @@
 	/// If the vendor should tip on anyone who walks by. Mainly used for brand intelligence
 	var/aggressive = FALSE
 
+	/// How often slogans will be used by vendors if they're aggressive.
 	var/aggressive_slogan_delay = (1 MINUTES)
 
 /obj/machinery/economy/vending/Initialize(mapload)
@@ -207,7 +208,7 @@
 			. += "<span class='notice'>You can <b>Alt-Click</b> it to right it.</span>"
 
 	if(aggressive)
-		. += "<span class='danger'>Its product lights seem to be blinking ominously...</span>"
+		. += "<span class='warning'>Its product lights seem to be blinking ominously...</span>"
 
 /obj/machinery/economy/vending/RefreshParts()         //Better would be to make constructable child
 	if(!component_parts)
@@ -448,6 +449,7 @@
 		tilt(AM, FALSE, FALSE)
 		aggressive = FALSE
 		// NOTE: AFTER THE GREAT MASSACRE OF 4/22/23 IT HAS BECOME INCREDIBLY CLEAR THAT NOT SETTING AGGRESSIVE TO FALSE HERE IS A BAD BAD IDEA
+		// ALSO DEAR GOD DO NOT MAKE THEM CRIT
 
 /obj/machinery/economy/vending/crowbar_act(mob/user, obj/item/I)
 	if(!component_parts)

--- a/code/game/machinery/vendors/vending.dm
+++ b/code/game/machinery/vendors/vending.dm
@@ -152,6 +152,8 @@
 	/// If the vendor should tip on anyone who walks by. Mainly used for brand intelligence
 	var/aggressive = FALSE
 
+	var/aggressive_slogan_delay = (1 MINUTES)
+
 /obj/machinery/economy/vending/Initialize(mapload)
 	. = ..()
 	var/build_inv = FALSE
@@ -203,6 +205,9 @@
 		. += "<span class='warning'>It's been tipped over and won't be usable unless it's righted.</span>"
 		if(Adjacent(user))
 			. += "<span class='notice'>You can <b>Alt-Click</b> it to right it.</span>"
+
+	if(aggressive)
+		. += "<span class='danger'>Its product lights seem to be blinking ominously...</span>"
 
 /obj/machinery/economy/vending/RefreshParts()         //Better would be to make constructable child
 	if(!component_parts)
@@ -432,16 +437,17 @@
 			break
 
 /obj/machinery/economy/vending/HasProximity(atom/movable/AM)
-	if(!aggressive)
+	if(!aggressive || tilted || !tiltable)
 		return
 
-	if(isliving(AM))
+	if(isliving(AM) && prob(25))
 		AM.visible_message(
 			"<span class='danger'>[src] suddenly topples over onto [AM]!</span>",
 			"<span class='userdanger'>[src] topples over onto you without warning!</span>"
 		)
-		tilt(AM, prob(75), FALSE)
-		// yes, it stays aggressive. This means you better deal with it from a distance.
+		tilt(AM, FALSE, FALSE)
+		aggressive = FALSE
+		// NOTE: AFTER THE GREAT MASSACRE OF 4/22/23 IT HAS BECOME INCREDIBLY CLEAR THAT NOT SETTING AGGRESSIVE TO FALSE HERE IS A BAD BAD IDEA
 
 /obj/machinery/economy/vending/crowbar_act(mob/user, obj/item/I)
 	if(!component_parts)
@@ -860,7 +866,8 @@
 		seconds_electrified--
 
 	//Pitch to the people!  Really sell it!
-	if(last_slogan + slogan_delay <= world.time && LAZYLEN(slogan_list) && !shut_up && prob(5))
+	// especially if we want to tip over onto them!
+	if((last_slogan + slogan_delay <= world.time || (aggressive && last_slogan + aggressive_slogan_delay <= world.time)) && LAZYLEN(slogan_list) && !shut_up && prob(5))
 		var/slogan = pick(slogan_list)
 		speak(slogan)
 		last_slogan = world.time


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Tweaks the changes recently introduced in #20904.

Makes the Brand Intelligence event a little less of a massacre by tweaking the random vending machine tilts.
- Aggressive vendors now only have a 25% chance to tilt over if someone walks by them.
- Aggressive vendors will only very rarely inflict crits. Mimics, on the other hand, still will, but they should be a bit easier to deal with (hopefully).
- You can now tell on examine if a vendor is aggressive or not, as they'll get a little extra flavor text.
- Aggressive vendors will have a much higher chance to speak, trying to draw you in closer to purchase so they can ruin your day.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

The revamped brand intelligence was up for one round.

![image](https://user-images.githubusercontent.com/89928798/233801282-011ab1ab-1647-4f8b-bfdb-df8114aebce4.png)


<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://user-images.githubusercontent.com/89928798/233800874-7e458eac-bb05-4520-a0a8-2e05a9dc9351.png)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Loaded in, ran through a whole event, seemed to work.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Better tunes brand intelligence to make it less of an outright bloodbath.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
