### PR TITLE
Improves how notify_ghosts works with larger icons

### DIFF
--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -563,13 +563,20 @@ GLOBAL_LIST_INIT(intents, list(INTENT_HELP,INTENT_DISARM,INTENT_GRAB,INTENT_HARM
 					A.action = action
 					A.target = source
 					if(!alert_overlay)
-						var/old_layer = source.layer
-						var/old_plane = source.plane
-						source.layer = FLOAT_LAYER
-						source.plane = FLOAT_PLANE
-						A.overlays += source
-						source.layer = old_layer
-						source.plane = old_plane
+						// if the icon is greater than 32x, use its base icon instead of its full actual appearance
+						// otherwise, if we don't do this, it totally messes with the viewport
+						var/icon/atom_icon = icon(source.icon, source.icon_state)
+						var/width = atom_icon.Width()
+						var/height = atom_icon.Height()
+						if(width > 32 || height > 32)
+							atom_icon.Scale(32, 32)
+							atom_icon.Crop(0, 0, 32, 32)
+							A.overlays += atom_icon
+						else
+							var/image/appearance = image(source)
+							appearance.layer = FLOAT_LAYER
+							appearance.plane = FLOAT_PLANE
+							A.overlays += appearance
 					else
 						alert_overlay.layer = FLOAT_LAYER
 						alert_overlay.plane = FLOAT_PLANE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes some weird behavior with ghost notifications on icons larger than 32x blowing up the viewport.

Before: 
![image](https://github.com/ParadiseSS13/Paradise/assets/89928798/fbc11103-d7ba-4bdc-9546-65d11af165b9)

After:

![image](https://github.com/ParadiseSS13/Paradise/assets/89928798/c536e876-e796-4c3d-8eda-6cd8355d0c51)

also: proof it still works with regular-sized icons
![image](https://github.com/ParadiseSS13/Paradise/assets/89928798/9219cffa-0b04-4715-a458-1c9a6c891077)



<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Large icons in these notifications can *really* mess with the viewport. While this won't fix every instance where something similar happens, it should fix the most noticeable, especially when a large atom is just Passed In as source
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


## Testing
Loaded in, granted deadchat control over a bunch of large and small things. Offered direct mob control to ghosts as well, to ensure smaller things with overlays still work.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Large icons in ghost notifications should no longer mess up the viewport.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
