### PR TITLE
Airlock wires panel no more pop ups when you're trying to open it

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -624,6 +624,8 @@ GLOBAL_LIST_EMPTY(airlock_emissive_underlays)
 		switch(security_level)
 			if(AIRLOCK_SECURITY_NONE)
 				. += "Its wires are exposed!"
+				if(get_dist(user, src) <= 1)
+					wires.Interact(user)
 			if(AIRLOCK_SECURITY_METAL)
 				. += "Its wires are hidden behind a welded metal cover."
 			if(AIRLOCK_SECURITY_PLASTEEL_I_S)
@@ -761,20 +763,11 @@ GLOBAL_LIST_EMPTY(airlock_emissive_underlays)
 /obj/machinery/door/airlock/attack_hand(mob/user)
 	if(shock_user(user, 100))
 		return
-
 	if(headbutt_airlock(user))
 		return // Smack that head against that airlock
 	if(remove_airlock_note(user, FALSE))
 		return
-
-	if(panel_open)
-		if(security_level)
-			to_chat(user, "<span class='warning'>Wires are protected!</span>")
-			return
-		wires.Interact(user)
-	else
-		..()
-
+	..()
 
 //Checks if the user can headbutt the airlock and does it if it can. Returns TRUE if it happened
 /obj/machinery/door/airlock/proc/headbutt_airlock(mob/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
This PR changes logic when you attack airlock with opened panel(screwdriver). Instead of displaying UI it will act as you touched it with closed panel, means you will try to open it(or close).

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
When you're playing with airlocks in fight you really do not want those pop up advertises with cable lists on half of your screen.
Also this will allow you to close/open airlocks with opened panel with your hand instead of bumping them with your body.

## Testing
<!-- How did you test the PR, if at all? -->
Compiled

## Changelog
:cl:
tweak: Airlock's opened panel no more forces you to see cables when you touch it with your hand/other object
tweak: Examining airlock with exposed wires now will open wires panel if you're staying next to it
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
