### PR TITLE
cryogenic area spelling fix

### DIFF
--- a/code/game/area/ss13_areas.dm
+++ b/code/game/area/ss13_areas.dm
@@ -988,12 +988,12 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	name = "\improper Auxiliary Toilets"
 
 /area/crew_quarters/sleep
-	name = "\improper Primary Cyrogenic Dormitories"
+	name = "\improper Primary Cryogenic Dormitories"
 	icon_state = "Sleep"
 	valid_territory = FALSE
 
 /area/crew_quarters/sleep/secondary
-	name = "\improper Secondary Cyrogenic Dormitories"
+	name = "\improper Secondary Cryogenic Dormitories"
 	icon_state = "Sleep"
 
 /area/crew_quarters/locker


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes Cryogenic being misspelled as cyrogenic

## Why It's Good For The Game
Spelling issues are bad

## Changelog
:cl:
spellcheck: Corrects Cyrogenic to Cryogenic on area names
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
