### PR TITLE
wizard dusts now on raging, now that gib no longer deletes items as constistantly

### DIFF
--- a/code/game/gamemodes/wizard/raginmages.dm
+++ b/code/game/gamemodes/wizard/raginmages.dm
@@ -54,18 +54,18 @@
 				end_squabble(get_area(wizard.current))
 			continue
 		if(wizard.current.stat==UNCONSCIOUS)
-			if(wizard.current.health < 0)
+			if(wizard.current.health < -100) //Lets make this not get funny rng crit involved
 				if(istype(get_area(wizard.current), /area/wizard_station))
 					to_chat(wizard.current, "<span class='warning'>If there aren't any admins on and another wizard is camping you in the wizard lair, report them on the forums</span>")
 					message_admins("[wizard.current] went into crit in the wizard lair, another wizard is likely camping")
 					end_squabble(get_area(wizard.current))
 				else
 					to_chat(wizard.current, "<span class='warning'><font size='4'>The Space Wizard Federation is upset with your performance and have terminated your employment.</font></span>")
-					wizard.current.gib() // *REAL* ACTION!! *REAL* DRAMA!! *REAL* BLOODSHED!!
+					wizard.current.dust() // *REAL* ACTION!! *REAL* DRAMA!! *REAL* BLOODSHED!!
 			continue
 		if(wizard.current.client && wizard.current.client.is_afk() > 10 * 60 * 10) // 10 minutes
 			to_chat(wizard.current, "<span class='warning'><font size='4'>The Space Wizard Federation is upset with your performance and have terminated your employment.</font></span>")
-			wizard.current.gib() // Let's keep the round moving
+			wizard.current.dust() // Let's keep the round moving
 			continue
 		if(!wizard.current.client)
 			continue // Could just be a bad connection, so SSD wiz's shouldn't be gibbed over it, but they're not "alive" either

--- a/code/game/gamemodes/wizard/raginmages.dm
+++ b/code/game/gamemodes/wizard/raginmages.dm
@@ -54,7 +54,7 @@
 				end_squabble(get_area(wizard.current))
 			continue
 		if(wizard.current.stat==UNCONSCIOUS)
-			if(wizard.current.health < -100) //Lets make this not get funny rng crit involved
+			if(wizard.current.health < HEALTH_THRESHOLD_DEAD) //Lets make this not get funny rng crit involved
 				if(istype(get_area(wizard.current), /area/wizard_station))
 					to_chat(wizard.current, "<span class='warning'>If there aren't any admins on and another wizard is camping you in the wizard lair, report them on the forums</span>")
 					message_admins("[wizard.current] went into crit in the wizard lair, another wizard is likely camping")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

wizards now dust instead of gib on raging. This means that when a wizard dies with the wand belt for the 800th time, crew doesnt polymorph the rest of the wizards. In the past gibbing blocked belt and similar items, but with modern gibbing it does not.

Updates the dust threshold to new crit, so sleepy time wizards don't gib when they sleep for half a second with no crew in sight while healing.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

See above.
(yes I posted it after a raging round, no, I did not die to wand belt, yes, this happens each raging round I admin. wizards that were wand of deathed also didn't gib so it was extra funny and bad.)

## Testing
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Wizards have learned of nt's dust implants, and now have imitated it into a spell form for raging wizards.
tweak: Wizards now dust at deep crit, vs sleeping at under 0 dusting
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
