### PR TITLE
Fixes access' around the brig and courtroom

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -93627,7 +93627,7 @@
 "sTz" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Office";
-	req_access_txt = "63"
+	req_access_txt = "1"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
@@ -95951,7 +95951,7 @@
 	},
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Office";
-	req_access_txt = "63"
+	req_access_txt = "1"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -90022,7 +90022,8 @@
 /area/hallway/secondary/exit)
 "wVH" = (
 /obj/machinery/door/airlock/security/glass{
-	name = "Prisoner Oversight"
+	name = "Prisoner Oversight";
+	req_access_txt = "1"
 	},
 /obj/structure/cable{
 	d1 = 4;


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #20193
Sort of... Court room access doesn't seem to actually do anything so getting it is pointless on all stations. It should probably just be removed but at least now all court  rooms require the same access
This PR changes access in the following areas
Delta Equip room: now you need more then front door access to the brig to get access to the open armoury
Delta Court room: now anyone with front door brig access can get into the courtroom and not just IAAs, this is done to make it inline with the Cyberiad
Cyberiad Prisoner Observation: You now need perma access in order to enter this room because otherwise the control for opening the perma doors has no access requirements and thus a CMO could release prisoners and access tear gas grenades
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
No walking into the armoury for the RD, no releasing prisoners for the CMO, and sec officers can finally access the courtroom on all maps
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
In case you have no idea what rooms have had access changes
Cyberiad Prisoner Observation Room:
![cyberiad prisoner observation](https://user-images.githubusercontent.com/19807682/234783233-d062780b-01ca-4e5b-9ce6-b2f44e202da6.png)

Delta Equip Room:
![equip room delta](https://user-images.githubusercontent.com/19807682/234783360-492dcd68-f7b6-4c9f-816c-636a3f6d4ea5.png)

Delta Court Room:
![delta court](https://user-images.githubusercontent.com/19807682/234783431-ef982069-f625-4fb9-9b49-05e7545c157a.png)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
1. Spawned as CMO on Cyberiad
2. Could not get to perma access controls
3. Spawned as RD on Delta
4. Could not get into the equip room or locker room
5. Spawned as Sec officer on Delta
6. Could get into the court room
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Tweaked delta court room access to be inline with cyberiad
fix: Proper access is no required to get to perma controls on cyberiad and to get into equip room on delta
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
