### PR TITLE
Fixes some issues with the advanced and operative pinpointers

### DIFF
--- a/code/game/gamemodes/nuclear/pinpointer.dm
+++ b/code/game/gamemodes/nuclear/pinpointer.dm
@@ -187,8 +187,6 @@
 		to_chat(usr, "<span class='warning'>[src] is locked. It can only track one specific target.</span>")
 		return
 
-	mode = MODE_OFF
-	icon_state = icon_off
 	target = null
 	location = null
 
@@ -209,12 +207,11 @@
 
 			to_chat(usr, "<span class='notice'>You set the pinpointer to locate [locationx],[locationy]</span>")
 
-
-			return attack_self(usr)
+			toggle_on()
 
 		if("Disk Recovery")
 			setting = SETTING_DISK
-			return attack_self(usr)
+			toggle_on()
 
 		if("Other Signature")
 			setting = SETTING_OBJECT
@@ -233,20 +230,18 @@
 
 					var/priority
 					var/backup
-					var/counter
 					var/list/target_candidates = get_all_of_type(item_paths[targetitem], subtypes = TRUE)
 					for(var/obj/item/candidate in target_candidates)
 						var/cand_z = (get_turf(candidate)).z
 						if(is_admin_level(cand_z))
 							continue
-						if(!usr.z == cand_z)
+						if(usr.z != cand_z)
 							if(!backup)
 								backup = candidate
 							continue
 						// no candidate set yet, or check if there is a closer one
 						if(!priority || (get_dist(usr, candidate) < get_dist(usr, priority)))
 							priority = candidate
-						counter++
 
 					if(priority)
 						target = priority
@@ -259,10 +254,7 @@
 						to_chat(usr, "<span class='warning'>Failed to locate [targetitem]!</span>")
 						return
 
-					if(counter <= 1)
-						to_chat(usr, "<span class='notice'>You set the pinpointer to locate [targetitem].</span>")
-					else
-						to_chat(usr, "<span class='notice'>You set the pinpointer to track the closest [targetitem].</span>")
+					to_chat(usr, "<span class='notice'>You set the pinpointer to locate [targetitem].</span>")
 
 				if("DNA")
 					var/DNAstring = input("Input DNA string to search for." , "Please Enter String." , "")
@@ -275,8 +267,12 @@
 							target = C
 							break
 
-			mode = MODE_OFF
-			return attack_self(usr)
+			toggle_on()
+
+/obj/item/pinpointer/advpinpointer/proc/toggle_on()
+	if(mode == MODE_OFF)
+		cur_index = 1
+		cycle(usr)
 
 ///////////////////////
 //nuke op pinpointers//


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->Advanced pinpointers will now point to the nearest of their selected items (for example, 2 hand teles, will point to the nearest one when recalibrated). It retains its original ability to track stuff even off z-level, but now stuff on the current z-level is prioritized. (for example, 1 hand tele on station, 1 at mining outpost. If you're on station, it will track the on station hand tele, if you're on mining, it will track the one at the mining base. If you're out in space, on not of the same z-levels, it will pick one of them randomly, saying that the backup is off-sector.)

Nukie borg pinpointers will now actually point at the nearest alive human operative, instead of that dead operatve brain on the floor.

This also makes it so advanced pinpointers won't toggle themselves off when changing target, but will still turn on when a target is set.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Fixes some oversights with both pinpointers

## Images
What shows up when the backup tracking is enabled because there's none on the same z-level as you
![image](https://github.com/ParadiseSS13/Paradise/assets/91113370/71587f41-3703-4750-82c6-a8aff05f3230)


## Testing
<!-- How did you test the PR, if at all? -->
Tested tracking both hand teles, throwing them off sector, etc. It always pointed onto the closest same z level one. (Within a reasonable range, if you're greater than 127 tiles away from them it doesn't care which is closer, which tbh is a byond issue with get_dist().

For the nukie pinpointer, I spawned 2 people, made them nukies. I tested tracking with the pinpointer as a syndi mediborg, and it pointed me to the nearest operative. I blew up one of the operatives, and it pointed to the only alive operative. It does still point to nukies that have a dead body (if they somehow don't gib with their microbomb inplant) since mediborgs could potentially still revive them.

For the advanced pinpointer not turning itself off: (there is an activation and deactivation message already)
![image](https://github.com/ParadiseSS13/Paradise/assets/91113370/8765adc2-dc2b-42c2-845c-c96a7bbb5eaf)


## Changelog
:cl:
fix: Advanced pinpointers will now point at the closest item selected
fix: Nukie borg pinpointers will now properly point at the closest operative
fix: Advanced pinpointers will no longer be turned off after changing target while the pinpointer is on
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
