### PR TITLE
Gravitational boots can now Gargantua stomp

### DIFF
--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -473,6 +473,17 @@
 	var/obj/item/clothing/shoes/magboots/gravity/G = target
 	G.dash(usr)
 
+//Gravitational boots garg stomp
+/datum/action/item_action/gravity_stomp
+	name = "Gravitational field"
+	desc = "Creates an inverse gravitational field around the user, flinging everyone backwards and causing damage to the hull."
+
+/datum/action/item_action/gravity_stomp/Trigger()
+	if(!IsAvailable())
+		return FALSE
+
+	var/obj/item/clothing/shoes/magboots/gravity/G = target
+	G.stomp(usr)
 
 ///prset for organ actions
 /datum/action/item_action/organ_action

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -140,7 +140,7 @@
 	desc = "These experimental boots try to get around the restrictions of magboots by installing miniture gravitational generators in the soles. Sadly, power hungry, and needs a gravitational anomaly core."
 	icon_state = "gravboots0"
 	origin_tech = "materials=6;magnets=6;engineering=6"
-	actions_types = list(/datum/action/item_action/toggle, /datum/action/item_action/gravity_jump, /datum/action/item_action/gravity_stomp) //In other news, combining magboots with jumpboots is a mess
+	actions_types = list(/datum/action/item_action/toggle, /datum/action/item_action/gravity_jump, /datum/action/item_action/gravity_stomp) //In other news, combining magboots with jumpboots is a mess //In other news, adding the garg stomp is a mess too
 	strip_delay = 10 SECONDS
 	put_on_delay = 10 SECONDS
 	slowdown_active = SHOES_SLOWDOWN

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -152,7 +152,7 @@
 	var/recharging_rate_dash = 6 SECONDS
 	var/recharging_time_dash = 0 // Time until next dash
 	var/dash_cost = 1000 // Cost to dash.
-	var/recharging_rate_stomp = 45 // Time until next stomp
+	var/recharging_rate_stomp = 45 SECONDS// Time until next stomp
 	var/recharging_time_stomp = 0 //Time until next dash
 	var/stomp_cost = 2500 // Cost to stomp.
 	var/max_range = 4 // max stomp range


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes it so the gravitational boots have an ability akin to a Gargantua stomp, knocking everyone back and causing minor station damage.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Grav boots are eh right now, and basically just reskinned advanced magboots with a jump. This adds an interesting ability to them, hopefully making them more viable and used more.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Went into a testserver
Angrily stomped about
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Gravitational boots can now Gargantua stomp
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
