### PR TITLE
Fractional slowdown under 0.5 no longer slows you, reduces damage neded to slow instead

### DIFF
--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -263,6 +263,8 @@
 // MOVE SPEED //
 ////////////////
 #define ADD_SLOWDOWN(__value) if(!ignoreslow || __value < 0) . += __value
+#define SLOWDOWN_INCREMENT 0.5
+#define SLOWDOWN_MULTIPLIER (1 / SLOWDOWN_INCREMENT)
 
 /datum/species/proc/movement_delay(mob/living/carbon/human/H)
 	. = 0	//We start at 0.
@@ -298,31 +300,40 @@
 		if(ignoreslow)
 			return . // Only malusses after here
 
+		if(H.dna.species.spec_movement_delay()) //Species overrides for slowdown due to feet/legs
+			. += 2 * H.stance_damage //damaged/missing feet or legs is slow
+
+		var/hungry = (500 - H.nutrition) / 5 // So overeat would be 100 and default level would be 80
+		if((hungry >= 70) && !flight)
+			. += hungry/50
+		if(HAS_TRAIT(H, TRAIT_FAT))
+			. += (1.5 - flight)
+
+		if(H.bodytemperature < BODYTEMP_COLD_DAMAGE_LIMIT && !(HAS_TRAIT(H, TRAIT_RESISTCOLD)))
+			. += (BODYTEMP_COLD_DAMAGE_LIMIT - H.bodytemperature) / COLD_SLOWDOWN_FACTOR
+
+		var/leftover = .
+		. = round_down(. * SLOWDOWN_MULTIPLIER) / SLOWDOWN_MULTIPLIER //This allows us to round in values of 0.5 A slowdown of 0.55 becomes 1.10, which is rounded to 1, then reduced to 0.5
+		leftover = leftover - .
+
 		var/health_deficiency = max(H.maxHealth - H.health, H.staminaloss)
-		var/hungry = (500 - H.nutrition)/5 // So overeat would be 100 and default level would be 80
 		if(H.reagents)
 			for(var/datum/reagent/R in H.reagents.reagent_list)
 				if(R.shock_reduction)
 					health_deficiency -= R.shock_reduction
 		if(!HAS_TRAIT(H, TRAIT_IGNOREDAMAGESLOWDOWN))
-			if(health_deficiency >= 40)
+			if(health_deficiency >= 40 - 40 * leftover * SLOWDOWN_MULTIPLIER) //If we have 0.25 slowdown, or halfway to the threshold of 0.5, we reduce the health threshold by that 50%
 				if(flight)
 					. += (health_deficiency / 75)
 				else
-					. += (health_deficiency / 25)
-		if(H.dna.species.spec_movement_delay()) //Species overrides for slowdown due to feet/legs
-			. += 2 * H.stance_damage //damaged/missing feet or legs is slow
-
-		if((hungry >= 70) && !flight)
-			. += hungry/50
-		if(HAS_TRAIT(H, TRAIT_FAT))
-			. += (1.5 - flight)
-		if(H.bodytemperature < BODYTEMP_COLD_DAMAGE_LIMIT && !(HAS_TRAIT(H, TRAIT_RESISTCOLD)))
-			. += (BODYTEMP_COLD_DAMAGE_LIMIT - H.bodytemperature) / COLD_SLOWDOWN_FACTOR
-
+					if(health_deficiency >= 40)
+						. += (health_deficiency / 25) //Once damage is over 40, you get the harsh formula
+					else
+						. += 0.5 //Otherwise, slowdown (from pain) is capped to 0.5 until you hit 40 damage. This only effects people with fractional slowdowns, and prevents some harshness from the lowered threshold
 	return .
 
 #undef ADD_SLOWDOWN
+#undef SLOWDOWN_INCREMENT
 
 /datum/species/proc/on_species_gain(mob/living/carbon/human/H) //Handles anything not already covered by basic species assignment.
 	for(var/slot_id in no_equip)

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -314,7 +314,7 @@
 
 		var/leftover = .
 		. = round_down(. * SLOWDOWN_MULTIPLIER) / SLOWDOWN_MULTIPLIER //This allows us to round in values of 0.5 A slowdown of 0.55 becomes 1.10, which is rounded to 1, then reduced to 0.5
-		leftover = leftover - .
+		leftover -= .
 
 		var/health_deficiency = max(H.maxHealth - H.health, H.staminaloss)
 		if(H.reagents)
@@ -330,7 +330,6 @@
 						. += (health_deficiency / 25) //Once damage is over 40, you get the harsh formula
 					else
 						. += 0.5 //Otherwise, slowdown (from pain) is capped to 0.5 until you hit 40 damage. This only effects people with fractional slowdowns, and prevents some harshness from the lowered threshold
-	return .
 
 #undef ADD_SLOWDOWN
 #undef SLOWDOWN_INCREMENT

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -334,6 +334,7 @@
 
 #undef ADD_SLOWDOWN
 #undef SLOWDOWN_INCREMENT
+#undef SLOWDOWN_MULTIPLIER
 
 /datum/species/proc/on_species_gain(mob/living/carbon/human/H) //Handles anything not already covered by basic species assignment.
 	for(var/slot_id in no_equip)

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -321,15 +321,16 @@
 			for(var/datum/reagent/R in H.reagents.reagent_list)
 				if(R.shock_reduction)
 					health_deficiency -= R.shock_reduction
-		if(!HAS_TRAIT(H, TRAIT_IGNOREDAMAGESLOWDOWN))
-			if(health_deficiency >= 40 - 40 * leftover * SLOWDOWN_MULTIPLIER) //If we have 0.25 slowdown, or halfway to the threshold of 0.5, we reduce the health threshold by that 50%
-				if(flight)
-					. += (health_deficiency / 75)
+		if(HAS_TRAIT(H, TRAIT_IGNOREDAMAGESLOWDOWN))
+			return
+		if(health_deficiency >= 40 - (40 * leftover * SLOWDOWN_MULTIPLIER)) //If we have 0.25 slowdown, or halfway to the threshold of 0.5, we reduce the health threshold by that 50%
+			if(flight)
+				. += (health_deficiency / 75)
+			else
+				if(health_deficiency >= 40)
+					. += (health_deficiency / 25) //Once damage is over 40, you get the harsh formula
 				else
-					if(health_deficiency >= 40)
-						. += (health_deficiency / 25) //Once damage is over 40, you get the harsh formula
-					else
-						. += 0.5 //Otherwise, slowdown (from pain) is capped to 0.5 until you hit 40 damage. This only effects people with fractional slowdowns, and prevents some harshness from the lowered threshold
+					. += 0.5 //Otherwise, slowdown (from pain) is capped to 0.5 until you hit 40 damage. This only effects people with fractional slowdowns, and prevents some harshness from the lowered threshold
 
 #undef ADD_SLOWDOWN
 #undef SLOWDOWN_INCREMENT

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -269,68 +269,69 @@
 /datum/species/proc/movement_delay(mob/living/carbon/human/H)
 	. = 0	//We start at 0.
 
-	if(has_gravity(H))
-		if(!IS_HORIZONTAL(H))
-			if(HAS_TRAIT(H, TRAIT_GOTTAGOFAST))
-				. -= 1
-			else if(HAS_TRAIT(H, TRAIT_GOTTAGONOTSOFAST))
-				. -= 0.5
+	if(!has_gravity(H))
+		return
+	if(!IS_HORIZONTAL(H))
+		if(HAS_TRAIT(H, TRAIT_GOTTAGOFAST))
+			. -= 1
+		else if(HAS_TRAIT(H, TRAIT_GOTTAGONOTSOFAST))
+			. -= 0.5
+	else
+		. += GLOB.configuration.movement.crawling_speed_reduction
+
+	var/ignoreslow = FALSE
+	if(HAS_TRAIT(H, TRAIT_IGNORESLOWDOWN))
+		ignoreslow = TRUE
+
+	var/flight = H.flying	//Check for flight and flying items
+
+	ADD_SLOWDOWN(speed_mod)
+
+	if(H.wear_suit)
+		ADD_SLOWDOWN(H.wear_suit.slowdown)
+	if(!H.buckled && H.shoes)
+		ADD_SLOWDOWN(H.shoes.slowdown)
+	if(H.back)
+		ADD_SLOWDOWN(H.back.slowdown)
+	if(H.l_hand && (H.l_hand.flags & HANDSLOW))
+		ADD_SLOWDOWN(H.l_hand.slowdown)
+	if(H.r_hand && (H.r_hand.flags & HANDSLOW))
+		ADD_SLOWDOWN(H.r_hand.slowdown)
+
+	if(ignoreslow)
+		return . // Only malusses after here
+
+	if(H.dna.species.spec_movement_delay()) //Species overrides for slowdown due to feet/legs
+		. += 2 * H.stance_damage //damaged/missing feet or legs is slow
+
+	var/hungry = (500 - H.nutrition) / 5 // So overeat would be 100 and default level would be 80
+	if((hungry >= 70) && !flight)
+		. += hungry/50
+	if(HAS_TRAIT(H, TRAIT_FAT))
+		. += (1.5 - flight)
+
+	if(H.bodytemperature < BODYTEMP_COLD_DAMAGE_LIMIT && !(HAS_TRAIT(H, TRAIT_RESISTCOLD)))
+		. += (BODYTEMP_COLD_DAMAGE_LIMIT - H.bodytemperature) / COLD_SLOWDOWN_FACTOR
+
+	var/leftover = .
+	. = round_down(. * SLOWDOWN_MULTIPLIER) / SLOWDOWN_MULTIPLIER //This allows us to round in values of 0.5 A slowdown of 0.55 becomes 1.10, which is rounded to 1, then reduced to 0.5
+	leftover -= .
+
+	var/health_deficiency = max(H.maxHealth - H.health, H.staminaloss)
+	if(H.reagents)
+		for(var/datum/reagent/R in H.reagents.reagent_list)
+			if(R.shock_reduction)
+				health_deficiency -= R.shock_reduction
+	if(HAS_TRAIT(H, TRAIT_IGNOREDAMAGESLOWDOWN))
+		return
+	if(health_deficiency >= 40 - (40 * leftover * SLOWDOWN_MULTIPLIER)) //If we have 0.25 slowdown, or halfway to the threshold of 0.5, we reduce the health threshold by that 50%
+		if(flight)
+			. += (health_deficiency / 75)
 		else
-			. += GLOB.configuration.movement.crawling_speed_reduction
-
-		var/ignoreslow = FALSE
-		if(HAS_TRAIT(H, TRAIT_IGNORESLOWDOWN))
-			ignoreslow = TRUE
-
-		var/flight = H.flying	//Check for flight and flying items
-
-		ADD_SLOWDOWN(speed_mod)
-
-		if(H.wear_suit)
-			ADD_SLOWDOWN(H.wear_suit.slowdown)
-		if(!H.buckled && H.shoes)
-			ADD_SLOWDOWN(H.shoes.slowdown)
-		if(H.back)
-			ADD_SLOWDOWN(H.back.slowdown)
-		if(H.l_hand && (H.l_hand.flags & HANDSLOW))
-			ADD_SLOWDOWN(H.l_hand.slowdown)
-		if(H.r_hand && (H.r_hand.flags & HANDSLOW))
-			ADD_SLOWDOWN(H.r_hand.slowdown)
-
-		if(ignoreslow)
-			return . // Only malusses after here
-
-		if(H.dna.species.spec_movement_delay()) //Species overrides for slowdown due to feet/legs
-			. += 2 * H.stance_damage //damaged/missing feet or legs is slow
-
-		var/hungry = (500 - H.nutrition) / 5 // So overeat would be 100 and default level would be 80
-		if((hungry >= 70) && !flight)
-			. += hungry/50
-		if(HAS_TRAIT(H, TRAIT_FAT))
-			. += (1.5 - flight)
-
-		if(H.bodytemperature < BODYTEMP_COLD_DAMAGE_LIMIT && !(HAS_TRAIT(H, TRAIT_RESISTCOLD)))
-			. += (BODYTEMP_COLD_DAMAGE_LIMIT - H.bodytemperature) / COLD_SLOWDOWN_FACTOR
-
-		var/leftover = .
-		. = round_down(. * SLOWDOWN_MULTIPLIER) / SLOWDOWN_MULTIPLIER //This allows us to round in values of 0.5 A slowdown of 0.55 becomes 1.10, which is rounded to 1, then reduced to 0.5
-		leftover -= .
-
-		var/health_deficiency = max(H.maxHealth - H.health, H.staminaloss)
-		if(H.reagents)
-			for(var/datum/reagent/R in H.reagents.reagent_list)
-				if(R.shock_reduction)
-					health_deficiency -= R.shock_reduction
-		if(HAS_TRAIT(H, TRAIT_IGNOREDAMAGESLOWDOWN))
-			return
-		if(health_deficiency >= 40 - (40 * leftover * SLOWDOWN_MULTIPLIER)) //If we have 0.25 slowdown, or halfway to the threshold of 0.5, we reduce the health threshold by that 50%
-			if(flight)
-				. += (health_deficiency / 75)
+			if(health_deficiency >= 40)
+				. += (health_deficiency / 25) //Once damage is over 40, you get the harsh formula
 			else
