### PR TITLE
Vampire/Changeling/Abductor anti-stuns remove all stuns instantly

### DIFF
--- a/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
@@ -113,6 +113,7 @@
 		M.SetStunned(0)
 		M.SetWeakened(0)
 		M.SetKnockDown(0)
+		M.stand_up(TRUE)
 		combat_cooldown = 0
 		START_PROCESSING(SSobj, src)
 

--- a/code/modules/antagonists/changeling/powers/epinephrine.dm
+++ b/code/modules/antagonists/changeling/powers/epinephrine.dm
@@ -22,6 +22,7 @@
 	user.SetWeakened(0)
 	user.setStaminaLoss(0)
 	user.SetKnockDown(0)
+	user.stand_up(TRUE)
 	SEND_SIGNAL(user, COMSIG_LIVING_CLEAR_STUNS)
 	user.reagents.add_reagent("synaptizine", 15)
 	user.reagents.add_reagent("stimulative_cling", 1)

--- a/code/modules/antagonists/vampire/vampire_powers/vampire_powers.dm
+++ b/code/modules/antagonists/vampire/vampire_powers/vampire_powers.dm
@@ -64,6 +64,7 @@
 	U.SetSleeping(0)
 	U.SetConfused(0)
 	U.adjustStaminaLoss(-100)
+	U.stand_up(TRUE)
 	SEND_SIGNAL(U, COMSIG_LIVING_CLEAR_STUNS)
 	to_chat(user, "<span class='notice'>You instill your body with clean blood and remove any incapacitating effects.</span>")
 	var/datum/antagonist/vampire/V = U.mind.has_antag_datum(/datum/antagonist/vampire)


### PR DESCRIPTION
## What Does This PR Do
Vampire's rejuvenate, Changeling's epinephrine overdose and Abductor agent's combat mode ability all now will instantly make you stand up when stunned, instead of making you eat a do_after while crawling to stand up again.

## Why It's Good For The Game
This was the case before crawling:tm:, the use of these abilities makes them severely limited when you're getting spammed with a stunbaton due to the slowdown of crawling.

## Testing
1. Spawned myself as all three
2. Looked at the code to find out that you switch vest mode in the abductor computer???? okay.
3. Batonged myself and used the ability afterwards, stood up.

## Changelog
:cl:
tweak: Vampire rejuvenate, Changeling epinephrine overdose and Abductor Agent combat mode ability will make you stand up instantly rather than having to crawl for a bit first.
/:cl: