### PR TITLE
[FIX] UFO crash site chamber no more enterable

### DIFF
--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_ufo_crash.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_ufo_crash.dmm
@@ -6,9 +6,7 @@
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "c" = (
-/obj/machinery/abductor/experiment{
-	stat = 1
-},
+/obj/machinery/abductor/experiment/broken,
 /turf/simulated/floor/plating/abductor,
 /area/ruin/unpowered/misc_lavaruin)
 "d" = (

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_ufo_crash.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_ufo_crash.dmm
@@ -6,7 +6,9 @@
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "c" = (
-/obj/machinery/abductor/experiment,
+/obj/machinery/abductor/experiment{
+	stat = 1
+},
 /turf/simulated/floor/plating/abductor,
 /area/ruin/unpowered/misc_lavaruin)
 "d" = (

--- a/code/game/gamemodes/miniantags/abduction/machinery/experiment.dm
+++ b/code/game/gamemodes/miniantags/abduction/machinery/experiment.dm
@@ -24,6 +24,8 @@
 		icon_state = "experiment-open"
 
 /obj/machinery/abductor/experiment/MouseDrop_T(mob/living/carbon/human/target, mob/user)
+	if(stat)
+		return
 	if(user.stat || HAS_TRAIT(user, TRAIT_UI_BLOCKED) || !Adjacent(user) || !target.Adjacent(user) || !ishuman(target))
 		return
 	if(isabductor(target))

--- a/code/game/gamemodes/miniantags/abduction/machinery/experiment.dm
+++ b/code/game/gamemodes/miniantags/abduction/machinery/experiment.dm
@@ -24,8 +24,6 @@
 		icon_state = "experiment-open"
 
 /obj/machinery/abductor/experiment/MouseDrop_T(mob/living/carbon/human/target, mob/user)
-	if(stat)
-		return
 	if(user.stat || HAS_TRAIT(user, TRAIT_UI_BLOCKED) || !Adjacent(user) || !target.Adjacent(user) || !ishuman(target))
 		return
 	if(isabductor(target))
@@ -229,3 +227,9 @@
 	occupant.forceMove(get_turf(src))
 	occupant = null
 	update_icon(UPDATE_ICON_STATE)
+
+/obj/machinery/abductor/experiment/broken
+	stat = 1
+
+/obj/machinery/abductor/experiment/broken/MouseDrop_T(mob/living/carbon/human/target, mob/user)
+	return

--- a/code/game/gamemodes/miniantags/abduction/machinery/experiment.dm
+++ b/code/game/gamemodes/miniantags/abduction/machinery/experiment.dm
@@ -229,7 +229,7 @@
 	update_icon(UPDATE_ICON_STATE)
 
 /obj/machinery/abductor/experiment/broken
-	stat = 1
+	stat = BROKEN
 
 /obj/machinery/abductor/experiment/broken/MouseDrop_T(mob/living/carbon/human/target, mob/user)
 	return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Remove Jokerge trap, where you can enter the experimentor, but can't leave it. At all. Forever.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

If it doesn't work, it shouldn't open and close doors on you.

## Testing
<!-- How did you test the PR, if at all? -->

Spawn it, stat 1, can't enter

## Changelog
:cl:
fix: UFO crash site chamber no more enterable. Jokerge trap is no more
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
