### PR TITLE
Fixes AI Restore Power Routine

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai_life.dm
+++ b/code/modules/mob/living/silicon/ai/ai_life.dm
@@ -45,6 +45,7 @@
 			aiRestorePowerRoutine = 0
 			update_sight()
 			to_chat(src, "Alert cancelled. Power has been restored[aiRestorePowerRoutine == 2 ? "without our assistance" : ""].")
+			apc_override = FALSE
 	else
 		if(lacks_power())
 			if(!aiRestorePowerRoutine)
@@ -121,9 +122,8 @@
 								to_chat(src, "Receiving control information from APC.")
 								sleep(2)
 								//bring up APC dialog
-								apc_override = 1
+								apc_override = TRUE
 								theAPC.attack_ai(src)
-								apc_override = 0
 								aiRestorePowerRoutine = 3
 						sleep(50)
 						theAPC = null

--- a/code/modules/tgui/states.dm
+++ b/code/modules/tgui/states.dm
@@ -66,7 +66,7 @@
 	return STATUS_INTERACTIVE
 
 /mob/living/silicon/ai/shared_ui_interaction(src_object)
-	if(lacks_power()) // Disable UIs if the AI is unpowered.
+	if(lacks_power() && !apc_override) // Disable UIs if the AI is unpowered.
 		return STATUS_DISABLED
 	return ..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
For quite a long while now, the AI has had a power restore sequence when the APC in their room is disabled. It also has been broken for a long while.
This PR fixes this power restoration routine. This means that if the APC in the AI's room is disabled for any reason, after the specified time (I believe it's currently roughly 20 seconds?) the AI gets access to their APC control panel, which would allow them to turn it back on (Assuming the APC doesn't have cut wires or the likes)
fixes: #19440
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Bug bad. 
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Become the AI.
Disable my own APC.
Wait for the APC screen to pop up.
Turn my APC back on.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: AI Restore Power Routine finally works again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
