### PR TITLE
Reset camera upon remoteview gene deactivation (#21465)

### DIFF
--- a/code/game/dna/mutations/mutation_powers.dm
+++ b/code/game/dna/mutations/mutation_powers.dm
@@ -1028,6 +1028,13 @@
 	..()
 	block = GLOB.remoteviewblock
 
+/datum/mutation/grant_spell/remoteview/deactivate(mob/user)
+	. = ..()
+	var/mob/living/carbon/human/H
+	if(ishuman(user))
+		H = user
+		H.remoteview_target = null
+		H.reset_perspective()
 
 /obj/effect/proc_holder/spell/remoteview
 	name = "Remote View"

--- a/code/game/dna/mutations/mutation_powers.dm
+++ b/code/game/dna/mutations/mutation_powers.dm
@@ -1030,9 +1030,8 @@
 
 /datum/mutation/grant_spell/remoteview/deactivate(mob/user)
 	. = ..()
-	var/mob/living/carbon/human/H
 	if(ishuman(user))
-		H = user
+		var/mob/living/carbon/human/H = user
 		H.remoteview_target = null
 		H.reset_perspective()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #21465. 

This change adds a `mutation#deactivate` override for `mutation/grant_spell/remoteview` that nulls any active remoteview target and resets the camera view for `mob/living/carbon/human`s.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Per #21465, previously, deactivation of the remoteview gene while its effects were active (thus shifting the camera to center on another mob) would result in the camera remaining stuck on its centered mob, without any way to reset the view. With this fix, the camera view is reset upon gene deactivation of remoteview.

## Testing
### Reproducing #21465 
From commit b3880e5,
1. I loaded a local copy of the server and joined as a geneticist.
2. I gave myself two mutadone pills with `spawn mutadone`.
3. I created a subject with `spawn human/monkey`, choosing the base type.
4. I fed the subject monkey one of the mutadone pills, humanizing it.
5. I opened the admin player panel for the geneticist I was controlling and activated the remoteview gene.
6. I `aghost`ed and took control over the subject humanized monkey.
7. I opened the admin player panel for the subject humanized monkey I was controlling and activated the remoteview gene.
8. I activated remoteview, centering the camera on the geneticist.
9. I ate the mutadone, as the subject humanized monkey, and lost the remoteview spell, received the remoteview deactivation message.
10. I observed that my camera was still centered on the geneticist, confirming the bug.

### Testing fixes
From commit d9f32d in this PR, I repeated steps 1-9. Upon receiving the deactivation message, my camera was recentered on the subject humanized monkey I was controlling.

## Changelog
:cl: Ascio
fix: Reset camera upon remoteview gene deactivation
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
