### PR TITLE
tomato.dm: Killer Tomato mob appearing at user's position, not Killer…

### DIFF
--- a/code/modules/hydroponics/grown/tomato.dm
+++ b/code/modules/hydroponics/grown/tomato.dm
@@ -141,7 +141,7 @@
 
 	spawn(30)
 		if(!QDELETED(src))
-			var/turf/T = get_turf(user)
+			var/turf/T = get_turf(src)
 			var/mob/living/simple_animal/hostile/killertomato/K = new /mob/living/simple_animal/hostile/killertomato(T)
 			K.maxHealth += round(seed.endurance / 3)
 			K.melee_damage_lower += round(seed.potency / 10)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
fixed years-old bug: when awakened, Killer Tomato (mob) would spawn at user's position, not Killer Tomato (item)'s position; thus, a thrown, awakening Killer Tomato (item) would, when awoken, instantly vanish unceremoniously into the ether... while elsewhere, the now-distant user who threw that Killer Tomato (item) would spontaneously generate a Killer Tomato (mob) under their feet.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
the bug interferes with the suspension of disbelief as that is not how killer tomatoes work irl

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
fix: fixed Killer Tomato mob being generated at user's current position, not item's current position
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
