### PR TITLE
Guardians can not manifest when user is in atmos machinery

### DIFF
--- a/code/_onclick/hud/guardian.dm
+++ b/code/_onclick/hud/guardian.dm
@@ -49,6 +49,10 @@
 /obj/screen/guardian/Manifest/Click()
 	if(isguardian(usr))
 		var/mob/living/simple_animal/hostile/guardian/G = usr
+		var/summoner_loc = G.summoner.loc
+		if(istype(summoner_loc, /obj/machinery/atmospherics))
+			to_chat(G, "<span class='warning'>You can not manifest while in these pipes!</span>")
+			return
 		if(G.loc == G.summoner)
 			G.Manifest()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Guardians can not manifest when user is in atmos machinery. This does include cryopods, though I do not think anyone was using cryopods for that.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Crew can't really fight a holopara when the user is in the pipes. Too mobile, and if the user is a plastic golem, they even take less damage.

This PR blocks holopara useage in pipes, without blocking somone using a locker (people can see where it pops out of / can check a locker), cham projector (TC / still pop out over an item, have to stealth the item out of the room once pulling the trick), or in a mech (Hard to get / have to leave mech for healing / people will guess that the durand has the guardian.)

## Testing
<!-- How did you test the PR, if at all? -->

Confirmed the guardian could not manifest in pipes.

## Changelog
:cl:
tweak: Guardians can not manifest when user is in atmos machinery such as pipes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
