### PR TITLE
Block wires from placed under floor catwalks

### DIFF
--- a/code/game/turfs/simulated/floor/misc_floor.dm
+++ b/code/game/turfs/simulated/floor/misc_floor.dm
@@ -242,7 +242,7 @@
 		return
 	pry_tile(I, user, TRUE)
 
-/turf/simulated/floor/transparent/glass/can_lay_cable()
+/turf/simulated/floor/catwalk/can_lay_cable()
 	return FALSE // Pry the catwalk up if you want to apply cables underneath
 
 /turf/simulated/floor/catwalk/ex_act(severity)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes a copy paste for a proc override on floor catwalks. You're not supposed to be able to place wires right through catwalks,

## Why It's Good For The Game
Fixes an oversight.

## Testing
Tried placing wires on catwalk floor. Attempted before the fix too just to see what the current behavior was.

## Changelog
:cl:
fix: Wires can't be placed through floor catwalks
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
