### PR TITLE
Prevents adding a head with a second brain to a body

### DIFF
--- a/code/modules/surgery/limb_reattach.dm
+++ b/code/modules/surgery/limb_reattach.dm
@@ -106,7 +106,10 @@
 		return SURGERY_BEGINSTEP_ABORT
 	var/list/organ_data = target.dna.species.has_limbs["[user.zone_selected]"]
 	if(isnull(organ_data))
-		to_chat(user, "<span class='warning'>[target.dna.species] don't have the anatomy for [E.name]!")
+		to_chat(user, "<span class='warning'>[target.dna.species] don't have the anatomy for [E.name]!</span>")
+		return SURGERY_BEGINSTEP_ABORT
+	if(E.search_contents_for(/obj/item/organ/internal/brain) && target.get_int_organ(/obj/item/organ/internal/brain))
+		to_chat(user, "<span class='warning'>Both [target] and [E.name] contain a brain, and [target] can't have two brains!</span>")
 		return SURGERY_BEGINSTEP_ABORT
 
 	user.visible_message(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
It is currently possible to add a head with a brain to a body with a roboticized chest containing an MMI, causing there to be two brains in one body. This PR fixes this.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
You really, really do not want two brains in one body.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Remove a skrell's brain.
Put the brain in an MMI.
Augement another skrell's chest (Henceforth referred to a skrell 2.)
Decapitate skrell 2.
Put MMI in skrell 2's chest.
Attempt to put skrell 2's head back.
Not possible.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: You can no longer add a head with a brain to a body that already contains a brain.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
