### PR TITLE
Fix wall/window stacking on Nar'sie shuttle.

### DIFF
--- a/_maps/map_files/shuttles/emergency_narnar.dmm
+++ b/_maps/map_files/shuttles/emergency_narnar.dmm
@@ -181,12 +181,6 @@
 	},
 /turf/simulated/floor/engine/cult,
 /area/shuttle/escape)
-"aD" = (
-/obj/effect/spawner/window/reinforced{
-	color = "red"
-	},
-/turf/simulated/wall/cult,
-/area/shuttle/escape)
 "aE" = (
 /obj/docking_port/mobile/emergency{
 	dwidth = 11;
@@ -691,14 +685,14 @@ aa
 ab
 ab
 ab
-aD
+ac
 ab
 ab
 ab
 ac
 ac
 ac
-aD
+ac
 ac
 ab
 ab


### PR DESCRIPTION
## What Does This PR Do
Fix window/wall stacking on cult emergency shuttle.

## Why It's Good For The Game
Map conformance. Continuation of https://github.com/ParadiseSS13/Paradise/pull/19875 (technically now https://github.com/ParadiseSS13/Paradise/pull/21390) burndown.

## Changelog
:cl:
tweak: Fix stacked walls on cult emergency shuttle.
/:cl:
