### PR TITLE
You can no longer cheese open shocked doors

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -317,7 +317,7 @@ GLOBAL_LIST_EMPTY(airlock_emissive_underlays)
 	if(output)
 		return TRUE //We got shocked, end of story
 	if(issilicon(user))
-		return TRUE //Borgs don't get door shocked
+		return FALSE //Borgs don't get door shocked
 	if(ishuman(user) && isElectrified()) //We don't want people without insulated gloves able to open doors.
 		var/mob/living/carbon/human/H = user
 		if(H.gloves)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -189,7 +189,7 @@ GLOBAL_LIST_EMPTY(airlock_emissive_underlays)
 /obj/machinery/door/airlock/bumpopen(mob/living/user) //Airlocks now zap you when you 'bump' them open when they're electrified. --NeoFite
 	if(!issilicon(usr))
 		if(isElectrified())
-			if(!shockCooldown <= world.time)
+			if(shockCooldown <= world.time)
 				if(shock(user, 100))
 					return
 			else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Fixes a bug where one could open shocked doors without being immune to shocks.
Shocked doors now can shock someone twice as often, however it's unlikely this will come into play unless someone puts a belt in front of the door.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

A bug that happened when we changed electricity stuns, is that there was ways to open a shocked door without shock immunity, by performing certain inputs on a door.

Now, if you try to open a shocked door on the "don't kill people too fast cooldown" it will refuse, unless one has insulated gloves.

If a door is shocked, you should need to depower it or get gloves.

## Testing
<!-- How did you test the PR, if at all? -->

Ran into / clicked on doors fast with and without gloves.

## Changelog
:cl:
fix: Fixes being able to open doors while they are shocked without gloves.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
