### PR TITLE
Lets dchat-controlled mobs fire guns

### DIFF
--- a/code/modules/mob/living/carbon/human/human_mob.dm
+++ b/code/modules/mob/living/carbon/human/human_mob.dm
@@ -2185,7 +2185,7 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 	else
 		// for his neutral special, he wields a Gun
 		held_gun.afterattack(possible_target, src)
-		visible_message("<span class='danger'>[src] shoots [held_gun][isturf(possible_target) ? "" : "at [possible_target]!"]</span>")
+		visible_message("<span class='danger'>[src] fires [held_gun][isturf(possible_target) ? "" : " towards [possible_target]!"]</span>")
 
 /mob/living/carbon/human/deadchat_plays(mode = DEADCHAT_DEMOCRACY_MODE, cooldown = 7 SECONDS)
 	var/list/inputs = list(

--- a/code/modules/mob/living/carbon/human/human_mob.dm
+++ b/code/modules/mob/living/carbon/human/human_mob.dm
@@ -2180,12 +2180,13 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 	var/obj/item/gun/held_gun = get_active_hand()
 	if(!held_gun)
 		visible_message("<span class='warning'>[src] makes fingerguns towards [possible_target]!</span>")
-	else if(!istype(held_gun))
+		return
+	if(!istype(held_gun))
 		visible_message("<span class='warning'>[src] points [held_gun] towards [possible_target]!</span>")
-	else
-		// for his neutral special, he wields a Gun
-		held_gun.afterattack(possible_target, src)
-		visible_message("<span class='danger'>[src] fires [held_gun][isturf(possible_target) ? "" : " towards [possible_target]!"]</span>")
+		return
+	// for his neutral special, he wields a Gun
+	held_gun.afterattack(possible_target, src)
+	visible_message("<span class='danger'>[src] fires [held_gun][isturf(possible_target) ? "" : " towards [possible_target]!"]</span>")
 
 /mob/living/carbon/human/deadchat_plays(mode = DEADCHAT_DEMOCRACY_MODE, cooldown = 7 SECONDS)
 	var/list/inputs = list(

--- a/code/modules/mob/living/carbon/human/human_mob.dm
+++ b/code/modules/mob/living/carbon/human/human_mob.dm
@@ -2122,6 +2122,9 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 		if(in_hand.flags & NODROP)
 			visible_message("<span class='warning'>[src] attempts to drop [in_hand], but it seems to be stuck to [p_their()] hand!</span>")
 			return
+		if(in_hand.flags & ABSTRACT)
+			visible_message("<span class='notice'>[src] seems to have [p_their()] hands full!</span>")
+			return
 		visible_message("<span class='notice'>[src] drops [in_hand] and picks up [thing] instead!</span>")
 		unEquip(in_hand)
 		in_hand.forceMove(old_loc)
@@ -2131,7 +2134,7 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 
 /mob/living/carbon/human/proc/dchat_throw()
 	var/obj/item/in_hand = get_active_hand()
-	if(!in_hand)
+	if(!in_hand || in_hand.flags & ABSTRACT)
 		visible_message("<span class='notice'>[src] makes a throwing motion!</span>")
 		return
 	var/atom/possible_target

--- a/code/modules/mob/living/carbon/human/human_mob.dm
+++ b/code/modules/mob/living/carbon/human/human_mob.dm
@@ -2119,6 +2119,9 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 	var/obj/item/in_hand = get_active_hand()
 
 	if(in_hand)
+		if(in_hand.flags & NODROP)
+			visible_message("<span class='warning'>[src] attempts to drop [in_hand], but it seems to be stuck to [p_their()] hand!</span>")
+			return
 		visible_message("<span class='notice'>[src] drops [in_hand] and picks up [thing] instead!</span>")
 		unEquip(in_hand)
 		in_hand.forceMove(old_loc)
@@ -2127,7 +2130,7 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 	put_in_active_hand(thing)
 
 /mob/living/carbon/human/proc/dchat_throw()
-	var/in_hand = get_active_hand()
+	var/obj/item/in_hand = get_active_hand()
 	if(!in_hand)
 		visible_message("<span class='notice'>[src] makes a throwing motion!</span>")
 		return
@@ -2144,9 +2147,11 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 			break
 
 	if(!possible_target)
-		throw_item(cur_turf)
-	else
-		throw_item(possible_target)
+		possible_target = cur_turf
+	if(in_hand.flags & NODROP)
+		visible_message("<span class='warning'>[src] tries to throw [in_hand][isturf(possible_target) ? "" : " towards [possible_target]"], but it won't come off [p_their()] hand!</span>")
+		return
+	throw_item(possible_target)
 
 /mob/living/carbon/human/proc/dchat_shove()
 	var/turf/ahead = get_turf(get_step(src, dir))
@@ -2156,6 +2161,28 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 		return
 	dna?.species.disarm(src, H)
 
+/mob/living/carbon/human/proc/dchat_shoot()
+
+	var/atom/possible_target
+	var/cur_turf = get_turf(src)
+	for(var/i in 1 to 5)
+		cur_turf = get_step(cur_turf, dir)
+		possible_target = locate(/mob/living) in cur_turf
+		if(possible_target)
+			break
+
+	if(!possible_target)
+		possible_target = cur_turf
+
+	var/obj/item/gun/held_gun = get_active_hand()
+	if(!held_gun)
+		visible_message("<span class='warning'>[src] makes fingerguns towards [possible_target]!</span>")
+	else if(!istype(held_gun))
+		visible_message("<span class='warning'>[src] points [held_gun] towards [possible_target]!</span>")
+	else
+		// for his neutral special, he wields a Gun
+		held_gun.afterattack(possible_target, src)
+		visible_message("<span class='danger'>[src] shoots [held_gun][isturf(possible_target) ? "" : "at [possible_target]!"]</span>")
 
 /mob/living/carbon/human/deadchat_plays(mode = DEADCHAT_DEMOCRACY_MODE, cooldown = 7 SECONDS)
 	var/list/inputs = list(
@@ -2166,6 +2193,7 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 		"throw" = CALLBACK(src, PROC_REF(dchat_throw)),
 		"disarm" = CALLBACK(src, PROC_REF(dchat_shove)),
 		"resist" = CALLBACK(src, PROC_REF(dchat_resist)),
+		"shoot" = CALLBACK(src, PROC_REF(dchat_shoot)),
 	)
 
 	AddComponent(/datum/component/deadchat_control/cardinal_movement, mode, inputs, cooldown)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Allows dchat-controlled mobs to fire guns.
Also adds handling for nodrop/abstract items, so admins can equip their victims with whatever they see fit.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
I got a request for this, and it provides one more little thing for dchat-controllable mobs.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

https://github.com/ParadiseSS13/Paradise/assets/89928798/692b1894-4862-496a-acd3-8c489900fa47


<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
See video.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: A new option, "shoot", is available when deadchat controlling a human to fire a gun it might be holding.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
