### PR TITLE
Allows us to drop NODROP items if there is other way to get rid of them

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -152,6 +152,12 @@ GLOBAL_DATUM_INIT(welding_sparks, /mutable_appearance, mutable_appearance('icons
 	if(isstorage(loc)) //marks all items in storage as being such
 		in_storage = TRUE
 
+/obj/item/proc/can_drop() //this proc is called if we want to check if used possibly can drop held item, but basic drop is restricted(NO_DROP flag for example)
+	return FALSE
+
+/obj/item/proc/failed_drop() //this proc is called if user tried to drop item by himself(by clicking Q), but for some reason he failed
+	return FALSE
+
 /obj/item/proc/determine_move_resist()
 	switch(w_class)
 		if(WEIGHT_CLASS_TINY)

--- a/code/modules/antagonists/vampire/vampire_powers/hemomancer_powers.dm
+++ b/code/modules/antagonists/vampire/vampire_powers/hemomancer_powers.dm
@@ -9,17 +9,16 @@
 /obj/effect/proc_holder/spell/vampire/self/vamp_claws/cast(mob/user)
 	if(user.l_hand || user.r_hand)
 		to_chat(user, "<span class='notice'>You drop what was in your hands as large blades spring from your fingers!</span>")
-		user.drop_l_hand()
-		user.drop_r_hand()
-	else
-		to_chat(user, "<span class='notice'>Large blades of blood spring from your fingers!</span>")
+		user.drop_l_hand(FALSE, TRUE)
+		user.drop_r_hand(FALSE, TRUE)
+	to_chat(user, "<span class='notice'>Large blades of blood spring from your fingers!</span>")
 	var/obj/item/twohanded/required/vamp_claws/claws = new /obj/item/twohanded/required/vamp_claws(user.loc)
 	user.put_in_hands(claws)
 
 
 /obj/effect/proc_holder/spell/vampire/self/vamp_claws/can_cast(mob/user, charge_check, show_message)
 	var/mob/living/L = user
-	if(L.canUnEquip(L.l_hand) && L.canUnEquip(L.r_hand))
+	if(L.canUnEquip(L.l_hand, FALSE, TRUE) && L.canUnEquip(L.r_hand, FALSE, TRUE))
 		return ..()
 
 /obj/item/twohanded/required/vamp_claws
@@ -40,6 +39,18 @@
 	var/durability = 15
 	var/blood_drain_amount = 15
 	var/blood_absorbed_amount = 5
+
+/obj/item/twohanded/required/vamp_claws/can_drop()
+	if(!ishuman(loc))
+		return FALSE
+	var/mob/living/carbon/human/owner = loc
+	return lowertext(owner.mind.special_role) == ROLE_VAMPIRE
+
+/obj/item/twohanded/required/vamp_claws/failed_drop()
+	if(!can_drop())
+		return FALSE
+	dispel()
+	return TRUE
 
 /obj/item/twohanded/required/vamp_claws/afterattack(atom/target, mob/user, proximity)
 	if(!proximity)
@@ -72,7 +83,12 @@
 		user.changeNext_move(CLICK_CD_MELEE * 0.5)
 
 /obj/item/twohanded/required/vamp_claws/attack_self(mob/user)
-	to_chat(user, "<span class='notice'>You dispel your claws!</span>")
+	dispel()
+
+/obj/item/twohanded/required/vamp_claws/proc/dispel()
+	var/mob/living/carbon/human/owner = loc
+	if(istype(owner))
+		to_chat(owner, "<span class='notice'>You dispel your claws!</span>")
 	qdel(src)
 
 /obj/effect/proc_holder/spell/vampire/blood_tendrils

--- a/code/modules/mob/inventory_procs.dm
+++ b/code/modules/mob/inventory_procs.dm
@@ -109,38 +109,42 @@
 /mob/proc/drop_item_v()		//this is dumb.
 	if(stat == CONSCIOUS && isturf(loc))
 		SEND_SIGNAL(usr, COMSIG_MOB_WILLINGLY_DROP)
-		return drop_item()
+		return drop_item(TRUE)
 	return 0
 
 //Drops the item in our left hand
-/mob/proc/drop_l_hand(force = FALSE)
-	return unEquip(l_hand, force) //All needed checks are in unEquip
+/mob/proc/drop_l_hand(force = FALSE, activated_by_user = FALSE)
+	return unEquip(l_hand, force, FALSE, activated_by_user) //All needed checks are in unEquip
 
 //Drops the item in our right hand
-/mob/proc/drop_r_hand(force = FALSE)
-	return unEquip(r_hand, force) //Why was this not calling unEquip in the first place jesus fuck.
+/mob/proc/drop_r_hand(force = FALSE, activated_by_user = FALSE)
+	return unEquip(r_hand, force, FALSE, activated_by_user) //Why was this not calling unEquip in the first place jesus fuck.
 
 //Drops the item in our active hand.
-/mob/proc/drop_item() //THIS. DOES. NOT. NEED. AN. ARGUMENT.
+/mob/proc/drop_item(activated_by_user = FALSE)
 	if(hand)
-		return drop_l_hand()
+		return drop_l_hand(FALSE, activated_by_user) // second arg is TRUE cause user activated it by himself
 	else
-		return drop_r_hand()
+		return drop_r_hand(FALSE, activated_by_user)
 
 //Here lie unEquip and before_item_take, already forgotten and not missed.
 
-/mob/proc/canUnEquip(obj/item/I, force)
+/mob/proc/canUnEquip(obj/item/I, force, activated_by_user = FALSE)
 	if(!I)
 		return TRUE
 	if((I.flags & NODROP) && !force)
+		if(activated_by_user)
+			return I.can_drop()
 		return FALSE
 	return TRUE
 
-/mob/proc/unEquip(obj/item/I, force, silent = FALSE) //Force overrides NODROP for things like wizarditis and admin undress.
+/mob/proc/unEquip(obj/item/I, force, silent = FALSE, activated_by_user = FALSE) //Force overrides NODROP for things like wizarditis and admin undress.
 	if(!I) //If there's nothing to drop, the drop is automatically succesfull. If(unEquip) should generally be used to check for NODROP.
 		return 1
 
 	if(!canUnEquip(I, force))
+		if(activated_by_user)
+			return I.failed_drop()
 		return 0
 
 	if(I == r_hand)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
This PR allows us to press Q on armblade, tentackle and vampire claws instead of clicking them, also allows us to add same logic for other objects.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
When you're in fight, you have adrenaline in your blood, your hands are shaking, you're trying to press right buttons, you activated your claws and just killed officer, now you need to fastly take their cutted off head and... and... why my Q button doesnt work? Ah right, i have vampire claws, what do i do with them? Hmmm... Clicking spell? No... Clicking Claws? YEAH, here we go! 

This up here is now gone, when you try to drop claws/armblade/tentackle, it will be dropped
Doesnt change logic when, for example, non-changeling tried to drop armblade, nothing will happen

## Testing
<!-- How did you test the PR, if at all? -->
compiled, pressed drop button, enjoyed myself, drank whiskey cola

## Changelog
:cl:
tweak: Now pressing drop button on vampire claws, armblade, tentacle will let you get rid of it if you supposed to can
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
