### PR TITLE
Gives the syndicate hardsuits some origin tech

### DIFF
--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -431,6 +431,7 @@
 	icon_state = "hardsuit1-syndi"
 	item_state = "syndie_hardsuit"
 	item_color = "syndi"
+	origin_tech = "engineering=6;syndicate=4"
 	w_class = WEIGHT_CLASS_NORMAL
 	var/on = TRUE
 	actions_types = list(/datum/action/item_action/toggle_hardsuit_mode)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
see title
Origin tech of engineering 6 and syndicate 4

## Why It's Good For The Game
Lots of new explorer players now, one of the loot items they can get are blood red hardsuits, they can't legally have these on station so it's sad they can't use it for syndicate tech to help out RND, or engineering tech (it has a jetpack) to get rnd to engineering 7 if cargo are being useless.

## Testing
Deconstructed one

## Changelog
:cl:
tweak: Syndicate hardsuits now have an origin tech of engineering 6 and syndicate 4
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
