### PR TITLE
golems no longer cause hijacks to fail

### DIFF
--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -304,7 +304,7 @@
 			continue
 		if(isanimal(player)) //Poly does not own the shuttle
 			continue
-		if(ishuman(player)) //hostages allowed on the shuttle, check for restraints
+		if(ishuman(player)) //hostages allowed on the shuttle, check for restraints/them being golems
 			var/mob/living/carbon/human/H = player
 			if(!H.check_death_method() && H.health <= HEALTH_THRESHOLD_DEAD) //new crit users who are in hard crit are considered dead
 				continue
@@ -316,6 +316,8 @@
 				var/obj/structure/closet/C = H.loc
 				if(C.welded || C.locked)
 					continue
+			if(isgolem(H)) // golems are often used in hijacks, so they really shouldn't all be forced to space themselves before the shuttle docks
+				continue
 		var/special_role = player.mind.special_role
 		if(special_role)
 			// There's a long list of special roles, but almost all of them are antags anyway.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Golems no longer cause hijacks to fail

## Why It's Good For The Game
If you are using golems for hijacking and you're not intent on hacking (or you're the ai) you'll need to get all your golems to walk out an airlock, which is obviously not good.
If you're not a hijacker you can just spam a bunch of golems at a hijacker, which is less problematic but also not great as they are a ghost role, and are pretty much have no value


## Testing
It compiled

## Changelog
:cl:
tweak: Golems no longer cause hijacks to fail
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
