### PR TITLE
[Refactor/Balance] Ammo Box and Casing price

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -395,8 +395,7 @@
 			S.amount = multiplier
 		else
 			var/obj/item/new_item = new D.build_path(BuildTurf)
-			new_item.materials[MAT_METAL] /= coeff
-			new_item.materials[MAT_GLASS] /= coeff
+			new_item.update_materials_coeff(coeff)
 	SStgui.update_uis(src)
 	desc = initial(desc)
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -59,6 +59,7 @@ GLOBAL_DATUM_INIT(welding_sparks, /mutable_appearance, mutable_appearance('icons
 	var/list/action_icon_state = list() //list of icon states for a given action to override the icon_state.
 
 	var/list/materials = list()
+	var/materials_coeff = 1
 	//Since any item can now be a piece of clothing, this has to be put here so all items share it.
 	var/flags_inv //This flag is used to determine when items in someone's inventory cover others. IE helmets making it so you can't see glasses, etc.
 	var/item_color = null
@@ -877,3 +878,11 @@ GLOBAL_DATUM_INIT(welding_sparks, /mutable_appearance, mutable_appearance('icons
 
 /obj/item/proc/remove_tape()
 	return
+
+/obj/item/proc/update_materials_coeff(new_coeff)
+	if(new_coeff <= 1)
+		materials_coeff = new_coeff
+	else
+		materials_coeff = 1 / new_coeff
+	for(var/material in materials)
+		materials[material] *= materials_coeff

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -7,6 +7,7 @@
 	slot_flags = SLOT_BELT
 	throwforce = 1
 	w_class = WEIGHT_CLASS_TINY
+	materials = list(MAT_METAL = 1000)
 	var/fire_sound = null						//What sound should play when this ammo is fired
 	var/casing_drop_sound = "casingdrop"               //What sound should play when this ammo hits the ground
 	var/caliber = null							//Which kind of guns it can be loaded into
@@ -121,7 +122,7 @@
 	flags = CONDUCT
 	slot_flags = SLOT_BELT
 	item_state = "syringe_kit"
-	materials = list(MAT_METAL = 30000)
+	materials = list(MAT_METAL = 500)
 	throwforce = 2
 	w_class = WEIGHT_CLASS_TINY
 	throw_speed = 4
@@ -133,13 +134,16 @@
 	var/caliber
 	var/multiload = 1
 	var/slow_loading = FALSE
-	var/list/initial_mats //For calculating refund values.
+	var/list/initial_mats
 
 /obj/item/ammo_box/Initialize(mapload)
 	. = ..()
-	for(var/i in 1 to max_ammo)
-		stored_ammo += new ammo_type(src)
+	if(ammo_type)
+		for(var/i in 1 to max_ammo)
+			stored_ammo += new ammo_type(src)
 	update_appearance(UPDATE_DESC|UPDATE_ICON)
+	initial_mats = materials.Copy()
+	update_mat_value()
 
 /obj/item/ammo_box/Destroy()
 	QDEL_LIST_CONTENTS(stored_ammo)
@@ -254,18 +258,23 @@
 	. = ..()
 	desc = "[initial(desc)] There are [length(stored_ammo)] shell\s left!"
 
-/obj/item/ammo_box/proc/update_mat_value()
-	var/num_ammo = 0
-	for(var/B in stored_ammo)
-		var/obj/item/ammo_casing/AC = B
-		if(!AC.BB) //Skip any casing which are empty
+/obj/item/ammo_box/update_materials_coeff(new_coeff)
+	. = ..()
+	for(var/obj/item/ammo_casing/ammo in stored_ammo)
+		if(!ammo.BB || !length(ammo.materials)) //Skip any casing which are empty
 			continue
-		num_ammo++
-	for(var/M in initial_mats) //In case we have multiple types of materials
-		var/materials_per = initial_mats[M] / max_ammo
+		ammo.update_materials_coeff(materials_coeff)
+	update_mat_value()
 
-		var/value = max(materials_per * num_ammo, 500) //Enforce a minimum of 500 units even if empty.
-		materials[M] = value
+/obj/item/ammo_box/proc/update_mat_value()
+	materials = initial_mats.Copy()
+	for(var/material in materials)
+		materials[material] *= materials_coeff
+	for(var/obj/item/ammo_casing/ammo in stored_ammo)
+		if(!ammo.BB || !length(ammo.materials)) //Skip any casing which are empty
+			continue
+		for(var/material in ammo.materials)
+			materials[material] += ammo.materials[material]
 
 //Behavior for magazines
 /obj/item/ammo_box/magazine/proc/ammo_count()

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -206,6 +206,7 @@
 				num_loaded++
 			if(!multiload || !did_load)
 				break
+		AM.update_mat_value()
 	if(istype(A, /obj/item/ammo_casing))
 		var/obj/item/ammo_casing/AC = A
 		if(give_round(AC, replace_spent))

--- a/code/modules/projectiles/ammunition/ammo_boxes.dm
+++ b/code/modules/projectiles/ammunition/ammo_boxes.dm
@@ -1,7 +1,7 @@
 /obj/item/ammo_box/a357
 	name = "speed loader (.357)"
 	desc = "Designed to quickly reload revolvers."
-	materials = list()
+	materials = list(MAT_METAL = 2000)
 	ammo_type = /obj/item/ammo_casing/a357
 	max_ammo = 7
 	multi_sprite_step = 1 // see: /obj/item/ammo_box/update_icon()
@@ -100,10 +100,10 @@
 /obj/item/ammo_box/shotgun
 	name = "shotgun speedloader (Slug)"
 	icon_state = "slugloader"
+	materials = list(MAT_METAL = 2000)
 	origin_tech = "combat=2"
 	ammo_type = /obj/item/ammo_casing/shotgun
 	max_ammo = 7
-	materials = list(MAT_METAL=28000)
 	multi_sprite_step = 1
 
 /obj/item/ammo_box/shotgun/buck
@@ -131,20 +131,16 @@
 	name = "shotgun speedloader (Beanbag shells)"
 	icon_state = "beanbagloader"
 	ammo_type = /obj/item/ammo_casing/shotgun/beanbag
-	materials = list(MAT_METAL=1750)
 
 /obj/item/ammo_box/shotgun/rubbershot
 	name = "shotgun speedloader (Rubbershot shells)"
 	icon_state = "rubbershotloader"
 	ammo_type = /obj/item/ammo_casing/shotgun/rubbershot
-	materials = list(MAT_METAL=1750)
 
 /obj/item/ammo_box/shotgun/tranquilizer
 	name = "shotgun speedloader (Tranquilizer darts)"
 	icon_state = "tranqloader"
 	ammo_type = /obj/item/ammo_casing/shotgun/tranquilizer
-	materials = list(MAT_METAL=1750)
-
 
 //FOAM DARTS
 /obj/item/ammo_box/foambox
@@ -153,12 +149,10 @@
 	icon_state = "foambox"
 	ammo_type = /obj/item/ammo_casing/caseless/foam_dart
 	max_ammo = 40
-	materials = list(MAT_METAL = 500)
 
 /obj/item/ammo_box/foambox/riot
 	icon_state = "foambox_riot"
 	ammo_type = /obj/item/ammo_casing/caseless/foam_dart/riot
-	materials = list(MAT_METAL = 50000)
 
 /obj/item/ammo_box/foambox/sniper
 	name = "ammo box (Foam Sniper Darts)"
@@ -166,13 +160,10 @@
 	icon_state = "foambox_sniper"
 	ammo_type = /obj/item/ammo_casing/caseless/foam_dart/sniper
 	max_ammo = 40
-	materials = list(MAT_METAL = 900)
 
 /obj/item/ammo_box/foambox/sniper/riot
 	icon_state = "foambox_sniper_riot"
 	ammo_type = /obj/item/ammo_casing/caseless/foam_dart/sniper/riot
-	materials = list(MAT_METAL = 90000)
-
 
 /obj/item/ammo_box/caps
 	name = "speed loader (caps)"

--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -1,5 +1,6 @@
 /obj/item/ammo_casing/a357
 	desc = "A .357 bullet casing."
+	materials = list(MAT_METAL = 4000)
 	caliber = "357"
 	projectile_type = /obj/item/projectile/bullet
 	muzzle_flash_strength = MUZZLE_FLASH_STRENGTH_NORMAL
@@ -7,12 +8,14 @@
 
 /obj/item/ammo_casing/rubber9mm
 	desc = "A 9mm rubber bullet casing."
+	materials = list(MAT_METAL = 650)
 	caliber = "9mm"
 	icon_state = "r-casing"
 	projectile_type = /obj/item/projectile/bullet/weakbullet4
 
 /obj/item/ammo_casing/a762
 	desc = "A 7.62mm bullet casing."
+	materials = list(MAT_METAL = 4000)
 	icon_state = "762-casing"
 	caliber = "a762"
 	projectile_type = /obj/item/projectile/bullet
@@ -20,10 +23,12 @@
 	muzzle_flash_range = MUZZLE_FLASH_RANGE_STRONG
 
 /obj/item/ammo_casing/a762/enchanted
+	materials = list(MAT_METAL = 1000)
 	projectile_type = /obj/item/projectile/bullet/weakbullet3
 
 /obj/item/ammo_casing/a50
 	desc = "A .50AE bullet casing."
+	materials = list(MAT_METAL = 4000)
 	caliber = ".50"
 	projectile_type = /obj/item/projectile/bullet
 	muzzle_flash_strength = MUZZLE_FLASH_STRENGTH_NORMAL
@@ -39,6 +44,7 @@
 /obj/item/ammo_casing/c10mm
 	desc = "A 10mm bullet casing."
 	caliber = "10mm"
+	materials = list(MAT_METAL=1500)
 	projectile_type = /obj/item/projectile/bullet/midbullet3
 	muzzle_flash_strength = MUZZLE_FLASH_STRENGTH_NORMAL
 	muzzle_flash_range = MUZZLE_FLASH_RANGE_NORMAL
@@ -56,39 +62,48 @@
 /obj/item/ammo_casing/c9mm
 	desc = "A 9mm bullet casing."
 	caliber = "9mm"
+	materials = list(MAT_METAL=1000)
 	projectile_type = /obj/item/projectile/bullet/weakbullet3
 	muzzle_flash_strength = MUZZLE_FLASH_STRENGTH_WEAK
 	muzzle_flash_range = MUZZLE_FLASH_RANGE_NORMAL
 
 /obj/item/ammo_casing/c9mm/ap
+	materials = list(MAT_METAL = 2000, MAT_SILVER = 200)
 	projectile_type = /obj/item/projectile/bullet/armourpiercing
 
 /obj/item/ammo_casing/c9mm/tox
+	materials = list(MAT_METAL = 2000, MAT_SILVER = 200, MAT_URANIUM = 300)
 	projectile_type = /obj/item/projectile/bullet/toxinbullet
 
 /obj/item/ammo_casing/c9mm/inc
+	materials = list(MAT_METAL = 2000, MAT_SILVER = 200, MAT_PLASMA = 300)
 	projectile_type = /obj/item/projectile/bullet/incendiary/firebullet
 	muzzle_flash_color = LIGHT_COLOR_FIRE
 
 /obj/item/ammo_casing/c46x30mm
 	desc = "A 4.6x30mm bullet casing."
+	materials = list(MAT_METAL = 1000)
 	caliber = "4.6x30mm"
 	projectile_type = /obj/item/projectile/bullet/weakbullet3
 	muzzle_flash_strength = MUZZLE_FLASH_STRENGTH_WEAK
 	muzzle_flash_range = MUZZLE_FLASH_RANGE_NORMAL
 
 /obj/item/ammo_casing/c46x30mm/ap
+	materials = list(MAT_METAL = 1500, MAT_SILVER = 150)
 	projectile_type = /obj/item/projectile/bullet/armourpiercing/wt550
 
 /obj/item/ammo_casing/c46x30mm/tox
+	materials = list(MAT_METAL = 1500, MAT_SILVER = 150, MAT_URANIUM = 200)
 	projectile_type = /obj/item/projectile/bullet/toxinbullet
 
 /obj/item/ammo_casing/c46x30mm/inc
+	materials = list(MAT_METAL = 1500, MAT_SILVER = 150, MAT_PLASMA = 200)
 	projectile_type = /obj/item/projectile/bullet/incendiary/firebullet
 	muzzle_flash_color = LIGHT_COLOR_FIRE
 
 /obj/item/ammo_casing/rubber45
 	desc = "A .45 rubber bullet casing."
+	materials = list(MAT_METAL = 650)
 	caliber = ".45"
 	icon_state = "r-casing"
 	projectile_type = /obj/item/projectile/bullet/midbullet_r
@@ -97,16 +112,19 @@
 
 /obj/item/ammo_casing/c45
 	desc = "A .45 bullet casing."
+	materials = list(MAT_METAL=1500)
 	caliber = ".45"
 	projectile_type = /obj/item/projectile/bullet/midbullet
 	muzzle_flash_strength = MUZZLE_FLASH_STRENGTH_NORMAL
 	muzzle_flash_range = MUZZLE_FLASH_RANGE_NORMAL
 
 /obj/item/ammo_casing/c45/nostamina
+	materials = list(MAT_METAL = 1500)
 	projectile_type = /obj/item/projectile/bullet/midbullet3
 
 /obj/item/ammo_casing/n762
 	desc = "A 7.62x38mmR bullet casing."
+	materials = list(MAT_METAL = 4000)
 	caliber = "n762"
 	projectile_type = /obj/item/projectile/bullet
 	muzzle_flash_strength = MUZZLE_FLASH_STRENGTH_NORMAL
@@ -137,6 +155,7 @@
 /obj/item/ammo_casing/shotgun/buckshot
 	name = "buckshot shell"
 	desc = "A 12 gauge buckshot shell."
+	materials = list(MAT_METAL = 4000)
 	icon_state = "gshell"
 	projectile_type = /obj/item/projectile/bullet/pellet
 	pellets = 6
@@ -145,19 +164,18 @@
 /obj/item/ammo_casing/shotgun/rubbershot
 	name = "rubber shot"
 	desc = "A shotgun casing filled with densely-packed rubber balls, used to incapacitate crowds from a distance."
+	materials = list(MAT_METAL = 1000)
 	icon_state = "cshell"
 	projectile_type = /obj/item/projectile/bullet/pellet/rubber
 	pellets = 6
 	variance = 25
-	materials = list(MAT_METAL=4000)
-
 
 /obj/item/ammo_casing/shotgun/beanbag
 	name = "beanbag slug"
 	desc = "A weak beanbag slug for riot control."
+	materials = list(MAT_METAL = 1000)
 	icon_state = "bshell"
 	projectile_type = /obj/item/projectile/bullet/weakbullet
-	materials = list(MAT_METAL=250)
 	muzzle_flash_strength = MUZZLE_FLASH_STRENGTH_NORMAL
 	muzzle_flash_range = MUZZLE_FLASH_RANGE_NORMAL
 
@@ -165,9 +183,9 @@
 /obj/item/ammo_casing/shotgun/improvised
 	name = "improvised shell"
 	desc = "An extremely weak shotgun shell with multiple small pellets made out of metal shards."
+	materials = list(MAT_METAL = 250)
 	icon_state = "improvshell"
 	projectile_type = /obj/item/projectile/bullet/pellet/weak
-	materials = list(MAT_METAL=250)
 	pellets = 10
 	variance = 25
 	muzzle_flash_strength = MUZZLE_FLASH_STRENGTH_NORMAL
@@ -178,9 +196,9 @@
 	name = "overloaded improvised shell"
 	desc = "An extremely weak shotgun shell with multiple small pellets made out of metal shards. This one has been packed with even more \
 	propellant. It's like playing russian roulette, with a shotgun."
+	materials = list(MAT_METAL = 250)
 	icon_state = "improvshell"
 	projectile_type = /obj/item/projectile/bullet/pellet/overload
-	materials = list(MAT_METAL=250)
 	pellets = 4
 	variance = 40
 	muzzle_flash_strength = MUZZLE_FLASH_STRENGTH_NORMAL
@@ -190,9 +208,9 @@
 /obj/item/ammo_casing/shotgun/stunslug
 	name = "taser slug"
 	desc = "A stunning taser slug."
+	materials = list(MAT_METAL = 250)
 	icon_state = "stunshell"
 	projectile_type = /obj/item/projectile/bullet/stunshot
-	materials = list(MAT_METAL=250)
 	muzzle_flash_strength = MUZZLE_FLASH_STRENGTH_NORMAL
 	muzzle_flash_range = MUZZLE_FLASH_RANGE_NORMAL
 	muzzle_flash_color = "#FFFF00"
@@ -261,12 +279,14 @@
 /obj/item/ammo_casing/shotgun/techshell
 	name = "unloaded technological shell"
 	desc = "A high-tech shotgun shell which can be loaded with materials to produce unique effects."
+	materials = list(MAT_METAL = 1000, MAT_GLASS = 200)
 	icon_state = "cshell"
 	projectile_type = null
 
 /obj/item/ammo_casing/shotgun/dart
 	name = "shotgun dart"
 	desc = "A dart for use in shotguns. Can be injected with up to 30 units of any chemical."
+	materials = list(MAT_METAL = 500, MAT_GLASS = 200)
 	icon_state = "cshell"
 	container_type = OPENCONTAINER
 	projectile_type = /obj/item/projectile/bullet/dart
@@ -294,11 +314,11 @@
 /obj/item/ammo_casing/shotgun/tranquilizer
 	name = "tranquilizer darts"
 	desc = "A tranquilizer round used to subdue individuals utilizing stimulants."
+	materials = list(MAT_METAL = 500, MAT_GLASS = 200)
 	icon_state = "nshell"
 	projectile_type = /obj/item/projectile/bullet/dart/syringe/tranquilizer
 	muzzle_flash_strength = MUZZLE_FLASH_STRENGTH_NORMAL
 	muzzle_flash_range = MUZZLE_FLASH_RANGE_NORMAL
-	materials = list(MAT_METAL=250)
 
 /obj/item/ammo_casing/shotgun/confetti
 	name = "confettishot"
@@ -308,6 +328,7 @@
 
 /obj/item/ammo_casing/a556
 	desc = "A 5.56mm bullet casing."
+	materials = list(MAT_METAL = 3250)
 	caliber = "a556"
 	projectile_type = /obj/item/projectile/bullet/heavybullet
 	muzzle_flash_strength = MUZZLE_FLASH_STRENGTH_NORMAL
@@ -315,6 +336,7 @@
 
 /obj/item/ammo_casing/a545
 	desc = "A 5.45x39mm bullet casing."
+	materials = list(MAT_METAL=1500)
 	caliber = "a545"
 	projectile_type = /obj/item/projectile/bullet/midbullet3
 	muzzle_flash_strength = MUZZLE_FLASH_STRENGTH_NORMAL
@@ -331,6 +353,7 @@
 /obj/item/ammo_casing/rocket
 	name = "rocket shell"
 	desc = "A high explosive designed to be fired from a launcher."
+	materials = list(MAT_METAL = 10000)
 	icon_state = "rocketshell"
 	projectile_type = /obj/item/projectile/missile
 	caliber = "rocket"
@@ -348,6 +371,7 @@
 
 /obj/item/ammo_casing/caseless/a75
 	desc = "A .75 bullet casing."
+	materials = list(MAT_METAL = 8000)
 	caliber = "75"
 	projectile_type = /obj/item/projectile/bullet/gyro
 	muzzle_flash_strength = MUZZLE_FLASH_STRENGTH_STRONG
@@ -356,6 +380,7 @@
 /obj/item/ammo_casing/a40mm
 	name = "40mm HE shell"
 	desc = "A cased high explosive grenade that can only be activated once fired out of a grenade launcher."
+	materials = list(MAT_METAL = 8000)
 	caliber = "40mm"
 	icon_state = "40mmHE"
 	projectile_type = /obj/item/projectile/bullet/a40mm
@@ -365,6 +390,7 @@
 /obj/item/ammo_casing/caseless/foam_dart
 	name = "foam dart"
 	desc = "It's nerf or nothing! Ages 8 and up."
+	materials = list(MAT_METAL = 10)
 	projectile_type = /obj/item/projectile/bullet/reusable/foam_dart
 	muzzle_flash_effect = null
 	caliber = "foam_force"
@@ -429,16 +455,17 @@
 /obj/item/ammo_casing/caseless/foam_dart/riot
 	name = "riot foam dart"
 	desc = "Whose smart idea was it to use toys as crowd control? Ages 18 and up."
+	materials = list(MAT_METAL = 650)
 	projectile_type = /obj/item/projectile/bullet/reusable/foam_dart/riot
 	icon_state = "foamdart_riot"
 
 /obj/item/ammo_casing/caseless/foam_dart/sniper
 	name = "foam sniper dart"
 	desc = "For the big nerf! Ages 8 and up."
+	materials = list(MAT_METAL = 20)
 	caliber = "foam_force_sniper"
 	projectile_type = /obj/item/projectile/bullet/reusable/foam_dart/sniper
 	icon_state = "foamdartsniper"
-
 
 /obj/item/ammo_casing/caseless/foam_dart/sniper/update_desc()
 	. = ..()
@@ -458,6 +485,7 @@
 /obj/item/ammo_casing/caseless/foam_dart/sniper/riot
 	name = "riot foam sniper dart"
 	desc = "For the bigger brother of the crowd control toy. Ages 18 and up."
+	materials = list(MAT_METAL = 1800)
 	caliber = "foam_force_sniper"
 	projectile_type = /obj/item/projectile/bullet/reusable/foam_dart/sniper/riot
 	icon_state = "foamdartsniper_riot"
@@ -465,6 +493,7 @@
 /obj/item/ammo_casing/shotgun/assassination
 	name = "assassination shell"
 	desc = "A specialist shrapnel shell that has been laced with a silencing toxin."
+	materials = list(MAT_METAL = 1500, MAT_GLASS = 200)
 	projectile_type = /obj/item/projectile/bullet/pellet/assassination
 	muzzle_flash_effect = null
 	icon_state = "gshell"
@@ -473,6 +502,7 @@
 
 /obj/item/ammo_casing/cap
 	desc = "A cap for children toys."
+	materials = list(MAT_METAL = 10)
 	caliber = "cap"
 	projectile_type = /obj/item/projectile/bullet/cap
 	muzzle_flash_strength = MUZZLE_FLASH_STRENGTH_NORMAL
@@ -481,6 +511,7 @@
 /obj/item/ammo_casing/caseless/laser
 	desc = "An experimental laser casing, designed to vaporize when fired."
 	caliber = "laser"
+	materials = list(MAT_METAL = 2000, MAT_PLASMA = 200)
 	projectile_type = /obj/item/projectile/beam/laser/ik //Subtype that breaks on firing if emp'd
 	muzzle_flash_effect = /obj/effect/temp_visual/target_angled/muzzle_flash/energy
 	muzzle_flash_strength = MUZZLE_FLASH_STRENGTH_WEAK

--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -184,6 +184,9 @@
 
 ///////////EXTERNAL MAGAZINES////////////////
 
+/obj/item/ammo_box/magazine
+	materials = list(MAT_METAL = 2000)
+
 /obj/item/ammo_box/magazine/m10mm
 	name = "pistol magazine (10mm)"
 	desc = "A gun magazine."
@@ -329,23 +332,19 @@
 	ammo_type = /obj/item/ammo_casing/c9mm
 	caliber = "9mm"
 	max_ammo = 21
-	materials = list(MAT_METAL = 2000)
 	multi_sprite_step = 4
 
 /obj/item/ammo_box/magazine/smgm9mm/ap
 	name = "\improper SMG magazine (Armour Piercing 9mm)"
 	ammo_type = /obj/item/ammo_casing/c9mm/ap
-	materials = list(MAT_METAL = 3000)
 
 /obj/item/ammo_box/magazine/smgm9mm/toxin
 	name = "\improper SMG magazine (Toxin Tipped 9mm)"
 	ammo_type = /obj/item/ammo_casing/c9mm/tox
-	materials = list(MAT_METAL = 3000)
 
 /obj/item/ammo_box/magazine/smgm9mm/fire
 	name = "\improper SMG Magazine (Incendiary 9mm)"
 	ammo_type = /obj/item/ammo_casing/c9mm/inc
-	materials = list(MAT_METAL = 3000)
 
 /obj/item/ammo_box/magazine/apsm10mm
 	name = "stechkin aps magazine (10mm)"

--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -317,6 +317,7 @@
 	. = ..()
 	stored_ammo.Cut()
 	update_appearance(UPDATE_DESC|UPDATE_ICON)
+	update_mat_value()
 
 /obj/item/ammo_box/magazine/uzim9mm
 	name = "uzi magazine (9mm)"
@@ -495,6 +496,7 @@
 
 /obj/item/ammo_box/magazine/toy
 	name = "foam force META magazine"
+	materials = list(MAT_METAL = 500)
 	ammo_type = /obj/item/ammo_casing/caseless/foam_dart
 	caliber = "foam_force"
 

--- a/code/modules/projectiles/firing.dm
+++ b/code/modules/projectiles/firing.dm
@@ -58,6 +58,7 @@
 	BB.preparePixelProjectile(target, targloc, user, params, spread)
 	if(BB)
 		BB.fire()
+	materials = list(MAT_METAL=0)
 	BB = null
 	return 1
 

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -443,7 +443,7 @@
 	name = "Beanbag Slug"
 	id = "beanbag_slug"
 	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 250)
+	materials = list(MAT_METAL = 1000)
 	build_path = /obj/item/ammo_casing/shotgun/beanbag
 	category = list("initial", "Security")
 
@@ -451,7 +451,7 @@
 	name = "Rubber Shot"
 	id = "rubber_shot"
 	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 4000)
+	materials = list(MAT_METAL = 1000)
 	build_path = /obj/item/ammo_casing/shotgun/rubbershot
 	category = list("initial", "Security")
 
@@ -651,7 +651,7 @@
 	name = "Box of Foam Darts"
 	id = "foam_dart"
 	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 500)
+	materials = list(MAT_METAL = 900)
 	build_path = /obj/item/ammo_box/foambox
 	category = list("initial", "Miscellaneous")
 
@@ -659,7 +659,7 @@
 	name = "Box of Sniper Foam Darts"
 	id = "foam_dart_sniper"
 	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 900)
+	materials = list(MAT_METAL = 1300)
 	build_path = /obj/item/ammo_box/foambox/sniper
 	category = list("initial", "Miscellaneous")
 
@@ -734,7 +734,7 @@
 	name = "Shotgun Dart"
 	id = "shotgun_dart"
 	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 4000)
+	materials = list(MAT_METAL = 500, MAT_GLASS = 200)
 	build_path = /obj/item/ammo_casing/shotgun/dart
 	category = list("hacked", "Security")
 
@@ -758,7 +758,7 @@
 	name = "Foam Riot Dart"
 	id = "riot_dart"
 	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 1000) //Discount for making individually - no box = less metal!
+	materials = list(MAT_METAL = 1000)
 	build_path = /obj/item/ammo_casing/caseless/foam_dart/riot
 	category = list("hacked", "Security")
 
@@ -766,7 +766,7 @@
 	name = "Foam Riot Sniper Dart"
 	id = "riot_dart_sniper"
 	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 1800) //Discount for making individually - no box = less metal!
+	materials = list(MAT_METAL = 1800)
 	build_path = /obj/item/ammo_casing/caseless/foam_dart/sniper/riot
 	category = list("hacked", "Security")
 
@@ -774,7 +774,7 @@
 	name = "Foam Riot Dart Box"
 	id = "riot_darts"
 	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 50000) //Comes with 40 darts
+	materials = list(MAT_METAL = 26500)
 	build_path = /obj/item/ammo_box/foambox/riot
 	category = list("hacked", "Security")
 
@@ -782,7 +782,7 @@
 	name = "Foam Riot Sniper Dart Box"
 	id = "riot_darts_sniper"
 	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 90000) //Comes with 40 darts
+	materials = list(MAT_METAL = 72500)
 	build_path = /obj/item/ammo_box/foambox/sniper/riot
 	category = list("hacked", "Security")
 
@@ -790,7 +790,7 @@
 	name = "Ammo Box (.357)"
 	id = "b357"
 	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 30000)
+	materials = list(MAT_METAL = 28500)
 	build_path = /obj/item/ammo_box/b357
 	category = list("hacked", "Security")
 
@@ -798,7 +798,7 @@
 	name = "Ammo Box (10mm)"
 	id = "c10mm"
 	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 30000)
+	materials = list(MAT_METAL = 30500)
 	build_path = /obj/item/ammo_box/c10mm
 	category = list("hacked", "Security")
 
@@ -806,7 +806,7 @@
 	name = "Ammo Box (.45)"
 	id = "c45"
 	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 30000)
+	materials = list(MAT_METAL = 30500)
 	build_path = /obj/item/ammo_box/c45
 	category = list("hacked", "Security")
 
@@ -814,7 +814,7 @@
 	name = "Ammo Box (9mm)"
 	id = "c9mm"
 	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 30000)
+	materials = list(MAT_METAL = 30500)
 	build_path = /obj/item/ammo_box/c9mm
 	category = list("hacked", "Security")
 

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -758,7 +758,7 @@
 	name = "Foam Riot Dart"
 	id = "riot_dart"
 	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 1000)
+	materials = list(MAT_METAL = 650)
 	build_path = /obj/item/ammo_casing/caseless/foam_dart/riot
 	category = list("hacked", "Security")
 

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -152,7 +152,7 @@
 	id = "mag_oldsmg"
 	req_tech = list("combat" = 1, "materials" = 1)
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 10000)
+	materials = list(MAT_METAL = 2000)
 	build_path = /obj/item/ammo_box/magazine/wt550m9/empty
 	category = list("Weapons")
 
@@ -162,7 +162,7 @@
 	id = "box_oldsmg"
 	req_tech = list("combat" = 1, "materials" = 1)
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 4000)
+	materials = list(MAT_METAL = 20500)
 	build_path = /obj/item/ammo_box/wt550
 	category = list("Weapons")
 
@@ -170,7 +170,7 @@
 	name = "WT-550 Auto Gun Armour Piercing Ammo Box (4.6x30mm AP)"
 	desc = "A box of 20 armour piercing rounds for the out of date security WT-550 Auto Rifle"
 	id = "box_oldsmg_ap"
-	materials = list(MAT_METAL = 6000, MAT_SILVER = 600)
+	materials = list(MAT_METAL = 30500, MAT_SILVER = 3000)
 	build_path = /obj/item/ammo_box/wt550/wtap
 	category = list("Weapons")
 
@@ -178,7 +178,7 @@
 	name = "WT-550 Auto Gun Incendiary Ammo Box (4.6x30mm IC)"
 	desc = "A box of 20 armour piercing rounds for the out of date security WT-550 Auto Rifle"
 	id = "box_oldsmg_ic"
-	materials = list(MAT_METAL = 6000, MAT_SILVER = 600, MAT_GLASS = 1000)
+	materials = list(MAT_METAL = 30500, MAT_SILVER = 3000, MAT_GLASS = 4000)
 	build_path = /obj/item/ammo_box/wt550/wtic
 	category = list("Weapons")
 
@@ -186,7 +186,7 @@
 	name = "WT-550 Auto Gun Uranium Ammo Box (4.6x30mm TX)"
 	desc = "A box of 20 uranium tipped rounds for the out of date security WT-550 Auto Rifle"
 	id = "box_oldsmg_tx"
-	materials = list(MAT_METAL = 6000, MAT_SILVER = 600, MAT_URANIUM = 2000)
+	materials = list(MAT_METAL = 30500, MAT_SILVER = 3000, MAT_URANIUM = 4000)
 	build_path = /obj/item/ammo_box/wt550/wttx
 	category = list("Weapons")
 
@@ -196,7 +196,7 @@
 	id = "mag_laser"
 	build_type = PROTOLATHE
 	req_tech = list("combat" = 4, "powerstorage" = 4)
-	materials = list(MAT_METAL = 4000, MAT_PLASMA = 600)
+	materials = list(MAT_METAL = 42000, MAT_PLASMA = 4000)
 	build_path = /obj/item/ammo_box/magazine/laser
 	category = list("Weapons")
 
@@ -206,7 +206,7 @@
 	id = "mag_laser"
 	build_type = PROTOLATHE
 	req_tech = list("combat" = 4, "powerstorage" = 4)
-	materials = list(MAT_METAL = 4000, MAT_PLASMA = 600)
+	materials = list(MAT_METAL = 40500, MAT_PLASMA = 4000)
 	build_path = /obj/item/ammo_box/laser
 	category = list("Weapons")
 

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -178,7 +178,7 @@
 	name = "WT-550 Auto Gun Incendiary Ammo Box (4.6x30mm IC)"
 	desc = "A box of 20 armour piercing rounds for the out of date security WT-550 Auto Rifle"
 	id = "box_oldsmg_ic"
-	materials = list(MAT_METAL = 30500, MAT_SILVER = 3000, MAT_GLASS = 4000)
+	materials = list(MAT_METAL = 30500, MAT_SILVER = 3000, MAT_PLASMA = 4000)
 	build_path = /obj/item/ammo_box/wt550/wtic
 	category = list("Weapons")
 

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -454,17 +454,18 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			machine.reagents.remove_reagent(R, being_built.reagents_list[R] * coeff)
 
 	var/key = usr.key
-	addtimer(CALLBACK(src, PROC_REF(finish_machine), key, amount, enough_materials, machine, being_built, efficient_mats), time_to_construct)
+	addtimer(CALLBACK(src, PROC_REF(finish_machine), key, amount, enough_materials, machine, being_built, coeff), time_to_construct)
 
-/obj/machinery/computer/rdconsole/proc/finish_machine(key, amount, enough_materials,  obj/machinery/r_n_d/machine, datum/design/being_built, list/efficient_mats)
+/obj/machinery/computer/rdconsole/proc/finish_machine(key, amount, enough_materials, obj/machinery/r_n_d/machine, datum/design/being_built, coeff)
 	if(machine)
 		if(enough_materials && being_built)
 			for(var/i in 1 to amount)
-				var/obj/item/new_item = new being_built.build_path(src)
+				var/obj/new_item = new being_built.build_path(src)
 				if(istype(new_item, /obj/item/storage/backpack/holding))
 					new_item.investigate_log("built by [key]","singulo")
-				if(!istype(new_item, /obj/item/stack/sheet)) // To avoid materials dupe glitches
-					new_item.materials = efficient_mats.Copy()
+				if(isitem(new_item) && !istype(new_item, /obj/item/stack/sheet)) // To avoid materials dupe glitches
+					var/obj/item/new_item_item = new_item
+					new_item_item.update_materials_coeff(coeff)
 				if(being_built.locked)
 					var/obj/item/storage/lockbox/research/L = new/obj/item/storage/lockbox/research(machine.loc)
 					new_item.forceMove(L)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Fixes:
