### PR TITLE
Vortex vetus no longer bloody dies when it charges at you more than once.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/ancient_robot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/ancient_robot.dm
@@ -276,7 +276,6 @@ Difficulty: Hard
 	if(P.damage)
 		disable_shield()
 
-
 /mob/living/simple_animal/hostile/megafauna/ancient_robot/attacked_by(obj/item/I, mob/living/user)
 	if(!body_shield_enabled)
 		return ..()
@@ -388,7 +387,7 @@ Difficulty: Hard
 	O.fire()
 
 // To make this fight harder, it scales it's attacks based on number of players, or as injured. Capped lower on station.
-/mob/living/simple_animal/hostile/megafauna/ancient_robot/proc/calculate_extra_player_anger() 
+/mob/living/simple_animal/hostile/megafauna/ancient_robot/proc/calculate_extra_player_anger()
 	var/anger = 0
 	var/cap = 0
 	for(var/mob/living/carbon/human/H in range(10, src))
@@ -486,7 +485,7 @@ Difficulty: Hard
 		if(BOTTOM_LEFT)
 			BL.leg_movement(target, 0.6)
 
-/mob/living/simple_animal/hostile/megafauna/anicent_robot/ex_act(severity, target)
+/mob/living/simple_animal/hostile/megafauna/ancient_robot/ex_act(severity, target)
 	switch(severity)
 		if(1)
 			adjustBruteLoss(25)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Fixes an ever so small but ever so important spelling mistake in vetus since it was added:

/mob/living/simple_animal/hostile/megafauna/anicent_robot/ex_act(severity, target) to:

/mob/living/simple_animal/hostile/megafauna/ancient_robot/ex_act(severity, target), which keeps vortex vetus from offing itself.

Also removes some extra spaces / uneeded extra line.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Vortex vetus doing ~ 1500 damage to itself in a 3 charge burst is not good.

## Testing
<!-- How did you test the PR, if at all? -->
https://tenor.com/view/minor-spelling-mistake-gif-21179057

Spawned in vetus, confirmed it no longer took damage charging.
Missed before as I had vetus charge at me as vortex with the tweak merged 2 weeks ago, so I did not see the health change, despawning it after I was sure it was ripping me apart with the charge from explosions.

## Changelog
:cl:
fix: Vortex vetus no longer hurts itself on charging.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
