### PR TITLE
Fixes bureaucratic error event runtime

### DIFF
--- a/code/modules/events/bureaucratic_error.dm
+++ b/code/modules/events/bureaucratic_error.dm
@@ -20,7 +20,7 @@
 	GLOB.major_announcement.Announce("A recent bureaucratic error in the Human Resources Department may result in personnel shortages in some departments and redundant staffing in others.", "Paperwork Mishap Alert")
 
 /datum/event/bureaucratic_error/start()
-	var/list/affected_jobs // For logging
+	var/list/affected_jobs = list() // For logging
 	var/list/jobs = SSjobs.occupations.Copy()
 	var/datum/job/overflow
 	var/overflow_amount = rand(1, 6)
@@ -33,6 +33,6 @@
 		if(overflow.type in blacklisted_jobs)
 			continue
 		overflow.total_positions = max(overflow.total_positions + random_change, 0)
-		affected_jobs += "[overflow] slot changed by [random_change].\n"
+		affected_jobs += "[overflow.title] slot changed by [random_change]."
 		errors++
-	log_and_message_admins(affected_jobs.Join(" "))
+	log_and_message_admins(affected_jobs.Join("\n"))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Bureaucractic error event now logs properly instead of runtiming
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
runtime bad, go away.
## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![image](https://user-images.githubusercontent.com/77684085/235813389-9e702c3e-f5a7-4f60-a622-2d24b7f7bf6b.png)

## Testing
<!-- How did you test the PR, if at all? -->
- Forced event to happen, did see image above
## Changelog
:cl:
fix: Bureaucractic error event now logs properly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
