### PR TITLE
Paramedic Tweaks (and Tiny CMO Tweak)

### DIFF
--- a/code/game/jobs/job/medical_jobs.dm
+++ b/code/game/jobs/job/medical_jobs.dm
@@ -284,8 +284,8 @@
 	supervisors = "the chief medical officer"
 	department_head = list("Chief Medical Officer")
 	selection_color = "#ffeef0"
-	access = list(ACCESS_PARAMEDIC, ACCESS_MEDICAL, ACCESS_MAINT_TUNNELS, ACCESS_EXTERNAL_AIRLOCKS, ACCESS_MORGUE)
-	minimal_access=list(ACCESS_PARAMEDIC, ACCESS_MEDICAL, ACCESS_MAINT_TUNNELS, ACCESS_EXTERNAL_AIRLOCKS, ACCESS_MORGUE)
+	access = list(ACCESS_PARAMEDIC, ACCESS_MEDICAL, ACCESS_MAINT_TUNNELS, ACCESS_EXTERNAL_AIRLOCKS, ACCESS_EVA, ACCESS_MORGUE)
+	minimal_access=list(ACCESS_PARAMEDIC, ACCESS_MEDICAL, ACCESS_MAINT_TUNNELS, ACCESS_EXTERNAL_AIRLOCKS, ACCESS_EVA, ACCESS_MORGUE)
 	minimal_player_age = 3
 	exp_map = list(EXP_TYPE_CREW = 180)
 	outfit = /datum/outfit/job/paramedic

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical_lockers.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical_lockers.dm
@@ -205,6 +205,7 @@
 	new /obj/item/storage/belt/medical(src)
 	new /obj/item/storage/firstaid/adv(src)
 	new /obj/item/clothing/glasses/hud/health(src)
+	new /obj/item/storage/toolbox/emergency(src)
 
 /obj/structure/closet/secure_closet/reagents
 	name = "chemical storage closet"

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical_lockers.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical_lockers.dm
@@ -41,7 +41,7 @@
 
 /obj/structure/closet/secure_closet/medical3
 	name = "medical doctor's locker"
-	req_access = list(ACCESS_SURGERY)
+	req_access = list(ACCESS_MEDICAL)
 	icon_state = "med_secure"
 	open_door_sprite = "white_secure_door"
 
@@ -149,6 +149,7 @@
 	new /obj/item/defibrillator/compact/advanced/loaded(src)
 	new /obj/item/handheld_defibrillator(src)
 	new /obj/item/storage/belt/medical(src)
+	new /obj/item/clothing/glasses/hud/health(src)
 	new /obj/item/flash(src)
 	new /obj/item/gun/syringe(src)
 	new /obj/item/reagent_containers/hypospray/CMO(src)
@@ -200,6 +201,10 @@
 	new /obj/item/key/ambulance(src)
 	new /obj/item/pinpointer/crew(src)
 	new /obj/item/handheld_defibrillator(src)
+	new /obj/item/defibrillator/loaded(src)
+	new /obj/item/storage/belt/medical(src)
+	new /obj/item/storage/firstaid/adv(src)
+	new /obj/item/clothing/glasses/hud/health(src)
 
 /obj/structure/closet/secure_closet/reagents
 	name = "chemical storage closet"

--- a/code/modules/clothing/spacesuits/misc_spacesuits.dm
+++ b/code/modules/clothing/spacesuits/misc_spacesuits.dm
@@ -195,6 +195,8 @@
 	icon_state = "paramedic-eva"
 	item_state = "paramedic-eva"
 	desc = "A brand new paramedic EVA suit. The nitrile seems a bit too thin to be space proof. Used for retrieving bodies in space."
+	slowdown = 0.25
+	w_class = WEIGHT_CLASS_NORMAL
 
 	sprite_sheets = list(
 		"Vox" = 'icons/mob/clothing/species/vox/suit.dmi',


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
- The Paramedic now has `EVA_ACCESS`.
- The Paramedic Locker now starts with its current contents plus a Defib, Medical Belt, Advanced Medkit, emergency toolbox, and a pair of MedHUD Sunglasses.
- To match literally every other Head, the CMO has ALSO been given MedHUD sunglasses.
- The Paramedic's EVA Suit is now storable in a bag and has a 0.25 slowdown (down from 1).
- Medical Storage lockers are now `ACCESS_MEDICAL` instead of `ACCESS_SURGERY`.

## Why It's Good For The Game
Paramedic is in a weird spot. Their EVA Suit is mega trash compared to the Medical Hardsuit (which quite literally have less slow down at 0.5) so it has been made into a proper "one of a kind useful" suit. They also now have EVA Access so they can actually get O2 tanks refilled.

Their access was lacking as well - you were unable to restock with gear or belts from the Medical closets (even the one RIGHT outside your office). As such, all `MEDICAL_ACCESS` can now get into Medical Closets. This does not change the access to the Anesthetics closets.

The Paramedic Locker now comes with proper gear for their job. A belt to store your tools, MedHUD Sunglasses (cant let pesky antags flash you for free in Maints), a defib, some medical supplies, and an emergency toolbox in case someone dies in a broken section of the Station.

The CMO was also given a pair of MedHUD Sunglasses because theyre the only head without one. I no longer have to watch CMOs break into the Departures area to get the free sunglasses there to convert.

## Testing
1. Checked if stuff went into its lockers correctly.
2. Success.

## Changelog
:cl:
tweak: Tweaked Paramedic Access + Gear
add: added MedHUD sunglasses to the CMO's locker.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
