### PR TITLE
Makes lwap scope not freak out if move before scoping

### DIFF
--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -159,13 +159,15 @@
 			to_chat(user, "<b><span class='robot'>SCOPE_CREEPER_[rand(1, 9999)] Online.</span></b>")
 			select_fire(H)
 			H.apply_status_effect(STATUS_EFFECT_LWAPSCOPE, stored_dir)
+		return
+	zoom(user, FALSE) //Moved while scope was booting, so we unzoom
 
 /obj/item/gun/energy/lwap/process()
 	. = ..()
 	if(!isliving(loc))
 		return
 	var/mob/living/M = loc
-	if(world.time - M.last_movement <= PROCESS_TIME_PLUS_DECISECOND && zoomed) //If they have moved in the last process cycle.
+	if(world.time - M.last_movement <= PROCESS_TIME_PLUS_DECISECOND && scope_active) //If they have moved in the last process cycle.
 		to_chat(M, "<span class='warning'>[src]'s scope is overloaded by movement and shuts down!</span>")
 		zoom(M, FALSE)
 

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -160,7 +160,8 @@
 			select_fire(H)
 			H.apply_status_effect(STATUS_EFFECT_LWAPSCOPE, stored_dir)
 		return
-	zoom(user, FALSE) //Moved while scope was booting, so we unzoom
+	if(zoomed)
+		zoom(user, FALSE) //Moved while scope was booting, so we unzoom
 
 /obj/item/gun/energy/lwap/process()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Lwap scope no longer freaks out if you move before scoping, it only does the process check when fully scoped, as the do_after checks for movement after starting to scope

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

scope being angry when you are standing still after moving bad

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
<!-- How did you test the PR, if at all? -->

confirmed I got yelled at less by the scope

## Changelog
:cl:
tweak: The lwap will no longer complain as much if you move before scoping in
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
