### PR TITLE
You can no longer give items to xenos

### DIFF
--- a/code/modules/mob/living/carbon/give.dm
+++ b/code/modules/mob/living/carbon/give.dm
@@ -84,9 +84,9 @@
 
 
 /datum/click_intercept/give/InterceptClickOn(mob/user, params, atom/object)
-	if(user == object || !iscarbon(object))
+	if(user == object || !ishuman(object))
 		return
-	var/mob/living/carbon/receiver = object
+	var/mob/living/carbon/human/receiver = object
 	if(receiver.stat != CONSCIOUS)
 		to_chat(user, "<span class='warning'>[receiver] can't accept any items because they're not conscious!</span>")
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes it so that you can only use the give verb to give items to other humanoids (`/mob/living/carbon/human`). This is more of a fix. Xenos should not be holding anything besides facehuggers really.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Fixes #21137
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
## Changelog
:cl:
fix: You can no longer use the give verb to give items to xenos.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
