### PR TITLE
Meta: Remove security dufflebag varedits.

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -81946,9 +81946,6 @@
 "sEM" = (
 /obj/structure/table,
 /obj/item/storage/backpack/duffel/security{
-	contents = newlist(/obj/item/scalpel,/obj/item/hemostat,/obj/item/retractor,/obj/item/cautery,/obj/item/circular_saw,/obj/item/surgical_drapes,/obj/item/clothing/mask/surgical);
-	desc = "A large duffelbag for holding extra supplies - this one has a material inlay with space for various sharp-looking tools.";
-	name = "duffelbag";
 	pixel_y = 5
 	},
 /obj/item/clothing/mask/balaclava,


### PR DESCRIPTION
## What Does This PR Do
Resets security duffels on Meta to not have custom names and descriptions or attempt to fill them with surgical tools (?)

## Why It's Good For The Game
This stuff shouldn't be in these and I assume `newlist` is a terrible idea anyway.

## Testing
Started rounds on Meta before and after, 

## Changelog
:cl:
fix: Meta: removed improperly customized security duffels
/:cl: