### PR TITLE
Changes the hacking implant to the abductor toolset implant

### DIFF
--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -334,7 +334,7 @@
 
 /datum/design/cyberimp_toolset
 	name = "Toolset Arm Implant"
-	desc = "A stripped-down version of engineering cyborg toolset, designed to be installed on subject's arm."
+	desc = "A stripped-down version of an engineering cyborg toolset, designed to be installed on subject's arm."
 	id = "ci-toolset"
 	req_tech = list("materials" = 3, "engineering" = 4, "biotech" = 4, "powerstorage" = 4)
 	build_type = PROTOLATHE | MECHFAB
@@ -365,15 +365,15 @@
 	build_path = /obj/item/organ/internal/cyberimp/arm/botanical
 	category = list("Medical")
 
-/datum/design/cyberimp_hacking
-	name = "Hacking Arm Implant"
-	desc = "A small arm implant containing an advanced screwdriver, wirecutters, and multitool designed for engineers and on-the-field machine modification. Actually legal, despite what the name may make you think."
+/datum/design/cyberimp_toolset_abductor
+	name = "Abductor Toolset Implant"
+	desc = "An alien toolset, designed to be installed on subject's arm."
 	id = "ci-hacking"
-	req_tech = list("materials" = 3, "engineering" = 5, "biotech" = 4, "programming" = 4, "abductor" = 4)
+	req_tech = list("materials" = 6, "engineering" = 6, "plasmatech" = 6, "abductor" = 4)
 	build_type = PROTOLATHE | MECHFAB
-	materials = list(MAT_METAL = 5000, MAT_SILVER = 2500, MAT_PLASMA = 5000, MAT_TITANIUM = 2000, MAT_DIAMOND = 2000)
+	materials = list(MAT_METAL = 20000, MAT_SILVER = 10000, MAT_PLASMA = 9000, MAT_TITANIUM = 8000, MAT_DIAMOND = 8000)
 	construction_time = 200
-	build_path = /obj/item/organ/internal/cyberimp/arm/hacking
+	build_path = /obj/item/organ/internal/cyberimp/arm/toolset_abductor
 	category = list("Medical")
 
 /datum/design/cyberimp_diagnostic_hud

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -233,15 +233,15 @@
 		return TRUE
 	return FALSE
 
-/obj/item/organ/internal/cyberimp/arm/hacking
-	name = "hacking arm implant"
-	desc = "A small arm implant containing an advanced screwdriver, wirecutters, and multitool designed for engineers and on-the-field machine modification. Actually legal, despite what the name may make you think."
-	origin_tech = "materials=3;engineering=4;biotech=3;powerstorage=4;abductor=3"
-	contents = newlist(/obj/item/screwdriver/cyborg, /obj/item/wirecutters/cyborg, /obj/item/multitool/abductor)
+/obj/item/organ/internal/cyberimp/arm/toolset_abductor
+	name = "Alien Toolset implant"
+	desc = "An alien toolset, designed to be installed on subject's arm."
+	origin_tech = "materials=5;engineering=5;plasmatech=5;powerstorage=4;abductor=3"
+	contents = newlist(/obj/item/screwdriver/abductor, /obj/item/wirecutters/abductor, /obj/item/crowbar/abductor, /obj/item/wrench/abductor, /obj/item/weldingtool/abductor, /obj/item/multitool/abductor)
 	action_icon = list(/datum/action/item_action/organ_action/toggle = 'icons/obj/device.dmi')
 	action_icon_state = list(/datum/action/item_action/organ_action/toggle = "hacktool")
 
-/obj/item/organ/internal/cyberimp/arm/hacking/l
+/obj/item/organ/internal/cyberimp/arm/toolset_abductor/l
 	parent_organ = "l_arm"
 
 /obj/item/organ/internal/cyberimp/arm/esword

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -238,8 +238,8 @@
 	desc = "An alien toolset, designed to be installed on subject's arm."
 	origin_tech = "materials=5;engineering=5;plasmatech=5;powerstorage=4;abductor=3"
 	contents = newlist(/obj/item/screwdriver/abductor, /obj/item/wirecutters/abductor, /obj/item/crowbar/abductor, /obj/item/wrench/abductor, /obj/item/weldingtool/abductor, /obj/item/multitool/abductor)
-	action_icon = list(/datum/action/item_action/organ_action/toggle = 'icons/obj/device.dmi')
-	action_icon_state = list(/datum/action/item_action/organ_action/toggle = "hacktool")
+	action_icon = list(/datum/action/item_action/organ_action/toggle = 'icons/obj/abductor.dmi')
+	action_icon_state = list(/datum/action/item_action/organ_action/toggle = "belt")
 
 /obj/item/organ/internal/cyberimp/arm/toolset_abductor/l
 	parent_organ = "l_arm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Removes the hacking implant from the game. Adds an upgraded toolset implant with abductor tools.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
The hacking implant was just, not used. This adds the ability to make an abductor toolset implant instead, which contains all of the abductor tools. This adds an extra lategame upgrade to engineering and anyone who uses tools, which in turn will add extra things for medbay to do.
The research required is one level higher than the lone tools, except for alien. The cost is about 60% of if you were to make them all individually.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Went into testserver, checked if resource costs were correct, and if it was unlocked by the right level of technologies. Also checked if the tools worked.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
add: Abductor toolset implant
del: Hacking implant
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
