### PR TITLE
Fix: Cyborgs can use quantum pads again

### DIFF
--- a/code/game/machinery/quantum_pad.dm
+++ b/code/game/machinery/quantum_pad.dm
@@ -130,17 +130,20 @@
 	add_fingerprint(user)
 	doteleport(user)
 
-/obj/machinery/quantumpad/attack_ai(mob/living/silicon/ai/user)
-	if(!isAI(user))
+/obj/machinery/quantumpad/attack_ai(mob/user)
+	if(isrobot(user))
+		return attack_hand(user)
+	var/mob/living/silicon/ai/AI = user
+	if(!istype(AI))
 		return
-	if(user.eyeobj.loc != loc)
-		user.eyeobj.setLoc(get_turf(loc))
+	if(AI.eyeobj.loc != loc)
+		AI.eyeobj.setLoc(get_turf(loc))
 		return
 	if(!check_usable(user))
 		return
 	var/turf/T = get_turf(linked_pad)
 	if(GLOB.cameranet && GLOB.cameranet.checkTurfVis(T))
-		user.eyeobj.setLoc(T)
+		AI.eyeobj.setLoc(T)
 	else
 		to_chat(user, "<span class='warning'>Linked pad is not on or near any active cameras on the station.</span>")
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes cyborgs capable of using quantum pads again.
fixes: #21252
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Walking all the way from one end of Farragus to the other as a cyborg is not fun.
Also bug bad.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Join as AI.
Use quantum pad.
Camera view jumps to other pad.
Join as borg.
Use quantum pad.
Teleport.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Cyborgs can use quantum pads again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
