### PR TITLE
allows med borgs to pet nymphs and mice

### DIFF
--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -72,7 +72,7 @@
 	switch(mode)
 		if(CYBORG_HUGS)
 			if(M.health >= 0)
-				if(isanimal(M))
+				if(isanimal(M) && !ismouse(M) && !isnymph(M))
 					var/list/modifiers = params2list(params)
 					M.attack_hand(user, modifiers) //This enables borgs to get the floating heart icon and mob emote from simple_animal's that have petbonus == true.
 					return

--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -72,7 +72,7 @@
 	switch(mode)
 		if(CYBORG_HUGS)
 			if(M.health >= 0)
-				if(isanimal(M) && !ismouse(M) && !isnymph(M))
+				if(isanimal(M) && !M.holder_type)
 					var/list/modifiers = params2list(params)
 					M.attack_hand(user, modifiers) //This enables borgs to get the floating heart icon and mob emote from simple_animal's that have petbonus == true.
 					return

--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -72,7 +72,7 @@
 	switch(mode)
 		if(CYBORG_HUGS)
 			if(M.health >= 0)
-				if(isanimal(M) && !M.holder_type)
+				if(isanimal(M) && !M.holder_type) // checks if holder_type exists to prevent picking up animals like mice
 					var/list/modifiers = params2list(params)
 					M.attack_hand(user, modifiers) //This enables borgs to get the floating heart icon and mob emote from simple_animal's that have petbonus == true.
 					return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Technically fixes #18895
This PR prevents medical borgos from picking up mice or diona nymphs. Now they pet them instead. This used to put them into the borg and they could not be dropped.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
No more undroppable mice
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
1. Spawn as med borg
2. pet mouse
3. pet nymph
4. profit!
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Fixed being able to pick up mice as medical borg
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
