### PR TITLE
Bear traps can now be made from the autolathe and other bear trap changes

### DIFF
--- a/code/game/objects/items/weapons/legcuffs.dm
+++ b/code/game/objects/items/weapons/legcuffs.dm
@@ -137,7 +137,7 @@
 				if(istype(L,/mob/living/simple_animal/hostile/bear))
 					L.apply_damage(trap_damage * 2.5, BRUTE)
 				else
-					L.apply_damage(trap_damage, BRUTE)
+					L.apply_damage(trap_damage * 1.75, BRUTE)
 	..()
 
 /obj/item/restraints/legcuffs/beartrap/energy

--- a/code/game/objects/items/weapons/legcuffs.dm
+++ b/code/game/objects/items/weapons/legcuffs.dm
@@ -10,7 +10,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	origin_tech = "engineering=3;combat=3"
 	slowdown = 7
-	breakouttime = 300	//Deciseconds = 30s = 0.5 minute
+	breakouttime = 30 SECONDS
 
 /obj/item/restraints/legcuffs/beartrap
 	name = "bear trap"
@@ -19,6 +19,7 @@
 	icon_state = "beartrap0"
 	desc = "A trap used to catch bears and other legged creatures."
 	origin_tech = "engineering=4"
+	breakouttime = 15 SECONDS
 	var/armed = FALSE
 	var/trap_damage = 20
 	///Do we want the beartrap not to make a visable message on arm? Use when a beartrap is applied by something else.
@@ -41,10 +42,16 @@
 
 /obj/item/restraints/legcuffs/beartrap/attack_self(mob/user)
 	..()
-	if(ishuman(user) && !user.stat && !user.restrained())
+	if(ishuman(user) && !user.stat && !user.restrained() && do_after(user, 20, target = src))
 		armed = !armed
 		update_icon(UPDATE_ICON_STATE)
-		to_chat(user, "<span class='notice'>[src] is now [armed ? "armed" : "disarmed"]</span>")
+		to_chat(user, "<span class='notice'>[src] is now [armed ? "armed" : "disarmed"].</span>")
+
+/obj/item/restraints/legcuffs/beartrap/can_enter_storage(obj/item/storage/S, mob/user)
+	if(armed)
+		to_chat(user, "<span class='warning'>[S] can't hold [src] while it's active!</span>")
+		return FALSE
+	return TRUE
 
 /obj/item/restraints/legcuffs/beartrap/attackby(obj/item/I, mob/user) //Let's get explosive.
 	if(istype(I, /obj/item/grenade/iedcasing))
@@ -127,7 +134,10 @@
 					SSblackbox.record_feedback("tally", "handcuffs", 1, type)
 
 			else
-				L.apply_damage(trap_damage, BRUTE)
+				if(istype(L,/mob/living/simple_animal/hostile/bear))
+					L.apply_damage(trap_damage * 2.5, BRUTE)
+				else
+					L.apply_damage(trap_damage, BRUTE)
 	..()
 
 /obj/item/restraints/legcuffs/beartrap/energy

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -888,7 +888,7 @@
 	build_path = /obj/item/assembly/mousetrap
 	category = list("initial", "Miscellaneous")
 
-/datum/design/mousetrap
+/datum/design/beartrap
 	name = "Bear Trap"
 	id = "beartrap"
 	build_type = AUTOLATHE

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -888,6 +888,14 @@
 	build_path = /obj/item/assembly/mousetrap
 	category = list("initial", "Miscellaneous")
 
+/datum/design/mousetrap
+	name = "Bear Trap"
+	id = "beartrap"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 12000)
+	build_path = /obj/item/restraints/legcuffs/beartrap
+	category = list("hacked", "Miscellaneous")
+
 /datum/design/vendor
 	name = "Machine Board (Vendor)"
 	desc = "The circuit board for a Vendor."


### PR DESCRIPTION
## What Does This PR Do
Allows hacked autolathes to make bear traps, costing 12000 units of metal each (or 6 sheets) unupgraded.
Bear traps deal 1.75x to simplemobs, and 2.5x more damage to bears.
Removing a bear trap now takes 15 seconds instead of 30.
Arming / Disarming a bear trap in your hand now takes 2 seconds of standing still.
Armed bear traps cannot be put in storage containers.

## Why It's Good For The Game
Bear traps are a somewhat rare item that are only available in janitor crates and janitor-themed rooms, this allows you to produce more to lay down traps with, while also dealing with some common balance complaints from them.

## Testing
1. booted up test server with changes
2. spawned myself with gamma engineer ert gear next to cargo autolathe
3. accidentally deconstructed my power drill on the autolathe because it was on the wrong mode
4. picked up the nearby screwdriver and hacked it
5. printed the bear traps and killed paperwork and bears with them

## Changelog
:cl:
add: Bear traps can now be printed from hacked autolathes.
tweak: Bear traps deal 1.75x more damage to simplemobs, and 2.5x more damage to bears.
tweak: Removing bear traps takes 15 seconds instead of 30.
tweak: Arming / Disarming a bear trap in your hand now takes 2 seconds of standing still.
tweak: Armed bear traps cannot be put in storage containers.
/:cl: