### PR TITLE
Fixes vox lungs being affected by infections

### DIFF
--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -319,7 +319,7 @@
 	safe_toxins_max = 0
 
 /obj/item/organ/internal/lungs/vox
-	name = "Vox lungs"
+	name = "vox lungs"
 	desc = "They're filled with dust....wow."
 	icon = 'icons/obj/species_organs/vox.dmi'
 	icon_state = "lungs"

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -323,6 +323,7 @@
 	desc = "They're filled with dust....wow."
 	icon = 'icons/obj/species_organs/vox.dmi'
 	icon_state = "lungs"
+	sterile = TRUE
 
 	safe_oxygen_min = 0 //We don't breathe this
 	safe_oxygen_max = 0.05 //This is toxic to us


### PR DESCRIPTION
## What Does This PR Do
Fixes an inconsistency where lungs were the only vox organ that wasn't sterile and accumulated infections.

## Why It's Good For The Game
Every other vox organ is sterile, wiki mentions *all* vox organs being unaffected by infections - might as well remove the inconsistency and make it actually correct.
Considering vox lungs are oddly not in the same file as the other vox organs, it also feels like a simple oversight.

## Testing
Forcefully dragged a vox into an OR and ripped their lungs out, VV'd them to make sure they don't amass infections anymore. Did the same with a vulpkanin to make sure other types of lungs weren't somehow affected by the change.

## Changelog
:cl:
fix: Vox lungs are no longer affected by infections.
/:cl:
