### PR TITLE
Switch thermomachines to Initialize

### DIFF
--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -26,8 +26,8 @@
 	var/base_heating = 140
 	var/base_cooling = 170
 
-/obj/machinery/atmospherics/unary/thermomachine/New()
-	..()
+/obj/machinery/atmospherics/unary/thermomachine/Initialize(mapload)
+	. = ..()
 	initialize_directions = dir
 	component_parts = list()
 	component_parts += new /obj/item/circuitboard/thermomachine(null)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Changes the `New` proc to `Initialize` for thermomachines.

## Why It's Good For The Game
Fixes #21328. No, really.

## Images of changes
![Therm](https://github.com/ParadiseSS13/Paradise/assets/80771500/43b04bb2-0bca-47bd-9e7e-39228352a49b)

## Testing
Took apart a thermomachine. Also used it to see if its functionality was unchanged.

## Changelog
:cl:
fix: Thermomachines give the proper amount of wire when disassembled.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
