### PR TITLE
Improved body scanner printouts

### DIFF
--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -360,8 +360,8 @@
 			var/obj/item/paper/P = new /obj/item/paper(loc)
 			playsound(loc, 'sound/goonstation/machines/printer_dotmatrix.ogg', 50, TRUE)
 			var/name = occupant ? occupant.name : "Unknown"
-			P.info = "<CENTER><B>Body Scan - [name]</B></CENTER><BR>"
-			P.info += "<b>Time of scan:</b> [station_time_timestamp()]<br><br>"
+			P.info = "<center><b>Patient: [name]</b></center>"
+			P.info += "<center><b>Time of scan:</b> [station_time_timestamp()]</center><br>"
 			P.info += "[generate_printing_text()]"
 			P.info += "<br><br><b>Notes:</b><br>"
 			P.name = "Body Scan - [name]"
@@ -406,7 +406,7 @@
 		dat += "[extra_font]\tBurn Severity %: [occupant.getFireLoss()]</font><br>"
 
 		extra_font = (occupant.radiation < 10 ? "<font color='blue'>" : "<font color='red'>")
-		dat += "[extra_font]\tRadiation Level %: [occupant.radiation]</font><br>"
+		dat += "[extra_font]\tRadiation Level: [occupant.radiation] rads</font><br>"
 
 		extra_font = (occupant.getCloneLoss() < 1 ? "<font color='blue'>" : "<font color='red'>")
 		dat += "[extra_font]\tGenetic Tissue Damage %: [occupant.getCloneLoss()]</font><br>"
@@ -449,66 +449,69 @@
 			if(e.status & ORGAN_INT_BLEEDING)
 				internal_bleeding = "<br>Internal bleeding"
 			if(istype(e, /obj/item/organ/external/chest) && occupant.is_lung_ruptured())
-				lung_ruptured = "Lung ruptured:"
+				lung_ruptured = "Lung ruptured"
 			if(e.status & ORGAN_SPLINTED)
-				splint = "Splinted:"
+				splint = "Splinted"
 			if(e.status & ORGAN_BROKEN)
-				AN = "[e.broken_description]:"
+				AN = "[e.broken_description]"
 			if(e.status & ORGAN_SALVED)
-				ointment = "Salved:"
+				ointment = "Salved"
 			if(e.status & ORGAN_BURNT)
-				burn_wound = "Critical Burn:"
+				burn_wound = "Critical Burn"
 			if(e.status & ORGAN_DEAD)
-				dead = "DEAD:"
+				dead = "DEAD"
 			if(e.is_robotic())
-				robot = "Robotic:"
+				robot = "Robotic"
 			if(e.open)
-				open = "Open:"
+				open = "Open"
 			switch(e.germ_level)
 				if(INFECTION_LEVEL_ONE to INFECTION_LEVEL_ONE + 200)
-					infected = "Mild Infection:"
+					infected = "Mild Infection"
 				if(INFECTION_LEVEL_ONE + 200 to INFECTION_LEVEL_ONE + 300)
-					infected = "Mild Infection+:"
+					infected = "Mild Infection+"
 				if(INFECTION_LEVEL_ONE + 300 to INFECTION_LEVEL_ONE + 400)
-					infected = "Mild Infection++:"
+					infected = "Mild Infection++"
 				if(INFECTION_LEVEL_TWO to INFECTION_LEVEL_TWO + 200)
-					infected = "Acute Infection:"
+					infected = "Acute Infection"
 				if(INFECTION_LEVEL_TWO + 200 to INFECTION_LEVEL_TWO + 300)
-					infected = "Acute Infection+:"
+					infected = "Acute Infection+"
 				if(INFECTION_LEVEL_TWO + 300 to INFECTION_LEVEL_TWO + 399)
-					infected = "Acute Infection++:"
+					infected = "Acute Infection++"
 				if(INFECTION_LEVEL_TWO + 400 to INFINITY)
-					infected = "Septic:"
+					infected = "Septic"
 
 			var/unknown_body = 0
 			for(var/I in e.embedded_objects)
 				unknown_body++
 
 			if(unknown_body || e.hidden)
-				imp += "Unknown body present:"
+				imp += "Unknown body present"
 			if(!AN && !open && !infected && !imp)
-				AN = "None:"
-			dat += "<td>[e.name]</td><td>[e.burn_dam]</td><td>[e.brute_dam]</td><td>[robot][bled][AN][splint][burn_wound][ointment][open][infected][imp][internal_bleeding][lung_ruptured][dead]</td>"
+				AN = ""
+			dat += "<td>[e.name]</td>"
+			dat += "<td>[e.burn_dam]</td>"
+			dat += "<td>[e.brute_dam]</td>"
+			dat += "<td>[robot][bled][AN][splint][burn_wound][ointment][open][infected][imp][internal_bleeding][lung_ruptured][dead]</td>"
 			dat += "</tr>"
 		for(var/obj/item/organ/internal/i in occupant.internal_organs)
-			var/mech = i.desc
-			var/infection = "None"
+			var/infection = ""
 			var/dead = ""
+			var/mech = i.desc
 			if(i.status & ORGAN_DEAD)
-				dead = "DEAD:"
+				dead = "DEAD"
 			switch(i.germ_level)
 				if(1 to INFECTION_LEVEL_ONE + 200)
-					infection = "Mild Infection:"
+					infection = "Mild Infection"
 				if(INFECTION_LEVEL_ONE + 200 to INFECTION_LEVEL_ONE + 300)
-					infection = "Mild Infection+:"
+					infection = "Mild Infection+"
 				if(INFECTION_LEVEL_ONE + 300 to INFECTION_LEVEL_ONE + 400)
-					infection = "Mild Infection++:"
+					infection = "Mild Infection++"
 				if(INFECTION_LEVEL_TWO to INFECTION_LEVEL_TWO + 200)
-					infection = "Acute Infection:"
+					infection = "Acute Infection"
 				if(INFECTION_LEVEL_TWO + 200 to INFECTION_LEVEL_TWO + 300)
-					infection = "Acute Infection+:"
+					infection = "Acute Infection+"
 				if(INFECTION_LEVEL_TWO + 300 to INFECTION_LEVEL_TWO + 399)
-					infection = "Acute Infection++:"
+					infection = "Acute Infection++"
 				if(INFECTION_LEVEL_TWO + 400 to INFINITY)
 					infection = "Septic:"
 

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -383,6 +383,37 @@
 				t1 = "*dead*"
 		dat += "[occupant.health > 50 ? "<font color='blue'>" : "<font color='red'>"]\tHealth %: [occupant.health], ([t1])</font><br>"
 
+		var/extra_font = null
+
+		var/blood_percent =  round((occupant.blood_volume / BLOOD_VOLUME_NORMAL) * 100, 1)
+
+		extra_font = (occupant.blood_volume > 448 ? "<font color='blue'>" : "<font color='red'>")
+		dat += "[extra_font]\tBlood Level %: [blood_percent] ([occupant.blood_volume] units)</font><br>"
+
+		extra_font = (occupant.bodytemperature < BODYTEMP_HEAT_DAMAGE_LIMIT && occupant.bodytemperature > BODYTEMP_COLD_DAMAGE_LIMIT ? "<font color='blue'>" : "<font color='red'>")
+		dat += "[extra_font]\tBody Temperature: [occupant.bodytemperature-T0C]&deg;C ([occupant.bodytemperature*1.8-459.67]&deg;F)</font><br>"
+
+		extra_font = (occupant.getBruteLoss() < 60 ? "<font color='blue'>" : "<font color='red'>")
+		dat += "[extra_font]\tBrute Damage %: [occupant.getBruteLoss()]</font><br>"
+
+		extra_font = (occupant.getOxyLoss() < 60 ? "<font color='blue'>" : "<font color='red'>")
+		dat += "[extra_font]\tRespiratory Damage %: [occupant.getOxyLoss()]</font><br>"
+
+		extra_font = (occupant.getToxLoss() < 60 ? "<font color='blue'>" : "<font color='red'>")
+		dat += "[extra_font]\tToxin Content %: [occupant.getToxLoss()]</font><br>"
+
+		extra_font = (occupant.getFireLoss() < 60 ? "<font color='blue'>" : "<font color='red'>")
+		dat += "[extra_font]\tBurn Severity %: [occupant.getFireLoss()]</font><br>"
+
+		extra_font = (occupant.radiation < 10 ? "<font color='blue'>" : "<font color='red'>")
+		dat += "[extra_font]\tRadiation Level %: [occupant.radiation]</font><br>"
+
+		extra_font = (occupant.getCloneLoss() < 1 ? "<font color='blue'>" : "<font color='red'>")
+		dat += "[extra_font]\tGenetic Tissue Damage %: [occupant.getCloneLoss()]</font><br>"
+
+		extra_font = (occupant.getBrainLoss() < 1 ? "<font color='blue'>" : "<font color='red'>")
+		dat += "[extra_font]\tApprox. Brain Damage %: [occupant.getBrainLoss()]</font><br>"
+
 		var/found_disease = FALSE
 		for(var/thing in occupant.viruses)
 			var/datum/disease/D = thing
@@ -391,52 +422,7 @@
 			found_disease = TRUE
 			break
 		if(found_disease)
-			dat += "<font color='red'>Disease detected in occupant.</font><BR>"
-
-		var/extra_font = null
-		extra_font = (occupant.getBruteLoss() < 60 ? "<font color='blue'>" : "<font color='red'>")
-		dat += "[extra_font]\t-Brute Damage %: [occupant.getBruteLoss()]</font><br>"
-
-		extra_font = (occupant.getOxyLoss() < 60 ? "<font color='blue'>" : "<font color='red'>")
-		dat += "[extra_font]\t-Respiratory Damage %: [occupant.getOxyLoss()]</font><br>"
-
-		extra_font = (occupant.getToxLoss() < 60 ? "<font color='blue'>" : "<font color='red'>")
-		dat += "[extra_font]\t-Toxin Content %: [occupant.getToxLoss()]</font><br>"
-
-		extra_font = (occupant.getFireLoss() < 60 ? "<font color='blue'>" : "<font color='red'>")
-		dat += "[extra_font]\t-Burn Severity %: [occupant.getFireLoss()]</font><br>"
-
-		extra_font = (occupant.radiation < 10 ?"<font color='blue'>" : "<font color='red'>")
-		dat += "[extra_font]\tRadiation Level %: [occupant.radiation]</font><br>"
-
-		extra_font = (occupant.getCloneLoss() < 1 ?"<font color='blue'>" : "<font color='red'>")
-		dat += "[extra_font]\tGenetic Tissue Damage %: [occupant.getCloneLoss()]<br>"
-
-		extra_font = (occupant.getBrainLoss() < 1 ?"<font color='blue'>" : "<font color='red'>")
-		dat += "[extra_font]\tApprox. Brain Damage %: [occupant.getBrainLoss()]<br>"
-
-		dat += "Inebriation Severity: [round(occupant.get_drunkenness() / 10)] seconds<br>"
-		dat += "Body Temperature: [occupant.bodytemperature-T0C]&deg;C ([occupant.bodytemperature*1.8-459.67]&deg;F)<br>"
-
-		dat += "<hr>"
-
-		var/blood_percent =  round((occupant.blood_volume / BLOOD_VOLUME_NORMAL) * 100, 1)
-
-		extra_font = (occupant.blood_volume > 448 ? "<font color='blue'>" : "<font color='red'>")
-		dat += "[extra_font]\tBlood Level %: [blood_percent] ([occupant.blood_volume] units)</font><br>"
-
-		if(occupant.reagents)
-			dat += "Epinephrine units: [occupant.reagents.get_reagent_amount("Epinephrine")] units<BR>"
-			dat += "Ether: [occupant.reagents.get_reagent_amount("ether")] units<BR>"
-
-			extra_font = (occupant.reagents.get_reagent_amount("silver_sulfadiazine") < 30 ? "<font color='black'>" : "<font color='red'>")
-			dat += "[extra_font]\tSilver Sulfadiazine: [occupant.reagents.get_reagent_amount("silver_sulfadiazine")]</font><br>"
-
-			extra_font = (occupant.reagents.get_reagent_amount("styptic_powder") < 30 ? "<font color='black'>" : "<font color='red'>")
-			dat += "[extra_font]\tStyptic Powder: [occupant.reagents.get_reagent_amount("styptic_powder")] units<BR>"
-
-			extra_font = (occupant.reagents.get_reagent_amount("salbutamol") < 30 ? "<font color='black'>" : "<font color='red'>")
-			dat += "[extra_font]\tSalbutamol: [occupant.reagents.get_reagent_amount("salbutamol")] units<BR>"
+			dat += "<font color='red'>Disease detected in occupant.</font><br>"
 
 		dat += "<hr><table border='1'>"
 		dat += "<tr>"

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -424,6 +424,13 @@
 		if(found_disease)
 			dat += "<font color='red'>Disease detected in occupant.</font><br>"
 
