### PR TITLE
Removes an accidental undef

### DIFF
--- a/code/modules/mob/mob_say_base.dm
+++ b/code/modules/mob/mob_say_base.dm
@@ -221,5 +221,4 @@
 		. += S.message + " "
 	. = trim_right(.)
 
-#undef USABLE_DEAD_EMOTES
 #undef ILLEGAL_CHARACTERS_LIST


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Removes an `#undef` that I accidentally left in after moving stuff around during #17544. The define isn't even in the same file anymore, so this undef is kind of spurious. I noticed this while working on another PR, but wanted to keep the changes atomic.

Non-player-facing.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
This isn't currently causing problems, but it seems like something that could cause some really sneaky bugs down the line.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
It still compiles, I think this is a pretty safe PR.
<!-- How did you test the PR, if at all? -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
