### PR TITLE
Adds Supply Medal

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/cargo_lockers.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/cargo_lockers.dm
@@ -25,3 +25,4 @@
 	new /obj/item/door_remote/quartermaster(src)
 	new /obj/item/organ/internal/eyes/cybernetic/meson(src)
 	new /obj/item/storage/bag/garment/quartermaster(src)
+	new /obj/item/clothing/accessory/medal/supply(src)

--- a/code/modules/clothing/under/accessories/accessory.dm
+++ b/code/modules/clothing/under/accessories/accessory.dm
@@ -264,8 +264,8 @@
 	desc = "An award issued by the Magistrate to legal staff who uphold the rule of law."
 
 /obj/item/clothing/accessory/medal/supply
-	name = "speedy supply medal"
-	desc = "An award issued by the Quartermaster to supply staff with dedication to fast deliveries."
+	name = "stable supply medal"
+	desc = "An award issued by the Quartermaster to supply staff dedicated to being effective."
 
 /obj/item/clothing/accessory/medal/heart
 	name = "bronze heart medal"

--- a/code/modules/clothing/under/accessories/accessory.dm
+++ b/code/modules/clothing/under/accessories/accessory.dm
@@ -264,8 +264,8 @@
 	desc = "An award issued by the Magistrate to legal staff who uphold the rule of law."
 
 /obj/item/clothing/accessory/medal/supply
-	name = "efficient supply medal"
-	desc = "An award issued by the Quartermaster to supply staff who make sure everything is running smoothly."
+	name = "speedy supply medal"
+	desc = "An award issued by the Quartermaster to supply staff with dedication to fast deliveries."
 
 /obj/item/clothing/accessory/medal/heart
 	name = "bronze heart medal"

--- a/code/modules/clothing/under/accessories/accessory.dm
+++ b/code/modules/clothing/under/accessories/accessory.dm
@@ -263,6 +263,10 @@
 	name = "meritous legal medal"
 	desc = "An award issued by the Magistrate to legal staff who uphold the rule of law."
 
+/obj/item/clothing/accessory/medal/supply
+	name = "efficient supply medal"
+	desc = "An award issued by the Quartermaster to supply staff who make sure everything is running smoothly."
+
 /obj/item/clothing/accessory/medal/heart
 	name = "bronze heart medal"
 	desc = "A rarely-awarded medal for those who sacrifice themselves in the line of duty to save their fellow crew."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds a "stable supply medal" to Quartermaster's locker.

Name and description are possibly subject to change.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Itt's odd Quartermaster never had one! While not being a head, he still is in charge of a (sub)department. And while yes, supply _technically_ is part of service, HoP is not around there nearly enough to have opinions strong enough to give out any medals. 
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![obraz](https://github.com/ParadiseSS13/Paradise/assets/108196626/09a082fb-e1a0-44d5-8576-d659644b15a6)
![obraz](https://github.com/ParadiseSS13/Paradise/assets/108196626/908b6da0-498a-43a1-8bf0-4eabf2f7bc97)
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Spawned in as QM, opened my locker, played around with the medal a bit, took above screenshots
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
add: QM's locker now starts with a supply medal.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
