### PR TITLE
garrote tweak

### DIFF
--- a/code/__DEFINES/status_effects.dm
+++ b/code/__DEFINES/status_effects.dm
@@ -125,6 +125,7 @@
 #define STATUS_EFFECT_DRUNKENNESS /datum/status_effect/transient/drunkenness
 #define STATUS_EFFECT_SILENCED /datum/status_effect/transient/silence
 #define STATUS_EFFECT_ABSSILENCED /datum/status_effect/transient/silence/absolute
+#define STATUS_EFFECT_NO_OXY_HEAL /datum/status_effect/transient/no_oxy_heal
 #define STATUS_EFFECT_JITTER /datum/status_effect/transient/jittery
 #define STATUS_EFFECT_CULT_SLUR /datum/status_effect/transient/cult_slurring
 #define STATUS_EFFECT_STAMMER /datum/status_effect/transient/stammering
@@ -160,4 +161,4 @@
 /// gives you fluff messages for cough, sneeze, headache, etc but without an actual virus
 #define STATUS_EFFECT_FAKE_VIRUS /datum/status_effect/fake_virus
 /// This status effect lets the user see the lwap dots.
-#define STATUS_EFFECT_LWAPSCOPE /datum/status_effect/lwap_scope 
+#define STATUS_EFFECT_LWAPSCOPE /datum/status_effect/lwap_scope

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -677,6 +677,9 @@
 /datum/status_effect/transient/silence/absolute // this one will mute all emote sounds including gasps
 	id = "abssilenced"
 
+/datum/status_effect/transient/no_oxy_heal
+	id = "no_oxy_heal"
+
 /datum/status_effect/transient/jittery
 	id = "jittering"
 

--- a/code/game/objects/items/weapons/garrote.dm
+++ b/code/game/objects/items/weapons/garrote.dm
@@ -154,7 +154,10 @@
 
 
 	strangling.AbsoluteSilence(6 SECONDS) // Non-improvised effects
-	strangling.apply_damage(4, OXY, "head")
+	if(G.state == GRAB_KILL)
+		strangling.PreventOxyHeal(6 SECONDS)
+		strangling.AdjustLoseBreath(6 SECONDS)
+		strangling.apply_damage(4, OXY, "head")
 
 
 /obj/item/twohanded/garrote/suicide_act(mob/user)

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -157,6 +157,8 @@
 	if(HAS_TRAIT(src, TRAIT_NOBREATH))
 		oxyloss = 0
 		return FALSE
+	if(amount < 0 && has_status_effect(STATUS_EFFECT_NO_OXY_HEAL))
+		return FALSE
 	var/old_oxyloss = oxyloss
 	oxyloss = max(oxyloss + amount, 0)
 	if(old_oxyloss == oxyloss)

--- a/code/modules/mob/living/living_status_procs.dm
+++ b/code/modules/mob/living/living_status_procs.dm
@@ -425,6 +425,15 @@ STATUS EFFECTS
 /mob/living/proc/SetAbsoluteSilence(amount)
 	SET_STATUS_EFFECT_STRENGTH(STATUS_EFFECT_ABSSILENCED, amount)
 
+/mob/living/proc/PreventedOxyHeal()
+	RETURN_STATUS_EFFECT_STRENGTH(STATUS_EFFECT_NO_OXY_HEAL)
+
+/mob/living/proc/PreventOxyHeal(amount)
+	SetPreventOxyHeal(max(PreventedOxyHeal(), amount))
+
+/mob/living/proc/SetPreventOxyHeal(amount)
+	SET_STATUS_EFFECT_STRENGTH(STATUS_EFFECT_NO_OXY_HEAL, amount)
+
 /mob/living/proc/AdjustSilence(amount, bound_lower = 0, bound_upper = INFINITY)
 	SetSilence(directional_bounded_sum(AmountSilenced(), amount, bound_lower, bound_upper))
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
This PR tweaks syndicate garrote logic. 
If you're garroting person but your grab is not in kill state, it will only mute them
If you're garroting person with grab in kill state, oxy healing chemicals, breathing tubes wont help them, the only thing could help is NO_BREATHE trait
Trait NO_BREATHE could be get from genes, from being some golem or a machine or from DNA vault

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Well. Actually i wanted to fix garroting salbutamol person not killing them, but this tweak is better by my sight. Currently if you try to garrote person with salbutamol, you'll be just unable to kill them, if you're garroting person with breathing tube that will be extremely slow

After those changes all garrote kills on full hp person will take like 2 mins(my tests showed 100, 128, 89, 106 and 122 seconds)
With garrote being absolute silent weapon time to kill 2 mins is fine, but being unable to kill cause they have chems or killing for like 10 mins cause they have breathing tube is kinda stupid
Also after those changes we will be able to steal person without killing them by just garroting if we will not push grab button which also sounds cool

This doesnt change logic of improvised garrote

## Testing
<!-- How did you test the PR, if at all? -->
tested, garroted

## Changelog
:cl:
tweak: Fiber wire garrote now kills only on kill grab
tweak: Fiber wire garrote prevents you to heal oxygen damage on kill grab
tweak: Fiber wire garrote forces you to loose breathe on kill grab
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
