### PR TITLE
Being well fed increases your blood regeneration 

### DIFF
--- a/code/modules/surgery/organs/blood.dm
+++ b/code/modules/surgery/organs/blood.dm
@@ -25,7 +25,8 @@
 	if(bodytemperature >= TCRYO && !HAS_TRAIT(src, TRAIT_BADDNA)) //cryosleep or husked people do not pump the blood.
 		if(blood_volume < BLOOD_VOLUME_NORMAL)
 			blood_volume += 0.1 // regenerate blood VERY slowly
-
+			if(nutrition >= NUTRITION_LEVEL_WELL_FED)
+				blood_volume += 0.1 // double it if you are well fed
 
 		//Effects of bloodloss
 		var/word = pick("dizzy","woozy","faint")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Raises your blood regeneration a tiny bit if you're well fed.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Adds a small boost to being well fed, also makes it so the perpetuating myth (that made it into the wiki somehow) is actually correct.

Also cookie
![image](https://github.com/ParadiseSS13/Paradise/assets/108773801/0aa260fc-6c70-4dc5-ae04-4c2951b92303)
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Shot some skrell with haemorrhage rounds and saw which one regenerated faster
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Being well fed now buffs your blood regeneration
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
