### PR TITLE
Allows IPCs to use adrenal implants

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -919,6 +919,7 @@
 	id = "stimulative_agent"
 	description = "Increases run speed and eliminates stuns, can heal minor damage. If overdosed it will deal toxin damage and be less effective for healing stamina."
 	color = "#C8A5DC"
+	process_flags = ORGANIC | SYNTHETIC
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 	overdose_threshold = 60
 	harmless = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Allows IPCs to processes stimulative_agent, the stamina reducing and speed increasing chem in adrenal implants. They do NOT gain the ability to to use the stimulant autoinjector nor gain the benefits of synaptazine, on the grounds that they lack an organic brain (and are very rarely slept or confused). IPCs are still unable to process omnizine. 

## Why It's Good For The Game
IPCs should have a consistent source of anti-stun in their uplinks, just like everyone else. Ions still two tap, so this isn't a massive balance change. 

## Testing
Spawn as an IPC. ZOOOOM. repeat for several minutes. 

## Changelog
:cl:
tweak: allows IPCs to gain anti stun from adrenal implants
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
