### PR TITLE
Ruin: fix lattices and APC nudge for blowntcommsat.

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/blowntcommsat.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/blowntcommsat.dmm
@@ -341,11 +341,6 @@
 /obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
 /area/ruin/space/tcommsat)
-"wD" = (
-/obj/structure/lattice,
-/obj/structure/lattice,
-/turf/template_noop,
-/area/space/nearstation)
 "wO" = (
 /obj/structure/lattice,
 /obj/structure/grille/broken,
@@ -547,10 +542,6 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/ruin/space/tcommsat)
-"LU" = (
-/obj/structure/lattice,
-/turf/simulated/wall/r_wall,
-/area/ruin/space/tcommsat)
 "Mt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/writing{
@@ -603,10 +594,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/airless,
 /area/ruin/space/tcommsat)
-"Pf" = (
-/obj/structure/lattice,
-/turf/simulated/wall/r_wall,
-/area/space/nearstation)
 "Pn" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -808,8 +795,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Worn-out APC";
-	pixel_x = 1;
-	pixel_y = 26
+	pixel_y = 24
 	},
 /obj/structure/cable{
 	d2 = 4;
@@ -1194,7 +1180,7 @@ nX
 PO
 zE
 zE
-Pf
+zE
 zE
 nX
 nX
@@ -1410,12 +1396,12 @@ nX
 Jr
 Jr
 PO
-wD
 PO
 PO
 PO
 PO
-wD
+PO
+PO
 Ac
 rs
 TW
@@ -1761,14 +1747,14 @@ FK
 PO
 PO
 PO
-LU
+Wr
 Wr
 Vh
 kP
 PP
 ad
 ot
-LU
+Wr
 nX
 nX
 nX
@@ -2085,14 +2071,14 @@ Qd
 PO
 PO
 PO
-LU
+Wr
 Wr
 ab
 KD
 Za
 vl
 ot
-LU
+Wr
 nX
 nX
 nX
@@ -2382,7 +2368,7 @@ Jr
 Jr
 Jr
 PO
-wD
+PO
 PO
 PO
 PO
@@ -2761,7 +2747,7 @@ zE
 nX
 nX
 nX
-Pf
+zE
 nX
 nX
 nX


### PR DESCRIPTION
## What Does This PR Do
Removes many stacked lattices and fix APC pixel shift. Continuation of #19875 burndown.

## Why It's Good For The Game
Map conformance.

## Images of changes

<details><summary>Images</summary>

![2023_06_18__11_23_51__paradise dme  blowntcommsat dmm  - StrongDMM](https://github.com/ParadiseSS13/Paradise/assets/59303604/ea7cf863-e255-4e41-a0a3-86deb293db73)
![2023_06_18__11_24_14__paradise dme  blowntcommsat dmm  - StrongDMM](https://github.com/ParadiseSS13/Paradise/assets/59303604/2f8c6ff4-f8f0-4463-bd48-aa5b3c9c282c)
![2023_06_18__11_24_33__paradise dme  blowntcommsat dmm  - StrongDMM](https://github.com/ParadiseSS13/Paradise/assets/59303604/29b18a33-11e1-4c55-9be0-42f3b8066aed)
![2023_06_18__11_24_55__paradise dme  blowntcommsat dmm  - StrongDMM](https://github.com/ParadiseSS13/Paradise/assets/59303604/6e5cf6d6-2ed8-4cf1-8726-38c005d8df9b)
![2023_06_18__11_25_11__paradise dme  blowntcommsat dmm  - StrongDMM](https://github.com/ParadiseSS13/Paradise/assets/59303604/f0659c51-47ae-471d-82ac-2732b231cd09)
![2023_06_18__11_25_28__paradise dme  blowntcommsat dmm  - StrongDMM](https://github.com/ParadiseSS13/Paradise/assets/59303604/2657417b-ba1f-412b-a554-24207be753ff)
![2023_06_18__11_25_50__paradise dme  blowntcommsat dmm  - StrongDMM](https://github.com/ParadiseSS13/Paradise/assets/59303604/12ef7a31-78d0-45ac-93af-981460cb9894)
![2023_06_18__11_26_02__paradise dme  blowntcommsat dmm  - StrongDMM](https://github.com/ParadiseSS13/Paradise/assets/59303604/62e100d7-fc60-416c-acc4-ed7d938f950c)

</details>

## Changelog
:cl:
fix: Fixed lattice and wall bump positions on tcommsat space ruin.
/:cl:
