### PR TITLE
Tweaks Psychiatrist starting Meth with less gamer drug

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/medical_lockers.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical_lockers.dm
@@ -107,8 +107,8 @@
 	new /obj/item/reagent_containers/food/pill/patch/nicotine(src)
 	new /obj/item/reagent_containers/food/pill/patch/nicotine(src)
 	new /obj/item/reagent_containers/food/pill/patch/nicotine(src)
-	new /obj/item/reagent_containers/food/pill/morphine(src)
-	new /obj/item/reagent_containers/food/pill/morphine(src)
+	new /obj/item/reagent_containers/food/pill/hydrocodone(src)
+	new /obj/item/reagent_containers/food/pill/hydrocodone(src)
 
 /obj/structure/closet/secure_closet/psychiatrist
 	name = "psychiatrist's locker"

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical_lockers.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical_lockers.dm
@@ -101,14 +101,14 @@
 	new /obj/item/reagent_containers/food/pill/haloperidol(src)
 	new /obj/item/reagent_containers/food/pill/haloperidol(src)
 	new /obj/item/reagent_containers/food/pill/haloperidol(src)
-	new /obj/item/reagent_containers/food/pill/methamphetamine(src)
-	new /obj/item/reagent_containers/food/pill/methamphetamine(src)
-	new /obj/item/reagent_containers/food/pill/methamphetamine(src)
+	new /obj/item/reagent_containers/food/pill/happy(src)
+	new /obj/item/reagent_containers/food/pill/happy(src)
+	new /obj/item/reagent_containers/food/pill/happy(src)
 	new /obj/item/reagent_containers/food/pill/patch/nicotine(src)
 	new /obj/item/reagent_containers/food/pill/patch/nicotine(src)
 	new /obj/item/reagent_containers/food/pill/patch/nicotine(src)
-	new /obj/item/reagent_containers/food/pill/hydrocodone(src)
-	new /obj/item/reagent_containers/food/pill/hydrocodone(src)
+	new /obj/item/reagent_containers/food/pill/morphine(src)
+	new /obj/item/reagent_containers/food/pill/morphine(src)
 
 /obj/structure/closet/secure_closet/psychiatrist
 	name = "psychiatrist's locker"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Changes the meth pills to happy pills (space drugs) and changes hydrocodone pills to morphine pills.

## Why It's Good For The Game
Ive already discussed this in the discord but,
Roundstart roles having very combat designed drugs like meth (and now Hydro in hindsight) at the start of the game is an easy risk free reward without putting any effort into making said drugs. Also Meth and ~~Hydro~~ are both very powerful drugs that make no sense in existing in the psych's hands. One is just abused to shit for power gaming, and the other is meth.



## Testing
yep

## Changelog
:cl: Octus
tweak: The Psych now gets happy pills instead of Meth
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
