### PR TITLE
Disabler Nerf: Slowdown Tweaks + Shot Reduction

### DIFF
--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -329,7 +329,7 @@
 			. += (health_deficiency / 75)
 		else
 			if(health_deficiency >= 40)
-				. += (health_deficiency / 25) //Once damage is over 40, you get the harsh formula
+				. += ((health_deficiency / 25) - 1.1) //Once damage is over 40, you get the harsh formula
 			else
 				. += 0.5 //Otherwise, slowdown (from pain) is capped to 0.5 until you hit 40 damage. This only effects people with fractional slowdowns, and prevents some harshness from the lowered threshold
 

--- a/code/modules/projectiles/ammunition/energy_lens.dm
+++ b/code/modules/projectiles/ammunition/energy_lens.dm
@@ -355,5 +355,5 @@
 	projectile_type = /obj/item/projectile/beam/silencer
 	muzzle_flash_effect = null
 	select_name = "silencing dissidents"
-	e_cost = 62.5 // 16 shots
+	e_cost = 50 // 16 shots
 	fire_sound = 'sound/weapons/silencer_laser.ogg'

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -54,7 +54,7 @@
 	flight_y_offset = 10
 	can_holster = TRUE
 
-/obj/item/gun/energy/disabler/Initialize(mapload, ...)
+/obj/item/gun/energy/disabler/Initialize(mapload)
 	. = ..()
 	cell.maxcharge = 800
 	cell.charge = 800

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -54,6 +54,11 @@
 	flight_y_offset = 10
 	can_holster = TRUE
 
+/obj/item/gun/energy/disabler/Initialize(mapload, ...)
+	. = ..()
+	cell.maxcharge = 800
+	cell.charge = 800
+
 /obj/item/gun/energy/disabler/process_fire(atom/target, mob/living/user, message, params, zone_override, bonus_spread)
 	var/obj/item/gun/energy/disabler/offhand_disabler = user.get_inactive_hand()
 	if(istype(offhand_disabler) && offhand_disabler.semicd && (user.a_intent != INTENT_HARM))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Tweaks the equation for slowdown to be less harsh at the 40 damage threshold and onward.

Reduces the amount of shots in the disabler from `20 > 16`

## Why It's Good For The Game
The disaber is a . . . weapon. It is VERY good at downing people at range. Currently, you have 20 shots per full charge disabler and it takes 2 shots to get to put you in slowdown.

With the current equation (`health_deficiency / 25`), 60 stamina gives a slowdown of `2.4`, rounding to `2.5`
With the new equation (`(health_deficiency / 25) - 1.1`), 60 stamina gives a slowdown of `1.3`, rounding to `1.5`
This should make the disabler a BIT less oppressive and allow for a slightly easier escape if you manage to dodge/counter the shots somehow. This also affects damage-damage, so this should make getting tagged by a shot or two on BOTH sides a bit less oppressive.

In addition, the SHEER amount of fire a pair of Officers can pump out with a disabler is a tad nuts. `20` shots a piece, `40` for a pair of Officers, and you only need to land `2` shots to get to slowdown. That means between two people you need to land 10% of your shots for stamcrit and only 5% for slowdown. That's way too few in my opinion. 

Therefore, the total shots for the disabler will also be reduced to `16`.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Tweaked the equation for damage slowdown.
tweak: Reduced the number of shots in a disabler from `20` to `16`.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
