### PR TITLE
Removes roundstart janitoral mines

### DIFF
--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -46053,8 +46053,8 @@
 "cpd" = (
 /obj/structure/mopbucket/full,
 /obj/item/mop,
-/obj/item/caution/proximity_sign,
-/obj/item/caution/proximity_sign,
+/obj/item/caution,
+/obj/item/caution,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkred"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Removes roundstart proximity mine janitorial signs and replaces them with normal signs.

## Why It's Good For The Game
Roundstart S class is bad. Janitors accidently blowing up medbay is also bad. 

## Testing
Join as janitor, confirm map properly loaded, confirm signs no longer explode you.

## Changelog
:cl:
tweak: Medical secondary storage wet floor signs are no longer the explosive varient.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
