### PR TITLE
QoL Unhusking tweaks

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -303,11 +303,11 @@
 			M.adjustFireLoss(-1.5*volume)
 			if(show_message)
 				to_chat(M, "<span class='notice'>The synthetic flesh integrates itself into your wounds, healing you.</span>")
-			if(ishuman(M))
-				var/mob/living/carbon/human/H = M
-				if(HAS_TRAIT_FROM(H, TRAIT_HUSK, BURN) && H.getFireLoss() < UNHUSK_DAMAGE_THRESHOLD && (H.reagents.get_reagent_amount("synthflesh") + volume >= SYNTHFLESH_UNHUSK_AMOUNT))
-					H.cure_husk(BURN)
-					H.visible_message("<span class='nicegreen'>The squishy liquid coats [H]'s burns. [H] looks a lot healthier!") //we're avoiding using the phrases "burnt flesh" and "burnt skin" here because humans could be a skeleton or a golem or something
+		if(ishuman(M))
+			var/mob/living/carbon/human/H = M
+			if(HAS_TRAIT_FROM(H, TRAIT_HUSK, BURN) && H.getFireLoss() < UNHUSK_DAMAGE_THRESHOLD && (H.reagents.get_reagent_amount("synthflesh") + volume >= SYNTHFLESH_UNHUSK_AMOUNT))
+				H.cure_husk(BURN)
+				H.visible_message("<span class='nicegreen'>The squishy liquid coats [H]'s burns. [H] looks a lot healthier!") //we're avoiding using the phrases "burnt flesh" and "burnt skin" here because humans could be a skeleton or a golem or something
 	..()
 
 /datum/reagent/medicine/synthflesh/reaction_turf(turf/T, volume) //let's make a mess!

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -305,7 +305,7 @@
 				to_chat(M, "<span class='notice'>The synthetic flesh integrates itself into your wounds, healing you.</span>")
 		if(ishuman(M))
 			var/mob/living/carbon/human/H = M
-			if(HAS_TRAIT_FROM(H, TRAIT_HUSK, BURN) && H.getFireLoss() < UNHUSK_DAMAGE_THRESHOLD && (H.reagents.get_reagent_amount("synthflesh") + volume >= SYNTHFLESH_UNHUSK_AMOUNT))
+			if(HAS_TRAIT_FROM(H, TRAIT_HUSK, BURN) && H.getFireLoss() <= UNHUSK_DAMAGE_THRESHOLD && (H.reagents.get_reagent_amount("synthflesh") + volume >= SYNTHFLESH_UNHUSK_AMOUNT))
 				H.cure_husk(BURN)
 				H.visible_message("<span class='nicegreen'>The squishy liquid coats [H]'s burns. [H] looks a lot healthier!") //we're avoiding using the phrases "burnt flesh" and "burnt skin" here because humans could be a skeleton or a golem or something
 	..()

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -293,6 +293,7 @@
 	description = "A resorbable microfibrillar collagen and protein mixture that can rapidly heal injuries when applied topically."
 	reagent_state = LIQUID
 	color = "#FFEBEB"
+	penetrates_skin = TRUE
 	taste_description = "blood"
 
 /datum/reagent/medicine/synthflesh/reaction_mob(mob/living/M, method=REAGENT_TOUCH, volume, show_message = 1)

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -299,15 +299,16 @@
 /datum/reagent/medicine/synthflesh/reaction_mob(mob/living/M, method=REAGENT_TOUCH, volume, show_message = 1)
 	if(iscarbon(M))
 		if(method == REAGENT_TOUCH)
-			M.adjustBruteLoss(-1.5*volume)
-			M.adjustFireLoss(-1.5*volume)
+			M.adjustBruteLoss(-1.5 * volume)
+			M.adjustFireLoss(-1.5 * volume)
 			if(show_message)
 				to_chat(M, "<span class='notice'>The synthetic flesh integrates itself into your wounds, healing you.</span>")
 		if(ishuman(M))
 			var/mob/living/carbon/human/H = M
 			if(HAS_TRAIT_FROM(H, TRAIT_HUSK, BURN) && H.getFireLoss() <= UNHUSK_DAMAGE_THRESHOLD && (H.reagents.get_reagent_amount("synthflesh") + volume >= SYNTHFLESH_UNHUSK_AMOUNT))
 				H.cure_husk(BURN)
-				H.visible_message("<span class='nicegreen'>The squishy liquid coats [H]'s burns. [H] looks a lot healthier!") //we're avoiding using the phrases "burnt flesh" and "burnt skin" here because humans could be a skeleton or a golem or something
+				// Could be a skeleton or a golem or sth, avoid phrases like "burnt flesh" and "burnt skin"
+				H.visible_message("<span class='nicegreen'>The squishy liquid coats [H]'s burns. [H] looks a lot healthier!")
 	..()
 
 /datum/reagent/medicine/synthflesh/reaction_turf(turf/T, volume) //let's make a mess!


### PR DESCRIPTION
## What Does This PR Do
- Makes Synthflesh "penetrate skin", meaning it'll deposit some of the reacted amount when splashed onto a body, saving some of the unhusking "progress" rather than requiring the full amount to be splashed at once
- Officially allows Synthflesh to unhusk on ingestion reactions (aka feeding, most commonly)

## Why It's Good For The Game
Currently, unhusking is somewhat clunky - it's quite unintuitive that splashing two 50u bottles doesn't work, and the actual condition is wacky enough that most of the playerbase doesn't even know you can actually *feed* some of the required total 100u of Synthflesh, without the need for a full large 100u beaker.

To anyone saying Synthflesh unhusking on ingestion reactions doesn't make sense as it's supposed to be a touch-only chemical: you could already *sort of* unhusk by feeding someone 100u of Synthflesh, then splashing another 0.1u on it. The second change simply removes this somewhat arbitrary extra step, as the code already checks the Synthflesh volume in the bloodstream, it just never triggered on ingestion reactions.

Besides, you're already losing out on the massive healing value of SF if you're not splashing it, I don't see why we can't at least let it still unhusk, which is a fairly rare occurrence anyway.

## Testing
- Spawned in a Unathi
- VV'd enough burns onto it to husk
- Splashed a beaker of Synthflesh, checked that an amount appropriate for their clothing was deposited in their bloodstream
- Treated their burns to under the unhusking threshold
- Fed them enough Synthflesh to hit the required 100u, checked that they were now unhusked

## Changelog
:cl:
add: Splashed Synthflesh now penetrates the subject's skin into their bloodstream, with the amount depending on their worn clothing
tweak: You can now unhusk bodies also by feeding them the required amount of Synthflesh
/:cl: