### PR TITLE
Debrain objective no longer requires being not dead

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -236,7 +236,7 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 	if(!target.current || !isbrain(target.current))
 		return FALSE
 	for(var/datum/mind/M in get_owners())
-		if(QDELETED(M.current) || M.current.stat == DEAD)
+		if(QDELETED(M.current))
 			continue // Maybe someone who's alive has the brain.
 		if(target.current in M.current.GetAllContents())
 			return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->Changes the debrain objective to not require you to be not dead for it to be a success. I found this while doing other objective changes, and it seemed weird, so this PR is up to change it. This does not make the debrain objective glorious death compatible.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->All other steal and assassinate objectives don't require the user to be alive, they usually have survive objective anyways if they want the full greentext. No where in the debrain objective does it state that you have to be alive.

## Testing
<!-- How did you test the PR, if at all? -->
Stole a brain and died, greentexted

## Changelog
:cl:
tweak: Being dead and having your debrain objective complete will now count as a success
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
