### PR TITLE
organs no longer gain germs while in a changeling egg/headslug

### DIFF
--- a/code/modules/antagonists/changeling/powers/become_headslug.dm
+++ b/code/modules/antagonists/changeling/powers/become_headslug.dm
@@ -42,7 +42,7 @@
 			crab.origin.active = TRUE
 			crab.origin.transfer_to(crab)
 			to_chat(crab, "<span class='warning'>You burst out of the remains of your former body in a shower of gore!</span>")
-			to_chat(crab, "<span class='boldnotice'>We must bite the corpse of a non-primitive humanoid to lay our egg within them.</span>")
+			to_chat(crab, "<span class='boldnotice'>Our eggs can be laid in any humanoid by ALT-CLICKing on them, this takes 5 seconds.</span>")
 			to_chat(crab, "<span class='boldnotice'>Though this form shall perish after laying the egg, our true self shall be reborn in time.</span>")
 
 	// This is done because after the original changeling gibs below, ALL of their actions are qdeleted

--- a/code/modules/mob/living/simple_animal/hostile/headslug.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headslug.dm
@@ -106,6 +106,7 @@
 
 		cling.give_power(new /datum/action/changeling/humanform)
 		M.key = origin.key
+		M.revive() // better make sure some weird shit doesn't happen, because it has in the past
 	owner.gib()
 
 #undef EGG_INCUBATION_DEAD_TIME

--- a/code/modules/surgery/organs/organ.dm
+++ b/code/modules/surgery/organs/organ.dm
@@ -127,6 +127,9 @@
 	if(istype(loc,/obj/item/mmi))
 		germ_level = max(0, germ_level - 1) // So a brain can slowly recover from being left out of an MMI
 		return TRUE
+	if(istype(loc, /mob/living/simple_animal/hostile/headslug) || istype(loc, /obj/item/organ/internal/body_egg/changeling_egg))
+		germ_level = 0 // weird stuff might happen, best to be safe
+		return TRUE
 	if(is_found_within(/obj/structure/closet/crate/freezer))
 		return TRUE
 	if(is_found_within(/obj/machinery/clonepod))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
See title
Adds a aheal at the end of the monkey spawn just to make sure that they're properly revived.
also improves clarification on how to lay your eggs

## Why It's Good For The Game
This is a fix, right now you can get necrotic organs if you wait too long to reproduce as a headslug (It's only a few minutes too, it's gonna happen). A cling with a dead brain is a soon to be dead cling.


## Testing
checked germ level in var panel

## Changelog
:cl:
fix: Last resort clings no longer have their organs necrotize if they don't reproduce quickly 
spellcheck: improves clarification on how to lay your eggs as a headslug
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
