### PR TITLE
Screwdrivers can now be recycled in autolathes

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -562,6 +562,9 @@
 #define COMSIG_TOOL_IN_USE "tool_in_use"
 ///from base of [/obj/item/proc/tool_start_check]: (mob/living/user)
 #define COMSIG_TOOL_START_USE "tool_start_use"
+///from base of [/obj/item/proc/tool_attack_chain]: (atom/tool, mob/user)
+#define COMSIG_TOOL_ATTACK "tool_attack"
+	#define COMPONENT_CANCEL_TOOLACT (1<<0)
 ///from [/obj/item/proc/disableEmbedding]:
 #define COMSIG_ITEM_DISABLE_EMBED "item_disable_embed"
 ///from [/obj/effect/mine/proc/triggermine]:

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -10,6 +10,9 @@
 /obj/item/proc/tool_attack_chain(mob/user, atom/target)
 	if(!tool_behaviour)
 		return FALSE
+	if (SEND_SIGNAL(target, COMSIG_TOOL_ATTACK, src, user) & COMPONENT_CANCEL_TOOLACT)
+		return FALSE
+
 	return target.tool_act(user, src, tool_behaviour)
 
 // Called when the item is in the active hand, and clicked; alternately, there is an 'activate held object' verb or you can hit pagedown.

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -10,7 +10,7 @@
 /obj/item/proc/tool_attack_chain(mob/user, atom/target)
 	if(!tool_behaviour)
 		return FALSE
-	if (SEND_SIGNAL(target, COMSIG_TOOL_ATTACK, src, user) & COMPONENT_CANCEL_TOOLACT)
+	if(SEND_SIGNAL(target, COMSIG_TOOL_ATTACK, src, user) & COMPONENT_CANCEL_TOOLACT)
 		return FALSE
 
 	return target.tool_act(user, src, tool_behaviour)

--- a/code/datums/components/material_container.dm
+++ b/code/datums/components/material_container.dm
@@ -65,8 +65,10 @@
 	var/list/tc = allowed_typecache
 	if(disable_attackby)
 		return
-	if(user.a_intent != INTENT_HELP)
-		return
+	// Allow screwdrivers to be recycled in the autolathe on harm intent
+	if(!(istype(source, /obj/machinery/autolathe) && istype(I, /obj/item/screwdriver) && user.a_intent == INTENT_HARM))
+		if(user.a_intent != INTENT_HELP)
+			return
 	if(I.flags & ABSTRACT)
 		return
 	if((I.flags_2 & (HOLOGRAM_2 | NO_MAT_REDEMPTION_2)) || (tc && !is_type_in_typecache(I, tc)))

--- a/code/datums/components/material_container.dm
+++ b/code/datums/components/material_container.dm
@@ -65,10 +65,10 @@
 	var/list/tc = allowed_typecache
 	if(disable_attackby)
 		return
-	// Allow screwdrivers to be recycled in the autolathe on harm intent
-	if(!(istype(source, /obj/machinery/autolathe) && istype(I, /obj/item/screwdriver) && user.a_intent == INTENT_HARM))
-		if(user.a_intent != INTENT_HELP)
-			return
+	// Allow tools to be inserted on harm intent since they might be used for construction
+	// otherwise user needs to be on help intent
+	if(!(I.tool_behaviour && user.a_intent == INTENT_HARM || user.a_intent == INTENT_HELP))
+		return
 	if(I.flags & ABSTRACT)
 		return
 	if((I.flags_2 & (HOLOGRAM_2 | NO_MAT_REDEMPTION_2)) || (tc && !is_type_in_typecache(I, tc)))

--- a/code/datums/components/material_container.dm
+++ b/code/datums/components/material_container.dm
@@ -65,9 +65,9 @@
 	var/list/tc = allowed_typecache
 	if(disable_attackby)
 		return
-	// Allow tools to be inserted on harm intent since they might be used for construction
+	// Allow tools to be inserted on harm and help intent since they might be used for construction
 	// otherwise user needs to be on help intent
-	if(!(I.tool_behaviour && user.a_intent == INTENT_HARM || user.a_intent == INTENT_HELP))
+	if(!((I.tool_behaviour && user.a_intent == INTENT_HARM) || user.a_intent == INTENT_HELP))
 		return
 	if(I.flags & ABSTRACT)
 		return

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -79,7 +79,7 @@
 	materials.retrieve_all()
 	return ..()
 
-/obj/machinery/autolathe/proc/OnToolAttack(datum/source, atom/tool, mob/user)
+/obj/machinery/autolathe/proc/on_tool_attack(datum/source, atom/tool, mob/user)
 	// Allows screwdrivers to be recycled on harm intent
 	if(istype(tool, /obj/item/screwdriver) && user.a_intent == INTENT_HARM)
 		return COMPONENT_CANCEL_TOOLACT

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -80,6 +80,7 @@
 	return ..()
 
 /obj/machinery/autolathe/proc/on_tool_attack(datum/source, atom/tool, mob/user)
+	SIGNAL_HANDLER
 	var/obj/item/I = tool
 	if(!istype(I))
 		return

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -50,6 +50,8 @@
 	component_parts += new /obj/item/stack/sheet/glass(null)
 	RefreshParts()
 
+	RegisterSignal(src, COMSIG_TOOL_ATTACK, PROC_REF(OnToolAttack))
+
 	wires = new(src)
 	files = new /datum/research/autolathe(src)
 	matching_designs = list()
@@ -76,6 +78,12 @@
 	var/datum/component/material_container/materials = GetComponent(/datum/component/material_container)
 	materials.retrieve_all()
 	return ..()
+
+/obj/machinery/autolathe/proc/OnToolAttack(datum/source, atom/tool, mob/user)
+	// Allows screwdrivers to be recycled on harm intent
+	if (istype(tool, /obj/item/screwdriver) && user.a_intent == INTENT_HARM)
+		return COMPONENT_CANCEL_TOOLACT
+	return
 
 /obj/machinery/autolathe/interact(mob/user)
 	if(shocked && !(stat & NOPOWER))

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -81,7 +81,7 @@
 
 /obj/machinery/autolathe/proc/OnToolAttack(datum/source, atom/tool, mob/user)
 	// Allows screwdrivers to be recycled on harm intent
-	if (istype(tool, /obj/item/screwdriver) && user.a_intent == INTENT_HARM)
+	if(istype(tool, /obj/item/screwdriver) && user.a_intent == INTENT_HARM)
 		return COMPONENT_CANCEL_TOOLACT
 	return
 

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -80,8 +80,11 @@
 	return ..()
 
 /obj/machinery/autolathe/proc/on_tool_attack(datum/source, atom/tool, mob/user)
+	var/obj/item/I = tool
+	if(!istype(I))
+		return
 	// Allows screwdrivers to be recycled on harm intent
-	if(istype(tool, /obj/item/screwdriver) && user.a_intent == INTENT_HARM)
+	if(I.tool_behaviour == TOOL_SCREWDRIVER && user.a_intent == INTENT_HARM)
 		return COMPONENT_CANCEL_TOOLACT
 	return
 

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -50,7 +50,7 @@
 	component_parts += new /obj/item/stack/sheet/glass(null)
 	RefreshParts()
 
-	RegisterSignal(src, COMSIG_TOOL_ATTACK, PROC_REF(OnToolAttack))
+	RegisterSignal(src, COMSIG_TOOL_ATTACK, PROC_REF(on_tool_attack))
 
 	wires = new(src)
 	files = new /datum/research/autolathe(src)

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -86,7 +86,6 @@
 	// Allows screwdrivers to be recycled on harm intent
 	if(I.tool_behaviour == TOOL_SCREWDRIVER && user.a_intent == INTENT_HARM)
 		return COMPONENT_CANCEL_TOOLACT
-	return
 
 /obj/machinery/autolathe/interact(mob/user)
 	if(shocked && !(stat & NOPOWER))

--- a/code/game/objects/items/tools/screwdriver.dm
+++ b/code/game/objects/items/tools/screwdriver.dm
@@ -27,6 +27,12 @@
 	. = ..()
 	AddComponent(/datum/component/surgery_initiator/robo)
 
+/obj/item/screwdriver/tool_attack_chain(mob/user, atom/target)
+	// Allow the screwdrivers to be recylcled on harm intent
+	if((istype(target, /obj/machinery/autolathe)) && (user.a_intent == INTENT_HARM))
+		return FALSE
+	return ..()
+
 /obj/item/screwdriver/nuke
 	name = "screwdriver"
 	desc = "A screwdriver with an ultra thin tip."

--- a/code/game/objects/items/tools/screwdriver.dm
+++ b/code/game/objects/items/tools/screwdriver.dm
@@ -27,11 +27,6 @@
 	. = ..()
 	AddComponent(/datum/component/surgery_initiator/robo)
 
-/obj/item/screwdriver/tool_attack_chain(mob/user, atom/target)
-	if(istype(target, /obj/machinery/autolathe) && (user.a_intent == INTENT_HARM))
-		return FALSE
-	return ..()
-
 /obj/item/screwdriver/nuke
 	name = "screwdriver"
 	desc = "A screwdriver with an ultra thin tip."

--- a/code/game/objects/items/tools/screwdriver.dm
+++ b/code/game/objects/items/tools/screwdriver.dm
@@ -28,7 +28,7 @@
 	AddComponent(/datum/component/surgery_initiator/robo)
 
 /obj/item/screwdriver/tool_attack_chain(mob/user, atom/target)
-	if((istype(target, /obj/machinery/autolathe)) && (user.a_intent == INTENT_HARM))
+	if(istype(target, /obj/machinery/autolathe) && (user.a_intent == INTENT_HARM))
 		return FALSE
 	return ..()
 

--- a/code/game/objects/items/tools/screwdriver.dm
+++ b/code/game/objects/items/tools/screwdriver.dm
@@ -28,7 +28,6 @@
 	AddComponent(/datum/component/surgery_initiator/robo)
 
 /obj/item/screwdriver/tool_attack_chain(mob/user, atom/target)
-	// Allow the screwdrivers to be recylcled on harm intent
 	if((istype(target, /obj/machinery/autolathe)) && (user.a_intent == INTENT_HARM))
 		return FALSE
 	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Fixes #20599, Holding a screwdriver on harm intent and clicking on the autolathe will recycle it.

Okay, this is more complicated than I thought, at least to not make it hacky. This PR adds a signal to intercept the tool attack and cancel the tool act. This is generally useful, but it is needed here to insert the screwdriver into the material container since the logic to insert items into the container relies on the AttackBy signal. Another necessary change is the if statement in the material container code that allows all tools to be inserted on harm intent. Otherwise, inserting any items with harm intent is impossible. I did all this to avoid using GetComponent and keep all the material container logic within the component.

Suppose you wanted to use GetComponent from within AutoLathe.dm, you would have to move a bunch of stuff around within the material component and make inserting items work without being an attack while separating the logic of the component from the component itself, which is not cool.

I'm still a bit new to this, so any feedback on the code or implementation would be nice.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
It fixes an oversight that made it so screwdrivers were the only tool that could not be recycled.

## Testing
<!-- How did you test the PR, if at all? -->
I could recycle all tools on harm intent and on help intent all tools and items except the screwdriver, which opens the panel.

## Changelog
:cl:
fix: Screwdrivers can now be recycled in autolathes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
