### PR TITLE
Morph buffs

### DIFF
--- a/code/datums/spells/mimic.dm
+++ b/code/datums/spells/mimic.dm
@@ -121,6 +121,7 @@
 		user.pixel_y = initial(user.pixel_y)
 		user.pixel_x = initial(user.pixel_x)
 		user.layer = MOB_LAYER // Avoids weirdness when mimicing something below the vent layer
+		user.density = form.density
 
 	playsound(user, "bonebreak", 75, TRUE)
 	show_change_form_message(user, old_name, "[user]")
@@ -150,6 +151,7 @@
 		user.name = initial(user.name)
 		user.desc = initial(user.desc)
 		user.color = initial(user.color)
+		user.density = initial(user.density)
 
 	playsound(user, "bonebreak", 150, TRUE)
 	if(show_message)
@@ -182,12 +184,16 @@
 	var/examine_text
 	/// What the name of the form is
 	var/name
+	/// What's the density of this form?
+	var/density
+	/// What's the special abilities of this form?
+	var/special_abilites
 
 /datum/mimic_form/New(atom/movable/form, mob/user)
 	appearance = form.appearance
 	examine_text = form.examine(user)
 	name = form.name
-
+	density = form.density
 
 /obj/effect/proc_holder/spell/mimic/morph
 	action_background_icon_state = "bg_morph"

--- a/code/game/gamemodes/miniantags/morph/morph.dm
+++ b/code/game/gamemodes/miniantags/morph/morph.dm
@@ -210,6 +210,11 @@
 	if(!.)
 		return FALSE
 
+/mob/living/simple_animal/hostile/morph/CanPass(atom/movable/mover, turf/target, height)
+	. = ..()
+	if(istype(mover, /obj/item/projectile)) // You're getting shot no matter what
+		return FALSE
+
 /mob/living/simple_animal/hostile/morph/attack_hand(mob/living/carbon/human/M)
 	if(ambush_prepared)
 		to_chat(M, "<span class='warning'>[src] feels a bit different from normal... it feels more.. </span><span class='userdanger'>SLIMEY?!</span>")
@@ -220,15 +225,21 @@
 #define MORPH_ATTACKED if((. = ..()) && morphed) mimic_spell.restore_form(src)
 
 /mob/living/simple_animal/hostile/morph/attackby(obj/item/O, mob/living/user)
-	if(user.a_intent == INTENT_HELP && ambush_prepared)
-		to_chat(user, "<span class='warning'>You try to use [O] on [src]... it seems different than no-</span>")
+	if(ambush_prepared)
+		if(user.a_intent == INTENT_HELP)
+			to_chat(user, "<span class='warning'>You try to use [O] on [src]... it seems different than no-</span>")
+		else
+			to_chat(user, "<span class='warning'>You strike [src], but [src] strikes back!</span>")
 		ambush_attack(user, TRUE)
 		return TRUE
 	MORPH_ATTACKED
 
 /mob/living/simple_animal/hostile/morph/attack_animal(mob/living/simple_animal/M)
-	if(M.a_intent == INTENT_HELP && ambush_prepared)
-		to_chat(M, "<span class='notice'>You nuzzle [src].</span><span class='danger'> And [src] nuzzles back!</span>")
+	if(ambush_prepared)
+		if(M.a_intent == INTENT_HELP)
+			to_chat(M, "<span class='notice'>You nuzzle [src].</span><span class='danger'> And [src] nuzzles back!</span>")
+		else
+			to_chat(M, "<span class='notice'>[M] [M.attacktext] [src].</span><span class='danger'> And [src] [M.attacktext] back!</span>")
 		ambush_attack(M, TRUE)
 		return TRUE
 	MORPH_ATTACKED


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Overall buffs the morph antagonist
Morphs are now only dense if their disguise is dense (No this does not mean you can matrix dodge projectiles by standing still)
Morphs attack back while ambushed regardless of the attackers intent
Probably some more cool shit I'm adding tomorrow, looking into giving it specific abilities focused on what item it's currently pretending to be (Shotguns for example, could shoot a spray of low damage bullets that uses your food).  
Make the second ambush thing ANOTHER do after so morphs know shit be happening
More experimental shit:

- [ ] Perhaps remove spaceproofing? They are rather reliant on this, but it doesn't mean it's an overall positive 
- [ ] Lessen food gained from small/simple mobs even more, this will require them to be given better options to deal with actual living crew, of course
- [ ] Maybe up the speed? Very experimental but morphs being slow is cool flavor wise, but I always find it to be clunky.
- [ ] Maybe let them just talk to people normally, could be fun. Letting them communicate with other morphs over communication could be a really cool gimmick that makes morph feel actually unique 

## Why It's Good For The Game
Morph is a really solid idea for an antagonist, but it is woefully underdeveloped. A lot of morph gameplay can be defined as raiding xenobiology, disposals, and space, and using those NPC mobs to snowball advantage and make a bunch of morphs, which often don't really do much when they try the conventional intended strats or accomplish stuff by abusing spaceproofness to attempt to bait people to fight them, with the major of the crew feeling absolutely nothing except frustration from the never ending morph stream (Swarmers also had this issue, it's just less present in morph). 

Regardless, current morphs feel like a first draft of a mechanic, not very in depth but it's got something going on, the point of this PR is to add that depth it is badly lacking. The current stuff I'm changing is pretty straightforward, the intent attacking stuff is just kinda weird and density is a really simple way of proving something like a toolbox is actually a morph. The more experimental stuff will be explained tomorrow, but they're attempts at adding more depth in a meaningful way as well as a more expansive playstyle. 

(also i'm betting someone is gonna say something about how this is a moderate therefore buffs aren't needed, I'm gonna be real we're not on the same page with this, it's about a lack of depth being an issue rather than a lack of power)
## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
draft

## Changelog
:cl:
experiment: This pr was not supposed to be merged, it is drafted
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
