### PR TITLE
Centcomm: remove stacked windows/spawners.

### DIFF
--- a/_maps/map_files/generic/centcomm.dmm
+++ b/_maps/map_files/generic/centcomm.dmm
@@ -7205,10 +7205,6 @@
 	},
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/supply)
-"BM" = (
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/wall/indestructible/fakeglass,
-/area/centcom/control)
 "BO" = (
 /obj/machinery/light/spot{
 	dir = 4
@@ -37962,7 +37958,7 @@ We
 We
 We
 od
-BM
+sm
 QI
 Kb
 Hm
@@ -38219,7 +38215,7 @@ We
 We
 We
 od
-BM
+sm
 ZC
 EV
 MB


### PR DESCRIPTION
## What Does This PR Do
Removes two spawners on top of indestructible windows. Continuation of #19875 burndown.

## Why It's Good For The Game
Map conformance.

## Images of changes
![2023_06_17__22_15_30__paradise dme  centcomm dmm  - StrongDMM](https://github.com/ParadiseSS13/Paradise/assets/59303604/749936bf-0e2e-405e-8d78-d98897a7103c)

## Changelog
:cl:
fix: Removed unnecessary window spawners on Centcomm
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
