### PR TITLE
Fix invisible rad storms bug

### DIFF
--- a/code/datums/weather/weather_datum.dm
+++ b/code/datums/weather/weather_datum.dm
@@ -145,3 +145,10 @@
 				N.layer = initial(N.layer)
 				N.plane = initial(N.plane)
 				N.set_opacity(FALSE)
+
+	// Workaround for issue where area graphics changes aren't applied
+	// immediately on clients, which caused invisible rad storms
+	for(var/mob/M in GLOB.player_list)
+		if (M.client)
+			M.client.UpdateView()
+

--- a/code/datums/weather/weather_types/radiation_storm.dm
+++ b/code/datums/weather/weather_types/radiation_storm.dm
@@ -48,11 +48,13 @@
 		L.rad_act(400)
 		if(HAS_TRAIT(H, TRAIT_GENELESS))
 			return
-		randmuti(H) // Applies bad mutation
+		randmuti(H) // Random appearance mutation
 		if(prob(50))
 			if(prob(90))
+				// High chance of bad mutation
 				randmutb(H)
 			else
+				// Small chance of good mutation
 				randmutg(H)
 
 		domutcheck(H, MUTCHK_FORCED)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Fixes the issue where you sometimes couldn't see active weather effects in areas until you walked into them.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Now you can know if you're walking into mutation-y death or not!

## Testing
<!-- How did you test the PR, if at all? -->

Reproduced bug locally by triggering radiation storms with the Event Manager Panel and sitting at a maint exit in medbay. After fix changes, bug no longer appears.

## Changelog
:cl:
fix: Rad storms are no longer mysteriously invisible in some areas
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
