### PR TITLE
Fixing infinite fire alarm sounds

### DIFF
--- a/code/datums/looping_sounds/looping_sound.dm
+++ b/code/datums/looping_sounds/looping_sound.dm
@@ -53,7 +53,7 @@
 	return ..()
 
 /datum/looping_sound/proc/start(atom/add_thing)
-	if(add_thing)
+	if(add_thing && !(add_thing in output_atoms))
 		LAZYADD(output_atoms, add_thing)
 	if(!muted)
 		return

--- a/code/datums/looping_sounds/looping_sound.dm
+++ b/code/datums/looping_sounds/looping_sound.dm
@@ -53,8 +53,8 @@
 	return ..()
 
 /datum/looping_sound/proc/start(atom/add_thing)
-	if(add_thing && !(add_thing in output_atoms))
-		LAZYADD(output_atoms, add_thing)
+	if(add_thing)
+		LAZYADDOR(output_atoms, add_thing)
 	if(!muted)
 		return
 	muted = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
This PR fixes a bug when some object that should emit looping sounds was added twice to list, makes object emitting sounds infinitely. Currently its happening when you EMP fire alarm with APC, magic happends and TADAA, loud fire alarm looped sound is here forever until you destroy it.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Bugs bad

## Testing
<!-- How did you test the PR, if at all? -->
Compiled, blew up big EMP bomb, enjoyed silence after disabling fire alarms

## Changelog
:cl:
fix: EMPd fire alarm(object) now will not emit fire alarm sounds forever
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
