### PR TITLE
You can now order gas canisters from cargo

### DIFF
--- a/code/game/objects/structures/crates_lockers/largecrate.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate.dm
@@ -49,6 +49,12 @@
 	else
 		return ..()
 
+/obj/structure/largecrate/Destroy()
+	for (var/obj/O in contents)
+		var/atom/movable/A = O
+		A.forceMove(get_turf(src))
+	return ..()
+
 /obj/structure/largecrate/mule
 
 /obj/structure/largecrate/lisa

--- a/code/game/objects/structures/crates_lockers/largecrate.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate.dm
@@ -50,9 +50,9 @@
 		return ..()
 
 /obj/structure/largecrate/Destroy()
-	for (var/obj/O in contents)
-		var/atom/movable/A = O
-		A.forceMove(get_turf(src))
+	var/src_turf = get_turf(src)
+	for(var/obj/O in contents)
+		O.forceMove(src_turf )
 	return ..()
 
 /obj/structure/largecrate/mule

--- a/code/game/objects/structures/crates_lockers/largecrate.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate.dm
@@ -50,9 +50,9 @@
 		return ..()
 
 /obj/structure/largecrate/Destroy()
-	var/src_turf = get_turf(src)
+	var/turf/src_turf = get_turf(src)
 	for(var/obj/O in contents)
-		O.forceMove(src_turf )
+		O.forceMove(src_turf)
 	return ..()
 
 /obj/structure/largecrate/mule

--- a/code/modules/supply/supply_packs/pack_engineering.dm
+++ b/code/modules/supply/supply_packs/pack_engineering.dm
@@ -220,3 +220,45 @@
 	containername = "thermo-electric generator crate"
 	access = ACCESS_CE
 	announce_beacons = list("Engineering" = list("Chief Engineer's Desk", "Atmospherics"))
+
+/datum/supply_packs/engineering/canister/nitrogen
+	name = "Nitrogen canister"
+	contains = list(/obj/machinery/atmospherics/portable/canister/nitrogen)
+	cost = 50
+	containertype = /obj/structure/largecrate
+	containername = "nitrogen canister crate"
+
+/datum/supply_packs/engineering/canister/oxygen
+	name = "Oxygen canister"
+	contains = list(/obj/machinery/atmospherics/portable/canister/oxygen)
+	cost = 50
+	containertype = /obj/structure/largecrate
+	containername = "oxygen canister crate"
+
+/datum/supply_packs/engineering/canister/air
+	name = "Air canister"
+	contains = list(/obj/machinery/atmospherics/portable/canister/air)
+	cost = 50
+	containertype = /obj/structure/largecrate
+	containername = "Air canister crate"
+
+/datum/supply_packs/engineering/canister/sleeping_agent
+	name = "Nitrous oxide canister"
+	contains = list(/obj/machinery/atmospherics/portable/canister/sleeping_agent)
+	cost = 250
+	containertype = /obj/structure/largecrate
+	containername = "Nitrous oxide canister crate"
+
+/datum/supply_packs/engineering/canister/carbon_dioxide
+	name = "Carbon dioxide canister"
+	contains = list(/obj/machinery/atmospherics/portable/canister/carbon_dioxide)
+	cost = 250
+	containertype = /obj/structure/largecrate
+	containername = "Carbon dioxide canister crate"
+
+/datum/supply_packs/engineering/canister/toxins
+	name = "Plasma canister"
+	contains = list(/obj/machinery/atmospherics/portable/canister/carbon_dioxide)
+	cost = 250
+	containertype = /obj/structure/largecrate
+	containername = "Plasma canister crate"

--- a/code/modules/supply/supply_packs/pack_engineering.dm
+++ b/code/modules/supply/supply_packs/pack_engineering.dm
@@ -258,7 +258,7 @@
 
 /datum/supply_packs/engineering/canister/toxins
 	name = "Plasma canister"
-	contains = list(/obj/machinery/atmospherics/portable/canister/carbon_dioxide)
+	contains = list(/obj/machinery/atmospherics/portable/canister/toxins)
 	cost = 250
 	containertype = /obj/structure/largecrate
 	containername = "Plasma canister crate"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds the ability to order gas canisters with cargo, in all the normally accessible flavours! Plasma, CO2 and N2O are all  very high in demand by traitors and crew alike, so the prices of those are of course raised.

This also adds a destroy() to large crates.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
In case of someone destroying the counter and all of the atmos air production gets nuked, this allows for small restocks so the station won't die a slow choking death.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Went to cargo, ordered some canisters of Oxygen and Plasma. 
Used my god-given right of the second amendement to open the crates up.
Watched the world burn.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
add: adds the ability to buy gas canisters from cargo
tweak: large crates drop their contents when they are destroyed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
