### PR TITLE
Dswords now return melee attack on parry.  Eswords reflect lasers on parry. Throwing bodies at a dsword user may not work well

### DIFF
--- a/code/game/objects/items/weapons/melee/energy_melee_weapons.dm
+++ b/code/game/objects/items/weapons/melee/energy_melee_weapons.dm
@@ -228,6 +228,24 @@
 		else
 			to_chat(user, "<span class='warning'>It's already fabulous!</span>")
 
+
+/obj/item/melee/energy/sword/saber/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
+	if(!active)
+		return FALSE
+	. = ..()
+	if(!.) // they did not block the attack
+		return
+	if(istype(hitby, /obj/item/projectile))
+		var/obj/item/projectile/P = hitby
+		if(P.reflectability == REFLECTABILITY_NEVER) //only 1 magic spell does this, but hey, needed
+			owner.visible_message("<span class='danger'>[owner] blocks [attack_text] with [src]!</span>")
+			playsound(src, 'sound/weapons/effects/ric3.ogg', 100, TRUE)
+			return TRUE
+		owner.visible_message("<span class='danger'>[owner] parries [attack_text] with [src]!</span>")
+		add_attack_logs(P.firer, src, "hit by [P.type] but got parried by [src]")
+		return -1
+	return TRUE
+
 /obj/item/melee/energy/sword/pirate
 	name = "energy cutlass"
 	desc = "Arrrr matey."

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -334,9 +334,23 @@
 		sleep(1)
 
 /obj/item/twohanded/dualsaber/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
-	if(wielded)
-		return ..()
-	return FALSE
+	if(!wielded)
+		return FALSE
+	. = ..()
+	if(!.) // they did not block the attack
+		return
+
+	if(attack_type == THROWN_PROJECTILE_ATTACK)
+		if(!isitem(hitby))
+			return TRUE
+		var/obj/item/TT = hitby
+		addtimer(CALLBACK(TT, TYPE_PROC_REF(/atom/movable, throw_at), locateUID(TT.thrownby), 10, 4, owner), 0.2 SECONDS) //Timer set to 0.2 seconds to ensure item finshes the throwing to prevent double embeds
+		return TRUE
+	if(isitem(hitby))
+		melee_attack_chain(owner, hitby.loc)
+	else
+		melee_attack_chain(owner, hitby)
+	return TRUE
 
 /obj/item/twohanded/dualsaber/attack_hulk(mob/living/carbon/human/user, does_attack_animation = FALSE)  //In case thats just so happens that it is still activated on the groud, prevents hulk from picking it up
 	if(wielded)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -622,6 +622,15 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 	hit_atom.hit_by_thrown_carbon(src, throwingdatum, damage, FALSE, FALSE)
 
 /mob/living/carbon/hit_by_thrown_carbon(mob/living/carbon/human/C, datum/thrownthing/throwingdatum, damage, mob_hurt, self_hurt)
+	for(var/obj/item/twohanded/dualsaber/D in contents)
+		if(D.wielded)
+			visible_message("<span class='danger'>[src] impales [C] with [D], before dropping them on the ground!</span>")
+			C.apply_damage(100, BRUTE, "chest", sharp = TRUE, used_weapon = "Impaled on [D].")
+			C.Stun(2 SECONDS) //Punishment. This could also be used by a traitor to throw someone into a dsword to kill them, but hey, teamwork!
+			C.KnockDown(6 SECONDS)
+			D.melee_attack_chain(src, C) //attack animation / jedi spin
+			C.emote("scream")
+			return
 	. = ..()
 	KnockDown(3 SECONDS)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

A thrown body at a dsword user will no longer disarm it. The thrown body will now be brutally stabbed and left for dead on the floor.

Dswords will now return an attack on parry. While this means someone still needs to chose over offense or defense, it should make it clear that batoning the esword user may not be a good idea. Thrown items can also be reflected (might take this off actually. Will have to make it not runtime, will do tomorow

Eswords reflect energy projectiles on PARRY. They do not passively do it, they must block to do it.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Esword and dsword have fell off. A gun is cheaper and hurts much more. As well, while active block is more engaging, for a weapon trying to attack people, it has issues. Trying to dsword someone? Disarms will push you back, often into a wall. Baton? Better hope you land that knockdown. This however should mean you can be a bit more defencive, and return fire on the officer trying to baton instead of shoot you, or the tider disarming you.

Throw change is to stop the classic body throw into dsword user. For the price dsword is at, it is no longer needed.

Esword also needed love (*cough powerfist exists), so it can now reflect energy projectiles on parry.

## Testing
<!-- How did you test the PR, if at all? -->

Beat up skrell, parried lasers, threw skrells at dsword user.

## Changelog
:cl:
tweak: A thrown body at a dsword user will no longer disarm it. The thrown body will now be brutally stabbed and left for dead on the floor.
tweak: Dswords return an attack on melee parry.
tweak: Eswords reflect energy projectiles on PARRY. They do not passively do it, they must block to do it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
