### PR TITLE
[FIX/FEAT]: Bomb Guardian fixes and more DETONATE options

### DIFF
--- a/code/game/gamemodes/miniantags/guardian/types/explosive_guardian.dm
+++ b/code/game/gamemodes/miniantags/guardian/types/explosive_guardian.dm
@@ -22,7 +22,7 @@
 	if(get_dist(get_turf(src), get_turf(A)) > 1)
 		to_chat(src, "<span class='danger'>You're too far from [A] to disguise it as a bomb.</span>")
 		return
-	if(isobj(A))
+	if(istype(A, /obj/) && can_plant(A))
 		if(bomb_cooldown <= world.time && !stat)
 			var/obj/item/guardian_bomb/B = new /obj/item/guardian_bomb(get_turf(A))
 			add_attack_logs(src, A, "booby trapped (summoner: [summoner])")
@@ -35,12 +35,22 @@
 		else
 			to_chat(src, "<span class='danger'>Your power is on cooldown! You must wait another [max(round((bomb_cooldown - world.time)*0.1, 0.1), 0)] seconds before you can place next bomb.</span>")
 
+/mob/living/simple_animal/hostile/guardian/bomb/proc/can_plant(atom/movable/A)
+	if(ismecha(A))
+		var/obj/mecha/target = A
+		if(target.occupant)
+			to_chat(src, "<span class='warning'>You can't disguise piloted mechs as a bomb!</span>")
+			return FALSE
+	if(istype(A, /obj/machinery/disposal)) // Have no idea why they just destroy themselves
+		to_chat(src, "<span class='warning'>You can't disguise disposal units as a bomb!</span>")
+		return FALSE
+	return TRUE
+
 /obj/item/guardian_bomb
 	name = "bomb"
 	desc = "You shouldn't be seeing this!"
 	var/obj/stored_obj
 	var/mob/living/spawner
-
 
 /obj/item/guardian_bomb/proc/disguise(obj/A)
 	A.forceMove(src)
@@ -83,6 +93,21 @@
 	detonate(user)
 
 /obj/item/guardian_bomb/attack_hand(mob/user)
+	detonate(user)
+
+/obj/item/guardian_bomb/MouseDrop_T(obj/item/I, mob/living/user)
+	detonate(user)
+
+/obj/item/guardian_bomb/AltClick(mob/living/user)
+	detonate(user)
+
+/obj/item/guardian_bomb/MouseDrop(mob/living/user)
+	detonate(user)
+
+/obj/item/guardian_bomb/Bumped(mob/living/user)
+	detonate(user)
+
+/obj/item/guardian_bomb/can_be_pulled(mob/living/user)
 	detonate(user)
 
 /obj/item/guardian_bomb/examine(mob/user)

--- a/code/game/gamemodes/miniantags/guardian/types/explosive_guardian.dm
+++ b/code/game/gamemodes/miniantags/guardian/types/explosive_guardian.dm
@@ -22,7 +22,7 @@
 	if(get_dist(get_turf(src), get_turf(A)) > 1)
 		to_chat(src, "<span class='danger'>You're too far from [A] to disguise it as a bomb.</span>")
 		return
-	if(istype(A, /obj/) && can_plant(A))
+	if(isobj(A) && can_plant(A))
 		if(bomb_cooldown <= world.time && !stat)
 			var/obj/item/guardian_bomb/B = new /obj/item/guardian_bomb(get_turf(A))
 			add_attack_logs(src, A, "booby trapped (summoner: [summoner])")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Detonate now happens on every time of action with an object, not just touching. Pushing a bomb is not a good idea.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Detonating only by touching by HAND, and not by pulling/pushing is not good?

## Testing
<!-- How did you test the PR, if at all? -->

Place bomb, touch it, ouchie

## Changelog
:cl:
add: Guardian Bomb now detonate almost on every interaction with it
tweak: Gurdian Bomb can't be placed to piloted mechs and disposals due to bugs with it
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
