### PR TITLE
Contort body day 1 changes

### DIFF
--- a/code/__HELPERS/mob_helpers.dm
+++ b/code/__HELPERS/mob_helpers.dm
@@ -334,7 +334,7 @@
 
 	msg_admin_attack("[key_name_admin(user)] vs [target_info]: [what_done]", loglevel)
 
-/proc/do_mob(mob/user, mob/target, time = 30, progress = 1, list/extra_checks = list(), only_use_extra_checks = FALSE)
+/proc/do_mob(mob/user, mob/target, time = 30, progress = 1, list/extra_checks = list(), only_use_extra_checks = FALSE, requires_upright = TRUE)
 	if(!user || !target)
 		return 0
 	var/user_loc = user.loc
@@ -375,7 +375,7 @@
 			drifting = 0
 			user_loc = user.loc
 
-		if((!drifting && user.loc != user_loc) || target.loc != target_loc || user.get_active_hand() != holding || user.incapacitated() || (L && IS_HORIZONTAL(L)) || check_for_true_callbacks(extra_checks))
+		if((!drifting && user.loc != user_loc) || target.loc != target_loc || user.get_active_hand() != holding || user.incapacitated() || (requires_upright && L && IS_HORIZONTAL(L)) || check_for_true_callbacks(extra_checks))
 			. = 0
 			break
 	if(progress)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -753,6 +753,9 @@ GLOBAL_LIST_EMPTY(airlock_emissive_underlays)
 			return TRUE
 		var/mob/living/living_mover = mover
 		if((istype(living_mover) && HAS_TRAIT(living_mover, TRAIT_CONTORTED_BODY) && IS_HORIZONTAL(living_mover))) // We really dont want people to get shocked on a door they're passing through
+			if(density && !do_mob(living_mover, living_mover, 2 SECONDS, requires_upright = FALSE))
+				return FALSE
+			living_mover.forceMove(get_turf(src))
 			return TRUE
 	if(isElectrified() && density && isitem(mover))
 		var/obj/item/I = mover

--- a/code/modules/antagonists/changeling/powers/contort_body.dm
+++ b/code/modules/antagonists/changeling/powers/contort_body.dm
@@ -2,7 +2,7 @@
 	name = "Contort Body"
 	desc = "We contort our body, allowing us to fit in and under things we normally wouldn't be able to. Costs 5 chemicals."
 	button_icon_state = "contort_body"
-	chemical_cost = 5
+	chemical_cost = 25
 	dna_cost = 2
 	power_type = CHANGELING_PURCHASABLE_POWER
 

--- a/code/modules/antagonists/changeling/powers/contort_body.dm
+++ b/code/modules/antagonists/changeling/powers/contort_body.dm
@@ -1,6 +1,6 @@
 /datum/action/changeling/contort_body
 	name = "Contort Body"
-	desc = "We contort our body, allowing us to fit in and under things we normally wouldn't be able to. Costs 5 chemicals."
+	desc = "We contort our body, allowing us to fit in and under things we normally wouldn't be able to. Costs 25 chemicals."
 	button_icon_state = "contort_body"
 	chemical_cost = 25
 	dna_cost = 2

--- a/code/modules/mob/living/living_status_procs.dm
+++ b/code/modules/mob/living/living_status_procs.dm
@@ -112,7 +112,7 @@ STATUS EFFECTS
 /mob/living/proc/on_lying_down(new_lying_angle)
 	if(layer == initial(layer)) //to avoid things like hiding larvas.
 		if(HAS_TRAIT(src, TRAIT_CONTORTED_BODY))
-			layer = TURF_LAYER + 0.2
+			layer = BLASTDOOR_LAYER
 		else
 			layer = LYING_MOB_LAYER //so mob lying always appear behind standing mobs
 	pixel_y = PIXEL_Y_OFFSET_LYING


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Ups the chemical cost from 5 to 25 chemicals (People were swapping this mid combat, which seemed to not be super great)
Takes 2 seconds of staying still to go under an airlock now, windoors can still be gone under easily, both because I can't find a good way to apply a timer there and because most windoor locations are a lot less favorable for break in vs an airlock
Clings with contort form are on a high layer now, so they don't fit under stuff like conveyer belts which can spammed nonstop

## Why It's Good For The Game
Bit overtuned, mostly fine but people using it in active combat has been a little much

## Testing
I hate semidense objects

## Changelog
:cl:
tweak: Contort form costs 25 chems to use compared to 5
tweak: Contort form takes an extra 2 seconds to go under doors now
tweak: Contort form costs can no longer fit under conveyers and some other objects
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
