### PR TITLE
Oversight fix: Augment Surgery Limb Status Fix

### DIFF
--- a/code/modules/surgery/limb_augmentation.dm
+++ b/code/modules/surgery/limb_augmentation.dm
@@ -16,7 +16,7 @@
 	if(ishuman(target))
 		var/mob/living/carbon/human/H = target
 		var/obj/item/organ/external/affected = H.get_organ(user.zone_selected)
-		if(affected.status & ~(ORGAN_SPLINTED | ORGAN_SALVED)) //The arm has to be in prime condition to augment it.
+		if(affected.status & ~(ORGAN_SPLINTED | ORGAN_SALVED)) //Checks the inverse of these flags, for example if the targeted limb was broken or burned. The limb must be in good condition to augment.
 			return FALSE
 		return TRUE
 

--- a/code/modules/surgery/limb_augmentation.dm
+++ b/code/modules/surgery/limb_augmentation.dm
@@ -16,7 +16,7 @@
 	if(ishuman(target))
 		var/mob/living/carbon/human/H = target
 		var/obj/item/organ/external/affected = H.get_organ(user.zone_selected)
-		if(affected.status & ORGAN_BROKEN) //The arm has to be in prime condition to augment it.
+		if(affected.status & ~(ORGAN_SPLINTED | ORGAN_SALVED)) //The arm has to be in prime condition to augment it.
 			return FALSE
 		return TRUE
 


### PR DESCRIPTION
## What Does This PR Do
Fixes: #21111 - an oversight that allows augmentation surgery to occur when limbs are damaged. 

## Why It's Good For The Game
Forces players to fix damaged body parts before performing augmentation surgery. Prevents possible jank from happening due to damage. 

## Testing
Tested to see if the surgery was available when limb was splinted or salved. Checked to see if the surgery was not available while broken/necrotic/burned/dead/IB. 

## Changelog
:cl:
tweak: Tweaked the augment limbs surgery eligibility check
/:cl:
