### PR TITLE
You can no longer get the supermatter sliver objective if the station does not have a supermatter

### DIFF
--- a/code/_globalvars/misc_globals.dm
+++ b/code/_globalvars/misc_globals.dm
@@ -51,3 +51,5 @@ GLOBAL_DATUM_INIT(data_core, /datum/datacore, new) // Station datacore, manifest
 GLOBAL_LIST_EMPTY(ability_verbs) // Create-level abilities
 GLOBAL_LIST_INIT(pipe_colors, list("grey" = PIPE_COLOR_GREY, "red" = PIPE_COLOR_RED, "blue" = PIPE_COLOR_BLUE, "cyan" = PIPE_COLOR_CYAN, "green" = PIPE_COLOR_GREEN, "yellow" = PIPE_COLOR_YELLOW, "purple" = PIPE_COLOR_PURPLE))
 
+GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/atmospherics/supermatter_crystal)
+

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -507,6 +507,8 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 				break
 		if(has_invalid_owner)
 			continue
+		if(!O.meets_objective_condition())
+			continue
 		if(O.flags & 2) // THEFT_FLAG_UNIQUE
 			continue
 

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -507,7 +507,7 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 				break
 		if(has_invalid_owner)
 			continue
-		if(!O.meets_objective_condition())
+		if(!O.check_objective_conditions())
 			continue
 		if(O.flags & 2) // THEFT_FLAG_UNIQUE
 			continue

--- a/code/game/gamemodes/steal_items.dm
+++ b/code/game/gamemodes/steal_items.dm
@@ -28,6 +28,11 @@
 			return 1
 	return 0
 
+//This proc is to be used for not granting objectives if a special requirement other than job is not met.
+
+/datum/theft_objective/proc/meets_objective_condition()
+	return TRUE
+
 /datum/proc/check_special_completion() //for objectives with special checks (is that slime extract unused? does that intellicard have an ai in it? etcetc)
 	return 1
 
@@ -143,6 +148,9 @@
 	location_override = "Engineering. You can use the box and instructions provided to harvest the sliver"
 	special_equipment = /obj/item/storage/box/syndie_kit/supermatter
 	job_possession = FALSE //The CE / engineers / atmos techs do not carry around supermater slivers.
+
+/datum/theft_objective/supermatter_sliver/meets_objective_condition() //If there is no supermatter, you don't get the objective. Yes, one could order it from cargo, but I don't think that is fair, especially if we get a map without a supermatter
+	return GLOB.main_supermatter_engine != null
 
 /datum/theft_objective/plutonium_core
 	name = "the plutonium core from the station's nuclear device"

--- a/code/game/gamemodes/steal_items.dm
+++ b/code/game/gamemodes/steal_items.dm
@@ -30,7 +30,7 @@
 
 //This proc is to be used for not granting objectives if a special requirement other than job is not met.
 
-/datum/theft_objective/proc/meets_objective_condition()
+/datum/theft_objective/proc/check_objective_conditions()
 	return TRUE
 
 /datum/proc/check_special_completion() //for objectives with special checks (is that slime extract unused? does that intellicard have an ai in it? etcetc)
@@ -149,8 +149,8 @@
 	special_equipment = /obj/item/storage/box/syndie_kit/supermatter
 	job_possession = FALSE //The CE / engineers / atmos techs do not carry around supermater slivers.
 
-/datum/theft_objective/supermatter_sliver/meets_objective_condition() //If there is no supermatter, you don't get the objective. Yes, one could order it from cargo, but I don't think that is fair, especially if we get a map without a supermatter
-	return GLOB.main_supermatter_engine != null
+/datum/theft_objective/supermatter_sliver/check_objective_conditions() //If there is no supermatter, you don't get the objective. Yes, one could order it from cargo, but I don't think that is fair, especially if we get a map without a supermatter
+	return !isnull(GLOB.main_supermatter_engine)
 
 /datum/theft_objective/plutonium_core
 	name = "the plutonium core from the station's nuclear device"

--- a/code/modules/power/engines/supermatter/supermatter.dm
+++ b/code/modules/power/engines/supermatter/supermatter.dm
@@ -86,8 +86,6 @@
 #define SUPERMATTER_SINGULARITY_LIGHT_COLOUR "#400060"
 
 
-GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/atmospherics/supermatter_crystal)
-
 /obj/machinery/atmospherics/supermatter_crystal
 	name = "supermatter crystal"
 	desc = "A strangely translucent and iridescent crystal."

--- a/code/modules/power/engines/supermatter/supermatter.dm
+++ b/code/modules/power/engines/supermatter/supermatter.dm
@@ -85,6 +85,9 @@
 #define SUPERMATTER_SINGULARITY_RAYS_COLOUR "#750000"
 #define SUPERMATTER_SINGULARITY_LIGHT_COLOUR "#400060"
 
+
+GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/atmospherics/supermatter_crystal)
+
 /obj/machinery/atmospherics/supermatter_crystal
 	name = "supermatter crystal"
 	desc = "A strangely translucent and iridescent crystal."
@@ -213,7 +216,8 @@
 	radio.follow_target = src
 	radio.config(list("Engineering" = 0))
 	investigate_log("has been created.", "supermatter")
-
+	if(is_main_engine)
+		GLOB.main_supermatter_engine = src
 	soundloop = new(list(src), TRUE)
 
 /obj/machinery/atmospherics/supermatter_crystal/Destroy()
@@ -227,6 +231,8 @@
 	if(!processes)
 		GLOB.frozen_atom_list -= src
 	QDEL_NULL(countdown)
+	if(is_main_engine && GLOB.main_supermatter_engine == src)
+		GLOB.main_supermatter_engine = null
 	QDEL_NULL(soundloop)
 	return ..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

You can no longer get the supermatter sliver objective if the station does not have a supermatter.
This mostly just means if the station doesn't have one roundstart (IE sheppard TM), you will not get the objective.

It also means if the supermatter has decontaminated, one will get the objective.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

While the option to order a shard in order to get a sliver is perfectly valid, and a good way to get around engineering being nerds and doing an ~~overcomplicated~~ awesome 7000 EER setup that they will kill you if you dare try to touch, an antagonist should not be *forced* to order a sliver, especially since the crystal is going to delam after the sliver is cut, less it is put in a setup. One should also not get the objective if the shard doesn't exist at all in the first place.

## Changelog
:cl:
tweak: You can no longer get the supermatter sliver objective if the station does not have a supermatter
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
