### PR TITLE
Fixes janidrobe charging for essential equipment

### DIFF
--- a/code/game/machinery/vendors/wardrobe_vendors.dm
+++ b/code/game/machinery/vendors/wardrobe_vendors.dm
@@ -602,9 +602,7 @@
 					/obj/item/clothing/shoes/galoshes = 3,
 					/obj/item/storage/belt/janitor = 3)
 	contraband = list(/obj/item/toy/figure/crew/janitor = 1)
-	prices = list(/obj/item/clothing/under/rank/civilian/janitor = 50,
-					/obj/item/clothing/head/soft/purple = 20,
-					/obj/item/clothing/gloves/color/black = 20)
+	prices = list(/obj/item/clothing/under/rank/civilian/janitor = 50)
 	refill_canister = /obj/item/vending_refill/janidrobe
 
 /obj/machinery/economy/vending/lawdrobe

--- a/code/game/machinery/vendors/wardrobe_vendors.dm
+++ b/code/game/machinery/vendors/wardrobe_vendors.dm
@@ -604,9 +604,7 @@
 	contraband = list(/obj/item/toy/figure/crew/janitor = 1)
 	prices = list(/obj/item/clothing/under/rank/civilian/janitor = 50,
 					/obj/item/clothing/head/soft/purple = 20,
-					/obj/item/clothing/gloves/color/black = 20,
-					/obj/item/clothing/shoes/galoshes = 20,
-					/obj/item/storage/belt/janitor = 75)
+					/obj/item/clothing/gloves/color/black = 20)
 	refill_canister = /obj/item/vending_refill/janidrobe
 
 /obj/machinery/economy/vending/lawdrobe


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Removes the price for galoshes, belts, gloves, and hats in the janidrobe.
Fixes https://github.com/ParadiseSS13/Paradise/issues/21587
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
The Janidrobe was added with the intent of charging for extra spares for an item.
However the free roundstart items were removed in a follow-up PR as the locker was refusing to close due to too many items. This PR makes the essential items free in the janidrobe.
New uniforms still cost as expected.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Looked at vendor prices
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Fixed janitors having to pay for galoshes, belts, gloves, and hats
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
