### PR TITLE
Minor deadchat control improvements

### DIFF
--- a/code/datums/components/deadchat_control.dm
+++ b/code/datums/components/deadchat_control.dm
@@ -47,7 +47,7 @@
 	if(!ismob(parent) && !(parent in GLOB.poi_list))
 		GLOB.poi_list |= parent
 		generated_point_of_interest = TRUE
-	message_admins("[parent] has been given deadchat control in [deadchat_mode == DEADCHAT_ANARCHY_MODE ? "anarchy" : "democracy"] mode with a cooldown of [input_cooldown SECONDS] second\s.")
+	message_admins("[parent] has been given deadchat control in [deadchat_mode == DEADCHAT_ANARCHY_MODE ? "anarchy" : "democracy"] mode with a cooldown of [input_cooldown] second\s.")
 
 	var/atom/A = parent
 	for(var/mob/dead/observer/ghost in A.get_orbiters())
@@ -197,6 +197,11 @@
 		examine_list += "<span class='deadsay'>As you have deadchat disabled, you will not see vote messages, nor be able to participate in voting.</span>"
 		return
 
+	if(!(user in orbiters))
+		examine_list += "<span class='deadsay bold'>Orbit [A.p_them()] and examine [A.p_them()] again to see the list of possible commands.</span>"
+		return
+
+
 	if(deadchat_mode & DEADCHAT_DEMOCRACY_MODE)
 		examine_list += "<span class='notice'>Type a command into chat to vote on an action. This happens once every [input_cooldown * 0.1] second\s.</span>"
 	else if(deadchat_mode & DEADCHAT_ANARCHY_MODE)
@@ -204,8 +209,7 @@
 
 	var/extended_examine = "<span class='notice'>Command list:"
 
-	for(var/possible_input in inputs)
-		extended_examine += " [possible_input]"
+	extended_examine += english_list(inputs)
 
 	extended_examine += ".</span>"
 

--- a/code/datums/components/deadchat_control.dm
+++ b/code/datums/components/deadchat_control.dm
@@ -145,6 +145,8 @@
 			to_chat(O, "<span class='deadsay'>You have deadchat muted, and as such will not receive messages related to, nor be able to participate in, controlling this object.</span>")
 			to_chat(O, "<span class='notice'>If you would like to participate, unmute deadchat and follow this object again.</span>")
 			return
+		else
+			to_chat(O, "<span class='deadsay'>[parent] is deadchat-controllable! Examine [parent] to see possible commands you can use while orbiting [parent.p_them()] to control [parent.p_their()] behavior!</span>")
 
 	RegisterSignal(orbiter, COMSIG_MOB_DEADSAY, PROC_REF(deadchat_react))
 	RegisterSignal(orbiter, COMSIG_MOB_AUTOMUTE_CHECK, PROC_REF(waive_automute))

--- a/code/datums/components/deadchat_control.dm
+++ b/code/datums/components/deadchat_control.dm
@@ -49,6 +49,11 @@
 		generated_point_of_interest = TRUE
 	message_admins("[parent] has been given deadchat control in [deadchat_mode == DEADCHAT_ANARCHY_MODE ? "anarchy" : "democracy"] mode with a cooldown of [input_cooldown SECONDS] second\s.")
 
+	var/atom/A = parent
+	for(var/mob/dead/observer/ghost in A.get_orbiters())
+		// get started with anyone who's already following
+		orbit_begin(A, ghost)
+
 /datum/component/deadchat_control/Destroy(force, silent)
 	var/message = "<span class='deadsay italics bold'>[parent] is no longer controllable.</span>"
 	for(var/mob/dead/observer/M in orbiters)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -639,7 +639,8 @@
 /// Easy way to remove the component when the fun has been played out
 /atom/movable/proc/stop_deadchat_plays()
 	var/datum/component/deadchat_control/comp = GetComponent(/datum/component/deadchat_control)
-	qdel(comp)
+	if(!QDELETED(comp))
+		qdel(comp)
 
 /atom/movable/vv_get_dropdown()
 	. = ..()

--- a/code/modules/mob/living/carbon/carbon_emote.dm
+++ b/code/modules/mob/living/carbon/carbon_emote.dm
@@ -36,7 +36,7 @@
 /datum/emote/living/carbon/clap/get_sound(mob/living/user)
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
-		if(!H?.mind.miming)
+		if(!H?.mind?.miming)
 			return pick(
 				'sound/misc/clap1.ogg',
 				'sound/misc/clap2.ogg',

--- a/code/modules/mob/living/carbon/human/human_mob.dm
+++ b/code/modules/mob/living/carbon/human/human_mob.dm
@@ -2070,7 +2070,7 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 
 /mob/living/carbon/human/proc/dchat_emote()
 	var/list/possible_emotes = list("scream", "clap", "snap", "crack", "dap", "burp")
-	emote(pick(possible_emotes))
+	emote(pick(possible_emotes), intentional = TRUE)
 
 /mob/living/carbon/human/proc/dchat_attack()
 	var/turf/ahead = get_turf(get_step(src, dir))

--- a/code/modules/mob/living/carbon/human/human_mob.dm
+++ b/code/modules/mob/living/carbon/human/human_mob.dm
@@ -2084,7 +2084,7 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 			if(INTENT_HARM)
 				visible_message("<span class='warning'>[src] swings [implement] wildly!</span>")
 			if(INTENT_HELP)
-				visible_message("<span class='warning'>[src] seems to be calm and collected!</span>")
+				visible_message("<span class='notice'>[src] seems to take a deep breath.</span>")
 		return
 	if(isLivingSSD(victim))
 		visible_message("<span class='notice'>[src] [intent == INTENT_HARM ? "reluctantly " : ""]lowers [p_their()] [implement].</span>")

--- a/code/modules/mob/living/carbon/human/human_mob.dm
+++ b/code/modules/mob/living/carbon/human/human_mob.dm
@@ -2072,7 +2072,7 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 	var/list/possible_emotes = list("scream", "clap", "snap", "crack", "dap", "burp")
 	emote(pick(possible_emotes), intentional = TRUE)
 
-/mob/living/carbon/human/proc/dchat_attack()
+/mob/living/carbon/human/proc/dchat_attack(intent)
 	var/turf/ahead = get_turf(get_step(src, dir))
 	var/atom/victim = locate(/mob/living) in ahead
 	var/obj/item/in_hand = get_active_hand()
@@ -2080,15 +2080,23 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 	if(!victim)
 		victim = locate(/obj/structure) in ahead
 	if(!victim)
-		visible_message("<span class='warning'>[src] swings [implement] wildly!</span>")
+		switch(intent)
+			if(INTENT_HARM)
+				visible_message("<span class='warning'>[src] swings [implement] wildly!</span>")
+			if(INTENT_HELP)
+				visible_message("<span class='warning'>[src] seems to be calm and collected!</span>")
 		return
 	if(isLivingSSD(victim))
-		visible_message("<span class='notice'>[src] reluctantly lowers [p_their()] [implement].</span>")
+		visible_message("<span class='notice'>[src] [intent == INTENT_HARM ? "reluctantly " : ""]lowers [p_their()] [implement].</span>")
 		return
+
+	var/original_intent = a_intent
+	a_intent = intent
 	if(in_hand)
 		in_hand.melee_attack_chain(src, victim)
 	else
 		UnarmedAttack(victim, TRUE)
+	a_intent = original_intent
 
 /mob/living/carbon/human/proc/dchat_resist()
 	if(!can_resist())
@@ -2099,7 +2107,7 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 		return
 
 	visible_message("<span class='warning'>[src] is trying to break free!</span>")
-	run_resist()
+	resist()
 
 /mob/living/carbon/human/proc/dchat_pickup()
 	var/turf/ahead = get_step(src, dir)
@@ -2152,7 +2160,8 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 /mob/living/carbon/human/deadchat_plays(mode = DEADCHAT_DEMOCRACY_MODE, cooldown = 7 SECONDS)
 	var/list/inputs = list(
 		"emote" = CALLBACK(src, PROC_REF(dchat_emote)),
-		"attack" = CALLBACK(src, PROC_REF(dchat_attack)),
+		"attack" = CALLBACK(src, PROC_REF(dchat_attack), INTENT_HARM),
+		"help" = CALLBACK(src, PROC_REF(dchat_attack), INTENT_HELP),
 		"pickup" = CALLBACK(src, PROC_REF(dchat_pickup)),
 		"throw" = CALLBACK(src, PROC_REF(dchat_throw)),
 		"disarm" = CALLBACK(src, PROC_REF(dchat_shove)),


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes some small tweaks to deadchat controlled humans:
- Attack now properly makes use of the attack chain (or unarmed attacks if nothing's in their hands), though still won't behave exactly like clicking their target.
- Humans now have a "resist" command, to attempt to escape restraints.
- Humans also have a "help" command, which attempts to click the target with help intent. If used on a mob with an empty hand, it'll give them a hug. "attack" now uses harm intent.
- Fixes a runtime with *clap failing if called by a mindless mob, and another with a qdel loop when removing the component from things with cardinal movement.
- Ghosts orbiting something with deadchat control added to it will be added to the controller list automatically without needing to refollow.
- Adds a message for people who start orbiting a followable object to suggest they examine the object for commands.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
People seem to generally enjoy deadchat control, this just adds some refinements to the existing experience.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Was able to command a vulp to walk around, hug a skrell, pick up a toolbox, beat them to death, get handcuffed, resist out.

Afterwards, I tried using the deadchat controls to do the same, and it seemed to work.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Deadchat control of humans now has new commands, "help" and "resist"
tweak: Adds some minor QoL improvements to the deadchat plays experience.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
