### PR TITLE
Glass floor interactions properly check if objects are above them for fire and blobs

### DIFF
--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -90,7 +90,7 @@
 /obj/blob_act(obj/structure/blob/B)
 	if(isturf(loc))
 		var/turf/T = loc
-		if((T.intact && level == 1) || T.transparent_floor) //the blob doesn't destroy thing below the floor
+		if(level == 1 && (T.intact|T.transparent_floor)) //the blob doesn't destroy thing below the floor
 			return
 	take_damage(400, BRUTE, MELEE, 0, get_dir(src, B))
 
@@ -200,7 +200,7 @@ GLOBAL_DATUM_INIT(acid_overlay, /mutable_appearance, mutable_appearance('icons/e
 /obj/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume, global_overlay = TRUE)
 	if(isturf(loc))
 		var/turf/T = loc
-		if((T.intact && level == 1) || T.transparent_floor) //fire can't damage things hidden below the floor.
+		if(level == 1 && (T.intact|T.transparent_floor)) //fire can't damage things hidden below the floor.
 			return
 	..()
 	if(QDELETED(src))  // Some items, like patches, might get qdeled in the parent call


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Tweaks the `obj`'s `fire_act` and `blob_act` so it checks the level regardless, instead of skipping completely if it's a transparent floor.

## Why It's Good For The Game
Fixes #21461, and blob too incidentally.

## Images of changes
https://github.com/ParadiseSS13/Paradise/assets/80771500/cc99d0d9-9db7-4ab5-b9f5-7eca8bc1e67b

## Testing
Lit paper while standing on glass floor.

## Changelog
:cl:
fix: Glass floors do not prevent things from being burned or damaged by blobs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
