### PR TITLE
turns off fire alarm sounds when power is off

### DIFF
--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -238,8 +238,11 @@ FIRE ALARM
 		set_light(l_power = LIGHTING_MINIMUM_POWER)
 
 /obj/machinery/firealarm/proc/update_fire_sound(fire)
+	var/area/A = get_area(src)
 	if(stat & NOPOWER)
 		GLOB.firealarm_soundloop.stop(src, TRUE)
+	else if(A.fire)
+		GLOB.firealarm_soundloop.start(src)
 
 /obj/machinery/firealarm/power_change()
 	if(!..())

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -237,11 +237,16 @@ FIRE ALARM
 	else
 		set_light(l_power = LIGHTING_MINIMUM_POWER)
 
+/obj/machinery/firealarm/proc/update_fire_sound(fire)
+	if(stat & NOPOWER)
+		GLOB.firealarm_soundloop.stop(src, TRUE)
+
 /obj/machinery/firealarm/power_change()
 	if(!..())
 		return
 	update_fire_light()
 	update_icon()
+	update_fire_sound()
 
 /obj/machinery/firealarm/attack_hand(mob/user)
 	if(stat & (NOPOWER|BROKEN) || buildstage != 2)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #20919
Turns off the fire alarm sound if it becomes unpowered
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
At least one person might be happy to stop hearing fire alarm sounds in the unlikely event the fire alarm is pulled and then an admin deletes the APC
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
1. pulled fire alarm
2. turned off power
3. alarm sounds stopped
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Fire alarm sounds no longer continue without power
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
