### PR TITLE
buffs cyborg emmitters

### DIFF
--- a/code/modules/projectiles/ammunition/energy_lens.dm
+++ b/code/modules/projectiles/ammunition/energy_lens.dm
@@ -294,7 +294,8 @@
 	select_name = "emitter"
 
 /obj/item/ammo_casing/energy/emitter/cyborg
-	e_cost = 500 // about 28 shots on an engineering borg from a borging machine, assuming some power is used for lights / movement. May need to change.
+	e_cost = 350 // about 42 shots on an engineering borg from a borging machine, Reads a lot better than it actually is because people miss shots and often your better abilities require charge as well
+	delay = 1 SECONDS
 
 /obj/item/ammo_casing/energy/bsg
 	projectile_type = /obj/item/projectile/energy/bsg


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Buffs cyborg emitters, now only requires 350 energy per shot and has a 1 second delay between shots, rather than 2

## Why It's Good For The Game
This ability is bad

I don't really need to elaborate much. This 50 point ability gives only engineering cyborgs a ranged option, this ranged option has a whopping 15 dps and the most obvious sound attached to it and you're still probably taking it because malf AI has three abilities that actually do something.
Well, maybe this ability will actually do something sometime, you're still probably going to want to use stun arm in every situation, but it's an ok flyswatter for unathi trying to screw up your core.

## Testing
I probably didn't need to test this but I did, it's 2 value changes

## Changelog
:cl:
tweak: Cyborg emitters fire twice as fast and take less energy per shot
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
