### PR TITLE
Make various machinery properly update their icons on init

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -559,7 +559,7 @@ GLOBAL_LIST_EMPTY(airlock_emissive_underlays)
 	overlays += damag_overlay
 	overlays += note_overlay
 
-	check_unres()
+	overlays += check_unres()
 
 	//EMISSIVE ICONS
 	if(buttons_underlay != old_buttons_underlay)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -60,6 +60,7 @@
 	real_explosion_block = explosion_block
 	explosion_block = EXPLOSION_BLOCK_PROC
 
+	update_icon()
 	air_update_turf(1)
 
 /obj/machinery/door/proc/set_init_door_layer()
@@ -464,23 +465,24 @@
 
 /obj/machinery/door/proc/check_unres() //unrestricted sides. This overlay indicates which directions the player can access even without an ID
 	if(hasPower() && unres_sides)
+		. = list()
 		set_light(l_range = 1, l_power = 1, l_color = "#00FF00")
 		if(unres_sides & NORTH)
 			var/image/I = image(icon='icons/obj/doors/airlocks/station/overlays.dmi', icon_state="unres_n") //layer=src.layer+1
 			I.pixel_y = 32
-			add_overlay(I)
+			. += I
 		if(unres_sides & SOUTH)
 			var/image/I = image(icon='icons/obj/doors/airlocks/station/overlays.dmi', icon_state="unres_s") //layer=src.layer+1
 			I.pixel_y = -32
-			add_overlay(I)
+			. += I
 		if(unres_sides & EAST)
 			var/image/I = image(icon='icons/obj/doors/airlocks/station/overlays.dmi', icon_state="unres_e") //layer=src.layer+1
 			I.pixel_x = 32
-			add_overlay(I)
+			. += I
 		if(unres_sides & WEST)
 			var/image/I = image(icon='icons/obj/doors/airlocks/station/overlays.dmi', icon_state="unres_w") //layer=src.layer+1
 			I.pixel_x = -32
-			add_overlay(I)
+			. += I
 
 /obj/machinery/door/morgue
 	icon = 'icons/obj/doors/doormorgue.dmi'

--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -118,8 +118,8 @@ GLOBAL_LIST_EMPTY(allRequestConsoles)
 	if(departmentType & RC_INFO)
 		GLOB.req_console_information |= department
 
-	// NOT BOOLEAN. DO NOT CONVERT.
 	update_icon()
+	// NOT BOOLEAN. DO NOT CONVERT.
 	set_light(1)
 
 /obj/machinery/requests_console/Destroy()

--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -119,6 +119,7 @@ GLOBAL_LIST_EMPTY(allRequestConsoles)
 		GLOB.req_console_information |= department
 
 	// NOT BOOLEAN. DO NOT CONVERT.
+	update_icon()
 	set_light(1)
 
 /obj/machinery/requests_console/Destroy()

--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -36,6 +36,7 @@ GLOBAL_LIST_EMPTY(status_displays)
 /obj/machinery/status_display/Initialize()
 	. = ..()
 	GLOB.status_displays |= src
+	update_icon(UPDATE_OVERLAYS)
 
 /obj/machinery/status_display/Destroy()
 	GLOB.status_displays -= src

--- a/code/game/machinery/vendors/vending.dm
+++ b/code/game/machinery/vendors/vending.dm
@@ -191,6 +191,7 @@
 		for(var/typepath in subtypesof(/datum/vendor_crit))
 			all_possible_crits[typepath] = new typepath()
 
+	update_icon(UPDATE_OVERLAYS)
 	reconnect_database()
 	power_change()
 

--- a/code/modules/mapping/mapping_helpers.dm
+++ b/code/modules/mapping/mapping_helpers.dm
@@ -122,6 +122,7 @@
 
 /obj/effect/mapping_helpers/airlock/unres/payload(obj/machinery/door/airlock)
 	airlock.unres_sides ^= dir
+	airlock.update_icon()
 
 /obj/effect/mapping_helpers/airlock/autoname
 	name = "airlock autoname helper"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds `update_icon` calls in various Inits, or helper payload. The unres proc for airlocks is slightly rewritten.

Vendors, airlocks, request consoles, status displays, and the unrestricted access helper are affected.

## Why It's Good For The Game
A lot of overlays or lightmasks weren't being set properly until some other action would prompt an object to update itself, which wasn't good for ambience.

## Images of changes
![2](https://github.com/ParadiseSS13/Paradise/assets/80771500/378afbec-bad1-4b9e-97df-91e468720189)

## Testing
Loaded into Boxstation, and killed all the lights.

## Changelog
:cl:
fix: Vendors, airlocks, request consoles, and status displays set their icons properly on round start.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
