### PR TITLE
Removes bluespace crystal sheets, makes crystals look as expected

### DIFF
--- a/code/datums/components/material_container.dm
+++ b/code/datums/components/material_container.dm
@@ -386,7 +386,7 @@
 /datum/material/bluespace
 	name = "Bluespace Mesh"
 	id = MAT_BLUESPACE
-	sheet_type = /obj/item/stack/sheet/bluespace_crystal
+	sheet_type = /obj/item/stack/ore/bluespace_crystal/refined
 	ore_type = /obj/item/stack/ore/bluespace_crystal
 
 /datum/material/bananium

--- a/code/modules/awaymissions/mission_code/ghost_role_spawners/golems.dm
+++ b/code/modules/awaymissions/mission_code/ghost_role_spawners/golems.dm
@@ -32,7 +32,7 @@
 		/obj/item/stack/sheet/mineral/plastitanium		= /datum/species/golem/plastitanium,
 		/obj/item/stack/sheet/mineral/abductor			= /datum/species/golem/alloy,
 		/obj/item/stack/sheet/wood						= /datum/species/golem/wood,
-		/obj/item/stack/sheet/bluespace_crystal			= /datum/species/golem/bluespace,
+		/obj/item/stack/ore/bluespace_crystal/refined	= /datum/species/golem/bluespace,
 		/obj/item/stack/medical/bruise_pack	        	= /datum/species/golem/cloth,
 		/obj/item/stack/medical/bruise_pack/improvised	= /datum/species/golem/cloth,
 		/obj/item/stack/sheet/cloth	                	= /datum/species/golem/cloth,

--- a/code/modules/telesci/bscrystal.dm
+++ b/code/modules/telesci/bscrystal.dm
@@ -3,16 +3,17 @@
 	name = "bluespace crystal"
 	desc = "A glowing bluespace crystal, not much is known about how they work. It looks very delicate."
 	icon = 'icons/obj/stacks/minerals.dmi'
-	icon_state = "refined_bluespace_crystal"
+	icon_state = "bluespace_crystal" //This is the raw ore from lavaland, so should look like the ore.
 	item_state = "bluespace_crystal"
 	w_class = WEIGHT_CLASS_TINY
 	materials = list(MAT_BLUESPACE = MINERAL_MATERIAL_AMOUNT)
 	origin_tech = "bluespace=6;materials=3"
 	points = 50
 	var/blink_range = 8 // The teleport range when crushed/thrown at someone.
-	refined_type = /obj/item/stack/sheet/bluespace_crystal
+	refined_type = /obj/item/stack/ore/bluespace_crystal/refined
 	toolspeed = 1
 	usesound = 'sound/items/deconstruct.ogg'
+	dynamic_icon_state = TRUE
 
 /obj/item/stack/ore/bluespace_crystal/New(loc, new_amount, merge = TRUE)
 	..()
@@ -38,9 +39,10 @@
 		blink_mob(hit_atom)
 	qdel(src)
 
-// Bluespace crystal fragments (stops point farming)
+// Refined Bluespace crystal fragments (stops point farming)
 /obj/item/stack/ore/bluespace_crystal/refined
 	name = "refined bluespace crystal"
+	icon_state = "refined_bluespace_crystal"
 	points = 0
 	refined_type = null
 
@@ -54,26 +56,3 @@
 	blink_range = 4 // Not as good as the organic stuff!
 	points = 0 // nice try
 	refined_type = null
-
-// Polycrystals, aka stacks
-
-GLOBAL_LIST_INIT(bluespace_crystal_recipes, list(new/datum/stack_recipe("Breakdown into bluespace crystal", /obj/item/stack/ore/bluespace_crystal/refined, 1)))
-
-/obj/item/stack/sheet/bluespace_crystal
-	name = "bluespace polycrystal"
-	icon_state = "bluespace_crystal"
-	item_state = "polycrystal"
-	desc = "A stable polycrystal, made of fused-together bluespace crystals. You could probably break one off."
-	origin_tech = "bluespace=6;materials=3"
-	merge_type = /obj/item/stack/sheet/bluespace_crystal
-	materials = list(MAT_BLUESPACE = MINERAL_MATERIAL_AMOUNT)
-	attack_verb = list("bluespace polybashed", "bluespace polybattered", "bluespace polybludgeoned", "bluespace polythrashed", "bluespace polysmashed")
-	toolspeed = 1
-	usesound = 'sound/items/deconstruct.ogg'
-	point_value = 30
-
-/obj/item/stack/sheet/bluespace_crystal/New()
-	..()
-	recipes = GLOB.bluespace_crystal_recipes
-	pixel_x = rand(0,4)-4
-	pixel_y = rand(0,4)-4


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Removes bluespace polycrystals (aka bluespace sheets). There only purpose was to be broken down... back into poly crystals. We can sepeate minerals into stack with alt click, there is no real need to have this, especially when we want to inherent the ability to crush crystals, and ore acts just like the stack when put into the ORM / protolathe again. We have 3 types of bluespace ore, we don't need a sheet on top of that.

Raw bluespace ore now is embeded in rock, which used to be what sheets looked like, despite being refined.

Refined bluspace crystals and artifical bluespace crystals now stack visually, were missing the dynamic icon state flag.

Golems are now crafted by refined bluespace crystals rather than sheets. Functionally the same, as you broke sheets into refined crystals.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Crystals appearing as expected is good.
Having a mineral sheet normally makes sense for an ore, EXECEPT when we have 3 variations of the ore already, and the only purpose of  the sheet is to be turned back into ore, so the ore can be crushed in hand. It makes no sense at that point. It's not a time gate or anything, its just there to make you separate it from the stack, which one can do by alt click.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

![image](https://user-images.githubusercontent.com/52090703/236363182-4ed26c9d-9226-4392-b101-94040c59c5b4.png)

Here are the crystals as expected. Raw crystals on the left, refined ones in the middle, and fake crystals on the right.

## Testing
<!-- How did you test the PR, if at all? -->

Ensured it refined correctly, worked for golems, could not be chesed for points, worked in protolathe, and did not brick the mineral system.

## Changelog
:cl:
tweak: You no longer get bluespace polycrystals out of the orm that have to be separated into refined crystals, you just get refined crystals now.
fix: Bluespace crystals now visually stack as intended.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
