### PR TITLE
Engi ERT now get hardened wireless interface implants

### DIFF
--- a/code/modules/response_team/ert_outfits.dm
+++ b/code/modules/response_team/ert_outfits.dm
@@ -228,7 +228,7 @@
 	suit_store = /obj/item/tank/internals/emergency_oxygen/engi
 	glasses = /obj/item/clothing/glasses/meson/engine
 	mask = /obj/item/clothing/mask/gas
-	cybernetic_implants = list(/obj/item/organ/internal/cyberimp/brain/wire_interface)
+	cybernetic_implants = list(/obj/item/organ/internal/cyberimp/brain/wire_interface/hardened)
 
 	l_pocket = /obj/item/gun/energy/gun/mini
 	r_pocket = /obj/item/melee/classic_baton/telescopic
@@ -251,7 +251,7 @@
 	cybernetic_implants = list(
 	/obj/item/organ/internal/eyes/cybernetic/shield,
 	/obj/item/organ/internal/cyberimp/chest/nutriment/hardened,
-	/obj/item/organ/internal/cyberimp/brain/wire_interface
+	/obj/item/organ/internal/cyberimp/brain/wire_interface/hardened
 	)
 	l_pocket = /obj/item/t_scanner
 	r_pocket = /obj/item/melee/classic_baton/telescopic
@@ -289,7 +289,7 @@
 		/obj/item/organ/internal/cyberimp/brain/anti_stam/hardened,
 		/obj/item/organ/internal/eyes/cybernetic/shield,
 		/obj/item/organ/internal/cyberimp/arm/toolset,
-		/obj/item/organ/internal/cyberimp/brain/wire_interface
+		/obj/item/organ/internal/cyberimp/brain/wire_interface/hardened
 	)
 
 	implants = list(/obj/item/implant/mindshield,

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -280,6 +280,13 @@
 	REMOVE_TRAIT(M, TRAIT_SHOW_WIRE_INFO, "show_wire_info[UID()]")
 	return ..()
 
+/obj/item/organ/internal/cyberimp/brain/wire_interface/hardened
+	name = "Hardened Wire interface implant"
+	desc = "This wire interface implant is actually wireless, to avoid issues with electromagnetic pulses."
+	origin_tech = "materials=6;programming=6;biotech=6"
+	emp_proof = TRUE
+
+
 //[[[[MOUTH]]]]
 /obj/item/organ/internal/cyberimp/mouth
 	parent_organ = "mouth"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Adds the hardened wire interface implant.
Replaces the wire implant on ERT with the hardened one.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

It's really funny watching ERT get hard stunned for 10 seconds from an EMP

It's less great balance wise however, and all other ERT implants that stun are hardened, so...

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
<!-- How did you test the PR, if at all? -->
![image](https://github.com/ParadiseSS13/Paradise/assets/52090703/b0af2a9a-d527-4be4-aa4f-dde249348431)

confirmed engi ERT had the emp proof implant.

## Changelog
:cl:
add: Adds the hardened wire interface implant, now with less wires.
tweak: Engineering ERT now get the hardened implant, rather than the normal one.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
