### PR TITLE
Do not spawn parrots with headsets.

### DIFF
--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -92,13 +92,6 @@
 	speech_buffer = list()
 	available_channels = list()
 	GLOB.hear_radio_list += src
-	if(!ears)
-		var/headset = pick(/obj/item/radio/headset/headset_sec, \
-						/obj/item/radio/headset/headset_eng, \
-						/obj/item/radio/headset/headset_med, \
-						/obj/item/radio/headset/headset_sci, \
-						/obj/item/radio/headset/headset_cargo)
-		ears = new headset(src)
 	update_speak()
 
 	parrot_sleep_dur = parrot_sleep_max //In case someone decides to change the max without changing the duration var


### PR DESCRIPTION
## What Does This PR Do
This PR stops headsets from spawning with parrots. Note that Poly's implementation retains the eng headset. Fixes https://github.com/ParadiseSS13/Paradise/issues/21632.

## Why It's Good For The Game
Crew should not be able to obtain departmental headsets, especially sec's, just by using flaptonium or slime extract.

## Testing
Relatively small change, no testing other than CI.

## Changelog
:cl:
del: Non-Poly Parrots no longer spawn with a random departmental headset.
/:cl: