### PR TITLE
Chemicals that reduce pain make the users personal health bar less accurate

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1122,6 +1122,14 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 	KnockDown(knockdown)
 	return TRUE
 
+/mob/living/carbon/proc/shock_reduction()
+	var/shock_reduction = 0
+	if(reagents)
+		for(var/datum/reagent/R in reagents.reagent_list)
+			if(R.shock_reduction)
+				shock_reduction += R.shock_reduction
+	return shock_reduction
+
 /mob/living/carbon/proc/can_eat(flags = 255)
 	return 1
 

--- a/code/modules/mob/living/carbon/carbon_life.dm
+++ b/code/modules/mob/living/carbon/carbon_life.dm
@@ -293,10 +293,15 @@
 /mob/living/carbon/update_damage_hud()
 	if(!client)
 		return
+	var/shock_reduction = 0
+	if(reagents)
+		for(var/datum/reagent/R in reagents.reagent_list)
+			if(R.shock_reduction)
+				shock_reduction += R.shock_reduction
 	if(stat == UNCONSCIOUS && health <= HEALTH_THRESHOLD_CRIT)
 		if(check_death_method())
 			var/severity = 0
-			switch(health)
+			switch(health - shock_reduction)
 				if(-20 to -10)
 					severity = 1
 				if(-30 to -20)
@@ -323,7 +328,7 @@
 			clear_fullscreen("crit")
 			if(getOxyLoss())
 				var/severity = 0
-				switch(getOxyLoss())
+				switch(getOxyLoss() - shock_reduction)
 					if(10 to 20)
 						severity = 1
 					if(20 to 25)
@@ -345,7 +350,7 @@
 		//Fire and Brute damage overlay (BSSR)
 		var/hurtdamage = getBruteLoss() + getFireLoss() + damageoverlaytemp
 		damageoverlaytemp = 0 // We do this so we can detect if someone hits us or not.
-		if(hurtdamage)
+		if(hurtdamage - shock_reduction > 0)
 			var/severity = 0
 			switch(hurtdamage)
 				if(5 to 15) severity = 1

--- a/code/modules/mob/living/carbon/carbon_life.dm
+++ b/code/modules/mob/living/carbon/carbon_life.dm
@@ -293,11 +293,7 @@
 /mob/living/carbon/update_damage_hud()
 	if(!client)
 		return
-	var/shock_reduction = 0
-	if(reagents)
-		for(var/datum/reagent/R in reagents.reagent_list)
-			if(R.shock_reduction)
-				shock_reduction += R.shock_reduction
+	var/shock_reduction = shock_reduction()
 	if(stat == UNCONSCIOUS && health <= HEALTH_THRESHOLD_CRIT)
 		if(check_death_method())
 			var/severity = 0

--- a/code/modules/mob/living/carbon/human/human_life.dm
+++ b/code/modules/mob/living/carbon/human/human_life.dm
@@ -658,6 +658,8 @@
 						to_chat(src, "<span class='userdanger'>You feel [pick("terrible", "awful", "like shit", "sick", "numb", "cold", "sweaty", "tingly", "horrible")]!</span>")
 						Weaken(6 SECONDS)
 
+#define BODYPART_PAIN_REDUCTION 5
+
 /mob/living/carbon/human/update_health_hud()
 	if(!client)
 		return
@@ -692,7 +694,7 @@
 				healthdoll.icon_state = "healthdoll_DEAD"
 				for(var/obj/item/organ/external/O in bodyparts)
 					var/damage = O.get_damage()
-					damage -= shock_reduction / 5
+					damage -= shock_reduction / BODYPART_PAIN_REDUCTION
 					var/comparison = (O.max_damage/5)
 					var/icon_num = 0
 					if(damage > 0)
@@ -709,6 +711,8 @@
 				healthdoll.overlays += (new_overlays - cached_overlays)
 				healthdoll.overlays -= (cached_overlays - new_overlays)
 				healthdoll.cached_healthdoll_overlays = new_overlays
+
+#undef BODYPART_PAIN_REDUCTION
 
 /mob/living/carbon/human/proc/handle_nutrition_alerts() //This is a terrible abuse of the alert system; something like this should be a HUD element
 	if(HAS_TRAIT(src, TRAIT_NOHUNGER))

--- a/code/modules/mob/living/carbon/human/human_life.dm
+++ b/code/modules/mob/living/carbon/human/human_life.dm
@@ -664,8 +664,13 @@
 	if(dna.species.update_health_hud())
 		return
 	else
+		var/shock_reduction = 0
+		if(reagents)
+			for(var/datum/reagent/R in reagents.reagent_list)
+				if(R.shock_reduction)
+					shock_reduction += R.shock_reduction
 		if(healths)
-			var/health_amount = get_perceived_trauma()
+			var/health_amount = get_perceived_trauma(shock_reduction)
 			if(..(health_amount)) //not dead
 				switch(health_hud_override)
 					if(HEALTH_HUD_OVERRIDE_CRIT)
@@ -687,9 +692,10 @@
 				healthdoll.icon_state = "healthdoll_DEAD"
 				for(var/obj/item/organ/external/O in bodyparts)
 					var/damage = O.get_damage()
+					damage -= shock_reduction / 5
 					var/comparison = (O.max_damage/5)
 					var/icon_num = 0
-					if(damage)
+					if(damage > 0)
 						icon_num = 1
 					if(damage > (comparison))
 						icon_num = 2

--- a/code/modules/mob/living/carbon/human/human_life.dm
+++ b/code/modules/mob/living/carbon/human/human_life.dm
@@ -666,11 +666,7 @@
 	if(dna.species.update_health_hud())
 		return
 	else
-		var/shock_reduction = 0
-		if(reagents)
-			for(var/datum/reagent/R in reagents.reagent_list)
-				if(R.shock_reduction)
-					shock_reduction += R.shock_reduction
+		var/shock_reduction = shock_reduction()
 		if(healths)
 			var/health_amount = get_perceived_trauma(shock_reduction)
 			if(..(health_amount)) //not dead

--- a/code/modules/mob/living/carbon/human/human_mob.dm
+++ b/code/modules/mob/living/carbon/human/human_mob.dm
@@ -2012,7 +2012,12 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 		visible_message("<span class='danger'>[src] is engulfed in shadows and fades into the darkness.</span>", "<span class='danger'>A sense of dread washes over you as you suddenly dim dark.</span>")
 
 /mob/living/carbon/human/proc/get_perceived_trauma()
-	return min(health, maxHealth - getStaminaLoss())
+	var/percieved_trauma = min(health, maxHealth - getStaminaLoss())
+	if(reagents)
+		for(var/datum/reagent/R in reagents.reagent_list)
+			if(R.shock_reduction)
+				percieved_trauma += R.shock_reduction
+	return percieved_trauma
 
 /mob/living/carbon/human/WakeUp(updating = TRUE)
 	if(dna.species.spec_WakeUp(src))

--- a/code/modules/mob/living/carbon/human/human_mob.dm
+++ b/code/modules/mob/living/carbon/human/human_mob.dm
@@ -2011,13 +2011,8 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 		O.toggle_biolum(TRUE)
 		visible_message("<span class='danger'>[src] is engulfed in shadows and fades into the darkness.</span>", "<span class='danger'>A sense of dread washes over you as you suddenly dim dark.</span>")
 
-/mob/living/carbon/human/proc/get_perceived_trauma()
-	var/percieved_trauma = min(health, maxHealth - getStaminaLoss())
-	if(reagents)
-		for(var/datum/reagent/R in reagents.reagent_list)
-			if(R.shock_reduction)
-				percieved_trauma += R.shock_reduction
-	return percieved_trauma
+/mob/living/carbon/human/proc/get_perceived_trauma(shock_reduction)
+	return min(health, maxHealth - getStaminaLoss()) + shock_reduction
 
 /mob/living/carbon/human/WakeUp(updating = TRUE)
 	if(dna.species.spec_WakeUp(src))

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -23,7 +23,7 @@
 	shock_reduction = 200
 	taste_description = "numbness"
 
-/datum/reagent/medicine/hydrocodone/on_mob_life(mob/living/M)
+/datum/reagent/medicine/hydrocodone/on_mob_life(mob/living/M) //Needed so the hud updates when injested / removed from system
 	var/update_flags = STATUS_UPDATE_HEALTH
 	return ..() | update_flags
 

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -23,6 +23,10 @@
 	shock_reduction = 200
 	taste_description = "numbness"
 
+/datum/reagent/medicine/hydrocodone/on_mob_life(mob/living/M)
+	var/update_flags = STATUS_UPDATE_HEALTH
+	return ..() | update_flags
+
 /datum/reagent/medicine/sterilizine
 	name = "Sterilizine"
 	id = "sterilizine"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Chemicals that reduce pain (salic acid, morphine, and hydrocodone) will add "health" to the health bar equal to the shock resist.
In short, this generally means that the user when on these chemicals, will not be able to tell how injured / the stamina damage they are from the health bar. 

Health bar is impacted by a fraction (20%) of this value.

The red filter applied to edges of your screen is also impacted and reduced by this

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

A few reasons why this is good / interesting.

It allows an antagonist to use a toxic chemical in someone that does toxic damage, without them instantly running to medbay, when combined with a pain killer. When someone eats food, and that heal bar goes off 100%, people scream they are poisioned instantly and rush to medbay. This buys some time for the poision to work, before a painkiller expires and damage becomes apperent.

It makes people undergoing surgery with painkillers not know quite how well they are doing health wise (at least if the console is not broadcasting their health, so a bit of subtle poisoning may be possible, or death by oxyloss till they try talking.

It slightly nerfs those who use hydrocodone to avoid pain / stamina slowdown, as they will have a little bit of a harder time telling how bad their injuries are. They can guess  by examining, or get a health analyzer, but not on the fly. If they are using the locational based healing items, unless if they remember what was hit / have a health analyser, they may be wasting / delaying proper treatment of said limbs.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

https://cdn.discordapp.com/attachments/145700045008797697/1101227762213199912/Paradise_Station_13_2023-04-27_15-25-19.mp4 

## Testing
<!-- How did you test the PR, if at all? -->

Poisioning myself, punching myself, ect, with and without hydrocodone.

## Changelog
:cl:
tweak: Pain killing drugs now make a users personal health bar, health doll, and red screen overlay less accurate
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
