### PR TITLE
Adds public teleporter shutters to box and meta stations

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -77815,15 +77815,6 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/cmo)
-"qvb" = (
-/obj/machinery/computer/teleporter{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/space/nearstation)
 "qvd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -80521,13 +80512,6 @@
 	icon_state = "dark"
 	},
 /area/engine/engineering)
-"rMt" = (
-/obj/machinery/teleport/hub,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/space/nearstation)
 "rNt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -87956,13 +87940,6 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
-"vHm" = (
-/obj/machinery/teleport/station,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/space/nearstation)
 "vHA" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -118684,7 +118661,7 @@ bgH
 bek
 bdb
 aYx
-rMt
+abq
 abq
 abq
 aJY
@@ -118941,7 +118918,7 @@ bdU
 bek
 bdb
 aYx
-vHm
+abq
 aBV
 aIb
 bkW
@@ -119198,7 +119175,7 @@ bNp
 bek
 bdb
 aYx
-qvb
+abq
 aCV
 boB
 bsb

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -25088,23 +25088,9 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads)
 "bzV" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Teleporter Room";
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	name = "north bump";
-	pixel_y = 30
-	},
-/turf/simulated/floor/plasteel,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/teleport/hub,
+/turf/simulated/floor/plating,
 /area/teleporter)
 "bzW" = (
 /obj/structure/cable/yellow{
@@ -29868,10 +29854,6 @@
 /turf/simulated/floor/plating,
 /area/bridge/hall)
 "bOJ" = (
-/obj/machinery/camera{
-	c_tag = "Command Hallway - Port";
-	dir = 1
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
@@ -30160,9 +30142,6 @@
 	},
 /area/medical/research)
 "bPn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 1
 	},
@@ -30170,7 +30149,12 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/turf/simulated/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/teleport/station,
+/turf/simulated/floor/plating,
 /area/teleporter)
 "bPo" = (
 /obj/structure/cable/yellow{
@@ -30193,7 +30177,11 @@
 	name = "north bump";
 	pixel_y = 28
 	},
-/turf/simulated/floor/plasteel,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/machinery/computer/teleporter,
+/turf/simulated/floor/plating,
 /area/teleporter)
 "bPq" = (
 /obj/structure/table,
@@ -30667,16 +30655,10 @@
 	},
 /area/hallway/primary/aft)
 "bQX" = (
-/obj/machinery/shieldwallgen,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "darkgrey"
-	},
+/turf/simulated/floor/plasteel,
 /area/teleporter)
 "bQZ" = (
 /obj/machinery/seed_extractor,
@@ -31283,11 +31265,15 @@
 /area/atmos)
 "bSN" = (
 /obj/machinery/shieldwallgen,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8;
+	pixel_x = -4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkgrey"
@@ -31303,15 +31289,6 @@
 /obj/effect/landmark/start/atmospheric,
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
-"bST" = (
-/obj/machinery/computer/teleporter{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/teleporter)
 "bSU" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -31404,13 +31381,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/portsolar)
-"bTk" = (
-/obj/machinery/teleport/hub,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/teleporter)
 "bTl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -33212,11 +33182,13 @@
 /turf/simulated/floor/carpet/blue,
 /area/blueshield)
 "bXZ" = (
-/obj/machinery/teleport/station,
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/shieldwallgen,
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel{
+	icon_state = "darkgrey"
+	},
 /area/teleporter)
 "bYa" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
@@ -77843,6 +77815,15 @@
 	icon_state = "whiteblue"
 	},
 /area/medical/cmo)
+"qvb" = (
+/obj/machinery/computer/teleporter{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/space/nearstation)
 "qvd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -78122,6 +78103,16 @@
 	icon_state = "redcorner"
 	},
 /area/security/brig)
+"qEm" = (
+/obj/machinery/camera{
+	c_tag = "Command Hallway - Port";
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/bridge/hall)
 "qEn" = (
 /obj/machinery/economy/vending/tool/free,
 /obj/effect/turf_decal/delivery,
@@ -80530,6 +80521,13 @@
 	icon_state = "dark"
 	},
 /area/engine/engineering)
+"rMt" = (
+/obj/machinery/teleport/hub,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/space/nearstation)
 "rNt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -87958,6 +87956,13 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
