### PR TITLE
Maps the janidrobe and lawdrobe in to all stations

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -7555,12 +7555,13 @@
 	name = "south bump";
 	pixel_y = -24
 	},
+/obj/structure/janitorialcart,
+/obj/item/reagent_containers/glass/bucket,
 /turf/simulated/floor/plasteel,
 /area/janitor)
 "aBx" = (
-/obj/structure/janitorialcart,
-/obj/item/reagent_containers/glass/bucket,
 /obj/machinery/light,
+/obj/machinery/economy/vending/janidrobe,
 /turf/simulated/floor/plasteel,
 /area/janitor)
 "aBy" = (
@@ -97555,8 +97556,8 @@
 /turf/simulated/floor/engine,
 /area/toxins/explab)
 "xKd" = (
-/obj/machinery/economy/vending/coffee,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/economy/vending/lawdrobe,
 /turf/simulated/floor/wood,
 /area/lawoffice)
 "xKC" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -19518,6 +19518,11 @@
 	pixel_x = -24
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/item/storage/box/lights/mixed,
+/obj/item/storage/box/lights/mixed,
+/obj/item/grenade/chem_grenade/cleaner,
+/obj/item/grenade/chem_grenade/cleaner,
+/obj/item/grenade/chem_grenade/cleaner,
 /turf/simulated/floor/plasteel,
 /area/janitor)
 "bmR" = (
@@ -20098,15 +20103,8 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/lobby)
 "bou" = (
-/obj/structure/table,
-/obj/item/storage/box/lights/mixed,
-/obj/item/storage/box/lights/mixed,
-/obj/item/grenade/chem_grenade/cleaner,
-/obj/item/grenade/chem_grenade/cleaner,
-/obj/item/grenade/chem_grenade/cleaner,
-/obj/item/storage/box/mousetraps,
-/obj/item/storage/box/mousetraps,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/economy/vending/janidrobe,
 /turf/simulated/floor/plasteel,
 /area/janitor)
 "bov" = (
@@ -20270,6 +20268,8 @@
 	},
 /obj/item/clothing/gloves/color/orange,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/storage/box/mousetraps,
+/obj/item/storage/box/mousetraps,
 /turf/simulated/floor/plasteel,
 /area/janitor)
 "boO" = (
@@ -65477,6 +65477,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/economy/vending/lawdrobe,
 /turf/simulated/floor/plasteel{
 	icon_state = "cult"
 	},

--- a/_maps/map_files/cerestation/cerestation.dmm
+++ b/_maps/map_files/cerestation/cerestation.dmm
@@ -24152,7 +24152,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fore2)
 "cph" = (
-/obj/machinery/economy/vending/coffee/free,
+/obj/machinery/economy/vending/lawdrobe,
 /turf/simulated/floor/plasteel{
 	icon_state = "cult"
 	},
@@ -44919,6 +44919,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/janitorialcart{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/janitor)
 "gLv" = (
@@ -50007,8 +50010,6 @@
 	},
 /area/medical/medbay)
 "iAF" = (
-/obj/item/mop,
-/obj/item/reagent_containers/glass/bucket,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/janitor)
@@ -52327,6 +52328,8 @@
 /obj/item/storage/box/lights/mixed,
 /obj/item/storage/box/lights/mixed,
 /obj/machinery/light,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/mop,
 /turf/simulated/floor/plasteel,
 /area/janitor)
 "jqW" = (
@@ -52776,12 +52779,10 @@
 /turf/simulated/floor/plating,
 /area/toxins/xenobiology)
 "jwW" = (
-/obj/structure/janitorialcart{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment/corner{
 	dir = 8
 	},
+/obj/machinery/economy/vending/janidrobe,
 /turf/simulated/floor/plasteel,
 /area/janitor)
 "jxb" = (

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -8505,7 +8505,6 @@
 	},
 /area/security/brig)
 "ayH" = (
-/obj/machinery/economy/vending/coffee,
 /obj/machinery/button/windowtint{
 	dir = 4;
 	id = "IAA";
@@ -8513,6 +8512,7 @@
 	pixel_y = 6;
 	req_access_txt = "38"
 	},
+/obj/machinery/economy/vending/lawdrobe,
 /turf/simulated/floor/plasteel{
 	icon_state = "cult"
 	},
@@ -41866,12 +41866,7 @@
 /turf/simulated/floor/plasteel,
 /area/janitor)
 "ccR" = (
-/obj/structure/table,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/item/key/janitor,
-/obj/item/grenade/chem_grenade/cleaner,
-/obj/item/grenade/chem_grenade/cleaner,
-/obj/item/grenade/chem_grenade/cleaner,
+/obj/machinery/economy/vending/janidrobe,
 /turf/simulated/floor/plasteel,
 /area/janitor)
 "ccW" = (
@@ -45324,6 +45319,12 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
+/obj/structure/table,
+/obj/item/key/janitor,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/grenade/chem_grenade/cleaner,
+/obj/item/grenade/chem_grenade/cleaner,
+/obj/item/grenade/chem_grenade/cleaner,
 /turf/simulated/floor/plasteel,
 /area/janitor)
 "cmV" = (


### PR DESCRIPTION
## What Does This PR Do
This is my first mapping PR if everything goes wrong when it comes to conflicting this I'm sorry
 - Adds the janidrobe to all custodial closets, and the lawdrobe to all IAA offices. Items in janitor closets shuffled around to make room, and the lawdrobes have replaced hot drinks machines where available (meta office lacked one and the others all have a hot drinks vendor 1-3 tiles away from the door in the hallway so they weren't needed.)

## Why It's Good For The Game
New drip, once added, available at shift start rather than having to build a vendor to get it

## Images of changes
Cyberiad: 
Custodial closet
![image](https://github.com/ParadiseSS13/Paradise/assets/25437893/1551f221-99bc-42e6-abd4-d8dc9b856e06)
Internal Affairs
![image](https://github.com/ParadiseSS13/Paradise/assets/25437893/55d0f0f5-8148-4ee9-811e-0c9b43daf1eb)

Cerebron:
Custodial closet
![image](https://github.com/ParadiseSS13/Paradise/assets/25437893/3d2e5583-41f2-457f-89b9-6256171f6034)
Internal Affairs
![image](https://github.com/ParadiseSS13/Paradise/assets/25437893/add52825-f5a9-49a8-b77d-58878df60359)

Kerberos:
Custodial closet
![image](https://github.com/ParadiseSS13/Paradise/assets/25437893/b8341ed4-5a86-42c0-a43e-ba70e2af871c)
Internal Affairs
![image](https://github.com/ParadiseSS13/Paradise/assets/25437893/b15fc082-1ea4-43f3-9c53-7ca50ace8806)

Farragus:
Custodial closet
![image](https://github.com/ParadiseSS13/Paradise/assets/25437893/fa316bb2-0ecd-4c28-90c5-5fe984135661)
Internal Affairs
![image](https://github.com/ParadiseSS13/Paradise/assets/25437893/65469ab8-7ca0-4c20-bf97-c2c2047f4adb)


## Testing
Boot server, go to area and check

## Changelog
:cl:
add: Janidrobe and Lawdrobe now mapped in to all stations
/:cl:
