### PR TITLE
Chem heater now shows beakers when screwed closed

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_heater.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_heater.dm
@@ -88,10 +88,7 @@
 
 /obj/machinery/chem_heater/screwdriver_act(mob/user, obj/item/I)
 	. = TRUE
-	if(!beaker)
-		default_deconstruction_screwdriver(user, "mixer0b", "mixer0b", I)
-	else
-		default_deconstruction_screwdriver(user, "mixer0b", "mixer1b", I)
+	default_deconstruction_screwdriver(user, "mixer0b", "mixer[beaker ? "1" : "0"]b", I)
 
 /obj/machinery/chem_heater/crowbar_act(mob/user, obj/item/I)
 	if(!panel_open)

--- a/code/modules/reagents/chemistry/machinery/chem_heater.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_heater.dm
@@ -88,7 +88,10 @@
 
 /obj/machinery/chem_heater/screwdriver_act(mob/user, obj/item/I)
 	. = TRUE
-	default_deconstruction_screwdriver(user, "mixer0b", "mixer0b", I)
+	if (!beaker)
+		default_deconstruction_screwdriver(user, "mixer0b", "mixer0b", I)
+	else
+		default_deconstruction_screwdriver(user, "mixer0b", "mixer1b", I)
 
 /obj/machinery/chem_heater/crowbar_act(mob/user, obj/item/I)
 	if(!panel_open)

--- a/code/modules/reagents/chemistry/machinery/chem_heater.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_heater.dm
@@ -88,7 +88,7 @@
 
 /obj/machinery/chem_heater/screwdriver_act(mob/user, obj/item/I)
 	. = TRUE
-	if (!beaker)
+	if(!beaker)
 		default_deconstruction_screwdriver(user, "mixer0b", "mixer0b", I)
 	else
 		default_deconstruction_screwdriver(user, "mixer0b", "mixer1b", I)


### PR DESCRIPTION

## What Does This PR Do
fixes: #20274
Fixed the chem heater sprite not properly displaying the beaker when the maintenance panel is opened then closed

## Why It's Good For The Game
fixes a minor graphical glitch with the heater

## Testing
unscrewed and re-screwed chem heater without a beaker
unscrewed and re-screwed chem heater with a beaker

## Changelog
:cl:
fix: fixed chem heater sprite update
/:cl:
