### PR TITLE
Fixes brig cell lockers not updating their icon when a prisoner is released.

### DIFF
--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -252,7 +252,7 @@
 		if(C.opened)
 			continue
 		C.locked = FALSE
-		C.icon_state = C.icon_closed
+		C.update_icon()
 
 	for(var/obj/machinery/treadmill_monitor/T in targets)
 		if(!T.stat)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes it so that the icons of the lockers in brig cells update when they are automatically unlocked after the timer runs out/the prisoner is released.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Bug bad.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Go to brig
Close and lock locker
Start timer
Timer runs out
Locker unlocks, visibly
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Brig cell lockers now update their icon on release.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
