### PR TITLE
Prevents IPC husking

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -99,7 +99,7 @@
 	else
 		heal_overall_damage(0, -amount, updating_health, FALSE, robotic)
 
-	if(((maxHealth - getFireLoss()) < HEALTH_THRESHOLD_DEAD * 2) && stat == DEAD)
+	if(((maxHealth - getFireLoss()) < HEALTH_THRESHOLD_DEAD * 2) && stat == DEAD && !ismachineperson(src))
 		become_husk(BURN)
 	// brainless default for now
 	return STATUS_UPDATE_HEALTH

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -99,7 +99,7 @@
 	else
 		heal_overall_damage(0, -amount, updating_health, FALSE, robotic)
 
-	if(((maxHealth - getFireLoss()) < HEALTH_THRESHOLD_DEAD * 2) && stat == DEAD && !ismachineperson(src))
+	if(((maxHealth - getFireLoss()) < HEALTH_THRESHOLD_DEAD * 2) && stat == DEAD)
 		become_husk(BURN)
 	// brainless default for now
 	return STATUS_UPDATE_HEALTH

--- a/code/modules/mob/living/carbon/human/human_death.dm
+++ b/code/modules/mob/living/carbon/human/human_death.dm
@@ -133,6 +133,9 @@
 	update_mutantrace()
 
 /mob/living/carbon/human/proc/become_husk(source)
+	if(ismachineperson(src))
+		return
+
 	if(!HAS_TRAIT(src, TRAIT_HUSK))
 		ADD_TRAIT(src, TRAIT_HUSK, source)
 		var/obj/item/organ/external/head/H = bodyparts_by_name["head"]


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #20584 
Adds a check to make sure Machine people aren't husked. Was unlikely but weirdly possible before.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
bugs bad?
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
1. Spawn dozens of IPCs in lava
2. No IPCs get the husk trait
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Prevents Machine people from being husked
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
