### PR TITLE
Nerfs suitless spacewalking: Cryoxodone now stuns while healing.

### DIFF
--- a/code/__DEFINES/atmospherics_defines.dm
+++ b/code/__DEFINES/atmospherics_defines.dm
@@ -10,7 +10,7 @@
 #define R_IDEAL_GAS_EQUATION	8.31	//kPa*L/(K*mol)
 #define ONE_ATMOSPHERE			101.325	//kPa
 #define TCMB					2.7		// -270.3degC
-#define TCRYO					265		// -48.15degC
+#define TCRYO					215		// -58.15degC
 #define T0C						273.15	// 0degC
 #define T20C					293.15	// 20degC
 /// -14C - Temperature used for kitchen cold room, medical freezer, etc.

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -127,7 +127,7 @@
 		if(method == REAGENT_INGEST && M.bodytemperature < TCRYO)
 			data = "Ingested"
 			if(show_message)
-				to_chat(M, "<span class='warning'>[src] freezes solid in your mouth!</span>") //Burn damage already happens on ingesting
+				to_chat(M, "<span class='warning'>[src] freezes solid as it enters your body!</span>") //Burn damage already happens on ingesting
 	..()
 
 /datum/reagent/medicine/cryoxadone/on_mob_life(mob/living/M)

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -124,22 +124,15 @@
 
 /datum/reagent/medicine/cryoxadone/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
-
-	var/external_temp
-	if(istype(M.loc, /obj/machinery/atmospherics/unary/cryo_cell))
-		var/obj/machinery/atmospherics/unary/cryo_cell/C = M.loc
-		external_temp = C.air_contents.temperature
-	else
-		var/turf/T = get_turf(M)
-		external_temp = T.temperature
-
-	if(external_temp < TCRYO)
+	if(M.bodytemperature < TCRYO - 50) //Experiment with this, perhaps a little colder, or ensure someone has been cold for a certain ammount of cycles.
 		update_flags |= M.adjustCloneLoss(-4, FALSE)
 		update_flags |= M.adjustOxyLoss(-10, FALSE)
 		update_flags |= M.adjustToxLoss(-3, FALSE)
 		update_flags |= M.adjustBruteLoss(-12, FALSE)
 		update_flags |= M.adjustFireLoss(-12, FALSE)
-
+		M.Stun(4 SECONDS) //You freeze up, but get good healing. Stops use as a combat drug, or for meming on blobs in space.
+		if(M.stat == CONSCIOUS && prob(25)) //So people know what is going on outside cryo tubes, in the event someone weaponises this.
+			to_chat(M, "<span class='warning'>Your veins and muscles are freezing!</span>")
 		if(ishuman(M))
 			var/mob/living/carbon/human/H = M
 			var/obj/item/organ/external/head/head = H.get_organ("head")

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -122,9 +122,17 @@
 	heart_rate_decrease = 1
 	taste_description = "a safe refuge"
 
+/datum/reagent/medicine/cryoxadone/reaction_mob(mob/living/M, method=REAGENT_TOUCH, volume, show_message = 1)
+	if(iscarbon(M))
+		if(method == REAGENT_INGEST && M.bodytemperature < TCRYO)
+			data = "Ingested"
+			if(show_message)
+				to_chat(M, "<span class='warning'>[src] freezes solid in your mouth!</span>") //Burn damage already happens on ingesting
+	..()
+
 /datum/reagent/medicine/cryoxadone/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
-	if(M.bodytemperature < TCRYO)
+	if(M.bodytemperature < TCRYO && data != "Ingested")
 		update_flags |= M.adjustCloneLoss(-4, FALSE)
 		update_flags |= M.adjustOxyLoss(-10, FALSE)
 		update_flags |= M.adjustToxLoss(-3, FALSE)

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -124,7 +124,7 @@
 
 /datum/reagent/medicine/cryoxadone/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
-	if(M.bodytemperature < TCRYO - 50)
+	if(M.bodytemperature < TCRYO)
 		update_flags |= M.adjustCloneLoss(-4, FALSE)
 		update_flags |= M.adjustOxyLoss(-10, FALSE)
 		update_flags |= M.adjustToxLoss(-3, FALSE)

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -122,7 +122,7 @@
 	heart_rate_decrease = 1
 	taste_description = "a safe refuge"
 
-/datum/reagent/medicine/cryoxadone/reaction_mob(mob/living/M, method=REAGENT_TOUCH, volume, show_message = 1)
+/datum/reagent/medicine/cryoxadone/reaction_mob(mob/living/M, method = REAGENT_TOUCH, volume, show_message = TRUE)
 	if(iscarbon(M))
 		if(method == REAGENT_INGEST && M.bodytemperature < TCRYO)
 			data = "Ingested"

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -124,7 +124,7 @@
 
 /datum/reagent/medicine/cryoxadone/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
-	if(M.bodytemperature < TCRYO - 50) //Experiment with this, perhaps a little colder, or ensure someone has been cold for a certain ammount of cycles.
+	if(M.bodytemperature < TCRYO - 50)
 		update_flags |= M.adjustCloneLoss(-4, FALSE)
 		update_flags |= M.adjustOxyLoss(-10, FALSE)
 		update_flags |= M.adjustToxLoss(-3, FALSE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Cryoxadone has been tweaked. Partially reverting https://github.com/ParadiseSS13/Paradise/pull/14440

Cryoxadone now once again works off internal tempatures, though a colder tempature, making it harder to use as a combat chemical, both for rapid on the spot healing, and so someone can't keep people stunned effectively with say, syringe guns.

It also will give messages to people  that are awake and weakened by it, so it won't hit people in cryotubes, but it will to those wondering why they can not move.

And naturally, as hinted at above, cryoxadone weakens the user for 4 seconds when healing. This does not add up, it just means they get the weaken removed 4 seconds after it is removed from their system.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

I mean to be frank this is for people that just walk into space without a suit. This is mainly seen on blob, where a user will outheal blob and space damage, while they will start suffering the moment they step on a metal tile, with an AEG, KA, or a well placed charger, they are not going to ever stop fighting the blob, nor be killed.

~~This change means that one can now again use it for healing on the fly with self cooling, however they will be vulnerable during this time.~~

~~`If the potential for healing on the fly is problimatic, it can go back to checking the turf for atmos tempature, though it is a bit silly being that way.~~

Cryox no longer heals when ingested. 

## Testing
<!-- How did you test the PR, if at all? -->

consumed pills, froze, healed, the usual.

## Changelog
:cl:
tweak: Cryoxodone stuns while healing.
tweak: Cryoxodone now works off internal tempature again, vs atmos of turf tempature
tweak: Cryoxodone now activates at 50 degrees colder than before.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
