### PR TITLE
Bookcases now pickup books on roundstart

### DIFF
--- a/code/modules/library/library_equipment.dm
+++ b/code/modules/library/library_equipment.dm
@@ -19,6 +19,18 @@
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, RAD = 0, FIRE = 50, ACID = 0)
 	var/list/allowed_books = list(/obj/item/book, /obj/item/spellbook, /obj/item/storage/bible, /obj/item/tome) //Things allowed in the bookcase
 
+/obj/structure/bookcase/Initialize(mapload)
+	. = ..()
+	if(mapload)
+		// same reasoning as closets
+		addtimer(CALLBACK(src, PROC_REF(take_contents)), 0)
+
+/obj/structure/bookcase/proc/take_contents()
+	for(var/obj/item/I in get_turf(src))
+		if(is_type_in_list(I, allowed_books))
+			I.forceMove(src)
+	update_icon(UPDATE_ICON_STATE)
+
 /obj/structure/bookcase/attackby(obj/item/O, mob/user)
 	if(is_type_in_list(O, allowed_books))
 		if(!user.drop_item())


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->Similar to lockers, but they pick up only books roundstart

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Maps have this stuff mapped in, but it doesnt actually work

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![image](https://github.com/ParadiseSS13/Paradise/assets/91113370/7ed98115-acf0-4c72-80ea-3e46967c573a)
![image](https://github.com/ParadiseSS13/Paradise/assets/91113370/2d7db47f-2803-4100-92e4-f66a5796f7d2)


## Testing
<!-- How did you test the PR, if at all? -->
Tested on a map, unfortunately I was not able to test the random books because of lack of an SQL database, so I went with what lockers used.

## Changelog
Only a mapping feature, nothing player related

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
