### PR TITLE
Biodegrade buff

### DIFF
--- a/code/modules/antagonists/changeling/powers/biodegrade.dm
+++ b/code/modules/antagonists/changeling/powers/biodegrade.dm
@@ -139,8 +139,9 @@
 	parent_action = new_parent
 
 /obj/item/melee/changeling_corrosive_acid/Destroy()
-	parent_action.current_hand = null
-	parent_action.UnregisterSignal(parent_action.owner, COMSIG_MOB_WILLINGLY_DROP)
+	if(parent_action)
+		parent_action.current_hand = null
+		parent_action.UnregisterSignal(parent_action.owner, COMSIG_MOB_WILLINGLY_DROP)
 	return ..()
 
 /obj/item/melee/changeling_corrosive_acid/afterattack(atom/target, mob/user, proximity, params)

--- a/code/modules/antagonists/changeling/powers/biodegrade.dm
+++ b/code/modules/antagonists/changeling/powers/biodegrade.dm
@@ -1,6 +1,6 @@
 /datum/action/changeling/biodegrade
 	name = "Biodegrade"
-	desc = "Dissolves restraints or other objects preventing free movement if we are restrained. Prepares hand to vomits acid on other object, doesnt work on living targets. Costs 30 chemicals."
+	desc = "Dissolves restraints or other objects preventing free movement if we are restrained. Prepares hand to vomit acid on other objects, doesn't work on living targets. Costs 30 chemicals."
 	helptext = "This is obvious to nearby people, and can destroy standard restraints and closets, and break you out of grabs."
 	button_icon_state = "biodegrade"
 	chemical_cost = 30 //High cost to prevent spam

--- a/code/modules/antagonists/changeling/powers/biodegrade.dm
+++ b/code/modules/antagonists/changeling/powers/biodegrade.dm
@@ -1,18 +1,17 @@
 /datum/action/changeling/biodegrade
 	name = "Biodegrade"
-	desc = "Dissolves restraints or other objects preventing free movement. Costs 30 chemicals."
+	desc = "Dissolves restraints or other objects preventing free movement if we are restrained. Prepares hand to vomits acid on other object, doesnt work on living targets. Costs 30 chemicals."
 	helptext = "This is obvious to nearby people, and can destroy standard restraints and closets, and break you out of grabs."
 	button_icon_state = "biodegrade"
 	chemical_cost = 30 //High cost to prevent spam
 	dna_cost = 2
 	req_human = TRUE
 	power_type = CHANGELING_PURCHASABLE_POWER
+	var/hand = /obj/item/melee/changeling_corrosive_acid
+	var/obj/item/melee/changeling_corrosive_acid/current_hand
 
 /datum/action/changeling/biodegrade/sting_action(mob/living/carbon/human/user)
 	var/used = FALSE // only one form of shackles removed per use
-	if(!user.restrained() && !user.legcuffed && !istype(user.loc, /obj/structure/closet) && !istype(user.loc, /obj/structure/spider/cocoon) && !user.grabbed_by)
-		to_chat(user, "<span class='warning'>We are already free!</span>")
-		return FALSE
 
 	if(user.handcuffed)
 		var/obj/O = user.get_item_by_slot(slot_handcuffed)
@@ -20,7 +19,7 @@
 			return FALSE
 		user.visible_message("<span class='warning'>[user] vomits a glob of acid on [user.p_their()] [O.name]!</span>", \
 			"<span class='warning'>We vomit acidic ooze onto our restraints!</span>")
-		addtimer(CALLBACK(src, PROC_REF(dissolve_restraint), user, O), 3 SECONDS)
+		dissolve_restraint(user, O)
 		used = TRUE
 
 	if(user.legcuffed)
@@ -29,7 +28,7 @@
 			return FALSE
 		user.visible_message("<span class='warning'>[user] vomits a glob of acid on [user.p_their()] [O.name]!</span>", \
 			"<span class='warning'>We vomit acidic ooze onto our leg restraints!</span>")
-		addtimer(CALLBACK(src, PROC_REF(dissolve_restraint), user, O), 3 SECONDS)
+		dissolve_restraint(user, O)
 		used = TRUE
 
 	if(user.wear_suit && user.wear_suit.breakouttime && !used)
@@ -38,7 +37,7 @@
 			return FALSE
 		user.visible_message("<span class='warning'>[user] vomits a glob of acid across the front of [user.p_their()] [S.name]!</span>", \
 			"<span class='warning'>We vomit acidic ooze onto our straight jacket!</span>")
-		addtimer(CALLBACK(src, PROC_REF(dissolve_restraint), user, S), 3 SECONDS)
+		dissolve_restraint(user, S)
 		used = TRUE
 
 	if(istype(user.loc, /obj/structure/closet) && !used)
@@ -67,9 +66,19 @@
 		user.SetWeakened(0)
 		playsound(user.loc, 'sound/weapons/sear.ogg', 50, TRUE)
 		used = TRUE
+
 	if(used)
 		SSblackbox.record_feedback("nested tally", "changeling_powers", 1, list("[name]"))
-	return TRUE
+		return TRUE
+
+	if(!current_hand)
+		if(!add_hand_spell(user))
+			return FALSE
+		to_chat(user, "<span class='warning'>We prepare hand to vomit acid!</span>")
+		return TRUE
+	else
+		remove_hand_spell(user, TRUE)
+		return FALSE
 
 /datum/action/changeling/biodegrade/proc/dissolve_restraint(mob/living/carbon/human/user, obj/O)
 	if(O && (user.handcuffed == O || user.legcuffed == O || user.wear_suit == O))
@@ -91,3 +100,57 @@
 	if(C && user.loc == C)
 		qdel(C) //The cocoon's destroy will move the changeling outside of it without interference
 		to_chat(user, "<span class='warning'>We dissolve the cocoon!</span>")
+
+/datum/action/changeling/biodegrade/proc/add_hand_spell(mob/living/carbon/human/user)
+	if(user.get_active_hand() && !user.drop_item())
+		to_chat(user, "<span class='warning'>[user.get_active_hand()] is stuck to our hand, we cannot emit acid on this hand.</span>")
+		return FALSE
+	current_hand = new hand(src)
+	user.put_in_active_hand(current_hand)
+	RegisterSignal(user, COMSIG_MOB_WILLINGLY_DROP, PROC_REF(remove_hand_spell))
+	return TRUE
+
+/datum/action/changeling/biodegrade/proc/remove_hand_spell(mob/living/carbon/human/user, any=FALSE)
+	SIGNAL_HANDLER
+	if(!current_hand)
+		return FALSE
+	if(any && user.get_active_hand() != current_hand)
+		return FALSE
+	qdel(current_hand)
+	current_hand = null
+	UnregisterSignal(user, COMSIG_MOB_WILLINGLY_DROP)
+	return TRUE
+
+/obj/item/melee/changeling_corrosive_acid
+	name = "Corrosive acid"
+	desc = "A fistfull of death."
+	icon_state = "alien_acid"
+	item_state = null
+	flags = ABSTRACT | NODROP | DROPDEL
+	w_class = WEIGHT_CLASS_HUGE
+	force = 0
+	throwforce = 0
+	throw_range = 0
+	throw_speed = 0
+	var/datum/action/changeling/biodegrade/parent_action
+
+/obj/item/melee/changeling_corrosive_acid/New(datum/action/changeling/biodegrade/new_parent)
+	. = ..()
+	parent_action = new_parent
+
+/obj/item/melee/changeling_corrosive_acid/afterattack(atom/target, mob/user, proximity, params)
+	if(target == user)
+		to_chat(user, "<span class='noticealien'>You withdraw your readied acid.</span>")
+		parent_action.remove_hand_spell(user)
+		return
+	if(isliving(target))
+		to_chat(user, "<span class='alert'>We dont have enough acid to assault living target!</span>")
+		return
+	if(!proximity || !iscarbon(user) || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED)) // Don't want xenos ditching out of cuffs
+		return
+	if(target.acid_act(200, 100))
+		visible_message("<span class='alert'>[user] vomits globs of vile stuff all over [target]. It begins to sizzle and melt under the bubbling mess of acid!</span>")
+		add_attack_logs(user, target, "Applied corrosive acid") // Want this logged
+	else
+		to_chat(user, "<span class='noticealien'>You cannot dissolve this object.</span>")
+	parent_action.remove_hand_spell(user)

--- a/code/modules/antagonists/changeling/powers/biodegrade.dm
+++ b/code/modules/antagonists/changeling/powers/biodegrade.dm
@@ -7,8 +7,10 @@
 	dna_cost = 2
 	req_human = TRUE
 	power_type = CHANGELING_PURCHASABLE_POWER
-	var/hand = /obj/item/melee/changeling_corrosive_acid //Type of acid hand we give to person
-	var/obj/item/melee/changeling_corrosive_acid/current_hand //Current hand given to human, null is we did not give hand, object if hand is given
+	/// Type of acid hand we give to person
+	var/hand = /obj/item/melee/changeling_corrosive_acid
+	/// Current hand given to human, null is we did not give hand, object if hand is given
+	var/obj/item/melee/changeling_corrosive_acid/current_hand
 
 /datum/action/changeling/biodegrade/sting_action(mob/living/carbon/human/user)
 	var/used = FALSE // only one form of shackles removed per use

--- a/code/modules/antagonists/changeling/powers/biodegrade.dm
+++ b/code/modules/antagonists/changeling/powers/biodegrade.dm
@@ -78,9 +78,8 @@
 			return FALSE
 		to_chat(user, "<span class='warning'>We prepare hand to vomit acid!</span>")
 		return TRUE
-	else
-		remove_hand_spell(user, TRUE)
-		return FALSE
+	remove_hand_spell(user, TRUE)
+	return FALSE
 
 /datum/action/changeling/biodegrade/proc/dissolve_restraint(mob/living/carbon/human/user, obj/O)
 	if(O && (user.handcuffed == O || user.legcuffed == O || user.wear_suit == O))

--- a/code/modules/antagonists/changeling/powers/biodegrade.dm
+++ b/code/modules/antagonists/changeling/powers/biodegrade.dm
@@ -7,8 +7,8 @@
 	dna_cost = 2
 	req_human = TRUE
 	power_type = CHANGELING_PURCHASABLE_POWER
-	var/hand = /obj/item/melee/changeling_corrosive_acid
-	var/obj/item/melee/changeling_corrosive_acid/current_hand
+	var/hand = /obj/item/melee/changeling_corrosive_acid //Type of acid hand we give to person
+	var/obj/item/melee/changeling_corrosive_acid/current_hand //Current hand given to human, null is we did not give hand, object if hand is given
 
 /datum/action/changeling/biodegrade/sting_action(mob/living/carbon/human/user)
 	var/used = FALSE // only one form of shackles removed per use

--- a/code/modules/antagonists/changeling/powers/biodegrade.dm
+++ b/code/modules/antagonists/changeling/powers/biodegrade.dm
@@ -119,7 +119,6 @@
 	if(any_hand && user.get_active_hand() != current_hand)
 		return FALSE
 	qdel(current_hand)
-	UnregisterSignal(user, COMSIG_MOB_WILLINGLY_DROP)
 	return TRUE
 
 /obj/item/melee/changeling_corrosive_acid
@@ -139,6 +138,11 @@
 	. = ..()
 	parent_action = new_parent
 
+/obj/item/melee/changeling_corrosive_acid/Destroy()
+	parent_action.current_hand = null
+	parent_action.UnregisterSignal(parent_action.owner, COMSIG_MOB_WILLINGLY_DROP)
+	return ..()
+
 /obj/item/melee/changeling_corrosive_acid/afterattack(atom/target, mob/user, proximity, params)
 	if(target == user)
 		to_chat(user, "<span class='noticealien'>You withdraw your readied acid.</span>")
@@ -155,7 +159,3 @@
 	else
 		to_chat(user, "<span class='noticealien'>You cannot dissolve this object.</span>")
 	parent_action.remove_hand_spell(user)
-
-/obj/item/melee/changeling_corrosive_acid/Destroy()
-	parent_action.current_hand = null
-	return ..()

--- a/code/modules/antagonists/changeling/powers/biodegrade.dm
+++ b/code/modules/antagonists/changeling/powers/biodegrade.dm
@@ -110,14 +110,13 @@
 	RegisterSignal(user, COMSIG_MOB_WILLINGLY_DROP, PROC_REF(remove_hand_spell))
 	return TRUE
 
-/datum/action/changeling/biodegrade/proc/remove_hand_spell(mob/living/carbon/human/user, any=FALSE)
+/datum/action/changeling/biodegrade/proc/remove_hand_spell(mob/living/carbon/human/user, any_hand=FALSE)
 	SIGNAL_HANDLER
 	if(!current_hand)
 		return FALSE
-	if(any && user.get_active_hand() != current_hand)
+	if(any_hand && user.get_active_hand() != current_hand)
 		return FALSE
 	qdel(current_hand)
-	current_hand = null
 	UnregisterSignal(user, COMSIG_MOB_WILLINGLY_DROP)
 	return TRUE
 
@@ -154,3 +153,7 @@
 	else
 		to_chat(user, "<span class='noticealien'>You cannot dissolve this object.</span>")
 	parent_action.remove_hand_spell(user)
+
+/obj/item/melee/changeling_corrosive_acid/Destroy()
+	parent_action.current_hand = null
+	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
This PR removed delay of removing cuffs, legcuffs, grabs when using biodegrade changeling ability
This PR adds acid hand as lesser version of xeno corrosive acid. It cant be used to attack someone(xeno corrosive is GREAT assault weapon), but still can melt walls and other objects.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Biodegrade costs 2 evolution points and 30 chemicals on use and thats the only way for changeling to remove handcuffs without statis. rn it has delay on removing cuffs which allows sec to just baton you and you're losing escape chance again.

By my sight it should work like basic freedom implant, meaning removing cuffs and other instantly, allows you to action.
Also using this acid to melt other objects looks fine. It wont overpower cling(cause its melting is TOO LONG to be OP and cant melt a LOT of objects) but makes ability more usable.

## Testing
<!-- How did you test the PR, if at all? -->
compiled, melted

## Changelog
:cl:
add: Using biodegrade without being restrained allows you to vomit acid at other object. It works like xenos corrosive acid, but cant melt living.
tweak: Biodegrade used while being restrained removes cuffs, legcuffs and grabs without delay.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
