### PR TITLE
Fixes reset modules not properly clearing upgrades

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_mob.dm
+++ b/code/modules/mob/living/silicon/robot/robot_mob.dm
@@ -550,6 +550,10 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 		weather_immunities -= "lava"
 	armor = getArmor(arglist(initial(armor)))
 
+	for(var/obj/item/borg/upgrade/U in contents)
+		QDEL_NULL(U)
+		//This is needed so that upgrades can be installed again after the borg's module is reset.
+
 	status_flags |= CANPUSH
 
 //for borg hotkeys, here module refers to borg inv slot, not core module


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Title - while reset modules remove the _effects_ of upgrades, they don't remove the upgrades themselves. This fixes that.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Bugs are bad
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Loaded in and applied upgrades to myself, then proc called reset_module and saw that it worked
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: The reset module upgrade now properly deletes other upgrades on use
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
