### PR TITLE
Lets the rnd server controller actually have use in blacklisting

### DIFF
--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -267,11 +267,17 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 /obj/machinery/computer/rdconsole/proc/sync_research()
 	if(!sync)
 		return
+	var/list/temp_unblacklist = list()
+	for(var/v in files.unblacklisted_designs)
+		temp_unblacklist += v
+	files.unblacklisted_designs = list() //Remove this asap, else it will stick around
 	clear_wait_message()
 	for(var/obj/machinery/r_n_d/server/S in GLOB.machines)
 		var/server_processed = FALSE
 
 		if((id in S.id_with_upload) || istype(S, /obj/machinery/r_n_d/server/centcom))
+			for(var/v in temp_unblacklist)
+				S.files.blacklisted_designs -= v
 			files.push_data(S.files)
 			server_processed = TRUE
 
@@ -606,7 +612,6 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 				to_chat(usr, "<span class='danger'>You must connect to the network first!</span>")
 			else
 				add_wait_message("Syncing Database...", SYNC_RESEARCH_DELAY)
-				griefProtection() //Putting this here because I dont trust the sync process
 				addtimer(CALLBACK(src, PROC_REF(sync_research)), SYNC_RESEARCH_DELAY)
 
 		if("togglesync") //Prevents the console from being synced by other consoles. Can still send data.

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -267,17 +267,14 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 /obj/machinery/computer/rdconsole/proc/sync_research()
 	if(!sync)
 		return
-	var/list/temp_unblacklist = list()
-	for(var/v in files.unblacklisted_designs)
-		temp_unblacklist += v
+	var/list/temp_unblacklist = files.unblacklisted_designs
 	files.unblacklisted_designs = list() //Remove this asap, else it will stick around
 	clear_wait_message()
 	for(var/obj/machinery/r_n_d/server/S in GLOB.machines)
 		var/server_processed = FALSE
 
 		if((id in S.id_with_upload) || istype(S, /obj/machinery/r_n_d/server/centcom))
-			for(var/v in temp_unblacklist)
-				S.files.blacklisted_designs -= v
+			S.files.blacklisted_designs -= temp_unblacklist
 			files.push_data(S.files)
 			server_processed = TRUE
 

--- a/code/modules/research/research.dm
+++ b/code/modules/research/research.dm
@@ -169,12 +169,6 @@ research holder datum.
 // Arguments:
 // `other` - The research datum to send designs and techs to
 /datum/research/proc/push_data(datum/research/other)
-	for(var/v in known_tech)
-		var/datum/tech/T = known_tech[v]
-		other.AddTech2Known(T)
-	for(var/v in known_designs)
-		var/datum/design/D = known_designs[v]
-		other.AddDesign2Known(D)
 	for(var/v in blacklisted_designs)
 		if(v in other.blacklisted_designs)
 			continue
@@ -183,7 +177,13 @@ research holder datum.
 		blacklisted_designs -= v
 		other.blacklisted_designs -= v
 		unblacklisted_designs -= v
-		other.unblacklisted_designs -= v //We dont want to leave these variables lying around or things stay blacklisted / dont get blacklisted
+		other.unblacklisted_designs += v //Needed so the main rnd console actually removes the rest of the blacklists in the fucking world
+	for(var/v in known_tech)
+		var/datum/tech/T = known_tech[v]
+		other.AddTech2Known(T)
+	for(var/v in known_designs)
+		var/datum/design/D = known_designs[v]
+		other.AddDesign2Known(D)
 	other.RefreshResearch()
 
 

--- a/code/modules/research/research.dm
+++ b/code/modules/research/research.dm
@@ -169,10 +169,7 @@ research holder datum.
 // Arguments:
 // `other` - The research datum to send designs and techs to
 /datum/research/proc/push_data(datum/research/other)
-	for(var/v in blacklisted_designs)
-		if(v in other.blacklisted_designs)
-			continue
-		other.blacklisted_designs += v
+	other.blacklisted_designs += (blacklisted_designs - other.blacklisted_designs)
 	for(var/v in unblacklisted_designs)
 		blacklisted_designs -= v
 		other.blacklisted_designs -= v

--- a/code/modules/research/research.dm
+++ b/code/modules/research/research.dm
@@ -132,9 +132,7 @@ research holder datum.
 			if(!AddDesign2Known(PD))
 				stack_trace("Game attempted to add a null design to list of known designs! Design: [PD] with ID: [PD.id]")
 	if(length(blacklisted_designs)) //No need to run this unless there are blacklisted designs
-		for(var/v in known_designs)
-			if(v in blacklisted_designs)
-				known_designs -= v
+		known_designs -= blacklisted_designs
 	for(var/v in known_tech)
 		var/datum/tech/T = known_tech[v]
 		T.level = clamp(T.level, 0, 20)

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -259,13 +259,21 @@
 		temp_server.files.RefreshResearch()
 
 	else if(href_list["reset_design"])
-		var/choice = alert("Design Data Deletion", "Are you sure you want to delete this design? Data lost cannot be recovered.", "Continue", "Cancel")
+		var/choice = alert("Design Data Deletion", "Are you sure you want to blacklist this design? Ensure you sync servers after this decision.", "Continue", "Cancel")
 		if(choice == "Continue")
 			for(var/I in temp_server.files.known_designs)
 				var/datum/design/D = temp_server.files.known_designs[I]
 				if(D.id == href_list["reset_design"])
 					temp_server.files.known_designs -= D.id
+					temp_server.files.blacklisted_designs += D.id
 					break
+		temp_server.files.RefreshResearch()
+
+	else if(href_list["restore_design"])
+		var/choice = alert("Design Data Restoration", "Are you sure you want to restore this design? Ensure you sync servers after this decision.", "Continue", "Cancel")
+		if(choice == "Continue")
+			temp_server.files.blacklisted_designs -= href_list["restore_design"]
+			temp_server.files.unblacklisted_designs += href_list["restore_design"]
 		temp_server.files.RefreshResearch()
 
 	updateUsrDialog()
@@ -323,7 +331,12 @@
 			for(var/I in temp_server.files.known_designs)
 				var/datum/design/D = temp_server.files.known_designs[I]
 				dat += "* [D.name] "
-				dat += "<A href='?src=[UID()];reset_design=[D.id]'>(Delete)</A><BR>"
+				dat += "<A href='?src=[UID()];reset_design=[D.id]'>(Blacklist)</A><BR>"
+			if(length(temp_server.files.blacklisted_designs))
+				dat += "Blacklisted Designs<BR>"
+					for(var/I in temp_server.files.blacklisted_designs)
+						dat += "* [I] "
+						dat += "<A href='?src=[UID()];restore_design=[I]'>(Restore design)</A><BR>"
 			dat += "<HR><A href='?src=[UID()];main=1'>Main Menu</A>"
 
 		if(3) //Server Data Transfer

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -334,9 +334,9 @@
 				dat += "<A href='?src=[UID()];reset_design=[D.id]'>(Blacklist)</A><BR>"
 			if(length(temp_server.files.blacklisted_designs))
 				dat += "Blacklisted Designs<BR>"
-					for(var/I in temp_server.files.blacklisted_designs)
-						dat += "* [I] "
-						dat += "<A href='?src=[UID()];restore_design=[I]'>(Restore design)</A><BR>"
+				for(var/I in temp_server.files.blacklisted_designs)
+					dat += "* [I] "
+					dat += "<A href='?src=[UID()];restore_design=[I]'>(Restore design)</A><BR>"
 			dat += "<HR><A href='?src=[UID()];main=1'>Main Menu</A>"
 
 		if(3) //Server Data Transfer


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Research datums have 2 new lists. The blacklisted list, and the unblacklisted list.
Instead of deleting a design (which currently does nothing RND wise, since once the servers link, the tech levels restore the design), RD can blacklist designs with the R&D server controller. This prevents a design from being printed from linked protolathes / circuit imprinters. A new rnd setup could still build said design.

The console can also unblacklist a design, allowing rnd to have it once again once the rnd console syncs again.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

The delete functioning being changed to something that works is useful. It allows silent sabatoge by an antagonistic traitor or AI, who can delete a certain design from rnd, to prevent the crew from making it. Shame that the illegals tech doesnt let security get a silencer. Shame that there is no ai upload board design. Crew building a phazon that will screw you over? Shame there is no weapon control board design for the phazon anymore. ect.

It also allows the RD / captain to restrict items that are being abused. Scientists trespassing everywhere with jaws of life? Blacklist it. Quantum pads everywhere and people are spacing themself with bags of holding? Blacklist it.

This is more or less what the delete function is for, now it mostly(*tm) works.

## TODO

- [x] Somehow, after blacklist is reverted, after 2 syncs from the rnd console, it returns. I suspect it is the blacklist surviving on the robotics server? CC server? Look into this.
- [x] have github actions pass

## Testing
<!-- How did you test the PR, if at all? -->
Ensured deleting and restoring, as well as rnd in general, worked. (See TODO)

## Changelog
:cl:
tweak: The RND server computer can now blacklist rnd designs from protolathes, circuit imprinters, and mech fabricators.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
