### PR TITLE
Slime Jelly Vomit Fix

### DIFF
--- a/code/modules/surgery/organs/blood.dm
+++ b/code/modules/surgery/organs/blood.dm
@@ -213,7 +213,7 @@
 		return blood_data
 	if(blood_id == "slimejelly")
 		var/blood_data = list()
-		blood_data["colour"] = dna.species.blood_color
+		blood_data["blood_color"] = dna.species.blood_color
 		return blood_data
 
 //get the id of the substance this mob use as blood.
@@ -256,7 +256,7 @@
 
 //to add a splatter of blood or other mob liquid.
 /mob/living/proc/add_splatter_floor(turf/T, small_drip, shift_x, shift_y)
-	if(get_blood_id() != "blood")//is it blood or welding fuel?
+	if((get_blood_id() != "blood") && (get_blood_id() != "slimejelly"))//is it blood or welding fuel?
 		return
 	if(!T)
 		T = get_turf(src)


### PR DESCRIPTION
## What Does This PR Do
Fixes #20298

Ensures that when slimes vomit blood, either via holy water or viruses, that the blood splatter is properly made and colored correctly.

## Why It's Good For The Game
Bugfixing

## Testing
gave holy water to a slime vampire to vomit jelly blood
gave slime a virus to vomit blood
cut self with a meat cleaver to bleed jelly blood
added alien organ to splatter jelly blood over the walls


## Changelog
:cl:
fix: Fixed slimes properly vomiting blood
/:cl:
