### PR TITLE
Reverts Slowdown on pulling #21056

### DIFF
--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -22,7 +22,6 @@ GLOBAL_VAR(bomb_set)
 	anchored = TRUE
 	power_state = NO_POWER_USE
 	requires_power = FALSE
-	pull_speed = 0
 
 	/// Are our bolts *supposed* to be in the floor, may not actually cause anchoring if the bolts are cut
 	var/extended = TRUE

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -6,7 +6,6 @@
 	icon = 'icons/goonstation/objects/iv.dmi'
 	icon_state = "stand"
 	anchored = FALSE
-	pull_speed = 0
 	mouse_drag_pointer = MOUSE_ACTIVE_POINTER
 	var/obj/item/reagent_containers/iv_bag/bag = null
 

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -7,7 +7,6 @@
 	layer = BELOW_OBJ_LAYER
 	armor = list(melee = 25, bullet = 10, laser = 10, energy = 0, bomb = 0, rad = 0, fire = 50, acid = 70)
 	atom_say_verb = "beeps"
-	pull_speed = 0.5
 	var/stat = 0
 
 	/// How is this machine currently passively consuming power?

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -32,8 +32,6 @@
 	var/suicidal_hands = FALSE // Does it requires you to hold it to commit suicide with it?
 	/// Is it emagged or not?
 	var/emagged = FALSE
-	/// slowndown on pulling by human. Bigger value = slower pulling
-	var/pull_speed = 0
 
 /obj/New()
 	..()

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -3,7 +3,6 @@
 	pressure_resistance = 8
 	max_integrity = 300
 	face_while_pulling = TRUE
-	pull_speed = 0.5
 	var/climbable
 	var/mob/living/climber
 	var/broken = FALSE

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -409,7 +409,6 @@
 	icon_state = "bluespace"
 	open_door_sprite = "bluespace_door"
 	storage_capacity = 60
-	pull_speed = 0
 	var/materials = list(MAT_METAL = 5000, MAT_PLASMA = 2500, MAT_TITANIUM = 500, MAT_BLUESPACE = 500)
 
 /obj/structure/closet/bluespace/CheckExit(atom/movable/AM)

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -315,7 +315,6 @@
 	icon_state = "trashcart"
 	icon_opened = "trashcart_open"
 	icon_closed = "trashcart"
-	pull_speed = 0
 
 /obj/structure/closet/crate/medical
 	desc = "A medical crate."

--- a/code/game/objects/structures/engicart.dm
+++ b/code/game/objects/structures/engicart.dm
@@ -6,7 +6,6 @@
 	face_while_pulling = FALSE
 	anchored = FALSE
 	density = TRUE
-	pull_speed = 0
 	var/obj/item/stack/sheet/glass/myglass = null
 	var/obj/item/stack/sheet/metal/mymetal = null
 	var/obj/item/stack/sheet/plasteel/myplasteel = null

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -9,7 +9,6 @@
 	density = TRUE
 	face_while_pulling = FALSE
 	container_type = OPENCONTAINER
-	pull_speed = 0
 	//copypaste sorry
 	var/maximum_volume = 150
 	var/amount_per_transfer_from_this = 5 //shit I dunno, adding this so syringes stop runtime erroring. --NeoFite

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -136,7 +136,6 @@
 	resistance_flags = NONE
 	anchored = FALSE
 	comfort = 1
-	pull_speed = 0
 	var/icon_up = "up"
 	var/icon_down = "down"
 	var/folded = /obj/item/roller

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -239,7 +239,6 @@
 	movable = TRUE
 	item_chair = null
 	buildstackamount = 5
-	pull_speed = 0
 
 /obj/structure/chair/comfy/shuttle
 	name = "shuttle seat"

--- a/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
@@ -4,7 +4,6 @@
 	item_chair = null
 	anchored = FALSE
 	movable = TRUE
-	pull_speed = 0
 	buildstackamount = 15
 
 	var/move_delay = null

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -776,7 +776,6 @@
 	icon_state = "tray"
 	buildstack = /obj/item/stack/sheet/mineral/titanium
 	buildstackamount = 2
-	pull_speed = 0
 	var/list/typecache_can_hold = list(/mob, /obj/item)
 	var/list/held_items = list()
 

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -3,9 +3,6 @@
 	. += ..()
 	. += GLOB.configuration.movement.human_delay
 	. += dna.species.movement_delay(src)
-	if(isobj(pulling) && has_gravity(pulling))
-		var/obj/pulled = pulling
-		. += pulled.pull_speed
 
 /mob/living/carbon/human/Process_Spacemove(movement_dir = 0)
 

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -79,7 +79,6 @@
 	name = "water tank"
 	desc = "A water tank."
 	icon_state = "water"
-	pull_speed = 0
 
 /obj/structure/reagent_dispensers/watertank/high
 	name = "high-capacity water tank"
@@ -94,7 +93,6 @@
 	icon_state = "oil"
 	reagent_id = "oil"
 	tank_volume = 3000
-	pull_speed = 0
 
 /obj/structure/reagent_dispensers/fueltank
 	name = "fuel tank"
@@ -103,7 +101,6 @@
 	reagent_id = "fuel"
 	tank_volume = 4000
 	anchored = TRUE
-	pull_speed = 0
 	var/obj/item/assembly_holder/rig = null
 	var/accepts_rig = 1
 
@@ -282,7 +279,6 @@
 	icon = 'icons/obj/nuclearbomb.dmi'
 	icon_state = "nuclearbomb0"
 	anchored = TRUE
-	pull_speed = 0
 
 /obj/structure/reagent_dispensers/beerkeg/nuke/update_overlays()
 	. = ..()

--- a/code/modules/vehicle/ambulance.dm
+++ b/code/modules/vehicle/ambulance.dm
@@ -109,7 +109,6 @@
 	icon = 'icons/vehicles/CargoTrain.dmi'
 	icon_state = "ambulance"
 	anchored = FALSE
-	pull_speed = 0
 
 /obj/structure/bed/amb_trolley/examine(mob/user)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Reverts PR #21056
You no longer have slowdown while pulling structures

## Why It's Good For The Game
To quote the PR that added this change

``There is gamer move in current build, you pull crate or something behind you and your chaser can not shoot you nor reach you which is kinda stupid. This PR makes person trying to defend yourself by pulling crate reachable. Doesnt affect pulling humans or enything else.``

That PR did not accomplish this goal. Structure pulling was still extremely effective when done in close quarters hallways (1 by 1s on maps like shepard, where even before this change locker pulling was at it's most viable) and the most common in those hallways. The most frustrating form of this tactic is when it was used with meth/any speed chemical, and even then you can still use it and you'll have a speed advantage. 

This still isn't my biggest gripe with the PR, the issue is that this PR effects EVERYONE rather than just structure pulling antagonists. There's no way around this, as most jobs this is just clunky and a sacrifice that really shouldn't be made. Pushing structures is also still a thing, so the far more oppressive strategy of simplemobs pushing structures remains unaffected, and to not suffer from slowdown you need to look and play like an idiot, it just sucks no way around it.

## Testing
No slowdown :D

## Changelog
:cl:
tweak: Pulling structures no longer slows you
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
