### PR TITLE
Cults can now "fall" when their numbers are too low.

### DIFF
--- a/code/game/gamemodes/cult/cult_mode.dm
+++ b/code/game/gamemodes/cult/cult_mode.dm
@@ -296,7 +296,7 @@ GLOBAL_LIST_EMPTY(all_cults)
 		if(!M.current || !ishuman(M.current))
 			continue
 		SEND_SOUND(M.current, sound('sound/hallucinations/im_here1.ogg'))
-		to_chat(M.current, "<span class='cultlarge'>Your cult is ascendant and the red harvest approaches - you cannot hide your true nature for much longer!")
+		to_chat(M.current, "<span class='cultlarge'>Your cult is ascendant and the red harvest approaches - you cannot hide your true nature for much longer!</span>")
 		addtimer(CALLBACK(src, PROC_REF(ascend), M.current), 20 SECONDS)
 	GLOB.major_announcement.Announce("Picking up extradimensional activity related to the Cult of [SSticker.cultdat ? SSticker.cultdat.entity_name : "Nar'Sie"] from your station. Data suggests that about [ascend_percent * 100]% of the station has been converted. Security staff are authorized to use lethal force freely against cultists. Non-security staff should be prepared to defend themselves and their work areas from hostile cultists. Self defense permits non-security staff to use lethal force as a last resort, but non-security staff should be defending their work areas, not hunting down cultists. Dead crewmembers must be revived and deconverted once the situation is under control.", "Central Command Higher Dimensional Affairs", 'sound/AI/commandreport.ogg')
 
@@ -306,14 +306,15 @@ GLOBAL_LIST_EMPTY(all_cults)
 		if(!M.current || !ishuman(M.current))
 			continue
 		SEND_SOUND(M.current, sound('sound/hallucinations/wail.ogg'))
-		to_chat(M.current, "<span class='cultlarge'>The veil repairs itself, your power grows weaker...")
+		to_chat(M.current, "<span class='cultlarge'>The veil repairs itself, your power grows weaker...</span>")
 		addtimer(CALLBACK(src, PROC_REF(descend), M.current), 20 SECONDS)
 	GLOB.major_announcement.Announce("Paranormal activity has returned to minimal levels. \
 									Security staff should minimize lethal force against cultists, using non-lethals where possible. \
 									All dead cultists should be taken to medbay or robotics for immediate revival and deconversion. \
 									Non-security staff may defend themselves, but should prioritize leaving any areas with cultists and reporting the cultists to security. \
 									Self defense permits non-security staff to use lethal force as a last resort. Hunting down cultists may make you liable for a manslaughter charge. \
-									All security gear that was handed out, should be returned. Access reset where needed, and weapons (including improvised) removed from the crew.",
+									Any access granted in response to the paranormal threat should be reset. \
+									Any and all security gear that was handed out should be returned. Finally, all weapons (including improvised) should be removed from the crew.",
 									"Central Command Higher Dimensional Affairs", 'sound/AI/commandreport.ogg')
 
 /datum/game_mode/proc/rise(cultist)
@@ -337,7 +338,7 @@ GLOBAL_LIST_EMPTY(all_cults)
 		var/mob/living/carbon/human/H = cultist
 		new /obj/effect/temp_visual/cult/sparks(get_turf(H), H.dir)
 		H.update_halo_layer()
-		to_chat(cultist, "<span class='userdanger'>The halo above your head shatters!")
+		to_chat(cultist, "<span class='userdanger'>The halo above your head shatters!</span>")
 		playsound(cultist, "shatter", 50, TRUE)
 
 /datum/game_mode/proc/update_cult_icons_added(datum/mind/cult_mind)

--- a/code/game/gamemodes/cult/cult_mode.dm
+++ b/code/game/gamemodes/cult/cult_mode.dm
@@ -306,7 +306,7 @@ GLOBAL_LIST_EMPTY(all_cults)
 		if(!M.current || !ishuman(M.current))
 			continue
 		SEND_SOUND(M.current, sound('sound/hallucinations/wail.ogg'))
-		to_chat(M.current, "<span class='cultlarge'>The veil grows stronger, your power growing weaker...")
+		to_chat(M.current, "<span class='cultlarge'>The veil grows stronger, your power grows weaker...")
 		addtimer(CALLBACK(src, PROC_REF(descend), M.current), 20 SECONDS)
 	GLOB.major_announcement.Announce("Paranormal activity has returned to minimal levels. \
 									Security staff should minimize lethal force against cultists, using non-lethals where possible. \

--- a/code/game/gamemodes/cult/cult_mode.dm
+++ b/code/game/gamemodes/cult/cult_mode.dm
@@ -306,7 +306,7 @@ GLOBAL_LIST_EMPTY(all_cults)
 		if(!M.current || !ishuman(M.current))
 			continue
 		SEND_SOUND(M.current, sound('sound/hallucinations/wail.ogg'))
-		to_chat(M.current, "<span class='cultlarge'>The veil grows stronger, your power grows weaker...")
+		to_chat(M.current, "<span class='cultlarge'>The veil repairs itself, your power grows weaker...")
 		addtimer(CALLBACK(src, PROC_REF(descend), M.current), 20 SECONDS)
 	GLOB.major_announcement.Announce("Paranormal activity has returned to minimal levels. \
 									Security staff should minimize lethal force against cultists, using non-lethals where possible. \

--- a/code/game/gamemodes/cult/cult_mode.dm
+++ b/code/game/gamemodes/cult/cult_mode.dm
@@ -283,7 +283,7 @@ GLOBAL_LIST_EMPTY(all_cults)
 /datum/game_mode/proc/cult_rise()
 	cult_risen = TRUE
 	for(var/datum/mind/M in cult)
-		if(!M.current || !ishuman(M.current))
+		if(!ishuman(M.current))
 			continue
 		SEND_SOUND(M.current, sound('sound/hallucinations/i_see_you2.ogg'))
 		to_chat(M.current, "<span class='cultlarge'>The veil weakens as your cult grows, your eyes begin to glow...</span>")
@@ -293,7 +293,7 @@ GLOBAL_LIST_EMPTY(all_cults)
 /datum/game_mode/proc/cult_ascend()
 	cult_ascendant = TRUE
 	for(var/datum/mind/M in cult)
-		if(!M.current || !ishuman(M.current))
+		if(!ishuman(M.current))
 			continue
 		SEND_SOUND(M.current, sound('sound/hallucinations/im_here1.ogg'))
 		to_chat(M.current, "<span class='cultlarge'>Your cult is ascendant and the red harvest approaches - you cannot hide your true nature for much longer!</span>")
@@ -303,7 +303,7 @@ GLOBAL_LIST_EMPTY(all_cults)
 /datum/game_mode/proc/cult_fall()
 	cult_ascendant = FALSE
 	for(var/datum/mind/M in cult)
-		if(!M.current || !ishuman(M.current))
+		if(!ishuman(M.current))
 			continue
 		SEND_SOUND(M.current, sound('sound/hallucinations/wail.ogg'))
 		to_chat(M.current, "<span class='cultlarge'>The veil repairs itself, your power grows weaker...</span>")
@@ -318,28 +318,31 @@ GLOBAL_LIST_EMPTY(all_cults)
 									"Central Command Higher Dimensional Affairs", 'sound/AI/commandreport.ogg')
 
 /datum/game_mode/proc/rise(cultist)
-	if(ishuman(cultist) && iscultist(cultist))
-		var/mob/living/carbon/human/H = cultist
-		if(!H.original_eye_color)
-			H.original_eye_color = H.get_eye_color()
-		H.change_eye_color(BLOODCULT_EYE, FALSE)
-		H.update_eyes()
-		ADD_TRAIT(H, CULT_EYES, CULT_TRAIT)
-		H.update_body()
+	if(!ishuman(cultist) || !iscultist(cultist))
+		return
+	var/mob/living/carbon/human/H = cultist
+	if(!H.original_eye_color)
+		H.original_eye_color = H.get_eye_color()
+	H.change_eye_color(BLOODCULT_EYE, FALSE)
+	H.update_eyes()
+	ADD_TRAIT(H, CULT_EYES, CULT_TRAIT)
+	H.update_body()
 
 /datum/game_mode/proc/ascend(cultist)
-	if(ishuman(cultist) && iscultist(cultist))
-		var/mob/living/carbon/human/H = cultist
-		new /obj/effect/temp_visual/cult/sparks(get_turf(H), H.dir)
-		H.update_halo_layer()
+	if(!ishuman(cultist) || !iscultist(cultist))
+		return
+	var/mob/living/carbon/human/H = cultist
+	new /obj/effect/temp_visual/cult/sparks(get_turf(H), H.dir)
+	H.update_halo_layer()
 
 /datum/game_mode/proc/descend(cultist)
-	if(ishuman(cultist) && iscultist(cultist))
-		var/mob/living/carbon/human/H = cultist
-		new /obj/effect/temp_visual/cult/sparks(get_turf(H), H.dir)
-		H.update_halo_layer()
-		to_chat(cultist, "<span class='userdanger'>The halo above your head shatters!</span>")
-		playsound(cultist, "shatter", 50, TRUE)
+	if(!ishuman(cultist) || !iscultist(cultist))
+		return
+	var/mob/living/carbon/human/H = cultist
+	new /obj/effect/temp_visual/cult/sparks(get_turf(H), H.dir)
+	H.update_halo_layer()
+	to_chat(cultist, "<span class='userdanger'>The halo above your head shatters!</span>")
+	playsound(cultist, "shatter", 50, TRUE)
 
 /datum/game_mode/proc/update_cult_icons_added(datum/mind/cult_mind)
 	var/datum/atom_hud/antag/culthud = GLOB.huds[ANTAG_HUD_CULT]


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->Security getting free reign to spam IKs and WTs at the 2 remaining cultists is never fun. This makes it so if the cult falls below half of the rise number (5% on highpop, 10% on lowpop), the cult will revert to the "risen" state and a special announcement will be played disincentivizing the murder by random crew and lethals by security. Any advice on specific wording in the announcement is appreciated, along with potential changes to the numbers that the cult reverts at.<br><br>
The percentages mean there is a 15% on highpop and 20% on lowpop difference between rising and falling, so these announcements can't be easily spammed (unless some metaclique is deconverting themselves and converting themselves, but that's an admin problem).<br>
Specific wording for any of the stuff in this PR is appreciated, I just kinda threw some stuff together.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Validhunter golems with chainsaws hunting down the last of the cult is never fun, and the crew need an announcement to know when its time to stop. Security has (mostly) regained control over the cult.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![image](https://github.com/ParadiseSS13/Paradise/assets/91113370/883f1c42-1be7-421a-9bc0-196dd5c5cd94)


## Testing
<!-- How did you test the PR, if at all? -->
See above, good old fashion proc calling. Because I can't get a ton of clients on the same server.

## Changelog
:cl:
tweak: Cults can now "fall" when their population falls low enough, letting the crew know to calm down in fighting cultists.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