+		if(HAS_TRAIT(occupant, TRAIT_BLIND))
+			dat += "<font color='red'>Cataracts detected.</font><br>"
+		if(HAS_TRAIT(occupant, TRAIT_COLORBLIND))
+			dat += "<font color='red'>Photoreceptor abnormalities detected.</font><br>"
+		if(HAS_TRAIT(occupant, TRAIT_NEARSIGHT))
+			dat += "<font color='red'>Retinal misalignment detected.</font><br>"
+
 		dat += "<hr>"
 		dat += "<table border='1' style='width:100%'>"
 		dat += "<tr>"
@@ -494,38 +501,32 @@
 		dat += "</tr>"
 
 		for(var/obj/item/organ/internal/i in occupant.internal_organs)
-			var/infection = ""
-			var/dead = ""
+			var/list/ailments = list()
+
 			if(i.status & ORGAN_DEAD)
-				dead = "Dead"
+				ailments |= "Dead"
 			switch(i.germ_level)
 				if(1 to INFECTION_LEVEL_ONE + 200)
-					infection = "Mild Infection"
+					ailments |= "Mild Infection"
 				if(INFECTION_LEVEL_ONE + 200 to INFECTION_LEVEL_ONE + 300)
-					infection = "Mild Infection+"
+					ailments |= "Mild Infection+"
 				if(INFECTION_LEVEL_ONE + 300 to INFECTION_LEVEL_ONE + 400)
-					infection = "Mild Infection++"
+					ailments |= "Mild Infection++"
 				if(INFECTION_LEVEL_TWO to INFECTION_LEVEL_TWO + 200)
-					infection = "Acute Infection"
+					ailments |= "Acute Infection"
 				if(INFECTION_LEVEL_TWO + 200 to INFECTION_LEVEL_TWO + 300)
-					infection = "Acute Infection+"
+					ailments |= "Acute Infection+"
 				if(INFECTION_LEVEL_TWO + 300 to INFECTION_LEVEL_TWO + 399)
-					infection = "Acute Infection++"
+					ailments |= "Acute Infection++"
 				if(INFECTION_LEVEL_TWO + 400 to INFINITY)
-					infection = "Septic"
+					ailments |= "Septic"
 			dat += "<tr>"
 			dat += "<td>[i.name]</td>"
 			dat += "<td>[i.damage]</td>"
-			dat += "<td>[infection]<br>[dead]</td>"
+			dat += "<td>[jointext(ailments, "<br>")]</td>"
 			dat += "</tr>"
 		dat += "</table>"
 
-		if(HAS_TRAIT(occupant, TRAIT_BLIND))
-			dat += "<font color='red'>Cataracts detected.</font><BR>"
-		if(HAS_TRAIT(occupant, TRAIT_COLORBLIND))
-			dat += "<font color='red'>Photoreceptor abnormalities detected.</font><BR>"
-		if(HAS_TRAIT(occupant, TRAIT_NEARSIGHT))
-			dat += "<font color='red'>Retinal misalignment detected.</font><BR>"
 	else
 		dat += "[src] is empty."
 

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -425,81 +425,71 @@
 			dat += "<font color='red'>Disease detected in occupant.</font><br>"
 
 		dat += "<hr>"
-		dat += "<table border='1'>"
+		dat += "<table border='1' style='width:100%'>"
 		dat += "<tr>"
-		dat += "<th>Organ</th>"
-		dat += "<th>Burn Damage</th>"
-		dat += "<th>Brute Damage</th>"
+		dat += "<th style='width:30%'>Body Part</th>"
+		dat += "<th style='width:10%'>Burn Damage</th>"
+		dat += "<th style='width:10%'>Brute Damage</th>"
 		dat += "<th>Injuries</th>"
 		dat += "</tr>"
 
 		for(var/obj/item/organ/external/e in occupant.bodyparts)
 			dat += "<tr>"
-			var/AN = ""
-			var/open = ""
-			var/infected = ""
-			var/dead = ""
-			var/robot = ""
-			var/imp = ""
-			var/bled = ""
-			var/splint = ""
-			var/internal_bleeding = ""
-			var/burn_wound = ""
-			var/ointment = ""
-			var/lung_ruptured = ""
+			var/list/ailments = list()
+
 			if(e.status & ORGAN_INT_BLEEDING)
-				internal_bleeding = "<br>Internal Bleeding"
+				ailments |= "Internal Bleeding"
 			if(istype(e, /obj/item/organ/external/chest) && occupant.is_lung_ruptured())
-				lung_ruptured = "Lung Ruptured"
+				ailments |= "Lung Ruptured"
 			if(e.status & ORGAN_SPLINTED)
-				splint = "Splinted"
+				ailments |= "Splinted"
 			if(e.status & ORGAN_BROKEN)
-				AN = "[e.broken_description]"
+				ailments |= "[e.broken_description]"
 			if(e.status & ORGAN_SALVED)
-				ointment = "Salved"
+				ailments |= "Salved"
 			if(e.status & ORGAN_BURNT)
-				burn_wound = "Critical Burn"
+				ailments |= "Critical Burn"
 			if(e.status & ORGAN_DEAD)
-				dead = "Dead"
+				ailments |= "Dead"
 			if(e.is_robotic())
-				robot = "Robotic"
+				ailments |= "Robotic"
 			if(e.open)
-				open = "Open"
+				ailments |= "Open"
 			switch(e.germ_level)
 				if(INFECTION_LEVEL_ONE to INFECTION_LEVEL_ONE + 200)
-					infected = "Mild Infection"
+					ailments |= "Mild Infection"
 				if(INFECTION_LEVEL_ONE + 200 to INFECTION_LEVEL_ONE + 300)
-					infected = "Mild Infection+"
+					ailments |= "Mild Infection+"
 				if(INFECTION_LEVEL_ONE + 300 to INFECTION_LEVEL_ONE + 400)
-					infected = "Mild Infection++"
+					ailments |= "Mild Infection++"
 				if(INFECTION_LEVEL_TWO to INFECTION_LEVEL_TWO + 200)
-					infected = "Acute Infection"
+					ailments |= "Acute Infection"
 				if(INFECTION_LEVEL_TWO + 200 to INFECTION_LEVEL_TWO + 300)
-					infected = "Acute Infection+"
+					ailments |= "Acute Infection+"
 				if(INFECTION_LEVEL_TWO + 300 to INFECTION_LEVEL_TWO + 399)
-					infected = "Acute Infection++"
+					ailments |= "Acute Infection++"
 				if(INFECTION_LEVEL_TWO + 400 to INFINITY)
-					infected = "Septic"
+					ailments |= "Septic"
 
 			var/unknown_body = 0
 			for(var/I in e.embedded_objects)
 				unknown_body++
 
 			if(unknown_body || e.hidden)
-				imp += "Unknown body present"
-			if(!AN && !open && !infected && !imp)
-				AN = ""
+				ailments |= "Unknown body present"
+
 			dat += "<td>[e.name]</td>"
 			dat += "<td>[e.burn_dam]</td>"
 			dat += "<td>[e.brute_dam]</td>"
-			dat += "<td>[robot][bled][AN][splint][burn_wound][ointment][open][infected][imp][internal_bleeding][lung_ruptured][dead]</td>"
+			dat += "<td>[jointext(ailments, "<br>")]</td>"
 			dat += "</tr>"
 		dat += "</table>"
+		dat += "<br>"
 
-		dat += "<table border='1'>"
+		dat += "<table border='1' style='width:100%'>"
 		dat += "<tr>"
-		dat += "<th>Organ</th>"
-		dat += "<th>Damage</th>"
+		dat += "<th style='width:30%'>Organ</th>"
+		dat += "<th style='width:10%'>Damage</th>"
 		dat += "<th>Injuries</th>"
 		dat += "</tr>"
 

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -380,39 +380,39 @@
 			if(1)
 				t1 = "Unconscious"
 			else
-				t1 = "*dead*"
-		dat += "[occupant.health > 50 ? "<font color='blue'>" : "<font color='red'>"]\tHealth %: [occupant.health], ([t1])</font><br>"
+				t1 = "*Dead*"
+		dat += "[occupant.health > 50 ? "<font color='blue'>" : "<font color='red'>"]\tHealth: [occupant.health]% ([t1])</font><br>"
 
 		var/extra_font = null
 
 		var/blood_percent =  round((occupant.blood_volume / BLOOD_VOLUME_NORMAL) * 100, 1)
 
 		extra_font = (occupant.blood_volume > 448 ? "<font color='blue'>" : "<font color='red'>")
-		dat += "[extra_font]\tBlood Level %: [blood_percent] ([occupant.blood_volume] units)</font><br>"
+		dat += "[extra_font]\tBlood Level: [blood_percent]% ([occupant.blood_volume] units)</font><br>"
 
 		extra_font = (occupant.bodytemperature < BODYTEMP_HEAT_DAMAGE_LIMIT && occupant.bodytemperature > BODYTEMP_COLD_DAMAGE_LIMIT ? "<font color='blue'>" : "<font color='red'>")
 		dat += "[extra_font]\tBody Temperature: [occupant.bodytemperature-T0C]&deg;C ([occupant.bodytemperature*1.8-459.67]&deg;F)</font><br>"
 
 		extra_font = (occupant.getBruteLoss() < 60 ? "<font color='blue'>" : "<font color='red'>")
-		dat += "[extra_font]\tBrute Damage %: [occupant.getBruteLoss()]</font><br>"
+		dat += "[extra_font]\tBrute Damage: [occupant.getBruteLoss()]</font><br>"
 
 		extra_font = (occupant.getOxyLoss() < 60 ? "<font color='blue'>" : "<font color='red'>")
-		dat += "[extra_font]\tRespiratory Damage %: [occupant.getOxyLoss()]</font><br>"
+		dat += "[extra_font]\tRespiratory Damage: [occupant.getOxyLoss()]</font><br>"
 
 		extra_font = (occupant.getToxLoss() < 60 ? "<font color='blue'>" : "<font color='red'>")
-		dat += "[extra_font]\tToxin Content %: [occupant.getToxLoss()]</font><br>"
+		dat += "[extra_font]\tToxin Damage: [occupant.getToxLoss()]</font><br>"
 
 		extra_font = (occupant.getFireLoss() < 60 ? "<font color='blue'>" : "<font color='red'>")
-		dat += "[extra_font]\tBurn Severity %: [occupant.getFireLoss()]</font><br>"
+		dat += "[extra_font]\tBurn Severity: [occupant.getFireLoss()]</font><br>"
 
 		extra_font = (occupant.radiation < 10 ? "<font color='blue'>" : "<font color='red'>")
 		dat += "[extra_font]\tRadiation Level: [occupant.radiation] rads</font><br>"
 
 		extra_font = (occupant.getCloneLoss() < 1 ? "<font color='blue'>" : "<font color='red'>")
-		dat += "[extra_font]\tGenetic Tissue Damage %: [occupant.getCloneLoss()]</font><br>"
+		dat += "[extra_font]\tCellular Tissue Damage: [occupant.getCloneLoss()]</font><br>"
 
 		extra_font = (occupant.getBrainLoss() < 1 ? "<font color='blue'>" : "<font color='red'>")
-		dat += "[extra_font]\tApprox. Brain Damage %: [occupant.getBrainLoss()]</font><br>"
+		dat += "[extra_font]\tApprox. Brain Damage: [occupant.getBrainLoss()]</font><br>"
 
 		var/found_disease = FALSE
 		for(var/thing in occupant.viruses)
@@ -424,12 +424,13 @@
 		if(found_disease)
 			dat += "<font color='red'>Disease detected in occupant.</font><br>"
 
-		dat += "<hr><table border='1'>"
+		dat += "<hr>"
+		dat += "<table border='1'>"
 		dat += "<tr>"
 		dat += "<th>Organ</th>"
 		dat += "<th>Burn Damage</th>"
 		dat += "<th>Brute Damage</th>"
-		dat += "<th>Other Wounds</th>"
+		dat += "<th>Injuries</th>"
 		dat += "</tr>"
 
 		for(var/obj/item/organ/external/e in occupant.bodyparts)
@@ -447,9 +448,9 @@
 			var/ointment = ""
 			var/lung_ruptured = ""
 			if(e.status & ORGAN_INT_BLEEDING)
-				internal_bleeding = "<br>Internal bleeding"
+				internal_bleeding = "<br>Internal Bleeding"
 			if(istype(e, /obj/item/organ/external/chest) && occupant.is_lung_ruptured())
-				lung_ruptured = "Lung ruptured"
+				lung_ruptured = "Lung Ruptured"
 			if(e.status & ORGAN_SPLINTED)
 				splint = "Splinted"
 			if(e.status & ORGAN_BROKEN)
@@ -459,7 +460,7 @@
 			if(e.status & ORGAN_BURNT)
 				burn_wound = "Critical Burn"
 			if(e.status & ORGAN_DEAD)
-				dead = "DEAD"
+				dead = "Dead"
 			if(e.is_robotic())
 				robot = "Robotic"
 			if(e.open)
@@ -493,12 +494,20 @@
 			dat += "<td>[e.brute_dam]</td>"
 			dat += "<td>[robot][bled][AN][splint][burn_wound][ointment][open][infected][imp][internal_bleeding][lung_ruptured][dead]</td>"
 			dat += "</tr>"
+		dat += "</table>"
+
+		dat += "<table border='1'>"
+		dat += "<tr>"
+		dat += "<th>Organ</th>"
+		dat += "<th>Damage</th>"
+		dat += "<th>Injuries/th>"
+		dat += "</tr>"
+
 		for(var/obj/item/organ/internal/i in occupant.internal_organs)
 			var/infection = ""
 			var/dead = ""
-			var/mech = i.desc
 			if(i.status & ORGAN_DEAD)
-				dead = "DEAD"
+				dead = "Dead"
 			switch(i.germ_level)
 				if(1 to INFECTION_LEVEL_ONE + 200)
 					infection = "Mild Infection"
@@ -513,12 +522,14 @@
 				if(INFECTION_LEVEL_TWO + 300 to INFECTION_LEVEL_TWO + 399)
 					infection = "Acute Infection++"
 				if(INFECTION_LEVEL_TWO + 400 to INFINITY)
-					infection = "Septic:"
-
+					infection = "Septic"
 			dat += "<tr>"
-			dat += "<td>[i.name]</td><td>N/A</td><td>[i.damage]</td><td>[infection]:[mech][dead]</td><td></td>"
+			dat += "<td>[i.name]</td>"
+			dat += "<td>[i.damage]</td>"
+			dat += "<td>[infection]<br>[dead]</td>"
 			dat += "</tr>"
 		dat += "</table>"
+
 		if(HAS_TRAIT(occupant, TRAIT_BLIND))
 			dat += "<font color='red'>Cataracts detected.</font><BR>"
 		if(HAS_TRAIT(occupant, TRAIT_COLORBLIND))

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -500,7 +500,7 @@
 		dat += "<tr>"
 		dat += "<th>Organ</th>"
 		dat += "<th>Damage</th>"
-		dat += "<th>Injuries/th>"
+		dat += "<th>Injuries</th>"
 		dat += "</tr>"
 
 		for(var/obj/item/organ/internal/i in occupant.internal_organs)


### PR DESCRIPTION
## What Does This PR Do
This PR cleans up the printouts from the body scanners used in medical and by ERT teams with handheld scanners. Changes include reorganizing and moving elements around, eliminating unnecessary readings, splitting organs into two tables and cleaning up the information listed.

## Why It's Good For The Game
It makes the reports easier to read, which aids medical personnel in examining the reports for critical information. 

## Images of changes
### **Before:**
![before](https://github.com/ParadiseSS13/Paradise/assets/116982774/f8c5888b-4827-45fa-978d-877054daac24)
### **After:**
![after](https://github.com/ParadiseSS13/Paradise/assets/116982774/b58127d4-fffa-4ca3-9358-8d1efeb097dd)


## Testing
Tested against various damage types and conditions to test for appearance and functionality. 

## Changelog
:cl: Burza and CinnamonSnowball
del: Removed some printout information to reduce clutter
tweak: Divided organ table into two tables for internal/external and fixed their format
tweak: Reorganized various elements and tweaked the format of the report
/:cl:
