### PR TITLE
morphine now processes on OD

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -611,6 +611,7 @@
 	shock_reduction = 50
 	harmless = FALSE
 	taste_description = "a delightful numbing"
+	allowed_overdose_process = TRUE
 
 /datum/reagent/medicine/morphine/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

morphine now processes on OD

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Morphine is supposed to sleep them when it is in their system for a while. This is the downside of morphine as a painkiller, and the upside if using it to sleep people. However, because I am an idiot and missed morphine as it had no personal overdose process, since morphine does not process when overdosed, overdosing on morphine lets you ignore the downside of morphine.

I probably should have made it true by default then false for the problematic reagents in the overdose pr, that is on me.

## Testing
<!-- How did you test the PR, if at all? -->

confirmed people go to sleepy zone

## Changelog
:cl:
fix: Overdosing on morphine once again will still have you be asleep.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
