### PR TITLE
readds the mind batterer, fully reworked

### DIFF
--- a/code/__DEFINES/status_effects.dm
+++ b/code/__DEFINES/status_effects.dm
@@ -160,4 +160,14 @@
 /// gives you fluff messages for cough, sneeze, headache, etc but without an actual virus
 #define STATUS_EFFECT_FAKE_VIRUS /datum/status_effect/fake_virus
 /// This status effect lets the user see the lwap dots.
-#define STATUS_EFFECT_LWAPSCOPE /datum/status_effect/lwap_scope 
+#define STATUS_EFFECT_LWAPSCOPE /datum/status_effect/lwap_scope
+
+//////////////////////////
+// Mind batter variants //
+//////////////////////////
+// Basically variants with differing effect times to their parent datums, nothing special
+
+#define STATUS_EFFECT_PACIFIED_BATTERER /datum/status_effect/pacifism/batterer
+
+#define STATUS_EFFECT_CLINGTENTACLE_BATTERER /datum/status_effect/cling_tentacle/batterer
+

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -223,6 +223,11 @@
 /datum/status_effect/pacifism/on_remove()
 	REMOVE_TRAIT(owner, TRAIT_PACIFISM, id)
 
+/datum/status_effect/pacifism/batterer
+	id = "pacifism_debuff_batterer"
+	alert_type = null
+	duration = 10 SECONDS
+
 // used to track if hitting someone with a cult dagger/sword should stamina crit.
 /datum/status_effect/cult_stun_mark
 	id = "cult_stun"
@@ -289,6 +294,10 @@
 /datum/status_effect/cling_tentacle/on_remove()
 	REMOVE_TRAIT(owner, TRAIT_IMMOBILIZED, "[id]")
 
+/datum/status_effect/cling_tentacle/batterer
+	id = "cling_tentacle"
+	alert_type = null
+	duration = 7 SECONDS
 // start of `living` level status procs.
 
 /**

--- a/code/datums/uplink_items/uplink_general.dm
+++ b/code/datums/uplink_items/uplink_general.dm
@@ -208,6 +208,13 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/twohanded/chainsaw
 	cost = 13
 
+/datum/uplink_item/dangerous/batterer
+	name = "Mind Batterer"
+	desc = "A  dangerous syndicate device focused on crowd control and escapes. Causes brain damage, confusion, and other nasty effects to those surrounding the user. Has 5 charges."
+	reference = "BTR"
+	item = /obj/item/batterer
+	cost = 5
+
 
 // Ammunition
 

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -245,3 +245,97 @@
 	charges = 8
 	max_charges = 8
 	flawless = TRUE
+
+/obj/item/batterer
+	name = "mind batterer"
+	desc = "A dangerous syndicate device focused on crowd control and escapes. Causes brain damage, confusion, and other nasty effects to those surrounding the user."
+	icon = 'icons/obj/device.dmi'
+	icon_state = "batterer"
+	throwforce = 5
+	w_class = WEIGHT_CLASS_TINY
+	throw_speed = 4
+	throw_range = 10
+	flags = CONDUCT
+	item_state = "electronic"
+	origin_tech = "magnets=3;combat=3;syndicate=3"
+
+	/// How many uses the mind batter has been used
+	var/times_used = 0
+	var/max_uses = 5
+
+/obj/item/batterer/examine(mob/user)
+	. = ..()
+	. += "<span class='warning'>Using this item in quick succession may cause fatigue to the user!</span>"
+	if(times_used >= max_uses)
+		. += "<span class='notice'>[src] is out of charge.</span>"
+	if(times_used < max_uses)
+		. += "<span class='notice'>[src] has [max_uses-times_used] charges left.</span>"
+
+/obj/item/batterer/attack_self(mob/living/carbon/user)
+	if(user)
+		if(times_used >= max_uses)
+			to_chat(user, "<span class='danger'>The mind batterer has been burnt out!</span>")
+			return
+		if(!do_after_once(user, 2 SECONDS, target = src, allow_moving = TRUE, attempt_cancel_message = "You think it's best to save this for later."))
+			return
+
+	for(var/mob/living/M in oview(7, get_turf(src)))
+		if(issilicon(M))
+			M.Weaken(10 SECONDS)
+		else
+			M.Confused(30 SECONDS)
+		M.adjustBrainLoss(10)
+		to_chat(M, "<span class='danger'>You feel a sudden, electric jolt travel through yourself,</span>")
+		switch(rand(1, 10))
+			if(1)
+				M.apply_status_effect(STATUS_EFFECT_CLINGTENTACLE_BATTERER)
+				to_chat(M, "<span class='warning'>and your legs lock up for a moment!</span>")
+			if(2)
+				M.apply_status_effect(STATUS_EFFECT_PACIFIED_BATTERER)
+				to_chat(M, "<span class='warning'>and you feel an innate love for life for a fleeting moment!</span>")
+			if(3)
+				if(prob(80))
+					M.Druggy(45 SECONDS)
+					to_chat(M, "<span class='warning'>and you feel like, totally chill dude!</span>")
+				else
+					M.AdjustHallucinate(45 SECONDS)
+					to_chat(M, "<span class='warning'>and this doesn't feel like a good trip!</span>")
+			if(4)
+				if(prob(80))
+					M.EyeBlurry(25 SECONDS)
+					to_chat(M, "<span class='warning'>and something in the back of your head stings like hell!</span>")
+				else
+					M.EyeBlind(15 SECONDS)
+					to_chat(M, "<span class='warning'>and you can't see a goddamn thing!</span>")
+			if(5)
+				M.adjustStaminaLoss(40)
+				to_chat(M, "<span class='warning'>and a wave of tiredness washes over you!</span>")
+			else
+				to_chat(M, "<span class='danger'>but as soon as it arrives, it fades.</span>")
+		add_attack_logs(user, M, "Mind battered with [src]")
+
+	playsound(get_turf(src), 'sound/misc/interference.ogg', 50, 1)
+	times_used++
+	to_chat(user, "<span class='notice'>You trigger [src]. It has [max_uses-times_used] charges left.</span>")
+	if(times_used >= max_uses)
+		icon_state = "battererburnt"
+
+/obj/item/batterer/throw_impact(atom/hit_atom)
+	..()
+	if(times_used >= max_uses)
+		return
+	visible_message("<span class='notice'>[src] suddenly triggers, sending a shower of sparks everywhere!</span>")
+	do_sparks(4, 0, get_turf(src))
+	attack_self()
+
+/obj/item/batterer/emp_act(severity)
+	if(times_used >= max_uses)
+		return
+	visible_message("<span class='notice'>[src] explodes into a light show of colors!</span>")
+	if(severity == EMP_HEAVY)
+		attack_self()
+		times_used = max_uses - 1
+		attack_self()
+	else
+		times_used = max_uses - 1
+		attack_self()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Mind batter added back to the uplink, 5 TC, 5 charges. Takes two seconds to activate. 
No longer stuns, confuses for 30 seconds on use (Or stuns silicons for 10), deals 10 brain damage, and has a chance to apply a different effect on hit, ranging from pacifism to blindness.
Weak against EMPs and activates when thrown.

## Why It's Good For The Game
The mind batterer used to be an antags go to ~~meme~~ AOE nonlethal option, and since it's removal antags have been lacking in those, leading people to often just absolutely fold to groups. An AOE confuse with a little bit extra sometimes should allow for actual nonlethal AOE rather than blowing a hole in medical because you have no other options. The brain damage applied by this item is really important because it forces people fighting you to understand inevitability, they'll WILL need to disengage at some point because shit will hit the fan otherwise. Same applies to nukies, where this item should be very effective at dealing with groups in choke points. 

Honestly there's not too much to say about this item, they're lacking a nonlethal option so here, take one. 

## Testing
Watched a skrell die from brain damage and a silicon cri

## Changelog
:cl:
add: Readds the mind batterer reworked, available in tot uplinks for 5 TC. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
