### PR TITLE
Fixes people not getting escape objectives when they should

### DIFF
--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -100,17 +100,15 @@
 	for(var/i in 1 to GLOB.configuration.gamemode.traitor_objectives_amount)
 		forge_single_human_objective()
 
-	// Are they required to stay alive for their objectives?
-	var/martyr_compatibility = TRUE
-	if(prob(20))
-		for(var/objective in owner.get_all_objectives())
-			var/datum/objective/O = objective
-			if(!O.martyr_compatible) // Check if our current objectives can co-exist with martyr.
-				martyr_compatibility = FALSE
-				break
+	var/can_succeed_if_dead = TRUE
+	for(var/objective in owner.get_all_objectives())
+		var/datum/objective/O = objective
+		if(!O.martyr_compatible) // Check if our current objectives can co-exist with martyr.
+			can_succeed_if_dead  = FALSE
+			break
 
 	// Give them an escape objective if they don't have one already.
-	if(!(locate(/datum/objective/escape) in owner.get_all_objectives()) && !martyr_compatibility)
+	if(!(locate(/datum/objective/escape) in owner.get_all_objectives()) && (!can_succeed_if_dead || prob(80)))
 		add_objective(/datum/objective/escape)
 
 /**


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes people not getting escape objectives when they should

## Why It's Good For The Game
This is unintended, whoops (Also makes the code easier to follow)

## Testing
Had my ears blown out by the traitor greeting 

## Changelog
:cl:
fix: You should always get an escape objective when you previously should have
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
