### PR TITLE
removes hallucination sting

### DIFF
--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -126,26 +126,6 @@
 	SSblackbox.record_feedback("nested tally", "changeling_powers", 1, list("[name]"))
 	return TRUE
 
-/datum/action/changeling/sting/LSD
-	name = "Hallucination Sting"
-	desc = "We cause mass terror to our victim. Costs 10 chemicals."
-	helptext = "We evolve the ability to sting a target with a powerful hallucinogenic chemical. The target does not notice they have been stung, and the effect occurs after 30 to 60 seconds."
-	button_icon_state = "sting_lsd"
-	sting_icon = "sting_lsd"
-	chemical_cost = 10
-	dna_cost = 1
-	power_type = CHANGELING_PURCHASABLE_POWER
-
-/datum/action/changeling/sting/LSD/sting_action(mob/user, mob/living/carbon/target)
-	add_attack_logs(user, target, "LSD sting (changeling)")
-	addtimer(CALLBACK(src, PROC_REF(start_hallucinations), target, 400 SECONDS), rand(30 SECONDS, 60 SECONDS))
-	SSblackbox.record_feedback("nested tally", "changeling_powers", 1, list("[name]"))
-	return TRUE
-
-/datum/action/changeling/sting/LSD/proc/start_hallucinations(mob/living/carbon/target, amount)
-	if(!QDELETED(target))
-		target.Hallucinate(amount)
-
 /datum/action/changeling/sting/cryo //Enable when mob cooling is fixed so that frostoil actually makes you cold, instead of mostly just hungry.
 	name = "Cryogenic Sting"
 	desc = "We silently sting our victim with a cocktail of chemicals that freezes them from the inside. Costs 15 chemicals."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
deletes hallucination sting

## Why It's Good For The Game
Yeah so this has been a longtime coming.
This ability isn't remotely useful, you instead use this to sting everyone in a hallway because it's 10 chemicals and then basically just grief with it. I've tried reworking this but lemme be honest, it ain't worth it at all. I cannot thing of a good thing to say about this ability so into the sun with it.

the actual utility from this ability is to sit around and watch someone get randomly hardstunned followed by a good armblading, you may have noticed this sucks.
## Testing
It compiled

## Changelog
:cl:
del: Hallucination sting
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
