### PR TITLE
Donut tax. Security now must pay for donuts from the security vendor.

### DIFF
--- a/code/game/machinery/vendors/departmental_vendors.dm
+++ b/code/game/machinery/vendors/departmental_vendors.dm
@@ -221,3 +221,5 @@
 					/obj/item/clothing/mask/muzzle/safety = 4)
 	contraband = list(/obj/item/clothing/glasses/sunglasses = 2, /obj/item/storage/fancy/donut_box = 2, /obj/item/hailer = 5)
 	refill_canister = /obj/item/vending_refill/security
+	prices = list(/obj/item/reagent_containers/food/snacks/donut = 40,
+					/obj/item/storage/fancy/donut_box = 200) //Bulk discount


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Donuts now cost 40 credits to buy, or 200 credits for a box of 6, so a discount in bulk. This is cheaper than bread tubes, to reduce complaints about the pr for now.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Food from vendors should cost money. Security has 24 donuts roundstart, 48 if you hack the vendors.
On cyberiad, at least, there are also *3* free donut boxes on the table of the security meeting room, but I'm not going to make a map edit over donut boxes, I'm not that drastic.

 Security, like any other department, should have to pay for food, or rely on finding more limited supplies such as maints, or the generosity of hydro / the chef giving out free food, or surgery for a nutriment pump. Donuts with frosting also heal security, making it extra fun. Double so when security is one of the bigger cargo spenders, on guns and such, they should not be also saving money off vendors.

The price starts out at 40 credits, cheaper than bread tubes.

## Testing
<!-- How did you test the PR, if at all? -->

Confirmed the donuts and boxes had cost, while the rest of the vendor gear was free.

## Changelog
:cl:
tweak: Donuts in the security vendor cost 40 credits, a box of 6 donuts costs 200.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
