### PR TITLE
Properly removes holobadge icon on removal

### DIFF
--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -70,6 +70,7 @@
 		for(var/X in actions)
 			var/datum/action/A = X
 			A.Remove(user)
+			src.actions -= X
 
 		icon_state = "armor"
 		user.update_inv_wear_suit()


### PR DESCRIPTION

## What Does This PR Do
Fixes #19452
ensures holobadge icons are properly removed from the armor instead of stacking infinitely

## Why It's Good For The Game
bugs bad

## Testing
put on and took off a lot of holobadges

## Changelog
:cl:
fix: Fixed holobadge icon removal
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
