### PR TITLE
Adds 5 mannitol pills to the psychiatrist's pill bottle

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/medical_lockers.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical_lockers.dm
@@ -109,6 +109,11 @@
 	new /obj/item/reagent_containers/food/pill/patch/nicotine(src)
 	new /obj/item/reagent_containers/food/pill/hydrocodone(src)
 	new /obj/item/reagent_containers/food/pill/hydrocodone(src)
+	new /obj/item/reagent_containers/food/pill/mannitol(src)
+	new /obj/item/reagent_containers/food/pill/mannitol(src)
+	new /obj/item/reagent_containers/food/pill/mannitol(src)
+	new /obj/item/reagent_containers/food/pill/mannitol(src)
+	new /obj/item/reagent_containers/food/pill/mannitol(src)
 
 /obj/structure/closet/secure_closet/psychiatrist
 	name = "psychiatrist's locker"


### PR DESCRIPTION
## What Does This PR Do
Adds 5 mannitol pills to the psychiatrist's pill bottle.

## Why It's Good For The Game
It's kind of weird that the psychiatrist doesn't have pills to treat brain injuries.  While the psychiatrist could easily walk into medical for this at roundstart, there's no reason why they wouldn't have their own stash.  This also gives the psychiatrist more of a practical role on the station.

## Testing
Pills are in bottle.

## Changelog
:cl:
add: 5 mannitol pills to the psychiatrist's pill bottle
/:cl: