### PR TITLE
Clown is slippery and the mime has no footsteps

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -304,6 +304,8 @@
 
 ///from base of /datum/mind/proc/transfer_to(mob/living/new_character)
 #define COMSIG_MIND_TRANSER_TO "mind_transfer_to"
+///called on the mob instead of the mind
+#define COMSIG_BODY_TRANSFER_TO "body_transfer_to"
 
 // /mob signals
 

--- a/code/datums/components/slippery.dm
+++ b/code/datums/components/slippery.dm
@@ -22,8 +22,10 @@
 	var/slip_always
 	/// The verb that players will see when someone slips on the parent. In the form of "You [slip_verb]ped on".
 	var/slip_verb
+	/// TRUE the player will only slip if the mob this datum is attached to is horizontal
+	var/horizontal_required
 
-/datum/component/slippery/Initialize(_description, _knockdown = 0, _slip_chance = 100, _slip_tiles = 0, _walking_is_safe = TRUE, _slip_always = FALSE, _slip_verb = "slip")
+/datum/component/slippery/Initialize(_description, _knockdown = 0, _slip_chance = 100, _slip_tiles = 0, _walking_is_safe = TRUE, _slip_always = FALSE, _slip_verb = "slip", _horizontal_required = FALSE)
 	if(!isatom(parent))
 		return COMPONENT_INCOMPATIBLE
 
@@ -34,6 +36,7 @@
 	walking_is_safe = _walking_is_safe
 	slip_always = _slip_always
 	slip_verb = _slip_verb
+	horizontal_required = _horizontal_required
 
 /datum/component/slippery/RegisterWithParent()
 	RegisterSignal(parent, list(COMSIG_MOVABLE_CROSSED, COMSIG_ATOM_ENTERED), PROC_REF(Slip))
@@ -52,5 +55,9 @@
 		var/atom/movable/owner = parent
 		if(!isturf(owner.loc))
 			return
+		if(isliving(owner))
+			var/mob/living/mob_owner = owner
+			if(horizontal_required && !IS_HORIZONTAL(mob_owner))
+				return
 		if(prob(slip_chance) && victim.slip(description, knockdown, slip_tiles, walking_is_safe, slip_always, slip_verb))
 			owner.after_slip(victim)

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -146,6 +146,7 @@
 	if(active)
 		new_character.key = key		//now transfer the key to link the client to our new body
 	SEND_SIGNAL(src, COMSIG_MIND_TRANSER_TO, new_character)
+	SEND_SIGNAL(new_character, COMSIG_BODY_TRANSFER_TO)
 
 /datum/mind/proc/store_memory(new_text)
 	memory += "[new_text]<BR>"

--- a/code/game/jobs/job/support.dm
+++ b/code/game/jobs/job/support.dm
@@ -307,6 +307,7 @@
 		H.dna.default_blocks.Add(GLOB.comicblock)
 	H.check_mutations = TRUE
 	H.add_language("Clownish")
+	H.AddComponent(/datum/component/slippery, H, 8 SECONDS, 100, 0, FALSE, TRUE, "slip", TRUE)
 
 //action given to antag clowns
 /datum/action/innate/toggle_clumsy
@@ -380,8 +381,7 @@
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/aoe/conjure/build/mime_wall(null))
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/mime/speak(null))
 		H.mind.miming = 1
-
-
+	qdel(H.GetComponent(/datum/component/footstep))
 
 /datum/job/janitor
 	title = "Janitor"

--- a/code/modules/mob/living/carbon/human/human_mob.dm
+++ b/code/modules/mob/living/carbon/human/human_mob.dm
@@ -20,6 +20,17 @@
 	UpdateAppearance()
 	GLOB.human_list += src
 	AddComponent(/datum/component/footstep, FOOTSTEP_MOB_HUMAN, 1, -6)
+	RegisterSignal(src, COMSIG_BODY_TRANSFER_TO, PROC_REF(mind_checks))
+
+/**
+  * Handles any adjustments to the mob after a mind transfer.
+  */
+
+/mob/living/carbon/human/proc/mind_checks()
+	if(!mind)
+		return
+	if(mind.miming)
+		qdel(GetComponent(/datum/component/footstep))
 
 /**
   * Sets up DNA and species.
@@ -68,6 +79,7 @@
 	splinted_limbs.Cut()
 	QDEL_NULL(physiology)
 	GLOB.human_list -= src
+	UnregisterSignal(src, COMSIG_BODY_TRANSFER_TO)
 
 /mob/living/carbon/human/dummy
 	real_name = "Test Dummy"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
The clown is now slippery, 8 second slip when they're horizontal and someone tries to walk over them
Mime now has no footsteps

## Why It's Good For The Game
Both these things work with the gimmick of the job. Mimes being silent and clowns being a little slippery (with their PDA and... well everything else). This gives a little more sillyness to the antagging side of both these roles as well, now you can do silent takedowns effectively as a mime.

## Testing
Walked around, heard nothing, slipped on a damn clown!

## Changelog
:cl:
tweak: The clown can now slip you while lying down, 8 second slip
tweak: The mime has no footstep sound
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
