### PR TITLE
 Bluespace RPD now fits in belts

### DIFF
--- a/code/game/objects/items/weapons/rpd.dm
+++ b/code/game/objects/items/weapons/rpd.dm
@@ -66,7 +66,7 @@
 
 /obj/item/rpd/bluespace
 	name = "bluespace rapid pipe dispenser"
-	desc = "This device can rapidly dispense atmospherics and disposals piping, manipulate loose piping, and recycle any detached pipes it is applied to, at any range.  It is slightly more compact than the standard version and can be stored in a toolbelt."
+	desc = "This device can rapidly dispense atmospherics and disposals piping, manipulate loose piping, and recycle any detached pipes it is applied to, at any range. It is slightly more compact than the standard version and can be stored in a toolbelt."
 	icon_state = "brpd"
 	materials = list(MAT_METAL = 75000, MAT_GLASS = 37500, MAT_SILVER = 3000)
 	origin_tech = "engineering=4;materials=2;bluespace=3"

--- a/code/game/objects/items/weapons/rpd.dm
+++ b/code/game/objects/items/weapons/rpd.dm
@@ -66,7 +66,7 @@
 
 /obj/item/rpd/bluespace
 	name = "bluespace rapid pipe dispenser"
-	desc = "This device can rapidly dispense atmospherics and disposals piping, manipulate loose piping, and recycle any detached pipes it is applied to, at any range."
+	desc = "This device can rapidly dispense atmospherics and disposals piping, manipulate loose piping, and recycle any detached pipes it is applied to, at any range.  It is slightly more compact than the standard version and can be stored in a toolbelt."
 	icon_state = "brpd"
 	materials = list(MAT_METAL = 75000, MAT_GLASS = 37500, MAT_SILVER = 3000)
 	origin_tech = "engineering=4;materials=2;bluespace=3"

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -101,7 +101,8 @@
 		/obj/item/analyzer,
 		/obj/item/geiger_counter,
 		/obj/item/extinguisher/mini,
-		/obj/item/holosign_creator)
+		/obj/item/holosign_creator,
+		/obj/item/rpd/bluespace)
 
 /obj/item/storage/belt/utility/full/populate_contents()
 	new /obj/item/screwdriver(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
The Bluespace Rapid Pipe Dispenser can now be put on a toolbelt, advanced toolbelt, etc.

## Why It's Good For The Game
the BS RPD is kind of in a weird spot where it's *cool* but not necessarily super useful.  You can spawn pipes at a distance, but you still have to walk over to them to wrench them down, so most people just don't bother getting one from R&D.  This gives an incentive to actually ask for one, because it can actually fit in a toolbelt, unlike the normal one, saving a step for those of us who use duffels and just making working with pipes that much easier.

## Images of changes
![bs rpd in bag](https://i.imgur.com/hewUhl4.png)

![bs rpd vs rpd](https://i.imgur.com/DMIsUkp.png)

![bs rpd description](https://i.imgur.com/l4tW4N9.png)

## Testing
Ran test server, tried to put bluespace RPD in toolbelt.  It fits.

## Changelog
:cl:
tweak: Bluespace RPD now fits in toolbelts, description changed to show as such.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
