### PR TITLE
Instruction for how to right a vending machine

### DIFF
--- a/code/game/machinery/vendors/vending.dm
+++ b/code/game/machinery/vendors/vending.dm
@@ -605,7 +605,7 @@
 		return
 
 	if(tilted)
-		to_chat(user, "<span class='warning'>[src] is tipped over and non-functional! You'll need to right it first.</span>")
+		to_chat(user, "<span class='warning'>[src] is tipped over and non-functional! Alt+click to right it first.</span>")
 		return
 
 	if(seconds_electrified != 0 && shock(user, 100))

--- a/code/game/machinery/vendors/vending.dm
+++ b/code/game/machinery/vendors/vending.dm
@@ -204,8 +204,7 @@
 	. = ..()
 	if(tilted)
 		. += "<span class='warning'>It's been tipped over and won't be usable unless it's righted.</span>"
-		if(Adjacent(user))
-			. += "<span class='notice'>You can <b>Alt-Click</b> it to right it.</span>"
+		. += "<span class='notice'>You can <b>Alt-Click</b> it to right it when adjacent.</span>"
 
 	if(aggressive)
 		. += "<span class='warning'>Its product lights seem to be blinking ominously...</span>"
@@ -605,7 +604,7 @@
 		return
 
 	if(tilted)
-		to_chat(user, "<span class='warning'>[src] is tipped over and non-functional! Alt+click to right it first.</span>")
+		to_chat(user, "<span class='warning'>[src] is tipped over and non-functional! <b>Alt-Click</b> to right it first.</span>")
 		return
 
 	if(seconds_electrified != 0 && shock(user, 100))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Adds instruction to the description of a tipped over vending machine about the need to alt+click to right it

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

New players will get less frustrated trying to figure out how to fix the vending machines

## Changelog
:cl:
tweak: Description of tipped vending machine now tells you how to put it up again (alt+click)
/:cl:
