### PR TITLE
Fixed Jestosterone removing clown waddles

### DIFF
--- a/code/modules/reagents/chemistry/reagents/misc_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/misc_reagents.dm
@@ -526,7 +526,7 @@
 
 /datum/reagent/jestosterone/on_mob_delete(mob/living/M)
 	..()
-	if (M.mind.assigned_role != "Clown")
+	if(M.mind.assigned_role != "Clown")
 		REMOVE_TRAIT(M, TRAIT_COMIC_SANS, id)
 		M.RemoveElement(/datum/element/waddling)
 	qdel(M.GetComponent(/datum/component/squeak))

--- a/code/modules/reagents/chemistry/reagents/misc_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/misc_reagents.dm
@@ -489,9 +489,10 @@
 		else
 			to_chat(C, "<span class='warning'>Something doesn't feel right...</span>")
 			C.AdjustDizzy(volume STATUS_EFFECT_CONSTANT)
-	ADD_TRAIT(C, TRAIT_COMIC_SANS, id)
+	if(C.mind.assigned_role != "Clown")
+		ADD_TRAIT(C, TRAIT_COMIC_SANS, id)
+		C.AddElement(/datum/element/waddling)
 	C.AddComponent(/datum/component/squeak, null, null, null, null, null, TRUE, falloff_exponent = 20)
-	C.AddElement(/datum/element/waddling)
 
 /datum/reagent/jestosterone/on_mob_life(mob/living/carbon/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -525,9 +526,11 @@
 
 /datum/reagent/jestosterone/on_mob_delete(mob/living/M)
 	..()
-	REMOVE_TRAIT(M, TRAIT_COMIC_SANS, id)
+	if (M.mind.assigned_role != "Clown")
+		REMOVE_TRAIT(M, TRAIT_COMIC_SANS, id)
+		M.RemoveElement(/datum/element/waddling)
 	qdel(M.GetComponent(/datum/component/squeak))
-	M.RemoveElement(/datum/element/waddling)
+
 
 /datum/reagent/royal_bee_jelly
 	name = "Royal bee jelly"


### PR DESCRIPTION
## What Does This PR Do
fixes #19583
Fixes jestosterone removing clown waddling when it leaves the system. Also added in some extra safegaurds due to some runtimes when clown drinks it, causing attempted overrides to the waddling.

## Why It's Good For The Game
station needs to properly HONK!

## Testing
drank jest as a clown, had a fun time and still clowned after
drank jest as a normal crew
drank jest as a mime and had a horrible time

## Changelog
:cl:
fix: Fixed jestosterone removing clown waddles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
