### PR TITLE
Prevents pulling anchored objects along while veil shifting

### DIFF
--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -338,8 +338,9 @@
 	if(C.pulling)
 		var/atom/movable/pulled = C.pulling
 		var/turf/turf_behind = get_turf(get_step(T, turn(C.dir, 180)))
-		pulled.forceMove(turf_behind)
-		. = pulled
+		if(!pulled.anchored)
+			pulled.forceMove(turf_behind)
+			. = pulled
 
 /obj/item/cult_shift/attack_self(mob/user)
 

--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -338,7 +338,7 @@
 	if(C.pulling)
 		var/atom/movable/pulled = C.pulling
 		var/turf/turf_behind = get_turf(get_step(T, turn(C.dir, 180)))
-		if(!pulled.anchored)
+		if(!pulled.anchored) //Item may have been anchored while pulling, and pulling state isn't updated until you move away, so we double check.
 			pulled.forceMove(turf_behind)
 			. = pulled
 

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -5,6 +5,7 @@
 	icon_state = "table2-idle"
 	density = TRUE
 	anchored = TRUE
+	interact_offline = TRUE
 	idle_power_consumption = 1
 	active_power_consumption = 5
 	can_buckle = TRUE // you can buckle someone if they have cuffs

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -5,7 +5,6 @@
 	icon_state = "table2-idle"
 	density = TRUE
 	anchored = TRUE
-	interact_offline = TRUE
 	idle_power_consumption = 1
 	active_power_consumption = 5
 	can_buckle = TRUE // you can buckle someone if they have cuffs


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
PR prevents pulling anchored items along while veil shifting. This could occur if you are pulling something, then anchor it down, so the pulling state does not get updated until you move. Examples include, but are no limited to pulling a vendor and wrenching it down, and screwdriving a window from the floor and back again.
fixes: #21364
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Bug bad.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Be a skrell cultist.
Drag a vendor and attempt a veil shift, it works.
Wrench the vendor down and attempt to veil shift, no dice.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: You can no longer pull anchored objects along while veil shifting.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
