### PR TITLE
Make moths able to eat (flammable) clothing

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -35,6 +35,35 @@
 	var/magical = FALSE
 	var/dyeable = FALSE
 	w_class = WEIGHT_CLASS_SMALL
+	var/times_eaten = 0 //How many times this clothing has been gnawed on
+	var/max_bites = 4 //How many times a clothing can be bitten before being depleted. You eated it
+
+/obj/item/clothing/attack(mob/M, mob/user)
+	if(M == user && ismoth(user))
+		if (resistance_flags & FLAMMABLE) // Loose indicator that something is made out of cloth
+			var/mob/living/carbon/human/H = user
+			if(!H.check_has_mouth())
+				to_chat(user, "<span class='warning'>You do not have a mouth!</span>")
+				return
+			times_eaten++
+			playsound(loc, 'sound/items/eatfood.ogg', 50, 0)
+			user.adjust_nutrition(5)
+			if(times_eaten < max_bites)
+				to_chat(user, "<span class='notice'>You take a bite of the [name]. Delicious!</span>")
+			else
+				to_chat(user, "<span class='warning'>There is no more of [name] left!</span>")
+				qdel(src)
+	else
+		..()
+
+/obj/item/clothing/examine(mob/user)
+	. = ..()
+	if(!user.Adjacent(src) || !times_eaten)
+		return
+	if(times_eaten == 1)
+		. += "<span class='notice'>[src] was bitten by someone!</span>"
+	else
+		. += "<span class='notice'>[src] was bitten multiple times!</span>"
 
 /obj/item/clothing/update_icon_state()
 	if(!can_toggle)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Makes Nians able to eat all clothing items with the FLAMMABLE resistance_flags set (so basic cloth items, and not things like magboots or hardsuits). Based on the _Tineola bisselliella_ in my closet, and the code for eating crayons.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

I think it adds a cute differentiating mechanical quirk to the Nian species, and might lead to some amusing situations or creative uses by players. Synergizes well with the "cocoon" ability. Reduce lag by munching spare hats?

## Testing
<!-- How did you test the PR, if at all? -->

Ran around as Nian and not-Nian trying to eat a bunch of things on the station

## Notes

Nutriment amount is currently small and could be increased. If needed, could be balanced by making the eat-clothes interaction take some time to work (similar to removing restraints), making it more an emergency source of food that you'd only eat if you have nothing else available.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