-				if(health_deficiency >= 40)
-					. += (health_deficiency / 25) //Once damage is over 40, you get the harsh formula
-				else
-					. += 0.5 //Otherwise, slowdown (from pain) is capped to 0.5 until you hit 40 damage. This only effects people with fractional slowdowns, and prevents some harshness from the lowered threshold
+				. += 0.5 //Otherwise, slowdown (from pain) is capped to 0.5 until you hit 40 damage. This only effects people with fractional slowdowns, and prevents some harshness from the lowered threshold
 
 #undef ADD_SLOWDOWN
 #undef SLOWDOWN_INCREMENT


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

If you have slowdown that is not a multiple of 0.5 BEFORE PAIN SLOWDOWN, your slowdown from items is reduced DOWN to the nearest multiple. 0.3 becomes 0, 0.9 becomes 0.5. Our speed system really only takes 0.5 multiples well.

If you have slowdown that is not a multiple of 0.5, that leftover value is saved, and used to adjust when the threshold of pain slowdown is.

If you have 0.25 leftover slowdown, your slowdown is set to 0, but pain slowdown begins at 20 for you, instead of 40. 
If you have 0.625 total slowdown, it is rounded to 0.5, and then you get pain slowdown begining at 30.

Pain slowdown will ONLY provide 0.5 slowdown to you below 40 damage. This means, having a 0.25 slowdown item, acts like a zero slowdown item till you hit 20 damage, then it would act more like a 0.5 slowdown item.

If you do not use a fractional slowdown item, this will not affect you in any way.

If you do use a fractional slowdown item, you get no slowdown from it until you hit the adjusted pain threshold, of which then the item will act **exactly like it does now without this change**

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

With modsuits, a lot of the clothing has fractional slowdown. Values like 0.25, 0.2, 0.75 pop up frequently.
However, with the slowdown system we have, this does not work well. 0.25 becomes 0.5. So does 0.1. 0.75 will become a slowdown of 1. This makes balancing modsuits problimatic, and means that if you only wear a modsuit back with a slowdown of 0.1, you still are as slow as if you had a 0.5 item, which slows you down quite fast.

By using this system, we can make these fractional items not actually slow you down, meaning wearing them does not suck, UNTILL you start taking damage. Then, when you hit the damage threshold, which is dependent on how much slowdown you have, and how close it is to the next 0.5 multiplier, you then get that 0.5 speed penalty. This way, modsuits with 0.25 speed are more combat viable, but still have the speed penalty once you start getting into combat and taking damage.

Again, if you do not wear a fractional clothing, your speed is not effected. If you wear something with slowdown that is fractional, your speed will be FASTER until you hit the damage threshold, then it is the SAME as it is now.

## Testing
<!-- How did you test the PR, if at all? -->

Confirmed that fractional items rounded their speed down, and that damage threshold is changed by damage properly.

## Changelog
:cl:
tweak: If as a human your slowdown is UNDER a multiple of 0.5, it is adjusted to 0. In exchange, the threshold you start taking damage slowdown is decreased relative to how much fractional slowdown you had. Damage slowdown under 40 HP is locked to 0.5. In effect, once you take damage over threshold but under 40, your speed is the same as it would be before this PR, otherwise you are now a speed threshold faster.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
