### PR TITLE
the thermal drill no longer grants the visual effect to deadchat every 2 minutes

### DIFF
--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -361,7 +361,7 @@ GLOBAL_LIST_EMPTY(safes)
 	for(var/mob/dead/observer/O in GLOB.player_list)
 		O.clear_fullscreen("payback")
 		O.overlay_fullscreen("payback", /obj/screen/fullscreen/payback, 1)
-	addtimer(CALLBACK(src, PROC_REF(ghost_payback_phase_2)), 2 MINUTES)
+	addtimer(CALLBACK(src, PROC_REF(clear_payback)), 2 MINUTES)
 
 /obj/structure/safe/proc/clear_payback()
 	for(var/mob/dead/observer/O in GLOB.player_list)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

The safe now calls the proper proc 2 minutes after granting the visual effects to ghosts, rather than calling the same proc again every 2 minutes.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

While security is always assaulting the crew, thats usual. We don't need to tell ghosts about security after the vault raid is done.

## Testing
<!-- How did you test the PR, if at all? -->

Triggered the event, waited 2 minutes for the effect to go away, waited 2 more minute for it to come back.

Think I messed this up when I renamed the procs in the past PR? Not sure.

## Changelog
:cl:
fix: The thermal drill no longer grants the visual effect to deadchat every 2 minutes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
