### PR TITLE
Roburger renamed to Hamborger and new description for clarity

### DIFF
--- a/code/modules/food_and_drinks/food/foods/sandwiches.dm
+++ b/code/modules/food_and_drinks/food/foods/sandwiches.dm
@@ -60,8 +60,8 @@
 	list_reagents = list("nutriment" = 6, "vitamin" = 1)
 	tastes = list("bun" = 4, "tofu" = 4)
 
-/obj/item/reagent_containers/food/snacks/roburger
-	name = "Hamborger"
+/obj/item/reagent_containers/food/snacks/hamborger
+	name = "hamborger"
 	desc = "Looking at this makes your flesh feel like a weakness."
 	icon_state = "roburger"
 	filling_color = "#CCCCCC"

--- a/code/modules/food_and_drinks/food/foods/sandwiches.dm
+++ b/code/modules/food_and_drinks/food/foods/sandwiches.dm
@@ -62,8 +62,8 @@
 
 /obj/item/reagent_containers/food/snacks/roburger
 	name = "roburger"
-	desc = "The lettuce is the only organic component. Beep."
-	icon_state = "roburger"
+	desc = "Looking at this makes your flesh feel like weakness."
+	icon_state = "Hamborger"
 	filling_color = "#CCCCCC"
 	bitesize = 3
 	list_reagents = list("nutriment" = 6, "nanomachines" = 10, "vitamin" = 1)

--- a/code/modules/food_and_drinks/food/foods/sandwiches.dm
+++ b/code/modules/food_and_drinks/food/foods/sandwiches.dm
@@ -61,9 +61,9 @@
 	tastes = list("bun" = 4, "tofu" = 4)
 
 /obj/item/reagent_containers/food/snacks/roburger
-	name = "roburger"
-	desc = "Looking at this makes your flesh feel like weakness."
-	icon_state = "Hamborger"
+	name = "Hamborger"
+	desc = "Looking at this makes your flesh feel like a weakness."
+	icon_state = "roburger"
 	filling_color = "#CCCCCC"
 	bitesize = 3
 	list_reagents = list("nutriment" = 6, "nanomachines" = 10, "vitamin" = 1)

--- a/code/modules/food_and_drinks/recipes/recipes_microwave.dm
+++ b/code/modules/food_and_drinks/recipes/recipes_microwave.dm
@@ -77,12 +77,12 @@
 	)
 	result = /obj/item/reagent_containers/food/snacks/brainburger
 
-/datum/recipe/microwave/roburger
+/datum/recipe/microwave/hamborger
 	items = list(
 		/obj/item/reagent_containers/food/snacks/bun,
 		/obj/item/robot_parts/head
 	)
-	result = /obj/item/reagent_containers/food/snacks/roburger
+	result = /obj/item/reagent_containers/food/snacks/hamborger
 
 /datum/recipe/microwave/xenoburger
 	items = list(


### PR DESCRIPTION
### What Does This PR Do
Changes Roburger name to Hamborger
Adds a new description for the item
### Why It's Good For The Game
Hamborger seems like a more natural sounding name than roburger and I feel the name more accurately alludes to what it does. It is a "borger". The description gives a better hint at what this burger does.
### Testing
The name and description are changed
### Changelog
:cl: RatNut
tweak: Renames roburger into hamborger
tweak: New examine description
/:cl:
