### PR TITLE
Changes the bridge on Box, Meta, and Delta to be more secure and stop hobo behavior

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -25282,18 +25282,6 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/primary/central)
-"bqy" = (
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "bridge blast north";
-	name = "Bridge Blast Doors";
-	opacity = 0
-	},
-/obj/structure/cable,
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
-/area/bridge)
 "bqA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -27643,183 +27631,8 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
 /area/hydroponics)
-"bwc" = (
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "bridge blast north";
-	name = "Bridge Blast Doors";
-	opacity = 0
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
-/area/bridge)
-"bwd" = (
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "bridge blast north";
-	name = "Bridge Blast Doors";
-	opacity = 0
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
-/area/bridge)
-"bwe" = (
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "bridge blast north";
-	name = "Bridge Blast Doors";
-	opacity = 0
-	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
-/area/bridge)
 "bwf" = (
 /turf/simulated/wall/r_wall,
-/area/bridge)
-"bwg" = (
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "bridge blast north";
-	name = "Bridge Blast Doors";
-	opacity = 0
-	},
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
-/area/bridge)
-"bwh" = (
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "bridge blast north";
-	name = "Bridge Blast Doors";
-	opacity = 0
-	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
-/area/bridge)
-"bwi" = (
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "bridge blast north";
-	name = "Bridge Blast Doors";
-	opacity = 0
-	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
-/area/bridge)
-"bwj" = (
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "bridge blast north";
-	name = "Bridge Blast Doors";
-	opacity = 0
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
-/area/bridge)
-"bwk" = (
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "bridge blast north";
-	name = "Bridge Blast Doors";
-	opacity = 0
-	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
-/area/bridge)
-"bwl" = (
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "bridge blast north";
-	name = "Bridge Blast Doors";
-	opacity = 0
-	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
 /area/bridge)
 "bwm" = (
 /turf/simulated/floor/plasteel{
@@ -28260,11 +28073,6 @@
 /area/bridge)
 "bxo" = (
 /obj/machinery/computer/med_data,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkblue"
@@ -28288,11 +28096,6 @@
 /area/bridge)
 "bxr" = (
 /obj/machinery/computer/security,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkred"
@@ -29093,26 +28896,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/bridge)
-"byZ" = (
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "bridge blast north";
-	name = "Bridge Blast Doors";
-	opacity = 0
-	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
-/area/bridge)
 "bza" = (
 /obj/machinery/light{
 	dir = 8
@@ -29630,11 +29413,6 @@
 /area/bridge)
 "bAx" = (
 /obj/machinery/computer/supplycomp,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkbrown"
@@ -29642,19 +29420,9 @@
 /area/bridge)
 "bAy" = (
 /obj/machinery/hologram/holopad,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/plasteel/dark,
 /area/bridge)
 "bAz" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel/dark,
 /area/bridge)
@@ -29683,11 +29451,6 @@
 /area/bridge)
 "bAD" = (
 /obj/machinery/computer/shuttle/mining,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkbrown"
@@ -30413,11 +30176,6 @@
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -30435,11 +30193,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -30487,11 +30240,6 @@
 /area/bridge)
 "bCt" = (
 /obj/structure/window/reinforced,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
@@ -30545,28 +30293,6 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/bridge)
-"bCw" = (
-/obj/structure/chair/office/dark{
-	dir = 1
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -135617,7 +135343,7 @@ btH
 aaa
 abj
 aaa
-bwg
+bwf
 bAw
 bCx
 byU
@@ -135874,7 +135600,7 @@ bsv
 abj
 abj
 abj
-bwe
+bwf
 bAx
 bCp
 bAB
@@ -136129,8 +135855,8 @@ bqu
 bIX
 btH
 aaa
-bwc
-bqy
+bwf
+bwf
 bwf
 aos
 bCl
@@ -136386,7 +136112,7 @@ bqu
 bIX
 btH
 aaa
-bwd
+bwf
 bxm
 byR
 wGL
@@ -136643,7 +136369,7 @@ bqu
 bIX
 btH
 aaa
-bwd
+bwf
 bxn
 byS
 byU
@@ -136900,9 +136626,9 @@ bqu
 bIX
 btH
 aaa
-bwe
+bwf
 bxo
-byT
+byV
 bAz
 bCq
 bEd
@@ -137414,7 +137140,7 @@ bqu
 bsm
 btH
 aaa
-bwg
+bwf
 bxq
 byV
 byU
@@ -137671,9 +137397,9 @@ bqt
 bsl
 btH
 aaa
-bwh
+bwf
 bxr
-bAB
+byU
 bAy
 bCt
 bEg
@@ -137928,7 +137654,7 @@ aXY
 bsm
 btH
 aaa
-bwi
+bwf
 bxs
 byV
 byU
@@ -138442,7 +138168,7 @@ aXY
 bwm
 btH
 aaa
-bwj
+bwf
 bxu
 byT
 bAA
@@ -138699,7 +138425,7 @@ aXY
 bwm
 btH
 aaa
-bwk
+bwf
 bxv
 byX
 byU
@@ -138956,7 +138682,7 @@ aXY
 bwm
 btH
 aaa
-bwk
+bwf
 bxw
 byY
 bAB
@@ -139213,8 +138939,8 @@ aXY
 bwm
 btH
 aaa
-bwl
-bqy
+bwf
+bwf
 bwf
 bAC
 bCl
@@ -139472,9 +139198,9 @@ bsv
 abj
 abj
 abj
-byZ
+bwf
 bAD
-bCw
+bCx
 byU
 bFN
 bWX
@@ -139729,7 +139455,7 @@ btH
 aaa
 abj
 aaa
-bwi
+bwf
 bAE
 bCx
 byU

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -5700,40 +5700,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
-"aBV" = (
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/effect/spawner/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "bridge blast";
-	name = "Bridge Blast Doors"
-	},
-/turf/simulated/floor/plating,
-/area/bridge)
-"aBY" = (
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/spawner/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "bridge blast";
-	name = "Bridge Blast Doors"
-	},
-/turf/simulated/floor/plating,
-/area/bridge)
 "aBZ" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/fsmaint)
@@ -5963,28 +5929,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/crew_quarters/locker/locker_toilet)
-"aCV" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/effect/spawner/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "bridge blast";
-	name = "Bridge Blast Doors"
-	},
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating,
-/area/bridge)
 "aCW" = (
 /obj/structure/sign/chinese{
 	pixel_x = -32
@@ -6226,18 +6170,6 @@
 	icon_state = "darkgrey"
 	},
 /area/security/nuke_storage)
-"aDK" = (
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/effect/spawner/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "bridge blast";
-	name = "Bridge Blast Doors"
-	},
-/turf/simulated/floor/plating,
-/area/bridge)
 "aDL" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
@@ -6283,18 +6215,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/permabrig)
-"aEh" = (
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/effect/spawner/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "bridge blast";
-	name = "Bridge Blast Doors"
-	},
-/turf/simulated/floor/plating,
-/area/bridge)
 "aEj" = (
 /obj/effect/landmark/burnturf,
 /turf/simulated/floor/plating,
@@ -6405,23 +6325,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
-"aEt" = (
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/effect/spawner/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "bridge blast";
-	name = "Bridge Blast Doors"
-	},
-/turf/simulated/floor/plating,
-/area/bridge)
 "aEv" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -7528,15 +7431,6 @@
 	icon_state = "white"
 	},
 /area/toxins/xenobiology)
-"aIb" = (
-/obj/structure/cable/yellow,
-/obj/effect/spawner/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "bridge blast";
-	name = "Bridge Blast Doors"
-	},
-/turf/simulated/floor/plating,
-/area/bridge)
 "aIc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -7789,23 +7683,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
-"aIH" = (
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/effect/spawner/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "bridge blast";
-	name = "Bridge Blast Doors"
-	},
-/turf/simulated/floor/plating,
-/area/bridge)
 "aIJ" = (
 /obj/effect/decal/cleanable/cobweb2,
 /obj/structure/closet/emcloset,
@@ -8354,18 +8231,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
-"aJY" = (
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/effect/spawner/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "bridge blast";
-	name = "Bridge Blast Doors"
-	},
-/turf/simulated/floor/plating,
-/area/bridge)
 "aKd" = (
 /obj/structure/disposalpipe/junction{
 	dir = 4;
@@ -19224,28 +19089,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/library)
-"bmf" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/effect/spawner/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "bridge blast";
-	name = "Bridge Blast Doors"
-	},
-/turf/simulated/floor/plating,
-/area/bridge)
 "bmg" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -19998,23 +19841,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/port2)
-"boe" = (
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/spawner/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "bridge blast";
-	name = "Bridge Blast Doors"
-	},
-/turf/simulated/floor/plating,
-/area/bridge)
 "bof" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -20168,19 +19994,6 @@
 	},
 /area/bridge)
 "boE" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/bridge)
-"boF" = (
-/obj/structure/chair/office/dark{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -20818,11 +20631,6 @@
 /turf/simulated/wall/r_wall,
 /area/crew_quarters/heads)
 "bqd" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/computer/monitor{
 	name = "Bridge Power Monitoring Console"
 	},
@@ -20872,11 +20680,6 @@
 	dir = 1
 	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -20902,11 +20705,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/port2)
 "bql" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/machinery/computer/prisoner,
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -21670,11 +21468,6 @@
 /obj/item/folder/red{
 	pixel_y = 3
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/light{
 	dir = 4
 	},
@@ -22329,11 +22122,6 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -22370,11 +22158,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
 	},
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -118645,7 +118428,7 @@ aYx
 abq
 abq
 abq
-aJY
+bkW
 bub
 bur
 bwg
@@ -118900,8 +118683,8 @@ bek
 bdb
 aYx
 abq
-aBV
-aIb
+bkW
+bkW
 bkW
 btY
 boE
@@ -119157,7 +118940,7 @@ bek
 bdb
 aYx
 abq
-aCV
+bkW
 boB
 bsb
 btT
@@ -119414,7 +119197,7 @@ bwn
 bdb
 aYx
 abq
-aBY
+bkW
 bop
 boC
 teE
@@ -119671,7 +119454,7 @@ svH
 oeP
 aYx
 abq
-aDK
+bkW
 bpV
 boD
 gDB
@@ -120185,7 +119968,7 @@ ber
 bdb
 aYx
 abq
-aEh
+bkW
 bqf
 boD
 gDB
@@ -120442,9 +120225,9 @@ bes
 bfU
 aYx
 abq
-bmf
+bkW
 bqd
-boF
+boD
 bqi
 bwe
 btV
@@ -120699,7 +120482,7 @@ tyF
 bfV
 aYx
 abq
-aDK
+bkW
 bqh
 boD
 hht
@@ -121213,7 +120996,7 @@ mFG
 jGr
 aYx
 abq
-aEh
+bkW
 cfh
 boD
 hht
@@ -121470,7 +121253,7 @@ bek
 bfV
 aYx
 abq
-boe
+bkW
 bqj
 boG
 mAa
@@ -121727,7 +121510,7 @@ bek
 bfV
 aYx
 abq
-boe
+bkW
 bql
 bsc
 btZ
@@ -121984,8 +121767,8 @@ bek
 bfV
 aYx
 abq
-aEt
-aIH
+bkW
+bkW
 bkW
 bum
 boE
@@ -122243,7 +122026,7 @@ aYx
 abq
 abq
 abq
-aJY
+bkW
 buE
 bvr
 cbY

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -10129,11 +10129,6 @@
 	},
 /area/security/prison/cell_block/A)
 "aCu" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/computer/med_data,
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -24637,18 +24632,6 @@
 "blT" = (
 /turf/simulated/wall,
 /area/civilian/pet_store)
-"blU" = (
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/effect/spawner/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "bridge blast north";
-	name = "Bridge Blast Doors"
-	},
-/turf/simulated/floor/plating,
-/area/bridge)
 "blV" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Pet Store"
@@ -24666,68 +24649,20 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/port)
 "blY" = (
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /obj/machinery/status_display{
 	layer = 4
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/spawner/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "bridge blast north";
-	name = "Bridge Blast Doors"
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/wall/r_wall,
 /area/bridge)
 "blZ" = (
 /turf/simulated/wall,
 /area/hallway/primary/central/nw)
-"bma" = (
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/effect/spawner/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "bridge blast north";
-	name = "Bridge Blast Doors"
-	},
-/turf/simulated/floor/plating,
-/area/bridge)
 "bmb" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/hallway/primary/central/nw)
 "bmc" = (
 /turf/simulated/wall/r_wall,
-/area/bridge)
-"bmd" = (
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/effect/spawner/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "bridge blast north";
-	name = "Bridge Blast Doors"
-	},
-/turf/simulated/floor/plating,
 /area/bridge)
 "bme" = (
 /obj/structure/disposalpipe/segment,
@@ -25478,10 +25413,6 @@
 /turf/simulated/floor/plasteel,
 /area/bridge)
 "bnV" = (
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/machinery/computer/monitor{
 	name = "Bridge Power Monitoring Computer"
 	},
@@ -26118,11 +26049,6 @@
 	},
 /area/hallway/primary/central/nw)
 "bpq" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "yellowcorner"
@@ -26180,13 +26106,6 @@
 	pixel_y = -2;
 	req_access_txt = "19"
 	},
-/obj/machinery/door_control{
-	id = "bridge blast north";
-	name = "North Bridge Blast Door Control";
-	pixel_x = 6;
-	pixel_y = 8;
-	req_access_txt = "19"
-	},
 /obj/machinery/keycard_auth{
 	pixel_x = -6;
 	pixel_y = 8
@@ -26197,11 +26116,6 @@
 	},
 /area/bridge)
 "bpx" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "greencorner"
@@ -26801,14 +26715,6 @@
 	icon_state = "chapel"
 	},
 /area/chapel/main)
-"bqX" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/bridge)
 "bqY" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/firstaid/regular,
@@ -27374,30 +27280,12 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plasteel,
 /area/bridge)
 "bsB" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
-"bsC" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel,
-/area/bridge)
 "bsD" = (
 /turf/simulated/floor/plating,
 /area/storage/emergency2)
@@ -28056,11 +27944,6 @@
 	},
 /area/hallway/primary/central/nw)
 "buo" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
 /area/bridge)
@@ -28504,11 +28387,6 @@
 /turf/simulated/floor/plasteel,
 /area/storage/tools)
 "bvA" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/bridge)
@@ -74400,23 +74278,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
-"kwt" = (
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/spawner/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "bridge blast north";
-	name = "Bridge Blast Doors"
-	},
-/turf/simulated/floor/plating,
-/area/bridge)
 "kwG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/spawner/nukedisc_respawn,
@@ -120078,7 +119939,7 @@ aRw
 bgV
 bmB
 bkA
-blU
+bmc
 bnU
 bpr
 bqR
@@ -120335,7 +120196,7 @@ aRw
 bgU
 bna
 bkz
-kwt
+bmc
 bnR
 bpo
 bqS
@@ -120849,7 +120710,7 @@ diw
 bhb
 bnd
 bkz
-kwt
+bmc
 bnV
 bpq
 buo
@@ -121106,11 +120967,11 @@ bdv
 bhc
 bnh
 bkz
-kwt
+bmc
 bnY
 bpu
 bqU
-bsF
+bqS
 bxD
 bvX
 bxq
@@ -121363,7 +121224,7 @@ bhd
 biI
 bnf
 bkz
-kwt
+bmc
 bnX
 bpt
 bqS
@@ -121620,7 +121481,7 @@ bhV
 biK
 bnj
 bkz
-kwt
+bmc
 boa
 bpw
 bqV
@@ -121877,7 +121738,7 @@ bdw
 bgW
 bni
 bkz
-kwt
+bmc
 aYf
 aYg
 bup
@@ -122391,11 +122252,11 @@ aDN
 bdD
 bna
 bkz
-bmd
+bmc
 aCu
 bpx
-bqX
-bsC
+bqS
+bsF
 bxU
 bvX
 bvX
@@ -122648,7 +122509,7 @@ aDN
 dkl
 bkG
 bno
-bma
+bmc
 boh
 bpB
 bqY


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Removes the windows from the bridge on Box, Meta, and Delta to reinforced wall. 

## Why It's Good For The Game
I think the windows are bad design in terms of behavior and map layout and ill explain why.

Firstly, the windows are the primary reason why alot of people like to fluoride stare into the bridge and encourage hobo behavior. A spot to view the juicy command drama and also stalk the Captain from five feet (the most targeted antag thanks to all his objective shit) hoboing is just LRP behavior, remove the main appeal to hoboing and it gets discouraged. also they just build and shit all over the hall, congesting traffic and ruining movement around it.

Two, one of the most important areas on the station being defended by the glass is pretty bad design from a mapper, and in game explanation. Not only is a pair of insulated gloves, and EVA on Delta and Meta enough to break into the bridge and start touching shit, it also wouldn't make sense for an area of commanding to be so public and easy to view into. Bridges are usually secure for a reason to keep conversations private and among command, while shutters exist yeah, alot of people just forget about them or dont use them.

Lastly, the removal of windows would make people be a bit more active throughout the station. Instead of standing in the hall like gophers, they can go chill in dorms, or the bar, or anywhere that is more interesting than a solid reinforced wall. This can also encourage command to actually go out and SOCIALIZE instead of sit in the chair all day as it requires more effort to talk with people.

Anyways, this is probably gonna be controversial, but I think my points are valid. 

## Images of changes
![StrongDMM_bznwunlJMo](https://github.com/ParadiseSS13/Paradise/assets/62493359/76322c94-d5f7-4d3d-885a-27de102d11e2)
![StrongDMM_gqLK6EjZVU](https://github.com/ParadiseSS13/Paradise/assets/62493359/359eee70-0740-4a1e-aa66-ff2519bcdc04)
![StrongDMM_HdCHqn9tRA](https://github.com/ParadiseSS13/Paradise/assets/62493359/c8aa72e1-1b9c-4c2a-8a11-bb4864bf99e8)


## Testing
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Change the windows on Box, Meta, and Delta to reinforced walls
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
