### PR TITLE
Prevents Captain's ID from being kept in the cryostorage console

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -229,7 +229,8 @@
 	)
 	// These items will NOT be preserved
 	var/list/do_not_preserve_items = list (
-		/obj/item/mmi/robotic_brain
+		/obj/item/mmi/robotic_brain,
+		/obj/item/card/id/captains_spare/assigned
 	)
 
 /obj/machinery/cryopod/right


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
The Captain's ID used to be the only ID kept in cryostorage, as it was a subtype of the spare ID. As I imagine this was not intended due to reasons bellow, now it follows the logic of all other personal IDs and gets deleted when the holder goes to cryo.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Spare not being deleted makes sense, as it is a necesary item that should always be kept on the station, as it is the only way to modify access without Captain/HoP. However, a normal Captain's ID being stored makes it so anyone with access to the console  (Head ID or Armory access) can get AA very easily, and on an unintutive way - as you would expect personal belongings to be removed on cryo. If you are antag Head and see the Captain cryos, you know you are getting All Access with no effort.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
- Spawn as captain
- "Didn't roll antag, better instacryo 🛏️🏃" 
- Check that the Spare and various objective items are preserved as expected, but the Captain's ID is not present.
![imagen](https://github.com/ParadiseSS13/Paradise/assets/58085266/51de0aaf-26e7-4041-aa5d-15d0dcc2316c)
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Captain's ID is no longer saved in Cryostorage. The spare will still be preserved, as it is necessary for the station.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
