### PR TITLE
Gives Bolting/Shocking a `do_after` Unless Antagonist

### DIFF
--- a/code/_onclick/ai_onclick.dm
+++ b/code/_onclick/ai_onclick.dm
@@ -210,7 +210,6 @@
 	if(isAntag(user) || do_after(user, 3 SECONDS, target = src, allow_moving = TRUE))
 		toggle_bolt(user)
 		return
-	toggle_bolt(user)
 
 
 /obj/machinery/door/airlock/AIAltClick(mob/living/silicon/user) // Electrifies doors.
@@ -225,8 +224,6 @@
 			electrify(-1, user, TRUE) // permanent shock + audio cue
 			playsound(loc, "sparks", 100, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
 			return
-		electrify(-1, user, TRUE)// permanent shock + audio cue
-		playsound(loc, "sparks", 100, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
 
 
 /obj/machinery/door/airlock/AIMiddleClick(mob/living/user) // Toggles door bolt lights.

--- a/code/_onclick/ai_onclick.dm
+++ b/code/_onclick/ai_onclick.dm
@@ -207,9 +207,8 @@
 
 	if(!ai_control_check(user))
 		return
-	if(!user.mind.special_role)
-		if(do_after(user, 3 SECONDS, target = src, allow_moving = TRUE))
-			toggle_bolt(user)
+	if(isAntag(user) || do_after(user, 3 SECONDS, target = src, allow_moving = TRUE))
+		toggle_bolt(user)
 		return
 	toggle_bolt(user)
 
@@ -222,11 +221,12 @@
 	if(isElectrified())
 		electrify(0, user, TRUE) // un-shock
 	else
-		if(!user.mind.special_role)
-			if(do_after(user, 3 SECONDS, target = src, allow_moving = TRUE))
-				electrify(-1, user, TRUE) // permanent shock
-				return
-		electrify(-1, user, TRUE)// permanent shock
+		if(isAntag(user) || do_after(user, 3 SECONDS, target = src, allow_moving = TRUE))
+			electrify(-1, user, TRUE) // permanent shock + audio cue
+			playsound(loc, "sparks", 100, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
+			return
+		electrify(-1, user, TRUE)// permanent shock + audio cue
+		playsound(loc, "sparks", 100, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
 
 
 /obj/machinery/door/airlock/AIMiddleClick(mob/living/user) // Toggles door bolt lights.

--- a/code/_onclick/ai_onclick.dm
+++ b/code/_onclick/ai_onclick.dm
@@ -209,7 +209,6 @@
 		return
 	if(isAntag(user) || do_after(user, 3 SECONDS, target = src, allow_moving = TRUE))
 		toggle_bolt(user)
-		return
 
 
 /obj/machinery/door/airlock/AIAltClick(mob/living/silicon/user) // Electrifies doors.
@@ -223,7 +222,6 @@
 		if(isAntag(user) || do_after(user, 3 SECONDS, target = src, allow_moving = TRUE))
 			electrify(-1, user, TRUE) // permanent shock + audio cue
 			playsound(loc, "sparks", 100, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
-			return
 
 
 /obj/machinery/door/airlock/AIMiddleClick(mob/living/user) // Toggles door bolt lights.

--- a/code/_onclick/ai_onclick.dm
+++ b/code/_onclick/ai_onclick.dm
@@ -209,7 +209,7 @@
 		return
 	if(!user.mind.special_role)
 		if(do_after(user, 2.5 SECONDS, target = src, allow_moving = TRUE))
-		toggle_bolt(user)
+			toggle_bolt(user)
 		return
 	toggle_bolt(user)
 

--- a/code/_onclick/ai_onclick.dm
+++ b/code/_onclick/ai_onclick.dm
@@ -208,7 +208,7 @@
 	if(!ai_control_check(user))
 		return
 	if(!user.mind.special_role)
-		if(do_after(user, 2.5 SECONDS, target = src, allow_moving = TRUE))
+		if(do_after(user, 3 SECONDS, target = src, allow_moving = TRUE))
 			toggle_bolt(user)
 		return
 	toggle_bolt(user)
@@ -223,7 +223,7 @@
 		electrify(0, user, TRUE) // un-shock
 	else
 		if(!user.mind.special_role)
-			if(do_after(user, 2.5 SECONDS, target = src, allow_moving = TRUE))
+			if(do_after(user, 3 SECONDS, target = src, allow_moving = TRUE))
 				electrify(-1, user, TRUE) // permanent shock
 				return
 		electrify(-1, user, TRUE)// permanent shock

--- a/code/_onclick/ai_onclick.dm
+++ b/code/_onclick/ai_onclick.dm
@@ -204,9 +204,15 @@
 	open_close(user)
 
 /obj/machinery/door/airlock/AICtrlClick(mob/living/silicon/user) // Bolts doors
+
 	if(!ai_control_check(user))
 		return
+	if(!user.mind.special_role)
+		if(do_after(user, 2.5 SECONDS, target = src, allow_moving = TRUE))
+		toggle_bolt(user)
+		return
 	toggle_bolt(user)
+
 
 /obj/machinery/door/airlock/AIAltClick(mob/living/silicon/user) // Electrifies doors.
 	if(!ai_control_check(user))
@@ -216,7 +222,11 @@
 	if(isElectrified())
 		electrify(0, user, TRUE) // un-shock
 	else
-		electrify(-1, user, TRUE) // permanent shock
+		if(!user.mind.special_role)
+			if(do_after(user, 2.5 SECONDS, target = src, allow_moving = TRUE))
+				electrify(-1, user, TRUE) // permanent shock
+				return
+		electrify(-1, user, TRUE)// permanent shock
 
 
 /obj/machinery/door/airlock/AIMiddleClick(mob/living/user) // Toggles door bolt lights.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Gives AI/Borgs/etc a `do_after` when shortcut-clicking to bolt or shock. You can queue up multiple of these AND move while doing so.

Bolting: `3 SECONDS`
Shocking: `3 SECONDS` + Audio Cue (short spark sound) for when a door near you is shocked.

This ONLY effects the shortcut and does not effect opening the menu to do so.

## Why It's Good For The Game
Currently AIs are VERY VERY VERY strong against antagonists. An AI can kinda just shaft any antagonist at will. Youre meant to be a moral-less cyborg who's only kept in check by your Laws. The fact that so many AI then choose to act like RoboCop (while not even ON the Lawset) is beyond absurd.

This change makes it so if you want to ignore the funny menuing to lock a door down, you have a slight delay to do so. This will ONLY effect non-antagonist AI - so malf/emagged borgs/etc do not have to deal with this change. Only the AI seems the `do_after` so you can still "pretend" youre limited to throw off the scent if people try to "malf check you" knowing this exists.

## Testing
Slammed and shocked some doors as both a malf and standard silicon.

## Changelog
:cl:
tweak: Non-antagonist door bolting and shocking now has a `do_after`.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
