### PR TITLE
supermatter gets darker as it delams, rather than brighter, below 50% it darkens the area

### DIFF
--- a/code/modules/power/engines/supermatter/supermatter.dm
+++ b/code/modules/power/engines/supermatter/supermatter.dm
@@ -920,25 +920,25 @@
 	if(!combined_gas > MOLE_PENALTY_THRESHOLD || !get_integrity() < SUPERMATTER_DANGER_PERCENT)
 		for(var/obj/D in darkness_effects)
 			qdel(D)
+			return
 
+	var/darkness_strength = clamp((damage - 450) / 75, 1, 8) / 2
+	var/darkness_aoe = clamp((damage - 450) / 25, 1, 25)
+	set_light(
+		l_range = 4 + darkness_aoe,
+		l_power = -1 - darkness_strength,
+		l_color = "#ddd6cf")
+	if(!length(darkness_effects) && moveable) //Don't do this on movable sms oh god. Ideally don't do this at all, but hey, that's lightning for you
+		darkness_effects += new /obj/effect/abstract(locate(x-3,y+3,z))
+		darkness_effects += new /obj/effect/abstract(locate(x+3,y+3,z))
+		darkness_effects += new /obj/effect/abstract(locate(x-3,y-3,z))
+		darkness_effects += new /obj/effect/abstract(locate(x+3,y-3,z))
 	else
-		var/darkness_strength = clamp((damage - 450) / 75, 1, 8) / 2
-		var/darkness_aoe = clamp((damage - 450) / 25, 1, 25)
-		set_light(
-			l_range = 4 + darkness_aoe,
-			l_power = -1 - darkness_strength,
-			l_color = "#ddd6cf")
-		if(!length(darkness_effects) && moveable) //Don't do this on movable sms oh god. Ideally don't do this at all, but hey, that's lightning for you
-			darkness_effects += new /obj/effect/abstract(locate(x-3,y+3,z))
-			darkness_effects += new /obj/effect/abstract(locate(x+3,y+3,z))
-			darkness_effects += new /obj/effect/abstract(locate(x-3,y-3,z))
-			darkness_effects += new /obj/effect/abstract(locate(x+3,y-3,z))
-		else
-			for(var/obj/O in darkness_effects)
-				O.set_light(
-					l_range = 0 + darkness_aoe,
-					l_power = -1 - darkness_strength / 1.25,
-					l_color = "#ddd6cf")
+		for(var/obj/O in darkness_effects)
+			O.set_light(
+				l_range = 0 + darkness_aoe,
+				l_power = -1 - darkness_strength / 1.25,
+				l_color = "#ddd6cf")
 
 /obj/effect/warp_effect/supermatter
 	plane = GRAVITY_PULSE_PLANE

--- a/code/modules/power/engines/supermatter/supermatter.dm
+++ b/code/modules/power/engines/supermatter/supermatter.dm
@@ -920,7 +920,7 @@
 	if(!combined_gas > MOLE_PENALTY_THRESHOLD || !get_integrity() < SUPERMATTER_DANGER_PERCENT)
 		for(var/obj/D in darkness_effects)
 			qdel(D)
-			return
+		return
 
 	var/darkness_strength = clamp((damage - 450) / 75, 1, 8) / 2
 	var/darkness_aoe = clamp((damage - 450) / 25, 1, 25)

--- a/code/modules/power/engines/supermatter/supermatter.dm
+++ b/code/modules/power/engines/supermatter/supermatter.dm
@@ -175,6 +175,8 @@
 	var/obj/effect/warp_effect/supermatter/warp
 	///A variable to have the warp effect for singulo SM work properly
 	var/pulse_stage = 0
+	///This list will hold 4 supermatter darkness effects when the supermatter is delaminating to a singulo delam. This lets me darken the area to look better, as it turns out, walls make the effect look ugly as shit.
+	var/list/darkness_effects = list()
 
 	///Boolean used for logging if we've been powered
 	var/has_been_powered = FALSE
@@ -234,6 +236,7 @@
 	if(is_main_engine && GLOB.main_supermatter_engine == src)
 		GLOB.main_supermatter_engine = null
 	QDEL_NULL(soundloop)
+	QDEL_NULL(darkness_effects)
 	return ..()
 
 /obj/machinery/atmospherics/supermatter_crystal/examine(mob/user)
@@ -908,12 +911,35 @@
 			l_power = 3,
 			l_color = SUPERMATTER_TESLA_COLOUR,
 		)
-	if(combined_gas > MOLE_PENALTY_THRESHOLD)
+	if(combined_gas > MOLE_PENALTY_THRESHOLD && get_integrity() > SUPERMATTER_DANGER_PERCENT)
 		set_light(
-			l_range = 4 + clamp(damage / 2, 10, 50),
+			l_range = 4 + clamp((450 - damage) / 10, 1, 50),
 			l_power = 3,
 			l_color = SUPERMATTER_SINGULARITY_LIGHT_COLOUR,
 		)
+	if(combined_gas > MOLE_PENALTY_THRESHOLD && get_integrity() < SUPERMATTER_DANGER_PERCENT)
+		var/darkness_strength = clamp((damage - 450) / 75, 1, 8) / 2
+		var/darkness_aoe = clamp((damage - 450) / 25, 1, 25)
+		set_light(
+			l_range = 4 + darkness_aoe,
+			l_power = -1 - darkness_strength,
+			l_color = "#ddd6cf")
+		if(!length(darkness_effects) && istype(src, /obj/machinery/atmospherics/supermatter_crystal/engine)) //Don't do this on movable sms oh god. Ideally don't do this at all, but hey, that's lightning for you
+			darkness_effects += new /obj/effect/abstract(locate(x-3,y+3,z))
+			darkness_effects += new /obj/effect/abstract(locate(x+3,y+3,z))
+			darkness_effects += new /obj/effect/abstract(locate(x-3,y-3,z))
+			darkness_effects += new /obj/effect/abstract(locate(x+3,y-3,z))
+		else
+			for(var/obj/O in darkness_effects)
+				O.set_light(
+					l_range = 0 + darkness_aoe,
+					l_power = -1 - darkness_strength / 1.25,
+					l_color = "#ddd6cf")
+	else
+		for(var/obj/D in darkness_effects)
+			qdel(D)
+
+
 
 
 /obj/effect/warp_effect/supermatter

--- a/code/modules/power/engines/supermatter/supermatter.dm
+++ b/code/modules/power/engines/supermatter/supermatter.dm
@@ -940,10 +940,6 @@
 					l_power = -1 - darkness_strength / 1.25,
 					l_color = "#ddd6cf")
 
-
-
-
-
 /obj/effect/warp_effect/supermatter
 	plane = GRAVITY_PULSE_PLANE
 	appearance_flags = PIXEL_SCALE|LONG_GLIDE // no tile bound so you can see it around corners and so

--- a/code/modules/power/engines/supermatter/supermatter.dm
+++ b/code/modules/power/engines/supermatter/supermatter.dm
@@ -917,14 +917,18 @@
 			l_power = 3,
 			l_color = SUPERMATTER_SINGULARITY_LIGHT_COLOUR,
 		)
-	if(combined_gas > MOLE_PENALTY_THRESHOLD && get_integrity() < SUPERMATTER_DANGER_PERCENT)
+	if(!combined_gas > MOLE_PENALTY_THRESHOLD || !get_integrity() < SUPERMATTER_DANGER_PERCENT)
+		for(var/obj/D in darkness_effects)
+			qdel(D)
+
+	else
 		var/darkness_strength = clamp((damage - 450) / 75, 1, 8) / 2
 		var/darkness_aoe = clamp((damage - 450) / 25, 1, 25)
 		set_light(
 			l_range = 4 + darkness_aoe,
 			l_power = -1 - darkness_strength,
 			l_color = "#ddd6cf")
-		if(!length(darkness_effects) && istype(src, /obj/machinery/atmospherics/supermatter_crystal/engine)) //Don't do this on movable sms oh god. Ideally don't do this at all, but hey, that's lightning for you
+		if(!length(darkness_effects) && moveable) //Don't do this on movable sms oh god. Ideally don't do this at all, but hey, that's lightning for you
 			darkness_effects += new /obj/effect/abstract(locate(x-3,y+3,z))
 			darkness_effects += new /obj/effect/abstract(locate(x+3,y+3,z))
 			darkness_effects += new /obj/effect/abstract(locate(x-3,y-3,z))
@@ -935,9 +939,7 @@
 					l_range = 0 + darkness_aoe,
 					l_power = -1 - darkness_strength / 1.25,
 					l_color = "#ddd6cf")
-	else
-		for(var/obj/D in darkness_effects)
-			qdel(D)
+
 
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

The singulo delamination, (when the supermatter has too many moles), now darkens as it heads to 50% integrity, rather than getting brighter as it delaminates. 

Below 50% integrity, the singulo slowly begins to darken the area, similarly to how light can not escape a black hole.

Does this accurately reflect physics? No, but it is cool.


## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Making an area bright and an eery glow as engineering makes either high power (over 5000 EER), or fucks up (too many moles) is cool.

But darkness, from the supermatter shard collapsing, is much cooler.

The darkness becomes stronger as the SM delams, blacking out the area  slowly over time, especially from cameras. For people actually working on the SM with mesons, pipes are generally viewable in a reasonable radius up until about 10% remaining integrity. Past that point, vision is limited, making fixing the delam a challenge. However, thats a whole 90% of supermatter integrity it must go through first.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

I'll embed a video shortly on imgur here.

## Testing
<!-- How did you test the PR, if at all? -->
Singulo delamed the sm a bunch and tweaked values till it felt right.


## Changelog
:cl:
tweak: The SM gets darker as it looses integrity on a singulo delam, until eventually, it begins to consume light in the area below 50% integrity.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
