### PR TITLE
Fixes inaccuracy in changeling chemical storage UI element.

### DIFF
--- a/code/modules/antagonists/changeling/changeling_power.dm
+++ b/code/modules/antagonists/changeling/changeling_power.dm
@@ -69,6 +69,7 @@
 
 /datum/action/changeling/proc/take_chemical_cost()
 	cling.chem_charges -= chemical_cost
+	cling.update_chem_charges_ui()
 
 /datum/action/changeling/proc/can_sting(mob/user, mob/target)
 	SHOULD_CALL_PARENT(TRUE)

--- a/code/modules/antagonists/changeling/datum_changeling.dm
+++ b/code/modules/antagonists/changeling/datum_changeling.dm
@@ -191,7 +191,7 @@
 		genetic_damage = max(0, genetic_damage - 1)
 	update_chem_charges_ui(H)
 
-/datum/antagonist/changeling/proc/update_chem_charges_ui(var/mob/living/carbon/human/H = owner.current)
+/datum/antagonist/changeling/proc/update_chem_charges_ui(mob/living/carbon/human/H = owner.current)
 	if(H.hud_used?.lingchemdisplay)
 		H.hud_used.lingchemdisplay.invisibility = 0
 		H.hud_used.lingchemdisplay.maptext = "<div align='center' valign='middle' style='position:relative; top:0px; left:6px'><font face='Small Fonts' color='#dd66dd'>[round(chem_charges)]</font></div>"

--- a/code/modules/antagonists/changeling/datum_changeling.dm
+++ b/code/modules/antagonists/changeling/datum_changeling.dm
@@ -183,15 +183,18 @@
 	if(!owner || !owner.current)
 		return PROCESS_KILL
 	var/mob/living/carbon/human/H = owner.current
-	if(H.hud_used?.lingchemdisplay)
-		H.hud_used.lingchemdisplay.invisibility = 0
-		H.hud_used.lingchemdisplay.maptext = "<div align='center' valign='middle' style='position:relative; top:0px; left:6px'><font face='Small Fonts' color='#dd66dd'>[round(chem_charges)]</font></div>"
 	if(H.stat == DEAD)
 		chem_charges = clamp(0, chem_charges + chem_recharge_rate - chem_recharge_slowdown, chem_storage * 0.5)
 		genetic_damage = directional_bounded_sum(genetic_damage, -1, LING_DEAD_GENETIC_DAMAGE_HEAL_CAP, 0)
 	else // Not dead? no chem/genetic_damage caps.
 		chem_charges = clamp(0, chem_charges + chem_recharge_rate - chem_recharge_slowdown, chem_storage)
 		genetic_damage = max(0, genetic_damage - 1)
+	update_chem_charges_ui(H)
+
+/datum/antagonist/changeling/proc/update_chem_charges_ui(var/mob/living/carbon/human/H = owner.current)
+	if(H.hud_used?.lingchemdisplay)
+		H.hud_used.lingchemdisplay.invisibility = 0
+		H.hud_used.lingchemdisplay.maptext = "<div align='center' valign='middle' style='position:relative; top:0px; left:6px'><font face='Small Fonts' color='#dd66dd'>[round(chem_charges)]</font></div>"
 
 /**
  * Respec the changeling's powers after first checking if they're able to respec.


### PR DESCRIPTION
## What Does This PR Do
Currently the changeling UI element for chemical storage updates before they generate chemicals causing it to be one step outside of what it should be (this can be easily observed by comparing it with the status panel, which does not suffer from this error).  This PR fixes this issue and also makes it so the UI element updates whenever a power takes it's cost, making it immediately accurate.

## Why It's Good For The Game
More accurate UI

## Testing
Grew and ungrew lots of armblades and used my eyeballs.

## Changelog
:cl:
tweak: Changeling storage now immediately updates when powers take chemicals
fix: Issue where the changeling chemical storage UI element would display incorrectly
/:cl: