### PR TITLE
trifecta no longer has an extra 25 players worth of antags

### DIFF
--- a/code/game/gamemodes/trifecta/trifecta.dm
+++ b/code/game/gamemodes/trifecta/trifecta.dm
@@ -79,7 +79,7 @@
 
 /datum/game_mode/trifecta/proc/calculate_quantities()
 	var/points = num_players()
-	points -= 25// So. to ensure that we had at least one vamp / changeling / traitor, I set the number of ammount to 1. I never subtracted points, leading to 25 players worth of antags added for free. Whoops.
+	points -= TOT_COST + VAMP_COST + CLING_COST// So. to ensure that we had at least one vamp / changeling / traitor, I set the number of ammount to 1. I never subtracted points, leading to 25 players worth of antags added for free. Whoops.
 	while(points > 0)
 		if(points < TOT_COST)
 			amount_tot++

--- a/code/game/gamemodes/trifecta/trifecta.dm
+++ b/code/game/gamemodes/trifecta/trifecta.dm
@@ -79,7 +79,8 @@
 
 /datum/game_mode/trifecta/proc/calculate_quantities()
 	var/points = num_players()
-	points -= TOT_COST + VAMP_COST + CLING_COST// So. to ensure that we had at least one vamp / changeling / traitor, I set the number of ammount to 1. I never subtracted points, leading to 25 players worth of antags added for free. Whoops.
+	// So. to ensure that we had at least one vamp / changeling / traitor, I set the number of ammount to 1. I never subtracted points, leading to 25 players worth of antags added for free. Whoops.
+	points -= TOT_COST + VAMP_COST + CLING_COST
 	while(points > 0)
 		if(points < TOT_COST)
 			amount_tot++

--- a/code/game/gamemodes/trifecta/trifecta.dm
+++ b/code/game/gamemodes/trifecta/trifecta.dm
@@ -9,7 +9,7 @@
 	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Blueshield", "Nanotrasen Representative", "Magistrate", "Internal Affairs Agent", "Nanotrasen Navy Officer", "Special Operations Officer", "Solar Federation General")
 	restricted_jobs = list("Cyborg")
 	secondary_restricted_jobs = list("AI")
-	required_players = 10
+	required_players = 25
 	required_enemies = 1	// how many of each type are required
 	recommended_enemies = 3
 	secondary_protected_species = list("Machine")
@@ -79,6 +79,7 @@
 
 /datum/game_mode/trifecta/proc/calculate_quantities()
 	var/points = num_players()
+	points -= 25// So. to ensure that we had at least one vamp / changeling / traitor, I set the number of ammount to 1. I never subtracted points, leading to 25 players worth of antags added for free. Whoops.
 	while(points > 0)
 		if(points < TOT_COST)
 			amount_tot++


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Trifecta now pays for the guaranteed vampire traitor and changeling it had, before it did not pay for it, leading to 25 players worth of extra antags.

Now requires 25 players (not that that will ever really matter)

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

25 extra antags in a gamemode is not great:tm:

## Testing
<!-- How did you test the PR, if at all? -->
![image](https://user-images.githubusercontent.com/52090703/234882220-6b4ce947-1922-417e-94b1-1a7fae5b9ac9.png)

Just number configuration, compiled.

## Changelog
:cl:
fix: Trifecta no longer has an extra 25 players worth of antags
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
