### PR TITLE
Ruins: fix APC bumps on moonoutpost19, onehalf, spacebar.

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/moonoutpost19.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/moonoutpost19.dmm
@@ -1193,7 +1193,7 @@
 	dir = 4;
 	locked = 0;
 	name = "Maintenance APC";
-	pixel_x = 25;
+	pixel_x = 24;
 	req_access = null;
 	start_charge = 100
 	},
@@ -1435,7 +1435,7 @@
 	dir = 4;
 	locked = 0;
 	name = "Research APC";
-	pixel_x = 25;
+	pixel_x = 24;
 	req_access = null
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2978,7 +2978,7 @@
 	dir = 1;
 	locked = 0;
 	name = "Habitat APC";
-	pixel_y = 25;
+	pixel_y = 24;
 	req_access = null;
 	start_charge = 100
 	},
@@ -3015,10 +3015,6 @@
 	name = "Specials This Week"
 	},
 /obj/effect/landmark/burnturf,
-/turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
-"fU" = (
-/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/ruin/space/unpowered)
 "fV" = (
@@ -8212,10 +8208,10 @@ eB
 eN
 aM
 aM
-fU
+bX
 gx
 gZ
-fU
+bX
 aL
 hn
 aL

--- a/_maps/map_files/RandomRuins/SpaceRuins/onehalf.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/onehalf.dmm
@@ -404,7 +404,7 @@
 	dir = 4;
 	keep_preset_name = 1;
 	name = "Crew Quarters APC";
-	pixel_x = 27
+	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -419,7 +419,7 @@
 	dir = 1;
 	keep_preset_name = 1;
 	name = "Mining Drone Bay APC";
-	pixel_y = 26
+	pixel_y = 24
 	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
@@ -762,7 +762,7 @@
 	dir = 1;
 	keep_preset_name = 1;
 	name = "Bridge APC";
-	pixel_y = 26
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/space/onehalf/abandonedbridge)

--- a/_maps/map_files/RandomRuins/SpaceRuins/spacebar.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/spacebar.dmm
@@ -177,10 +177,6 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/ruin/space/powered/bar)
-"aR" = (
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/wall,
-/area/ruin/space/powered/bar)
 "aS" = (
 /obj/machinery/door/airlock/external,
 /turf/simulated/floor/plating,
@@ -1095,7 +1091,7 @@ ai
 ai
 ag
 ag
-aR
+aQ
 aT
 aQ
 ag


### PR DESCRIPTION
## What Does This PR Do
Fix wall bump nudges on several space ruins. Continuation of #19875 burndown.

## Why It's Good For The Game
Map conformance.

## Changelog
:cl:
fix: APCs are correctly positioned on space ruins.
/:cl: