### PR TITLE
[FIX] Mute people can show Emote Typing Indicator

### DIFF
--- a/code/modules/mob/typing_indicator.dm
+++ b/code/modules/mob/typing_indicator.dm
@@ -21,7 +21,7 @@ GLOBAL_LIST_EMPTY(typing_indicator)
 		var/image/I = GLOB.typing_indicator[bubble_icon]
 		I.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
 
-	if(ishuman(src))
+	if(ishuman(src) && !me)
 		var/mob/living/carbon/human/H = src
 		if(HAS_TRAIT(H, TRAIT_MUTE))
 			overlays -= GLOB.typing_indicator[bubble_icon]


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Mutes can now show that they are emoting

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Mutes can still Emote, so, they shouldn't be blocked from Emote Typing Indicator

## Testing
<!-- How did you test the PR, if at all? -->

Be mute, try to say, try to me

## Changelog
:cl:
fix: Mute people can show Emote Typing Indicator
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
