### PR TITLE
gives spellblade with lightning grant the user shock immunity

### DIFF
--- a/code/game/objects/items/weapons/melee/melee_misc.dm
+++ b/code/game/objects/items/weapons/melee/melee_misc.dm
@@ -174,6 +174,8 @@
 	var/ranged = FALSE
 	/// stores the world.time after which it can be used again, the `initial(cooldown)` is the cooldown between activations.
 	var/cooldown = -1
+	///If the spellblade has traits, has it applied them?
+	var/applied_traits = FALSE
 
 /datum/enchantment/proc/on_hit(mob/living/target, mob/living/user, proximity, obj/item/melee/spellblade/S)
 	if(world.time < cooldown)
@@ -189,22 +191,39 @@
 
 /datum/enchantment/proc/on_gain(obj/item/melee/spellblade, mob/living/user)
 
+/datum/enchantment/proc/toggle_traits(obj/item/I, mob/living/user)
+
 /datum/enchantment/lightning
 	name = "lightning"
-	desc = "this blade conducts arcane energy to arc between its victims"
+	desc = "this blade conducts arcane energy to arc between its victims. It also makes the user immune to shocks."
 	// the damage of the first lighting arc.
 	power = 20
 	cooldown = 3 SECONDS
+
+/datum/enchantment/lightning/on_gain(obj/item/melee/spellblade/S, mob/living/user)
+	..()
+	RegisterSignal(S, list(COMSIG_ITEM_PICKUP, COMSIG_ITEM_DROPPED), PROC_REF(toggle_traits))
+	if(user)
+		toggle_traits(S, user)
+
 
 /datum/enchantment/lightning/on_hit(mob/living/target, mob/living/user, proximity, obj/item/melee/spellblade/S)
 	. = ..()
 	if(.)
 		zap(target, user, list(user), power)
 
+/datum/enchantment/lightning/toggle_traits(obj/item/I, mob/living/user)
+	var/enchant_ID = UID(src) // so it only removes the traits applied by this specific enchant.
+	if(applied_traits)
+		REMOVE_TRAIT(user, TRAIT_SHOCKIMMUNE, "[enchant_ID]")
+		applied_traits = FALSE
+	else
+		ADD_TRAIT(user, TRAIT_SHOCKIMMUNE, "[enchant_ID]")
+		applied_traits = TRUE
 
 /datum/enchantment/lightning/proc/zap(mob/living/target, mob/living/source, protected_mobs, voltage)
 	source.Beam(target, "lightning[rand(1,12)]", 'icons/effects/effects.dmi', time = 2 SECONDS, maxdistance = 7, beam_type = /obj/effect/ebeam/chain)
-	if(!target.electrocute_act(voltage, flags = SHOCK_TESLA)) // if it fails to shock someone, break the chain
+	if(!target.electrocute_act(voltage, "lightning", flags = SHOCK_TESLA)) // if it fails to shock someone, break the chain
 		return
 	protected_mobs += target
 	addtimer(CALLBACK(src, PROC_REF(arc), target, voltage, protected_mobs), 2.5 SECONDS)
@@ -224,7 +243,6 @@
 	name = "fire"
 	desc = "this blade ignites on striking a foe, releasing a ball of fire. It also makes the wielder immune to fire"
 	cooldown = 8 SECONDS
-	var/applied_traits = FALSE
 
 /datum/enchantment/fire/on_gain(obj/item/melee/spellblade/S, mob/living/user)
 	..()
@@ -232,7 +250,7 @@
 	if(user)
 		toggle_traits(S, user)
 
-/datum/enchantment/fire/proc/toggle_traits(obj/item/I, mob/living/user)
+/datum/enchantment/fire/toggle_traits(obj/item/I, mob/living/user)
 	var/enchant_ID = UID(src) // so it only removes the traits applied by this specific enchant.
 	if(applied_traits)
 		REMOVE_TRAIT(user, TRAIT_NOFIRE, "[enchant_ID]")

--- a/code/game/objects/items/weapons/melee/melee_misc.dm
+++ b/code/game/objects/items/weapons/melee/melee_misc.dm
@@ -190,8 +190,10 @@
 	return TRUE
 
 /datum/enchantment/proc/on_gain(obj/item/melee/spellblade, mob/living/user)
+	return
 
 /datum/enchantment/proc/toggle_traits(obj/item/I, mob/living/user)
+	return
 
 /datum/enchantment/lightning
 	name = "lightning"

--- a/code/game/objects/items/weapons/melee/melee_misc.dm
+++ b/code/game/objects/items/weapons/melee/melee_misc.dm
@@ -174,7 +174,7 @@
 	var/ranged = FALSE
 	/// stores the world.time after which it can be used again, the `initial(cooldown)` is the cooldown between activations.
 	var/cooldown = -1
-	///If the spellblade has traits, has it applied them?
+	/// If the spellblade has traits, has it applied them?
 	var/applied_traits = FALSE
 
 /datum/enchantment/proc/on_hit(mob/living/target, mob/living/user, proximity, obj/item/melee/spellblade/S)
@@ -216,10 +216,9 @@
 	var/enchant_ID = UID(src) // so it only removes the traits applied by this specific enchant.
 	if(applied_traits)
 		REMOVE_TRAIT(user, TRAIT_SHOCKIMMUNE, "[enchant_ID]")
-		applied_traits = FALSE
 	else
 		ADD_TRAIT(user, TRAIT_SHOCKIMMUNE, "[enchant_ID]")
-		applied_traits = TRUE
+	applied_traits = !applied_traits
 
 /datum/enchantment/lightning/proc/zap(mob/living/target, mob/living/source, protected_mobs, voltage)
 	source.Beam(target, "lightning[rand(1,12)]", 'icons/effects/effects.dmi', time = 2 SECONDS, maxdistance = 7, beam_type = /obj/effect/ebeam/chain)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Spellblade with the lightning enchantment grants the user immunity to shocks. A: Makes sense, but more importantly B: Keeps the user from being stuned from the shock when they stab the person they are dragging with spellblade.

Spellblade actually zaps people with the name of "lightning", so it no longer says someone was shocked by the !

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Spellblade stunning / knockdowning  the user with the lightning enchantment is silly. Making the person immune to shocks fixes the issue, and makes sense like the fire spellblade.

Bugs are bad.

fixes #16986
fixes #18330


## Testing
<!-- How did you test the PR, if at all? -->

Electrified fish with lightning.
Compiled and ran code, attacked dragged skrell with lightning spellblade. Worked as expected.

## Changelog
:cl:
tweak: Lightning spellblade grants the user shock immunity.
fix: Spellblade user no longer gets shocked from the user from lightning shocks hitting the person they are draging.
fix: Spellblade shocks no longer are nameless.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
