### PR TITLE
Objects on the same tile as a megaphone user can now hear them

### DIFF
--- a/code/game/objects/items/devices/megaphone.dm
+++ b/code/game/objects/items/devices/megaphone.dm
@@ -82,7 +82,7 @@
 
 	audible_message("<span class='game say'><span class='name'>[user.GetVoice()]</span> [user.GetAltName()] broadcasts, <span class='[span]'>\"[message]\"</span></span>", hearing_distance = 14)
 	log_say(message, user)
-	for(var/obj/O in oview(14, get_turf(src)))
+	for(var/obj/O in view(14, get_turf(src)))
 		O.hear_talk(user, message_to_multilingual("<span class='[span]'>[message]</span>"))
 
 	for(var/mob/M in get_mobs_in_view(7, src))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->Objects on the same tile as a megaphone user can now hear them. This means if you use a megaphone and you're recording yourself with a tape recorder, or using an intercom it can hear you now on the same tile.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Fixes two bugs in one

## Testing
<!-- How did you test the PR, if at all? -->
Megaphone worked in both cases

## Changelog
:cl:
fix: Megaphones now work properly with intercoms or tape recorders on the same time as the megaphone
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
