### PR TITLE
Make burning Oil into Ash *actually* not cause fires at 30u or below

### DIFF
--- a/code/modules/reagents/chemistry/reagents/misc_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/misc_reagents.dm
@@ -209,20 +209,35 @@
 	var/reagent_after_burning = "ash"
 
 /datum/reagent/oil/reaction_temperature(exposed_temperature, exposed_volume)
-	if(exposed_temperature > T0C + 600)
-		var/turf/T = get_turf(holder.my_atom)
-		holder.my_atom.visible_message("<b>The oil burns!</b>")
-		var/datum/reagents/old_holder = holder
-		fire_flash_log(holder, id)
-		if(holder)
-			holder.del_reagent(id) // Remove first. Else fireflash triggers a reaction again
+	if(exposed_temperature <= T0C + 600)
+		return
 
-		fireflash(T, min(max(0, volume / 40), 8))
-		var/datum/effect_system/smoke_spread/bad/BS = new
-		BS.set_up(1, FALSE, T)
-		BS.start()
-		if(!QDELETED(old_holder) && reagent_after_burning)
-			old_holder.add_reagent(reagent_after_burning, round(volume * 0.5))
+	var/violent = volume > 30
+	var/message_type = violent ? "class='boldwarning'" : "class='warning'"
+	holder.my_atom.visible_message("<span [message_type]>The oil [violent ? "boils and burns violently" : "burns"]!</span>")
+
+	var/datum/reagents/old_holder = holder
+	var/turf/T = get_turf(holder.my_atom)
+	var/smoke_type = /datum/effect_system/smoke_spread
+
+	if(violent)
+		// Log -> remove reagent -> fireflash. Else the log fails or fireflash triggers a reaction again
+		fire_flash_log(holder, id)
+		holder.del_reagent(id)
+		fireflash(T, clamp(volume / 40, 0, 8))
+
+		smoke_type = /datum/effect_system/smoke_spread/bad
+	else
+		holder.del_reagent(id)
+
+	// Flavor reaction effects
+	playsound(T, 'sound/goonstation/misc/drinkfizz.ogg', 80, TRUE)
+	var/datum/effect_system/smoke_spread/BS = new smoke_type
+	BS.set_up(1, FALSE, T)
+	BS.start()
+
+	if(!QDELETED(old_holder) && reagent_after_burning)
+		old_holder.add_reagent(reagent_after_burning, round(volume * 0.5))
 
 /datum/reagent/oil/reaction_turf(turf/T, volume)
 	if(volume >= 3 && !isspaceturf(T) && !(locate(/obj/effect/decal/cleanable/blood/oil) in T))


### PR DESCRIPTION
## What Does This PR Do
- Most importantly - title. Makes burning oil not create flash fires if you use >=30u. Previously you *always* had a flash fire regardless of volume (though it only explodes nearby oil tanks if the amount burned is actually *>=40u*).
- Improves the feedback slightly, giving you a slightly different message depending on whether the reaction explodes in a flash of fire or not, as well as introducing a minor detail in the form of making the resulting smoke non-cough-inducing for the safe burned volume range.
- Adds some sound to the reaction to indicate boiling and sizzling oil; previously it was silent aside from the coughing.

## Why It's Good For The Game
Yet another case of wiki misinformation that became a widespread myth (or maybe the other way around?). Figured it's better to adjust the game rather than the wiki, as chemists should have some - ideally safe - form of making Ash without having to resort to the "apply lighter to paper" meta.

## Testing
- Burned 30u of oil, enjoyed being flame-free, a refreshing new sound effect, and a pleasant mild smoke with the scent of charred wood.
- Burned 31u of oil, started burning alive as agonizing sound of sizzling grease and skin filled my ears, coughing my lungs out while inhaling the toxic fumes.

## Changelog
:cl:
fix: Burning up to 30u of Oil is now *actually* safe.
/:cl:
