### PR TITLE
Fixes oversight in simplemob smashing code

### DIFF
--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -261,7 +261,7 @@
 
 /obj/machinery/door/window/attack_animal(mob/living/simple_animal/M)
 	. = ..()
-	if(M.environment_smash >= ENVIRONMENT_SMASH_WALLS)
+	if(. && M.environment_smash >= ENVIRONMENT_SMASH_WALLS)
 		playsound(src, 'sound/effects/grillehit.ogg', 80, TRUE)
 		deconstruct(FALSE)
 		M.visible_message("<span class='danger'>[M] smashes through [src]!</span>", "<span class='notice'>You smash through [src].</span>")

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -79,13 +79,17 @@
 		shockcooldown = world.time + my_shockcooldown
 
 /obj/structure/grille/attack_animal(mob/living/simple_animal/user)
-	if(QDELETED(src) || shock(user, 70))
+	. = ..()
+	if(!. || QDELETED(src) || shock(user, 70))
 		return
+
 	if(user.environment_smash >= ENVIRONMENT_SMASH_STRUCTURES)
 		playsound(src, 'sound/effects/grillehit.ogg', 80, TRUE)
 		obj_break()
 		user.visible_message("<span class='danger'>[user] smashes through [src]!</span>", "<span class='notice'>You smash through [src].</span>")
-	return ..()
+		return
+
+	take_damage(rand(5,10), BRUTE, MELEE, 1)
 
 /obj/structure/grille/hulk_damage()
 	return 60

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -85,9 +85,7 @@
 		playsound(src, 'sound/effects/grillehit.ogg', 80, TRUE)
 		obj_break()
 		user.visible_message("<span class='danger'>[user] smashes through [src]!</span>", "<span class='notice'>You smash through [src].</span>")
-	else
-		take_damage(rand(5, 10), BRUTE, MELEE, 1)
-		return ..()
+	return ..()
 
 /obj/structure/grille/hulk_damage()
 	return 60

--- a/code/game/objects/structures/railings.dm
+++ b/code/game/objects/structures/railings.dm
@@ -23,7 +23,7 @@
 
 /obj/structure/railing/attack_animal(mob/living/simple_animal/M)
 	. = ..()
-	if(M.environment_smash >= ENVIRONMENT_SMASH_WALLS)
+	if(. && M.environment_smash >= ENVIRONMENT_SMASH_WALLS)
 		deconstruct(FALSE)
 		M.visible_message("<span class='danger'>[M] tears apart [src]!</span>", "<span class='notice'>You tear apart [src]!</span>")
 

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -241,7 +241,7 @@
 
 /obj/structure/table/attack_animal(mob/living/simple_animal/M)
 	. = ..()
-	if(M.environment_smash >= minimum_env_smash)
+	if(. && M.environment_smash >= minimum_env_smash)
 		deconstruct(FALSE)
 		M.visible_message("<span class='danger'>[M] smashes [src]!</span>", "<span class='notice'>You smash [src].</span>")
 

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -180,10 +180,6 @@
 	if(M.environment_smash >= env_smash_level)
 		deconstruct(FALSE)
 		M.visible_message("<span class='danger'>[M] smashes through [src]!</span>", "<span class='warning'>You smash through [src].</span>", "<span class='warning'>You hear glass breaking.</span>")
-	else
-		to_chat(M, "<span class='notice'>You smash against the window.</span>")
-		take_damage(rand(25, 75))
-
 
 /obj/structure/window/attackby(obj/item/I, mob/living/user, params)
 	if(!can_be_reached(user))

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -177,7 +177,7 @@
 	if(!can_be_reached(M))
 		return
 	. = ..()
-	if(M.environment_smash >= env_smash_level)
+	if(. && M.environment_smash >= env_smash_level)
 		deconstruct(FALSE)
 		M.visible_message("<span class='danger'>[M] smashes through [src]!</span>", "<span class='warning'>You smash through [src].</span>", "<span class='warning'>You hear glass breaking.</span>")
 

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -171,8 +171,7 @@
 /obj/structure/window/attack_generic(mob/user, damage_amount = 0, damage_type = BRUTE, damage_flag = 0, sound_effect = 1)	//used by attack_alien, attack_animal, and attack_slime
 	if(!can_be_reached(user))
 		return
-	..()
-
+	return ..()
 /obj/structure/window/attack_animal(mob/living/simple_animal/M)
 	if(!can_be_reached(M))
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes an oversight with https://github.com/ParadiseSS13/Paradise/pull/21209 that lets all simplemobs do extreme damage to windows when they could not previously.
Fixes an issue where smashing happens regardless of intent.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
mice shouldn't be able to do 75 damage to windows.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed an issue that let simplemobs do extreme damage to windows
fix: Fixed help intent animals smashing things accidentally
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
