### PR TITLE
Fixes a few issues with flipping tables

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -345,15 +345,15 @@
 	verbs -=/obj/structure/table/verb/do_flip
 	verbs +=/obj/structure/table/proc/do_put
 
+	dir = direction
+	if(dir != NORTH)
+		layer = 5
 	var/list/targets = list(get_step(src,dir),get_step(src,turn(dir, 45)),get_step(src,turn(dir, -45)))
 	for(var/atom/movable/A in get_turf(src))
 		if(!A.anchored)
 			spawn(0)
 				A.throw_at(pick(targets),1,1)
 
-	dir = direction
-	if(dir != NORTH)
-		layer = 5
 	flipped = TRUE
 	smoothing_flags = NONE
 	flags |= ON_BORDER
@@ -381,7 +381,8 @@
 
 	layer = initial(layer)
 	flipped = FALSE
-	smoothing_flags = initial(smoothing_flags)
+	// Initial smoothing flags doesn't add the required SMOOTH_OBJ flag, thats done on init
+	smoothing_flags = initial(smoothing_flags) | SMOOTH_OBJ
 	flags &= ~ON_BORDER
 	for(var/D in list(turn(dir, 90), turn(dir, -90)))
 		if(locate(/obj/structure/table,get_step(src,D)))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->When tables are flipped, their items will go flying in the right direction, instead of at the user. Unflipping a table will actually make the table look like its supposed to.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Fixes #21362, Fixes #12312

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

https://github.com/ParadiseSS13/Paradise/assets/91113370/94f83cda-ea4f-4ea1-8668-78539aedc9c0


## Testing
<!-- How did you test the PR, if at all? -->
See above

## Changelog
:cl:
fix: Flipping a table will send the items on it flying in the right direction
fix: Unflipping a table will now make the table look correct
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
