### PR TITLE
There is now a visual indicator if you can't use your hand

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -436,6 +436,7 @@
 /obj/screen/inventory/hand
 	var/image/active_overlay
 	var/image/handcuff_overlay
+	var/static/mutable_appearance/blocked_overlay = mutable_appearance('icons/mob/screen_gen.dmi', "blocked")
 
 /obj/screen/inventory/hand/update_overlays()
 	. = ..()
@@ -450,6 +451,10 @@
 			var/mob/living/carbon/C = hud.mymob
 			if(C.handcuffed)
 				. += handcuff_overlay
+
+			var/obj/item/organ/external/hand = C.get_organ("[slot_id == slot_l_hand ? "l" : "r"]_hand")
+			if(!hand || !hand.is_usable())
+				. += blocked_overlay
 
 		if(slot_id == slot_l_hand && hud.mymob.hand)
 			. += active_overlay

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -194,12 +194,7 @@
 				to_chat(usr, "<span class='warning'>Your other hand is too busy holding the [item_in_hand.name]</span>")
 				return
 	hand = !hand
-	if(hud_used && hud_used.inv_slots[slot_l_hand] && hud_used.inv_slots[slot_r_hand])
-		var/obj/screen/inventory/hand/H
-		H = hud_used.inv_slots[slot_l_hand]
-		H.update_icon()
-		H = hud_used.inv_slots[slot_r_hand]
-		H.update_icon()
+	update_hands_hud()
 	SEND_SIGNAL(src, COMSIG_CARBON_SWAP_HANDS)
 
 
@@ -1033,7 +1028,7 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 		changeNext_move(CLICK_CD_RAPID) //reset click cooldown from handcuffs
 	update_action_buttons_icon() //some of our action buttons might be unusable when we're handcuffed.
 	update_inv_handcuffed()
-	update_hud_handcuffed()
+	update_hands_hud()
 
 /mob/living/carbon/get_standard_pixel_y_offset()
 	if(IS_HORIZONTAL(src))

--- a/code/modules/mob/living/carbon/carbon_update_icons.dm
+++ b/code/modules/mob/living/carbon/carbon_update_icons.dm
@@ -29,13 +29,13 @@
 	return
 
 //update whether handcuffs appears on our hud.
-/mob/living/carbon/proc/update_hud_handcuffed()
-	if(hud_used)
-		var/obj/screen/inventory/R = hud_used.inv_slots[slot_r_hand]
-		var/obj/screen/inventory/L = hud_used.inv_slots[slot_l_hand]
-		if(R && L)
-			R.update_icon()
-			L.update_icon()
+/mob/living/carbon/proc/update_hands_hud()
+	if(!hud_used)
+		return
+	var/obj/screen/inventory/R = hud_used.inv_slots[slot_r_hand]
+	R?.update_icon()
+	var/obj/screen/inventory/L = hud_used.inv_slots[slot_l_hand]
+	L?.update_icon()
 
 /mob/living/carbon/update_inv_r_hand(ignore_cuffs)
 	if(handcuffed && !ignore_cuffs)

--- a/code/modules/surgery/organs/subtypes/standard_organs.dm
+++ b/code/modules/surgery/organs/subtypes/standard_organs.dm
@@ -177,6 +177,7 @@
 
 /obj/item/organ/external/hand/remove()
 	if(owner)
+		update_hand_missing()
 		if(owner.gloves)
 			owner.unEquip(owner.gloves)
 		if(owner.l_hand)
@@ -185,6 +186,26 @@
 			owner.unEquip(owner.r_hand, TRUE)
 
 	. = ..()
+
+/obj/item/organ/external/hand/necrotize(update_sprite)
+	. = ..()
+	update_hand_missing()
+
+/obj/item/organ/external/hand/mutate()
+	. = ..()
+	update_hand_missing()
+
+/obj/item/organ/external/hand/receive_damage(brute, burn, sharp, used_weapon, list/forbidden_limbs, ignore_resists, updating_health)
+	. = ..()
+	update_hand_missing()
+
+/obj/item/organ/external/hand/droplimb(clean, disintegrate, ignore_children, nodamage)
+	. = ..()
+	update_hand_missing()
+
+/obj/item/organ/external/hand/proc/update_hand_missing()
+	// we need to come back to this once the hand is actually removed/dead
+	addtimer(CALLBACK(owner, TYPE_PROC_REF(/mob/living/carbon/human, update_hands_hud), 0))
 
 /obj/item/organ/external/hand/right
 	limb_name = "r_hand"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->There is now a visual indicator if you can't use your hand. Also refactors some code so that we use a consistent update proc. Idea is from TG, code wasn't a clean port so I made it work with our system.

Tried using just normal calls with delimbs, and didnt work. Neither did async. So I had to do a 0 tick callback (fun)

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Giving the player knowledge about their body is good

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![image](https://github.com/ParadiseSS13/Paradise/assets/91113370/ca4f8754-b85f-4510-be9b-9514d61fe122)

## Testing
<!-- How did you test the PR, if at all? -->
![image](https://github.com/ParadiseSS13/Paradise/assets/91113370/eac8c5fb-0835-4dd4-9c0c-419a9b829846)
Handcuffs still work, swapping active hands still works.

## Changelog
:cl:
add: Your hands now have a "blocked" symbol if you can't use them (i.e. no hand, dead hand)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
