### PR TITLE
Add a flag that allows atoms to block lights in their contents, with storage items being the first to use it

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -48,6 +48,7 @@
 #define STATIONLOVING_2			16
 #define INFORM_ADMINS_ON_RELOCATE_2	32
 #define BANG_PROTECT_2			64
+#define BLOCKS_LIGHT_2          128 // Light sources placed in anything with that flag will not emit light through them.
 
 // A mob with OMNITONGUE has no restriction in the ability to speak
 // languages that they know. So even if they wouldn't normally be able to

--- a/code/game/objects/items/weapons/storage/storage_base.dm
+++ b/code/game/objects/items/weapons/storage/storage_base.dm
@@ -9,6 +9,7 @@
 	name = "storage"
 	icon = 'icons/obj/storage.dmi'
 	w_class = WEIGHT_CLASS_NORMAL
+	flags_2 = BLOCKS_LIGHT_2
 	/// No message on putting items in.
 	var/silent = FALSE
 	/// List of objects which this item can store (if set, it can't store anything else)

--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -32,7 +32,10 @@
 /datum/light_source/New(atom/owner, atom/top)
 	source_atom = owner // Set our new owner.
 	LAZYADD(source_atom.light_sources, src)
-	top_atom = top
+	if(top.flags_2 & BLOCKS_LIGHT_2) // If the top atom blocks light, then our owner becomes the topmost instead. This still allows atoms that block light to be a light of their own.
+		top_atom = source_atom
+	else
+		top_atom = top
 	if(top_atom != source_atom)
 		LAZYADD(top_atom.light_sources, src)
 
@@ -77,7 +80,10 @@
 		if(top_atom != source_atom && top_atom.light_sources) // Remove ourselves from the light sources of that top atom.
 			LAZYREMOVE(top_atom.light_sources, src)
 
-		top_atom = new_top_atom
+		if(new_top_atom.flags_2 & BLOCKS_LIGHT_2)
+			top_atom = source_atom
+		else
+			top_atom = new_top_atom
 
 		if(top_atom != source_atom)
 			LAZYADD(top_atom.light_sources, src) // Add ourselves to the light sources of our new top atom.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds the flag `BLOCKS_LIGHT_2` (Bit 8 was oddly skipped, so it was wedged in there instead of creating a new var) for atoms, and have the light datum check if their top atom has said flag. If they do, they're not set as the top, with the originating atom becoming the top atom instead.

Atoms with the flag can still be light sources of their own as the flag only pertains to contents.

## Why It's Good For The Game
This was raised when bags would suddenly start emitting light when dropped, as they'd become the top atom for their content's light instead of the mob. For shadow demons in particular that was rather problematic.

If there's storage items that _should_ let light through, it'd be nice to be pointed out. Right now it's all `/obj/item/storage`.

## Images of changes
https://github.com/ParadiseSS13/Paradise/assets/80771500/29f28598-26f8-4b4e-a414-10b502c8dc73

## Testing
Spawned in with a flashlight, turned it on, put it in a bag and dropped the bag. Picked it up and took out the light.

## Changelog
:cl:
tweak: Lights in bags and other kinds of storage do not emit through them when dropped.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
