### PR TITLE
Fixes body scanner printout not properly displaying blood level 

### DIFF
--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -420,7 +420,7 @@
 
 		dat += "<hr>"
 
-		var/blood_percent =  round((occupant.blood_volume /  BLOOD_VOLUME_NORMAL) * 100, 1)
+		var/blood_percent =  round((occupant.blood_volume / BLOOD_VOLUME_NORMAL) * 100, 1)
 
 		extra_font = (occupant.blood_volume > 448 ? "<font color='blue'>" : "<font color='red'>")
 		dat += "[extra_font]\tBlood Level %: [blood_percent] ([occupant.blood_volume] units)</font><br>"

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -420,8 +420,7 @@
 
 		dat += "<hr>"
 
-		var/blood_percent =  round((occupant.blood_volume / BLOOD_VOLUME_NORMAL))
-		blood_percent *= 100
+		var/blood_percent =  round(occupant.blood_volume /BLOOD_VOLUME_NORMAL * 100, 1)
 
 		extra_font = (occupant.blood_volume > 448 ? "<font color='blue'>" : "<font color='red'>")
 		dat += "[extra_font]\tBlood Level %: [blood_percent] ([occupant.blood_volume] units)</font><br>"

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -420,11 +420,7 @@
 
 		dat += "<hr>"
 
-<<<<<<< HEAD
-		var/blood_percent =  round((occupant.blood_volume / BLOOD_VOLUME_NORMAL) * 100, 1)
-=======
-		var/blood_percent =  round(occupant.blood_volume / BLOOD_VOLUME_NORMAL * 100, 1)
->>>>>>> 009bb06a54e38ba04efc3ae31c087d1da6eb537d
+		var/blood_percent =  round((occupant.blood_volume /  BLOOD_VOLUME_NORMAL) * 100, 1)
 
 		extra_font = (occupant.blood_volume > 448 ? "<font color='blue'>" : "<font color='red'>")
 		dat += "[extra_font]\tBlood Level %: [blood_percent] ([occupant.blood_volume] units)</font><br>"

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -420,7 +420,7 @@
 
 		dat += "<hr>"
 
-		var/blood_percent =  round(occupant.blood_volume /BLOOD_VOLUME_NORMAL * 100, 1)
+		var/blood_percent =  round((occupant.blood_volume / BLOOD_VOLUME_NORMAL) * 100, 1)
 
 		extra_font = (occupant.blood_volume > 448 ? "<font color='blue'>" : "<font color='red'>")
 		dat += "[extra_font]\tBlood Level %: [blood_percent] ([occupant.blood_volume] units)</font><br>"


### PR DESCRIPTION
## What Does This PR Do
Fixes the body scanners so they display blood level percentage properly when using the printout option. 

## Why It's Good For The Game
Allows for equipment to function as intended.

## Images of changes
**Before:**
![before_printout](https://github.com/ParadiseSS13/Paradise/assets/116982774/5ff14719-0e37-4416-9b77-21d79b75b79a)
**After:**
![after_printout](https://github.com/ParadiseSS13/Paradise/assets/116982774/7e0107d2-9c6b-4541-8563-d0703b0f4a96)

## Testing
Checked blood percentages on both the stationary and handheld body scanner.

## Changelog
:cl:
fix: Fixed body scanner printout and blood percentages
/:cl:
