### PR TITLE
Buffs Cyborgificaiton machine for malf AI

### DIFF
--- a/code/game/machinery/transformer.dm
+++ b/code/game/machinery/transformer.dm
@@ -11,7 +11,7 @@
 	/// TRUE if the mob can be standing and still be transformed.
 	var/transform_standing = TRUE
 	/// Cooldown between each transformation, in deciseconds.
-	var/cooldown_duration = 1 MINUTES
+	var/cooldown_duration = 30 SECONDS
 	/// If the factory is currently on cooldown from its last transformation.
 	var/is_on_cooldown = FALSE
 	/// The type of cell that newly created borgs get.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Decreases the cooldown for the malf AI borgifier to 30 seconds from 1 minute.

## Why It's Good For The Game
While I do understand the need for a longer cooldown on this device, the length of the cooldown often results in long ques for people to be borged. Ive seen this end in one of two ways: an orderly line to get chopped to robo-bits, or a free for all that results in borgs just killing people since the wait is too long. Ive only seen the first one once in my over 2k hours on paradise. The goal of this PR is to reduce the latter of the above outcomes and allow more people to get in on the chaos. 

## Testing
Once I understood the weakness of the skrell's flesh, it disgusted me. The omnissiah was fed every 30 seconds for two minutes.

## Changelog
:cl:
tweak: reduces malf AI borg factory cooldown from 1 minute to 30 seconds
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
