### PR TITLE
Blacklists some other bottles from silver slimes

### DIFF
--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -216,6 +216,8 @@
 							/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
 							/obj/item/reagent_containers/food/drinks/drinkingglass,
 							/obj/item/reagent_containers/food/drinks/bottle,
+							/obj/item/reagent_containers/food/drinks/bottle/dragonsbreath,
+							/obj/item/reagent_containers/food/drinks/bottle/immortality,
 							/obj/item/reagent_containers/food/drinks/mushroom_bowl
 							)
 	blocked += typesof(/obj/item/reagent_containers/food/drinks/flask)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Blacklists the dragons breath and drop of immortality bottle from slime reactions

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

In my defense I did block the stimulating steak before in the pr.
Pie is left, it's purely healing, those pills can be got from space, and its not much diffrent from botany plant memes.

## Testing
<!-- How did you test the PR, if at all? -->
confirmed they were blocked

## Changelog
:cl:
tweak: Blacklists some problimatic bottles from silver slimes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
