### PR TITLE
Droplimb Chance Tweak

### DIFF
--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -269,9 +269,9 @@
 	//If limb took enough damage, try to cut or tear it off
 	if(owner)
 		if(sharp && !(limb_flags & CANNOT_DISMEMBER))
-			if(brute_dam >= max_damage && prob(brute / 2))
+			if(brute_dam >= max_damage && owner.health <= HEALTH_THRESHOLD_CRIT && prob(brute))
 				droplimb(0, DROPLIMB_SHARP)
-			if(burn_dam >= max_damage && prob(burn / 2))
+			if(burn_dam >= max_damage && owner.health <= HEALTH_THRESHOLD_CRIT && prob(burn))
 				droplimb(0, DROPLIMB_BURN)
 
 	if(owner_old)

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -207,7 +207,6 @@
 		if(internal_organs && internal_organs.len)
 			var/obj/item/organ/internal/I = pick(internal_organs)
 			I.receive_damage(brute * 0.5)
-			brute -= brute * 0.5
 
 	if(status & ORGAN_BROKEN && prob(40) && brute && !owner.stat)
 		owner.emote("scream")	//getting hit on broken hand hurts

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -268,9 +268,9 @@
 	//If limb took enough damage, try to cut or tear it off
 	if(owner)
 		if(sharp && !(limb_flags & CANNOT_DISMEMBER))
-			if(brute_dam >= max_damage && owner.health <= HEALTH_THRESHOLD_CRIT && prob(brute))
+			if(brute_dam >= max_damage && prob(brute))
 				droplimb(0, DROPLIMB_SHARP)
-			if(burn_dam >= max_damage && owner.health <= HEALTH_THRESHOLD_CRIT && prob(burn))
+			if(burn_dam >= max_damage && prob(burn))
 				droplimb(0, DROPLIMB_BURN)
 
 	if(owner_old)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Fixes two oversights involving sharp weapon delimb chance.

How it works right now is that the chance of delimbing per attack with a sharp weapon is half of the damage that the attack deals to the limb itself. This is a problem because when you reach the limb's damage cap, half or more of your attack's damage is then distributed to other limbs. An esword attacking a head that is at its damage cap of 75 health will not have a 15% chance of delimbing, but rather a 7.5% chance or lower depending on what organs the damage is split between. 

The second oversight is that there was a 5% chance to deal internal organ damage when attacking with a brute weapon. This had the effect of halving the damage of the hit and dealing negligible damage to a random internal organ. It now deals half the damage of the hit to the internal organ and full external damage from the hit.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Delimbing heads for brain steal objectives is no longer a noob trap that involves amputation surgery and a circular saw or a changeling armblade. I've seen countless people smack a body for minutes without delimbing the head.
This will also effectively buff all sharp melee weapons, as they will now pose a much greater threat of lopping limbs off of people. 

## Testing
<!-- How did you test the PR, if at all? -->
Verified that the limbs of skrells detached at a statistically acceptable rate. 
## Changelog
:cl:
tweak:doubles delimb chance to correct for oversight. you must now be in crit to be delimbed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
