### PR TITLE
Stunbaton delayed knockdown now respects antistuns

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -861,3 +861,5 @@
 #define COMSIG_OBJECTIVE_CHECK_VALID_TARGET "objective_check_valid_target"
 	#define OBJECTIVE_VALID_TARGET		(1<<0)
 	#define OBJECTIVE_INVALID_TARGET	(1<<1)
+
+#define COMSIG_PREVENT_DELAYED_KNOCKDOWN "prevent_delayed_knockdown"

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -862,4 +862,4 @@
 	#define OBJECTIVE_VALID_TARGET		(1<<0)
 	#define OBJECTIVE_INVALID_TARGET	(1<<1)
 
-#define COMSIG_PREVENT_DELAYED_KNOCKDOWN "prevent_delayed_knockdown"
+#define COMSIG_LIVING_CLEAR_STUNS "prevent_delayed_knockdown"

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -862,4 +862,4 @@
 	#define OBJECTIVE_VALID_TARGET		(1<<0)
 	#define OBJECTIVE_INVALID_TARGET	(1<<1)
 
-#define COMSIG_LIVING_CLEAR_STUNS "prevent_delayed_knockdown"
+#define COMSIG_LIVING_CLEAR_STUNS "living_clear_stuns"

--- a/code/__DEFINES/status_effects.dm
+++ b/code/__DEFINES/status_effects.dm
@@ -74,7 +74,7 @@
 
 #define STATUS_EFFECT_SUMMONEDGHOST /datum/status_effect/cultghost //is a cult ghost: can see dead people, can't manifest more ghosts
 
-#define STATUS_EFFECT_BATONNED /datum/status_effect/stunbaton //stunbaton delayed knockdown
+#define STATUS_EFFECT_DELAYED /datum/status_effect/delayed //delayed status effect: gets /datum/callback to call on expire, signal if we want to prevent and duration
 
 #define STATUS_EFFECT_CRUSHERMARK /datum/status_effect/crusher_mark //if struck with a proto-kinetic crusher, takes a ton of damage
 

--- a/code/__DEFINES/status_effects.dm
+++ b/code/__DEFINES/status_effects.dm
@@ -74,6 +74,8 @@
 
 #define STATUS_EFFECT_SUMMONEDGHOST /datum/status_effect/cultghost //is a cult ghost: can see dead people, can't manifest more ghosts
 
+#define STATUS_EFFECT_BATONNED /datum/status_effect/stunbaton //stunbaton delayed knockdown
+
 #define STATUS_EFFECT_CRUSHERMARK /datum/status_effect/crusher_mark //if struck with a proto-kinetic crusher, takes a ton of damage
 
 #define STATUS_EFFECT_SAWBLEED /datum/status_effect/saw_bleed //if the bleed builds up enough, takes a ton of damage
@@ -160,4 +162,4 @@
 /// gives you fluff messages for cough, sneeze, headache, etc but without an actual virus
 #define STATUS_EFFECT_FAKE_VIRUS /datum/status_effect/fake_virus
 /// This status effect lets the user see the lwap dots.
-#define STATUS_EFFECT_LWAPSCOPE /datum/status_effect/lwap_scope 
+#define STATUS_EFFECT_LWAPSCOPE /datum/status_effect/lwap_scope

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -23,35 +23,6 @@
 	owner.adjustFireLoss(0.1)
 	owner.adjustToxLoss(0.2)
 
-/datum/status_effect/delayed
-	id = "delayed_status_effect"
-	status_type = STATUS_EFFECT_UNIQUE
-	alert_type = null
-	var/prevent_signal = null
-	var/datum/callback/expire_proc = null
-
-/datum/status_effect/delayed/on_creation(mob/living/new_owner, new_duration, datum/callback/new_expire_proc, new_prevent_signal = null)
-	if(!duration || !new_expire_proc || !istype(new_expire_proc))
-		qdel(src)
-	duration = new_duration
-	expire_proc = new_expire_proc
-	. = ..()
-	if(new_prevent_signal)
-		RegisterSignal(owner, new_prevent_signal, PROC_REF(prevent_action))
-		prevent_signal = new_prevent_signal
-
-/datum/status_effect/proc/prevent_action()
-	qdel(src)
-
-/datum/status_effect/delayed/on_remove()
-	if(prevent_signal)
-		UnregisterSignal(owner, prevent_signal)
-	. = ..()
-
-/datum/status_effect/delayed/on_timeout()
-	. = ..()
-	expire_proc.Invoke()
-
 /datum/status_effect/cultghost //is a cult ghost and can't use manifest runes, can see ghosts and dies if too far from summoner
 	id = "cult_ghost"
 	duration = -1

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -23,6 +23,16 @@
 	owner.adjustFireLoss(0.1)
 	owner.adjustToxLoss(0.2)
 
+/datum/status_effect/stunbaton
+	id = "stunbatonned"
+	duration = 2.5 SECONDS
+	status_type = STATUS_EFFECT_UNIQUE
+	alert_type = null
+
+/datum/status_effect/stunbaton/on_timeout()
+	. = ..()
+	owner.KnockDown(10 SECONDS)
+
 /datum/status_effect/cultghost //is a cult ghost and can't use manifest runes, can see ghosts and dies if too far from summoner
 	id = "cult_ghost"
 	duration = -1

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -30,12 +30,12 @@
 	var/prevent_signal = null
 	var/datum/callback/expire_proc = null
 
-/datum/status_effect/delayed/on_creation(mob/living/new_owner, new_duration, var/datum/callback/new_expire_proc, new_prevent_signal = null)
+/datum/status_effect/delayed/on_creation(mob/living/new_owner, new_duration, datum/callback/new_expire_proc, new_prevent_signal = null)
 	if(!duration || !new_expire_proc || !istype(new_expire_proc))
 		qdel(src)
-	. = ..()
 	duration = new_duration
 	expire_proc = new_expire_proc
+	. = ..()
 	if(new_prevent_signal)
 		RegisterSignal(owner, new_prevent_signal, PROC_REF(prevent_action))
 		prevent_signal = new_prevent_signal

--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -227,7 +227,7 @@
 	var/datum/callback/expire_proc = null
 
 /datum/status_effect/delayed/on_creation(mob/living/new_owner, new_duration, datum/callback/new_expire_proc, new_prevent_signal = null)
-	if(!duration || !new_expire_proc || !istype(new_expire_proc))
+	if(!new_duration || !istype(new_expire_proc))
 		qdel(src)
 		return
 	duration = new_duration

--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -229,6 +229,7 @@
 /datum/status_effect/delayed/on_creation(mob/living/new_owner, new_duration, datum/callback/new_expire_proc, new_prevent_signal = null)
 	if(!duration || !new_expire_proc || !istype(new_expire_proc))
 		qdel(src)
+		return
 	duration = new_duration
 	expire_proc = new_expire_proc
 	. = ..()
@@ -237,6 +238,7 @@
 		prevent_signal = new_prevent_signal
 
 /datum/status_effect/proc/prevent_action()
+	SIGNAL_HANDLER
 	qdel(src)
 
 /datum/status_effect/delayed/on_remove()

--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -218,3 +218,32 @@
 /// Remove the image from the lwap user's screen
 /obj/effect/temp_visual/lwap_ping/proc/remove_mind(mob/living/looker)
 	looker.client?.images -= lwap_image
+
+/datum/status_effect/delayed
+	id = "delayed_status_effect"
+	status_type = STATUS_EFFECT_MULTIPLE
+	alert_type = null
+	var/prevent_signal = null
+	var/datum/callback/expire_proc = null
+
+/datum/status_effect/delayed/on_creation(mob/living/new_owner, new_duration, datum/callback/new_expire_proc, new_prevent_signal = null)
+	if(!duration || !new_expire_proc || !istype(new_expire_proc))
+		qdel(src)
+	duration = new_duration
+	expire_proc = new_expire_proc
+	. = ..()
+	if(new_prevent_signal)
+		RegisterSignal(owner, new_prevent_signal, PROC_REF(prevent_action))
+		prevent_signal = new_prevent_signal
+
+/datum/status_effect/proc/prevent_action()
+	qdel(src)
+
+/datum/status_effect/delayed/on_remove()
+	if(prevent_signal)
+		UnregisterSignal(owner, prevent_signal)
+	. = ..()
+
+/datum/status_effect/delayed/on_timeout()
+	. = ..()
+	expire_proc.Invoke()

