### PR TITLE
xenos no longer permakill dead carbon mobs by consuming them

### DIFF
--- a/code/modules/mob/living/carbon/carbon_life.dm
+++ b/code/modules/mob/living/carbon/carbon_life.dm
@@ -242,7 +242,7 @@
 			LAZYREMOVE(stomach_contents, M)
 			continue
 		if(stat != DEAD)
-			if(M.stat == DEAD)
+			if(M.stat == DEAD && !iscarbon(M))
 				LAZYREMOVE(stomach_contents, M)
 				qdel(M)
 				continue


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Xenos no longer permakill dead carbon mobs by consuming them

## Why It's Good For The Game
Recently, xeno gibbing was removed due to the constant permakilling of people. It's frustrating to be killed by a midround and then be out of the round forever. This was kept, xenos can consume the infected after a larva hatches to kill anyone to remove the chance of anyone being revived after being infected, or just kill a bunch of people then eat them. It's also rather common to see newer xenos eat a corpse with no idea what will happen, and have that corpse be out of the round forever which is frustrating both for the xeno and corpse. I don't think there's a good reason why this should exist as it just causes more salt and frustations. 
## Testing
Ate some people
## Changelog
:cl:
tweak: aliens no longer permakill dead carbon mobs by consuming them
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
