### PR TITLE
Slime Blueprints have a nicer colortint

### DIFF
--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -567,7 +567,7 @@
 	..()
 	var/area/A = get_area(src)
 	for(var/turf/T in A)
-		T.color = "#2956B2"
+		T.color = "#7ea9ff"
 	A.xenobiology_compatible = TRUE
 	qdel(src)
 


### PR DESCRIPTION
## What Does This PR Do
Makes the Slime Blueprint's colortint slightly lighter.

## Why It's Good For The Game
Current version makes areas an eyesore, and actually impossible to differentiate between ironwalls/plating in maintenance.

## Images of changes
Before
![kM6h1w8s1S](https://github.com/ParadiseSS13/Paradise/assets/48032385/25751cf9-a2a3-4271-94bd-393f50a74a5d)
After
![p8eRkxp3Eu](https://github.com/ParadiseSS13/Paradise/assets/48032385/348d482e-bac9-42ba-9081-edec3b876f0d)

Bear in mind this is in fully illuminated rooms, imagine doing this in maintenance. Please imagine it because I did not get a picture for that case and I do not wanna test again for the sake of making you not imagine how it looks like.

## Changelog
:cl:
tweak: Slime Blueprints apply a lighter color filter on rooms.
/:cl: