### PR TITLE
you can now reload 357 revolver speedloaders from ammo boxes

### DIFF
--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -197,7 +197,7 @@
 	var/num_loaded = 0
 	if(!can_load(user))
 		return
-	if(istype(A, /obj/item/ammo_box) && !istype(A, /obj/item/ammo_box/b357))
+	if(istype(A, /obj/item/ammo_box))
 		var/obj/item/ammo_box/AM = A
 		for(var/obj/item/ammo_casing/AC in AM.stored_ammo)
 			var/did_load = give_round(AC, replace_spent)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
you can now reload 357 revolver speedloaders from ammo boxes

## Why It's Good For The Game
Right now you can't do this. Considering you can drop all the bullets on the ground and then click on the turf to reload those bullets, that's pretty stupid and unintuitive and greatly benefits people on hotkey mode over legacy. Let a new player reload easier rather than someone who knew about this niche mechanic beforehand. 

## Testing
Put bullets in speedloader

## Changelog
:cl:
tweak: you can now reload 357 revolver speedloaders from ammo boxes rather than needing to drop the bullets on the ground first
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
