### PR TITLE
Comms consoles can now only change alert level on red or lower alert

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -131,7 +131,8 @@
 			var/mob/living/carbon/human/H = usr
 			var/obj/item/card/id/I = H.get_idcard(TRUE)
 			if(istype(I))
-				if(ACCESS_CAPTAIN in I.access)
+				// You must have captain access and it must be red alert or lower (no getting off delta/epsilon)
+				if(ACCESS_CAPTAIN in I.access && GLOB.security_level <= SEC_LEVEL_RED)
 					change_security_level(text2num(params["level"]))
 				else
 					to_chat(usr, "<span class='warning'>You are not authorized to do this.</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->Comms consoles can now only change alert level on red or lower alert

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Being able to change alert from gamma/delta/epsilon to green alert, isn't intended I believe

## Testing
<!-- How did you test the PR, if at all? -->
Set alert to epsilon, wasnt able to set it to green
![image](https://github.com/ParadiseSS13/Paradise/assets/91113370/9e9fbb4b-f1cf-4cb8-b302-f8efc4fec9d2)


## Changelog
:cl:
fix: Comms consoles can only change alert on red or lower
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
