### PR TITLE
Fixes duplicate airlocks spawning

### DIFF
--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -152,10 +152,7 @@
 		return
 	to_chat(user, "<span class='notice'>You finish the airlock.</span>")
 	var/obj/machinery/door/airlock/door
-	if(glass)
-		door = new glass_type(loc)
-		door.polarized_glass = polarized_glass
-	if(reinforced_glass)
+	if(glass || reinforced_glass)
 		door = new glass_type(loc)
 		door.polarized_glass = polarized_glass
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Stops the duplication of airlocks.
Also makes polarized airlocks not freak out when built with reinforced glass
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Bug bad. Item duplication worse.
Fixes #21452 
Fixes #21479
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Shot an airlock, repaired airlock to full afterwards. No duplicate airlocks.

Constructed an airlock from scratch with reinforced glass, polarized it, checked if anything weird was going on.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Fixed airlocks duplicating themselves
fix: Fixed polarized airlocks not freaking out when built
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
