### PR TITLE
Decals now do not decline your action

### DIFF
--- a/code/game/objects/effects/effects.dm
+++ b/code/game/objects/effects/effects.dm
@@ -104,6 +104,8 @@
 /obj/effect/decal/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/reagent_containers/glass) || istype(I, /obj/item/reagent_containers/food/drinks))
 		scoop(I, user)
+	else if(issimulatedturf(loc))
+		I.melee_attack_chain(user, loc)
 
 /obj/effect/decal/proc/scoop(obj/item/I, mob/user)
 	if(reagents && I.reagents && !no_scoop)

--- a/code/game/objects/effects/effects.dm
+++ b/code/game/objects/effects/effects.dm
@@ -12,9 +12,6 @@
 /obj/effect/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir)
 	return
 
-/obj/effect/attack_hulk(mob/living/carbon/human/user, does_attack_animation = FALSE)
-	return FALSE
-
 /obj/effect/singularity_act()
 	qdel(src)
 	return FALSE
@@ -106,6 +103,18 @@
 		scoop(I, user)
 	else if(issimulatedturf(loc))
 		I.melee_attack_chain(user, loc)
+
+/obj/effect/decal/attack_animal(mob/living/simple_animal/M)
+	if(issimulatedturf(loc))
+		loc.attack_animal(M)
+
+/obj/effect/decal/attack_hand(mob/living/user)
+	if(issimulatedturf(loc))
+		loc.attack_hand(user)
+
+/obj/effect/decal/attack_hulk(mob/living/carbon/human/user, does_attack_animation = FALSE)
+	if(issimulatedturf(loc))
+		loc.attack_hulk(user, does_attack_animation)
 
 /obj/effect/decal/proc/scoop(obj/item/I, mob/user)
 	if(reagents && I.reagents && !no_scoop)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
This PR adds check for decals attackby
If nothing happends on our click on decal(we didnt try to collect fungus with beaker if we are brown terror escaping five thousand ERT shooters), it starts action on its location, which must be simulated turf(walls are)

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Have you even been scared by this fella?
![image](https://user-images.githubusercontent.com/61080616/236912898-dab71d49-3959-492e-87b2-790146b8471a.png)
When you want to make falsewall or fastly touch the wall under it, you need to hit little pixel on the top right of it or you get your action declined and message like "You heat the space fungus with the integrated welding tool."
This PR allows you to just hit this fella instead, you will hit the wall, no actions will be declined.
This wont affect your default actions with those, if you want to collect them, you will do that and not hit the wall with beaker
It only affects if default action did not happend

## Testing
<!-- How did you test the PR, if at all? -->
compiled, welded fungus, enjoyed superiority

## Changelog
:cl:
fix: If you click decal(like space fungus), but nothing happened, wall under decal will be clicked instead.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
