### PR TITLE
Rework the cryo cell's handling of the occupant icon

### DIFF
--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -90,6 +90,7 @@
 			break
 
 /obj/machinery/atmospherics/unary/cryo_cell/Destroy()
+	qdel(occupant_overlay)
 	QDEL_NULL(beaker)
 	return ..()
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -27,8 +27,6 @@
 	var/injection_cooldown = 34 SECONDS
 	var/efficiency
 
-	var/running_bob_animation = FALSE // This is used to prevent threads from building up if update_icons is called multiple times
-
 	light_color = LIGHT_COLOR_WHITE
 
 /obj/machinery/atmospherics/unary/cryo_cell/examine(mob/user)

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -88,7 +88,7 @@
 			break
 
 /obj/machinery/atmospherics/unary/cryo_cell/Destroy()
-	qdel(occupant_overlay)
+	QDEL_NULL(occupant_overlay)
 	QDEL_NULL(beaker)
 	return ..()
 
@@ -342,7 +342,7 @@
 /obj/machinery/atmospherics/unary/cryo_cell/update_overlays()
 	. = ..()
 	if(occupant_overlay)
-		qdel(occupant_overlay)
+		QDEL_NULL(occupant_overlay)
 	if(!occupant)
 		. += "lid[on]" //if no occupant, just put the lid overlay on, and ignore the rest
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Reworks how the bobbing mob is displayed for the cryo cell. This involves making an effect and some layering, but that is more reliable overall than having a separate thread that's constantly adding and removing overlays.

## Why It's Good For The Game
Fixes #20875. Doesn't rely on spawns.

## Images of changes
https://user-images.githubusercontent.com/80771500/235948908-4cc47b39-30cd-440d-a0cf-5b212337adac.mp4

## Testing
Stuffed a mob in the cryo cell and turned it on and off.

## Changelog
:cl:
fix: Fixed ghost image of cryo cell being stuck
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
