### PR TITLE
Fix some defib bugs

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -570,10 +570,6 @@
 	#define COMPONENT_BLOCK_DEFIB_DEAD (1<<0)
 	/// Something else: we won't have a custom message for this and should let the defib handle it.
 	#define COMPONENT_BLOCK_DEFIB_MISC (1<<1)
-	/// If our safeties are on, turn them off for this shock.
-	#define COMPONENT_DEFIB_BECOME_THE_DANGER (1<<2)
-	/// If our safeties are off, turn them on for this shock.
-	#define COMPONENT_DEFIB_BECOME_SAFE (1<<3)
 /// Called when a defib has been successfully used, and a shock has been applied. (mob/living/user, mob/living/target, harmful, successful)
 #define COMSIG_DEFIB_SHOCK_APPLIED "defib_zap"
 /// Called when a defib's cooldown has run its course and it is once again ready. ()

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -576,8 +576,6 @@
 	#define COMPONENT_DEFIB_BECOME_SAFE (1<<3)
 /// Called when a defib has been successfully used, and a shock has been applied. (mob/living/user, mob/living/target, harmful, successful)
 #define COMSIG_DEFIB_SHOCK_APPLIED "defib_zap"
-/// Called when a defib is aborted and no shock was applied. (mob/living/user, mob/living/target, harmful)
-#define COMSIG_DEFIB_ABORTED "defib_aborted"
 /// Called when a defib's cooldown has run its course and it is once again ready. ()
 #define COMSIG_DEFIB_READY "defib_ready"
 

--- a/code/__DEFINES/misc_defines.dm
+++ b/code/__DEFINES/misc_defines.dm
@@ -409,9 +409,9 @@
 
 // Defib stats
 /// Past this much time the patient is unrecoverable (in deciseconds).
-#define DEFIB_TIME_LIMIT 300 SECONDS
+#define DEFIB_TIME_LIMIT (300 SECONDS)
 /// Brain damage starts setting in on the patient after some time left rotting.
-#define DEFIB_TIME_LOSS 60 SECONDS
+#define DEFIB_TIME_LOSS (60 SECONDS)
 
 //different types of atom colorations
 #define ADMIN_COLOUR_PRIORITY 		1 //only used by rare effects like greentext coloring mobs and when admins varedit color

--- a/code/datums/components/defibrillator.dm
+++ b/code/datums/components/defibrillator.dm
@@ -134,11 +134,6 @@
 	// Check what the unit itself has to say about how the defib went
 	var/application_result = SEND_SIGNAL(parent, COMSIG_DEFIB_PADDLES_APPLIED, user, target, should_cause_harm)
 
-	if(!should_cause_harm && (application_result & COMPONENT_DEFIB_BECOME_THE_DANGER))
-		should_cause_harm = TRUE
-	if(should_cause_harm && (application_result & COMPONENT_DEFIB_BECOME_SAFE))
-		should_cause_harm = FALSE
-
 	if(application_result & COMPONENT_BLOCK_DEFIB_DEAD)
 		user.visible_message("<span class='notice'>[defib_ref] beeps: Unit is unpowered.</span>")
 		playsound(get_turf(defib_ref), 'sound/machines/defib_failed.ogg', 50, 0)
@@ -192,12 +187,13 @@
 		busy = FALSE
 		return
 
-	signal_result |= SEND_SIGNAL(target, COMSIG_LIVING_DEFIBBED, user, parent, ghost)
 	if(istype(target.wear_suit, /obj/item/clothing/suit/space) && !combat)
 		user.visible_message("<span class='notice'>[defib_ref] buzzes: Patient's chest is obscured. Operation aborted.</span>")
 		playsound(get_turf(defib_ref), 'sound/machines/defib_failed.ogg', 50, 0)
 		busy = FALSE
 		return
+
+	signal_result |= SEND_SIGNAL(target, COMSIG_LIVING_DEFIBBED, user, parent, ghost)
 
 	if(signal_result & COMPONENT_DEFIB_OVERRIDE)
 		// Let our signal handle it

--- a/code/datums/components/defibrillator.dm
+++ b/code/datums/components/defibrillator.dm
@@ -274,7 +274,7 @@
 		target.adjustBruteLoss(-heal_amount)
 
 		// Inflict some brain damage scaling with time spent dead
-		var/defib_time_brain_damage = min(100 * (DEFIB_TIME_LIMIT - time_dead) / DEFIB_TIME_LIMIT, 99) // 20 from 1 minute onward, +20 per minute up to 99
+		var/defib_time_brain_damage = min(100 * time_dead / DEFIB_TIME_LIMIT, 99) // 20 from 1 minute onward, +20 per minute up to 99
 		if(time_dead > DEFIB_TIME_LOSS && defib_time_brain_damage > target.getBrainLoss())
 			target.setBrainLoss(defib_time_brain_damage)
 

--- a/code/datums/components/defibrillator.dm
+++ b/code/datums/components/defibrillator.dm
@@ -273,9 +273,10 @@
 		target.adjustFireLoss(-heal_amount)
 		target.adjustBruteLoss(-heal_amount)
 
