### PR TITLE
Xenomorph Deathrattle

### DIFF
--- a/code/modules/mob/living/carbon/alien/alien_base.dm
+++ b/code/modules/mob/living/carbon/alien/alien_base.dm
@@ -193,6 +193,29 @@
 
 	return threatcount
 
+/mob/living/carbon/alien/death(gibbed)
+	. = ..()
+	if(!.)
+		return
+
+	deathrattle()
+
+
+/mob/living/carbon/alien/proc/deathrattle()
+	var/alien_message = deathrattle_message()
+	// var/ghost_message = deathrattle_message(TRUE)
+	for(var/mob/M in GLOB.player_list)
+		if(!isobserver(M) && !isalien(M))
+			continue
+
+		if(isobserver(M))
+			to_chat(M, deathrattle_message(M))
+		else
+			to_chat(M, alien_message)
+
+/mob/living/carbon/alien/proc/deathrattle_message(mob/dead/observer/G)
+	return "<i><span class='alien'>The hivemind echoes: [name][!isnull(G) ? " ([ghost_follow_link(src, ghost=G)]) " : ""] has been slain!</span></i>"
+
 /*----------------------------------------
 Proc: AddInfectionImages()
 Des: Gives the client of the alien an image on each infected mob.

--- a/code/modules/mob/living/carbon/alien/alien_base.dm
+++ b/code/modules/mob/living/carbon/alien/alien_base.dm
@@ -206,7 +206,7 @@
 	for(var/mob/living/carbon/alien/M in GLOB.player_list)
 		to_chat(M, alien_message)
 
-/mob/living/carbon/alien/proc/deathrattle_message(mob/dead/observer/G)
+/mob/living/carbon/alien/proc/deathrattle_message()
 	return "<i><span class='alien'>The hivemind echoes: [name] has been slain!</span></i>"
 
 /*----------------------------------------

--- a/code/modules/mob/living/carbon/alien/alien_base.dm
+++ b/code/modules/mob/living/carbon/alien/alien_base.dm
@@ -203,18 +203,11 @@
 
 /mob/living/carbon/alien/proc/deathrattle()
 	var/alien_message = deathrattle_message()
-	// var/ghost_message = deathrattle_message(TRUE)
-	for(var/mob/M in GLOB.player_list)
-		if(!isobserver(M) && !isalien(M))
-			continue
-
-		if(isobserver(M))
-			to_chat(M, deathrattle_message(M))
-		else
-			to_chat(M, alien_message)
+	for(var/mob/living/carbon/alien/M in GLOB.player_list)
+		to_chat(M, alien_message)
 
 /mob/living/carbon/alien/proc/deathrattle_message(mob/dead/observer/G)
-	return "<i><span class='alien'>The hivemind echoes: [name][!isnull(G) ? " ([ghost_follow_link(src, ghost=G)]) " : ""] has been slain!</span></i>"
+	return "<i><span class='alien'>The hivemind echoes: [name] has been slain!</span></i>"
 
 /*----------------------------------------
 Proc: AddInfectionImages()

--- a/code/modules/mob/living/carbon/alien/humanoid/queen.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/queen.dm
@@ -41,7 +41,7 @@
 		/obj/item/organ/internal/alien/neurotoxin,
 	)
 
-/mob/living/carbon/alien/humanoid/queen/deathrattle_message(for_ghosts)/mob/living/carbon/alien/proc/deathrattle_message(mob/dead/observer/G)
+/mob/living/carbon/alien/humanoid/queen/deathrattle_message()
 	return "<i><span class='alien reallybig'>A shock reverberates through the hive; [name] has been slain!</span></i>"
 
 /mob/living/carbon/alien/humanoid/queen/can_inject(mob/user, error_msg, target_zone, penetrate_thick)

--- a/code/modules/mob/living/carbon/alien/humanoid/queen.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/queen.dm
@@ -42,7 +42,7 @@
 	)
 
 /mob/living/carbon/alien/humanoid/queen/deathrattle_message(for_ghosts)/mob/living/carbon/alien/proc/deathrattle_message(mob/dead/observer/G)
-	return "<i><span class='alien reallybig'>A shock reverberates through the hive; [name][!isnull(G) ? " ([ghost_follow_link(src, ghost=G)]) " : ""] has been slain!</span></i>"
+	return "<i><span class='alien reallybig'>A shock reverberates through the hive; [name] has been slain!</span></i>"
 
 /mob/living/carbon/alien/humanoid/queen/can_inject(mob/user, error_msg, target_zone, penetrate_thick)
 	return FALSE

--- a/code/modules/mob/living/carbon/alien/humanoid/queen.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/queen.dm
@@ -41,6 +41,8 @@
 		/obj/item/organ/internal/alien/neurotoxin,
 	)
 
+/mob/living/carbon/alien/humanoid/queen/deathrattle_message(for_ghosts)/mob/living/carbon/alien/proc/deathrattle_message(mob/dead/observer/G)
+	return "<i><span class='alien reallybig'>A shock reverberates through the hive; [name][!isnull(G) ? " ([ghost_follow_link(src, ghost=G)]) " : ""] has been slain!</span></i>"
 
 /mob/living/carbon/alien/humanoid/queen/can_inject(mob/user, error_msg, target_zone, penetrate_thick)
 	return FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Sends a message to all living xenomorphs when a xenomorph is killed, with an even bigger one being sent when a queen is killed. Inspired by tgmc.

If you have better suggestions for the messages, feel free to make suggestions.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
If xenomorphs aren't communicating or run out and die, it can be pretty easy to lose track of just how the fight is going. It's especially important to know if the queen dies, and this should help xenomorphs stay better coordinated.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://user-images.githubusercontent.com/89928798/236097668-9817a651-c7be-4edf-b11c-f1e866bd6161.png)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Killed a bunch of benos.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
add: Xenomorphs are now notified when their sisters die.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
