### PR TITLE
Delta: Add cargo technician lockers.

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -15435,6 +15435,7 @@
 /turf/simulated/floor/plasteel/dark,
 /area/crew_quarters/theatre)
 "aUG" = (
+/obj/structure/closet/secure_closet/cargotech,
 /turf/simulated/floor/plasteel{
 	icon_state = "brown"
 	},
@@ -19223,6 +19224,7 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "bcL" = (
+/obj/structure/closet/secure_closet/cargotech,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "purple"


### PR DESCRIPTION
## What Does This PR Do

Adds cargo technician lockers to cargo.

## Why It's Good For The Game

All other stations have these lockers. Besides being a place to put personal items they also include the cargo headset.

## Images of changes

![2023_06_08__01_29_12__paradise dme  delta dmm  - StrongDMM](https://github.com/ParadiseSS13/Paradise/assets/59303604/dd6132c2-4e31-4925-8a7e-2fc2433b7f90)

## Testing
No testing, YOLO

## Changelog
:cl:
add: Kerberos Cargo now has CT lockers.
/:cl:
