### PR TITLE
Rebalancing the BSG

### DIFF
--- a/code/modules/projectiles/ammunition/energy_lens.dm
+++ b/code/modules/projectiles/ammunition/energy_lens.dm
@@ -304,7 +304,7 @@
 	fire_sound = 'sound/weapons/wave.ogg'
 	e_cost = 10000
 	select_name = "the experimental setting"
-	delay = 10 SECONDS //Looooooong cooldown
+	delay = 4 SECONDS //Looooooong cooldown
 
 /obj/item/ammo_casing/energy/teleport
 	projectile_type = /obj/item/projectile/energy/teleport

--- a/code/modules/projectiles/ammunition/energy_lens.dm
+++ b/code/modules/projectiles/ammunition/energy_lens.dm
@@ -304,7 +304,7 @@
 	fire_sound = 'sound/weapons/wave.ogg'
 	e_cost = 10000
 	select_name = "the experimental setting"
-	delay = 4 SECONDS //Looooooong cooldown
+	delay = 4 SECONDS //Looooooong cooldown // Used to be 10 seconds, has been rebalanced to be normal firing rate now
 
 /obj/item/ammo_casing/energy/teleport
 	projectile_type = /obj/item/projectile/energy/teleport

--- a/code/modules/projectiles/guns/energy/special_eguns.dm
+++ b/code/modules/projectiles/guns/energy/special_eguns.dm
@@ -522,12 +522,6 @@
 		return
 	return ..()
 
-/obj/item/gun/energy/bsg/process_chamber()
-	if(prob(25))
-		shatter()
-	..()
-	update_icon()
-
 /obj/item/gun/energy/bsg/update_icon_state()
 	if(core)
 		if(has_bluespace_crystal)

--- a/code/modules/projectiles/guns/energy/special_eguns.dm
+++ b/code/modules/projectiles/guns/energy/special_eguns.dm
@@ -460,7 +460,7 @@
 	origin_tech = "combat=6;materials=6;powerstorage=6;bluespace=6;magnets=6" //cutting edge technology, be my guest if you want to deconstruct one instead of use it.
 	ammo_type = list(/obj/item/ammo_casing/energy/bsg)
 	weapon_weight = WEAPON_HEAVY
-	w_class = WEIGHT_CLASS_HUGE
+	w_class = WEIGHT_CLASS_BULKY
 	can_holster = FALSE
 	slot_flags = SLOT_BACK
 	cell_type = /obj/item/stock_parts/cell/bsg


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
With the blessings of Qwertytoforty, the BSG has now been buffed as to make it less of a meme weapon for something that needs an anomaly core. Reduces firerate by 6 seconds, making it the same as normal energy weapons, and removes the random chance for a bluespace crystal to be destroyed.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
The BSG was never used, and is not on par with other items that require anomaly cores. This makes it so the anomaly core is a choice between the reactive armor and a BSG.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
<!-- How did you test the PR, if at all? -->
Yes

## Changelog
:cl:
tweak: BSG firerate is now 4 seconds, random chance to crack bluespace crystals is gone
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
