### PR TITLE
Sets the SM layer to be above normal mobs

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -85,6 +85,7 @@
 	icon_state = "darkmatter"
 	density = TRUE
 	anchored = TRUE
+	layer = ABOVE_MOB_LAYER + 0.01
 	flags_2 = RAD_PROTECT_CONTENTS_2 | RAD_NO_CONTAMINATE_2 | IMMUNE_TO_SHUTTLECRUSH_2 | NO_MALF_EFFECT_2 | CRITICAL_ATOM_2
 	light_range = 4
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF | FREEZE_PROOF


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes the SM be a tad above the mob layer instead of defaulting to above objects.

## Why It's Good For The Game
Doesn't really make sense for the SM to be below mobs when they'll dust them, and being two turfs in height, it needs to obscure them.

## Images of changes
![SM_Layer](https://github.com/ParadiseSS13/Paradise/assets/80771500/dfde5aae-2fbc-4d86-9954-1fd163be1aaa)

## Testing
Set railings around the SM, spawned a mob on the turf above it.

## Changelog
:cl:
fix: SM crystal's layer is set above mobs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