--- a/code/game/objects/items/weapons/implants/implant_adrenalin.dm
+++ b/code/game/objects/items/weapons/implants/implant_adrenalin.dm
@@ -16,7 +16,7 @@
 	imp_in.SetParalysis(0)
 	imp_in.adjustStaminaLoss(-75)
 	imp_in.stand_up(TRUE)
-	imp_in.remove_status_effect(STATUS_EFFECT_BATONNED)
+	SEND_SIGNAL(imp_in, COMSIG_PREVENT_DELAYED_KNOCKDOWN)
 
 	imp_in.reagents.add_reagent("synaptizine", 10)
 	imp_in.reagents.add_reagent("omnizine", 10)

--- a/code/game/objects/items/weapons/implants/implant_adrenalin.dm
+++ b/code/game/objects/items/weapons/implants/implant_adrenalin.dm
@@ -16,6 +16,7 @@
 	imp_in.SetParalysis(0)
 	imp_in.adjustStaminaLoss(-75)
 	imp_in.stand_up(TRUE)
+	imp_in.remove_status_effect(STATUS_EFFECT_BATONNED)
 
 	imp_in.reagents.add_reagent("synaptizine", 10)
 	imp_in.reagents.add_reagent("omnizine", 10)

--- a/code/game/objects/items/weapons/implants/implant_adrenalin.dm
+++ b/code/game/objects/items/weapons/implants/implant_adrenalin.dm
@@ -16,7 +16,7 @@
 	imp_in.SetParalysis(0)
 	imp_in.adjustStaminaLoss(-75)
 	imp_in.stand_up(TRUE)
-	SEND_SIGNAL(imp_in, COMSIG_PREVENT_DELAYED_KNOCKDOWN)
+	SEND_SIGNAL(imp_in, COMSIG_LIVING_CLEAR_STUNS)
 
 	imp_in.reagents.add_reagent("synaptizine", 10)
 	imp_in.reagents.add_reagent("omnizine", 10)

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -206,7 +206,8 @@
 		H.adjustStaminaLoss(stam_damage)
 
 	ADD_TRAIT(L, TRAIT_WAS_BATONNED, user_UID) // so one person cannot hit the same person with two separate batons
-	addtimer(CALLBACK(src, PROC_REF(baton_knockdown), L, user_UID, knockdown_duration), knockdown_delay)
+	L.apply_status_effect(STATUS_EFFECT_BATONNED)
+	addtimer(CALLBACK(src, PROC_REF(baton_knockdown), L, user_UID), knockdown_delay)
 
 	SEND_SIGNAL(L, COMSIG_LIVING_MINOR_SHOCK, 33)
 
@@ -220,8 +221,7 @@
 	deductcharge(hitcost)
 	return TRUE
 
-/obj/item/melee/baton/proc/baton_knockdown(mob/living/target, user_UID, knockdown_duration)
-	target.KnockDown(knockdown_duration)
+/obj/item/melee/baton/proc/baton_knockdown(mob/living/target, user_UID)
 	REMOVE_TRAIT(target, TRAIT_WAS_BATONNED, user_UID)
 
 /obj/item/melee/baton/emp_act(severity)

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -206,7 +206,7 @@
 		H.adjustStaminaLoss(stam_damage)
 
 	ADD_TRAIT(L, TRAIT_WAS_BATONNED, user_UID) // so one person cannot hit the same person with two separate batons
-	L.apply_status_effect(STATUS_EFFECT_BATONNED)
+	L.apply_status_effect(STATUS_EFFECT_DELAYED, 2.5 SECONDS, CALLBACK(L, TYPE_PROC_REF(/mob/living/, KnockDown), 10), COMSIG_PREVENT_DELAYED_KNOCKDOWN)
 	addtimer(CALLBACK(src, PROC_REF(baton_delay), L, user_UID), knockdown_delay)
 
 	SEND_SIGNAL(L, COMSIG_LIVING_MINOR_SHOCK, 33)

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -206,7 +206,7 @@
 		H.adjustStaminaLoss(stam_damage)
 
 	ADD_TRAIT(L, TRAIT_WAS_BATONNED, user_UID) // so one person cannot hit the same person with two separate batons
-	L.apply_status_effect(STATUS_EFFECT_DELAYED, knockdown_delay, CALLBACK(L, TYPE_PROC_REF(/mob/living/, KnockDown), knockdown_duration), COMSIG_PREVENT_DELAYED_KNOCKDOWN)
+	L.apply_status_effect(STATUS_EFFECT_DELAYED, knockdown_delay, CALLBACK(L, TYPE_PROC_REF(/mob/living/, KnockDown), knockdown_duration), COMSIG_LIVING_CLEAR_STUNS)
 	addtimer(CALLBACK(src, PROC_REF(baton_delay), L, user_UID), knockdown_delay)
 
 	SEND_SIGNAL(L, COMSIG_LIVING_MINOR_SHOCK, 33)

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -207,7 +207,7 @@
 
 	ADD_TRAIT(L, TRAIT_WAS_BATONNED, user_UID) // so one person cannot hit the same person with two separate batons
 	L.apply_status_effect(STATUS_EFFECT_BATONNED)
-	addtimer(CALLBACK(src, PROC_REF(baton_knockdown), L, user_UID), knockdown_delay)
+	addtimer(CALLBACK(src, PROC_REF(baton_delay), L, user_UID), knockdown_delay)
 
 	SEND_SIGNAL(L, COMSIG_LIVING_MINOR_SHOCK, 33)
 
@@ -221,7 +221,7 @@
 	deductcharge(hitcost)
 	return TRUE
 
-/obj/item/melee/baton/proc/baton_knockdown(mob/living/target, user_UID)
+/obj/item/melee/baton/proc/baton_delay(mob/living/target, user_UID)
 	REMOVE_TRAIT(target, TRAIT_WAS_BATONNED, user_UID)
 
 /obj/item/melee/baton/emp_act(severity)

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -206,7 +206,7 @@
 		H.adjustStaminaLoss(stam_damage)
 
 	ADD_TRAIT(L, TRAIT_WAS_BATONNED, user_UID) // so one person cannot hit the same person with two separate batons
-	L.apply_status_effect(STATUS_EFFECT_DELAYED, 2.5 SECONDS, CALLBACK(L, TYPE_PROC_REF(/mob/living/, KnockDown), 10), COMSIG_PREVENT_DELAYED_KNOCKDOWN)
+	L.apply_status_effect(STATUS_EFFECT_DELAYED, knockdown_delay, CALLBACK(L, TYPE_PROC_REF(/mob/living/, KnockDown), knockdown_duration), COMSIG_PREVENT_DELAYED_KNOCKDOWN)
 	addtimer(CALLBACK(src, PROC_REF(baton_delay), L, user_UID), knockdown_delay)
 
 	SEND_SIGNAL(L, COMSIG_LIVING_MINOR_SHOCK, 33)

--- a/code/modules/antagonists/changeling/powers/epinephrine.dm
+++ b/code/modules/antagonists/changeling/powers/epinephrine.dm
@@ -22,6 +22,7 @@
 	user.SetWeakened(0)
 	user.setStaminaLoss(0)
 	user.SetKnockDown(0)
+	user.remove_status_effect(STATUS_EFFECT_BATONNED)
 	user.reagents.add_reagent("synaptizine", 15)
 	user.reagents.add_reagent("stimulative_cling", 1)
 

--- a/code/modules/antagonists/changeling/powers/epinephrine.dm
+++ b/code/modules/antagonists/changeling/powers/epinephrine.dm
@@ -22,7 +22,7 @@
 	user.SetWeakened(0)
 	user.setStaminaLoss(0)
 	user.SetKnockDown(0)
-	user.remove_status_effect(STATUS_EFFECT_BATONNED)
+	SEND_SIGNAL(user, COMSIG_PREVENT_DELAYED_KNOCKDOWN)
 	user.reagents.add_reagent("synaptizine", 15)
 	user.reagents.add_reagent("stimulative_cling", 1)
 

--- a/code/modules/antagonists/changeling/powers/epinephrine.dm
+++ b/code/modules/antagonists/changeling/powers/epinephrine.dm
@@ -22,7 +22,7 @@
 	user.SetWeakened(0)
 	user.setStaminaLoss(0)
 	user.SetKnockDown(0)
-	SEND_SIGNAL(user, COMSIG_PREVENT_DELAYED_KNOCKDOWN)
+	SEND_SIGNAL(user, COMSIG_LIVING_CLEAR_STUNS)
 	user.reagents.add_reagent("synaptizine", 15)
 	user.reagents.add_reagent("stimulative_cling", 1)
 

--- a/code/modules/antagonists/vampire/vampire_powers/vampire_powers.dm
+++ b/code/modules/antagonists/vampire/vampire_powers/vampire_powers.dm
@@ -64,6 +64,7 @@
 	U.SetSleeping(0)
 	U.SetConfused(0)
 	U.adjustStaminaLoss(-100)
+	U.remove_status_effect(STATUS_EFFECT_BATONNED)
 	to_chat(user, "<span class='notice'>You instill your body with clean blood and remove any incapacitating effects.</span>")
 	var/datum/antagonist/vampire/V = U.mind.has_antag_datum(/datum/antagonist/vampire)
 	var/rejuv_bonus = V.get_rejuv_bonus()

--- a/code/modules/antagonists/vampire/vampire_powers/vampire_powers.dm
+++ b/code/modules/antagonists/vampire/vampire_powers/vampire_powers.dm
@@ -64,7 +64,7 @@
 	U.SetSleeping(0)
 	U.SetConfused(0)
 	U.adjustStaminaLoss(-100)
-	U.remove_status_effect(STATUS_EFFECT_BATONNED)
+	SEND_SIGNAL(U, COMSIG_PREVENT_DELAYED_KNOCKDOWN)
 	to_chat(user, "<span class='notice'>You instill your body with clean blood and remove any incapacitating effects.</span>")
 	var/datum/antagonist/vampire/V = U.mind.has_antag_datum(/datum/antagonist/vampire)
 	var/rejuv_bonus = V.get_rejuv_bonus()

--- a/code/modules/antagonists/vampire/vampire_powers/vampire_powers.dm
+++ b/code/modules/antagonists/vampire/vampire_powers/vampire_powers.dm
@@ -64,7 +64,7 @@
 	U.SetSleeping(0)
 	U.SetConfused(0)
 	U.adjustStaminaLoss(-100)
-	SEND_SIGNAL(U, COMSIG_PREVENT_DELAYED_KNOCKDOWN)
+	SEND_SIGNAL(U, COMSIG_LIVING_CLEAR_STUNS)
 	to_chat(user, "<span class='notice'>You instill your body with clean blood and remove any incapacitating effects.</span>")
 	var/datum/antagonist/vampire/V = U.mind.has_antag_datum(/datum/antagonist/vampire)
 	var/rejuv_bonus = V.get_rejuv_bonus()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -486,6 +486,7 @@
 	RestoreEars()
 	heal_overall_damage(1000, 1000)
 	ExtinguishMob()
+	remove_status_effect(STATUS_EFFECT_BATONNED)
 	fire_stacks = 0
 	on_fire = 0
 	suiciding = 0

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -486,7 +486,7 @@
 	RestoreEars()
 	heal_overall_damage(1000, 1000)
 	ExtinguishMob()
-	remove_status_effect(STATUS_EFFECT_BATONNED)
+	SEND_SIGNAL(src, COMSIG_PREVENT_DELAYED_KNOCKDOWN)
 	fire_stacks = 0
 	on_fire = 0
 	suiciding = 0

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -486,7 +486,7 @@
 	RestoreEars()
 	heal_overall_damage(1000, 1000)
 	ExtinguishMob()
-	SEND_SIGNAL(src, COMSIG_PREVENT_DELAYED_KNOCKDOWN)
+	SEND_SIGNAL(src, COMSIG_LIVING_CLEAR_STUNS)
 	fire_stacks = 0
 	on_fire = 0
 	suiciding = 0

--- a/code/modules/mob/living/simple_animal/bot/ed209bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/ed209bot.dm
@@ -576,7 +576,7 @@
 	C.SetStuttering(10 SECONDS)
 	C.adjustStaminaLoss(60)
 	baton_delayed = TRUE
-	C.apply_status_effect(STATUS_EFFECT_DELAYED, 2.5 SECONDS, CALLBACK(C, TYPE_PROC_REF(/mob/living/, KnockDown), 10), COMSIG_PREVENT_DELAYED_KNOCKDOWN)
+	C.apply_status_effect(STATUS_EFFECT_DELAYED, 2.5 SECONDS, CALLBACK(C, TYPE_PROC_REF(/mob/living/, KnockDown), 10 SECONDS), COMSIG_PREVENT_DELAYED_KNOCKDOWN)
 	addtimer(VARSET_CALLBACK(src, baton_delayed, FALSE), BATON_COOLDOWN)
 	add_attack_logs(src, C, "batoned")
 	if(declare_arrests)

--- a/code/modules/mob/living/simple_animal/bot/ed209bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/ed209bot.dm
@@ -576,7 +576,7 @@
 	C.SetStuttering(10 SECONDS)
 	C.adjustStaminaLoss(60)
 	baton_delayed = TRUE
-	addtimer(CALLBACK(C, PROC_REF(KnockDown), 10 SECONDS), 2.5 SECONDS)
+	C.apply_status_effect(STATUS_EFFECT_BATONNED)
 	addtimer(VARSET_CALLBACK(src, baton_delayed, FALSE), BATON_COOLDOWN)
 	add_attack_logs(src, C, "batoned")
 	if(declare_arrests)

--- a/code/modules/mob/living/simple_animal/bot/ed209bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/ed209bot.dm
@@ -576,7 +576,7 @@
 	C.SetStuttering(10 SECONDS)
 	C.adjustStaminaLoss(60)
 	baton_delayed = TRUE
-	C.apply_status_effect(STATUS_EFFECT_BATONNED)
+	C.apply_status_effect(STATUS_EFFECT_DELAYED, 2.5 SECONDS, CALLBACK(C, TYPE_PROC_REF(/mob/living/, KnockDown), 10), COMSIG_PREVENT_DELAYED_KNOCKDOWN)
 	addtimer(VARSET_CALLBACK(src, baton_delayed, FALSE), BATON_COOLDOWN)
 	add_attack_logs(src, C, "batoned")
 	if(declare_arrests)

--- a/code/modules/mob/living/simple_animal/bot/ed209bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/ed209bot.dm
@@ -576,7 +576,7 @@
 	C.SetStuttering(10 SECONDS)
 	C.adjustStaminaLoss(60)
 	baton_delayed = TRUE
-	C.apply_status_effect(STATUS_EFFECT_DELAYED, 2.5 SECONDS, CALLBACK(C, TYPE_PROC_REF(/mob/living/, KnockDown), 10 SECONDS), COMSIG_PREVENT_DELAYED_KNOCKDOWN)
+	C.apply_status_effect(STATUS_EFFECT_DELAYED, 2.5 SECONDS, CALLBACK(C, TYPE_PROC_REF(/mob/living/, KnockDown), 10 SECONDS), COMSIG_LIVING_CLEAR_STUNS)
 	addtimer(VARSET_CALLBACK(src, baton_delayed, FALSE), BATON_COOLDOWN)
 	add_attack_logs(src, C, "batoned")
 	if(declare_arrests)

--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -266,7 +266,7 @@
 	C.SetStuttering(10 SECONDS)
 	C.adjustStaminaLoss(60)
 	baton_delayed = TRUE
-	C.apply_status_effect(STATUS_EFFECT_DELAYED, 2.5 SECONDS, CALLBACK(C, TYPE_PROC_REF(/mob/living/, KnockDown), 10 SECONDS), COMSIG_PREVENT_DELAYED_KNOCKDOWN)
+	C.apply_status_effect(STATUS_EFFECT_DELAYED, 2.5 SECONDS, CALLBACK(C, TYPE_PROC_REF(/mob/living/, KnockDown), 10 SECONDS), COMSIG_LIVING_CLEAR_STUNS)
 	addtimer(VARSET_CALLBACK(src, baton_delayed, FALSE), BATON_COOLDOWN)
 	add_attack_logs(src, C, "batoned")
 	if(declare_arrests)

--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -266,7 +266,7 @@
 	C.SetStuttering(10 SECONDS)
 	C.adjustStaminaLoss(60)
 	baton_delayed = TRUE
-	addtimer(CALLBACK(C, PROC_REF(KnockDown), 10 SECONDS), 2.5 SECONDS)
+	C.apply_status_effect(STATUS_EFFECT_BATONNED)
 	addtimer(VARSET_CALLBACK(src, baton_delayed, FALSE), BATON_COOLDOWN)
 	add_attack_logs(src, C, "batoned")
 	if(declare_arrests)

--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -266,7 +266,7 @@
 	C.SetStuttering(10 SECONDS)
 	C.adjustStaminaLoss(60)
 	baton_delayed = TRUE
-	C.apply_status_effect(STATUS_EFFECT_BATONNED)
+	C.apply_status_effect(STATUS_EFFECT_DELAYED, 2.5 SECONDS, CALLBACK(C, TYPE_PROC_REF(/mob/living/, KnockDown), 10), COMSIG_PREVENT_DELAYED_KNOCKDOWN)
 	addtimer(VARSET_CALLBACK(src, baton_delayed, FALSE), BATON_COOLDOWN)
 	add_attack_logs(src, C, "batoned")
 	if(declare_arrests)

--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -266,7 +266,7 @@
 	C.SetStuttering(10 SECONDS)
 	C.adjustStaminaLoss(60)
 	baton_delayed = TRUE
-	C.apply_status_effect(STATUS_EFFECT_DELAYED, 2.5 SECONDS, CALLBACK(C, TYPE_PROC_REF(/mob/living/, KnockDown), 10), COMSIG_PREVENT_DELAYED_KNOCKDOWN)
+	C.apply_status_effect(STATUS_EFFECT_DELAYED, 2.5 SECONDS, CALLBACK(C, TYPE_PROC_REF(/mob/living/, KnockDown), 10 SECONDS), COMSIG_PREVENT_DELAYED_KNOCKDOWN)
 	addtimer(VARSET_CALLBACK(src, baton_delayed, FALSE), BATON_COOLDOWN)
 	add_attack_logs(src, C, "batoned")
 	if(declare_arrests)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
This PR moves stunbaton delayed knockdown into status effect
Adds removing this status effect to adrenal bio-chip, changeling adrenals, vampire rejuvenate and to admin rejuvenate
So now if you got batonned and you pressed adrenals to run away you will not fall down in two meters if you didnt get hit after you used it

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Thats what adrenals, rejuvenate and other supposed to do. They supposed to reduce or remove all bad effects like stamina damage and other but stunbaton delayed knockdown was ignoring that all, so when you see adrenals guy you can just spam your stunbaton at them and there is high chance that they will not run away

This PR makes them all(adrenals, changeling adrenals, rejuvenate) act like intended. You are great vampire, you just healed tons of damage and all stamina, you SHOULD NOT drop down in two meters cause someone batonned you before

There were other PRs about it bit it seems they died 
https://github.com/ParadiseSS13/Paradise/pull/20715
https://github.com/ParadiseSS13/Paradise/pull/20440

So there is my version of those changings

## Testing
<!-- How did you test the PR, if at all? -->
compiled, batonned

## Changelog
:cl:
tweak: If you activate adrenals biochip/epinephrine(changeling)/rejuvenate(vampire)/rejuvenate(admin) after getting batonned, you will not be knockdowned. Works with beepsky, ED209, stunbatons and stunprods
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
