### PR TITLE
Fix(CI): mysqladmin symlink is gone in latest mariadb docker container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
           MYSQL_ROOT_PASSWORD: root
         ports:
           - 3306
-        options: --health-cmd "mysqladmin ping" --health-interval 10s --health-timeout 5s --health-retries 10
+        options: --health-cmd "mariadb-admin ping" --health-interval 10s --health-timeout 5s --health-retries 10
     steps:
       - uses: actions/checkout@v3
       - name: Setup Cache


### PR DESCRIPTION
## What Does This PR Do
Fixes CI error on mariadb container setup

https://github.com/MariaDB/mariadb-docker/issues/512
https://github.com/tgstation/tgstation-server/pull/1532
![image](https://github.com/ParadiseSS13/Paradise/assets/8555356/d5d5f360-98e1-4eea-827b-8a4ad581e608)
https://mariadb.com/kb/en/mariadb-11-0-1-release-notes/#docker-official-images

## Why It's Good For The Game

## Images of changes
![image](https://github.com/ParadiseSS13/Paradise/assets/8555356/c04d836a-3a8f-4876-b915-388bd4ec6350)


## Testing
<!-- How did you test the PR, if at all? -->

## Changelog
:cl: azizonkg
fix: CI error on mariadb container setup
/:cl:
