### PR TITLE
[TWEAK] Activate and Drop now Extend and Retract arm implants in THE ARM

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -441,7 +441,7 @@
 	return
 
 /obj/item/organ/internal/cyberimp/arm/katana/Retract()
-	var/obj/item/cursed_katana/katana = holder
+	var/obj/item/cursed_katana/katana = active_item
 	if(!katana || katana.shattered)
 		return FALSE
 	if(!katana.drew_blood)
@@ -678,7 +678,7 @@
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		for(var/obj/item/organ/internal/cyberimp/arm/katana/O in H.internal_organs)
-			if(O.holder == src)
+			if(O.active_item == src)
 				O.Retract()
 	shattered = TRUE
 	addtimer(CALLBACK(src, PROC_REF(coagulate), user), 45 SECONDS)

--- a/code/modules/mob/living/carbon/human/human_mob.dm
+++ b/code/modules/mob/living/carbon/human/human_mob.dm
@@ -2172,3 +2172,9 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 	)
 
 	AddComponent(/datum/component/deadchat_control/cardinal_movement, mode, inputs, cooldown)
+
+/mob/living/carbon/human/limb_attack_self()
+	var/obj/item/organ/external/arm = hand ? get_organ(BODY_ZONE_L_ARM) : get_organ(BODY_ZONE_R_ARM)
+	if(arm)
+		arm.attack_self(src)
+	return ..()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -503,6 +503,16 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 	return seen_mobs
 
 /**
+  * Called by using Activate Held Object with an empty hand/limb
+  *
+  * Does nothing by default. The intended use is to allow limbs to call their
+  * own attack_self procs. It is up to the individual mob to override this
+  * parent and actually use it.
+  */
+/mob/proc/limb_attack_self()
+	return
+
+/**
  * Returns an assoc list which contains the mobs in range and their "visible" name.
  * Mobs out of view but in range will be listed as unknown. Else they will have their visible name
 */
@@ -656,17 +666,14 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 /mob/proc/run_mode()
 	if(ismecha(loc)) return
 
-	if(hand)
-		var/obj/item/W = l_hand
-		if(W)
-			W.attack_self(src)
-			update_inv_l_hand()
-	else
-		var/obj/item/W = r_hand
-		if(W)
-			W.attack_self(src)
-			update_inv_r_hand()
-	return
+	var/obj/item/I = get_active_hand()
+	if(I)
+		I.attack_self(src)
+		update_inv_l_hand()
+		update_inv_r_hand()
+		return
+
+	limb_attack_self()
 
 /*
 /mob/verb/dump_source()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Now, when you actiavte you empty hand with an implant, a radial menu opens. When you drop your hand with an implant active, it retracts

Also, it adds an ability to use an empty hand. So, probably, add xeno's spit into the hand by using it? :eyes:

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

More straight-forward arm implant usage?

## Testing
<!-- How did you test the PR, if at all? -->

Implant armtoolset, use it all the ways possible

## Changelog
:cl:
tweak: Activate and Drop now Extend and Retract arm implants in THE ARM. Z/Q (by defaults) Extend and Retracts.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
