### PR TITLE
Recharger icon update fix

### DIFF
--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -231,6 +231,9 @@
 	else
 		recharge_cell(C, RECHARGER_POWER_USAGE_MISC)
 
+	if(!check_cell_needs_recharging(C)) // we recharged cell, does it still need power? If no, recharger should bling yellow
+		return FALSE
+
 	return TRUE
 
 /obj/machinery/recharger/examine(mob/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
This PR adds second check if cell is recharged after applying power to it in recharger

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Recharger showing "recharge state" while cell is already 100% forces player to shiftclick recharger a lot of times to check if their gun/cell/baton is already 100%. That is uncool, lets make rechargers more intuitive

## Testing
<!-- How did you test the PR, if at all? -->
compiled, recharged

## Changelog
:cl:
fix: Recharger now updates icon at moment cell got 100% charge, not later
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
