### PR TITLE
Reworks changeling's last resort

### DIFF
--- a/code/modules/antagonists/changeling/powers/headslug.dm
+++ b/code/modules/antagonists/changeling/powers/headslug.dm
@@ -9,7 +9,7 @@
 	power_type = CHANGELING_PURCHASABLE_POWER
 
 /datum/action/changeling/headslug/try_to_sting(mob/user, mob/target)
-	if(alert("Are you sure you wish to do this? This action cannot be undone.",,"Yes","No")=="No")
+	if(alert("Are you sure you wish to do this? This action cannot be undone.",,"Yes","No") == "No")
 		return
 	..()
 
@@ -20,21 +20,21 @@
 	for(var/obj/item/organ/internal/I in organs)
 		I.remove(user, TRUE)
 
-	explosion(get_turf(user),0,0,2,0,silent=1)
-	for(var/mob/living/carbon/human/H in range(2,user))
+	explosion(get_turf(user), 0, 0, 2, 0, silent = TRUE)
+	for(var/mob/living/carbon/human/H in range(2, user))
 		to_chat(H, "<span class='userdanger'>You are blinded by a shower of blood!</span>")
-		H.Stun(2 SECONDS)
+		H.KnockDown(4 SECONDS)
 		H.EyeBlurry(40 SECONDS)
 		var/obj/item/organ/internal/eyes/E = H.get_int_organ(/obj/item/organ/internal/eyes)
 		if(istype(E))
 			E.receive_damage(5, 1)
 		H.AdjustConfused(6 SECONDS)
-	for(var/mob/living/silicon/S in range(2,user))
+	for(var/mob/living/silicon/S in range(2, user))
 		to_chat(S, "<span class='userdanger'>Your sensors are disabled by a shower of blood!</span>")
 		S.Weaken(6 SECONDS)
-	var/new_location = user.drop_location()
+	var/turf/our_turf = get_turf(user)
 	spawn(5) // So it's not killed in explosion
-		var/mob/living/simple_animal/hostile/headslug/crab = new(new_location)
+		var/mob/living/simple_animal/hostile/headslug/crab = new(our_turf)
 		for(var/obj/item/organ/internal/I in organs)
 			I.forceMove(crab)
 		crab.origin = M

--- a/code/modules/mob/living/simple_animal/hostile/headslug.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headslug.dm
@@ -1,5 +1,5 @@
-#define EGG_INCUBATION_TIME 120
-
+#define EGG_INCUBATION_DEAD_TIME 120
+#define EGG_INCUBATION_LIVING_TIME 200
 /mob/living/simple_animal/hostile/headslug
 	name = "headslug"
 	desc = "Absolutely not de-beaked or harmless. Keep away from corpses."
@@ -23,14 +23,12 @@
 	density = FALSE
 	ventcrawler = 2
 	a_intent = INTENT_HARM
+	speed = -0.3
+	can_hide = TRUE
+	pass_door_while_hidden = TRUE
 	var/datum/mind/origin
-	var/egg_lain = 0
+	var/egg_layed = FALSE
 	sentience_type = SENTIENCE_OTHER
-
-/mob/living/simple_animal/hostile/headslug/examine(mob/user)
-	. = ..()
-	if(stat == DEAD)
-		. += "It appears to be dead."
 
 /mob/living/simple_animal/hostile/headslug/proc/Infect(mob/living/carbon/victim)
 	var/obj/item/organ/internal/body_egg/changeling_egg/egg = new(victim)
@@ -43,32 +41,37 @@
 		I.forceMove(egg)
 	visible_message("<span class='warning'>[src] plants something in [victim]'s flesh!</span>", \
 					"<span class='danger'>We inject our egg into [victim]'s body!</span>")
-	egg_lain = 1
+	egg_layed = TRUE
 
-/mob/living/simple_animal/hostile/headslug/AttackingTarget()
-	. = ..()
-	if(. && !egg_lain && iscarbon(target) && !issmall(target))
-		// Changeling egg can survive in aliens!
-		var/mob/living/carbon/C = target
-		if(C.stat == DEAD)
-			if(HAS_TRAIT(C, TRAIT_XENO_HOST))
-				to_chat(src, "<span class='userdanger'>A foreign presence repels us from this body. Perhaps we should try to infest another?</span>")
-				return
-			Infect(target)
-			to_chat(src, "<span class='userdanger'>With our egg laid, our death approaches rapidly...</span>")
-			addtimer(CALLBACK(src, PROC_REF(death)), 10 SECONDS)
+/mob/living/simple_animal/hostile/headslug/AltClickOn(mob/living/carbon/carbon_target)
+	if(egg_layed || !istype(carbon_target))
+		return ..()
+	if(carbon_target.stat != DEAD && !do_mob(src, carbon_target, 5 SECONDS))
+		return
+	if(HAS_TRAIT(carbon_target, TRAIT_XENO_HOST))
+		to_chat(src, "<span class='userdanger'>A foreign presence repels us from this body. Perhaps we should try to infest another?</span>")
+		return
+	Infect(carbon_target)
+	to_chat(src, "<span class='userdanger'>With our egg laid, our death approaches rapidly...</span>")
+	addtimer(CALLBACK(src, PROC_REF(death)), 25 SECONDS)
 
 /obj/item/organ/internal/body_egg/changeling_egg
 	name = "changeling egg"
 	desc = "Twitching and disgusting."
 	origin_tech = "biotech=7" // You need to be really lucky to obtain it.
 	var/datum/mind/origin
-	var/time
+	var/time = 0
 
 /obj/item/organ/internal/body_egg/changeling_egg/egg_process()
-	// Changeling eggs grow in dead people
-	time++
-	if(time >= EGG_INCUBATION_TIME)
+	// Changeling eggs grow in everyone
+	if(time >= 30 && prob(30))
+		owner.bleed(5)
+	if(time >= 60 && prob(5))
+		to_chat(owner, pick("<span class='danger'>We feel great!</span>", "<span class='danger'>Something hurts for a moment but it's gone now.</span>", "<span class='danger'>You feel like you should go to a dark place.</span>", "<span class='danger'>You feel really tired.</span>"))
+	if(time >= 90 && prob(5))
+		to_chat(owner, pick("<span class='danger'>Something hurts.</span>", "<span class='danger'>Someone is thinking, but it's not you.</span>", "<span class='danger'>You feel at peace.</span>", "<span class='danger'>Close your eyes.</span>"))
+		owner.adjustToxLoss(5)
+	if(time >= EGG_INCUBATION_DEAD_TIME && owner.stat == DEAD || time >= EGG_INCUBATION_LIVING_TIME)
 		Pop()
 		STOP_PROCESSING(SSobj, src)
 		qdel(src)
@@ -104,4 +107,5 @@
 		M.key = origin.key
 	owner.gib()
 
-#undef EGG_INCUBATION_TIME
+#undef EGG_INCUBATION_DEAD_TIME
+#undef EGG_INCUBATION_LIVING_TIME

--- a/code/modules/mob/living/simple_animal/hostile/headslug.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headslug.dm
@@ -23,7 +23,7 @@
 	density = FALSE
 	ventcrawler = 2
 	a_intent = INTENT_HARM
-	speed = -0.3
+	speed = 0.3
 	can_hide = TRUE
 	pass_door_while_hidden = TRUE
 	var/datum/mind/origin

--- a/code/modules/mob/living/simple_animal/hostile/headslug.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headslug.dm
@@ -64,6 +64,7 @@
 
 /obj/item/organ/internal/body_egg/changeling_egg/egg_process()
 	// Changeling eggs grow in everyone
+	time++
 	if(time >= 30 && prob(30))
 		owner.bleed(5)
 	if(time >= 60 && prob(5))

--- a/code/modules/mob/living/simple_animal/hostile/headslug.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headslug.dm
@@ -44,7 +44,7 @@
 	egg_layed = TRUE
 
 /mob/living/simple_animal/hostile/headslug/AltClickOn(mob/living/carbon/carbon_target)
-	if(egg_layed || !istype(carbon_target))
+	if(egg_layed || !istype(carbon_target) || !Adjacent(carbon_target))
 		return ..()
 	if(carbon_target.stat != DEAD && !do_mob(src, carbon_target, 5 SECONDS))
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Reworks last resort
Last resort no longer stuns for 2 seconds, knocks down now for 4
Headslugs now move much faster, a 1 speed delay to a .3 speed delay, still slower than a human 
Planting your eggs is now done with alt-click
Eggs can now be planted in living mobs, takes 5 seconds of them staying still to do so, hatches slower, and gives them notices that they are infected
Eggs can now be planted in small mobs
Headslugs now die after 25 seconds post egging, instead of 10
Headslugs can now hide and pass under doors while hidden

## Why It's Good For The Game
I've been running a poll on changeling balance stuff, and this is considered to be the weakest changeling ability only tied by organic shield. I must agree this ability fucking sucks

This ability requires you to have
1. A body basically set up in advanced (semi permakilling someone or rolling geneticist access, you're not getting someone from the morgue unless the coroner is awful). This also requires the body sticks around.
2. A way to actually get out of the whole "surrounded by officers" situation you're probably in, not assisted with your pathetic melee damage and slow speed
3. Some way to not get instantly merc'd after actually reviving, which is rare (And will still be rare after this buff)

It's not a remotely practical ability at all, requiring significant setup on your "last resort" sort of sucks.

Small lock has been removed because TBF it's not an issue to be able to use a monkey as a target for your headslug because they'll almost always be in a somewhat public area and doesn't really resolve the issue of you being nearly defenseless after becoming a monkey.
 
Speed was increased because there really isn't a way to escape from anything with half carbon speed. The ability to hide was added along with being able to pass under doors so that headslugs can actually somewhat escape a room that requires actual access. Longer death delay was added because I think it would just generally be more fun.  Stun was replaced with a knockdown because it's just not really needed, you can escape normally if you want to now. Being able to egg living mobs probably won't come up often but it'll be really funny when it does. Just requiring an alt-click has been added to give a little extra degree of control to the headslug.

## Testing
it do work

## Changelog
:cl:
tweak: Last resort has been reworked 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
