### PR TITLE
Martial arts now use a weight system to determine which one is active

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -39,6 +39,7 @@
 
 	var/list/spell_list = list() // Wizard mode & "Give Spell" badmin button.
 	var/datum/martial_art/martial_art
+	var/list/known_martial_arts = list()
 
 	var/role_alt_title
 

--- a/code/modules/martial_arts/adminfu.dm
+++ b/code/modules/martial_arts/adminfu.dm
@@ -2,6 +2,7 @@
 	name = "Way of the Dancing Admin"
 	has_explaination_verb = TRUE
 	combos = list(/datum/martial_combo/adminfu/healing_palm)
+	weight = 99999999 //Matt Malvor?
 
 /datum/martial_art/adminfu/harm_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	MARTIAL_ARTS_ACT_CHECK

--- a/code/modules/martial_arts/brawling.dm
+++ b/code/modules/martial_arts/brawling.dm
@@ -1,5 +1,6 @@
 /datum/martial_art/boxing
 	name = "Boxing"
+	weight = 1
 
 /datum/martial_art/boxing/disarm_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	to_chat(A, "<span class='warning'>Can't disarm while boxing!</span>")
@@ -43,6 +44,7 @@
 
 /datum/martial_art/drunk_brawling
 	name = "Drunken Brawling"
+	weight = 2
 
 /datum/martial_art/drunk_brawling/grab_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	if(prob(70))

--- a/code/modules/martial_arts/cqc.dm
+++ b/code/modules/martial_arts/cqc.dm
@@ -1,5 +1,6 @@
 /datum/martial_art/cqc
 	name = "CQC"
+	weight = 6
 	has_explaination_verb = TRUE
 	can_parry = TRUE
 	combos = list(/datum/martial_combo/cqc/slam, /datum/martial_combo/cqc/kick, /datum/martial_combo/cqc/restrain, /datum/martial_combo/cqc/pressure, /datum/martial_combo/cqc/consecutive)
@@ -26,8 +27,10 @@
 		for(var/obj/item/slapper/parry/smacking_hand in held_items)
 			qdel(smacking_hand)
 		can_parry = FALSE
+		weight = 0
 	else
 		can_parry = TRUE
+		weight = 5
 
 /datum/martial_art/cqc/under_siege/can_use(mob/living/carbon/human/H)
 	var/area/A = get_area(H)

--- a/code/modules/martial_arts/grav_stomp.dm
+++ b/code/modules/martial_arts/grav_stomp.dm
@@ -1,5 +1,6 @@
 /datum/martial_art/grav_stomp
 	name = "Gravitational Boots"
+	weight = 4
 
 /datum/martial_art/grav_stomp/harm_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	MARTIAL_ARTS_ACT_CHECK

--- a/code/modules/martial_arts/krav_maga.dm
+++ b/code/modules/martial_arts/krav_maga.dm
@@ -1,5 +1,6 @@
 /datum/martial_art/krav_maga
 	name = "Krav Maga"
+	weight = 7 //Higher weight, since you can choose to put on or take off the gloves
 	var/datum/action/neck_chop/neckchop = new/datum/action/neck_chop()
 	var/datum/action/leg_sweep/legsweep = new/datum/action/leg_sweep()
 	var/datum/action/lung_punch/lungpunch = new/datum/action/lung_punch()

--- a/code/modules/martial_arts/krav_maga.dm
+++ b/code/modules/martial_arts/krav_maga.dm
@@ -25,12 +25,16 @@
 	button_icon_state = "neckchop"
 
 /datum/action/neck_chop/Trigger()
+	var/mob/living/carbon/human/H = owner
+	var/datum/martial_art/krav_maga/krav = new()
+	if(!istype(krav, H.mind.martial_art))
+		to_chat(owner, "<span class='warning'>You don't know how to do that right now.</span>")
+		return
 	if(owner.incapacitated())
 		to_chat(owner, "<span class='warning'>You can't use Krav Maga while you're incapacitated.</span>")
 		return
 	to_chat(owner, "<b><i>Your next attack will be a Neck Chop.</i></b>")
 	owner.visible_message("<span class='danger'>[owner] assumes the Neck Chop stance!</span>")
-	var/mob/living/carbon/human/H = owner
 	H.mind.martial_art.combos.Cut()
 	H.mind.martial_art.combos.Add(/datum/martial_combo/krav_maga/neck_chop)
 	H.mind.martial_art.reset_combos()
@@ -40,6 +44,11 @@
 	button_icon_state = "legsweep"
 
 /datum/action/leg_sweep/Trigger()
+	var/mob/living/carbon/human/H = owner
+	var/datum/martial_art/krav_maga/krav = new()
+	if(!istype(krav, H.mind.martial_art))
+		to_chat(owner, "<span class='warning'>You don't know how to do that right now.</span>")
+		return
 	if(owner.incapacitated())
 		to_chat(owner, "<span class='warning'>You can't use Krav Maga while you're incapacitated.</span>")
 		return
@@ -48,7 +57,6 @@
 		return
 	to_chat(owner, "<b><i>Your next attack will be a Leg Sweep.</i></b>")
 	owner.visible_message("<span class='danger'>[owner] assumes the Leg Sweep stance!</span>")
-	var/mob/living/carbon/human/H = owner
 	H.mind.martial_art.combos.Cut()
 	H.mind.martial_art.combos.Add(/datum/martial_combo/krav_maga/leg_sweep)
 	H.mind.martial_art.reset_combos()
@@ -59,12 +67,16 @@
 	button_icon_state = "lungpunch"
 
 /datum/action/lung_punch/Trigger()
+	var/mob/living/carbon/human/H = owner
+	var/datum/martial_art/krav_maga/krav = new()
+	if(!istype(krav, H.mind.martial_art))
+		to_chat(owner, "<span class='warning'>You don't know how to do that right now.</span>")
+		return
 	if(owner.incapacitated())
 		to_chat(owner, "<span class='warning'>You can't use Krav Maga while you're incapacitated.</span>")
 		return
 	to_chat(owner, "<b><i>Your next attack will be a Lung Punch.</i></b>")
 	owner.visible_message("<span class='danger'>[owner] assumes the Lung Punch stance!</span>")
-	var/mob/living/carbon/human/H = owner
 	H.mind.martial_art.combos.Cut()
 	H.mind.martial_art.combos.Add(/datum/martial_combo/krav_maga/lung_punch)
 	H.mind.martial_art.reset_combos()

--- a/code/modules/martial_arts/krav_maga.dm
+++ b/code/modules/martial_arts/krav_maga.dm
@@ -26,7 +26,7 @@
 
 /datum/action/neck_chop/Trigger()
 	var/mob/living/carbon/human/H = owner
-	var/datum/martial_art/krav_maga/krav = new()
+	var/datum/martial_art/krav_maga/krav = new() //This is a janky solution, but I want to refactor krav anyway and un-jank this (written in may 2023)
 	if(!istype(krav, H.mind.martial_art))
 		to_chat(owner, "<span class='warning'>You don't know how to do that right now.</span>")
 		return

--- a/code/modules/martial_arts/krav_maga.dm
+++ b/code/modules/martial_arts/krav_maga.dm
@@ -25,9 +25,8 @@
 	button_icon_state = "neckchop"
 
 /datum/action/neck_chop/Trigger()
-	var/mob/living/carbon/human/H = owner
-	var/datum/martial_art/krav_maga/krav = new() //This is a janky solution, but I want to refactor krav anyway and un-jank this (written in may 2023)
-	if(!istype(krav, H.mind.martial_art))
+	var/mob/living/carbon/human/H = owner //This is a janky solution, but I want to refactor krav anyway and un-jank this (written in may 2023)
+	if(!istype(H.mind.martial_art, /datum/martial_art/krav_maga))
 		to_chat(owner, "<span class='warning'>You don't know how to do that right now.</span>")
 		return
 	if(owner.incapacitated())
@@ -45,8 +44,7 @@
 
 /datum/action/leg_sweep/Trigger()
 	var/mob/living/carbon/human/H = owner
-	var/datum/martial_art/krav_maga/krav = new()
-	if(!istype(krav, H.mind.martial_art))
+	if(!istype(H.mind.martial_art, /datum/martial_art/krav_maga))
 		to_chat(owner, "<span class='warning'>You don't know how to do that right now.</span>")
 		return
 	if(owner.incapacitated())
@@ -68,8 +66,7 @@
 
 /datum/action/lung_punch/Trigger()
 	var/mob/living/carbon/human/H = owner
-	var/datum/martial_art/krav_maga/krav = new()
-	if(!istype(krav, H.mind.martial_art))
+	if(!istype(H.mind.martial_art, /datum/martial_art/krav_maga))
 		to_chat(owner, "<span class='warning'>You don't know how to do that right now.</span>")
 		return
 	if(owner.incapacitated())

--- a/code/modules/martial_arts/martial.dm
+++ b/code/modules/martial_arts/martial.dm
@@ -138,7 +138,6 @@
 /datum/martial_art/proc/teach(mob/living/carbon/human/H, make_temporary = FALSE)
 	if(!H.mind)
 		return
-	var/datum/martial_art/MA = src
 	for(var/datum/martial_art/MA in H.mind.known_martial_arts)
 		if(istype(MA, src))
 			return

--- a/code/modules/martial_arts/martial.dm
+++ b/code/modules/martial_arts/martial.dm
@@ -33,7 +33,7 @@
 	var/in_stance = FALSE
 	/// If the martial art allows parrying.
 	var/can_parry = FALSE
-	/// The priority of which martial art is picked from all the ones someone knows.
+	/// The priority of which martial art is picked from all the ones someone knows, the higher the number, the higher the priority.
 	var/weight = 0
 
 /datum/martial_art/New()
@@ -155,6 +155,7 @@
 		H.mind.martial_art = get_highest_weight(H)
 	H.verbs -= /mob/living/carbon/human/proc/martial_arts_help
 
+///	Returns the martial art with the highest weight from all the ones someone knows.
 /datum/martial_art/proc/get_highest_weight(mob/living/carbon/human/H)
 	var/datum/martial_art/highest_weight = null
 	for(var/datum/martial_art/MA in H.mind.known_martial_arts)

--- a/code/modules/martial_arts/martial.dm
+++ b/code/modules/martial_arts/martial.dm
@@ -150,9 +150,8 @@
 	var/datum/martial_art/MA = src
 	if(!H.mind)
 		return
-	else
-		H.mind.known_martial_arts.Remove(MA)
-		H.mind.martial_art = get_highest_weight(H)
+	H.mind.known_martial_arts.Remove(MA)
+	H.mind.martial_art = get_highest_weight(H)
 	H.verbs -= /mob/living/carbon/human/proc/martial_arts_help
 
 ///	Returns the martial art with the highest weight from all the ones someone knows.

--- a/code/modules/martial_arts/mimejutsu.dm
+++ b/code/modules/martial_arts/mimejutsu.dm
@@ -1,5 +1,6 @@
 /datum/martial_art/mimejutsu
 	name = "Mimejutsu"
+	weight = 6
 	has_explaination_verb = TRUE
 	combos = list(/datum/martial_combo/mimejutsu/mimechucks, /datum/martial_combo/mimejutsu/smokebomb, /datum/martial_combo/mimejutsu/silent_palm)
 

--- a/code/modules/martial_arts/plasma_fist.dm
+++ b/code/modules/martial_arts/plasma_fist.dm
@@ -1,5 +1,6 @@
 /datum/martial_art/plasma_fist
 	name = "Plasma Fist"
+	weight = 6
 	combos = list(/datum/martial_combo/plasma_fist/tornado_sweep, /datum/martial_combo/plasma_fist/throwback, /datum/martial_combo/plasma_fist/plasma_fist)
 	has_explaination_verb = TRUE
 

--- a/code/modules/martial_arts/sleeping_carp.dm
+++ b/code/modules/martial_arts/sleeping_carp.dm
@@ -1,6 +1,6 @@
 //Used by the gang of the same name. Uses combos. Basic attacks bypass armor and never miss
 /datum/martial_art/the_sleeping_carp
-	weight = 6
+	weight = 8
 	name = "The Sleeping Carp"
 	deflection_chance = 100
 	reroute_deflection = TRUE

--- a/code/modules/martial_arts/sleeping_carp.dm
+++ b/code/modules/martial_arts/sleeping_carp.dm
@@ -1,5 +1,6 @@
 //Used by the gang of the same name. Uses combos. Basic attacks bypass armor and never miss
 /datum/martial_art/the_sleeping_carp
+	weight = 6
 	name = "The Sleeping Carp"
 	deflection_chance = 100
 	reroute_deflection = TRUE

--- a/code/modules/martial_arts/wrestling.dm
+++ b/code/modules/martial_arts/wrestling.dm
@@ -1,6 +1,6 @@
 /datum/martial_art/wrestling
 	name = "Wrestling"
-	weight = 5
+	weight = 3
 	help_verb = /mob/living/carbon/human/proc/wrestling_help
 
 //	combo refence since wrestling uses a different format to sleeping carp and plasma fist.

--- a/code/modules/martial_arts/wrestling.dm
+++ b/code/modules/martial_arts/wrestling.dm
@@ -1,5 +1,6 @@
 /datum/martial_art/wrestling
 	name = "Wrestling"
+	weight = 5
 	help_verb = /mob/living/carbon/human/proc/wrestling_help
 
 //	combo refence since wrestling uses a different format to sleeping carp and plasma fist.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
This PR changes how martial arts are stored, and gives each one a weight for determining which ones should be overridden by others.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Right now, getting new martial arts does not properly remove the old one, resulting in a weird mess of having multiple instances of CQC or carp. Not only does this fix some runtimes, but current martial arts are automatically overriden by any new ones you get. This means that getting drunk, or putting on boxing gloves will temporarily disable any other martial arts someone might have. This system makes it so they learn the new martial art, but if it's a lower weight value than their current one, it won't be as the active martial art.

Fixes #13501
## Testing
<!-- How did you test the PR, if at all? -->
Spawned in, gave myself many duplicate martial arts, gave myself many different martial arts and made sure they were weighted properly, and tested chef's CQC to make sure that did not break either.
## Changelog
:cl:
tweak: New martial arts don't automatically override old ones, instead using a weighted system to determine what's active.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
