### PR TITLE
Tranquilizer Shells can be ordered from Cargo

### DIFF
--- a/code/modules/supply/supply_packs/pack_security.dm
+++ b/code/modules/supply/supply_packs/pack_security.dm
@@ -273,6 +273,13 @@
 	cost = 300
 	containername = "laser rifle ammo crate"
 
+/datum/supply_packs/security/armory/tranqammo
+	name = "Tranquilizer Shell Crate"
+	contains = list(/obj/item/storage/box/tranquilizer,
+					/obj/item/storage/box/tranquilizer)
+	cost = 400
+	containername = "tranquilizer shell crate"
+
 /////// Implants & etc
 
 /datum/supply_packs/security/armory/mindshield


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Allows you to buy two box's of tranquilizer shells for 400 credits in cargo.

## Why It's Good For The Game
A very niche, but none replenishable shell for the shotgun. Meth is very common and a majority of answers to it is lethals. While I think lethals are still viable and good to handling threats like these, the shotgun's whole niche is being a specialist weapon that can be used to solve problems with its shell types. Tranq shot is a hard counter to meth/stimulants and should be more utilized in game.

## Testing
yes

## Changelog
:cl:
tweak: You can now order tranquilizer shells from cargo in the security tab
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
