### PR TITLE
Lets you click the blob overmind

### DIFF
--- a/code/modules/events/blob/overmind.dm
+++ b/code/modules/events/blob/overmind.dm
@@ -7,6 +7,7 @@
 	see_in_dark = 8
 	invisibility = INVISIBILITY_OBSERVER
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
+	mouse_opacity = MOUSE_OPACITY_OPAQUE
 
 	pass_flags = PASSBLOB
 	faction = list(ROLE_BLOB)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
This turns the blob overmind icon into a tilsized clickable object, for easy follow, and allows admins to use the right-click options on blob overmind. Fixes #20987

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Lets it be clickable as an observer or admin.

## Testing
<!-- How did you test the PR, if at all? -->
Boot up server, spawned a blob mouse, waited for it to pop, aghosted and confirmed that I could both click and right click it.

## Changelog
:cl: ppi
fix: Makes the Blob Overmind clickable
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
