### PR TITLE
Migrates meson stuff FULLY to traits

### DIFF
--- a/code/modules/clothing/glasses/engine_goggles.dm
+++ b/code/modules/clothing/glasses/engine_goggles.dm
@@ -12,8 +12,7 @@
 	item_state = "trayson-meson"
 	actions_types = list(/datum/action/item_action/toggle_mode)
 	origin_tech = "materials=3;magnets=3;engineering=3;plasmatech=3"
-	vision_flags = NONE
-	invis_view = SEE_INVISIBLE_LIVING
+	active_on_pickup = FALSE
 
 	var/list/modes = list(MODE_NONE = MODE_MESON, MODE_MESON = MODE_TRAY, MODE_TRAY = MODE_RAD, MODE_RAD = MODE_NONE)
 	var/mode = MODE_NONE
@@ -32,14 +31,13 @@
 	mode = modes[mode]
 	to_chat(user, "<span class='[voluntary ? "notice" : "warning"]'>[voluntary ? "You turn the goggles" : "The goggles turn"] [mode ? "to [mode] mode" : "off"][voluntary ? "." : "!"]</span>")
 
-	switch(mode)
-		if(MODE_MESON)
-			vision_flags = SEE_TURFS
-			lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
-
-		if(MODE_TRAY) //undoes the last mode, meson
-			vision_flags = NONE
-			lighting_alpha = null
+	if(mode == MODE_MESON)
+		if(!HAS_TRAIT_FROM(user, TRAIT_MESON_VISION, "meson_glasses[UID()]"))
+			ADD_TRAIT(user, TRAIT_MESON_VISION, "meson_glasses[UID()]")
+		active_on_pickup = TRUE
+	else
+		REMOVE_TRAIT(user, TRAIT_MESON_VISION, "meson_glasses[UID()]")
+		active_on_pickup = FALSE
 
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user

--- a/code/modules/clothing/glasses/engine_goggles.dm
+++ b/code/modules/clothing/glasses/engine_goggles.dm
@@ -12,7 +12,7 @@
 	item_state = "trayson-meson"
 	actions_types = list(/datum/action/item_action/toggle_mode)
 	origin_tech = "materials=3;magnets=3;engineering=3;plasmatech=3"
-	active_on_pickup = FALSE
+	active_on_equip = FALSE
 
 	var/list/modes = list(MODE_NONE = MODE_MESON, MODE_MESON = MODE_TRAY, MODE_TRAY = MODE_RAD, MODE_RAD = MODE_NONE)
 	var/mode = MODE_NONE
@@ -34,10 +34,10 @@
 	if(mode == MODE_MESON)
 		if(!HAS_TRAIT_FROM(user, TRAIT_MESON_VISION, "meson_glasses[UID()]"))
 			ADD_TRAIT(user, TRAIT_MESON_VISION, "meson_glasses[UID()]")
-		active_on_pickup = TRUE
+		active_on_equip = TRUE
 	else
 		REMOVE_TRAIT(user, TRAIT_MESON_VISION, "meson_glasses[UID()]")
-		active_on_pickup = FALSE
+		active_on_equip = FALSE
 
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -84,11 +84,11 @@
 		"Kidan" = 'icons/mob/clothing/species/kidan/eyes.dmi'
 		)
 
-	var/active_on_pickup = TRUE
+	var/active_on_equip = TRUE
 
 /obj/item/clothing/glasses/meson/equipped(mob/user, slot, initial)
 	. = ..()
-	if(active_on_pickup && slot == slot_glasses)
+	if(active_on_equip && slot == slot_glasses)
 		ADD_TRAIT(user, TRAIT_MESON_VISION, "meson_glasses[UID()]")
 
 /obj/item/clothing/glasses/meson/dropped(mob/user)

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -74,8 +74,6 @@
 	icon_state = "meson"
 	item_state = "meson"
 	origin_tech = "magnets=1;engineering=2"
-	vision_flags = SEE_TURFS
-	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
 	prescription_upgradable = TRUE
 
 	sprite_sheets = list(
@@ -85,6 +83,18 @@
 		"Drask" = 'icons/mob/clothing/species/drask/eyes.dmi',
 		"Kidan" = 'icons/mob/clothing/species/kidan/eyes.dmi'
 		)
+
+	var/active_on_pickup = TRUE
+
+/obj/item/clothing/glasses/meson/equipped(mob/user, slot, initial)
+	. = ..()
+	if(active_on_pickup && slot == slot_glasses)
+		ADD_TRAIT(user, TRAIT_MESON_VISION, "meson_glasses[UID()]")
+
+/obj/item/clothing/glasses/meson/dropped(mob/user)
+	. = ..()
+	if(user)
+		REMOVE_TRAIT(user, TRAIT_MESON_VISION, "meson_glasses[UID()]")
 
 /obj/item/clothing/glasses/meson/night
 	name = "night vision optical meson scanner"

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -54,7 +54,16 @@
 	name = "meson visor helmet"
 	desc = "A helmet with a built-in meson scanning visor."
 	icon_state = "helmetmesons"
-	vision_flags = SEE_TURFS
+
+/obj/item/clothing/head/helmet/meson/equipped(mob/user, slot, initial)
+	. = ..()
+	if(slot == slot_head)
+		ADD_TRAIT(user, TRAIT_MESON_VISION, "meson_helmet[UID()]")
+
+/obj/item/clothing/head/helmet/meson/dropped(mob/user)
+	. = ..()
+	if(user)
+		REMOVE_TRAIT(user, TRAIT_MESON_VISION, "meson_helmet[UID()]")
 
 /obj/item/clothing/head/helmet/material
 	name = "material visor helmet"

--- a/code/modules/power/engines/singularity/singularity.dm
+++ b/code/modules/power/engines/singularity/singularity.dm
@@ -454,14 +454,9 @@
 		if(isbrain(M)) //Ignore brains
 			continue
 
-		if(M.stat == CONSCIOUS)
-			if(ishuman(M))
-				var/mob/living/carbon/human/H = M
-				if(istype(H.glasses, /obj/item/clothing/glasses/meson))
-					var/obj/item/clothing/glasses/meson/MS = H.glasses
-					if(MS.vision_flags == SEE_TURFS)
-						to_chat(H, "<span class='notice'>You look directly into [src], good thing you had your protective eyewear on!</span>")
-						return
+		if(HAS_TRAIT(M, TRAIT_MESON_VISION))
+			to_chat(M, "<span class='notice'>You look directly into [src], but your meson vision protects you!</span>")
+			return
 
 		M.Stun(6 SECONDS)
 		M.visible_message("<span class='danger'>[M] stares blankly at [src]!</span>", \

--- a/code/modules/power/engines/supermatter/supermatter.dm
+++ b/code/modules/power/engines/supermatter/supermatter.dm
@@ -238,8 +238,7 @@
 	. = ..()
 	var/mob/living/carbon/human/H = user
 	if(istype(H))
-		var/immune = istype(H.glasses, /obj/item/clothing/glasses/meson)
-		if(!immune && !HAS_TRAIT(H, TRAIT_MESON_VISION) && (get_dist(user, src) < HALLUCINATION_RANGE(power)))
+		if(!HAS_TRAIT(H, TRAIT_MESON_VISION) && (get_dist(user, src) < HALLUCINATION_RANGE(power)))
 			. += "<span class='danger'>You get headaches just from looking at it.</span>"
 	. += "<span class='notice'>When actived by an item hitting this awe-inspiring feat of engineering, it emits radiation and heat. This is the basis of the use of the pseudo-perpetual energy source, the supermatter crystal.</span>"
 	. +="<span class='notice'>Any object that touches [src] instantly turns to dust, be it complex as a human or as simple as a metal rod. These bursts of energy can cause hallucinations if meson scanners are not worn near the crystal.</span>"
@@ -549,7 +548,7 @@
 
 	//Makes em go mad and accumulate rads.
 	for(var/mob/living/carbon/human/l in view(src, HALLUCINATION_RANGE(power))) // If they can see it without mesons on.  Bad on them.
-		if(!istype(l.glasses, /obj/item/clothing/glasses/meson) && !HAS_TRAIT(l, TRAIT_MESON_VISION) && !HAS_TRAIT(l, SM_HALLUCINATION_IMMUNE))
+		if(!HAS_TRAIT(l, TRAIT_MESON_VISION) && !HAS_TRAIT(l, SM_HALLUCINATION_IMMUNE))
 			var/D = sqrt(1 / max(1, get_dist(l, src)))
 			var/hallucination_amount = power * hallucination_power * D
 			l.AdjustHallucinate(hallucination_amount, 0, 200 SECONDS)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->Meson helmets, meson goggles, and the other goggles with meson modes now use traits instead! Also removes unnecessary vision_flags and invis_view from the goggles since those are applied via the trait also.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Getting rid of istypes() when we have a trait for it is good!

## Testing
<!-- How did you test the PR, if at all? -->
Meson helmets protect from the SM now. Meson glasses still protect from the SM. 
engineering scanner goggles now only protect on their meson mode, as expected.
Atmos t-ray scanners do not protect from the SM anymore, as expected.
Meson Eyes protect you from the SM.
Looking through walls still works as expected with the meson_vision

## Changelog
:cl:
fix: The meson vision helmet now works properly again.
fix: Engineering scanner goggles now only protect from the SM on their meson mode.
fix: Atmos t-ray scanners do not protect from the SM anymore.
fix: Meson vision now consistently protect you from singularity weakening
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
