### PR TITLE
Fix stacked lattices on debris1, derelict3, and dj ruins.

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/debris1.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/debris1.dmm
@@ -129,11 +129,6 @@
 /obj/item/shard,
 /turf/space,
 /area/space)
-"N" = (
-/obj/structure/lattice,
-/obj/structure/lattice,
-/turf/space,
-/area/space)
 "O" = (
 /obj/machinery/power/apc/worn_out{
 	pixel_y = -24
@@ -467,7 +462,7 @@ X
 v
 X
 v
-N
+v
 E
 E
 K

--- a/_maps/map_files/RandomRuins/SpaceRuins/derelict3.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/derelict3.dmm
@@ -12,11 +12,6 @@
 /obj/structure/lattice,
 /turf/template_noop,
 /area/space/nearstation)
-"e" = (
-/obj/structure/lattice,
-/obj/structure/lattice,
-/turf/template_noop,
-/area/space/nearstation)
 
 (1,1,1) = {"
 a
@@ -471,7 +466,7 @@ a
 d
 d
 a
-e
+d
 d
 b
 a

--- a/_maps/map_files/RandomRuins/SpaceRuins/dj.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/dj.dmm
@@ -70,11 +70,6 @@
 	},
 /turf/template_noop,
 /area/space/nearstation)
-"ak" = (
-/obj/structure/lattice,
-/obj/structure/lattice,
-/turf/template_noop,
-/area/space/nearstation)
 "al" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -880,7 +875,7 @@ aa
 aa
 aa
 ab
-ak
+ad
 ad
 ae
 aa


### PR DESCRIPTION
## What Does This PR Do
Removes stacked lattices for several space ruins. Continuation of https://github.com/ParadiseSS13/Paradise/pull/19875 burndown.
## Why It's Good For The Game
Map conformance.
## Images of changes
<details><summary>Images</summary>

![2023_06_18__11_35_58__paradise dme  debris1 dmm  - StrongDMM](https://github.com/ParadiseSS13/Paradise/assets/59303604/19f93433-adfa-482c-94df-b6117ebb973c)
![2023_06_18__11_36_37__paradise dme  derelict3 dmm  - StrongDMM](https://github.com/ParadiseSS13/Paradise/assets/59303604/d6b5fdc4-a8d9-4202-bcec-a37555fe3c86)
![2023_06_18__11_37_35__paradise dme  dj dmm  - StrongDMM](https://github.com/ParadiseSS13/Paradise/assets/59303604/0de90afc-4393-4fc6-98e1-1e19da36c9d4)

</details>

## Changelog
:cl:
fix: Remove stacked lattices on several space ruins.
/:cl: