### PR TITLE
if baton would stun cyborgs, it would stun bots too

### DIFF
--- a/code/game/objects/items/weapons/batons.dm
+++ b/code/game/objects/items/weapons/batons.dm
@@ -56,6 +56,8 @@
 		return
 	if(issilicon(target) && !affect_silicon)
 		return ..()
+	if(isbot(target) && !affect_silicon)
+		return ..()
 	else
 		baton_knockdown(target, user)
 
@@ -71,15 +73,19 @@
 		user.visible_message("<span class='danger'>[user] pulses [target]'s sensors with [src]!</span>",\
 							"<span class='danger'>You pulse [target]'s sensors with [src]!</span>")
 		on_silicon_stun(target, user)
-	else
-		// Check for shield/countering
-		if(ishuman(target))
-			var/mob/living/carbon/human/H = target
-			if(H.check_shields(src, 0, "[user]'s [name]", MELEE_ATTACK))
-				return FALSE
+
+	// Check for shield/countering
+	if(ishuman(target))
+		var/mob/living/carbon/human/H = target
+		if(H.check_shields(src, 0, "[user]'s [name]", MELEE_ATTACK))
+			return FALSE
 		user.visible_message("<span class='danger'>[user] knocks down [target] with [src]!</span>",\
 							"<span class='danger'>You knock down [target] with [src]!</span>")
 		on_non_silicon_stun(target, user)
+
+	if(isbot(target))
+		var/mob/living/simple_animal/bot/H = target
+		H.disable(stun_time_silicon)
 	// Visuals and sound
 	user.do_attack_animation(target)
 	playsound(target, stun_sound, 75, TRUE, -1)

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -32,6 +32,7 @@
 	var/allow_pai = TRUE // Are we even allowed to insert a pai card.
 	var/bot_name
 
+	var/disabling_timer_id = null
 	var/list/player_access = list()
 	var/emagged = 0
 	var/obj/item/card/id/access_card			// the ID card that the bot "holds"
@@ -121,6 +122,8 @@
 		return "<span class='average'>[mode_name[mode]]</span>"
 
 /mob/living/simple_animal/bot/proc/turn_on()
+	if(disabling_timer_id)
+		return FALSE
 	if(stat)
 		return 0
 	on = TRUE
@@ -415,6 +418,20 @@
 /mob/living/simple_animal/bot/proc/un_emp(was_on)
 	stat &= ~EMPED
 	if(was_on)
+		turn_on()
+
+/mob/living/simple_animal/bot/proc/disable(time)
+	if(disabling_timer_id)
+		deltimer(disabling_timer_id) // if we already have disabling timer, lets replace it with new one
+	if(on)
+		turn_off()
+	disabling_timer_id = addtimer(CALLBACK(src, PROC_REF(enable)), time, TIMER_STOPPABLE)
+
+/mob/living/simple_animal/bot/proc/enable()
+	if(disabling_timer_id)
+		deltimer(disabling_timer_id)
+		disabling_timer_id = null
+	if(!on)
 		turn_on()
 
 /mob/living/simple_animal/bot/rename_character(oldname, newname)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
This PR allowes batons with affect_silicon baton bots aswell as cyborgs

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Imagine, you're contractor, you have baton capable for cyborgs and humans, you can do whatever you want, but here is BEEPSKY
and you can do nothing, you cant stun it with your baton. Only EMP would help you.

This PR changes this. If your baton has affect_silicon = TRUE(currently only contractor baton has this), you will be able to stun bots
Stunned bot wont be able to be turned on, but after timer ends he will turn on by himself

## Testing
<!-- How did you test the PR, if at all? -->
compiled, contracted beepsky

## Changelog
:cl:
tweak: Batons with affect_silicon = TRUE (contractor baton) now can stun bots aswell as cyborgs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
