### PR TITLE
Adds some overlooked objects to pull slowdown exclusion

### DIFF
--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -6,6 +6,7 @@
 	icon = 'icons/goonstation/objects/iv.dmi'
 	icon_state = "stand"
 	anchored = FALSE
+	pull_speed = 0
 	mouse_drag_pointer = MOUSE_ACTIVE_POINTER
 	var/obj/item/reagent_containers/iv_bag/bag = null
 

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -313,6 +313,7 @@
 	icon_state = "trashcart"
 	icon_opened = "trashcart_open"
 	icon_closed = "trashcart"
+	pull_speed = 0
 
 /obj/structure/closet/crate/medical
 	desc = "A medical crate."

--- a/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
@@ -4,6 +4,7 @@
 	item_chair = null
 	anchored = FALSE
 	movable = TRUE
+	pull_speed = 0
 	buildstackamount = 15
 
 	var/move_delay = null


### PR DESCRIPTION
## What Does This PR Do
Removes pull slowdown from IV drip stands, wheelchairs, and trash cart crates

## Why It's Good For The Game
Most other common objects with wheels were excluded, why shouldn't these

## Testing
Spawned thingy in, pulled thingy around

## Changelog
:cl:
fix: Fixed some objects with wheels still having pull slowdown
/:cl: