### PR TITLE
Fire rolling no longer hardstuns you because its not 2016 and is current year

### DIFF
--- a/code/__HELPERS/trait_helpers.dm
+++ b/code/__HELPERS/trait_helpers.dm
@@ -281,6 +281,3 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_CANNOT_PULL "pullblocked"
 /// Abstract condition that prevents movement if being pulled and might be resisted against. Handcuffs and straight jackets, basically.
 #define TRAIT_RESTRAINED "restrained"
-/// Applies the on fire burning effect toward the user.
-#define TRAIT_FIRE_ROLLING "burning"
-

--- a/code/__HELPERS/trait_helpers.dm
+++ b/code/__HELPERS/trait_helpers.dm
@@ -281,4 +281,6 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_CANNOT_PULL "pullblocked"
 /// Abstract condition that prevents movement if being pulled and might be resisted against. Handcuffs and straight jackets, basically.
 #define TRAIT_RESTRAINED "restrained"
+/// Applies the on fire burning effect toward the user.
+#define TRAIT_FIRE_ROLLING "burning"
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -911,18 +911,17 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 	return FALSE
 
 /mob/living/carbon/resist_fire()
-	if(HAS_TRAIT(src, TRAIT_FIRE_ROLLING))
+	if(IsKnockedDown())
 		return
 	fire_stacks -= 5
-	ADD_TRAIT(src, TRAIT_FIRE_ROLLING, TRAIT_GENERIC)
-	KnockDown(6 SECONDS, TRUE) //We dont check for CANWEAKEN, I don't care how immune to weakening you are, if you're rolling on the ground, you're busy.
+	Weaken (2 SECONDS, TRUE) //Your busy dying from fire, no way you could be able to roll and reach for a snack in your bag
+	KnockDown(6 SECONDS, TRUE) //Ok now you can have that snack if you want
 	spin(32, 2)
 	visible_message("<span class='danger'>[src] rolls on the floor, trying to put [p_themselves()] out!</span>",
 		"<span class='notice'>You stop, drop, and roll!</span>")
 	addtimer(CALLBACK(src, PROC_REF(extinguish_roll), 3 SECONDS))
 
 /mob/living/carbon/proc/extinguish_roll()
-	REMOVE_TRAIT(src, TRAIT_FIRE_ROLLING, TRAIT_GENERIC)
 	if(fire_stacks <= 0)
 		visible_message("<span class='danger'>[src] has successfully extinguished [p_themselves()]!</span>","<span class='notice'>You extinguish yourself.</span>")
 		ExtinguishMob()

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -911,17 +911,21 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 	return FALSE
 
 /mob/living/carbon/resist_fire()
+	if(HAS_TRAIT(src, TRAIT_FIRE_ROLLING))
+		return
 	fire_stacks -= 5
-	Weaken(6 SECONDS, TRUE) //We dont check for CANWEAKEN, I don't care how immune to weakening you are, if you're rolling on the ground, you're busy.
+	ADD_TRAIT(src, TRAIT_FIRE_ROLLING, TRAIT_GENERIC)
+	KnockDown(6 SECONDS, TRUE) //We dont check for CANWEAKEN, I don't care how immune to weakening you are, if you're rolling on the ground, you're busy.
 	spin(32, 2)
 	visible_message("<span class='danger'>[src] rolls on the floor, trying to put [p_themselves()] out!</span>",
 		"<span class='notice'>You stop, drop, and roll!</span>")
-	sleep(3 SECONDS)
-	if(fire_stacks <= 0)
-		visible_message("<span class='danger'>[src] has successfully extinguished [p_themselves()]!</span>",
-			"<span class='notice'>You extinguish yourself.</span>")
-		ExtinguishMob()
+	addtimer(CALLBACK(src, PROC_REF(extinguish_roll), 3 SECONDS))
 
+/mob/living/carbon/proc/extinguish_roll()
+	REMOVE_TRAIT(src, TRAIT_FIRE_ROLLING, TRAIT_GENERIC)
+	if(fire_stacks <= 0)
+		visible_message("<span class='danger'>[src] has successfully extinguished [p_themselves()]!</span>","<span class='notice'>You extinguish yourself.</span>")
+		ExtinguishMob()
 
 /mob/living/carbon/resist_restraints()
 	INVOKE_ASYNC(src, PROC_REF(resist_muzzle))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Changes how fire rolling works, it no longer weakens and stuns you, now you can roll and crawl while also being able to use things.
![dreamseeker_Siu04Qz1fH](https://github.com/ParadiseSS13/Paradise/assets/62493359/49d40900-c16b-431f-a3b5-204c64db4319)


## Why It's Good For The Game
Hard stun bad, 7 year mechanic that nobody bothered to update bad, less restrictive movement good, more fun and not one sided status effects good.

## Testing
set self on fire, rolled while on fire and moved, amazing

## Changelog
:cl: Octus SabreML
tweak: Putting yourself out via rolling while on fire no longer stuns you, its now just a knockdown
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
