### PR TITLE
Pull slowdown tweak

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -3,7 +3,7 @@
 	. += ..()
 	. += GLOB.configuration.movement.human_delay
 	. += dna.species.movement_delay(src)
-	if(mob_has_gravity() && isobj(pulling))
+	if(isobj(pulling) && has_gravity(pulling))
 		var/obj/pulled = pulling
 		. += pulled.pull_speed
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
This PR changes a BIT new pulling slowdown feature. Now slowdown will be applied only if pulled object has gravity.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
This looks better for people using magboots in space. Magboots are designed to be used in space but currently they force you to have gravity and have slowdown. After the change you will move as fast as before in space, if you're pulling object also in space.

## Testing
<!-- How did you test the PR, if at all? -->
compiled

## Changelog
:cl:
tweak: Pulling slowdown now applied only if pulled object has gravity
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
