### PR TITLE
Fixes a runtime with railings

### DIFF
--- a/code/game/objects/structures/railings.dm
+++ b/code/game/objects/structures/railings.dm
@@ -81,7 +81,7 @@
 		return TRUE
 	if(ismob(mover))
 		var/mob/living/M = mover
-		if(M.flying || (IS_HORIZONTAL(M) && HAS_TRAIT(M, TRAIT_CONTORTED_BODY)))
+		if(M.flying || (istype(M) && IS_HORIZONTAL(M) && HAS_TRAIT(M, TRAIT_CONTORTED_BODY)))
 			return TRUE
 	if(mover.throwing)
 		return TRUE


### PR DESCRIPTION
## What Does This PR Do
`body_position` is a `/mob/living` variable. We need to make sure the mob is living before running `IS_HORIZONTAL(M)`.

## Why It's Good For The Game
Runtime fix:
```
[2023-06-29T16:13:59] Runtime in code/game/objects/structures/railings.dm,84: undefined variable /mob/camera/aiEye/var/body_position
   proc name: CanPass (/obj/structure/railing/CanPass)
   src: the railing (/obj/structure/railing)
   src.loc: space (64,32,2) (/turf/space)
   call stack:
   the railing (/obj/structure/railing): CanPass
   B.R.A.D (AI Eye) (/mob/camera/aiEye): get_spacemove_backup
   B.R.A.D (AI Eye) (/mob/camera/aiEye): Process_Spacemove
   B.R.A.D (AI Eye) (/mob/camera/aiEye): newtonian_move
   B.R.A.D (AI Eye) (/mob/camera/aiEye): Moved
   B.R.A.D (AI Eye) (/mob/camera/aiEye): setLoc
   B.R.A.D (AI Eye) (/mob/camera/aiEye): setLoc
   [CKEY] (/client): AIMove
   [CKEY] (/client): Move
   B.R.A.D (/mob/living/silicon/ai): key_loop
   [CKEY] (/client): key_loop
   Input (/datum/controller/subsystem/input): fire
   Input (/datum/controller/subsystem/input): ignite
   Master (/datum/controller/master): RunQueue
   Master (/datum/controller/master): Loop
   Master (/datum/controller/master): StartProcessing
   ```
## Testing
Spawned as AI on Cyberiad. Moved over the railings in medbay a bunch, no runtimes.

## Changelog
N/A