### PR TITLE
plasmamen detectives now spawn with bowman headsets

### DIFF
--- a/code/datums/outfits/plasmamen_outfits.dm
+++ b/code/datums/outfits/plasmamen_outfits.dm
@@ -51,7 +51,6 @@
 
 	head = /obj/item/clothing/head/helmet/space/plasmaman/white
 	uniform = /obj/item/clothing/under/plasmaman/enviroslacks
-	l_ear = /obj/item/radio/headset/headset_sec
 
 /datum/outfit/plasmaman/warden
 	name = "Plasmaman Warden"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
See title

## Why It's Good For The Game
I chalk this up to likely being an error. There's no reason to restrict detective plasmamen from spawning with a bowman headset. 

## Testing
Compiled, ran, joined as a detective plasmaman

## Changelog
:cl:
fix: Detective plasmamen now spawn with a bowman headset
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
