### PR TITLE
Clicking on RCD carts with an RCD loads it.

### DIFF
--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -162,27 +162,28 @@
 	if(user.incapacitated() || !user.Adjacent(src))
 		return FALSE
 	return TRUE
-
-/obj/item/rcd/attackby(obj/item/W, mob/user, params)
-	if(!istype(W, /obj/item/rcd_ammo))
-		return ..()
-
-	var/obj/item/rcd_ammo/R = W
-	if((matter + R.ammoamt) > max_matter)
+/**
+*Tries to load ammo into an RCD, borgs will not use this.
+* Arguments:
+* * cart - the compressed matter catridge to insert
+* * user - the user to display the chat messages to
+*/
+/obj/item/rcd/proc/load(obj/item/rcd_ammo/cart, mob/living/user)
+	if(matter == max_matter)
 		to_chat(user, "<span class='notice'>The RCD can't hold any more matter-units.</span>")
-		return
-
-	if(!user.unEquip(R))
-		to_chat(user, "<span class='warning'>[R] is stuck to your hand!</span>")
-		return
-
-	matter += R.ammoamt
-	qdel(R)
+		return FALSE
+	matter = clamp((matter + cart.ammoamt), 0, 100)
+	qdel(cart)
 	playsound(loc, 'sound/machines/click.ogg', 50, 1)
 	to_chat(user, "<span class='notice'>The RCD now holds [matter]/[max_matter] matter-units.</span>")
 	update_icon(UPDATE_OVERLAYS)
 	SStgui.update_uis(src)
 
+/obj/item/rcd/attackby(obj/item/W, mob/user, params)
+	if(!istype(W, /obj/item/rcd_ammo))
+		return ..()
+	var/obj/item/rcd_ammo/R = W
+	load(R, user)
 /**
  * Creates and displays a radial menu to a user when they trigger the `attack_self` of the RCD.
  *
@@ -689,6 +690,12 @@
 	origin_tech = "materials=3"
 	materials = list(MAT_METAL=16000, MAT_GLASS=8000)
 	var/ammoamt = 20
+
+/obj/item/rcd_ammo/attackby(obj/item/I, mob/user)
+	if(!istype(I, /obj/item/rcd) || issilicon(user))
+		return ..()
+	var/obj/item/rcd/R = I
+	R.load(src, user)
 
 /obj/item/rcd_ammo/large
 	ammoamt = 100


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
This PR allows players to click on the compressed matter cart with an RCD, instead of needing to pick up each individual cart and add it to the RCD. Also changes logic to allow players to reload an RCD when the extra ammo would go over the maximum capacity.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Loading RCDs is tedious, and this has annoyed me ever since I found out you can install pKA mods by clicking on them.

## Testing
<!-- How did you test the PR, if at all? -->
Loaded and used an RCD a lot, made sure borgs couldn't also reload their RCDs.
## Changelog
:cl:
tweak: RCDs can be reloaded by clicking on a cartridge with it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
