### PR TITLE
fixes ripleys having their movespeed capped while using thrusters

### DIFF
--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -195,6 +195,9 @@
 			O.forceMove(drop_location())
 
 /obj/mecha/working/ripley/proc/update_pressure()
+	if(thrusters_active)
+		return // Don't calculate this if they have thrusters on, this is calculated right after domove because of course it is
+
 	var/turf/T = get_turf(loc)
 
 	if(lavaland_equipment_pressure_check(T))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes ripleys having a capped movespeed while using thrusters

## Why It's Good For The Game
Not supposed to happen and the returns are diminishing anyways, they can go a little faster if they want to. 
God I fucking hate mechcode

## Testing
became speed via a ripley, watched my power cell drain in a minute

## Changelog
:cl:
fix: Speed cap removed on ripleys with exosuit ion thrusters
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
