### PR TITLE
Fixes vaccines not merging properly

### DIFF
--- a/code/modules/reagents/chemistry/reagents/water.dm
+++ b/code/modules/reagents/chemistry/reagents/water.dm
@@ -197,9 +197,9 @@
 				D.cure()
 		M.resistances |= data
 
-/datum/reagent/vaccine/on_merge(list/data)
-	if(istype(data))
-		data |= data.Copy()
+/datum/reagent/vaccine/on_merge(list/incoming_data)
+	if(islist(incoming_data))
+		data |= incoming_data.Copy()
 
 /datum/reagent/fishwater
 	name = "Fish Water"


### PR DESCRIPTION
## What Does This PR Do
Fixes a variable shadowing bug where adding a vaccine reagent to a container with a different vaccine reagent would merge the incoming vaccine's data onto itself, doing nothing in practice.

## Why It's Good For The Game
Extremely minor annoyance begone

## Testing
Gave meself a cold and a flu, cured both, synthesized their respective vaccines, poured both into a single container, infected a monke with the same diseases, gave the monke a sip of the good juice, confirmed that both diseases vanish (rather than only the first added).

## Changelog
:cl:
fix: Merging vaccine samples into a single multivaccine now works properly.
/:cl:
