### PR TITLE
Fix 0.1u reagent amounts behaving inconsistently

### DIFF
--- a/code/modules/reagents/chemistry/reagents_holder.dm
+++ b/code/modules/reagents/chemistry/reagents_holder.dm
@@ -1,4 +1,5 @@
 #define ADDICTION_TIME 4800 //8 minutes
+#define MINIMUM_REAGENT_AMOUNT 0.09 // To account for 0.1 sometimes being 0.09996 and etc.
 
 /**
  * # Reagents Holder
@@ -559,7 +560,7 @@
 	total_volume = 0
 	for(var/A in reagent_list)
 		var/datum/reagent/R = A
-		if(R.volume < 0.1)
+		if(R.volume < MINIMUM_REAGENT_AMOUNT)
 			del_reagent(R.id)
 		else
 			total_volume += R.volume


### PR DESCRIPTION
## What Does This PR Do
Changes the minimum reagent amount threshold from 0.1 to 0.09 to account for computers not being great at storing decimal values, and converts the magic number into a define.

## Why It's Good For The Game
Fixes 0.1u pills being unreliable (sometimes you'd get the ChemMaster yelling at you that there wasn't enough reagents, and sometimes it'd just straight up print empty pills), fixes some chemicals' metabolism rates/specific injection amounts of chemicals not always giving them an extra cycle when they should.

## Testing
1. Put 1u of Water in a beaker
2. Made 10 pills out of it in a ChemMaster
3. Rejoiced when the machine did not yell at me, all 10 pills were properly created, and all of them when shoved back into the beaker combined into the full 1u
<!---->
1. Put 2u of Chlorine and 18u of Iodine (chemical that does nothing) into an IV bag
2. Inserted the needle into myself and waited a minute for everything to be injected
3. After everything metabolized, checked my vitals with a health analyzer to confirm I took exactly 20 burn damage (10 per 1u of Chlorine used; for a more consistent difference use more Chlorine and Iodine and wait longer)

## Changelog
:cl:
fix: Fixed chemicals occasionally evaporating at 0.1u as opposed to only <0.1u
/:cl:
