### PR TITLE
Adds some missing checks for suicides on revivals, prevents clings from suiciding

### DIFF
--- a/code/datums/components/defibrillator.dm
+++ b/code/datums/components/defibrillator.dm
@@ -284,7 +284,7 @@
 		else
 			user.visible_message("<span class='boldnotice'>[defib_ref] buzzes: Resuscitation failed - Patient's brain is unresponsive. Further attempts may succeed.</span>")
 		defib_success = FALSE
-	else if((signal_result & COMPONENT_BLOCK_DEFIB) || HAS_TRAIT(target, TRAIT_FAKEDEATH) || HAS_TRAIT(target, TRAIT_BADDNA))  // these are a bit more arbitrary
+	else if((signal_result & COMPONENT_BLOCK_DEFIB) || HAS_TRAIT(target, TRAIT_FAKEDEATH) || HAS_TRAIT(target, TRAIT_BADDNA) || target.suiciding)  // these are a bit more arbitrary
 		user.visible_message("<span class='boldnotice'>[defib_ref] buzzes: Resuscitation failed.</span>")
 		defib_success = FALSE
 

--- a/code/datums/components/defibrillator.dm
+++ b/code/datums/components/defibrillator.dm
@@ -279,7 +279,7 @@
 		user.visible_message("<span class='boldnotice'>[defib_ref] buzzes: Resuscitation failed - No brain detected within patient.</span>")
 		defib_success = FALSE
 	else if(ghost)
-		if(!ghost.can_reenter_corpse) // DNR or AntagHUD
+		if(!ghost.can_reenter_corpse || target.suiciding) // DNR or AntagHUD
 			user.visible_message("<span class='boldnotice'>[defib_ref] buzzes: Resuscitation failed - No electrical brain activity detected.</span>")
 		else
 			user.visible_message("<span class='boldnotice'>[defib_ref] buzzes: Resuscitation failed - Patient's brain is unresponsive. Further attempts may succeed.</span>")

--- a/code/game/machinery/computer/aifixer.dm
+++ b/code/game/machinery/computer/aifixer.dm
@@ -61,6 +61,9 @@
 		return
 	switch(action)
 		if("fix")
+			if(occupant.suiciding)
+				to_chat(usr, "<span class='warning'>Memory corruption detected in recovery partition, likely due to a sudden self-induced shutdown. AI is unrecoverable.</span>")
+				return
 			if(active) // Prevent from starting a fix while fixing.
 				to_chat(usr, "<span class='warning'>You are already fixing this AI!</span>")
 				return

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -66,7 +66,7 @@
 
 	var/mob/dead/observer/G = M.get_ghost()
 
-	if(M.mind && !M.mind.suicided)
+	if(M.mind && !M.mind.suicided && !M.suiciding)
 		if(M.client)
 			status = REVIVABLE
 			return

--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -21,6 +21,11 @@
 
 	var/confirm = null
 	if(!forced)
+		if(ischangeling(src))
+			// the alternative is to allow clings to commit suicide, but then you'd probably have them
+			// killing themselves as soon as they're in cuffs
+			to_chat(src, "<span class='warning'>We refuse to take the coward's way out.</span>")
+			return
 		confirm = alert("Are you sure you want to commit suicide?", "Confirm Suicide", "Yes", "No")
 
 	if(stat == DEAD || suiciding) //We check again, because alerts sleep until a choice is made

--- a/code/modules/mob/living/carbon/brain/brain_update_status.dm
+++ b/code/modules/mob/living/carbon/brain/brain_update_status.dm
@@ -3,7 +3,7 @@
 		return
 		// if(health <= min_health)
 	if(stat == DEAD)
-		if(container && health > HEALTH_THRESHOLD_DEAD)
+		if(container && health > HEALTH_THRESHOLD_DEAD && !suiciding)
 			update_revive()
 			create_debug_log("revived, trigger reason: [reason]")
 			return

--- a/code/modules/mob/living/carbon/human/human_update_status.dm
+++ b/code/modules/mob/living/carbon/human/human_update_status.dm
@@ -6,7 +6,7 @@
 		if(dna.species && dna.species.can_revive_by_healing)
 			var/obj/item/organ/internal/brain/B = get_int_organ(/obj/item/organ/internal/brain)
 			if(B)
-				if((health >= (HEALTH_THRESHOLD_DEAD + HEALTH_THRESHOLD_CRIT) * 0.5) && getBrainLoss() < 120)
+				if((health >= (HEALTH_THRESHOLD_DEAD + HEALTH_THRESHOLD_CRIT) * 0.5) && getBrainLoss() < 120 && !suiciding)
 					update_revive()
 					create_debug_log("revived from healing, trigger reason: [reason]")
 

--- a/code/modules/mob/living/silicon/robot/robot_update_status.dm
+++ b/code/modules/mob/living/silicon/robot/robot_update_status.dm
@@ -23,7 +23,7 @@
 				WakeUp()
 				create_debug_log("woke up, trigger reason: [reason]")
 	else
-		if(health > 0)
+		if(health > 0 && !suiciding)
 			update_revive()
 			var/mob/dead/observer/ghost = get_ghost()
 			if(ghost)

--- a/code/modules/mob/living/stat_states.dm
+++ b/code/modules/mob/living/stat_states.dm
@@ -57,6 +57,9 @@
 	set_stat(UNCONSCIOUS) // this is done as `WakeUp` early returns if they are `stat = DEAD`
 	WakeUp()
 
+	if(suiciding)
+		message_admins("[key_name(src)] was revived after having committed suicide. This is likely a bug.")
+
 	GLOB.dead_mob_list -= src
 	GLOB.alive_mob_list |= src
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds some missing checks on some revivals to prevent the revival of people (silicons included) who have used the IC/OOC "I'm done playing my character" button, but didn't choose to ghost and leave their live body behind.
Also adds a check to entirely prevent changelings from committing suicide. With their weird sort of existence in and out of death (as well as the weird sort of IC thing that suiciding is), it feels like giving them the unique ability among antagonists to commit suicide without catching a jobban is a little strange, and would probably have security ahelping about them every time. Easier to just put a hard stop there.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Suicide, as stated before, is by design a mechanic that is supposed to remove you, the player, from re-entering the game as your character permanently. While it's a bit flashier than just ghosting, it's still supposed to provide the same result.
Also, changelings. Since they can revive themselves, being able to commit suicide in cuffs because they got caught and still be able to revive afterwards with no consequences (while security ahelps because antags aren't generally supposed to be doing that) may be a little iffy, and invite a new meta of doing exactly that.
Also if seccies try to clingtest by telling people to low tier god themselves I'm guessing they will also catch a very quick jobban.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Tried to revive folks who had killed themselves in a few different ways, found myself unable to.
This included (the most key ones):z
- suiciding as an AI and trying to be revived in the integrity restorer
- trying to revive someone who suicided by way of
  - defib
  - IPC surgery 
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Changelings now cannot commit suicide.
fix: Some methods of revival now properly check if the user has committed suicide.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
