### PR TITLE
Adds the "Ingredient Crate"

### DIFF
--- a/code/modules/supply/supply_packs/pack_organic.dm
+++ b/code/modules/supply/supply_packs/pack_organic.dm
@@ -37,6 +37,27 @@
 	cost = 500
 	containername = "Pizza crate"
 
+/datum/supply_packs/misc/randomised/ingredients // its a bit hacky...
+	num_contained = 25
+	contains = list(/obj/item/reagent_containers/food/snacks/grown/wheat,
+					/obj/item/reagent_containers/food/snacks/grown/tomato,
+					/obj/item/reagent_containers/food/snacks/grown/potato,
+					/obj/item/reagent_containers/food/snacks/grown/carrot,
+					/obj/item/reagent_containers/food/snacks/grown/pumpkin,
+					/obj/item/reagent_containers/food/snacks/grown/chili,
+					/obj/item/reagent_containers/food/snacks/grown/cocoapod,
+					/obj/item/reagent_containers/food/snacks/grown/corn,
+					/obj/item/reagent_containers/food/snacks/grown/eggplant,
+					/obj/item/reagent_containers/food/snacks/grown/apple,
+					/obj/item/reagent_containers/food/snacks/grown/banana,
+					/obj/item/reagent_containers/food/snacks/grown/cherries)
+	name = "Ingredient Crate"
+	cost = 300
+	containername = "ingredient crate"
+	group = SUPPLY_ORGANIC
+	containertype = /obj/structure/closet/crate/freezer
+	department_restrictions = list(DEPARTMENT_SERVICE)
+
 /datum/supply_packs/organic/monkey
 	name = "Monkey Crate"
 	contains = list (/obj/item/storage/box/monkeycubes)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->Adds the Ingredient Crate to cargo, containing 25 random plants. The crate includes wheat, tomatos, potatos, carrots, pumpkins, chilis, cocoa pods, corn, eggplants, apples, bananas, and cherries. The crate can be bought for 300 credits, it was originally 500 but Marm talked me down. 25 plants wont be able to fuel the kitchen for the entire round, they'll either need to buy multiple crates or still rely on botany.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Sometimes chefs want to cook with more variety, and botany can't provide (or simply fails to provide, looking at you 17 million pound marijuana brick).

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
Heres an example of what you can get in a crate
![image](https://github.com/ParadiseSS13/Paradise/assets/91113370/ac18b345-e74f-4a3f-9da9-9ff84aab51b2)


## Testing
<!-- How did you test the PR, if at all? -->
Used the create crate command, plants were in it correctly.
Bought some crates via cargo, all the plants were in there. I then turned all those plants into seeds, and tried to sell them. Since they were all normal seeds, centcomm did not buy them back.

## Changelog
:cl:
add: An Ingredient Crate full of a random assortment of plants for chefs to cook with
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
