### PR TITLE
Xenomorphs can no longer make resin in pipes

### DIFF
--- a/code/datums/spells/alien_spells/plasma_weeds.dm
+++ b/code/datums/spells/alien_spells/plasma_weeds.dm
@@ -21,5 +21,10 @@
 		revert_cast()
 		return
 
+	if(!isturf(T))
+		to_chat(user, "<span class='noticealien'>You cannot plant [weed_name]s inside something!</span>")
+		revert_cast()
+		return
+
 	user.visible_message("<span class='alertalien'>[user] has planted a [weed_name]!</span>")
 	new weed_type(T)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Xenomorphs can no longer make resin in pipes

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

No. You should not be able to place resin anywhere in pipes.

## Testing
<!-- How did you test the PR, if at all? -->

Confirm it worked

## Changelog
:cl:
fix: Xenomorphs can no longer make resin in pipes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
