### PR TITLE
cere: remove null req_access varedits

### DIFF
--- a/_maps/map_files/cerestation/cerestation.dmm
+++ b/_maps/map_files/cerestation/cerestation.dmm
@@ -24114,8 +24114,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/research{
 	name = "Research Division Access";
-	req_access_txt = "47";
-	req_one_access_txt = null
+	req_access_txt = "47"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,


### PR DESCRIPTION
## What Does This PR Do
Removes null varedits for `req_*_access_txt` varedits.

## Why It's Good For The Game
Map conformance. Only one of these are allowed by default, and their default value should be the string `"0"`, not null.

## Testing
Ensured map and code compilation, loaded map and verified door spawns, checked logs for unexpected errors.