### PR TITLE
Improves illusions, nerfs stealth armor

### DIFF
--- a/code/modules/clothing/suits/armor_suits.dm
+++ b/code/modules/clothing/suits/armor_suits.dm
@@ -518,12 +518,13 @@
 	if(!active)
 		return FALSE
 	if(reaction_check(hitby) && use_power())
-		var/mob/living/simple_animal/hostile/illusion/escape/E = new(owner.loc)
+		var/mob/living/simple_animal/hostile/illusion/escape/stealth/E = new(owner.loc)
 		E.Copy_Parent(owner, 50)
 		E.GiveTarget(owner) //so it starts running right away
 		E.Goto(owner, E.move_to_delay, E.minimum_distance)
 		owner.visible_message("<span class='danger'>[owner] is hit by [attack_text] in the chest!</span>") //We pretend to be hit, since blocking it would stop the message otherwise
 		owner.make_invisible()
+		disable(rand(4, 5)) //No blocking while invisible
 		addtimer(CALLBACK(owner, TYPE_PROC_REF(/mob/living, reset_visibility)), 4 SECONDS)
 		return TRUE
 

--- a/code/modules/mob/living/simple_animal/hostile/illusion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/illusion.dm
@@ -42,7 +42,7 @@
 	pixel_y = initial(pixel_y)
 	pixel_x = initial(pixel_x)
 	fake_huds()
-	add_to_all_human_data_huds() //For testing the spawn no shooting
+	add_to_all_human_data_huds()
 
 /mob/living/simple_animal/hostile/illusion/examine(mob/user)
 	if(parent_mob)

--- a/code/modules/mob/living/simple_animal/hostile/illusion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/illusion.dm
@@ -19,7 +19,10 @@
 	var/multiply_chance = 0 //if we multiply on hit
 	deathmessage = "vanishes into thin air! It was a fake!"
 	del_on_death = TRUE
-
+	hud_possible = list(
+		HEALTH_HUD, STATUS_HUD, SPECIALROLE_HUD, // from /mob/living
+		ID_HUD, WANTED_HUD, IMPMINDSHIELD_HUD, IMPCHEM_HUD, IMPTRACK_HUD
+	)
 
 /mob/living/simple_animal/hostile/illusion/Life()
 	..()
@@ -38,6 +41,8 @@
 	transform = initial(transform)
 	pixel_y = initial(pixel_y)
 	pixel_x = initial(pixel_x)
+	fake_huds()
+	add_to_all_human_data_huds() //For testing the spawn no shooting
 
 /mob/living/simple_animal/hostile/illusion/examine(mob/user)
 	if(parent_mob)
@@ -45,6 +50,61 @@
 	else
 		. = ..()
 
+/mob/living/simple_animal/hostile/illusion/proc/fake_huds()
+	if(!parent_mob || !ishuman(parent_mob))
+		return
+	var/mob/living/carbon/human/H = parent_mob
+	var/image/holder = hud_list[ID_HUD]
+	holder.icon_state = "hudunknown"
+	if(H.wear_id)
+		holder.icon_state = "hud[ckey(H.wear_id.get_job_name())]"
+	var/image/holder2
+	for(var/i in list(IMPTRACK_HUD, IMPMINDSHIELD_HUD, IMPCHEM_HUD))
+		holder2 = hud_list[i]
+		holder2.icon_state = null
+	for(var/obj/item/implant/I in H)
+		if(I.implanted)
+			if(istype(I,/obj/item/implant/tracking))
+				holder2 = hud_list[IMPTRACK_HUD]
+				holder2.icon_state = "hud_imp_tracking"
+			else if(istype(I,/obj/item/implant/mindshield))
+				holder2 = hud_list[IMPMINDSHIELD_HUD]
+				holder2.icon_state = "hud_imp_loyal"
+			else if(istype(I,/obj/item/implant/chem))
+				holder2 = hud_list[IMPCHEM_HUD]
+				holder2.icon_state = "hud_imp_chem"
+	var/image/holder3 = hud_list[WANTED_HUD]
+	var/perpname = H.get_visible_name(TRUE) //gets the name of the perp, works if they have an id or if their face is uncovered
+	if(!SSticker) return //wait till the game starts or the monkeys runtime....
+	if(perpname)
+		var/datum/data/record/R = find_record("name", perpname, GLOB.data_core.security)
+		if(R)
+			switch(R.fields["criminal"])
+				if(SEC_RECORD_STATUS_EXECUTE)
+					holder3.icon_state = "hudexecute"
+					return
+				if(SEC_RECORD_STATUS_ARREST)
+					holder3.icon_state = "hudwanted"
+					return
+				if(SEC_RECORD_STATUS_SEARCH)
+					holder3.icon_state = "hudsearch"
+					return
+				if(SEC_RECORD_STATUS_MONITOR)
+					holder3.icon_state = "hudmonitor"
+					return
+				if(SEC_RECORD_STATUS_DEMOTE)
+					holder3.icon_state = "huddemote"
+					return
+				if(SEC_RECORD_STATUS_INCARCERATED)
+					holder3.icon_state = "hudincarcerated"
+					return
+				if(SEC_RECORD_STATUS_PAROLLED)
+					holder3.icon_state = "hudparolled"
+					return
+				if(SEC_RECORD_STATUS_RELEASED)
+					holder3.icon_state = "hudreleased"
+					return
+	holder3.icon_state = null
 
 /mob/living/simple_animal/hostile/illusion/AttackingTarget()
 	. = ..()
@@ -79,3 +139,7 @@
 
 /mob/living/simple_animal/hostile/illusion/escape/cult
 	loot = list(/obj/effect/temp_visual/cult/sparks)
+
+/mob/living/simple_animal/hostile/illusion/escape/stealth
+	maxHealth = 20
+	health = 20

--- a/code/modules/mob/living/simple_animal/hostile/illusion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/illusion.dm
@@ -51,7 +51,9 @@
 		. = ..()
 
 /mob/living/simple_animal/hostile/illusion/proc/fake_huds()
-	if(!parent_mob || !ishuman(parent_mob))
+	if(SSticker.current_state != GAME_STATE_PLAYING)
+		return
+	if(!ishuman(parent_mob))
 		return
 	var/mob/living/carbon/human/H = parent_mob
 	var/image/holder = hud_list[ID_HUD]
@@ -64,18 +66,17 @@
 		holder2.icon_state = null
 	for(var/obj/item/implant/I in H)
 		if(I.implanted)
-			if(istype(I,/obj/item/implant/tracking))
+			if(istype(I, /obj/item/implant/tracking))
 				holder2 = hud_list[IMPTRACK_HUD]
 				holder2.icon_state = "hud_imp_tracking"
-			else if(istype(I,/obj/item/implant/mindshield))
+			else if(istype(I, /obj/item/implant/mindshield))
 				holder2 = hud_list[IMPMINDSHIELD_HUD]
 				holder2.icon_state = "hud_imp_loyal"
-			else if(istype(I,/obj/item/implant/chem))
+			else if(istype(I, /obj/item/implant/chem))
 				holder2 = hud_list[IMPCHEM_HUD]
 				holder2.icon_state = "hud_imp_chem"
 	var/image/holder3 = hud_list[WANTED_HUD]
 	var/perpname = H.get_visible_name(TRUE) //gets the name of the perp, works if they have an id or if their face is uncovered
-	if(!SSticker) return //wait till the game starts or the monkeys runtime....
 	if(perpname)
 		var/datum/data/record/R = find_record("name", perpname, GLOB.data_core.security)
 		if(R)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Illusions now copy sec huds, tracking implants, chemical implants, and mindshields, so it actually fools anyone that has a security hud.

Stealth armor illusions now have 20 hp.
Stealth armor no longer can trigger while the user is invisible.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Illusion creating abilities are fun, but people rarely fall for them as the security hud quickly gives away that the illusion is a fake. Now, security should have a harder time telling illusions, though there are still tells.

Reactive stealth armor was a bit too good, and has been nerfed. Illusions now have only 20 hp, so a single laser will take it out., but a punch or 1 baton will not.

Reactive stealth armor no longer can trigger when the user is invisible from it, to reduce the tankiness already created by the illusions.

## Testing
<!-- How did you test the PR, if at all? -->
Shot myself off a titanium wall a bunch

## Changelog
:cl:
tweak: Illusions now copy sec hud, mindshields, tracking implants, and chemical implants.
tweak: Stealth armor illusions have much less health, and can no longer activate while invisible from the armor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
