### PR TITLE
Improved cooldown visualisation on spells with charges

### DIFF
--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -590,11 +590,13 @@
 		return ..() // This means that the spell is charged but unavailable due to something else
 
 	var/alpha = 220
+	alpha = 220 - 140 * progress
 	var/datum/spell_cooldown/charges/handler = S.cooldown_handler
-	if(istype(handler) && handler.current_charges == 0 || !istype(handler))
-		alpha = 220 - 140 * progress
-	else
-		alpha = 60
+	if(istype(handler))
+		if(handler.charge_time > world.time)
+			alpha = 220
+		else if(handler.current_charges != 0)
+			alpha = 60
 
 	var/image/img = image('icons/mob/screen_white.dmi', icon_state = "template")
 	img.alpha = alpha

--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -107,8 +107,10 @@
 
 		ApplyIcon(button)
 
+		var/obj/effect/proc_holder/spell/S = target
+
 		// If the action isn't available, darken the button
-		if(!IsAvailable())
+		if(!IsAvailable() || istype(S) && S.cooldown_handler.get_availability_percentage() != 1)
 			apply_unavailable_effect()
 		else
 			return TRUE
@@ -587,7 +589,12 @@
 	if(progress == 1)
 		return ..() // This means that the spell is charged but unavailable due to something else
 
-	var/alpha = 220 - 140 * progress
+	var/alpha = 220
+	var/datum/spell_cooldown/charges/handler = S.cooldown_handler
+	if(istype(handler) && handler.current_charges == 0 || !istype(handler))
+		alpha = 220 - 140 * progress
+	else
+		alpha = 60
 
 	var/image/img = image('icons/mob/screen_white.dmi', icon_state = "template")
 	img.alpha = alpha
@@ -598,7 +605,8 @@
 	// Make a holder for the charge text
 	var/image/count_down_holder = image('icons/effects/effects.dmi', icon_state = "nothing")
 	count_down_holder.plane = FLOAT_PLANE + 1.1
-	count_down_holder.maptext = "<div style=\"font-size:6pt;color:[recharge_text_color];font:'Small Fonts';text-align:center;\" valign=\"bottom\">[round_down(progress * 100)]%</div>"
+	var/text = S.cooldown_handler.statpanel_info()
+	count_down_holder.maptext = "<div style=\"font-size:6pt;color:[recharge_text_color];font:'Small Fonts';text-align:center;\" valign=\"bottom\">[text]</div>"
 	button.add_overlay(count_down_holder)
 
 /*

--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -69,9 +69,6 @@
 /datum/action/proc/override_location() // Override to set coordinates manually
 	return
 
-/datum/action/proc/should_show_cooldown() // Should we show cooldown in HUD panel or not
-	return !IsAvailable()
-
 /datum/action/proc/IsAvailable()// returns 1 if all checks pass
 	if(!owner)
 		return FALSE
@@ -109,8 +106,8 @@
 		button.desc = desc
 
 		ApplyIcon(button)
-
-		if(should_show_cooldown())
+		var/obj/effect/proc_holder/spell/S = target
+		if(istype(S) && S.cooldown_handler.should_draw_cooldown())
 			apply_unavailable_effect()
 		else
 			return TRUE
@@ -581,28 +578,12 @@
 		return spell.can_cast(owner)
 	return FALSE
 
-/datum/action/spell_action/should_show_cooldown()
-	var/obj/effect/proc_holder/spell/S = target
-	var/datum/spell_cooldown/charges/handler = S.cooldown_handler
-	if(!istype(S) || !istype(handler))
-		return ..()
-	return handler.current_charges < handler.max_charges
-
 /datum/action/spell_action/apply_unavailable_effect()
 	var/obj/effect/proc_holder/spell/S = target
 	if(!istype(S))
 		return ..()
-	var/progress = S.cooldown_handler.get_availability_percentage()
-	if(progress == 1)
-		return ..() // This means that the spell is charged but unavailable due to something else
 
-	var/alpha = 220 - 140 * progress
-	var/datum/spell_cooldown/charges/handler = S.cooldown_handler
-	if(istype(handler))
-		if(handler.charge_time > world.time)
-			alpha = 220
-		else if(handler.current_charges != 0)
-			alpha = 60
+	var/alpha = S.cooldown_handler.get_cooldown_alpha()
 
 	var/image/img = image('icons/mob/screen_white.dmi', icon_state = "template")
 	img.alpha = alpha

--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -107,7 +107,7 @@
 
 		ApplyIcon(button)
 		var/obj/effect/proc_holder/spell/S = target
-		if(istype(S) && S.cooldown_handler.should_draw_cooldown())
+		if(istype(S) && S.cooldown_handler.should_draw_cooldown() || !IsAvailable())
 			apply_unavailable_effect()
 		else
 			return TRUE

--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -69,6 +69,9 @@
 /datum/action/proc/override_location() // Override to set coordinates manually
 	return
 
+/datum/action/proc/ShouldShowCooldown() // Should we show cooldown in HUD panel or not
+	return !IsAvailable()
+
 /datum/action/proc/IsAvailable()// returns 1 if all checks pass
 	if(!owner)
 		return FALSE
@@ -107,10 +110,7 @@
 
 		ApplyIcon(button)
 
-		var/obj/effect/proc_holder/spell/S = target
-
-		// If the action isn't available, darken the button
-		if(!IsAvailable() || istype(S) && S.cooldown_handler.get_availability_percentage() != 1)
+		if(ShouldShowCooldown())
 			apply_unavailable_effect()
 		else
 			return TRUE
@@ -579,6 +579,15 @@
 
 	if(owner)
 		return spell.can_cast(owner)
+	return FALSE
+
+/datum/action/spell_action/ShouldShowCooldown()
+	var/obj/effect/proc_holder/spell/S = target
+	var/datum/spell_cooldown/charges/handler = S.cooldown_handler
+	if(!istype(S) || !istype(handler))
+		return ..()
+	if(handler.current_charges < handler.max_charges)
+		return TRUE
 	return FALSE
 
 /datum/action/spell_action/apply_unavailable_effect()

--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -589,8 +589,7 @@
 	if(progress == 1)
 		return ..() // This means that the spell is charged but unavailable due to something else
 
-	var/alpha = 220
-	alpha = 220 - 140 * progress
+	var/alpha = 220 - 140 * progress
 	var/datum/spell_cooldown/charges/handler = S.cooldown_handler
 	if(istype(handler))
 		if(handler.charge_time > world.time)

--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -586,9 +586,7 @@
 	var/datum/spell_cooldown/charges/handler = S.cooldown_handler
 	if(!istype(S) || !istype(handler))
 		return ..()
-	if(handler.current_charges < handler.max_charges)
-		return TRUE
-	return FALSE
+	return handler.current_charges < handler.max_charges
 
 /datum/action/spell_action/apply_unavailable_effect()
 	var/obj/effect/proc_holder/spell/S = target

--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -69,7 +69,7 @@
 /datum/action/proc/override_location() // Override to set coordinates manually
 	return
 
-/datum/action/proc/ShouldShowCooldown() // Should we show cooldown in HUD panel or not
+/datum/action/proc/should_show_cooldown() // Should we show cooldown in HUD panel or not
 	return !IsAvailable()
 
 /datum/action/proc/IsAvailable()// returns 1 if all checks pass
@@ -110,7 +110,7 @@
 
 		ApplyIcon(button)
 
-		if(ShouldShowCooldown())
+		if(should_show_cooldown())
 			apply_unavailable_effect()
 		else
 			return TRUE
@@ -581,7 +581,7 @@
 		return spell.can_cast(owner)
 	return FALSE
 
-/datum/action/spell_action/ShouldShowCooldown()
+/datum/action/spell_action/should_show_cooldown()
 	var/obj/effect/proc_holder/spell/S = target
 	var/datum/spell_cooldown/charges/handler = S.cooldown_handler
 	if(!istype(S) || !istype(handler))

--- a/code/datums/spell_cooldown/spell_charges.dm
+++ b/code/datums/spell_cooldown/spell_charges.dm
@@ -20,6 +20,7 @@
 	if(recharge_time > world.time)
 		return FALSE
 	current_charges++
+	spell_parent.action.UpdateButtonIcon()
 	if(current_charges < max_charges) // we have more recharges to go
 		recharge_time = world.time + recharge_duration
 		return FALSE

--- a/code/datums/spell_cooldown/spell_charges.dm
+++ b/code/datums/spell_cooldown/spell_charges.dm
@@ -43,5 +43,5 @@
 		return 1
 
 	if(charge_time > world.time)
-		return (charge_duration - (charge_time - world.time)) / charge_duration
-	return (recharge_duration - (recharge_time - world.time)) / recharge_duration //parent proc without the on cooldown check
+		return min(1, (charge_duration - (charge_time - world.time)) / charge_duration)
+	return min(1, (recharge_duration - (recharge_time - world.time)) / recharge_duration) //parent proc without the on cooldown check

--- a/code/datums/spell_cooldown/spell_charges.dm
+++ b/code/datums/spell_cooldown/spell_charges.dm
@@ -36,7 +36,7 @@
 	charge_time = world.time
 
 /datum/spell_cooldown/charges/statpanel_info()
-	return "[current_charges] / [max_charges], [..()]"
+	return "[..()]\n[current_charges] / [max_charges]"
 
 /datum/spell_cooldown/charges/get_availability_percentage()
 	if(max_charges == current_charges)
@@ -44,5 +44,4 @@
 
 	if(charge_time > world.time)
 		return (charge_duration - (charge_time - world.time)) / charge_duration
-
 	return (recharge_duration - (recharge_time - world.time)) / recharge_duration //parent proc without the on cooldown check

--- a/code/datums/spell_cooldown/spell_charges.dm
+++ b/code/datums/spell_cooldown/spell_charges.dm
@@ -13,6 +13,14 @@
 	if(starts_off_cooldown)
 		current_charges = max_charges
 
+/datum/spell_cooldown/charges/get_cooldown_alpha()
+	if(current_charges == 0 || charge_time > world.time)
+		return 220 - 140 * get_availability_percentage()
+	return 60
+
+/datum/spell_cooldown/charges/should_draw_cooldown()
+	return recharge_time > world.time || current_charges < max_charges
+
 /datum/spell_cooldown/charges/is_on_cooldown()
 	return !current_charges || charge_time >= world.time
 
@@ -32,12 +40,19 @@
 		charge_time = world.time + charge_duration
 	..()
 
+/datum/spell_cooldown/charges/get_recharge_time()
+	if(recharge_time > world.time)
+		return recharge_time
+	return ..()
+
 /datum/spell_cooldown/charges/revert_cast()
 	..()
 	charge_time = world.time
 
 /datum/spell_cooldown/charges/statpanel_info()
-	return "[..()]\n[current_charges] / [max_charges]"
+	var/charge_string = charge_duration != 0 ? round(min(1, (charge_duration - (charge_time - world.time)) / charge_duration), 0.01) * 100 : 100 // need this for possible 0 charge duration
+	var/recharge_string = recharge_duration != 0 ? round(min(1, (recharge_duration - (recharge_time - world.time)) / recharge_duration), 0.01) * 100 : 100
+	return "[charge_string != 100 ? "[charge_string]%\n" : ""][recharge_string != 100 ? "[recharge_string]%\n" : ""][current_charges]/[max_charges]"
 
 /datum/spell_cooldown/charges/get_availability_percentage()
 	if(max_charges == current_charges)

--- a/code/datums/spell_cooldown/spell_cooldown.dm
+++ b/code/datums/spell_cooldown/spell_cooldown.dm
@@ -17,6 +17,12 @@
 	if(!starts_off_cooldown)
 		start_recharge()
 
+/datum/spell_cooldown/proc/should_draw_cooldown()
+	return is_on_cooldown()
+
+/datum/spell_cooldown/proc/get_cooldown_alpha()
+	return 220 - 140 * get_availability_percentage()
+
 /datum/spell_cooldown/proc/is_on_cooldown()
 	return recharge_time > world.time
 
@@ -47,9 +53,14 @@
 		return 1
 	return min(1, (recharge_duration - (recharge_time - world.time)) / recharge_duration)
 
+/datum/spell_cooldown/proc/get_recharge_time()
+	return world.time + recharge_duration
+
 /datum/spell_cooldown/proc/start_recharge(recharge_duration_override = 0)
-	var/recharge_increment = recharge_duration_override || recharge_duration
-	recharge_time = world.time + recharge_increment
+	if(recharge_duration_override)
+		recharge_time = world.time + recharge_duration_override
+	else
+		recharge_time = get_recharge_time()
 	if(spell_parent.action)
 		spell_parent.action.UpdateButtonIcon()
 		START_PROCESSING(SSfastprocess, src)

--- a/code/datums/spell_cooldown/spell_cooldown.dm
+++ b/code/datums/spell_cooldown/spell_cooldown.dm
@@ -45,7 +45,7 @@
 /datum/spell_cooldown/proc/get_availability_percentage()
 	if(!is_on_cooldown()) // if off cooldown, we don't bother with the maths
 		return 1
-	return (recharge_duration - (recharge_time - world.time)) / recharge_duration
+	return min(1, (recharge_duration - (recharge_time - world.time)) / recharge_duration)
 
 /datum/spell_cooldown/proc/start_recharge(recharge_duration_override = 0)
 	var/recharge_increment = recharge_duration_override || recharge_duration


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
This PR improves spell with charges icon when its recharging. Now it shows you amount of charges and progress on recharging new one.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Currently its only vampire glare and you want to know when you have two glares or when it will be avaiable

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![image](https://github.com/ParadiseSS13/Paradise/assets/61080616/0b4c9556-6bbc-48bd-92b0-2e5e44e8081e)
![image](https://github.com/ParadiseSS13/Paradise/assets/61080616/aa30ff6b-2ec9-43b0-a98a-1ee11f2baea1)
![image](https://github.com/ParadiseSS13/Paradise/assets/61080616/fc080e82-e57c-4c6f-ad43-e9f4aca796c4)

## Testing
<!-- How did you test the PR, if at all? -->
compiled, glared

## Changelog
:cl:
tweak: Spells with charges(vampire glare) will now show current charge level and recharging process
tweak: Using spell charge while recharging no more reset recharge timer
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
