### PR TITLE
Buffs 3 Umbra powers. 

### DIFF
--- a/code/modules/antagonists/vampire/vampire_powers/umbrae_powers.dm
+++ b/code/modules/antagonists/vampire/vampire_powers/umbrae_powers.dm
@@ -25,12 +25,11 @@
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		if(V.iscloaking)
-			H.physiology.burn_mod *= 1.3
+			H.physiology.burn_mod *= 1.1
 			user.RegisterSignal(user, COMSIG_LIVING_IGNITED, TYPE_PROC_REF(/mob/living, update_vampire_cloak))
 		else
 			user.UnregisterSignal(user, COMSIG_LIVING_IGNITED)
-			H.physiology.burn_mod /= 1.3
-
+			H.physiology.burn_mod /= 1.1
 	update_name()
 	to_chat(user, "<span class='notice'>You will now be [V.iscloaking ? "hidden" : "seen"] in darkness.</span>")
 
@@ -117,8 +116,8 @@
 
 /obj/effect/proc_holder/spell/vampire/soul_anchor
 	name = "Soul Anchor (30)"
-	desc = "You summon a dimenional anchor after a delay, casting again will teleport you back to the anchor. You are forced back after 2 minutes if you have not cast again."
-	gain_desc = "You have gained the ability to save a point in space and teleport back to it at will. Unless you willingly teleport back to that point within 2 minutes, you are forced back."
+	desc = "You summon a dimenional anchor after a delay, casting again will teleport you back to the anchor. You will fake a recall after 2 minutes."
+	gain_desc = "You have gained the ability to save a point in space and teleport back to it at will. Unless you willingly teleport back to that point within 2 minutes, you will fake a recall."
 	required_blood = 30
 	centcom_cancast = FALSE
 	base_cooldown = 3 MINUTES
@@ -128,7 +127,7 @@
 	var/obj/structure/shadow_anchor/anchor
 	/// Are we making an anchor?
 	var/making_anchor = FALSE
-	/// Holds a reference to the timer until the caster is forced to recall
+	/// Holds a reference to the timer until the caster fake recalls
 	var/timer
 
 /obj/effect/proc_holder/spell/vampire/soul_anchor/create_new_targeting()
@@ -142,7 +141,7 @@
 	if(!making_anchor && !anchor) // first cast, setup the anchor
 		var/turf/anchor_turf = get_turf(user)
 		making_anchor = TRUE
-		if(do_mob(user, user, 10 SECONDS, only_use_extra_checks = TRUE)) // no checks, cant fail
+		if(do_mob(user, user, 5 SECONDS, only_use_extra_checks = TRUE)) // no checks, cant fail
 			make_anchor(user, anchor_turf)
 			making_anchor = FALSE
 			return
@@ -153,10 +152,10 @@
 
 /obj/effect/proc_holder/spell/vampire/soul_anchor/proc/make_anchor(mob/user, turf/anchor_turf)
 	anchor = new(anchor_turf)
-	timer = addtimer(CALLBACK(src, PROC_REF(recall), user), 2 MINUTES, TIMER_STOPPABLE)
+	timer = addtimer(CALLBACK(src, PROC_REF(recall), user, TRUE), 2 MINUTES, TIMER_STOPPABLE)
 	should_recharge_after_cast = TRUE
 
-/obj/effect/proc_holder/spell/vampire/soul_anchor/proc/recall(mob/user)
+/obj/effect/proc_holder/spell/vampire/soul_anchor/proc/recall(mob/user, fake = FALSE)
 	if(timer)
 		deltimer(timer)
 		timer = null
@@ -168,7 +167,16 @@
 	if(!is_teleport_allowed(end_turf.z))
 		return
 
-	user.forceMove(end_turf)
+	if(fake)
+		var/mob/living/simple_animal/hostile/illusion/escape/E = new(end_turf)
+		E.Copy_Parent(user, 10 SECONDS)
+		for(var/mob/living/L in view(7, E)) //We want it to start running
+			E.GiveTarget(L)
+			break
+		user.make_invisible()
+		addtimer(CALLBACK(user, TYPE_PROC_REF(/mob/living, reset_visibility)), 4 SECONDS)
+	else
+		user.forceMove(end_turf)
 
 	if(end_turf.z == start_turf.z)
 		shadow_to_animation(start_turf, end_turf, user)
@@ -273,43 +281,46 @@
 
 /obj/effect/proc_holder/spell/vampire/self/eternal_darkness
 	name = "Eternal Darkness"
-	desc = "When toggled, you shroud the area around you in darkness and slowly lower the body temperature of people nearby."
+	desc = "When toggled, you shroud the area around you in darkness and slowly lower the body temperature of people nearby. Energy projectiles will dim in its radius."
 	gain_desc = "You have gained the ability to shroud the area around you in darkness, only the strongest of lights can pierce your unholy powers."
 	base_cooldown = 10 SECONDS
 	action_icon_state = "eternal_darkness"
 	required_blood = 5
-	var/shroud_power = -4
+	var/shroud_power = -6
 
 /obj/effect/proc_holder/spell/vampire/self/eternal_darkness/cast(list/targets, mob/user)
 	var/datum/antagonist/vampire/V = user.mind.has_antag_datum(/datum/antagonist/vampire)
 	var/mob/target = targets[1]
 	if(!V.get_ability(/datum/vampire_passive/eternal_darkness))
 		V.force_add_ability(/datum/vampire_passive/eternal_darkness)
-		target.set_light(6, shroud_power, "#AAD84B")
+		target.set_light(8, shroud_power, "#ddd6cf")
 	else
 		for(var/datum/vampire_passive/eternal_darkness/E in V.powers)
 			V.remove_ability(E)
 
 /datum/vampire_passive/eternal_darkness
-	gain_desc = "You surround yourself in a unnatural darkness, freezing those around you."
+	gain_desc = "You surround yourself in a unnatural darkness, freezing those around you and dimming energy projectiles."
 
 /datum/vampire_passive/eternal_darkness/New()
 	..()
-	START_PROCESSING(SSobj, src)
+	START_PROCESSING(SSfastprocess, src)
 
 /datum/vampire_passive/eternal_darkness/Destroy(force, ...)
 	owner.remove_light()
-	STOP_PROCESSING(SSobj, src)
+	STOP_PROCESSING(SSfastprocess, src)
 	return ..()
 
 /datum/vampire_passive/eternal_darkness/process()
 	var/datum/antagonist/vampire/V = owner.mind.has_antag_datum(/datum/antagonist/vampire)
 
-	for(var/mob/living/L in view(6, owner))
+	for(var/mob/living/L in view(8, owner))
 		if(L.affects_vampire(owner))
-			L.adjust_bodytemperature(-20 * TEMPERATURE_DAMAGE_COEFFICIENT)
+			L.adjust_bodytemperature(-3 * TEMPERATURE_DAMAGE_COEFFICIENT) //The dark is cold and unforgiving. Equivelnt to -60 with previous values.
+	for(var/obj/item/projectile/P in view(8, owner))
+		if(P.flag == ENERGY || P.flag == LASER)
+			P.damage *= 0.7
 
-	V.bloodusable = max(V.bloodusable - 5, 0)
+	V.bloodusable = max(V.bloodusable - 0.25, 0) //2.5 per second, 5 per 2, same as before
 
 	if(!V.bloodusable || owner.stat == DEAD)
 		V.remove_ability(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Umbrae's burn mode is reduced to 1.1 when cloaking. Burn wounds / IK are common, along with immolators generally means they don't need this mod to be as strong.

Shadow anchor fake recalls after 2 minutes, making the user invisible for 4 seconds, and makes an illusion for 10 seconds at the anchor. Allows for fake outs / makes this not insanely risky to use without being full power.

If / when modsuits are merged, I'll add middle click functionality to this ability and shadow step, to fake do the shadow step or anchor, for mind games.

Eternal darkness has been buffed greatly, to synergise with shadow boxing a little better, and feel a bit more worthy of being a final ability (see BBR) without being a press to win button.

The darkness is stronger, and has 2 tiles more range. The colour of the darkness is actual shadow, vs purple, making it better for stealth.

The ability will chill people faster. However, it *still* is very slow to kill, and thermo regulator modules for modsuits is how I expect security to deal with this.

Finally, the trade off / actual strength of the ability: Laser / energy projectiles will be weakened passing through the shadowy area. This means bullets may be needed instead of laser spam, but also gives the vampire a downside when active that them using lasers will not be as effective.

This forces security to either get close into the cloud of darkness, where their projectiles will deal near full damage, or switch to bullets over immolator spam (immolators still light on fire breaking cloaking) . Of course, going into the cloud allows an umbra to use shadow boxing effectively.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Umbruh could use some love. Burn wounds with the extra laser damage and IKS is very nasty, and could use a tone down for them, so burn mod is lowered to 1.1

Hal will shoot me for this, but everyone I talk to says the same thing. Shadow anchor is suicidal without full power. Security finds it, camps it, and you die. Just "hiding it well" doesn't work, as an ability should not be based off of "just hope sec doesn't find it"

I would love to lean more into mindgames, making middle click fake the recall instantly, or making middle click on shadow step do a similar thing, however without modsuit middle click stuff being in, not an option. Perhaps a future PR.

Finally, eternal darkness. It is, an ability. It needs love. Final abilities like that should be strong, but not an I win button.

First we made it darker / actual darkness colour. This means it won't be as visible (see purple shadows vs actual darkness) as well as expanding the range. Unfortunately simple NV upgrades beat this still, but that is where the other changes come in.

It chills people faster, however one quickly warms up outside its radius, and security modsuits with thermal regulators will combat it well, I suspect.

The final change, as was detailed above, is the trade off / strenth of weakening lasers / disablers / decloners / ebows, ect, in the range of the shadows. Very useful, however forces the umbra to use other weapons or lose effectiveness when on, and has security to either have to get close to an umbra, where shadow boxing can be used, or get bullets which the vampire has no protection from.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

I should get an image, for the mean time, just think shadow cocoon darkness vs shadow shroom darkness.

## Testing
<!-- How did you test the PR, if at all? -->

I became the night, health scanned a lot, tested lasers, faked out some stuff.

## Changelog
:cl:
tweak: Umbrae cloaked vampires take 10% more burn rather than 30% cloaked.
tweak: Umbrae shadow anchor does a fake recall after 2 minutes, rather than a real one.
tweak: Umbrae eternal darkness is colder, darker, and will dim the power of energy and laser projectiles.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
