### PR TITLE
Fixes tickets not logging awho properly

### DIFF
--- a/code/controllers/subsystem/tickets/tickets.dm
+++ b/code/controllers/subsystem/tickets/tickets.dm
@@ -358,8 +358,8 @@ SUBSYSTEM_DEF(tickets)
 	ticketNum = num
 	ticketState = TICKET_OPEN
 
-	var/list/this_data = list()
 	for(var/client/C in GLOB.admins)
+		var/list/this_data = list()
 		this_data["ckey"] = C.ckey
 		this_data["rank"] = C.holder.rank
 		this_data["afk"] = C.inactivity


### PR DESCRIPTION
## What Does This PR Do
Makes the tickets table actually capture the `awho` column properly

## Why It's Good For The Game
This is good
```json
[{"ckey":"affectedarc07","rank":"Host & Maintainer","afk":26.5},{"ckey":"cornmycob","rank":"Game Admin","afk":0.5}]
```

This is bad
```json
[{"ckey":"warriorstar","rank":"Runtimes Access","afk":46},{"ckey":"warriorstar","rank":"Runtimes Access","afk":46},{"ckey":"warriorstar","rank":"Runtimes Access","afk":46},{"ckey":"warriorstar","rank":"Runtimes Access","afk":46},{"ckey":"warriorstar","rank":"Runtimes Access","afk":46},{"ckey":"warriorstar","rank":"Runtimes Access","afk":46},{"ckey":"warriorstar","rank":"Runtimes Access","afk":46}]
```

A moment of silence please for the **7 months** of scuffed data.

## Testing
Made ahelp with 2 people on test server, logged properly.

## Changelog
Nothing player facing