### PR TITLE
box: remove null req_access varedits

### DIFF
--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -56855,8 +56855,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance{
 	name = "Engineering Maintenance";
-	req_access_txt = "10";
-	req_one_access_txt = null
+	req_access_txt = "10"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -57221,8 +57220,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering";
-	req_access_txt = "10";
-	req_one_access_txt = null
+	req_access_txt = "10"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -93077,8 +93075,7 @@
 "xPo" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Atmospherics Maintenance";
-	req_access_txt = "10";
-	req_one_access_txt = null
+	req_access_txt = "10"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/storage)
@@ -93879,8 +93876,7 @@
 "ykt" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Atmospherics Maintenance";
-	req_access_txt = "10";
-	req_one_access_txt = null
+	req_access_txt = "10"
 	},
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Engineering";


### PR DESCRIPTION
## What Does This PR Do
Removes null varedits for `req_*_access_txt` varedits.

## Why It's Good For The Game
Map conformance. Only one of these are allowed by default, and their default value should be the string `"0"`, not null.

## Testing
Ensured map and code compilation, loaded map and verified door spawns, checked logs for unexpected errors.