+"vHm" = (
+/obj/machinery/teleport/station,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/space/nearstation)
 "vHA" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -89498,10 +89503,16 @@
 	},
 /area/toxins/xenobiology)
 "wyB" = (
-/obj/machinery/shieldwallgen,
-/turf/simulated/floor/plasteel{
-	icon_state = "darkgrey"
+/obj/structure/extinguisher_cabinet{
+	name = "south bump";
+	pixel_y = -30
 	},
+/obj/machinery/firealarm{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/turf/simulated/floor/plasteel,
 /area/teleporter)
 "wyE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -92564,6 +92575,17 @@
 	icon_state = "darkbluecorners"
 	},
 /area/medical/surgeryobs)
+"xYo" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters{
+	dir = 2;
+	id_tag = "teleshutter";
+	name = "Teleport Access Shutters"
+	},
+/turf/simulated/floor/plating,
+/area/teleporter)
 "xYC" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
@@ -92657,6 +92679,19 @@
 	icon_state = "darkbluecorners"
 	},
 /area/medical/biostorage)
+"yaj" = (
+/obj/machinery/camera{
+	c_tag = "Teleporter Room";
+	dir = 4
+	},
+/obj/machinery/door_control{
+	id = "teleshutter";
+	name = "Teleporter Shutters Access Control";
+	pixel_x = -24;
+	req_access_txt = "62"
+	},
+/turf/simulated/floor/plasteel,
+/area/teleporter)
 "yap" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -117637,9 +117672,9 @@ bFH
 bEx
 bJg
 bOJ
-bMW
+xYo
 bzV
-uEE
+yaj
 wyB
 bMW
 bMS
@@ -117893,7 +117928,7 @@ bsO
 biL
 bFR
 vBv
-bKT
+qEm
 bMW
 bPn
 bQX
@@ -118154,7 +118189,7 @@ bKT
 bMW
 bPp
 bSh
-bTk
+uEE
 bMW
 bWB
 bWD
@@ -118649,7 +118684,7 @@ bgH
 bek
 bdb
 aYx
-abq
+rMt
 abq
 abq
 aJY
@@ -118668,7 +118703,7 @@ tbd
 bMW
 bPq
 bSk
-bST
+bXZ
 bMW
 bWR
 bWF
@@ -118906,7 +118941,7 @@ bdU
 bek
 bdb
 aYx
-abq
+vHm
 aBV
 aIb
 bkW
@@ -119163,7 +119198,7 @@ bNp
 bek
 bdb
 aYx
-abq
+qvb
 aCV
 boB
 bsb

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -73799,6 +73799,16 @@
 	icon_state = "brown"
 	},
 /area/quartermaster/qm)
+"khB" = (
+/obj/effect/decal/warning_stripes/south,
+/obj/machinery/door_control{
+	id = "teleshutter";
+	name = "Teleporter Shutters Access Control";
+	pixel_x = -24;
+	req_access_txt = "62"
+	},
+/turf/simulated/floor/plasteel,
+/area/teleporter)
 "khK" = (
 /obj/machinery/atmospherics/unary/vent_pump/siphon/on{
 	dir = 1;
@@ -84679,6 +84689,16 @@
 	icon_state = "darkblue"
 	},
 /area/medical/surgeryobs)
+"sMZ" = (
+/obj/machinery/door/poddoor/shutters{
+	dir = 2;
+	id_tag = "teleshutter";
+	name = "Teleport Access Shutters"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/teleporter)
 "sNJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -122456,8 +122476,8 @@ bUD
 bSi
 bVP
 bXx
-bXl
-cbl
+khB
+bZc
 bSi
 ceF
 cgj
@@ -122714,7 +122734,7 @@ bSi
 bTO
 bXw
 bXl
-bZa
+cbl
 bSi
 cdN
 cgj
@@ -122971,7 +122991,7 @@ bSi
 bTS
 bXz
 bXl
-bZb
+bZa
 bSi
 ccm
 cgp
@@ -123228,8 +123248,8 @@ bSi
 bTR
 bXy
 bXl
-bZc
-bSi
+bZb
+sMZ
 bFO
 cgo
 cfB


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Adds a teleporter shutter for public usage of the teleporter if the heads wishes to open it.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Now that the gateway is going away its a good moment to include public teleporter shutters, that other maps already have, to send your crew to any place you desire, without the risk of someone sabotaging it.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![image](https://user-images.githubusercontent.com/77684085/235312179-71cda6a1-3598-4c6d-a206-ff608d26042b.png)

![image](https://user-images.githubusercontent.com/77684085/235312209-909e3e09-8d1a-49e1-8bc2-d886679e4c8c.png)

## Testing
<!-- How did you test the PR, if at all? -->
- Used the shutter both on box and meta.
## Changelog
:cl:
tweak: Added public teleporter shutters to Cyberiad and Cerebron
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
