### PR TITLE
calculates richest escapee by including account balance along with cash

### DIFF
--- a/code/game/gamemodes/scoreboard.dm
+++ b/code/game/gamemodes/scoreboard.dm
@@ -161,14 +161,9 @@ GLOBAL_VAR(scoreboard) // Variable to save the scoreboard string once it's been 
 /// A function to determine the cash plus the account balance of the wealthiest escapee
 /datum/scoreboard/proc/get_score_person_worth(mob/living/carbon/human/H)
 	if(!H.mind)
-		return
-	. = get_score_container_worth(H)
-
-	if(!H.mind.initial_account)
-		return
-
-	var/balance = H.mind.initial_account.credit_balance
-	. += balance
+		return // if they have no mind, we don't care
+	// return value of space cash on the person + whatever balance they currently have in their original money account
+	return get_score_container_worth(H) + H.mind.initial_account?.credit_balance
 
 // A recursive function to properly determine the cash on the wealthiest escapee
 /datum/scoreboard/proc/get_score_container_worth(atom/C, level = 0)

--- a/code/game/gamemodes/scoreboard.dm
+++ b/code/game/gamemodes/scoreboard.dm
@@ -158,7 +158,7 @@ GLOBAL_VAR(scoreboard) // Variable to save the scoreboard string once it's been 
 		damaged_job = H.job
 		damaged_key = H.key
 
-// A function to determine the cash plus the account balance of the wealthiest escapee
+/// A function to determine the cash plus the account balance of the wealthiest escapee
 /datum/scoreboard/proc/get_score_person_worth(mob/living/carbon/human/H)
 	if(!H.mind)
 		return

--- a/code/game/gamemodes/scoreboard.dm
+++ b/code/game/gamemodes/scoreboard.dm
@@ -160,7 +160,12 @@ GLOBAL_VAR(scoreboard) // Variable to save the scoreboard string once it's been 
 
 // A function to determine the cash plus the account balance of the wealthiest escapee
 /datum/scoreboard/proc/get_score_person_worth(mob/living/carbon/human/H)
+	if(!H.mind)
+		return
 	. = get_score_container_worth(H)
+
+	if(!H.mind.initial_account)
+		return
 
 	var/balance = H.mind.initial_account.credit_balance
 	. += balance

--- a/code/game/gamemodes/scoreboard.dm
+++ b/code/game/gamemodes/scoreboard.dm
@@ -144,7 +144,7 @@ GLOBAL_VAR(scoreboard) // Variable to save the scoreboard string once it's been 
 
 	score_escapees++
 
-	var/cash_score = get_score_container_worth(H)
+	var/cash_score = get_score_person_worth(H)
 	if(cash_score > richest_cash)
 		richest_cash = cash_score
 		richest_name = H.real_name
@@ -158,7 +158,14 @@ GLOBAL_VAR(scoreboard) // Variable to save the scoreboard string once it's been 
 		damaged_job = H.job
 		damaged_key = H.key
 
-// A recursive function to properly determine the wealthiest escapee
+// A function to determine the cash plus the account balance of the wealthiest escapee
+/datum/scoreboard/proc/get_score_person_worth(mob/living/carbon/human/H)
+	. = get_score_container_worth(H)
+
+	var/balance = H.mind.initial_account.credit_balance
+	. += balance
+
+// A recursive function to properly determine the cash on the wealthiest escapee
 /datum/scoreboard/proc/get_score_container_worth(atom/C, level = 0)
 	. = 0
 	if(level >= 5) // in case the containers recurse or something

--- a/code/game/gamemodes/scoreboard.dm
+++ b/code/game/gamemodes/scoreboard.dm
@@ -165,7 +165,7 @@ GLOBAL_VAR(scoreboard) // Variable to save the scoreboard string once it's been 
 	// return value of space cash on the person + whatever balance they currently have in their original money account
 	return get_score_container_worth(H) + H.mind.initial_account?.credit_balance
 
-// A recursive function to properly determine the cash on the wealthiest escapee
+/// A recursive function to properly determine the cash on the wealthiest escapee
 /datum/scoreboard/proc/get_score_container_worth(atom/C, level = 0)
 	. = 0
 	if(level >= 5) // in case the containers recurse or something


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #20641
This PR takes a persons account balance into consideration when determining the richest escapee at the end of the round. Before the richest escapee was determined purely based on the cash carried on their person.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Accurate end of the round statistic is accurate
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
1. spawn as captain
2. spawn in 1000 credits
3. put 500 into ATM account and 500 into bag
4. account balance = 1100
5. end round
6. richest escapee has 1600 credits
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Fixed the richest escapee check to be accurate
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
