### PR TITLE
[FIX] Mining Vendor now spits ID on power_off

### DIFF
--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -103,7 +103,7 @@
 	. = ..()
 	update_icon(UPDATE_ICON_STATE)
 	if(inserted_id && !(stat & NOPOWER))
-		visible_message("<span class='notice'>The ID slot indicator light flickers on \the [src] as it spits out a card before powering down.</span>")
+		visible_message("<span class='notice'>The ID slot indicator light flickers on [src] as it spits out a card before powering down.</span>")
 		remove_id()
 
 /obj/machinery/mineral/equipment_vendor/update_icon_state()

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -102,7 +102,7 @@
 /obj/machinery/mineral/equipment_vendor/power_change()
 	. = ..()
 	update_icon(UPDATE_ICON_STATE)
-	if(inserted_id && !(stat & NOPOWER))
+	if(. && inserted_id && (stat & NOPOWER))
 		visible_message("<span class='notice'>The ID slot indicator light flickers on [src] as it spits out a card before powering down.</span>")
 		remove_id()
 

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -93,13 +93,17 @@
 	)
 	prize_list["Extra"] = list() // Used in child vendors
 
+/obj/machinery/mineral/equipment_vendor/proc/remove_id()
+	if(inserted_id)
+		inserted_id.forceMove(get_turf(src))
+		inserted_id = null
+		return TRUE
+
 /obj/machinery/mineral/equipment_vendor/power_change()
 	if(!..())
-		return
-	update_icon(UPDATE_ICON_STATE)
-	if(inserted_id && !(stat & NOPOWER))
-		visible_message("<span class='notice'>The ID slot indicator light flickers on \the [src] as it spits out a card before powering down.</span>")
-		inserted_id.forceMove(loc)
+		update_icon(UPDATE_ICON_STATE)
+		if(remove_id())
+			visible_message("<span class='notice'>The ID slot indicator light flickers on \the [src] as it spits out a card before powering down.</span>")
 
 /obj/machinery/mineral/equipment_vendor/update_icon_state()
 	if(has_power())
@@ -203,8 +207,7 @@
 		return
 	if(panel_open)
 		if(istype(I, /obj/item/crowbar))
-			if(inserted_id)
-				inserted_id.forceMove(loc) //Prevents deconstructing the ORM from deleting whatever ID was inside it.
+			remove_id()
 			default_deconstruction_crowbar(user, I)
 		return TRUE
 	if(istype(I, /obj/item/mining_voucher))
@@ -268,8 +271,7 @@
 		qdel(src)
 
 /obj/machinery/mineral/equipment_vendor/Destroy()
-	if(inserted_id)
-		inserted_id.forceMove(loc)
+	remove_id()
 	return ..()
 
 

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -100,10 +100,11 @@
 		return TRUE
 
 /obj/machinery/mineral/equipment_vendor/power_change()
-	if(!..())
-		update_icon(UPDATE_ICON_STATE)
-		if(remove_id())
-			visible_message("<span class='notice'>The ID slot indicator light flickers on \the [src] as it spits out a card before powering down.</span>")
+	. = ..()
+	update_icon(UPDATE_ICON_STATE)
+	if(inserted_id && !(stat & NOPOWER))
+		visible_message("<span class='notice'>The ID slot indicator light flickers on \the [src] as it spits out a card before powering down.</span>")
+		remove_id()
 
 /obj/machinery/mineral/equipment_vendor/update_icon_state()
 	if(has_power())


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Mining Vendor now spits ID on power_off

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

My card, no! Also someone broke the check, it used to dupe it, but I fixed it too

## Testing
<!-- How did you test the PR, if at all? -->

Put card inside, turn off power

## Changelog
:cl:
fix: Mining Vendor now spits ID on power_off
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
