### PR TITLE
Converts Perfluorodecalin's side-effect into an actual overdose

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -501,6 +501,7 @@
 	color = "#C8A5DC"
 	metabolization_rate = 0.2
 	overdose_threshold = 4
+	allowed_overdose_process = TRUE
 	addiction_chance = 1
 	addiction_chance_additional = 20
 	addiction_threshold = 10

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -500,6 +500,7 @@
 	reagent_state = LIQUID
 	color = "#C8A5DC"
 	metabolization_rate = 0.2
+	overdose_threshold = 4
 	addiction_chance = 1
 	addiction_chance_additional = 20
 	addiction_threshold = 10
@@ -508,13 +509,17 @@
 
 /datum/reagent/medicine/perfluorodecalin/on_mob_life(mob/living/carbon/human/M)
 	var/update_flags = STATUS_UPDATE_NONE
+
 	update_flags |= M.adjustOxyLoss(-25*REAGENTS_EFFECT_MULTIPLIER, FALSE)
-	if(volume >= 4)
-		M.LoseBreath(12 SECONDS)
 	if(prob(33))
 		update_flags |= M.adjustBruteLoss(-1*REAGENTS_EFFECT_MULTIPLIER, FALSE)
 		update_flags |= M.adjustFireLoss(-1*REAGENTS_EFFECT_MULTIPLIER, FALSE)
+
 	return ..() | update_flags
+
+/datum/reagent/medicine/perfluorodecalin/overdose_process(mob/living/M)
+	M.LoseBreath(12 SECONDS)
+	return list(0, STATUS_UPDATE_NONE)
 
 /datum/reagent/medicine/ephedrine
 	name = "Ephedrine"


### PR DESCRIPTION
## What Does This PR Do
Title.

## Why It's Good For The Game
- Makes it show up as `OVERDOSING` on the health analyzer, less confusion.
- Not strictly intentional, but it lifts the actual range in which you get the overdose to *above* 4u (metabolism code is jank, can't really control it without making the threshold an ugly float), though I figure it's fine to give the players a tiny bit more leeway.

## Images of changes
![2023-05-13 18_02_26](https://github.com/ParadiseSS13/Paradise/assets/100448493/c605e00a-ceeb-4823-9947-07eb436772a6)

## Testing
- Drank 5u of Perfluorodecalin, suffered as advertised by the health analyzer.
- Drank 4u of Perfluorodecalin, did not suffer.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Perfluorodecalin overdose now shows up as such on health analyzers
/:cl:
