### PR TITLE
stamina damage logging

### DIFF
--- a/code/datums/log_record.dm
+++ b/code/datums/log_record.dm
@@ -42,7 +42,8 @@
 	var/TX = L.getToxLoss() > 50 	? 	"<b>[L.getToxLoss()]</b>" 		: L.getToxLoss()
 	var/BU = L.getFireLoss() > 50 	? 	"<b>[L.getFireLoss()]</b>" 		: L.getFireLoss()
 	var/BR = L.getBruteLoss() > 50 	? 	"<b>[L.getBruteLoss()]</b>" 	: L.getBruteLoss()
-	return " ([L.health]: <font color='deepskyblue'>[OX]</font> - <font color='green'>[TX]</font> - <font color='#FFA500'>[BU]</font> - <font color='red'>[BR]</font>)"
+	var/ST = L.getStaminaLoss() > 50 	? 	"<b>[L.getStaminaLoss()]</b>" 	: L.getStaminaLoss()
+	return " ([L.health]: <font color='deepskyblue'>[OX]</font> - <font color='green'>[TX]</font> - <font color='#FFA500'>[BU]</font> - <font color='red'>[BR]</font> - <font color='cyan'>[ST]</font>)"
 
 /datum/log_record/proc/should_log_health(log_type)
 	if(log_type == ATTACK_LOG || log_type == DEFENSE_LOG)

--- a/code/modules/projectiles/projectile_base.dm
+++ b/code/modules/projectiles/projectile_base.dm
@@ -177,9 +177,10 @@
 			reagent_note += num2text(R.volume) + ") "
 		additional_log_text = "[additional_log_text] (containing [reagent_note])"
 
+	L.apply_effects(stun, weaken, knockdown, paralyze, irradiate, slur, stutter, eyeblur, drowsy, blocked, stamina, jitter)
+
 	if(!log_override && firer && !alwayslog)
 		add_attack_logs(firer, L, "Shot with a [type][additional_log_text]")
-	return L.apply_effects(stun, weaken, knockdown, paralyze, irradiate, slur, stutter, eyeblur, drowsy, blocked, stamina, jitter)
 
 /obj/item/projectile/proc/get_splatter_blockage(turf/step_over, atom/target, splatter_dir, target_loca) //Check whether the place we want to splatter blood is blocked (i.e. by windows).
 	var/turf/step_cardinal = !(splatter_dir in list(NORTH, SOUTH, EAST, WEST)) ? get_step(target_loca, get_cardinal_dir(target_loca, step_over)) : null

--- a/code/modules/projectiles/projectile_base.dm
+++ b/code/modules/projectiles/projectile_base.dm
@@ -177,10 +177,12 @@
 			reagent_note += num2text(R.volume) + ") "
 		additional_log_text = "[additional_log_text] (containing [reagent_note])"
 
-	L.apply_effects(stun, weaken, knockdown, paralyze, irradiate, slur, stutter, eyeblur, drowsy, blocked, stamina, jitter)
+	var/were_affects_applied = L.apply_effects(stun, weaken, knockdown, paralyze, irradiate, slur, stutter, eyeblur, drowsy, blocked, stamina, jitter)
 
 	if(!log_override && firer && !alwayslog)
 		add_attack_logs(firer, L, "Shot with a [type][additional_log_text]")
+
+	return were_affects_applied
 
 /obj/item/projectile/proc/get_splatter_blockage(turf/step_over, atom/target, splatter_dir, target_loca) //Check whether the place we want to splatter blood is blocked (i.e. by windows).
 	var/turf/step_cardinal = !(splatter_dir in list(NORTH, SOUTH, EAST, WEST)) ? get_step(target_loca, get_cardinal_dir(target_loca, step_over)) : null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Logs stamina damage in the log viewer

## Why It's Good For The Game
Stamina damage is pretty important now, good to know if someone is in stamcrit or not
## Images of changes
![image](https://github.com/ParadiseSS13/Paradise/assets/96800819/6c707313-012d-43ef-8158-94fe3c322139)

(The cyan is stamina damage)

## Testing
~~Found out that stamina damage isn't properly logged for the first strike because of sequencing in the projectile code (In practice this will only really affect the detectives revolver and beanbags, as every other weapon that deals straight damage + stamina is going to put you far into stamina crit, still gotta find a solution though)~~

ok should fully work now

Joy
## Changelog
:cl:
tweak: Stamina damage now appears in admin logs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
