### PR TITLE
chameleon counterfeiter no longer gives illegals 3

### DIFF
--- a/code/game/objects/items/devices/chameleon_counter.dm
+++ b/code/game/objects/items/devices/chameleon_counter.dm
@@ -6,7 +6,7 @@
 	slot_flags = SLOT_BELT
 	item_state = "electronic"
 	w_class = WEIGHT_CLASS_SMALL
-	origin_tech = "syndicate=3;magnets=3"
+	origin_tech = "syndicate=1;magnets=3"
 	var/can_use = TRUE
 	var/saved_name
 	var/saved_desc


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

chameleon counterfeiter no longer gives illegals 3, gives illegals 1 instead.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Too cheap. We did this with the chameleon flag back in the day.

When tech webs come out, and we divide all illegals stuff into levels, it should probably be standardized to illegals 2 items 1-3 tc, illegals 3 items 4-9 TC, and illegals 5 items (ebow) 10+ TC items.

## Testing
<!-- How did you test the PR, if at all? -->

I tweaked numbers.

## Changelog
:cl:
tweak: chameleon counterfeiter no longer gives illegals 3
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
