### PR TITLE
Beanbag shot now throws a tile. Increases the spread on rubbershot / lasershot / weakbuckshot

### DIFF
--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -148,7 +148,7 @@
 	icon_state = "cshell"
 	projectile_type = /obj/item/projectile/bullet/pellet/rubber
 	pellets = 6
-	variance = 25
+	variance = 35
 	materials = list(MAT_METAL=4000)
 
 
@@ -169,7 +169,7 @@
 	projectile_type = /obj/item/projectile/bullet/pellet/weak
 	materials = list(MAT_METAL=250)
 	pellets = 10
-	variance = 25
+	variance = 35
 	muzzle_flash_strength = MUZZLE_FLASH_STRENGTH_NORMAL
 	muzzle_flash_range = MUZZLE_FLASH_RANGE_NORMAL
 
@@ -253,7 +253,7 @@
 	icon_state = "lshell"
 	projectile_type = /obj/item/projectile/beam/scatter
 	pellets = 8
-	variance = 25
+	variance = 35
 	muzzle_flash_strength = MUZZLE_FLASH_STRENGTH_NORMAL
 	muzzle_flash_range = MUZZLE_FLASH_RANGE_NORMAL
 	muzzle_flash_color = LIGHT_COLOR_DARKRED

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -16,9 +16,9 @@
 	. = ..()
 	if(isliving(target))
 		var/mob/living/L = target
-		if(M.move_resist < INFINITY)
-			var/atom/throw_target = get_edge_target_turf(M, get_dir(src, get_step_away(firer, M)))
-			M.throw_at(throw_target, 1, 2)
+		if(L.move_resist < INFINITY)
+			var/atom/throw_target = get_edge_target_turf(L, get_dir(src, get_step_away(L, starting)))
+			L.throw_at(throw_target, 1, 2)
 
 /obj/item/projectile/bullet/weakbullet/booze
 

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -15,9 +15,9 @@
 /obj/item/projectile/bullet/weakbullet/on_hit(atom/target, blocked = 0)
 	. = ..()
 	if(isliving(target))
-		var/mob/living/M = target
+		var/mob/living/L = target
 		if(M.move_resist < INFINITY)
-			var/atom/throw_target = get_edge_target_turf(M, get_dir(src, get_step_away(M, src)))
+			var/atom/throw_target = get_edge_target_turf(M, get_dir(src, get_step_away(firer, M)))
 			M.throw_at(throw_target, 1, 2)
 
 /obj/item/projectile/bullet/weakbullet/booze

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -12,6 +12,14 @@
 	damage = 5
 	stamina = 40
 
+/obj/item/projectile/bullet/weakbullet/on_hit(atom/target, blocked = 0)
+	. = ..()
+	if(isliving(target))
+		var/mob/living/M = target
+		if(M.move_resist < INFINITY)
+			var/atom/throw_target = get_edge_target_turf(M, get_dir(src, get_step_away(M, src)))
+			M.throw_at(throw_target, 1, 2)
+
 /obj/item/projectile/bullet/weakbullet/booze
 
 /obj/item/projectile/bullet/weakbullet/booze/on_hit(atom/target, blocked = 0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Lasershot, rubbershot, and weak buckshot have their spread increased by 10 degrees to 35, from  25.

Actual buckshot, which is gamma or nukie only, is uneffected.

Beanbags now throw people back a tile. This can wall knockdown / do damage / vendor crush. Good for keeping people you do not like away from you, rather than an ammo you want to be close for, like buckshot.
Also good for making people drop what they drag.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Beanbag is not used often. Disablers / eguns are easier to get, and rubbershot is insanely good. 
This makes beanbags a weapon about positioning, or keeping people away from you. Could be useful!

As for lasershot / rubbershot, this makes the ammo miss partially when the victim is 3 tiles away from the shotgunner. This should help make it less painful at range while still being effective point blank.

This also makes more shots go into walls at longer ranges. Lasershot is criminal in this regard.

At a 7 tile range currently, lasershot will hit a target 3 times, for 15 damage.
This may sound reasonable, after all, this is less than a laser.
But remeber, this is not a laser perfectly going into a target. This is a shotgun hitting a hallway. You can not *dodge* this 15 damage blast. Unlike a laser, in which one can dodge at long range, this lasershot *will* hit you. It's a devistating 40 damage blast point blank, and is still more certain to damage you than a laser at long range. 7 shots from a shotgun? Thats 105 damage, unless you turn a corner or have armor. Adding the extra spread assists with this, leading to at most 10 damage at 7 tiles, which is still probably too strong, but better.

## Testing
<!-- How did you test the PR, if at all? -->

Shot a bunch of skrell at various ranges.

## Changelog
:cl:
add: Beanbag shot now throws the person you hit back a tile
tweak: Rubbershot, lasershot, and weak buckshot now have 10 degrees more spread.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
