### PR TITLE
Adds golems to the check antagonists panel, and gives a message when their owner is an antagonist/hijacker

### DIFF
--- a/code/modules/awaymissions/mission_code/ghost_role_spawners/golems.dm
+++ b/code/modules/awaymissions/mission_code/ghost_role_spawners/golems.dm
@@ -105,6 +105,13 @@
 		but avoid actively interfering with the station, you are required to adminhelp and request permission to board the main station.</span>")
 	else
 		new_spawn.mind.store_memory("<b>Serve [owner.real_name], your creator.</b>")
+		if(owner.mind.special_role)
+			new_spawn.mind.store_memory("<b>[owner.real_name], your creator, is also an antagonist.</b>")
+			to_chat(new_spawn, "<b>[owner.real_name], your creator, is also an antagonist.</b>")
+			SSticker.mode.traitors.Add(new_spawn.mind)
+		if(locate(/datum/objective/hijack) in owner.mind.get_all_objectives())
+			new_spawn.mind.store_memory("<b>They must hijack the shuttle.</b>")
+			to_chat(new_spawn, "<b>They are also a hijacker.</b>")
 		log_game("[key_name(new_spawn)] possessed a golem shell enslaved to [key_name(owner)].")
 		log_admin("[key_name(new_spawn)] possessed a golem shell enslaved to [key_name(owner)].")
 	if(ishuman(new_spawn))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds antag made golems to the check antagonists panel.
Gives golems who's owner was an antagonist a message in the chat and in their notes.
Owners who are hijackers give an extra message.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Clarity for the golems is good, so you can easily distinguish griefing scientists and hijackers.
Also, golem spams are hell for admins, adding them to the check antagonist panel helps.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://github.com/ParadiseSS13/Paradise/assets/108773801/547253de-3799-4733-8c54-afb5bc33cb2c)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
See image
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
add: Added a message when the owner of you (a golem) is an antagonist
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
