### PR TITLE
Moves the traitor posion bottle to the main uplink from job specific

### DIFF
--- a/code/datums/uplink_items/uplink_general.dm
+++ b/code/datums/uplink_items/uplink_general.dm
@@ -319,6 +319,13 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/gun/syringe/rapidsyringe/preloaded/half
 	cost = 8
 
+/datum/uplink_item/stealthy_weapons/poisonbottle
+	name = "Poison Bottle"
+	desc = "The Syndicate will ship a bottle containing 40 units of a randomly selected poison. The poison can range from highly irritating to incredibly lethal."
+	reference = "TPB"
+	item = /obj/item/reagent_containers/glass/bottle/traitor
+	cost = 2
+
 /datum/uplink_item/stealthy_weapons/silencer
 	name = "Universal Suppressor"
 	desc = "Fitted for use on any small caliber weapon with a threaded barrel, this suppressor will silence the shots of the weapon for increased stealth and superior ambushing capability."

--- a/code/datums/uplink_items/uplink_traitor.dm
+++ b/code/datums/uplink_items/uplink_traitor.dm
@@ -260,16 +260,6 @@
 	cost = 8
 	job = list("Scientist", "Research Director", "Geneticist", "Chief Medical Officer", "Medical Doctor", "Psychiatrist", "Chemist", "Paramedic", "Coroner", "Virologist")
 
-//Tator Poison Bottles
-
-/datum/uplink_item/jobspecific/poisonbottle
-	name = "Poison Bottle"
-	desc = "The Syndicate will ship a bottle containing 40 units of a randomly selected poison. The poison can range from highly irritating to incredibly lethal."
-	reference = "TPB"
-	item = /obj/item/reagent_containers/glass/bottle/traitor
-	cost = 2
-	job = list("Research Director", "Chief Medical Officer", "Medical Doctor", "Psychiatrist", "Chemist", "Paramedic", "Virologist", "Bartender", "Chef")
-
 // Paper contact poison pen
 
 /datum/uplink_item/jobspecific/poison_pen


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Moves the traitor posion bottle to the main uplink from job specific

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Some people have asked me to do this in the past, and I agree.
The jobs that can buy the bottle, do often feed people reagents. However, these people can already make reagents to poison with, there is no reason to keep the poison to them.

We allow anyone to buy the sleepy pen / RSG / dart pistol kit, so we might as well let them gamble on toxins to reload it with.

## Testing
<!-- How did you test the PR, if at all? -->

Confirmed uplink had it.

## Changelog
:cl:
tweak: Any traitor can now buy the traitor poison bottles.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
