### PR TITLE
lavaland: remove null req_access varedits

### DIFF
--- a/_maps/map_files/generic/Lavaland.dmm
+++ b/_maps/map_files/generic/Lavaland.dmm
@@ -3282,9 +3282,7 @@
 	},
 /obj/machinery/door/airlock/external{
 	id_tag = "laborcamp_away2";
-	name = "Labor Camp Airlock";
-	req_access_txt = null;
-	req_one_access_txt = null
+	name = "Labor Camp Airlock"
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
@@ -3347,9 +3345,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/external{
 	id_tag = "laborcamp_away2";
-	name = "Labor Camp Airlock";
-	req_access_txt = null;
-	req_one_access_txt = null
+	name = "Labor Camp Airlock"
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
@@ -6191,9 +6187,7 @@
 "TU" = (
 /obj/machinery/door/airlock/external{
 	id_tag = "laborcamp_away";
-	name = "Labor Camp Airlock";
-	req_access_txt = null;
-	req_one_access_txt = null
+	name = "Labor Camp Airlock"
 	},
 /obj/structure/fans/tiny,
 /turf/simulated/floor/plating,


### PR DESCRIPTION
## What Does This PR Do
Removes null varedits for `req_*_access_txt` varedits.

## Why It's Good For The Game
Map conformance. Only one of these are allowed by default, and their default value should be the string `"0"`, not null. Note that this does not change the access of these airlocks. Despite being on gulag, these airlocks (the external facing ones and the prisoner-side shuttle entrance) did not (and presumably are not meant to) have any access restrictions.

## Testing
Ensured map and code compilation, loaded map and verified door spawns, checked logs for unexpected errors, checked access.