### PR TITLE
Makes the beer keg nuke more realistic

### DIFF
--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -33,6 +33,7 @@
 	. = ..()
 	create_reagents(tank_volume)
 	reagents.add_reagent(reagent_id, tank_volume)
+	update_icon(UPDATE_OVERLAYS)
 
 /obj/structure/reagent_dispensers/wrench_act(mob/user, obj/item/I)
 	if(!can_be_unwrenched)
@@ -41,6 +42,7 @@
 	if(!I.tool_use_check(user, 0))
 		return
 	default_unfasten_wrench(user, I)
+	update_icon(UPDATE_OVERLAYS)
 
 /obj/structure/reagent_dispensers/examine(mob/user)
 	. = ..()
@@ -277,6 +279,11 @@
 	icon = 'icons/obj/nuclearbomb.dmi'
 	icon_state = "nuclearbomb0"
 	anchored = TRUE
+
+/obj/structure/reagent_dispensers/beerkeg/nuke/update_overlays()
+	. = ..()
+	if(anchored)
+		. += "nukebolts"
 
 /obj/structure/reagent_dispensers/virusfood
 	name = "virus food dispenser"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds some logic for reagent container structures to have overlays, and gives the beer keg nuke the real nuke's bolted wheels overlay when it's wrenched in place.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
The model nuke should demonstrate the real nuke's capability to be anchored in place! Also, if people want to sprite similar overlays for water or fuel tanks in the future, they can add that pretty easily now by basically copying what I did for the beer keg nuke.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://github.com/ParadiseSS13/Paradise/assets/47290811/380037f7-612e-4684-97f7-65591fd569e1)
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Loaded in, wrenched and unwrenched the beer keg nuke a few times.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: The beer keg nuke now has anchoring bolts just like the real nuke
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
