### PR TITLE
Prevents /camera/ mobs from being put in lockers

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -133,7 +133,7 @@
 			break
 		if(isobserver(M))
 			continue
-		if(istype(M, /mob/living/simple_animal/bot/mulebot))
+		if(istype(M, /mob/living/simple_animal/bot/mulebot) || istype(M, /mob/camera))
 			continue
 		if(M.buckled || M.anchored || M.has_buckled_mobs())
 			continue


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
fixes #20982
## Why It's Good For The Game
mobs that don't really exist shouldn't fit in lockers, weird jank things are bad for the game

## Changelog
:cl:
fix: Camera mobs(AI and blob overminds) no longer fit in lockers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
