### PR TITLE
Fix typo with voice analyzer

### DIFF
--- a/code/modules/assembly/voice.dm
+++ b/code/modules/assembly/voice.dm
@@ -15,7 +15,7 @@
 	if(recorded || listening)
 		. += "A meter on it flickers with every nearby sound."
 	else
-		. += "It is is deactivated."
+		. += "It is deactivated."
 
 /obj/item/assembly/voice/hear_talk(mob/living/M as mob, list/message_pieces)
 	hear_input(M, multilingual_to_message(message_pieces), 0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Removes an extra "is" from the voice analyzer's description.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
It's it's good to not have double words.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
I think this is a fair case of "it compiles"
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
spellcheck: Removes a spurious "is" from the voice analyzer description
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
