### PR TITLE
Allows for the gravity generator to be cmagged.

### DIFF
--- a/code/datums/elements/waddling.dm
+++ b/code/datums/elements/waddling.dm
@@ -23,3 +23,6 @@
 	var/prev_trans = matrix(target.transform)
 	animate(pixel_z = 0, transform = turn(target.transform, pick(-12, 0, 12)), time = 2)
 	animate(pixel_z = 0, transform = prev_trans, time = 0)
+
+/datum/element/waddling/clown_gravity
+	// alternate element so we don't go removing the existing one.

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -32,6 +32,8 @@
 	var/list/apc = list()
 
 	var/has_gravity = TRUE
+	/// If TRUE, everyone will waddle when entering the area (and slip if they enter from an area with it being FALSE)
+	var/has_cmagged_gravity = FALSE
 
 	var/no_air = null
 
@@ -439,12 +441,45 @@
 	if((oldarea.has_gravity == 0) && (newarea.has_gravity == 1) && (L.m_intent == MOVE_INTENT_RUN)) // Being ready when you change areas gives you a chance to avoid falling all together.
 		thunk(L)
 
+	if(oldarea.has_cmagged_gravity && !newarea.has_cmagged_gravity)
+		clown_thunk(L, FALSE)
+
+	else if(!oldarea.has_cmagged_gravity && newarea.has_cmagged_gravity)
+		clown_thunk(L, TRUE)
+
 	//Ship ambience just loops if turned on.
 	if(L && L.client && !L.client.ambience_playing && (L.client.prefs.sound & SOUND_BUZZ))
 		L.client.ambience_playing = TRUE
 		SEND_SOUND(L, sound('sound/ambience/shipambience.ogg', repeat = TRUE, wait = FALSE, volume = 35 * L.client.prefs.get_channel_volume(CHANNEL_BUZZ), channel = CHANNEL_BUZZ))
 	else if(L && L.client && !(L.client.prefs.sound & SOUND_BUZZ))
 		L.client.ambience_playing = FALSE
+
+/area/proc/cmag_grav_change(cmag_gravity = FALSE, area/A)
+	var/existing_grav = A.has_cmagged_gravity
+	A.has_cmagged_gravity = cmag_gravity
+
+	for(var/mob/living/M in A)
+		if(cmag_gravity != existing_grav)
+			clown_thunk(M, cmag_gravity)
+
+
+/area/proc/clown_thunk(mob/living/M, clown_gravity_enabled)
+	if(!istype(M))
+		return
+
+	if(iscarbon(M))
+		if(!IS_HORIZONTAL(M))
+			playsound(M, 'sound/misc/slip.ogg', 50, FALSE)
+			M.KnockDown(5 SECONDS)
+	else
+		M.Weaken(5 SECONDS)  // sure
+
+	if(clown_gravity_enabled)
+		to_chat(M, "<span class='warning sans'>Gravity...?</span>")
+		M.AddElement(/datum/element/waddling/clown_gravity)
+	else
+		to_chat(M, "<span class='notice'>You feel a bit more steady on your feet.</span>")
+		M.RemoveElement(/datum/element/waddling/clown_gravity)
 
 /area/proc/gravitychange(gravitystate = 0, area/A)
 	A.has_gravity = gravitystate

--- a/code/modules/power/gravitygenerator.dm
+++ b/code/modules/power/gravitygenerator.dm
@@ -298,6 +298,7 @@ GLOBAL_LIST_EMPTY(gravity_generators)
 				if(!is_station_level(A.z))
 					continue
 				A.gravitychange(TRUE, A)
+				A.cmag_grav_change(TRUE, A)
 
 	else if(generators_in_level() == TRUE) // Turned off, and there is gravity
 		alert = TRUE
@@ -307,6 +308,7 @@ GLOBAL_LIST_EMPTY(gravity_generators)
 			if(!is_station_level(A.z))
 				continue
 			A.gravitychange(FALSE, A)
+			A.cmag_grav_change(FALSE, A)
 
 	update_icon()
 	update_gen_list()
@@ -328,11 +330,13 @@ GLOBAL_LIST_EMPTY(gravity_generators)
 
 /obj/machinery/gravity_generator/main/proc/do_cmagging(mob/user)
 	// give the perp a moment to get away, even though it will be incredibly obvious who did it.
-	for(var/area/A in world)
-		if(!is_station_level(A.z))
-			continue
-		A.cmag_grav_change(TRUE, A)
-	shake_everyone()
+	if(on)
+		// if it was already off, then we'll have a fun surprise when it wakes up
+		for(var/area/A in world)
+			if(!is_station_level(A.z))
+				continue
+			A.cmag_grav_change(TRUE, A)
+		shake_everyone()
 	add_fingerprint(user)
 	on_cmag_cooldown = TRUE
 	addtimer(VARSET_CALLBACK(src, on_cmag_cooldown, FALSE), 5 MINUTES)

--- a/code/modules/power/gravitygenerator.dm
+++ b/code/modules/power/gravitygenerator.dm
@@ -335,7 +335,7 @@ GLOBAL_LIST_EMPTY(gravity_generators)
 	shake_everyone()
 	add_fingerprint(user)
 	on_cmag_cooldown = TRUE
-	addtimer(VARSET_CALLBACK(src, on_cmag_cooldown, FALSE), 2 MINUTES)
+	addtimer(VARSET_CALLBACK(src, on_cmag_cooldown, FALSE), 5 MINUTES)
 
 /obj/machinery/gravity_generator/main/uncmag()
 	for(var/area/A in world)

--- a/code/modules/power/gravitygenerator.dm
+++ b/code/modules/power/gravitygenerator.dm
@@ -319,9 +319,9 @@ GLOBAL_LIST_EMPTY(gravity_generators)
 	if(HAS_TRAIT(src, TRAIT_CMAGGED))
 		return
 	if(on_cmag_cooldown)
-		to_chat(user, "<span class='danger'>Some of the ooze is still sticking around from the last time it was slathered, you should probably wait a bit.</span>")
+		to_chat(user, "<span class='danger'>[src] still smells faintly of burned banana, you should probably wait a bit.</span>")
 		return
-	to_chat(user, "<span class='warning'>You slap the card around the gravity generator, and it seems to draw some of the ooze off of it by itself! Looks like it'll take effect shortly.</span>")
+	to_chat(user, "<span class='warning'>You slap the card around [src], and its gravity draws some ooze off of the card and into its core! Looks like it'll take effect shortly.</span>")
 	playsound(src, "sparks", 75, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
 	ADD_TRAIT(src, TRAIT_CMAGGED, CLOWN_EMAG)
 	add_attack_logs(user, src, "cmagged, making everyone flippery.")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds a new cmag interaction to the gravity generator.
When someone uses a cmag on a gravity generator, after about ten seconds or so, the gravitational dampeners will activate in a way that...isn't quite right.
Everyone in range of the generator will slip on first activation, and then begin to waddle, with no other downsides.
Like all cmag interactions, this is incredibly easy to fix, just requiring soap or some other cleaning implement to be applied to the gravity generator.
Once a gravity generator has been cmagged, there's a five minute delay before the generator can be cmagged again, to prevent spamming.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
I think it's good for a few reasons:
- It's a pretty harmless prank, as waddling just animates your walk animation. There isn't even squeaking.
- It applies equally to everyone; everyone gets knocked down (yes, even the clown)
- Most importantly of all, it's incredibly loud, and *it'll be incredibly obvious who the culprit is, which means security will need to go on a waddling goose chase to lynch the clown (who can now be arrested for a large number of significant crimes).* High risk, honk reward.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

https://user-images.githubusercontent.com/89928798/234316040-275019fb-1668-4cdb-bcc1-7f8d6e33ae2d.mp4


<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
add: Adds a cmag interaction for the gravity generator. Honk!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
