### PR TITLE
Remove obsolete pod mainboard.

### DIFF
--- a/code/game/mecha/mecha_parts.dm
+++ b/code/game/mecha/mecha_parts.dm
@@ -466,8 +466,3 @@
 /obj/item/circuitboard/mecha/odysseus/peripherals
 	board_name = "Odysseus Peripherals Control Module"
 	icon_state = "mcontroller"
-
-
-/obj/item/circuitboard/mecha/pod
-	board_name = "Space Pod Mainboard"
-	icon_state = "mainboard"


### PR DESCRIPTION
## What Does This PR Do
Removes the unused type `/obj/item/circuitboard/mecha/pod`, since it appears to be a remnant from space pods, and is not used anywhere.

## Why It's Good For The Game
Removing dead code or unnecessary object types is good for code quality.

## Testing
Successful compilation after removal. Double-checked to ensure path wasn't present in non-station maps.

## Changelog

Dead code removal, no changelog.