### PR TITLE
The syndicate balloon now has a special suicide action

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -128,7 +128,7 @@
 	if(!user)
 		return
 
-	user.visible_message("<span class='suicide'>[user] ties [src] around their neck and starts to float away! It looks like [user.p_theyre()] trying to commit suicide!</span>")
+	user.visible_message("<span class='suicide'>[user] ties [src] around [user.p_their()] neck and starts to float away! It looks like [user.p_theyre()] trying to commit suicide!</span>")
 
 	playsound(get_turf(user),'sound/magic/fleshtostone.ogg', 80, TRUE)
 

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -130,7 +130,6 @@
 
 	user.visible_message("<span class='suicide'>[user] ties [src] around their neck and starts to float away! It looks like [user.p_theyre()] trying to commit suicide!</span>")
 
-	// playsound(get_turf(user), 'sound/magic/tail_swing.ogg', 80, TRUE)
 	playsound(get_turf(user),'sound/magic/fleshtostone.ogg', 80, TRUE)
 
 	user.Immobilize(10 SECONDS)
@@ -141,6 +140,9 @@
 
 	user.forceMove(holder_obj)
 	animate(holder_obj, pixel_z = 1000, time = 50)
+
+	for(var/obj/item/W in user)
+		user.unEquip(W)
 
 	user.notransform = TRUE
 	icon = null

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -130,7 +130,7 @@
 
 	user.visible_message("<span class='suicide'>[user] ties [src] around [user.p_their()] neck and starts to float away! It looks like [user.p_theyre()] trying to commit suicide!</span>")
 
-	playsound(get_turf(user),'sound/magic/fleshtostone.ogg', 80, TRUE)
+	playsound(get_turf(user), 'sound/magic/fleshtostone.ogg', 80, TRUE)
 
 	user.Immobilize(10 SECONDS)
 
@@ -147,8 +147,8 @@
 	user.notransform = TRUE
 	icon = null
 	invisibility = 101
-	QDEL_IN(user, 20)
-	QDEL_IN(src, 20)
+	QDEL_IN(user, 2 SECONDS)
+	QDEL_IN(src, 2 SECONDS)
 	return OBLITERATION
 
 /*

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -123,6 +123,32 @@
 	user.visible_message("<span class='notice'>[user] plays with [src].</span>", "<span class='notice'>You [playverb].</span>")
 	lastused = world.time
 
+/obj/item/toy/syndicateballoon/suicide_act(mob/living/user)
+	. = ..()
+	if(!user)
+		return
+
+	user.visible_message("<span class='suicide'>[user] ties [src] around their neck and starts to float away! It looks like [user.p_theyre()] trying to commit suicide!</span>")
+
+	// playsound(get_turf(user), 'sound/magic/tail_swing.ogg', 80, TRUE)
+	playsound(get_turf(user),'sound/magic/fleshtostone.ogg', 80, TRUE)
+
+	user.Immobilize(10 SECONDS)
+
+	// yes im stealing fulton code
+	var/obj/effect/extraction_holder/holder_obj = new(get_turf(user))
+	holder_obj.appearance = user.appearance
+
+	user.forceMove(holder_obj)
+	animate(holder_obj, pixel_z = 1000, time = 50)
+
+	user.notransform = TRUE
+	icon = null
+	invisibility = 101
+	QDEL_IN(user, 20)
+	QDEL_IN(src, 20)
+	return OBLITERATION
+
 /*
  * Fake telebeacon
  */


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->The syndicate balloon now has a special suicide act, which makes you float into the air. The sound is the same one the ash drake uses when it launches. It drops everything except balloon, and the balloon is vaporized. Balloon thieves are now 100x more dangerous.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Adds more fun to the game

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

(slightly outdated, clothes and stuff are left on the ground now). 


https://github.com/ParadiseSS13/Paradise/assets/91113370/3bb90189-98bc-49f6-9b15-9b744dc1179a

![image](https://github.com/ParadiseSS13/Paradise/assets/91113370/a1610f8d-f0e0-4f86-828f-eb3915488b14)


## Testing
<!-- How did you test the PR, if at all? -->
See above, also tested with contractor balloon

## Changelog
:cl:
add: Syndicate balloons now have a special suicide action
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