-		// Set brain damage to 100 * ratio of time spent dead over max defib time threshold
-		if(time_dead > DEFIB_TIME_LOSS)
-			target.setBrainLoss(clamp(100 * (DEFIB_TIME_LIMIT - time_dead) / DEFIB_TIME_LIMIT, 0, 99))
+		// Inflict some brain damage scaling with time spent dead
+		var/defib_time_brain_damage = min(100 * (DEFIB_TIME_LIMIT - time_dead) / DEFIB_TIME_LIMIT, 99) // 20 from 1 minute onward, +20 per minute up to 99
+		if(time_dead > DEFIB_TIME_LOSS && defib_time_brain_damage > target.getBrainLoss())
+			target.setBrainLoss(defib_time_brain_damage)
 
 		target.update_revive()
 		target.KnockOut()

--- a/code/datums/components/defibrillator.dm
+++ b/code/datums/components/defibrillator.dm
@@ -177,7 +177,6 @@
 
 	if(!do_after(user, 3 SECONDS * speed_multiplier, target = target)) // Beginning to place the paddles on patient's chest to allow some time for people to move away to stop the process
 		busy = FALSE
-		SEND_SIGNAL(parent, COMSIG_DEFIB_ABORTED, user, target, should_cause_harm)
 		return
 
 	user.visible_message("<span class='notice'>[user] places [parent] on [target]'s chest.</span>", "<span class='warning'>You place [parent] on [target]'s chest.</span>")
@@ -191,7 +190,6 @@
 
 	if(!do_after(user, 2 SECONDS * speed_multiplier, target = target)) // Placed on chest and short delay to shock for dramatic effect, revive time is 5sec total
 		busy = FALSE
-		SEND_SIGNAL(parent, COMSIG_DEFIB_ABORTED, user, target, should_cause_harm)
 		return
 
 	signal_result |= SEND_SIGNAL(target, COMSIG_LIVING_DEFIBBED, user, parent, ghost)
@@ -199,13 +197,11 @@
 		user.visible_message("<span class='notice'>[defib_ref] buzzes: Patient's chest is obscured. Operation aborted.</span>")
 		playsound(get_turf(defib_ref), 'sound/machines/defib_failed.ogg', 50, 0)
 		busy = FALSE
-		SEND_SIGNAL(parent, COMSIG_DEFIB_ABORTED, user, target, should_cause_harm)
 		return
 
 	if(signal_result & COMPONENT_DEFIB_OVERRIDE)
 		// Let our signal handle it
 		busy = FALSE
-		SEND_SIGNAL(parent, COMSIG_DEFIB_ABORTED, user, target, should_cause_harm)
 		return
 
 	if(target.undergoing_cardiac_arrest()) // Can have a heart attack and heart is either missing, necrotic, or not beating
@@ -216,7 +212,6 @@
 			user.visible_message("<span class='boldnotice'>[defib_ref] buzzes: Resuscitation failed - Heart necrosis detected.</span>")
 		if(!heart || (heart.status & ORGAN_DEAD))
 			playsound(get_turf(defib_ref), 'sound/machines/defib_failed.ogg', 50, 0)
-			SEND_SIGNAL(parent, COMSIG_DEFIB_ABORTED, user, target, should_cause_harm)
 			busy = FALSE
 			return
 
@@ -235,7 +230,6 @@
 	if(target.stat != DEAD && !HAS_TRAIT(target, TRAIT_FAKEDEATH))
 		user.visible_message("<span class='notice'>[defib_ref] buzzes: Patient is not in a valid state. Operation aborted.</span>")
 		playsound(get_turf(defib_ref), 'sound/machines/defib_failed.ogg', 50, 0)
-		SEND_SIGNAL(parent, COMSIG_DEFIB_ABORTED, user, target, should_cause_harm)
 		busy = FALSE
 		return
 

--- a/code/datums/components/defibrillator.dm
+++ b/code/datums/components/defibrillator.dm
@@ -208,17 +208,13 @@
 		SEND_SIGNAL(parent, COMSIG_DEFIB_ABORTED, user, target, should_cause_harm)
 		return
 
