### PR TITLE
Allows proximity mine signs to be used by all traitors

### DIFF
--- a/code/datums/uplink_items/uplink_traitor.dm
+++ b/code/datums/uplink_items/uplink_traitor.dm
@@ -123,7 +123,6 @@
 	item = /obj/item/caution/proximity_sign
 	cost = 2
 	job = list("Janitor")
-	surplus = 0
 
 //Virology
 

--- a/code/game/objects/items/weapons/caution.dm
+++ b/code/game/objects/items/weapons/caution.dm
@@ -24,6 +24,8 @@
 /obj/item/caution/proximity_sign/attack_self(mob/user as mob)
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
+		if(H.mind.special_role != "Traitor")
+			return
 		if(armed)
 			armed = FALSE
 			to_chat(user, "<span class='notice'>You disarm \the [src].</span>")

--- a/code/game/objects/items/weapons/caution.dm
+++ b/code/game/objects/items/weapons/caution.dm
@@ -24,7 +24,7 @@
 /obj/item/caution/proximity_sign/attack_self(mob/user as mob)
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
-		if(H.mind.special_role != "Traitor")
+		if(!(H.mind.has_antag_datum(/datum/antagonist/traitor) || H.mind.has_antag_datum(/datum/antagonist/mindslave)))
 			return
 		if(armed)
 			armed = FALSE

--- a/code/game/objects/items/weapons/caution.dm
+++ b/code/game/objects/items/weapons/caution.dm
@@ -24,8 +24,6 @@
 /obj/item/caution/proximity_sign/attack_self(mob/user as mob)
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
-		if(H.mind.assigned_role != "Janitor")
-			return
 		if(armed)
 			armed = FALSE
 			to_chat(user, "<span class='notice'>You disarm \the [src].</span>")

--- a/code/game/objects/items/weapons/caution.dm
+++ b/code/game/objects/items/weapons/caution.dm
@@ -24,7 +24,7 @@
 /obj/item/caution/proximity_sign/attack_self(mob/user as mob)
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
-		if(!(H.mind.has_antag_datum(/datum/antagonist/traitor) || H.mind.has_antag_datum(/datum/antagonist/mindslave) && !(H.mind.has_antag_datum(/datum/antagonist/mindslave/thrall))))
+		if(!H.mind.has_antag_datum(/datum/antagonist/traitor) && !ismindslave(H))
 			return
 		if(armed)
 			armed = FALSE

--- a/code/game/objects/items/weapons/caution.dm
+++ b/code/game/objects/items/weapons/caution.dm
@@ -24,7 +24,7 @@
 /obj/item/caution/proximity_sign/attack_self(mob/user as mob)
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
-		if(!(H.mind.has_antag_datum(/datum/antagonist/traitor) || H.mind.has_antag_datum(/datum/antagonist/mindslave)))
+		if(!(H.mind.has_antag_datum(/datum/antagonist/traitor) || H.mind.has_antag_datum(/datum/antagonist/mindslave) && !(H.mind.has_antag_datum(/datum/antagonist/mindslave/thrall))))
 			return
 		if(armed)
 			armed = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Changes the mind requirement to arm and disarm proximity mine floor signs from the janitor role to the traitor special role.
Additionally, allows proximity mines to be found in surplus boxes

## Why It's Good For The Game
This item is very rarely used, so a buff to its usability as a surplus item could be interesting. Could be very useful as a way to remove the knees of any security officers poking around near a traitors hideout. 

## Testing
Spawn a proximity sign, confirm it fails to arm or disarm. Traitor yourself, and confirm it arms and disams. un-traitor self and confirm you cannot disarm it. Explode. Repeat with mindslaves.

## Changelog
:cl:
tweak: Changes mind requirement for proximity mine signs from "janitor" to "traitor" and/or "mindslave"
Tweak: Proximity mine janitorial signs can now be found in surplus crates
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
