### PR TITLE
Meta: fix wall/lattice stacking.

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -21901,14 +21901,6 @@
 	},
 /turf/space,
 /area/space/nearstation)
-"bsQ" = (
-/obj/structure/transit_tube{
-	icon_state = "E-W-Pass"
-	},
-/obj/structure/lattice,
-/obj/structure/lattice,
-/turf/space,
-/area/space/nearstation)
 "bsS" = (
 /obj/structure/transit_tube{
 	icon_state = "W-SE"
@@ -51756,11 +51748,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
-"dKY" = (
-/obj/structure/lattice,
-/obj/structure/lattice,
-/turf/space,
-/area/space/nearstation)
 "dLg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -51781,11 +51768,6 @@
 	icon_state = "redcorner"
 	},
 /area/security/brig)
-"dLs" = (
-/obj/structure/lattice,
-/obj/structure/grille,
-/turf/simulated/wall/r_wall,
-/area/space/nearstation)
 "dLU" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 1
@@ -60055,10 +60037,6 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
-"hLL" = (
-/obj/structure/lattice,
-/turf/simulated/wall,
-/area/crew_quarters/recreation)
 "hLT" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/grown/harebell,
@@ -131390,7 +131368,7 @@ aaa
 aaa
 aaa
 aaa
-hLL
+afb
 afH
 ajD
 afH
@@ -140152,7 +140130,7 @@ abq
 abq
 aaa
 abq
-dKY
+abq
 aCg
 aOd
 vCR
@@ -140727,8 +140705,8 @@ bCX
 bCX
 bCX
 bCX
-dLs
-dLs
+bre
+bCX
 abq
 abq
 abq
@@ -141239,7 +141217,7 @@ bCX
 bCX
 bCX
 aup
-dLs
+bCX
 bCX
 bCX
 abq
@@ -144288,7 +144266,7 @@ abq
 aef
 aef
 ahv
-bsQ
+bFk
 abq
 aef
 abq


### PR DESCRIPTION
## What Does This PR Do
Removes stacked wall/lattice tiles on Meta. 

## Why It's Good For The Game
Map conformance. Continuation of #19875 (technically now #21390) burndown. Note that while it looks like a tile with a transit tube has been removed, it's just now a repeat of a tile definition of the transit tube below it.

## Images of changes

<details><summary>Changed Tiles</summary>


![2023_06_22__15_29_57__paradise dme  MetaStation dmm  - StrongDMM](https://github.com/ParadiseSS13/Paradise/assets/59303604/c4cdfaf6-b560-451a-a76a-13c7d06337d5)
![2023_06_22__15_31_15__paradise dme  MetaStation dmm  - StrongDMM](https://github.com/ParadiseSS13/Paradise/assets/59303604/d77f03f8-11e9-46e5-a826-69683a394d06)
![2023_06_22__15_31_38__paradise dme  MetaStation dmm  - StrongDMM](https://github.com/ParadiseSS13/Paradise/assets/59303604/390c9454-5193-4c14-b40f-7ba0548710b8)
![2023_06_22__15_31_57__paradise dme  MetaStation dmm  - StrongDMM](https://github.com/ParadiseSS13/Paradise/assets/59303604/528ce7d0-228e-416d-ab3d-a03f4cd00323)
![2023_06_22__15_32_31__paradise dme  MetaStation dmm  - StrongDMM](https://github.com/ParadiseSS13/Paradise/assets/59303604/f3de599a-9e3f-417c-a3de-76e696950142)
![2023_06_22__15_32_58__paradise dme  MetaStation dmm  - StrongDMM](https://github.com/ParadiseSS13/Paradise/assets/59303604/573946a7-a4a7-4656-b0fa-a6c3c6794342)
</details>


## Changelog
:cl:
fix: Fix wall/lattice stacking on Cerebron.
/:cl:
