### PR TITLE
Officer slots can no longer be opened or closed

### DIFF
--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -48,7 +48,8 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 		/datum/job/judge,
 		/datum/job/blueshield,
 		/datum/job/nanotrasenrep,
-		/datum/job/chaplain
+		/datum/job/chaplain,
+		/datum/job/officer
 	)
 	//The scaling factor of max total positions in relation to the total amount of people on board the station in %
 	var/max_relative_positions = 30 //30%: Seems reasonable, limit of 6 @ 20 players


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Adds security officers to the light blacklist. Crew can still priorities sec officers, but the number of slots are locked. Admins can still increase numbers.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

So, of late we have had issues with traitor hop lowering security slots without anyone noticing, or command raising security slots greatly when it is not needed, leading to the situation of 5 vampires to 14 security members excluding warden. 

As such, I am proposing applying security officer jobs to the minor blacklist. This means command can prioritize the job, but not raise or lower it. We can still manually raise it as admins, and it will not stop mainfest hires in situations that need it. It will purely stop sec from being taken out before they exist from an HOP, and stop command from raising security to over needed levels, and keep the role balanced to population. Admins would still be able to free job slots if needed as well.

We may have to look into making officers scale higher on super high pop.

## Testing
<!-- How did you test the PR, if at all? -->

Ensured it worked correctly like other jobs in that list.

## Changelog
:cl:
tweak: Security officer slots can no longer be raised or lowered, but still can be prioritized.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
