### PR TITLE
Welders now use 0.5 fuel on attack. 

### DIFF
--- a/code/game/objects/items/tools/welder.dm
+++ b/code/game/objects/items/tools/welder.dm
@@ -142,9 +142,7 @@
 	. = ..()
 	if(!tool_enabled)
 		return
-	else
-		remove_fuel(0.5)
-		return
+	remove_fuel(0.5)
 
 /obj/item/weldingtool/use_tool(atom/target, user, delay, amount, volume, datum/callback/extra_checks)
 	target.add_overlay(GLOB.welding_sparks)

--- a/code/game/objects/items/tools/welder.dm
+++ b/code/game/objects/items/tools/welder.dm
@@ -138,6 +138,14 @@
 	remove_fuel(amount)
 	return TRUE
 
+/obj/item/weldingtool/afterattack(atom/target, mob/user, proximity, params)
+	. = ..()
+	if(!tool_enabled)
+		return
+	else
+		remove_fuel(0.5)
+		return
+
 /obj/item/weldingtool/use_tool(atom/target, user, delay, amount, volume, datum/callback/extra_checks)
 	target.add_overlay(GLOB.welding_sparks)
 	var/did_thing = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
See title, welders now use 0.5 fuel on attack on any object/mob, this will get you one blob tile per one fuel for reference. 
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Welders are more and more becoming a multi tool for combat, mass printed, and used for everything. this PR aims to not make them a 15 burn damage powerhouse for every bio hazard, and _any_ task that requires damage at zero fuel cost, hopefully getting people to use other means of damage/be more conservative with their fuel.

## Testing
<!-- How did you test the PR, if at all? -->
Booted up a test server, THWACKED a few things to make sure fuel was being spent correctly, and it was.
## Changelog
:cl:
tweak: Welders now use 0.5 fuel on hit on any mob/tile
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
## Additional notes.
As this is quite the tweak, I'll request a TM to see if the fuel would need to be upped/lowered at all. Or if there's some bizarre glitch i didn't think of.

Also, apologies if i should have spoken to the balance team before making this, i got mixed messages about doing so.