### PR TITLE
Fixes Jani closet "been full on round start".

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/job_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/job_closets.dm
@@ -76,8 +76,6 @@
 	new /obj/item/flashlight(src)
 	new /obj/item/melee/flyswatter(src)
 	new /obj/item/melee/flyswatter(src)
-	new /obj/item/clothing/shoes/galoshes(src)
-	new /obj/item/clothing/shoes/galoshes(src)
 	new /obj/item/soap(src)
 	new /obj/item/soap(src)
 	new /obj/item/reagent_containers/spray/cleaner(src)
@@ -95,13 +93,9 @@
 	new /obj/item/holosign_creator/janitor(src)
 	new /obj/item/watertank/janitor(src)
 	new /obj/item/watertank/janitor(src)
-	new /obj/item/storage/belt/janitor(src)
-	new /obj/item/storage/belt/janitor(src)
-	new /obj/item/clothing/gloves/color/black(src)
-	new /obj/item/clothing/head/soft/purple(src)
 	new /obj/item/radio/headset/headset_service(src)
 	new /obj/item/radio/headset/headset_service(src)
-	new /obj/item/clothing/under/rank/civilian/janitor(src)
+	new /obj/item/cartridge/janitor(src)
 	new /obj/item/cartridge/janitor(src)
 
 //Paramedic


### PR DESCRIPTION
## What Does This PR Do
Fix issue mentioned in #21297


## Why It's Good For The Game
Remove Clothes from Janitor Closet, now we have Janidrobe, with contain all necessary clothes.

## Images of changes
![image](https://github.com/ParadiseSS13/Paradise/assets/89580971/bf4b3e78-3121-4aa3-87c7-ee6941f8a08f)

## Testing
Runned test server, it worked.

## Changelog
:cl:
add: Add one more Janitor Cardridge to Janitor Closet.
del: Removed Clothes from Janitor Closet.
/:cl:
