### PR TITLE
makes resin doors a tad less jank

### DIFF
--- a/code/game/objects/structures/aliens.dm
+++ b/code/game/objects/structures/aliens.dm
@@ -140,11 +140,6 @@
 	. = ..()
 	move_update_air(T)
 
-/obj/structure/alien/resin/door/Crossed(mob/living/L, oldloc)
-	..()
-	if(!state_open)
-		return try_to_operate(L)
-
 /obj/structure/alien/resin/door/attack_ai(mob/user)
 	return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes resin doors only try to open on bump rather than on crossed as well

## Why It's Good For The Game
This causes janky situations where the door will instantly close when you try an open it, as well as weird closing delays
This also called parent as well, which is extremely funny

## Testing
Ensured this game was 1% less russian

## Changelog
:cl:
fix: Resin doors no longer "lock up" in weird situations 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
