### PR TITLE
Makes duplicate events have less weight work / work based on percentage now.

### DIFF
--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -49,6 +49,7 @@ GLOBAL_LIST_EMPTY(event_last_fired)
 
 		log_debug("Starting event '[next_event.name]' of severity [GLOB.severity_to_string[severity]].")
 		SSblackbox.record_feedback("nested tally", "events", 1, list(GLOB.severity_to_string[severity], next_event.name))
+		GLOB.event_last_fired[next_event] = world.time
 		next_event = null						// When set to null, a random event will be selected next time
 	else
 		// If not, wait for one minute, instead of one tick, before checking again.
@@ -68,9 +69,9 @@ GLOBAL_LIST_EMPTY(event_last_fired)
 
 	for(var/event_meta in last_event_time) if(possible_events[event_meta])
 		var/time_passed = world.time - GLOB.event_last_fired[event_meta]
-		var/weight_modifier = max(0, (GLOB.configuration.event.expected_round_length - time_passed) / 300)
-		var/new_weight = max(possible_events[event_meta] - weight_modifier, 0)
-
+		var/half_of_round = GLOB.configuration.event.expected_round_length / 2
+		var/weight_modifier = min(1, 1 - ((half_of_round - time_passed) / half_of_round)) //With this formula, an event ran 30 minutes ago has half weight, and an event ran an hour ago, has 100 % weight. This works better in general for events, as super high wieght events are impacted in a meaningful way.
+		var/new_weight = max(possible_events[event_meta] * weight_modifier, 0)
 		if(new_weight)
 			possible_events[event_meta] = new_weight
 		else

--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -70,7 +70,8 @@ GLOBAL_LIST_EMPTY(event_last_fired)
 	for(var/event_meta in last_event_time) if(possible_events[event_meta])
 		var/time_passed = world.time - GLOB.event_last_fired[event_meta]
 		var/half_of_round = GLOB.configuration.event.expected_round_length / 2
-		var/weight_modifier = min(1, 1 - ((half_of_round - time_passed) / half_of_round)) //With this formula, an event ran 30 minutes ago has half weight, and an event ran an hour ago, has 100 % weight. This works better in general for events, as super high wieght events are impacted in a meaningful way.
+		var/weight_modifier = min(1, 1 - ((half_of_round - time_passed) / half_of_round)) 
+		//With this formula, an event ran 30 minutes ago has half weight, and an event ran an hour ago, has 100 % weight. This works better in general for events, as super high weight events are impacted in a meaningful way.
 		var/new_weight = max(possible_events[event_meta] * weight_modifier, 0)
 		if(new_weight)
 			possible_events[event_meta] = new_weight


### PR DESCRIPTION
### This is a tweak and fix, the bug must be fixed to make a balance of it work, and as such should be a design or balance vote, depending on who we decide should vote on how duplicate events works

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Event manager now adds events to GLOB.event_last_fired.
Without doing this, it just checked how long ago the start of the round was for duplicate events, and thus had no impact, when events start rolling at say, 30 minutes, then 50 minutes, at 50 minutes this would remove... 150 points, rather than 200 as expected, and this only gets worse as the round goes on.

Event manager now uses a percentage system, over a flat point deduction system. This means events with a higher rate get deducted a higher value, and smaller events that are not one shot don't get basically treated as a one shot, just become rare.

The way the duplicate event weight is calculated is 
![image](https://github.com/ParadiseSS13/Paradise/assets/52090703/7164c8e3-caba-4643-9945-9549c546c242)
which translates to 60 minutes as 36000. This means a duplicate event after 30 minutes has a 50% weight, a duplicate event at 45 minutes has a 75% weight, and an event over an hour has a 100% weight.
This means that events reset after an hour. This allows events to role multiple times at a sensible weight, and doesn't keep common events like nothing, which should be common but not too common, nerfed the entire round. This can be moved to the entire round if we wish, this means an  event ran at 30 minutes would be a 50% weight at 1:30 into the round.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

See above, a lot of it was explained in what is changed. Duplicate events should be reduced as expected, and a percentage system is better than a flat system, when we have weights varying by _2000 points_ between the rares events in medium and the most common events.

naturally fixes #21355

## Testing
<!-- How did you test the PR, if at all? -->
Confirmed events work as expected, with their percentage base nerfing..

## Changelog
:cl:
fix: For checking how to nerf duplicate events, event manager now checks when the event was last ran in the round, vs how long ago the start of the round was.
tweak: The event manager now nerfs duplicate event weight by a percentage, vs 300-0 points depending on time. This means super high weight events will be duplicate less than before, and less common events will duplicate *slightly* more, though their weight will still be *very* low.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
