### PR TITLE
Makes meteor events more consistant, with major meteors being more deadly.

### DIFF
--- a/code/game/objects/effects/meteors.dm
+++ b/code/game/objects/effects/meteors.dm
@@ -8,8 +8,8 @@ GLOBAL_LIST_INIT(meteors_normal, list(/obj/effect/meteor/dust = 3, /obj/effect/m
 GLOBAL_LIST_INIT(meteors_threatening, list(/obj/effect/meteor/medium = 4, /obj/effect/meteor/big = 8,
 						/obj/effect/meteor/flaming = 3, /obj/effect/meteor/irradiated = 3, /obj/effect/meteor/bananium = 1)) //for threatening meteor event
 
-GLOBAL_LIST_INIT(meteors_catastrophic, list(/obj/effect/meteor/medium = 5, /obj/effect/meteor/big = 75,
-						/obj/effect/meteor/flaming = 10, /obj/effect/meteor/irradiated = 10, /obj/effect/meteor/bananium = 3, /obj/effect/meteor/tunguska = 1)) //for catastrophic meteor event
+GLOBAL_LIST_INIT(meteors_catastrophic, list(/obj/effect/meteor/medium = 3, /obj/effect/meteor/big = 10,
+						/obj/effect/meteor/flaming = 10, /obj/effect/meteor/irradiated = 10, /obj/effect/meteor/bananium = 2, /obj/effect/meteor/meaty = 2, /obj/effect/meteor/meaty/xeno = 2, /obj/effect/meteor/tunguska = 1)) //for catastrophic meteor event
 
 GLOBAL_LIST_INIT(meteors_gore, list(/obj/effect/meteor/meaty = 5, /obj/effect/meteor/meaty/xeno = 1)) //for meaty ore event
 
@@ -253,7 +253,8 @@ GLOBAL_LIST_INIT(meteors_ops, list(/obj/effect/meteor/goreops)) //Meaty Ops
 	..()
 	explosion(loc, 0, 0, 4, 3, 0)
 	new /obj/effect/decal/cleanable/greenglow(get_turf(src))
-	radiation_pulse(src, 500)
+	radiation_pulse(src, 5000, 7)
+	//Hot take on this one. This often hits walls. It really has to breach into somewhere important to matter. This at leats makes the area slightly dangerous for a bit
 
 /obj/effect/meteor/bananium
 	name = "bananium meteor"

--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -195,7 +195,7 @@ GLOBAL_LIST_EMPTY(event_last_fired)
 		//new /datum/event_meta(EVENT_LEVEL_MAJOR, "Containment Breach",	/datum/event/prison_break/station,	0,			list(ASSIGNMENT_ANY = 5)),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "APC Overload",		/datum/event/apc_overload,		0),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Blob",				/datum/event/blob, 				30,		list(ASSIGNMENT_ENGINEER =  5), TRUE),
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Meteor Wave",			/datum/event/meteor_wave,		30,		list(ASSIGNMENT_ENGINEER =  5),	TRUE),
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Meteor Wave",			/datum/event/meteor_wave,		0,		list(ASSIGNMENT_ENGINEER =  10),	TRUE),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Abductor Visit",		/datum/event/abductor, 		    20, 	list(ASSIGNMENT_SECURITY =  3), TRUE),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Alien Infestation",	/datum/event/alien_infestation, 20,		list(ASSIGNMENT_SECURITY = 4), TRUE),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Traders",				/datum/event/traders,			85, 	is_one_shot = TRUE),

--- a/code/modules/events/meteors_event.dm
+++ b/code/modules/events/meteors_event.dm
@@ -11,7 +11,7 @@
 		if(A)
 			screen_alert = A
 
-	waves = severity * rand(1,3)
+	waves = severity * 2 + rand(0, severity) //4-6 waves on medium. 6-9 waves on major. More consistant.
 
 /datum/event/meteor_wave/announce()
 	switch(severity)
@@ -51,4 +51,4 @@
 			return GLOB.meteors_normal
 
 /datum/event/meteor_wave/proc/get_meteor_count()
-	return severity * rand(1, 2)
+	return severity + rand(1, severity) //3 to 4 per wave for medium, 4-6 for major


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Meteor events now use severity *2 + rand(0, severity) waves, leading to more meteors on average than before.
Meteor waves are now severity +rand(1, severity) meteors, leading to more meteors on average now.

The major meteor pool now contains meaty ores and xenomorph ores rarely. These have human organs in them, or xeno organs.

We already have traders with xenomicrobes (much less space ruins), so this will not be an issue

The weight overall of major meteors has been rebalanced, with the big meteor weight GREATLY lowered.

Due to the above, major meteors now has a weight of ZERO, scaling at 10 per engineer. This means a shift with no engineers will not be subjected to this, and a 6 engineer crew now having a weight of 60, same as a 6 engineer crew now.

Also radioactive meteors have a much bigger radioactive pulse so they mean something. 
This generally doesnt hit anything other than objects within 2-3 tiles from it, but will contaminate them for a while. 

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Major events should be major.

More specifically:
Lets look at how meteors determine how many spawn. First, we multiply the severity of the event by 1, 2, or 3
This means a medium event could have 6 waves, and a major event could have 3. This is not ideal.
We then spawn severity x 1 or 2 meteors per wave.
Large variation in potential here. This can easily make the major event quite overwhelming, spawning only 9-18 meteors.

Speaking of meteors, let us look at the loot pool!

This is the weight for medium meteors.

`GLOBAL_LIST_INIT(meteors_threatening, list(/obj/effect/meteor/medium = 4, /obj/effect/meteor/big = 8,
                        /obj/effect/meteor/flaming = 3, /obj/effect/meteor/irradiated = 3, /obj/effect/meteor/bananium = 1)) //for threatening meteor event`

This is a graph.
![image](https://github.com/ParadiseSS13/Paradise/assets/52090703/65e97249-93cf-4434-aa02-f010cea92057)


Reasonable enough.
Lets look at major.

`GLOBAL_LIST_INIT(meteors_catastrophic, list(/obj/effect/meteor/medium = 5, /obj/effect/meteor/big = 75,
                        /obj/effect/meteor/flaming = 10, /obj/effect/meteor/irradiated = 10, /obj/effect/meteor/bananium = 3, /obj/effect/meteor/tunguska = 1)) //for catastrophic meteor event`

![image](https://github.com/ParadiseSS13/Paradise/assets/52090703/94af51e6-9441-4633-8a1c-029059432a70)

Ah. 74% of the time,  it is a boring old plain meteor.
1/103 of meteors, are the dreaded tungska.

This is... Well, it could use some variety. Big meteors are OK, but plasma and radioactive at least spice it up.

My proposed pool is thus:


`GLOBAL_LIST_INIT(meteors_catastrophic, list(/obj/effect/meteor/medium = 3, /obj/effect/meteor/big = 10,
						/obj/effect/meteor/flaming = 10, /obj/effect/meteor/irradiated = 10, /obj/effect/meteor/bananium = 2, /obj/effect/meteor/meaty = 2, /obj/effect/meteor/meaty/xeno = 2, /obj/effect/meteor/tunguska = 1)) //for catastrophic meteor event`

![image](https://github.com/ParadiseSS13/Paradise/assets/52090703/38045792-69bd-4a8a-a57d-03ee32211455)

This chart is a little more balanced. We get big meteors, reliable. We get plasma and radioactive meteors, interesting.
We then get the remaining 25% of the time, small meteors, meaty meatores that grant funny organs, same with xeno ones, and the 2.5% chance for a tungska.
Combined with the above changes to event spawning, major meteors should be more of a major threat, rather than something that kinda fizzles.

Meteor shields still lower the event / blow up meteors. That is unchanged.
Meteors can still miss the station.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Radioactive meteors are more radioactive.
tweak: Meteor events should have more meteors on average.
tweak: Major meteor events should have a more deadly loot pool.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
