### PR TITLE
improves clarification on having martial arts as a non carbon

### DIFF
--- a/code/__DEFINES/mob_defines.dm
+++ b/code/__DEFINES/mob_defines.dm
@@ -267,6 +267,7 @@
 
 #define isAutoAnnouncer(A)	(istype((A), /mob/living/automatedannouncer))
 
+#define iscameramob(A)	(istype((A), /mob/camera))
 #define isAIEye(A)		(istype((A), /mob/camera/aiEye))
 #define isovermind(A)	(istype((A), /mob/camera/blob))
 

--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -637,9 +637,9 @@
 		if(!check_rights(R_SERVER|R_EVENT))	return
 
 		var/mob/living/carbon/C = locateUID(href_list["givemartialart"])
-		if(!istype(C))
-			to_chat(usr, "This can only be done to instances of type /mob/living/carbon")
-			return
+//		if(!istype(C))
+//			to_chat(usr, "This can only be done to instances of type /mob/living/carbon")
+//			return
 
 		var/list/artpaths = subtypesof(/datum/martial_art)
 		var/list/artnames = list()

--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -637,9 +637,9 @@
 		if(!check_rights(R_SERVER|R_EVENT))	return
 
 		var/mob/living/carbon/C = locateUID(href_list["givemartialart"])
-//		if(!istype(C))
-//			to_chat(usr, "This can only be done to instances of type /mob/living/carbon")
-//			return
+		if(!istype(C))
+			to_chat(usr, "This can only be done to instances of type /mob/living/carbon")
+			return
 
 		var/list/artpaths = subtypesof(/datum/martial_art)
 		var/list/artnames = list()

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -133,7 +133,7 @@
 			break
 		if(isobserver(M))
 			continue
-		if(istype(M, /mob/living/simple_animal/bot/mulebot) || istype(M, /mob/camera))
+		if(istype(M, /mob/living/simple_animal/bot/mulebot) || iscameramob(M))
 			continue
 		if(M.buckled || M.anchored || M.has_buckled_mobs())
 			continue

--- a/code/modules/martial_arts/martial.dm
+++ b/code/modules/martial_arts/martial.dm
@@ -175,6 +175,9 @@
 	if(issilicon(H))
 		to_chat(usr, "<span class='notice'>Your malformed steel body can barely perform basic tasks, let alone complex martial arts.</span>")
 		return
+	if(isalien(H))
+		to_chat(usr, "<span class='notice'>The hivemind's fighting style has been blessed upon you, you have no need for this useless style.</span>")
+		return
 
 /datum/martial_art/proc/give_explaination(user = usr)
 	explaination_header(user)

--- a/code/modules/martial_arts/martial.dm
+++ b/code/modules/martial_arts/martial.dm
@@ -163,10 +163,18 @@
 	set desc = "Gives information about the martial arts you know."
 	set category = "Martial Arts"
 	var/mob/living/carbon/human/H = usr
-	if(!istype(H))
+	if(istype(H))
+		H.mind.martial_art.give_explaination(H)
+		return
+	if(isobserver(H) || iscameramob(H))
 		to_chat(usr, "<span class='warning'>You shouldn't have access to this verb. Report this as a bug to the github please.</span>")
 		return
-	H.mind.martial_art.give_explaination(H)
+	if(isanimal(H))
+		to_chat(usr, "<span class='notice'>Your beastial form isn't compatible with any martial arts you know.</span>")
+		return
+	if(issilicon(H))
+		to_chat(usr, "<span class='notice'>Your malformed steel body can barely perform basic tasks, let alone complex martial arts.</span>")
+		return
 
 /datum/martial_art/proc/give_explaination(user = usr)
 	explaination_header(user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
See title

## Why It's Good For The Game
You keep martial arts even as different mob because it's stored in the mind, so if you get revived again as a human you keep said arts. It's not good to encourage people to file github reports over things that aren't issues because the author of an older PR didn't consider an edge case. 

## Testing
Tried it in game

## Changelog
:cl:
spellcheck: improved clarification on having martial arts as a non carbon
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
