### PR TITLE
flash ability to destroy shadow snare

### DIFF
--- a/code/modules/antagonists/vampire/vampire_powers/umbrae_powers.dm
+++ b/code/modules/antagonists/vampire/vampire_powers/umbrae_powers.dm
@@ -88,6 +88,16 @@
 		to_chat(user, "<span class='userdanger'>The snare sends a psychic backlash!</span>")
 		C.EyeBlind(20 SECONDS)
 
+/obj/item/restraints/legcuffs/beartrap/shadow_snare/attackby(obj/item/I, mob/user)
+	var/obj/item/flash/flash = I
+	if(!istype(flash) || !flash.try_use_flash(user))
+		. = ..()
+		return
+	user.visible_message("<span class='danger'>[user] points [I] at [src]!</span>",
+	"<span class='danger'>You point [I] at [src]!</span>")
+	visible_message("<span class='notice'>[src] withers away.</span>")
+	qdel(src)
+
 /obj/item/restraints/legcuffs/beartrap/shadow_snare/process()
 	var/turf/T = get_turf(src)
 	var/lighting_count = T.get_lumcount() * 10

--- a/code/modules/antagonists/vampire/vampire_powers/umbrae_powers.dm
+++ b/code/modules/antagonists/vampire/vampire_powers/umbrae_powers.dm
@@ -91,8 +91,7 @@
 /obj/item/restraints/legcuffs/beartrap/shadow_snare/attackby(obj/item/I, mob/user)
 	var/obj/item/flash/flash = I
 	if(!istype(flash) || !flash.try_use_flash(user))
-		. = ..()
-		return
+		return ..()
 	user.visible_message("<span class='danger'>[user] points [I] at [src]!</span>",
 	"<span class='danger'>You point [I] at [src]!</span>")
 	visible_message("<span class='notice'>[src] withers away.</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
This PR adds flash ability to destroy shadow snares(vampire umbrae powers)

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Shadow Snare is half invisible trap hiding in shadows, its hard to detect without nightvision or something else, but once you find it, its hard to remove it too. You need to keep light for about to 5 seconds near it to destroy. Using flash at it would do nothing, same as anything else, just light. So adding ability to fastly remove it looks nice to me and this flash utilization supposed to be there.

## Testing
<!-- How did you test the PR, if at all? -->
Compiled, flashed.

## Changelog
:cl:
tweak: Shadow Snare could be instantly destroyed by using flash on it
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
