### PR TITLE
Fix an unnecessary pixel offset on gulag APC.

### DIFF
--- a/_maps/map_files/generic/Lavaland.dmm
+++ b/_maps/map_files/generic/Lavaland.dmm
@@ -609,7 +609,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Labor Camp APC";
-	pixel_x = 1;
 	pixel_y = 24
 	},
 /obj/machinery/computer/cryopod{


### PR DESCRIPTION
## What Does This PR Do
Removes a 1px nudge from labor camp APC.
## Why It's Good For The Game

Map conformance. Continuation of #19875 (technically now #21390) burndown.

## Changelog
:cl:
tweak: Labor camp APC positioning was off
/:cl: