### PR TITLE
Gives psychologist a garment bag

### DIFF
--- a/code/game/objects/items/weapons/storage/garment.dm
+++ b/code/game/objects/items/weapons/storage/garment.dm
@@ -276,3 +276,18 @@
 	new /obj/item/clothing/gloves/ring/silver(src)
 	new /obj/item/clothing/gloves/ring/gold(src)
 	new /obj/item/clothing/gloves/ring/gold(src)
+
+/obj/item/storage/bag/garment/psychologist
+	name = "psychologist's garment bag"
+	desc = "A bag for storing extra clothes and shoes. This one belongs to the psychologist."
+
+/obj/item/storage/bag/garment/psychologist/populate_contents()
+	new /obj/item/clothing/under/rank/medical/psych(src)
+	new /obj/item/clothing/under/rank/medical/psych/turtleneck(src)
+	new /obj/item/clothing/under/rank/medical/doctor(src)
+	new /obj/item/clothing/under/rank/medical/doctor/skirt(src)
+	new /obj/item/clothing/suit/storage/labcoat/psych(src)
+	new /obj/item/clothing/shoes/laceup(src)
+	new /obj/item/clothing/glasses/hud/health(src)
+	new /obj/item/clothing/glasses/hud/skills(src)
+	new /obj/item/clothing/accessory/blue(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical_lockers.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical_lockers.dm
@@ -117,6 +117,7 @@
 	open_door_sprite = "white_secure_door"
 
 /obj/structure/closet/secure_closet/psychiatrist/populate_contents()
+	new /obj/item/storage/bag/garment/psychologist(src)
 	new /obj/item/clothing/suit/straight_jacket(src)
 	new /obj/item/reagent_containers/syringe(src)
 	new /obj/item/reagent_containers/glass/bottle/ether(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Gives psychologist a garment bag with following contents:
- Psychiatrist Jumpsuit
- Psychologist Turtleneck
- Medical Doctor Jumpsuit (job title "therapist" starts with it)
- Medical Doctor Jumpskirt (for good measure)
- Psychologist Labcoat
- Laceup Shoes
- Medical HUD (they steal one every round anyways - access to records on the fly)
- Skills HUD (they start with one in their office on Cyberiad and it's an INCREDIBELY useful tool for RP - doing background checks in patient's employment records)
- Blue Tie

If anyone has further ideas for drip psych could use - feel free to leave them below!

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Psych drip is a strange case, where most of it (mainly jumpsuits) are, simply, unaccessible to you if you have the wrong JOB TITLE of all things.
In addition, his locker is absolutely filled with other misc items, creating the need for garment bag.

This PR helps with that.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Opened psych's locker - all seems to work.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
add: Gave Psychologist a garment bag
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
