### PR TITLE
Tape removes AI inbuilt Camera while Carded

### DIFF
--- a/code/datums/components/ducttape.dm
+++ b/code/datums/components/ducttape.dm
@@ -19,6 +19,7 @@
 		var/datum/action/item_action/remove_tape/RT = new(I)
 		if(I.loc == user)
 			RT.Grant(user)
+	I.add_tape()
 
 /datum/component/proc/add_tape_text(datum/source, mob/user, list/examine_list)
 	examine_list += "<span class='notice'>There's some sticky tape attached to [source].</span>"
@@ -40,6 +41,7 @@
 		qdel(RT)
 	I.cut_overlay(tape_overlay)
 	user.transfer_fingerprints_to(I)
+	I.remove_tape()
 	qdel(src)
 
 /datum/component/ducttape/proc/afterattack(obj/item/I, atom/target, mob/user, proximity, params)

--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -316,6 +316,11 @@ That prevents a few funky behaviors.
 		AI.forceMove(loc)//To replace the terminal.
 		to_chat(AI, "You have been uploaded to a stationary terminal. Remote device connection restored.")
 		to_chat(user, "<span class='boldnotice'>Transfer successful</span>: [AI.name] ([rand(1000,9999)].exe) installed and executed successfully. Local copy has been removed.</span>")
+		if(!AI.builtInCamera && GetComponent(/datum/component/ducttape))
+			AI.builtInCamera = new /obj/machinery/camera/portable(AI)
+			AI.builtInCamera.c_tag = AI.name
+			AI.builtInCamera.network = list("SS13")
 		qdel(src)
 	else //If for some reason you use an empty card on an empty AI terminal.
 		to_chat(user, "There is no AI loaded on this terminal!")
+

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -871,3 +871,9 @@ GLOBAL_DATUM_INIT(welding_sparks, /mutable_appearance, mutable_appearance('icons
 
 /obj/item/proc/GetID()
 	return null
+
+/obj/item/proc/add_tape()
+	return
+
+/obj/item/proc/remove_tape()
+	return

--- a/code/game/objects/items/devices/aicard.dm
+++ b/code/game/objects/items/devices/aicard.dm
@@ -123,3 +123,17 @@
 		AI.adjustOxyLoss(2)
 		sleep(10)
 	flush = FALSE
+
+/obj/item/aicard/add_tape()
+	var/mob/living/silicon/ai/AI = locate() in src
+	if(!AI)
+		return
+	QDEL_NULL(AI.builtInCamera)
+
+/obj/item/aicard/remove_tape()
+	var/mob/living/silicon/ai/AI = locate() in src
+	if(!AI)
+		return
+	AI.builtInCamera = new /obj/machinery/camera/portable(AI)
+	AI.builtInCamera.c_tag = AI.name
+	AI.builtInCamera.network = list("SS13")

--- a/code/modules/mob/living/silicon/ai/ai_mob.dm
+++ b/code/modules/mob/living/silicon/ai/ai_mob.dm
@@ -1307,6 +1307,8 @@ GLOBAL_LIST_INIT(ai_verbs_default, list(
 		aiRestorePowerRoutine = 0//So the AI initially has power.
 		control_disabled = TRUE //Can't control things remotely if you're stuck in a card!
 		aiRadio.disabledAi = TRUE //No talking on the built-in radio for you either!
+		if(GetComponent(/datum/component/ducttape))
+			QDEL_NULL(builtInCamera)
 		forceMove(card) //Throw AI into the card.
 		to_chat(src, "You have been downloaded to a mobile storage device. Remote device connection severed.")
 		to_chat(user, "<span class='boldnotice'>Transfer successful</span>: [name] ([rand(1000,9999)].exe) removed from host terminal and stored within local memory.")

--- a/code/modules/mob/living/silicon/ai/ai_mob.dm
+++ b/code/modules/mob/living/silicon/ai/ai_mob.dm
@@ -172,7 +172,6 @@ GLOBAL_LIST_INIT(ai_verbs_default, list(
 	// Remove inherited verbs that effectively do nothing for AIs, or lead to unintended behaviour.
 	verbs -= /mob/living/verb/rest
 	verbs -= /mob/living/verb/mob_sleep
-	verbs -= /mob/living/verb/resist
 	verbs -= /mob/living/verb/stop_pulling1
 	verbs -= /mob/living/silicon/verb/pose
 	verbs -= /mob/living/silicon/verb/set_flavor
@@ -1466,5 +1465,19 @@ GLOBAL_LIST_INIT(ai_verbs_default, list(
 		runechat_msg_location = loc.UID()
 	else
 		return ..()
+
+/mob/living/silicon/ai/run_resist()
+	if(!istype(loc, /obj/item/aicard))
+		return..()
+
+	var/obj/item/aicard/card = loc
+	var/datum/component/ducttape/ducttapecomponent = card.GetComponent(/datum/component/ducttape)
+	if(!ducttapecomponent)
+		return
+	to_chat(src, "<span class='notice'>The tiny fan that could begins to work against the tape to remove it.</span>")
+	if(!do_after(src, 2 MINUTES, target = card))
+		return
+	to_chat(src, "<span class='notice'>The tiny in built fan finally removes the tape!</span>")
+	ducttapecomponent.remove_tape(card, src)
 
 #undef TEXT_ANNOUNCEMENT_COOLDOWN


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR makes it so when applying tape to a Carded AI, the built in camera no longer functions until that tape is removed OR its placed back into its Core.

On request by Qwerty, the carded AI can remove the tape after a 2 minute resist. If the card is moved in any way during this, it stops the removal of the tape. There is a notice for the AI that it is being removed and an audible tape removal sound effect for everyone nearby.

## Why It's Good For The Game
Currently, the AI steal objective for any antag is the worst objective to get as an antag. Not only do you have to worry about borgs being told locations through binary chat from the AI but also anyone at a camera console can just sit down and callout the location of the holder, refreshing it without delay. This issue in turn makes it so most antags either wipe the AI and restore later OR wait till the last 5 minutes to do it which either option is not fun.

EDIT: Grammar "delay. This issue in turn makes it"


## Testing
1. Spawn in as AI. 
2. Move soul to a body that can handle a card.
3. Tape card and remove tape.
4. Then card the ai and check that its camera works from a camera console (it uses the name given to the AI on round start, not the name they choose, Paracode moment.)
5. Tape the card and check the console again, both roundstart name and AI name, doesn't show up.
6. Remove the tape and recheck both names (it updates to the NEW name of the AI this time but otherwise works as normal)
7. Place AI back in the core and check its built in camera works which it does.

Tape removal
1. Be the carded tape\d AI and use resist verb in IC tab
2. Wait two minutes
3. Tape is removed and camera works again.

## Changelog
:cl:
tweak: Tape removes AI inbuilt Camera while Carded
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
