### PR TITLE
Fixes molotov cocktails being used to craft molotov cocktails

### DIFF
--- a/code/modules/crafting/craft.dm
+++ b/code/modules/crafting/craft.dm
@@ -197,6 +197,7 @@
 	var/list/parts_used = list()
 	var/list/reagent_containers_for_deletion = list()
 	var/list/item_stacks_for_deletion = list()
+	var/list/blacklisted = list()
 
 	for(var/thing in recipe.reqs)
 		var/needed_amount = recipe.reqs[thing]
@@ -248,6 +249,11 @@
 		else
 			for(var/i in 1 to needed_amount)
 				var/atom/movable/part_atom = locate(thing) in (surroundings - parts_used)
+				while(recipe.blacklist.Find(part_atom.type))
+					blacklisted += part_atom
+					part_atom = locate(thing) in (surroundings - parts_used - blacklisted)
+					if(!part_atom)
+						break
 				if(!part_atom)
 					stack_trace("While crafting [recipe], the [thing] went missing!")
 					continue

--- a/code/modules/crafting/craft.dm
+++ b/code/modules/crafting/craft.dm
@@ -197,7 +197,7 @@
 	var/list/parts_used = list()
 	var/list/reagent_containers_for_deletion = list()
 	var/list/item_stacks_for_deletion = list()
-	var/list/blacklisted = list()
+	var/list/blacklisted = list() // list of items not to use from the surroundings based on recipe blacklist
 
 	for(var/thing in recipe.reqs)
 		var/needed_amount = recipe.reqs[thing]
@@ -249,11 +249,12 @@
 		else
 			for(var/i in 1 to needed_amount)
 				var/atom/movable/part_atom = locate(thing) in (surroundings - parts_used)
-				while(recipe.blacklist.Find(part_atom.type))
+				for(var/j in 1 to length(surroundings - parts_used))
+					if(!recipe.blacklist.Find(part_atom.type))
+						break
 					blacklisted += part_atom
 					part_atom = locate(thing) in (surroundings - parts_used - blacklisted)
-					if(!part_atom)
-						break
+
 				if(!part_atom)
 					stack_trace("While crafting [recipe], the [thing] went missing!")
 					continue

--- a/code/modules/crafting/craft.dm
+++ b/code/modules/crafting/craft.dm
@@ -248,12 +248,11 @@
 
 		else
 			for(var/i in 1 to needed_amount)
-				var/atom/movable/part_atom = locate(thing) in (surroundings - parts_used)
-				for(var/j in 1 to length(surroundings - parts_used))
-					if(!recipe.blacklist.Find(part_atom.type))
+				var/atom/movable/part_atom
+				for(var/atom/movable/candidate as anything in (surroundings - parts_used))
+					if(istype(candidate, thing) && !is_type_in_list(candidate, recipe.blacklist)
+						part_atom = candidate
 						break
-					blacklisted += part_atom
-					part_atom = locate(thing) in (surroundings - parts_used - blacklisted)
 
 				if(!part_atom)
 					stack_trace("While crafting [recipe], the [thing] went missing!")

--- a/code/modules/crafting/craft.dm
+++ b/code/modules/crafting/craft.dm
@@ -249,7 +249,7 @@
 			for(var/i in 1 to needed_amount)
 				var/atom/movable/part_atom
 				for(var/atom/movable/candidate as anything in (surroundings - parts_used))
-					if(istype(candidate, thing) && !is_type_in_list(candidate, recipe.blacklist)
+					if(istype(candidate, thing) && !is_type_in_list(candidate, recipe.blacklist))
 						part_atom = candidate
 						break
 

--- a/code/modules/crafting/craft.dm
+++ b/code/modules/crafting/craft.dm
@@ -197,7 +197,6 @@
 	var/list/parts_used = list()
 	var/list/reagent_containers_for_deletion = list()
 	var/list/item_stacks_for_deletion = list()
-	var/list/blacklisted = list() // list of items not to use from the surroundings based on recipe blacklist
 
 	for(var/thing in recipe.reqs)
 		var/needed_amount = recipe.reqs[thing]

--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -42,6 +42,7 @@
 	result = list(/obj/item/reagent_containers/food/drinks/bottle/molotov)
 	reqs = list(/obj/item/reagent_containers/glass/rag = 1,
 				/obj/item/reagent_containers/food/drinks/bottle = 1)
+	blacklist = list(/obj/item/reagent_containers/food/drinks/bottle/molotov)
 	parts = list(/obj/item/reagent_containers/food/drinks/bottle = 1)
 	time = 40
 	category = CAT_WEAPONRY


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #20871
Molotov cocktails are now blacklisted from being used to craft molotov cocktails.
Now blacklisted items can not be used to craft. For instance you can no longer use molotov cocktails to craft molotov cocktails. Before blacklisted items only prevented selecting the craft option for a given item but could still be used in the crafting if a valid crafting item was in the players reach.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Prevents wasting materials and not getting what you intended to craft.  Things working as intended is good.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
1. spawn as bartender
2. spawn in 5 damp rags
3. grab 5 bottles of whiskey
4. craft 5 molotov cocktails
5. Profit
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Fixed being able to use molotov cocktails to craft molotov cocktails
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