- Fixes an issue where inserting from one Ammo Box to another didn't update the price of the first one. Duping.

Refactor:
- When ammo box is printed, the price of each bullet is recalculated depending on the parts
- Every usual ammo casing now has its own price which depends on its damage or printing price
- Ammo Box now has a price of 500 metal, a magazine and speed loaders have a price of 2000 metal
- Ammo Box with ammo now calculates its price as [Ammo Box cost + Each ammo casing cost]

Balance:
- Empty ammo casing have a value of 0
- WT550 and Laser ammo have greatly increased price (roughly 5 times more)
- Rubber ammo have slightly decreased price'

## New values:
### Designs:
- Beanbag: 250 -> 1000
- Rubbershot: 4000 -> 1000
- Box of Foam: 500 -> 900
- Box of Sniper Foam: 900 -> 1300
- Shotgun Dart: 4000 -> 500 + 200 glass
- Foam Riot: 1000 -> 650
- Foarm Riot Sniper: 1800
- Box Foam Riot: 50000 -> 26500
- Box Foarm Sniper Riot: 90000 -> 72500
- .357 box: 30000 -> 28500
- 10m box: 30000 -> 30500
- .45 box: 30000 -> 30500

- 4.6x30 empty: 10000 -> 2000
- 4.6x30 box: 4000 -> 20500
- 4.6x30 ap box: 6000 + 600 silver -> 30500 + 3000 silver
- 4.6x30 ic box: 6000 + 600 silver + 1000 glass -> 30500 + 3000 silver + 4000 plasma
- 4.6x30 tox box: 6000 + 600 silver + 2000 uranium -> 30500 + 3000 silver + 4000 uranium
- Laser mag: 4000 + 600 plasma -> 42000 + 4000 plasma
- Laser box: 4000 + 600 plasma -> 40500 + 4000 plasma

### Defaults:
- Ammo casing:  0 -> 1000 (default value)
- Ammo Box: 30000 -> 500 (default value)
- Magazine: 30000 -> 2000 (default value)

### Ammo Boxes:
- speed loader (.357): 0 -> magazine default (2000)
- shotgun speedloader: 28000/1750 -> magazine default (2000)
- Foambox riot: 50000 -> defaut (500)
- Foam Sniper: 900 -> default (500)
- Foam Sniper Riot: 90000 -> default (500)

### Casings:
- 357: 0 -> 4000
- 9mm rubber: 0 -> 650
- 7.62: 0 -> 4000
- 7.62 ench: 0 -> 100
- .50AE: 0 -> 4000
- 10mm: 0 -> 1500
- 9mm: 0 -> 1000
- 9mm ap: 0 -> 2000 + 200 silver
- 9mm tox: 0 -> 2000 + 200 silver 300 uranium
- 9mm inc: 0 -> 2000 + 200 silver 300 plasma
- 4.6x30: 0 -> 1000
- 4.6x30 ap: 0 -> 1500 + 150 silver
- 4.6x30 tox: 0 -> 1500 + 150 silver 200 uranium
- 4.6x30 inc: 0 -> 1500 + 150 silver 200 plasma
- .45 rubber: 0 -> 650
- .45: 0 -> 1500
- .45 nostamina: 0 -> 1500
- 7.62x38: 0 -> 4000
- Buckshot: 0 -> 4000
- Rubbershot: 4000 -> 1000
- Beanbag: 250 -> 1000
- Techshell: 0 -> 1000 + 200 glass
- Dart: 0 -> 500 + 200 glass
- Tranq: 250 -> 500 + 200 glass
- 5.56: 0 -> 3250
- 5.45: 0 -> 1500
- Rocket shell: 0 -> 10000
- .75: 0 -> 8000
- 40mm: 0 -> 8000
- Foam dart: 0 -> 10
- Foam riot: 0 -> 650
- Foam sniper: 0 -> 20
- Foam riot sniper: 0 -> 1800
- Assassin. shell: 0 -> 1500 + 200 glass
- Cap: 0 -> 10
- Laser: 0 -> 2000 + 200 plasma

### Magazines:
- foam force META mag: 30000 -> 500

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Ammo Boxes now calculate its cost based on ammo inside, which is good.

I'm not sure of that current balance of WT550 and Laser, so the input is pretty much required.

## Testing
<!-- How did you test the PR, if at all? -->
- Printed every possible ammo_box and inserted it back into an autolathe
- Combined discounted ammo with normal cost ammo and inserted combinations back into an autolathe

## Changelog
:cl:
fix: Fixes an issue where inserting from one Ammo Box to another didn't update the price of the first one.
tweak: Ammo Box prices now are based on ammo inside AND box cost
tweak: WT550 and Laser ammo cost is greatly increased (roughly 5 times more)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
