### PR TITLE
Fixes labeling disks when using DNA Modifier 

### DIFF
--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -783,7 +783,7 @@
 						return
 					var/datum/dna2/record/buf = buffers[bufferId]
 					disk.buf = buf.copy()
-					disk.name = "data disk - '[buf.dna.real_name]'"
+					disk.name = "data disk - '[buf.name]'"
 		if("wipeDisk")
 			if(isnull(disk) || disk.read_only)
 				return


### PR DESCRIPTION
## What Does This PR Do
This fixes the labels on disks that are copied from the DNA modifying console. 

## Why It's Good For The Game
Makes sure that disks are labeled properly as intended.

## Images of changes
### Before
![WffRWWEsKx](https://github.com/ParadiseSS13/Paradise/assets/116982774/e2437e54-f26b-4908-ab2e-d6596daa61e6)

### After
![YDbU9Osvgw](https://github.com/ParadiseSS13/Paradise/assets/116982774/4032f11f-e958-4029-99a3-41dfe5847fa5)

## Testing
Copied SE of subject and labeled a disk.
Exported disk and examined the label.

## Changelog
:cl: Burza and Contrabang
fix: Fixed disk labeling
/:cl:
