### PR TITLE
Merge the mediborg gripper into the hugging module

### DIFF
--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -38,7 +38,7 @@
 /obj/item/borg/cyborghug
 	name = "hugging module"
 	icon_state = "hugmodule"
-	desc = "For when a someone really needs a hug."
+	desc = "For when someone really needs a hug, or helping people to stand up."
 	var/mode = CYBORG_HUGS //0 = Hugs 1 = "Hug" 2 = Shock 3 = CRUSH
 	var/ccooldown = 0
 	var/scooldown = 0
@@ -71,32 +71,24 @@
 		return
 	switch(mode)
 		if(CYBORG_HUGS)
-			if(M.health >= 0)
+			if(ishuman(M))
+				var mob/living/carbon/human/H = M
+				if(H.on_fire)
+					user.pat_out(H)
+				else
+					H.help_shake_act(user)
+			else if(M.health >= 0)
 				if(isanimal(M) && !M.holder_type) // checks if holder_type exists to prevent picking up animals like mice
 					var/list/modifiers = params2list(params)
 					M.attack_hand(user, modifiers) //This enables borgs to get the floating heart icon and mob emote from simple_animal's that have petbonus == true.
 					return
-				if(user.zone_selected == BODY_ZONE_HEAD)
-					user.visible_message("<span class='notice'>[user] playfully boops [M] on the head!</span>", "<span class='notice'>You playfully boop [M] on the head!</span>")
-					user.do_attack_animation(M, ATTACK_EFFECT_BOOP)
-					playsound(loc, 'sound/weapons/tap.ogg', 50, TRUE, -1)
-				else if(ishuman(M))
-					if(M.resting)
-						user.visible_message("<span class='notice'>[user] shakes [M] trying to get [M.p_them()] up!</span>", "<span class='notice'>You shake [M] trying to get [M.p_them()] up!</span>")
-						M.stand_up()
-					else
-						user.visible_message("<span class='notice'>[user] hugs [M] to make [M.p_them()] feel better!</span>", "<span class='notice'>You hug [M] to make [M.p_them()] feel better!</span>")
 				else
 					user.visible_message("<span class='notice'>[user] pets [M]!</span>", "<span class='notice'>You pet [M]!</span>")
 				playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, TRUE, -1)
 		if(CYBORG_HUG)
 			if(M.health >= 0)
 				if(ishuman(M))
-					if(M.resting)
-						user.visible_message("<span class='notice'>[user] shakes [M] trying to get [M.p_them()] up!</span>", "<span class='notice'>You shake [M] trying to get [M.p_them()] up!</span>")
-						M.resting = FALSE
-						M.stand_up()
-					else if(user.zone_selected == BODY_ZONE_HEAD)
+					if(user.zone_selected == BODY_ZONE_HEAD)
 						user.visible_message("<span class='warning'>[user] bops [M] on the head!</span>", "<span class='warning'>You bop [M] on the head!</span>")
 						user.do_attack_animation(M, ATTACK_EFFECT_PUNCH)
 					else

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -258,11 +258,10 @@
 		adjustStaminaLoss(-10)
 		resting = FALSE
 		stand_up() // help them up if possible
-		if(!player_logged)
-			M.visible_message( \
-				"<span class='notice'>[M] shakes [src] trying to wake [p_them()] up!</span>",\
-				"<span class='notice'>You shake [src] trying to wake [p_them()] up!</span>",\
-				)
+		M.visible_message( \
+			"<span class='notice'>[M] shakes [src] trying to wake [p_them()] up!</span>",\
+			"<span class='notice'>You shake [src] trying to wake [p_them()] up!</span>",\
+			)
 	else if(M.zone_selected == "head")
 		M.visible_message(\
 		"<span class='notice'>[M] pats [src] on the head.</span>",\

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -222,6 +222,14 @@
 			check_self_for_injuries()
 		return
 
+	// If it has any of the highfive statuses, dap, handshake, etc
+	var/datum/status_effect/effect = has_status_effect_type(STATUS_EFFECT_HIGHFIVE)
+	if(effect)
+		M.apply_status_effect(effect.type)
+		return
+
+	// Any of the cases below involve M touching the src suit/uniform
+	// so we add a corresponding fingerprint
 	if(ishuman(src))
 		var/mob/living/carbon/human/H = src
 		if(H.wear_suit)
@@ -229,12 +237,7 @@
 		else if(H.w_uniform)
 			H.w_uniform.add_fingerprint(M)
 
-	// If it has any of the highfive statuses, dap, handshake, etc
-	var/datum/status_effect/effect = has_status_effect_type(STATUS_EFFECT_HIGHFIVE)
-	if(effect)
-		M.apply_status_effect(effect.type)
-		return
-
+	// Currently the same sound for hugs, pats, shaking etc
 	playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 
 	if(stat == DEAD)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -250,10 +250,6 @@
 		"<span class='notice'>You shake [src], but [p_theyre()] unresponsive. Probably suffering from SSD.</span>")
 	else if(IS_HORIZONTAL(src)) // /vg/: For hugs. This is how update_icon figgers it out, anyway.  - N3X15
 		add_attack_logs(M, src, "Shaked", ATKLOG_ALL)
-		if(ishuman(src))
-			var/mob/living/carbon/human/H = src
-			if(H.w_uniform)
-				H.w_uniform.add_fingerprint(M)
 		AdjustSleeping(-10 SECONDS)
 		AdjustParalysis(-6 SECONDS)
 		AdjustStunned(-6 SECONDS)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -222,13 +222,20 @@
 			check_self_for_injuries()
 		return
 
-	playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 	if(ishuman(src))
 		var/mob/living/carbon/human/H = src
 		if(H.wear_suit)
 			H.wear_suit.add_fingerprint(M)
 		else if(H.w_uniform)
 			H.w_uniform.add_fingerprint(M)
+
+	// If it has any of the highfive statuses, dap, handshake, etc
+	var/datum/status_effect/effect = has_status_effect_type(STATUS_EFFECT_HIGHFIVE)
+	if(effect)
+		M.apply_status_effect(effect.type)
+		return
+
+	playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 
 	if(stat == DEAD)
 		M.visible_message("<span class='notice'>[M] desperately shakes [src] trying to wake [p_them()] up, but sadly there is no reaction!</span>", \
@@ -266,12 +273,6 @@
 		"<span class='notice'>You pat [src] on the head.</span>",\
 		)
 	else
-		// If it has any of the highfive statuses, dap, handshake, etc
-		var/datum/status_effect/effect = has_status_effect_type(STATUS_EFFECT_HIGHFIVE)
-		if(effect)
-			M.apply_status_effect(effect.type)
-			return
-
 		// BEGIN HUGCODE - N3X
 		M.visible_message(\
 		"<span class='notice'>[M] gives [src] a [pick("hug","warm embrace")].</span>",\

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1151,3 +1151,33 @@
 	C.take_organ_damage(damage)
 	C.KnockDown(3 SECONDS)
 	C.visible_message("<span class='danger'>[C] crashes into [src], knocking them both over!</span>", "<span class='userdanger'>You violently crash into [src]!</span>")
+
+
+/**
+  * Handles patting out a fire on someone.
+  *
+  * Removes 0.5 fire stacks per pat, with a 30% chance of the user burning their hand if they don't have adequate heat resistance.
+  * Arguments:
+  * * src - The mob doing the patting
+  * * target - The mob who is currently on fire
+  */
+/mob/living/proc/pat_out(mob/living/target)
+	if(target == src) // stop drop and roll, no trying to put out fire on yourself for free.
+		to_chat(src, "<span class='warning'>Stop drop and roll!</span>")
+		return
+	var/self_message = "<span class='warning'>You try to extinguish [target]!</span>"
+	if(prob(30) && ishuman(src)) // 30% chance of burning your hands
+		var/mob/living/carbon/human/H = src
+		var/protected = FALSE // Protected from the fire
+		if((H.gloves?.max_heat_protection_temperature > 360) || HAS_TRAIT(H, TRAIT_RESISTHEAT) || HAS_TRAIT(H, TRAIT_RESISTHEATHANDS))
+			protected = TRUE
+
+		var/obj/item/organ/external/active_hand = H.get_active_hand()
+		if(active_hand && !protected) // Wouldn't really work without a hand
+			active_hand.receive_damage(0, 5)
+			self_message = "<span class='danger'>You burn your hand trying to extinguish [target]!</span>"
+			H.update_icons()
+
+	target.visible_message("<span class='warning'>[src] tries to extinguish [target]!</span>", self_message)
+	playsound(target, 'sound/weapons/thudswoosh.ogg', 50, TRUE, -1)
+	target.adjust_fire_stacks(-0.5)

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -38,31 +38,6 @@
 	//Item currently being held.
 	var/obj/item/gripped_item = null
 
-/obj/item/gripper_medical
-	name = "medical gripper"
-	desc = "A grasping tool used to help patients up once surgery is complete, or to substitute for hands in surgical operations."
-	icon = 'icons/obj/device.dmi'
-	icon_state = "gripper"
-
-
-/obj/item/gripper_medical/afterattack(atom/target, mob/living/user, proximity, params)
-	if(!proximity || !target || !ishuman(target))
-		return
-	var/mob/living/carbon/human/pickup_target = target
-	if(!IS_HORIZONTAL(pickup_target))
-		return
-	pickup_target.AdjustSleeping(-10 SECONDS)
-	pickup_target.AdjustParalysis(-6 SECONDS)
-	pickup_target.AdjustStunned(-6 SECONDS)
-	pickup_target.AdjustWeakened(-6 SECONDS)
-	pickup_target.AdjustKnockDown(-6 SECONDS)
-	pickup_target.stand_up()
-	playsound(user.loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
-	user.visible_message( \
-		"<span class='notice'>[user] shakes [pickup_target] trying to wake [pickup_target.p_them()] up!</span>",\
-		"<span class='notice'>You shake [pickup_target] trying to wake [pickup_target.p_them()] up!</span>",\
-		)
-
 /obj/item/gripper_engineering/Initialize(mapload)
 	. = ..()
 	can_hold = typecacheof(can_hold)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -324,8 +324,7 @@
 		/obj/item/stack/medical/bruise_pack/advanced/cyborg,
 		/obj/item/stack/medical/ointment/advanced/cyborg,
 		/obj/item/stack/medical/splint/cyborg,
-		/obj/item/stack/nanopaste/cyborg,
-		/obj/item/gripper_medical
+		/obj/item/stack/nanopaste/cyborg
 	)
 	emag_modules = list(/obj/item/reagent_containers/spray/cyborg_facid)
 	special_rechargables = list(/obj/item/reagent_containers/spray/cyborg_facid, /obj/item/extinguisher/mini)
@@ -638,8 +637,7 @@
 		/obj/item/stack/medical/splint/cyborg/syndicate,
 		/obj/item/stack/nanopaste/cyborg/syndicate,
 		/obj/item/gun/medbeam,
-		/obj/item/extinguisher/mini,
-		/obj/item/gripper_medical
+		/obj/item/extinguisher/mini
 	)
 	special_rechargables = list(/obj/item/extinguisher/mini)
 

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -211,12 +211,9 @@
  * Returns TRUE if the tool can be used, or FALSE otherwise
  */
 /datum/surgery_step/proc/is_valid_tool(mob/living/user, obj/item/tool)
-
 	var/success = FALSE
 	if(accept_hand)
 		if(!tool)
-			success = TRUE
-		if(isrobot(user) && istype(tool, /obj/item/gripper_medical))
 			success = TRUE
 
 	if(accept_any_item)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Removes the medical gripper module from mediborgs and moves the helping-up functionality to the hugging module. Helping people up is no longer special-cased for mediborgs and instead just reuses the regular help intent code, making the behavior more consistent.

## Why It's Good For The Game
The medical gripper doesn't really do much and is a source of confusion. The description indicates that it can "substitute for hands in surgical operations", however in almost all relevant cases (implants, organ transplants) it cannot actually do this. The only thing it's commonly used for is getting people up from the ground, and even then it doesn't always work properly.

We might as well just remove the gripper and put that basic help-intent functionality in the hugging module, which has the icon of the help intent and already does other help intent-ish things. Slightly simpler!

## Testing
Did various unethical medical experiments with fire and morphine on a monkey

## Changelog
:cl:
tweak: Mediborg can now pat out fire or help people wake up with the hugging module
tweak: Removed the largely-unused medical gripper from mediborg
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
