### PR TITLE
Solar flare now only affects station level

### DIFF
--- a/code/datums/weather/weather_datum.dm
+++ b/code/datums/weather/weather_datum.dm
@@ -111,14 +111,14 @@
 /datum/weather/proc/can_weather_act(mob/living/L) //Can this weather impact a mob?
 	var/turf/mob_turf = get_turf(L)
 	if(!istype(L))
-		return
+		return FALSE
 	if(mob_turf && !(mob_turf.z in impacted_z_levels))
-		return
+		return FALSE
 	if(immunity_type in L.weather_immunities)
-		return
+		return FALSE
 	if(!(get_area(L) in impacted_areas))
-		return
-	return 1
+		return FALSE
+	return TRUE
 
 /datum/weather/proc/weather_act(mob/living/L) //What effect does this weather have on the hapless mob?
 	return

--- a/code/datums/weather/weather_types/solar_flare.dm
+++ b/code/datums/weather/weather_types/solar_flare.dm
@@ -14,7 +14,7 @@
 
 	end_duration = 10 // wind_down() does not do anything for this event, so we just trigger end() semi-immediately
 	end_message = null
-	area_type = /area/space // read generate_area_list() as well below
+	area_type = /area // read generate_area_list() as well below
 	protected_areas = list(/area/shuttle/arrival/station)
 	target_trait = STATION_LEVEL
 	immunity_type = "burn"
@@ -39,15 +39,11 @@
 	SSsun.solar_gen_rate = initial(SSsun.solar_gen_rate) * 40
 
 /datum/weather/solar_flare/can_weather_act(mob/living/L)
-	. = ..()
-	if(.) //If true the mob is already affected, no need to keep processing
-		return TRUE
-	var/turf/mob_turf = get_turf(L)
-	if(mob_turf && !(mob_turf.z in impacted_z_levels))
-		return FALSE
 	if(isanimal(L)) //while this might break immersion, I don't want to spam the server with calling this on simplemobs
 		return FALSE
 	if(isdrone(L)) //same with poor maint drones who just wanna have fun
+		return FALSE
+	if(!..(L)) //If true the mob is already affected, no need to keep processing
 		return FALSE
 	for(var/turf/T in oview(get_turf(L)))
 		if(isspaceturf(T) || istransparentturf(T))

--- a/code/datums/weather/weather_types/solar_flare.dm
+++ b/code/datums/weather/weather_types/solar_flare.dm
@@ -42,6 +42,9 @@
 	. = ..()
 	if(.) //If true the mob is already affected, no need to keep processing
 		return TRUE
+	var/turf/mob_turf = get_turf(L)
+	if(mob_turf && !(mob_turf.z in impacted_z_levels))
+		return FALSE
 	if(isanimal(L)) //while this might break immersion, I don't want to spam the server with calling this on simplemobs
 		return FALSE
 	if(isdrone(L)) //same with poor maint drones who just wanna have fun

--- a/code/datums/weather/weather_types/solar_flare.dm
+++ b/code/datums/weather/weather_types/solar_flare.dm
@@ -44,7 +44,7 @@
 	if(isdrone(L)) //same with poor maint drones who just wanna have fun
 		return FALSE
 	. = ..()
-	if(!.) //If true the mob is already affected, no need to keep processing
+	if(!.) // If false the mob is not currently a valid target, no need to keep processing
 		return FALSE
 	for(var/turf/T in oview(get_turf(L)))
 		if(isspaceturf(T) || istransparentturf(T))

--- a/code/datums/weather/weather_types/solar_flare.dm
+++ b/code/datums/weather/weather_types/solar_flare.dm
@@ -43,7 +43,8 @@
 		return FALSE
 	if(isdrone(L)) //same with poor maint drones who just wanna have fun
 		return FALSE
-	if(!..(L)) //If true the mob is already affected, no need to keep processing
+	. = ..()
+	if(!.) //If true the mob is already affected, no need to keep processing
 		return FALSE
 	for(var/turf/T in oview(get_turf(L)))
 		if(isspaceturf(T) || istransparentturf(T))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Solar flare now only affects station level instead of all players that can see space (Including those on CentComm). This does mean solar flares no longer affect other space Z-levels.
Fixes: #21282
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Bug bad
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Spawned a skrell in CentComm.
Spawned a skrell on station.
Spawned a skrell on a space ruin.
Skrell on station gets burnt, others do not.
Smells like napalm, tastes like chicken.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Solar flare now only affects station level
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
