### PR TITLE
Implements balling

### DIFF
--- a/code/game/objects/items/sport.dm
+++ b/code/game/objects/items/sport.dm
@@ -12,6 +12,17 @@
 	throw_speed = 1
 	throw_range = 20
 	flags = CONDUCT
+	var/dribbleable = FALSE // Most balls do not have a dribble animation
+
+/obj/item/beach_ball/attack_self(mob/user)
+	if(!dribbleable)
+		return
+
+	if(!user.get_inactive_hand()) // We ballin
+		user.unEquip(src)
+		user.put_in_inactive_hand(src)
+	else
+		to_chat(user, "<span class='warning'>You can't dribble to an occupied hand!</span>")
 
 /obj/item/beach_ball/baseball
 	name = "baseball"
@@ -27,6 +38,7 @@
 	icon = 'icons/obj/basketball.dmi'
 	icon_state = "dodgeball"
 	item_state = "dodgeball"
+	dribbleable = TRUE
 	var/list/suit_types = list(/obj/item/clothing/suit/redtag, /obj/item/clothing/suit/bluetag)
 
 /obj/item/beach_ball/dodgeball/throw_impact(atom/hit_atom)
@@ -44,6 +56,7 @@
 	icon = 'icons/obj/basketball.dmi'
 	icon_state = "basketball"
 	item_state = "basketball"
+	dribbleable = TRUE
 	w_class = WEIGHT_CLASS_BULKY //Stops people from hiding it in their bags/pockets
 
 /obj/structure/holohoop

--- a/code/modules/admin/verbs/onlyoneteam.dm
+++ b/code/modules/admin/verbs/onlyoneteam.dm
@@ -67,6 +67,7 @@
 	icon = 'icons/obj/basketball.dmi'
 	icon_state = "dodgeball"
 	item_state = "dodgeball"
+	dribbleable = TRUE
 
 /obj/item/beach_ball/dodgeball_team/throw_impact(atom/hit_atom)
 	..()


### PR DESCRIPTION
## What Does This PR Do
Adds a use-in-hand action for balls (subtypes of `beach_ball`) that have an animation that looks like dribbling, that simply moves it to your offhand.

## Why It's Good For The Game
We ball

## Images of changes
[2023-06-23 12_39_18.webm](https://github.com/ParadiseSS13/Paradise/assets/100448493/17df930c-9116-45cf-8056-68a9299e40e9)


## Testing
- Spawned in all the beach ball subtypes
- Checked that only those with a dribbling-like animation can be dribbled
- Checked that you can't dribble if your offhand is occupied, and get a feedback message instead

## Changelog
:cl:
add: You can now dribble dodgeballs and basketballs
/:cl: