### PR TITLE
Operating table no longer forces you to rest after unbuckling

### DIFF
--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -99,7 +99,6 @@
 		user.visible_message("[user] climbs on [src].","You climb on [src].")
 	else
 		visible_message("<span class='alert'>[new_patient] has been laid on [src] by [user].</span>")
-	new_patient.resting = TRUE
 	if(new_patient.s_active) //Close the container opened
 		new_patient.s_active.close(new_patient)
 	add_fingerprint(user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Previously after getting put onto a surgery table you'd be in a resting state even after unbuckling. This PR makes it so that the surgery table behaves like a bed, so after you unbuckle you will stand up (Unless you were resting previously).
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
A decent amount of people have been complaining about how annoying it is that you remain resting even after you unbuckle from the surgery table, this PR aims to make it a little less tedious.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Be a skrell and lie down on the surgery table.
Unbuckle, and I automatically get up.
Buckle another skrell to the surgery table.
Attempt to start a surgery and succeed.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Operating table no longer forces you to rest after unbuckling
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
