### PR TITLE
Fixes a survival pod runtime

### DIFF
--- a/code/modules/mining/equipment/survival_pod.dm
+++ b/code/modules/mining/equipment/survival_pod.dm
@@ -242,7 +242,7 @@
 /obj/machinery/smartfridge/survival_pod/accept_check(obj/item/O)
 	return isitem(O)
 
-/obj/machinery/smartfridge/survival_pod/default_unfasten_wrench()
+/obj/machinery/smartfridge/survival_pod/default_unfasten_wrench(mob/user, obj/item/I, time)
 	return FALSE
 
 /obj/machinery/smartfridge/survival_pod/empty


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes this runtime
```[2023-04-24T23:34:49] Runtime in ,: bad arg name 'time'
[2023-04-24T23:34:49]   proc name: default unfasten wrench (/obj/machinery/smartfridge/survival_pod/default_unfasten_wrench)
[2023-04-24T23:34:49]   usr: *REDACTED USER*
[2023-04-24T23:34:49]   usr.loc: The pod floor (52,221,6) (/turf/simulated/floor/pod)
[2023-04-24T23:34:49]   src: the survival pod storage (/obj/machinery/smartfridge/survival_pod)
[2023-04-24T23:34:49]   src.loc: the pod floor (52,222,6) (/turf/simulated/floor/pod)
[2023-04-24T23:34:49]   call stack:
[2023-04-24T23:34:49]   the survival pod storage (/obj/machinery/smartfridge/survival_pod): default_unfasten_wrench
[2023-04-24T23:34:49]   the survival pod storage (/obj/machinery/smartfridge/survival_pod): wrench_act
[2023-04-24T23:34:49]   the survival pod storage (/obj/machinery/smartfridge/survival_pod): tool_act
[2023-04-24T23:34:49]   the wrench (/obj/item/wrench): tool_attack_chain
[2023-04-24T23:34:49]   the wrench (/obj/item/wrench): melee_attack_chain
[2023-04-24T23:34:49]   Bestatten Steorra (/mob/living/carbon/human): ClickOn
[2023-04-24T23:34:49]   the survival pod storage (/obj/machinery/smartfridge/survival_pod): Click
```

## Why It's Good For The Game
Args still need to be applied to a proc regardless if they're being used or not
