### PR TITLE
Puts a cap on the size of Water-Potassium explosions

### DIFF
--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -8,7 +8,7 @@
 
 /datum/chemical_reaction/explosion_potassium/on_reaction(datum/reagents/holder, created_volume)
 	var/datum/effect_system/reagents_explosion/e = new()
-	e.set_up(min(round (created_volume/10, 1), 30), holder.my_atom, 0, 0)
+	e.set_up(min(round(created_volume / 10, 1), 30), holder.my_atom, 0, 0)
 	e.start()
 	holder.clear_reagents()
 

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -8,7 +8,7 @@
 
 /datum/chemical_reaction/explosion_potassium/on_reaction(datum/reagents/holder, created_volume)
 	var/datum/effect_system/reagents_explosion/e = new()
-	e.set_up(round (created_volume/10, 1), holder.my_atom, 0, 0)
+	e.set_up(min(round (created_volume/10, 1), 30), holder.my_atom, 0, 0)
 	e.start()
 	holder.clear_reagents()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Limits the size of water-potassium explosions to "30 TNT". Previously, it had no cap. See "Images of changes" for the difference this makes.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
We have a whole host of cool chemicals to blow shit up like black powder, nitroglycerine, but none of it matters if the chemicals you can pour out of a chemical dispenser straight can still make explosions nearly as large or just as large simply by using larger beakers. Making massive explosions should take either actually using chemistry to make the cooler explosion chems or toxins to make toxin bombs (which have their own downsides). Water + Potassium grenades will still not be _terrible_ for causing significant damage, but if you want to run around with a bunch of pocket maxcaps you'll have to make the more complicated chemicals.
## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
Before: (300 water, 300 potassium, large grenade) Explosion size was (4, 10, 20, 0)
![image](https://github.com/ParadiseSS13/Paradise/assets/71326864/507b4906-d903-4c79-96d1-9ae5514968a4)

After: (300 water, 300 potassium, large grenade) Explosion size was (1, 4, 9, 0)
![image](https://github.com/ParadiseSS13/Paradise/assets/71326864/c53e220f-5a5f-4c1a-a47f-dc21022f7336)
## Testing
<!-- How did you test the PR, if at all? -->
See above.
## Changelog
:cl:
tweak: Added a cap on the size of Water-Potassium reactions.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
