### PR TITLE
LWAP scope now checks if its overloaded before activating

### DIFF
--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -143,6 +143,9 @@
 
 
 /obj/item/gun/energy/lwap/zoom(mob/living/user, forced_zoom)
+	if(world.time - user.last_movement <= PROCESS_TIME_PLUS_DECISECOND && !zoomed)
+		to_chat(user, "<span class='warning'>[src]'s scope is overloaded by movement and cannot be used yet!</span>")
+		return
 	. = ..()
 	if(!ishuman(user))
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
LWAP scope now checks if it cannot be used now(its still overloaded, means user moved less than 2 seconds back)

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
When i first time touched reworked LWAP i met weird behaviour, i activate scope, it works for a second, then disables with message, that scope is overloaded by moving when my character was not moving.

By checking into code i found, that if user moved less than 2.1 seconds ago, LWAP scope will be disabled. This was made to prevent user from running with active scope.

So to make its behaviour more expectable, i added check for scope activation if it should not be active due to user moevement, should be more understandable now

## Testing
<!-- How did you test the PR, if at all? -->
compiled, scoped drask

## Changelog
:cl:
fix: LWAP scope now cant be activated if it supposed to be off(currently if your character moved less than 2.1 seconds ago)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
