### PR TITLE
Quantum pads now check AI cam visibility (#21074)

### DIFF
--- a/code/game/machinery/quantum_pad.dm
+++ b/code/game/machinery/quantum_pad.dm
@@ -125,7 +125,7 @@
 /obj/machinery/quantumpad/attack_hand(mob/user)
 	if(isAI(user))
 		return
-	if(!checkUsable(user))
+	if(!check_usable(user))
 		return
 	add_fingerprint(user)
 	doteleport(user)
@@ -136,7 +136,7 @@
 	if(user.eyeobj.loc != loc)
 		user.eyeobj.setLoc(get_turf(loc))
 		return
-	if(!checkUsable(user))
+	if(!check_usable(user))
 		return
 	var/turf/T = get_turf(linked_pad)
 	if(GLOB.cameranet && GLOB.cameranet.checkTurfVis(T))

--- a/code/game/machinery/quantum_pad.dm
+++ b/code/game/machinery/quantum_pad.dm
@@ -95,7 +95,8 @@
 		return
 	default_deconstruction_screwdriver(user, "pad-idle-o", "qpad-idle", I)
 
-/obj/machinery/quantumpad/attack_hand(mob/user)
+/obj/machinery/quantumpad/proc/check_usable(mob/user)
+	. = FALSE
 	if(panel_open)
 		to_chat(user, "<span class='warning'>The panel must be closed before operating this machine!</span>")
 		return
@@ -119,8 +120,29 @@
 	if(linked_pad.stat & NOPOWER)
 		to_chat(user, "<span class='warning'>Linked pad is not responding to ping.</span>")
 		return
+	return TRUE
+
+/obj/machinery/quantumpad/attack_hand(mob/user)
+	if(isAI(user))
+		return
+	if(!checkUsable(user))
+		return
 	add_fingerprint(user)
 	doteleport(user)
+
+/obj/machinery/quantumpad/attack_ai(mob/living/silicon/ai/user)
+	if(!isAI(user))
+		return
+	if(user.eyeobj.loc != loc)
+		user.eyeobj.setLoc(get_turf(loc))
+		return
+	if(!checkUsable(user))
+		return
+	var/turf/T = get_turf(linked_pad)
+	if(GLOB.cameranet && GLOB.cameranet.checkTurfVis(T))
+		user.eyeobj.setLoc(T)
+	else
+		to_chat(user, "<span class='warning'>Linked pad is not on or near any active cameras on the station.</span>")
 
 /obj/machinery/quantumpad/proc/sparks()
 	do_sparks(5, 1, get_turf(src))


### PR DESCRIPTION
## What Does This PR Do
This change adds handling for AI eye interactions with quantum pads.
* When an AI eye user clicks on the quantum pad, the eye will center on the pad if it is not already, mimicking holopad behavior.
* If the AI eye is already centered on the pad when it is clicked, the pad will be tested for usability in the same manner it is for users, which logic has been moved to its own proc. 
* If the pad is usable, the turf of the linked pad will be checked for visibility. 
* If the turf of the linked pad is visible, `setLoc` is called on the AI eye, allowing visibility chunks to be updated. 
* If it is not usable, the AI will receive a warning notification similar to the one used when unable to track a mob via cameranet.

Usability tests for quantum pads have been moved from `/obj/machinery/quantumpad/attack_hand` to a new proc, `/obj/machinery/quantumpad/proc/check_usable`, so that its logic can be shared with /obj/machinery/quantumpad/attack_ai`.

Fixes #21074 .

## Why It's Good For The Game
Previously, quantum pads operated identically for living carbon mobs and for the AI, teleporting the mob activating the pad via /proc/do_teleport. This bypassed the AI Freelook visibility checking, allowing AIs to view turfs surrounding the linked pad without actual camera visibility. This issue was labeled as an oversight. This PR fixes #21074 .

## Testing
### Reproducing #21074
I loaded a local copy of the server from commit 14d0c68 and joined the game at roundstart as a Research Director. I used the `spawn` verb to create a pair of quantum pads: one in the Captain's office, and one in the AI observation room. I spawned in a screwdriver, wirecutters, and multitool on my person. I linked the two pads. I then cut the camera wires in the Captain's office.  After testing that the quantum pads worked as expected, I used the player panel to send myself back to lobby, and logged in as the AI. I panned over to confirm that I did not have camera visibility in the Captain's office. Then I jumped to the AI observation room, positioned the center of my screen over the quantum pad, and clicked on it. As documented in the issue, my camera became fixed on the linked pad in the maints tunnel, and I had full visibility of all nearby turfs and objects.

### Testing fixes
I loaded a local copy of the server from the commit in this PR, and repeated the steps involved in reproducing the issue. After testing that quantum pads still worked as expected as a Research Director, I logged in as the AI as before, and panned over to confirm I had no visibility in the Captain's office. Then I jumped to the AI observation room, positioned the center of my screen over the quantum pad, and clicked on it. As expected, I received the message "Linked pad is not on or near any active cameras on the station."

I then took control of the Research Director again (by `aghost`ing and click+dragging my ghost to the RD's body) and returned to the Captain's office to mend the camera wires. After doing so, I took control over the AI likewise, and tested the quantum pad in the observation room again. On the first click, I got the message "Linked pad is not on or near any active cameras on the station.", but this may be due to delays in cameranet updates. On the second click, my screen was centered on the linked pad in the Captain's office (as expected), and I was unable to see any turfs or objects that were not visible to cameras (as expected).

## Changelog
:cl: Ascio
fix: AIs can no longer access linked quantum pads that their cameras can't see
/:cl: