### PR TITLE
Buffs revivers, Again.

### DIFF
--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -403,15 +403,16 @@
 	if(cooldown > world.time || owner.suiciding) // don't heal while you're in cooldown!
 		return
 	if(reviving)
-		if(owner.health <= HEALTH_THRESHOLD_CRIT)
+		reviving = FALSE
+		if(owner.health <= HEALTH_THRESHOLD_CRIT + 10) //We do not want to leave them on the end of crit constantly.
 			addtimer(CALLBACK(src, PROC_REF(heal)), 30)
-		else
-			reviving = FALSE
-			if(owner.HasDisease(new /datum/disease/critical/shock(0)) && prob(15)) //If they are no longer in crit, but have shock, and pass a 15% chance:
-				for(var/datum/disease/critical/shock/S in owner.viruses)
-					S.cure()
-					revive_cost += 150
-					to_chat(owner, "<span class='notice'>You feel better.</span>")
+			reviving = TRUE
+		if(owner.health > HEALTH_THRESHOLD_CRIT && owner.HasDisease(new /datum/disease/critical/shock(0)) && prob(15)) //We do not do an else, as we need them to cure shock inside this magic zone of 10 damage
+			for(var/datum/disease/critical/shock/S in owner.viruses)
+				S.cure()
+				revive_cost += 150
+				to_chat(owner, "<span class='notice'>You feel better.</span>")
+		if(!reviving)
 			return
 	cooldown = revive_cost + world.time
 	revive_cost = 0
@@ -424,14 +425,14 @@
 		owner.adjustOxyLoss(-3)
 		revive_cost += 5
 	if(prob(75) && owner.getBruteLoss())
-		owner.adjustBruteLoss(-1)
-		revive_cost += 20
+		owner.adjustBruteLoss(-1.5)
+		revive_cost += 15
 	if(prob(75) && owner.getFireLoss())
-		owner.adjustFireLoss(-1)
-		revive_cost += 20
+		owner.adjustFireLoss(-1.5)
+		revive_cost += 15
 	if(prob(40) && owner.getToxLoss())
 		owner.adjustToxLoss(-1)
-		revive_cost += 50
+		revive_cost += 25
 
 
 /obj/item/organ/internal/cyberimp/chest/reviver/emp_act(severity)

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -425,10 +425,10 @@
 		owner.adjustOxyLoss(-3)
 		revive_cost += 5
 	if(prob(75) && owner.getBruteLoss())
-		owner.adjustBruteLoss(-1.5)
+		owner.adjustBruteLoss(-2)
 		revive_cost += 15
 	if(prob(75) && owner.getFireLoss())
-		owner.adjustFireLoss(-1.5)
+		owner.adjustFireLoss(-2)
 		revive_cost += 15
 	if(prob(40) && owner.getToxLoss())
 		owner.adjustToxLoss(-1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Revivers heal to 10 hp rather than stopping at 0 hp.
Reviver cooldown reduced on brute, burn, or toxin healing, and healing of brute / burn doubled to 2

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Let us discuss what the reviver is, and what it does.
The reviver is supposed to _try_ to heal you out of critical condition. It is something you must undergo sugery for, and take the risks and time of surgery. It should not heal you out of crit, or save you from being beaten to death, or save you in a hostile enviroment like plasma / space / fire. You also take the risk of EMP certifying your death unless someone has a handheld defib near you. It's not supposed to save you from having to go to medbay after

Now, what does it do in practice:

Fuck all, really.

It leaves you on the end of crit, struggling to heal shock if the person has any blood loss past 10%. It's heal rate is incredibly slow, healing once every 3-4 seconds if the user has a pure damage type and oxygen in crit. If you suffer from brute and burn, it will be even slower. If you have 10 or so toxin damage in you for one reason or another, lol. That will make your healing slow to a crawl.  It almost certainly won't save you without epi, and to be frank, saline is easier to get from the public med fridge, and will heal you better for less effort. 

Or of course, a healing virus from medbay. Which heals you forever out of crit, and heals you much faster, and unless you get IB/ broken bones / burn wounds, you won't need to go to medbay with one, unless you get super deep and need to epi pen, requiring you to get a refill.

For all the risks of the reviver, it's "rewards" are not worth it. It's nice to have non combat implants being used. Good for robotics and medbay to do stuff. The issue is no one gets reviver as it is not worth it. Even now, it probably still is not worth it, as I don't want to make the healing stack too much with other sources. This will save you if you get nicked 5-15 or so damage into crit. Past that, you will either need to get epi, in order to keep stage 2 crit from killing you, or an upgraded cybernetic heart. You also, unlike the healing virus, will still need to go to medbay.

Sure, I could make the reviver fix stage 2 crit, but people are going to get the upgraded cybernetic heart if they are getting a reviver, so it won't change much, in those regards.

The reviver should be over twice as effective now. If you are only just put past crit, it will work much better for you. Deeper will be less painful, and will work well with epi, but epi will be needed.

## Testing
<!-- How did you test the PR, if at all? -->
Hurt myself with a reviver a bunch.

## Changelog
:cl:
tweak: Reviver now heals brute and burn more. Reviver has slightly less cooldown between healing, and reviver will heal you to 10 points off crit, rather than stopping at 0 hp.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
