### PR TITLE
Fixes secure safe inventory breaking

### DIFF
--- a/code/game/objects/items/weapons/storage/secure.dm
+++ b/code/game/objects/items/weapons/storage/secure.dm
@@ -152,7 +152,8 @@
 				locked = TRUE
 				overlays = null
 				code = null
-				close(usr)
+				if(usr.s_active == src)
+					close(usr)
 			else
 				code += text("[]", href_list["type"])
 				if(length(code) > 5)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #20238
By adding a check to make sure that resetting a secure safe it will only close your inventory if the safe is your active inventory, we get no more stacked inventories
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
bug bad
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
1. spawn as captain
2. open backpack
3. go to secure safe(wall safe) and press "R"
4. Enter passcode and open safe
5. safe inventory replaces backpack inventory
6. Profit!
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Fixed issue where safe inventory appeared over other inventories
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
