### PR TITLE
Borgs no longer get their forcemodules overriden when joining as an ERT borg

### DIFF
--- a/code/modules/response_team/ert.dm
+++ b/code/modules/response_team/ert.dm
@@ -146,7 +146,7 @@ GLOBAL_VAR_INIT(ert_request_answered, FALSE)
 /client/proc/create_response_team_part_1(new_gender, new_species, role, turf/spawn_location)
 	if(role == "Cyborg")
 		var/mob/living/silicon/robot/ert/R = new GLOB.active_team.borg_path(spawn_location)
-		if(!GLOB.active_team.cyborg_security_permitted)
+		if(!GLOB.active_team.cyborg_security_permitted && !length(R.force_modules))
 			R.force_modules = list("Engineering", "Medical")
 		return R
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Title
Fixes #21008

## Why It's Good For The Game
Combat borgs and sec borgs should spawn through an ERT spawner

## Changelog
:cl:
fix: Combat and security borgs can be spawned through the ERT pannel again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