-	if(target.undergoing_cardiac_arrest()) // Can have a heart attack, and heart is either missing, necrotic, or not beating
-		if(!target.get_int_organ(/obj/item/organ/internal/heart) // Prevents defibing someone still alive suffering from a heart attack attack if they lack a heart
-			user.visible_message("<span class='boldnotice'>[defib_ref] buzzes: Resuscitation failed - Failed to pick up any heart electrical activity.</span>")
-			playsound(get_turf(defib_ref), 'sound/machines/defib_failed.ogg', 50, 0)
-			SEND_SIGNAL(parent, COMSIG_DEFIB_ABORTED, user, target, should_cause_harm)
-			busy = FALSE
-			return
-
+	if(target.undergoing_cardiac_arrest()) // Can have a heart attack and heart is either missing, necrotic, or not beating
 		var/obj/item/organ/internal/heart/heart = target.get_int_organ(/obj/item/organ/internal/heart)
-		if(heart.status & ORGAN_DEAD)
+		if(!heart)
+			user.visible_message("<span class='boldnotice'>[defib_ref] buzzes: Resuscitation failed - Failed to pick up any heart electrical activity.</span>")
+		else if(heart.status & ORGAN_DEAD)
 			user.visible_message("<span class='boldnotice'>[defib_ref] buzzes: Resuscitation failed - Heart necrosis detected.</span>")
+		if(!heart || (heart.status & ORGAN_DEAD))
 			playsound(get_turf(defib_ref), 'sound/machines/defib_failed.ogg', 50, 0)
 			SEND_SIGNAL(parent, COMSIG_DEFIB_ABORTED, user, target, should_cause_harm)
 			busy = FALSE
@@ -251,7 +247,6 @@
 	var/defib_success = TRUE
 
 	// Run through some quick failure states after shocking.
-
 	var/time_dead = world.time - target.timeofdeath
 
 	if(time_dead > DEFIB_TIME_LIMIT)

--- a/code/datums/components/defibrillator.dm
+++ b/code/datums/components/defibrillator.dm
@@ -215,7 +215,7 @@
 		return
 
 	if(target.undergoing_cardiac_arrest())
-		if(!target.get_int_organ(/obj/item/organ/internal/heart) && !target.get_int_organ(/obj/item/organ/internal/brain/slime)) //prevents defibing someone still alive suffering from a heart attack attack if they lack a heart
+		if(!target.get_int_organ(/obj/item/organ/internal/heart) //prevents defibing someone still alive suffering from a heart attack attack if they lack a heart
 			user.visible_message("<span class='boldnotice'>[defib_ref] buzzes: Resuscitation failed - Failed to pick up any heart electrical activity.</span>")
 			playsound(get_turf(defib_ref), 'sound/machines/defib_failed.ogg', 50, 0)
 			SEND_SIGNAL(parent, COMSIG_DEFIB_ABORTED, user, target, should_cause_harm)

--- a/code/datums/components/defibrillator.dm
+++ b/code/datums/components/defibrillator.dm
@@ -320,7 +320,7 @@
 	target.KnockDown(10 SECONDS)
 	playsound(get_turf(parent), 'sound/machines/defib_zap.ogg', 50, 1, -1)
 	target.emote("gasp")
-	if(combat && prob(heart_attack_chance)) // If the victim is not having a heart attack, and a 10% chance passes, or the defib has heart attack variable to TRUE while being a combat defib, or if another 10% chance passes with combat being TRUE
+	if(combat && prob(heart_attack_chance))
 		target.set_heartattack(TRUE)
 	SEND_SIGNAL(target, COMSIG_LIVING_MINOR_SHOCK, 100)
 	add_attack_logs(user, target, "Stunned with [parent]")

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -312,11 +312,8 @@
 	if(!wielded)
 		to_chat(user, "<span class='boldnotice'>You need to wield the paddles in both hands before you can use them on someone!</span>")
 		return COMPONENT_BLOCK_DEFIB_MISC
-
 	if(!defib.powered)
 		return COMPONENT_BLOCK_DEFIB_DEAD
-
-	return
 
 /obj/item/twohanded/shockpaddles/proc/on_cooldown_expire(obj/item/paddles)
 	SIGNAL_HANDLER  // COMSIG_DEFIB_READY

--- a/code/modules/mob/living/carbon/human/human_life.dm
+++ b/code/modules/mob/living/carbon/human/human_life.dm
@@ -896,13 +896,12 @@
 /mob/living/carbon/human/proc/undergoing_cardiac_arrest()
 	if(!can_heartattack())
 		return FALSE
+
 	var/obj/item/organ/internal/heart/heart = get_int_organ(/obj/item/organ/internal/heart)
-	if(istype(heart))
-		if(heart.status & ORGAN_DEAD)
-			return TRUE
-		if(heart.beating)
-			return FALSE
-	return TRUE
+	if(!istype(heart) || (heart.status & ORGAN_DEAD) || !heart.beating)
+		return TRUE
+
+	return FALSE
 
 /mob/living/carbon/human/proc/set_heartattack(status)
 	if(!can_heartattack())


### PR DESCRIPTION
## What Does This PR Do
- Fixes like three different bugs with the way defibrillators inflicted brain damage (previously not only did it completely overwrite old brain damage even if new value was *lower*, it also scaled *backwards*, and was even subject to a macro expansion bug that made the actual value go fuck knows where)
- Fixes a runtime that happened when you tried to defib a heart-removed slimeperson due to some some presumably pre-newcrit code where slimeperson cores (brains) used to double as hearts
- Reorganizes code slightly so it's more readable

## Why It's Good For The Game
Less runtimes is nice, defibs also should not be *reducing* brain damage

## Testing
Put a skrell into crit so it got some brain damage; defibbed it very quickly to see it didn't gain any brain damage as expected, but also didn't lose any; killed the skrell again and waited for a longer while; defibbed it again to see its brain damage went up as it should.
Spawned in a slimeperson and surgically removed it's heart and waited for it to die; defibbed and ensured there's no runtime.

## Changelog
:cl:
fix: Defibrillators brain damage now scales properly
fix: Defibrillators no longer break down when reviving a slimeperson without a heart
/:cl:
