### PR TITLE
Ear Organ Refactor + Deafness is a status effect

### DIFF
--- a/code/__DEFINES/status_effects.dm
+++ b/code/__DEFINES/status_effects.dm
@@ -137,6 +137,7 @@
 #define STATUS_EFFECT_BLURRY_EYES /datum/status_effect/transient/eye_blurry
 #define STATUS_EFFECT_BLINDED /datum/status_effect/transient/blindness
 #define STATUS_EFFECT_DRUGGED /datum/status_effect/transient/drugged
+#define STATUS_EFFECT_DEAF /datum/status_effect/transient/deaf
 
 /////////////
 // NEUTRAL //

--- a/code/datums/diseases/advance/symptoms/deafness.dm
+++ b/code/datums/diseases/advance/symptoms/deafness.dm
@@ -36,4 +36,4 @@ Bonus
 				to_chat(M, "<span class='warning'>[pick("You hear a ringing in your ear.", "Your ears pop.")]</span>")
 			if(5)
 				to_chat(M, "<span class='userdanger'>Your ears pop and begin ringing loudly!</span>")
-				ears.deaf = min(20, ears.deaf + 15)
+				M.Deaf(40 SECONDS)

--- a/code/datums/elements/earhealing.dm
+++ b/code/datums/elements/earhealing.dm
@@ -31,6 +31,6 @@
 		var/obj/item/organ/internal/ears/ears = user.get_int_organ(/obj/item/organ/internal/ears)
 		if(!ears || HAS_TRAIT_NOT_FROM(user, TRAIT_DEAF, EAR_DAMAGE))
 			continue
-		ears.deaf = max(ears.deaf - 0.25, (ears.damage < 100 ? 0 : 1)) // Do not clear deafness if our ears are too damaged
-		ears.damage = max(ears.damage - 0.025, 0)
+		user.AdjustDeaf(-1 SECONDS)
+		ears.heal_internal_damage(0.025)
 		CHECK_TICK

--- a/code/datums/elements/earhealing.dm
+++ b/code/datums/elements/earhealing.dm
@@ -31,6 +31,6 @@
 		var/obj/item/organ/internal/ears/ears = user.get_int_organ(/obj/item/organ/internal/ears)
 		if(!ears || HAS_TRAIT_NOT_FROM(user, TRAIT_DEAF, EAR_DAMAGE))
 			continue
-		ears.deaf = max(ears.deaf - 0.25, (ears.ear_damage < 100 ? 0 : 1)) // Do not clear deafness if our ears are too damaged
-		ears.ear_damage = max(ears.ear_damage - 0.025, 0)
+		ears.deaf = max(ears.deaf - 0.25, (ears.damage < 100 ? 0 : 1)) // Do not clear deafness if our ears are too damaged
+		ears.damage = max(ears.damage - 0.025, 0)
 		CHECK_TICK

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -677,6 +677,17 @@
 /datum/status_effect/transient/silence/absolute // this one will mute all emote sounds including gasps
 	id = "abssilenced"
 
+/datum/status_effect/transient/deaf
+	id = "deafened"
+
+/datum/status_effect/transient/deaf/on_apply()
+	. = ..()
+	ADD_TRAIT(owner, TRAIT_DEAF, EAR_DAMAGE)
+
+/datum/status_effect/transient/deaf/on_remove()
+	. = ..()
+	REMOVE_TRAIT(owner, TRAIT_DEAF, EAR_DAMAGE)
+
 /datum/status_effect/transient/no_oxy_heal
 	id = "no_oxy_heal"
 

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -220,7 +220,7 @@
 		to_chat(M, "<font color='red' size='7'>HONK</font>")
 		M.SetSleeping(0)
 		M.Stuttering(40 SECONDS)
-		M.AdjustEarDamage(0, 30)
+		M.Deaf(30 SECONDS)
 		M.KnockDown(6 SECONDS)
 		M.Jitter(40 SECONDS)
 		///else the mousetraps are useless

--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -62,11 +62,12 @@
 				M.KnockDown(10 SECONDS)
 			if(!ear_safety)
 				M.KnockDown(status_duration)
-				M.AdjustEarDamage(5, 15)
+				M.Deaf(30 SECONDS)
 				if(iscarbon(M))
 					var/mob/living/carbon/C = M
 					var/obj/item/organ/internal/ears/ears = C.get_int_organ(/obj/item/organ/internal/ears)
 					if(istype(ears))
+						ears.receive_damage(5)
 						if(ears.damage >= 15)
 							to_chat(M, "<span class='warning'>Your ears start to ring badly!</span>")
 							if(prob(ears.damage - 5))

--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -67,9 +67,9 @@
 					var/mob/living/carbon/C = M
 					var/obj/item/organ/internal/ears/ears = C.get_int_organ(/obj/item/organ/internal/ears)
 					if(istype(ears))
-						if(ears.ear_damage >= 15)
+						if(ears.damage >= 15)
 							to_chat(M, "<span class='warning'>Your ears start to ring badly!</span>")
-							if(prob(ears.ear_damage - 5))
+							if(prob(ears.damage - 5))
 								to_chat(M, "<span class='warning'>You can't hear anything!</span>")
-						else if(ears.ear_damage >= 5)
+						else if(ears.damage >= 5)
 							to_chat(M, "<span class='warning'>Your ears start to ring!</span>")

--- a/code/modules/antagonists/changeling/powers/shriek.dm
+++ b/code/modules/antagonists/changeling/powers/shriek.dm
@@ -17,7 +17,7 @@
 				if(H.check_ear_prot() >= HEARING_PROTECTION_TOTAL)
 					continue
 			if(!M.mind || !ischangeling(M))
-				M.AdjustEarDamage(0, 30)
+				M.Deaf(30 SECONDS)
 				M.AdjustConfused(40 SECONDS)
 				M.Jitter(100 SECONDS)
 			else

--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
@@ -60,12 +60,12 @@
 
 			f_loss += 60
 
-			AdjustEarDamage(30, 120)
+			Deaf(2 MINUTES)
 		if(3.0)
 			b_loss += 30
 			if(prob(50) && !shielded)
 				Paralyse(2 SECONDS)
-			AdjustEarDamage(15, 60)
+			Deaf(1 MINUTES)
 
 	take_overall_damage(b_loss, f_loss)
 

--- a/code/modules/mob/living/carbon/alien/larva/larva.dm
+++ b/code/modules/mob/living/carbon/alien/larva/larva.dm
@@ -60,12 +60,12 @@
 		if(2.0)
 			brute_loss += 60
 			fire_loss += 60
-			AdjustEarDamage(30, 120)
+			Deaf(2 MINUTES)
 		if(3.0)
 			brute_loss += 30
 			if(prob(50))
 				Paralyse(2 SECONDS)
-			AdjustEarDamage(15, 60)
+			Deaf(1 MINUTES)
 
 	adjustBruteLoss(brute_loss)
 	adjustFireLoss(fire_loss)

--- a/code/modules/mob/living/carbon/human/human_mob.dm
+++ b/code/modules/mob/living/carbon/human/human_mob.dm
@@ -222,6 +222,7 @@
 	var/list/valid_limbs = list("l_arm", "l_leg", "r_arm", "r_leg")
 	var/limbs_amount = 1
 	var/limb_loss_chance = 50
+	var/obj/item/organ/internal/ears/ears = get_int_organ(/obj/item/organ/internal/ears)
 
 	switch(severity)
 		if(EXPLODE_DEVASTATE)
@@ -243,7 +244,8 @@
 				brute_loss = 30 * (2 - round(bomb_armor * 0.01, 0.05))
 				burn_loss = brute_loss				//Damage gets reduced from 120 to up to 60 combined brute+burn
 			if(check_ear_prot() < HEARING_PROTECTION_TOTAL)
-				AdjustEarDamage(30, 120)
+				Deaf(2 MINUTES)
+				ears.receive_damage(30)
 			Weaken(stuntime)
 			KnockDown(stuntime * 3) //Up to 15 seconds of knockdown
 
@@ -252,7 +254,8 @@
 			if(bomb_armor)
 				brute_loss = 15 * (2 - round(bomb_armor * 0.01, 0.05)) //Reduced from 30 to up to 15
 			if(check_ear_prot() < HEARING_PROTECTION_TOTAL)
-				AdjustEarDamage(15, 60)
+				Deaf(1 MINUTES)
+				ears.receive_damage(15)
 			KnockDown(10 SECONDS - bomb_armor) //Between no knockdown to 10 seconds of knockdown depending on bomb armor
 			valid_limbs = list("l_hand", "l_foot", "r_hand", "r_foot")
 			limb_loss_chance = 25

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -483,7 +483,7 @@
 	CureNervous()
 	SetEyeBlind(0)
 	SetEyeBlurry(0)
-	RestoreEars()
+	SetDeaf(0)
 	heal_overall_damage(1000, 1000)
 	ExtinguishMob()
 	SEND_SIGNAL(src, COMSIG_LIVING_CLEAR_STUNS)

--- a/code/modules/mob/living/living_status_procs.dm
+++ b/code/modules/mob/living/living_status_procs.dm
@@ -437,6 +437,19 @@ STATUS EFFECTS
 /mob/living/proc/AdjustSilence(amount, bound_lower = 0, bound_upper = INFINITY)
 	SetSilence(directional_bounded_sum(AmountSilenced(), amount, bound_lower, bound_upper))
 
+//DEAFNESS
+/mob/living/proc/AmountDeaf()
+	RETURN_STATUS_EFFECT_STRENGTH(STATUS_EFFECT_DEAF)
+
+/mob/living/proc/Deaf(amount)
+	SetDeaf(max(amount, AmountDeaf()))
+
+/mob/living/proc/SetDeaf(amount)
+	SET_STATUS_EFFECT_STRENGTH(STATUS_EFFECT_DEAF, amount)
+
+/mob/living/proc/AdjustDeaf(amount, bound_lower = 0, bound_upper = INFINITY)
+	SetDeaf(directional_bounded_sum(AmountDeaf(), amount, bound_lower, bound_upper))
+
 // SLEEPING
 /mob/living/proc/IsSleeping()
 	return has_status_effect(STATUS_EFFECT_SLEEPING)

--- a/code/modules/mob/living/simple_animal/bot/honkbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/honkbot.dm
@@ -175,7 +175,7 @@
 			if(H.check_ear_prot() >= HEARING_PROTECTION_MAJOR)
 				return
 			C.SetStuttering(40 SECONDS) //stammer
-			C.AdjustEarDamage(0, 5) //far less damage than the H.O.N.K.
+			C.Deaf(5 SECONDS) //far less damage than the H.O.N.K.
 			C.Jitter(100 SECONDS)
 			C.Weaken(10 SECONDS)
 			if(client) //prevent spam from players..

--- a/code/modules/mob/mob_status_procs_base.dm
+++ b/code/modules/mob/mob_status_procs_base.dm
@@ -1,11 +1,5 @@
 // some legacy code that needs to be moved to /mob/living
 
-/mob/proc/RestoreEars()
-	return
-
-/mob/proc/AdjustEarDamage()
-	return
-
 /mob/proc/adjust_bodytemperature(amount, min_temp = 0, max_temp = INFINITY)
 	if(bodytemperature >= min_temp && bodytemperature <= max_temp)
 		bodytemperature = clamp(bodytemperature + amount, min_temp, max_temp)

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -653,7 +653,7 @@
 			var/obj/item/organ/internal/ears/ears = C.get_int_organ(/obj/item/organ/internal/ears)
 			if(istype(ears))
 				ears.AdjustEarDamage(-1)
-				if(ears.ear_damage < 25 && prob(30))
+				if(ears.damage < 25 && prob(30))
 					ears.deaf = 0
 		M.AdjustEyeBlurry(-2 SECONDS)
 		update_flags |= M.AdjustEarDamage(-1)

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -652,11 +652,10 @@
 				E.heal_internal_damage(1)
 			var/obj/item/organ/internal/ears/ears = C.get_int_organ(/obj/item/organ/internal/ears)
 			if(istype(ears))
-				ears.AdjustEarDamage(-1)
+				ears.heal_internal_damage(1)
 				if(ears.damage < 25 && prob(30))
-					ears.deaf = 0
+					C.SetDeaf(0)
 		M.AdjustEyeBlurry(-2 SECONDS)
-		update_flags |= M.AdjustEarDamage(-1)
 	if(prob(50))
 		update_flags |= M.cure_nearsighted(EYE_DAMAGE, FALSE)
 	if(prob(30))

--- a/code/modules/surgery/organs/ears.dm
+++ b/code/modules/surgery/organs/ears.dm
@@ -22,7 +22,7 @@
 	if(HAS_TRAIT_NOT_FROM(C, TRAIT_DEAF, EAR_DAMAGE))
 		return
 
-	if(damage >= 100)
+	if(status & ORGAN_DEAD)
 		deaf = max(deaf, 1) // if we're failing we always have at least 1 deaf stack (and thus deafness)
 	else
 		deaf = max(deaf - 1, 0)
@@ -41,7 +41,7 @@
 	damage = 0
 
 /obj/item/organ/internal/ears/proc/AdjustEarDamage(ddmg, ddeaf)
-	damage = clamp(damage + (ddmg * damage_multiplier), 0, 100)
+	receive_damage(ddmg * damage_multiplier)
 	deaf = max(deaf + (ddeaf * damage_multiplier), 0)
 
 /obj/item/organ/internal/ears/surgeryize()

--- a/code/modules/surgery/organs/ears.dm
+++ b/code/modules/surgery/organs/ears.dm
@@ -17,8 +17,6 @@
 	if(!iscarbon(owner))
 		return
 	var/mob/living/carbon/C = owner
-	if(damage < 100)
-		AdjustEarDamage(-0.1)
 
 	// if we have non-damage related deafness like mutations, quirks or clothing (earmuffs), don't bother processing here. Ear healing from earmuffs or chems happen elsewhere
 	if(HAS_TRAIT_NOT_FROM(C, TRAIT_DEAF, EAR_DAMAGE))

--- a/code/modules/surgery/organs/ears.dm
+++ b/code/modules/surgery/organs/ears.dm
@@ -9,10 +9,7 @@
 	// `deaf` measures "ticks" of deafness. While > 0, the person is deaf.
 	var/deaf = 0
 
-	// `ear_damage` measures long term damage to the ears, if too high,
-	// the person will not have either `deaf` or `ear_damage` decrease
-	// without external aid (earmuffs, drugs)
-	var/ear_damage = 0
+
 	// Multiplier for both long term and short term ear damage
 	var/damage_multiplier = 1
 
@@ -20,18 +17,18 @@
 	if(!iscarbon(owner))
 		return
 	var/mob/living/carbon/C = owner
-	if(ear_damage < 100)
+	if(damage < 100)
 		AdjustEarDamage(-0.1)
 
 	// if we have non-damage related deafness like mutations, quirks or clothing (earmuffs), don't bother processing here. Ear healing from earmuffs or chems happen elsewhere
 	if(HAS_TRAIT_NOT_FROM(C, TRAIT_DEAF, EAR_DAMAGE))
 		return
 
-	if(ear_damage >= 100)
+	if(damage >= 100)
 		deaf = max(deaf, 1) // if we're failing we always have at least 1 deaf stack (and thus deafness)
 	else
 		deaf = max(deaf - 1, 0)
-		if((ear_damage > 10) && prob(ear_damage / 30))
+		if((damage > 10) && prob(ear_damage / 30))
 			AdjustEarDamage(0, 4)
 			SEND_SOUND(owner, sound('sound/weapons/flash_ring.ogg'))
 
@@ -43,10 +40,10 @@
 
 /obj/item/organ/internal/ears/proc/RestoreEars()
 	deaf = 0
-	ear_damage = 0
+	damage = 0
 
 /obj/item/organ/internal/ears/proc/AdjustEarDamage(ddmg, ddeaf)
-	ear_damage = clamp(ear_damage + (ddmg * damage_multiplier), 0, 100)
+	damage = clamp(damage + (ddmg * damage_multiplier), 0, 100)
 	deaf = max(deaf + (ddeaf * damage_multiplier), 0)
 
 /obj/item/organ/internal/ears/surgeryize()
@@ -75,4 +72,4 @@
 	if(emp_proof)
 		return
 	..()
-	ear_damage += 40 / severity
+	damage += 40 / severity

--- a/code/modules/surgery/organs/ears.dm
+++ b/code/modules/surgery/organs/ears.dm
@@ -4,14 +4,6 @@
 	gender = PLURAL
 	organ_tag = "ears"
 	parent_organ = "head"
-	slot = "ears"
-
-	// `deaf` measures "ticks" of deafness. While > 0, the person is deaf.
-	var/deaf = 0
-
-
-	// Multiplier for both long term and short term ear damage
-	var/damage_multiplier = 1
 
 /obj/item/organ/internal/ears/on_life()
 	if(!iscarbon(owner))
@@ -23,40 +15,17 @@
 		return
 
 	if(status & ORGAN_DEAD)
-		deaf = max(deaf, 1) // if we're failing we always have at least 1 deaf stack (and thus deafness)
+		C.Deaf(2 SECONDS)
 	else
-		deaf = max(deaf - 1, 0)
 		if((damage > 10) && prob(damage / 30))
-			AdjustEarDamage(0, 4)
+			C.Deaf(4 SECONDS)
 			SEND_SOUND(owner, sound('sound/weapons/flash_ring.ogg'))
 
-	if(deaf)
-		ADD_TRAIT(owner, TRAIT_DEAF, EAR_DAMAGE)
-	else
-		REMOVE_TRAIT(owner, TRAIT_DEAF, EAR_DAMAGE)
 
-
-/obj/item/organ/internal/ears/proc/RestoreEars()
-	deaf = 0
-	damage = 0
-
-/obj/item/organ/internal/ears/proc/AdjustEarDamage(ddmg, ddeaf)
-	receive_damage(ddmg * damage_multiplier)
-	deaf = max(deaf + (ddeaf * damage_multiplier), 0)
 
 /obj/item/organ/internal/ears/surgeryize()
-	RestoreEars()
-
-// Mob procs
-/mob/living/carbon/RestoreEars()
-	var/obj/item/organ/internal/ears/ears = get_int_organ(/obj/item/organ/internal/ears)
-	if(ears)
-		ears.RestoreEars()
-
-/mob/living/carbon/AdjustEarDamage(ddmg, ddeaf)
-	var/obj/item/organ/internal/ears/ears = get_int_organ(/obj/item/organ/internal/ears)
-	if(ears)
-		ears.AdjustEarDamage(ddmg, ddeaf)
+	owner.SetDeaf(0)
+	heal_internal_damage(100)
 
 /obj/item/organ/internal/ears/cybernetic
 	name = "cybernetic ears"
@@ -64,7 +33,6 @@
 	desc = "a basic cybernetic designed to mimic the operation of ears."
 	origin_tech = "biotech=4"
 	status = ORGAN_ROBOT
-	damage_multiplier = 0.9
 
 /obj/item/organ/internal/ears/cybernetic/emp_act(severity)
 	if(emp_proof)

--- a/code/modules/surgery/organs/ears.dm
+++ b/code/modules/surgery/organs/ears.dm
@@ -28,7 +28,7 @@
 		deaf = max(deaf, 1) // if we're failing we always have at least 1 deaf stack (and thus deafness)
 	else
 		deaf = max(deaf - 1, 0)
-		if((damage > 10) && prob(ear_damage / 30))
+		if((damage > 10) && prob(damage / 30))
 			AdjustEarDamage(0, 4)
 			SEND_SOUND(owner, sound('sound/weapons/flash_ring.ogg'))
 

--- a/code/modules/surgery/organs/ears.dm
+++ b/code/modules/surgery/organs/ears.dm
@@ -18,7 +18,7 @@
 		C.Deaf(2 SECONDS)
 	else
 		if((damage > 10) && prob(damage / 30))
-			C.Deaf(4 SECONDS)
+			C.Deaf(8 SECONDS)
 			SEND_SOUND(owner, sound('sound/weapons/flash_ring.ogg'))
 
 

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -236,7 +236,7 @@
 		to_chat(owner, "<font color='red' size='7'>HONK</font>")
 		owner.SetSleeping(0)
 		owner.Stuttering(40 SECONDS)
-		owner.AdjustEarDamage(0, 30)
+		owner.Deaf(30 SECONDS)
 		owner.Weaken(6 SECONDS)
 		SEND_SOUND(owner, sound('sound/items/airhorn.ogg'))
 		if(prob(30))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
This PR brings ears in line with how other organs deal, and heal from damage. They can now die like any other organ, and won't work until healed via surgery if they do die.

Additionally, temporary deafness has been changed to be a status effect.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Consistency in how organs work is good, and being able to actually see how damaged ears are when scanning is also good. 
The justification for removing natural healing is that even though ears do take (invisible) damage, you would never notice because by the time you get un-deafened most of the damage you'd already taken has healed up.



## Testing
<!-- How did you test the PR, if at all? -->
Made sure things that dealt ear damage still did, killed the ears of a few skrells, then fixed them back to make sure they worked again. Also made sure I didn't accidentally make everyone deaf permanently.

After the status effect changes, more testing needs to be done.
## Changelog
:cl:
del: Ears no longer heal passively.
Fix: Ears now take damage like every other organ, and ear damage shows up on body scanners.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
