### PR TITLE
dchat now gets an alert on what jobs have changed in Bureaucratic error

### DIFF
--- a/code/modules/events/bureaucratic_error.dm
+++ b/code/modules/events/bureaucratic_error.dm
@@ -37,4 +37,4 @@
 		errors++
 	log_and_message_admins(affected_jobs.Join(".\n"))
 	for(var/mob/M as anything in GLOB.dead_mob_list)
-		to_chat(M, "<span class='deadsay'><bBureaucratic Error:</b> The following job slots have changed: [affected_jobs.Join(", ")].</span>")
+		to_chat(M, "<span class='deadsay'><b>Bureaucratic Error:</b> The following job slots have changed: [affected_jobs.Join(", ")].</span>")

--- a/code/modules/events/bureaucratic_error.dm
+++ b/code/modules/events/bureaucratic_error.dm
@@ -33,6 +33,8 @@
 		if(overflow.type in blacklisted_jobs)
 			continue
 		overflow.total_positions = max(overflow.total_positions + random_change, 0)
-		affected_jobs += "[overflow.title] slot changed by [random_change]."
+		affected_jobs += "[overflow.title] slot changed by [random_change]"
 		errors++
-	log_and_message_admins(affected_jobs.Join("\n"))
+	log_and_message_admins(affected_jobs.Join(".\n"))
+	for(var/mob/M as anything in GLOB.dead_mob_list)
+		to_chat(M, "<span class='deadsay'><bBureaucratic Error:</b> The following job slots have changed: [affected_jobs.Join(", ")].</span>")


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
See title, they get a dsay message about it

## Why It's Good For The Game
Why wouldn't ghosts have this info?

## Testing
Saw it in game

## Changelog
:cl:
tweak: dchat now gets an alert on what jobs have changed in Bureaucratic error
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
