### PR TITLE
[FIX] Jobbaned can't spam-spawn as cult harvesters

### DIFF
--- a/code/game/gamemodes/wizard/soulstone.dm
+++ b/code/game/gamemodes/wizard/soulstone.dm
@@ -421,11 +421,12 @@
 	qdel(shade)
 	qdel(SS)
 
-/proc/make_new_construct(mob/living/simple_animal/hostile/construct/c_type, mob/target, mob/user, cult_override = FALSE)
+/proc/make_new_construct(mob/living/simple_animal/hostile/construct/c_type, mob/target, mob/user, cult_override = FALSE, create_smoke = FALSE)
 	if(jobban_isbanned(target, ROLE_CULTIST))
 		return
 	var/mob/living/simple_animal/hostile/construct/C = new c_type(get_turf(target))
-	new /obj/effect/particle_effect/smoke/sleeping(target.loc)
+	if(create_smoke)
+		new /obj/effect/particle_effect/smoke/sleeping(target.loc)
 	C.faction |= "\ref[user]"
 	C.key = target.key
 	if(user && iscultist(user) || cult_override)

--- a/code/game/gamemodes/wizard/soulstone.dm
+++ b/code/game/gamemodes/wizard/soulstone.dm
@@ -425,8 +425,7 @@
 	if(jobban_isbanned(target, ROLE_CULTIST))
 		return
 	var/mob/living/simple_animal/hostile/construct/C = new c_type(get_turf(target))
-	if(istype(c_type, /mob/living/simple_animal/hostile/construct/harvester))
-		new /obj/effect/particle_effect/smoke/sleeping(target.loc)
+	new /obj/effect/particle_effect/smoke/sleeping(target.loc)
 	C.faction |= "\ref[user]"
 	C.key = target.key
 	if(user && iscultist(user) || cult_override)

--- a/code/game/gamemodes/wizard/soulstone.dm
+++ b/code/game/gamemodes/wizard/soulstone.dm
@@ -425,6 +425,8 @@
 	if(jobban_isbanned(target, ROLE_CULTIST))
 		return
 	var/mob/living/simple_animal/hostile/construct/C = new c_type(get_turf(target))
+	if(istype(c_type, /mob/living/simple_animal/hostile/construct/harvester))
+		new /obj/effect/particle_effect/smoke/sleeping(target.loc)
 	C.faction |= "\ref[user]"
 	C.key = target.key
 	if(user && iscultist(user) || cult_override)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -919,7 +919,7 @@
 
 /mob/living/narsie_act()
 	if(client)
-		make_new_construct(/mob/living/simple_animal/hostile/construct/harvester, src, cult_override = TRUE)
+		make_new_construct(/mob/living/simple_animal/hostile/construct/harvester, src, cult_override = TRUE, create_smoke = TRUE)
 	spawn_dust()
 	gib()
 

--- a/code/modules/power/engines/singularity/narsie.dm
+++ b/code/modules/power/engines/singularity/narsie.dm
@@ -69,7 +69,7 @@
 
 /obj/singularity/narsie/large/attack_ghost(mob/dead/observer/user as mob)
 	user.forceMove(get_turf(src)) //make_new_construct spawns harvesters at observers locations, could be used to get into admin rooms/CC
-	make_new_construct(/mob/living/simple_animal/hostile/construct/harvester, user, cult_override = TRUE)
+	make_new_construct(/mob/living/simple_animal/hostile/construct/harvester, user, cult_override = TRUE, create_smoke = TRUE)
 
 /obj/singularity/narsie/process()
 	eat()

--- a/code/modules/power/engines/singularity/narsie.dm
+++ b/code/modules/power/engines/singularity/narsie.dm
@@ -70,8 +70,6 @@
 /obj/singularity/narsie/large/attack_ghost(mob/dead/observer/user as mob)
 	user.forceMove(get_turf(src)) //make_new_construct spawns harvesters at observers locations, could be used to get into admin rooms/CC
 	make_new_construct(/mob/living/simple_animal/hostile/construct/harvester, user, cult_override = TRUE)
-	new /obj/effect/particle_effect/smoke/sleeping(user.loc)
-
 
 /obj/singularity/narsie/process()
 	eat()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Jobbanned can spam smoke with Nar'Sie, when it should spawn only on harverster spawn. It fixes this.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Jobbanned shouldn't be able to make server lag

## Testing
<!-- How did you test the PR, if at all? -->

Nope, just hoping for the best...

## Changelog
:cl:
fix: Jobbanned can't spam NarSie harvester smoke anymore
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
