### PR TITLE
[FIX] Brand Intelligence will live in refillable vendor

### DIFF
--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -17,17 +17,20 @@
 	GLOB.minor_announcement.Announce("Rampant brand intelligence has been detected aboard [station_name()], please stand-by. The origin is believed to be \a [originMachine.name].", "Machine Learning Alert", 'sound/AI/brand_intelligence.ogg')
 
 /datum/event/brand_intelligence/start()
-	for(var/obj/machinery/economy/vending/V in GLOB.machines)
-		if(!is_station_level(V.z))
+	var/list/obj/machinery/economy/vending/leaderables = list()
+	for(var/obj/machinery/economy/vending/candidate in GLOB.machines)
+		if(!is_station_level(candidate.z))
 			continue
-		RegisterSignal(V, COMSIG_PARENT_QDELETING, PROC_REF(vendor_destroyed))
-		vendingMachines.Add(V)
+		RegisterSignal(candidate, COMSIG_PARENT_QDELETING, PROC_REF(vendor_destroyed))
+		vendingMachines.Add(candidate)
+		if(candidate.refill_canister)
+			leaderables.Add(candidate)
 
-	if(!length(vendingMachines))
+	if(!length(leaderables))
 		kill()
 		return
 
-	originMachine = pick(vendingMachines)
+	originMachine = pick(leaderables)
 	vendingMachines.Remove(originMachine)
 	originMachine.shut_up = FALSE
 	originMachine.shoot_inventory = TRUE


### PR DESCRIPTION
https://github.com/ss220-space/Paradise/pull/1343

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Brand Intelligence leader now cares if it can be disassembled.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Fighting the virus is disassembling, not destroying vendors.

## Testing
<!-- How did you test the PR, if at all? -->

I HOPE IT WORKS HERE TOO

## Changelog
:cl:
fix: Brand Intelligence leader now cares if it can be disassembled.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
