### PR TITLE
All living mobs can now go through security holobarrier signs

### DIFF
--- a/code/game/objects/structures/holosigns.dm
+++ b/code/game/objects/structures/holosigns.dm
@@ -62,9 +62,9 @@
 		return TRUE
 	if(mover.pass_flags & (PASSGLASS|PASSTABLE|PASSGRILLE))
 		return TRUE
-	if(iscarbon(mover))
-		var/mob/living/carbon/C = mover
-		if(allow_walk && (C.m_intent == MOVE_INTENT_WALK || (C.pulledby && C.pulledby.m_intent == MOVE_INTENT_WALK)))
+	if(isliving(mover))
+		var/mob/living/walker = mover
+		if(allow_walk && (walker.m_intent == MOVE_INTENT_WALK || (walker.pulledby && walker.pulledby.m_intent == MOVE_INTENT_WALK)))
 			return TRUE
 
 /obj/structure/holosign/barrier/engineering


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Closes #21046
See title

## Why It's Good For The Game
The fact it's restricted to carbons seems more like an oversight if anything considering these are mob vars. Silicons and simplemobs really should be able to use these because they'll just destroy them otherwise. It's weird, unintuitive, and doesn't really add anything. 

## Testing
Compiled and ran 
Walked into some barriers
## Changelog
:cl:
tweak: All mobs can now walk through security barriers, rather than just carbons
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
