### PR TITLE
Allows e-dagger to embed when thrown

### DIFF
--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -150,6 +150,7 @@
 	var/backstab_sound = 'sound/items/unsheath.ogg'
 	var/backstab_damage = 12
 	armour_penetration_flat = 20
+	throw_speed = 4
 
 /obj/item/pen/edagger/attack(mob/living/M, mob/living/user, def_zone)
 	var/extra_force_applied = FALSE


### PR DESCRIPTION
increases e-dagger throw speed to 4 from 3 to allow embeds

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #20078
By increasing the throw speed of the e-dagger it now embeds when thrown at someone.
As mentioned in the above issue the e-dagger already had an embed chance of 100 but because its throw speed was too slow  it could not actually embed.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
It seems to have been the intent from the beginning that the e-dagger embeds, so this makes that reality. 
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Threw e-dagger at things, embeds.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Fixed e-dagger ability to embed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
