### PR TITLE
Cigarette vendor tweaks

### DIFF
--- a/code/game/machinery/vendors/generic_vendors.dm
+++ b/code/game/machinery/vendors/generic_vendors.dm
@@ -899,9 +899,7 @@
 		/obj/item/clothing/mask/cigarette/cigar/havana = 2,
 		/obj/item/reagent_containers/food/pill/patch/nicotine = 10,
 		/obj/item/storage/box/matches = 10,
-		/obj/item/lighter/random = 4
-
-		)
+		/obj/item/lighter/random = 4)
 	contraband = list(/obj/item/lighter/zippo = 4, /obj/item/storage/fancy/rollingpapers = 5)
 	prices = list(/obj/item/storage/fancy/cigarettes/cigpack_robust = 25,
 		/obj/item/storage/fancy/cigarettes/cigpack_uplift = 35,

--- a/code/game/machinery/vendors/generic_vendors.dm
+++ b/code/game/machinery/vendors/generic_vendors.dm
@@ -891,7 +891,8 @@
 	icon_state = "cigs"
 	icon_lightmask = "cigs"
 	products = list(
-		/obj/item/storage/fancy/cigarettes/cigpack_robust = 12,
+		/obj/item/storage/fancy/cigarettes/cigpack_robust = 6,
+		/obj/item/storage/fancy/cigarettes/cigpack_carp = 6,
 		/obj/item/storage/fancy/cigarettes/cigpack_uplift = 6,
 		/obj/item/storage/fancy/cigarettes/cigpack_midori = 6,
 		/obj/item/storage/fancy/cigarettes/cigpack_random = 6,
@@ -899,9 +900,11 @@
 		/obj/item/clothing/mask/cigarette/cigar/havana = 2,
 		/obj/item/reagent_containers/food/pill/patch/nicotine = 10,
 		/obj/item/storage/box/matches = 10,
-		/obj/item/lighter/random = 4)
-	contraband = list(/obj/item/lighter/zippo = 4, /obj/item/storage/fancy/rollingpapers = 5)
+		/obj/item/lighter/random = 4,
+		/obj/item/lighter/zippo = 2)
+	contraband = list(/obj/item/storage/fancy/rollingpapers = 5)
 	prices = list(/obj/item/storage/fancy/cigarettes/cigpack_robust = 25,
+		/obj/item/storage/fancy/cigarettes/cigpack_carp = 25,
 		/obj/item/storage/fancy/cigarettes/cigpack_uplift = 35,
 		/obj/item/storage/fancy/cigarettes/cigpack_midori = 60,
 		/obj/item/storage/fancy/cigarettes/cigpack_random = 80,
@@ -909,6 +912,7 @@
 		/obj/item/reagent_containers/food/pill/patch/nicotine = 70,
 		/obj/item/storage/box/matches = 20,
 		/obj/item/lighter/random = 40,
+		/obj/item/lighter/zippo = 80,
 		/obj/item/storage/fancy/rollingpapers = 30,
 		/obj/item/clothing/mask/cigarette/cigar/havana = 80)
 	refill_canister = /obj/item/vending_refill/cigarette

--- a/code/game/machinery/vendors/generic_vendors.dm
+++ b/code/game/machinery/vendors/generic_vendors.dm
@@ -944,6 +944,7 @@
 					/obj/item/storage/box/matches = 10,
 					/obj/item/lighter/zippo = 4,
 					/obj/item/storage/fancy/rollingpapers = 5)
+	contraband = list()
 	prices = list()
 
 /obj/machinery/economy/vending/wallmed

--- a/code/game/machinery/vendors/generic_vendors.dm
+++ b/code/game/machinery/vendors/generic_vendors.dm
@@ -895,11 +895,14 @@
 		/obj/item/storage/fancy/cigarettes/cigpack_uplift = 6,
 		/obj/item/storage/fancy/cigarettes/cigpack_midori = 6,
 		/obj/item/storage/fancy/cigarettes/cigpack_random = 6,
+		/obj/item/storage/fancy/cigarettes/cigpack_robustgold = 1,
+		/obj/item/clothing/mask/cigarette/cigar/havana = 2,
 		/obj/item/reagent_containers/food/pill/patch/nicotine = 10,
 		/obj/item/storage/box/matches = 10,
-		/obj/item/lighter/random = 4,
-		/obj/item/storage/fancy/rollingpapers = 5)
-	contraband = list(/obj/item/lighter/zippo = 4, /obj/item/storage/fancy/cigarettes/cigpack_robustgold = 1, /obj/item/clothing/mask/cigarette/cigar/havana = 2)
+		/obj/item/lighter/random = 4
+
+		)
+	contraband = list(/obj/item/lighter/zippo = 4, /obj/item/storage/fancy/rollingpapers = 5)
 	prices = list(/obj/item/storage/fancy/cigarettes/cigpack_robust = 25,
 		/obj/item/storage/fancy/cigarettes/cigpack_uplift = 35,
 		/obj/item/storage/fancy/cigarettes/cigpack_midori = 60,
@@ -938,10 +941,11 @@
 					/obj/item/storage/fancy/cigarettes/cigpack_robust = 3,
 					/obj/item/storage/fancy/cigarettes/cigpack_carp = 3,
 					/obj/item/storage/fancy/cigarettes/cigpack_midori = 3,
+					/obj/item/clothing/mask/cigarette/cigar/havana = 2,
 					/obj/item/storage/box/matches = 10,
-					/obj/item/lighter/random = 4,
+					/obj/item/lighter/zippo = 4,
 					/obj/item/storage/fancy/rollingpapers = 5)
-	contraband = list(/obj/item/storage/fancy/cigarettes/cigpack_robustgold = 1, /obj/item/clothing/mask/cigarette/cigar/havana = 2, /obj/item/lighter/zippo = 3)
+	contraband = list(/obj/item/storage/fancy/cigarettes/cigpack_robustgold = 1)
 	prices = list()
 
 /obj/machinery/economy/vending/wallmed

--- a/code/game/machinery/vendors/generic_vendors.dm
+++ b/code/game/machinery/vendors/generic_vendors.dm
@@ -939,11 +939,11 @@
 					/obj/item/storage/fancy/cigarettes/cigpack_robust = 3,
 					/obj/item/storage/fancy/cigarettes/cigpack_carp = 3,
 					/obj/item/storage/fancy/cigarettes/cigpack_midori = 3,
+					/obj/item/storage/fancy/cigarettes/cigpack_robustgold = 1,
 					/obj/item/clothing/mask/cigarette/cigar/havana = 2,
 					/obj/item/storage/box/matches = 10,
 					/obj/item/lighter/zippo = 4,
 					/obj/item/storage/fancy/rollingpapers = 5)
-	contraband = list(/obj/item/storage/fancy/cigarettes/cigpack_robustgold = 1)
 	prices = list()
 
 /obj/machinery/economy/vending/wallmed


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
**Cigarette vendor changes:**

- Moves cigars and robust golds out of contraband - it sucks that you need to hack a vendor to have access to perfectly valid flavor items. They are NOT contraband. They are not money-efficient either. They are just cool. If design team decides they are too accessible like that, I can rack up their price, altrough I don't think it's necessary.
- Moves zippos out of contraband, halves their amount and gives them a price (80 credits) - pretty much same reasons as above, having to hack the vendor for fluff gear sucks.
- Moves rolling papers into contraband - now those ARE fit for contraband. They are for rolling weed and, more rarely, your own cigarettes. Average joe won't use them - only drug dealers and botanists will.
- Adds Carp Classics, halves Robusts amount - carps are BASICALLY robusts but in blue package. They cost the same and have same amount, realistically nothing changes.

**Beach cigarette vendor changes:**

- Moves cigars and robust golds out of contraband - reasons same as above. If miner finds it and gets two free cigars, good for them.
- Does NOT move rolling paper packs to contraband - beach bums cannot hack the vendor, let them have fun in case they find a way to use the paper.
- Replaces cheap lighters with zippos - beach bums, again, cannot hack the vendor by default. This gives them a tiny bit more flavor.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Explained my reasonings above.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Spawned in, checked all the cigarette vendors. Changes applied, didn't break syndicate vendors. Hacked all of them too.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Cigars, Robust Gold Cigarettes and Zippos no longer require hacking
tweak: Rolling Paper packs are now locked behind hacking
tweak: added Carp Classic Cigarettes to the Cigarette vendor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
