### PR TITLE
fixes mining armblades being unable to be picked up after being dropped

### DIFF
--- a/code/game/objects/items/weapons/holy_weapons.dm
+++ b/code/game/objects/items/weapons/holy_weapons.dm
@@ -421,7 +421,10 @@
 /obj/item/nullrod/armblade/mining/pickup(mob/living/user)
 	..()
 	flags += ABSTRACT
-	return FALSE
+
+/obj/item/nullrod/armblade/mining/dropped(mob/living/user)
+	..()
+	flags -= ABSTRACT
 
 /obj/item/nullrod/carp
 	name = "carp-sie plushie"

--- a/code/game/objects/items/weapons/holy_weapons.dm
+++ b/code/game/objects/items/weapons/holy_weapons.dm
@@ -424,7 +424,7 @@
 
 /obj/item/nullrod/armblade/mining/dropped(mob/living/user)
 	..()
-	flags -= ABSTRACT
+	flags ^= ABSTRACT
 
 /obj/item/nullrod/carp
 	name = "carp-sie plushie"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
fixes #21332 

## Why It's Good For The Game
Stuff that gets dropped should be able to be picked up again, especially if it was able to be picked up in the first place

## Testing
I cut off my arm and then put it back on

## Changelog
:cl:
fix: You can pick up a dropped mining dark blessing
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
