### PR TITLE
Wenting ghost or getting mob deleted with throw mode on now making mouse pointer default

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -22,7 +22,7 @@
 /mob/living/carbon/ghostize(can_reenter_corpse)
 	if(in_throw_mode)
 		toggle_throw_mode()
-	. = ..()
+	return ..()
 
 /mob/living/carbon/handle_atom_del(atom/A)
 	LAZYREMOVE(processing_patches, A)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -15,7 +15,14 @@
 	QDEL_LIST_CONTENTS(stomach_contents)
 	QDEL_LIST_CONTENTS(processing_patches)
 	GLOB.carbon_list -= src
+	if(in_throw_mode)
+		toggle_throw_mode()
 	return ..()
+
+/mob/living/carbon/ghostize(can_reenter_corpse)
+	if(in_throw_mode)
+		toggle_throw_mode()
+	. = ..()
 
 /mob/living/carbon/handle_atom_del(atom/A)
 	LAZYREMOVE(processing_patches, A)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Fixes a bug, when you go ghost with throw mode on or get mob deleted, your mouse pointer no more stays in throw mode

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Bugs bad
Fixes https://github.com/ParadiseSS13/Paradise/issues/21418

## Changelog
:cl:
fix: Throw mode cursor doesnt follow you in ghost world anymore
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
