### PR TITLE
Corgis can now use fire extinguishers on their back

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/dog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/dog.dm
@@ -105,6 +105,18 @@
 	..(gibbed)
 	regenerate_icons()
 
+/mob/living/simple_animal/pet/dog/corgi/RangedAttack(atom/A, params)
+	if(inventory_back)
+		inventory_back.afterattack(A, src, )
+
+/mob/living/simple_animal/pet/dog/corgi/UnarmedAttack(atom/A)
+	if(inventory_back)
+		if(istype(inventory_back, /obj/item/extinguisher))
+			var/obj/item/extinguisher/E = inventory_back
+			E.AttemptRefill(A, src)
+			return
+	. = ..()
+
 /mob/living/simple_animal/pet/dog/corgi/show_inv(mob/user)
 	if(user.incapacitated() || !Adjacent(user))
 		return


### PR DESCRIPTION
## What Does This PR Do
Makes corgis able to use fire extinguishers placed on their backs, they are also able to refill the fire extinguishers with water tanks

## Why It's Good For The Game
The fire extinguisher is already one of the few things you can put on a corgis back so it would make sense that they can use it

## Testing
Tried splaying around, refilling the fire extinguisher

## Changelog
:cl:
add: Corgis can now use fire extinguishers on their back
/:cl: