### PR TITLE
Removes need for the cake hat when making Birthday Cake

### DIFF
--- a/code/modules/food_and_drinks/recipes/recipes_oven.dm
+++ b/code/modules/food_and_drinks/recipes/recipes_oven.dm
@@ -401,12 +401,14 @@
 	result = /obj/item/reagent_containers/food/snacks/croissant
 
 /datum/recipe/oven/birthdaycake
-	reagents = list("milk" = 5, "sugar" = 5)
+	reagents = list("milk" = 5, "sugar" = 15, "vanilla" = 10)
 	items = list(
 		/obj/item/reagent_containers/food/snacks/dough,
 		/obj/item/reagent_containers/food/snacks/dough,
 		/obj/item/reagent_containers/food/snacks/dough,
-		/obj/item/clothing/head/cakehat
+		/obj/item/candle,
+		/obj/item/candle,
+		/obj/item/candle,
 	)
 	result = /obj/item/reagent_containers/food/snacks/sliceable/birthdaycake
 


### PR DESCRIPTION
## What Does This PR Do
Closes #21015
Makes it so that birthday cake requires mutated botany plants (10u vanilla), 3 candles, raised the amount of sugar to 15u to be in line with other cakes. Removed the need for using the cake hat for its recipe so it can be made on other stations, and can be made more than once (realistically).

New cake recipe overview:

- 3 doughs
- 3 candles
- 15u sugar
- 10u vanilla
- 5u milk

## Why It's Good For The Game
Needing a hat for cooking both limits where and how many can be made, but needing a hat is just silly. 

## Testing
made some beautiful cakes

## Changelog
:cl:
tweak: tweaked the birthday cake recipe
/:cl:

