### PR TITLE
Makes anomalies deadlier. Again.

### DIFF
--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -133,9 +133,10 @@
 			step_towards(M,src)
 	for(var/obj/O in range(0, src))
 		if(!O.anchored && O.loc != src && O.move_resist < MOVE_FORCE_OVERPOWERING) // so it cannot throw the anomaly core or super big things
-			var/mob/living/target = locate() in view(4, src)
-			if(target && !target.stat)
-				O.throw_at(target, 5, 10, dodgeable = FALSE)
+			for(var/mob/living/target in view(4, src))
+				if(target && !target.stat && (get_dist(target, src) > 1 || prob(50))) //We don't want to always throw at the person that is in the anomaly, fuck up people around it.
+					O.throw_at(target, 5, 10, dodgeable = FALSE)
+					break
 	//anomaly quickly contracts then slowly expands it's ring
 	animate(warp, time = 6, transform = matrix().Scale(0.5,0.5))
 	animate(time = 14, transform = matrix())
@@ -160,6 +161,13 @@
 		A.throw_at(target, 5, 1)
 		boing = FALSE
 
+/obj/effect/anomaly/grav/detonate()
+	if(drops_core)
+		var/turf/T = get_turf(src)
+		if(T && GLOB.gravity_generators["[T.z]"])
+			var/obj/machinery/gravity_generator/main/G = pick(GLOB.gravity_generators["[T.z]"])
+			G.set_broken() //Requires engineering to fix the gravity generator, as it gets overloaded by the anomaly.
+
 /////////////////////
 
 /obj/effect/anomaly/flux
@@ -178,13 +186,16 @@
 /obj/effect/anomaly/flux/Initialize(mapload, new_lifespan, drops_core = TRUE, _explosive = TRUE)
 	. = ..()
 	explosive = _explosive
+	if(explosive)
+		zap_flags = ZAP_MOB_DAMAGE | ZAP_OBJ_DAMAGE | ZAP_MOB_STUN
+		power = 15000
 
 /obj/effect/anomaly/flux/anomalyEffect()
 	..()
 	canshock = TRUE
 	for(var/mob/living/M in get_turf(src))
 		mobShock(M)
-	if(explosive && prob(50)) //Let us not fuck up the sm that much
+	if(explosive) //Let us not fuck up the sm that much
 		tesla_zap(src, zap_range, power, zap_flags)
 
 
@@ -229,9 +240,9 @@
 
 /obj/effect/anomaly/bluespace/anomalyEffect()
 	..()
-	for(var/mob/living/M in range(3, src))
+	for(var/mob/living/M in range(4, src))
 		do_teleport(M, locate(M.x, M.y, M.z), 4)
-	for(var/obj/item/O in range (3, src))
+	for(var/obj/O in range (4, src))
 		if(!O.anchored && O.invisibility == 0 && prob(50))
 			do_teleport(O, locate(O.x, O.y, O.z), 6)
 
@@ -320,13 +331,13 @@
 			M.adjust_fire_stacks(4)
 			M.IgniteMob()
 
-	if(ticks < 5)
+	if(ticks < 4)
 		return
 	else
 		ticks = 0
 	var/turf/simulated/T = get_turf(src)
 	if(istype(T))
-		T.atmos_spawn_air(LINDA_SPAWN_HEAT | LINDA_SPAWN_TOXINS | LINDA_SPAWN_OXYGEN, 5)
+		T.atmos_spawn_air(LINDA_SPAWN_HEAT | LINDA_SPAWN_TOXINS | LINDA_SPAWN_OXYGEN, 20)
 
 /obj/effect/anomaly/pyro/detonate()
 	if(produces_slime)
@@ -365,16 +376,16 @@
 		qdel(src)
 		return
 
-	grav(rand(0, 3), rand(2, 3), 50, 25)
+	grav(rand(0, 3), rand(2, 3), 100, 30)
 
 	//Throwing stuff around!
-	for(var/obj/O in range(2, src))
+	for(var/obj/O in range(3, src))
 		if(O == src || O.loc == src)
 			return //DON'T DELETE YOURSELF OR YOUR CORE GOD DAMN
 		if(!O.anchored)
-			var/mob/living/target = locate() in view(4, src)
+			var/mob/living/target = locate() in view(5, src)
 			if(target && !target.stat)
-				O.throw_at(target, 7, 5)
+				O.throw_at(target, 7, 5, dodgeable = FALSE)
 		else
 			O.ex_act(EXPLODE_HEAVY)
 
@@ -400,6 +411,9 @@
 				step_towards(O, src)
 		for(var/mob/living/M in T.contents)
 			step_towards(M, src)
+			if(drops_core)
+				M.Weaken(3.5 SECONDS) //You ran into a black hole, you ride the pain train.
+			M.KnockDown(7 SECONDS)
 
 	//Damaging the turf
 	if(T && prob(turf_removal_chance))

--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -162,11 +162,12 @@
 		boing = FALSE
 
 /obj/effect/anomaly/grav/detonate()
-	if(drops_core)
-		var/turf/T = get_turf(src)
-		if(T && GLOB.gravity_generators["[T.z]"])
-			var/obj/machinery/gravity_generator/main/G = pick(GLOB.gravity_generators["[T.z]"])
-			G.set_broken() //Requires engineering to fix the gravity generator, as it gets overloaded by the anomaly.
+	if(!drops_core)
+		return
+	var/turf/T = get_turf(src)
+	if(T && GLOB.gravity_generators["[T.z]"])
+		var/obj/machinery/gravity_generator/main/G = pick(GLOB.gravity_generators["[T.z]"])
+		G.set_broken() //Requires engineering to fix the gravity generator, as it gets overloaded by the anomaly.
 
 /////////////////////
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Gravitational anomalies no longer throw items at people inside them as much, meaning they will be more deadly when someone is dead in the middle of it.
Gravitational anomalies from events will short out the gravity generator if not defused, meaning engineering will have to repair it. Fun for the whole family!

Flux anomalies (not from supermatter / vetus) are MUCH deadlier. You will require insulated gloves to defuse this safely. If you have a flux anomaly and you do not have gloves, my advice is to get out of there. It *will* kill you if you don't get away from it.

Bluespace anomalies will now teleport unanchored structures / machines, rather than just items passively, and increases the range of selecting things to teleport by one tile.

Pyro anomalies produced a near meaningless ammount of plasma every 10 seconds. It now produces 4x more plasma each cycle every 8 seconds. As such, it will be slightly more dangerous to be around, but most crew will still be able to defuse it.

Vortex... Well it will break turfs more often, and trip people, stunning them occassionally if event spawned, but due to how it works (look at the grav proc, it's special), you'll probably still be able to disarm it unless you are a slime person

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Anomalies should be dangerous. You shouldn't be standing gawking at them while barely being affected.

Gravity was nice and deadly, but a person dying in it kinda defused it's throw mechanic. The for loop over locate should help. As well, if not defused, it forces gravity off for a bit, meaning the station will have to deal with no pain slowdown for a bit and loss of control, for better or worse.

Flux anomalies only were a danger if you touched them. the zap did a pathetic amount of damage. Now, one should have insulated gloves (and a hardsuit / modsuit that is shock proof) to deal with them. Engi borgs probably still defuse it easily.

Bluespace naturally isn't deadly, but this should make it re-organise a room more, and *slightly* harder to defuse. Really have to run for it if you want to not get teleported away when trying to defuse.

Pyro kinda, lit people on fire, but unless it exploded, the heat / fire didn't do much damage. Increasing the volume / how often the plasma spurts should increase the danger.

Vortex isn't deadly unless you are a slime. It still isn't that deadly, but with RNG feeling mean it might be cruel to someone, and it will break apart an area better, forcing engineering to do some repairs, which is good.

## Testing
<!-- How did you test the PR, if at all? -->
Spawned the anomaly types, watch their effects, have them kill skrells / spew plasma / break gravity.

## Changelog
:cl:
tweak: All anomalies are deadlier. Flux anomalies are much stronger, grav anomalies defuse gravity, pyro anomalies are hotter, and vortex might pull your feet out from under you.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
