### PR TITLE
Cere: fix lattice dupes and spawner over wall in NTR office.

### DIFF
--- a/_maps/map_files/cerestation/cerestation.dmm
+++ b/_maps/map_files/cerestation/cerestation.dmm
@@ -11133,7 +11133,6 @@
 /area/crew_quarters/bar)
 "bjB" = (
 /obj/structure/lattice,
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 4
 	},
@@ -46881,7 +46880,6 @@
 /area/maintenance/disposal/west)
 "hvW" = (
 /obj/structure/lattice,
-/obj/structure/lattice,
 /turf/space,
 /area/space/nearstation)
 "hwf" = (
@@ -59291,7 +59289,6 @@
 	icon_state = "1-2"
 	},
 /obj/structure/lattice/catwalk,
-/obj/structure/lattice/catwalk,
 /turf/space,
 /area/space/nearstation)
 "lEk" = (
@@ -59530,10 +59527,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/library)
-"lID" = (
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/wall,
-/area/ntrep)
 "lIN" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -130874,7 +130867,7 @@ gch
 gch
 gch
 gch
-lID
+gch
 rNK
 rNK
 rNK


### PR DESCRIPTION
## What Does This PR Do
Removes a handful of duplicate lattices and a window spawner over a wall in the NTR office. Continuation of #19875 burndown.

## Why It's Good For The Game
Map conformance.

## Images of changes
![2023_06_17__21_57_35__paradise dme  cerestation dmm  - StrongDMM](https://github.com/ParadiseSS13/Paradise/assets/59303604/c339a367-c66f-4388-921c-841d28166113)


## Changelog
:cl:
fix: lattice and window spawner issues on Cere
/:cl: