### PR TITLE
Fix cryo cells not autoejecting patients with burn wounds

### DIFF
--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -175,11 +175,14 @@ I use this to standardize shadowling dethrall code
 
 /mob/living/carbon/human/has_organic_damage()
 	var/robo_damage = 0
+	var/perma_injury_damage = 0
 	for(var/obj/item/organ/external/E in bodyparts)
 		if(E.is_robotic())
 			robo_damage += E.brute_dam
 			robo_damage += E.burn_dam
-	return health < maxHealth - robo_damage
+		if(E.perma_injury > (E.brute_dam + E.burn_dam))
+			perma_injury_damage += E.perma_injury - (E.brute_dam + E.burn_dam)
+	return health < maxHealth - robo_damage - perma_injury_damage
 
 /mob/living/carbon/human/proc/handle_splints() //proc that rebuilds the list of splints on this person, for ease of processing
 	splinted_limbs.Cut()

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -193,7 +193,7 @@
 
 	// See if bones need to break
 	check_fracture(brute)
-	// see if we need to inflict severe burns
+	// See if we need to inflict severe burns
 	check_for_burn_wound(burn)
 	// Threshold needed to have a chance of hurting internal bits with something sharp
 #define LIMB_SHARP_THRESH_INT_DMG 5
@@ -448,11 +448,11 @@ Note that amputating the affected organ does in fact remove the infection from t
 	if(damage > 15 && local_damage > 30 && prob(damage))
 		cause_internal_bleeding()
 
-/obj/item/organ/external/proc/check_for_burn_wound(damage)
+/obj/item/organ/external/proc/check_for_burn_wound(damage, update_health = TRUE)
 	if(is_robotic())
 		return
 	if(burn_dam >= min_broken_damage && prob(damage * max(owner.bodytemperature / BODYTEMP_HEAT_DAMAGE_LIMIT, 1)))
-		cause_burn_wound()
+		cause_burn_wound(update_health)
 
 // new damage icon system
 // returns just the brute/burn damage code
@@ -460,8 +460,8 @@ Note that amputating the affected organ does in fact remove the infection from t
 	var/tburn = 0
 	var/tbrute = 0
 
-	if(burn_dam ==0)
-		tburn =0
+	if(burn_dam == 0)
+		tburn = 0
 	else if(burn_dam < (max_damage * 0.25 / 2))
 		tburn = 1
 	else if(burn_dam < (max_damage * 0.75 / 2))
@@ -695,17 +695,19 @@ Note that amputating the affected organ does in fact remove the infection from t
 		return
 	status &= ~ORGAN_INT_BLEEDING
 
-/obj/item/organ/external/proc/cause_burn_wound()
+/obj/item/organ/external/proc/cause_burn_wound(update_health = TRUE)
 	if(is_robotic() || (limb_flags & CANNOT_BURN) || (status & ORGAN_BURNT))
 		return
 	status |= ORGAN_BURNT
 	perma_injury = min_broken_damage
+	if(update_health)
+		owner.updatehealth("burn wound inflicted")
 
 /obj/item/organ/external/proc/fix_burn_wound(update_health = TRUE)
 	status &= ~ORGAN_BURNT
 	perma_injury = max(perma_injury - min_broken_damage, 0)
 	if(update_health)
-		owner.updatehealth("burn wound")
+		owner.updatehealth("burn wound fixed")
 
 /obj/item/organ/external/robotize(company, make_tough = FALSE, convert_all = TRUE)
 	..()


### PR DESCRIPTION
## What Does This PR Do
Modifies `has_organic_damage()` proc (used by the autoejection mechanic) to exclude `perma_injury` on limbs.
Also fixes a minor oversight where burn wounds did not call a health update (doesn't change much on live since only time burn wounds are inflicted is on damage taken, which eventually calls a health update later).

## Why It's Good For The Game
Cryocells shouldn't keep patients stuck inside for no good reason.

## Testing
- Spawned in a lighter
- Toggled it off/on enough to cause some serious damage, checking for an eventual burn wound as well
- Hopped into a cryocell, waited a while
- Rejoiced when the cryocell spat me out when all the burn damage was healed

## Changelog
:cl:
fix: Cryo cells no longer eternally imprison occupants with burn wounds.
/:cl:
