### PR TITLE
Cleans up and fixes some bugs in operating table code

### DIFF
--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -53,10 +53,10 @@
 /obj/machinery/optable/MouseDrop_T(atom/movable/O, mob/user)
 	return take_patient(O, user)
 
-/// Updates the `patient` var to be the mob occupying the table
+/// Updates `patient` to be a carbon mob occupying the table, and returns it
 /obj/machinery/optable/proc/update_patient()
 	if(patient in buckled_mobs)
-		return // Current patient is still here, no need to look
+		return patient // Current patient is still here, no need to look
 
 	patient = null
 	if(length(buckled_mobs))
@@ -70,17 +70,13 @@
 		else
 			icon_state = "table2-idle"
 
-/// Returns `TRUE` if table is occupied
-/obj/machinery/optable/proc/is_occupied()
-	update_patient()
-	if(patient)
-		to_chat(usr, "<span class='notice'>The table is already occupied!</span>")
-		return TRUE
+	return patient
 
 /obj/machinery/optable/proc/take_patient(mob/living/carbon/new_patient, mob/living/carbon/user)
 	if((!ishuman(user) && !isrobot(user)) || !istype(new_patient))
 		return
-	if(is_occupied())
+	if(update_patient())
+		to_chat(usr, "<span class='notice'>The table is already occupied!</span>")
 		return
 
 	// Attempt to settle the patient in

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -106,23 +106,6 @@
 	add_fingerprint(user)
 	update_patient()
 
-/obj/machinery/optable/verb/climb_on()
-	set name = "Climb On Table"
-	set category = "Object"
-	set src in oview(1)
-	if(usr.stat || !iscarbon(usr) || usr.restrained() || !check_table())
-		return
-	take_patient(usr, usr)
-
-/obj/machinery/optable/attackby(obj/item/I, mob/living/carbon/user, params)
-	if(istype(I, /obj/item/grab))
-		var/obj/item/grab/G = I
-		if(iscarbon(G.affecting))
-			take_patient(G.affecting, user)
-			qdel(G)
-	else
-		return ..()
-
 /obj/machinery/optable/wrench_act(mob/user, obj/item/I)
 	. = TRUE
 	if(!I.tool_start_check(src, user, 0))

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -37,13 +37,6 @@
 	. = ..()
 	. += "<span class='notice'><b>Click-drag</b> someone to the table to place them on top of the table.</span>"
 
-/obj/machinery/optable/attack_hulk(mob/living/carbon/human/user, does_attack_animation = FALSE)
-	if(user.a_intent == INTENT_HARM)
-		..(user, TRUE)
-		visible_message("<span class='warning'>[user] destroys [src]!</span>")
-		qdel(src)
-		return TRUE
-
 /obj/machinery/optable/CanPass(atom/movable/mover, turf/target, height=0)
 	if(height == 0)
 		return TRUE
@@ -53,13 +46,11 @@
 		return FALSE
 
 /obj/machinery/optable/MouseDrop_T(atom/movable/O, mob/user)
-	if(!ishuman(user) && !isrobot(user)) //Only Humanoids and Cyborgs can put things on this table
+	if(!ishuman(user) && !isrobot(user)) // Only Humanoids and Cyborgs can put things on this table
 		return
 	if(!check_table()) //If the Operating Table is occupied, you cannot put someone else on it
 		return
-	if(user.buckled || user.incapacitated()) //Is the person trying to use the table incapacitated or restrained?
-		return
-	if(!ismob(O) || !iscarbon(O)) //Only Mobs and Carbons can go on this table (no syptic patches please)
+	if(!iscarbon(O))
 		return
 	if(!user_buckle_mob(O, user, check_loc = FALSE))
 		return

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -88,13 +88,12 @@
 
 /obj/machinery/optable/process()
 	update_patient()
-	if(length(injected_reagents))
-		for(var/mob/living/carbon/C in get_turf(src))
-			if(C.stat == DEAD)
-				continue
-			var/datum/reagents/R = C.reagents
-			for(var/chemical in injected_reagents)
-				R.check_and_add(chemical,reagent_target_amount,inject_amount)
+
+	if(!length(injected_reagents) || patient.stat == DEAD)
+		return
+
+	for(var/chemical in injected_reagents)
+		patient.reagents.check_and_add(chemical, reagent_target_amount, inject_amount)
 
 /obj/machinery/optable/wrench_act(mob/user, obj/item/I)
 	. = TRUE

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -53,7 +53,7 @@
 /obj/machinery/optable/MouseDrop_T(atom/movable/O, mob/user)
 	if(!ishuman(user) && !isrobot(user)) // Only Humanoids and Cyborgs can put things on this table
 		return
-	if(!check_table()) //If the Operating Table is occupied, you cannot put someone else on it
+	if(is_occupied())
 		return
 	if(!iscarbon(O))
 		return
@@ -79,13 +79,11 @@
 		else
 			icon_state = "table2-idle"
 
-/// Returns `FALSE` if table is occupied
-/obj/machinery/optable/proc/check_table()
+/// Returns `TRUE` if table is occupied
+/obj/machinery/optable/proc/is_occupied()
 	update_patient()
-	if(patient != null)
+	if(patient)
 		to_chat(usr, "<span class='notice'>The table is already occupied!</span>")
-		return FALSE
-	else
 		return TRUE
 
 /obj/machinery/optable/proc/take_patient(mob/living/carbon/new_patient, mob/living/carbon/user)

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -89,7 +89,7 @@
 /obj/machinery/optable/process()
 	update_patient()
 
-	if(!length(injected_reagents) || patient.stat == DEAD)
+	if(!length(injected_reagents) || !patient || patient.stat == DEAD)
 		return
 
 	for(var/chemical in injected_reagents)

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -61,13 +61,17 @@
   * Updates the `patient` var to be the mob occupying the table
   */
 /obj/machinery/optable/proc/update_patient()
-	var/mob/living/carbon/C = locate(/mob/living/carbon, loc)
-	if(C && IS_HORIZONTAL(C))
-		patient = C
-	else
-		patient = null
+	if(patient in buckled_mobs)
+		return // Current patient is still here, no need to look
+
+	patient = null
+	if(length(buckled_mobs))
+		for(var/mob/living/carbon/C in buckled_mobs)
+			patient = C
+			break
+
 	if(!no_icon_updates)
-		if(C && C.pulse)
+		if(patient && patient.pulse)
 			icon_state = "table2-active"
 		else
 			icon_state = "table2-idle"

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -51,16 +51,7 @@
 		to_chat(AM, "<span class='danger'>You feel a series of tiny pricks!</span>")
 
 /obj/machinery/optable/MouseDrop_T(atom/movable/O, mob/user)
-	if(!ishuman(user) && !isrobot(user)) // Only Humanoids and Cyborgs can put things on this table
-		return
-	if(is_occupied())
-		return
-	if(!iscarbon(O))
-		return
-	if(!user_buckle_mob(O, user, check_loc = FALSE))
-		return
-	take_patient(O, user)
-	return TRUE
+	return take_patient(O, user)
 
 /// Updates the `patient` var to be the mob occupying the table
 /obj/machinery/optable/proc/update_patient()
@@ -87,14 +78,24 @@
 		return TRUE
 
 /obj/machinery/optable/proc/take_patient(mob/living/carbon/new_patient, mob/living/carbon/user)
+	if((!ishuman(user) && !isrobot(user)) || !istype(new_patient))
+		return
+	if(is_occupied())
+		return
+	if(!user_buckle_mob(O, user, check_loc = FALSE)) // Is the user incapacitated, the patient already buckled to something, etc.?
+		return
+
 	if(new_patient == user)
 		user.visible_message("[user] climbs on [src].","You climb on [src].")
 	else
 		visible_message("<span class='alert'>[new_patient] has been laid on [src] by [user].</span>")
+
 	if(new_patient.s_active) //Close the container opened
 		new_patient.s_active.close(new_patient)
+
 	add_fingerprint(user)
 	update_patient()
+	return TRUE
 
 /obj/machinery/optable/process()
 	update_patient()

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -45,11 +45,6 @@
 	else
 		return FALSE
 
-/obj/machinery/optable/Crossed(atom/movable/AM, oldloc)
-	. = ..()
-	if(iscarbon(AM) && length(injected_reagents))
-		to_chat(AM, "<span class='danger'>You feel a series of tiny pricks!</span>")
-
 /obj/machinery/optable/MouseDrop_T(atom/movable/O, mob/user)
 	return take_patient(O, user)
 
@@ -59,9 +54,14 @@
 		return patient // Current patient is still here, no need to look
 
 	patient = null
+
 	if(length(buckled_mobs))
 		for(var/mob/living/carbon/C in buckled_mobs)
 			patient = C
+
+			if(length(injected_reagents))
+				to_chat(C, "<span class='danger'>You feel a series of tiny pricks!</span>")
+
 			break
 
 	if(!no_icon_updates)

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -82,18 +82,11 @@
 		return
 	if(is_occupied())
 		return
-	if(!user_buckle_mob(O, user, check_loc = FALSE)) // Is the user incapacitated, the patient already buckled to something, etc.?
-		return
 
-	if(new_patient == user)
-		user.visible_message("[user] climbs on [src].","You climb on [src].")
-	else
-		visible_message("<span class='alert'>[new_patient] has been laid on [src] by [user].</span>")
+	// Attempt to settle the patient in
+	if(!user_buckle_mob(new_patient, user, check_loc = FALSE))
+		return // User is incapacitated, patient is already buckled to something else, etc.
 
-	if(new_patient.s_active) //Close the container opened
-		new_patient.s_active.close(new_patient)
-
-	add_fingerprint(user)
 	update_patient()
 	return TRUE
 

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -47,7 +47,7 @@
 
 /obj/machinery/optable/Crossed(atom/movable/AM, oldloc)
 	. = ..()
-	if(iscarbon(AM) && LAZYLEN(injected_reagents))
+	if(iscarbon(AM) && length(injected_reagents))
 		to_chat(AM, "<span class='danger'>You feel a series of tiny pricks!</span>")
 
 /obj/machinery/optable/MouseDrop_T(atom/movable/O, mob/user)
@@ -88,7 +88,7 @@
 
 /obj/machinery/optable/process()
 	update_patient()
-	if(LAZYLEN(injected_reagents))
+	if(length(injected_reagents))
 		for(var/mob/living/carbon/C in get_turf(src))
 			if(C.stat == DEAD)
 				continue

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -20,8 +20,8 @@
 
 /obj/machinery/optable/Initialize(mapload)
 	. = ..()
-	for(dir in list(NORTH,EAST,SOUTH,WEST))
-		computer = locate(/obj/machinery/computer/operating, get_step(src, dir))
+	for(var/direction in list(NORTH,EAST,SOUTH,WEST))
+		computer = locate(/obj/machinery/computer/operating, get_step(src, direction))
 		if(computer)
 			computer.table = src
 			break


### PR DESCRIPTION
## What Does This PR Do
Refactors and cleans up a bunch of operating table code, fixing some bugs as well as removing doubled-up feedback introduced during the switch to buckling, an unnecessary inventory closing, and the old and bugged methods (grab-clicking, verb) of putting people on operating tables.
Also removes the `attack_hulk()` proc override, which removes another case of doubled feedback and makes operating tables take a whopping ***2*** hits to destroy by hulks instead of just 1.

## Why It's Good For The Game
Outdated code bad, bugs even worse

## Testing
Tested all of the fixes
Made sure you still can't put non-carbons or multiple carbons at once on operating tables, that abductor tables still inject chemicals properly, that you can't buckle people while incapacitated, etc.

## Changelog
:cl:
fix: Fixed being unable to buckle someone to an operating table if they lie prone on the table's turf
fix: Fixed operating table patients facing towards the operating computer rather than up
tweak: Being put onto an operating table no longer closes your open inventory for no reason
fix: Alien operating tables no longer inject mobs passing through the table that aren't patients on it
spellcheck: Fixed some double-feedback from operating tables
/:cl:
