### PR TITLE
Makes things dust when the SM bumps them as well

### DIFF
--- a/code/modules/power/engines/supermatter/supermatter.dm
+++ b/code/modules/power/engines/supermatter/supermatter.dm
@@ -793,10 +793,6 @@
 	else if(isobj(AM) && !iseffect(AM))
 		AM.visible_message("<span class='danger'>[AM] smacks into [src] and rapidly flashes to ash.</span>", null,\
 		"<span class='italics'>You hear a loud crack as you are washed with a wave of heat.</span>")
-	else if(istype(A, /obj/machinery/economy/vending))
-		var/obj/machinery/economy/vending/V = A
-		V.tilt(src)
-		AddElement(/datum/element/squish, 80 SECONDS)
 	else
 		return
 

--- a/code/modules/power/engines/supermatter/supermatter.dm
+++ b/code/modules/power/engines/supermatter/supermatter.dm
@@ -245,6 +245,8 @@
 	. +="<span class='notice'>Any object that touches [src] instantly turns to dust, be it complex as a human or as simple as a metal rod. These bursts of energy can cause hallucinations if meson scanners are not worn near the crystal.</span>"
 	if(isAntag(user))
 		. += "<span class='warning'>Although a T.E.G. is more costly, there's a damn good reason the syndicate doesn't use this. If the integrity of [src] dips to 0%, perhaps from overheating, the supermatter will violently explode destroying nearly everything even somewhat close to it and releasing massive amounts of radiation.</span>"
+	if(moveable)
+		. += "<span class='notice'>It can be [anchored ? "unfastened from" : "fastened to"] the floor with a wrench.</span>"
 
 /obj/machinery/atmospherics/supermatter_crystal/proc/get_status()
 	var/turf/T = get_turf(src)

--- a/code/modules/power/engines/supermatter/supermatter.dm
+++ b/code/modules/power/engines/supermatter/supermatter.dm
@@ -793,11 +793,19 @@
 	else if(isobj(AM) && !iseffect(AM))
 		AM.visible_message("<span class='danger'>[AM] smacks into [src] and rapidly flashes to ash.</span>", null,\
 		"<span class='italics'>You hear a loud crack as you are washed with a wave of heat.</span>")
+	else if(istype(A, /obj/machinery/economy/vending))
+		var/obj/machinery/economy/vending/V = A
+		V.tilt(src)
+		AddElement(/datum/element/squish, 80 SECONDS)
 	else
 		return
 
 	playsound(get_turf(src), 'sound/effects/supermatter.ogg', 50, TRUE)
 	Consume(AM)
+
+/obj/machinery/atmospherics/supermatter_crystal/Bump(atom/A, yes)
+	..()
+	Bumped(A)
 
 /obj/machinery/atmospherics/supermatter_crystal/proc/Consume(atom/movable/AM)
 	if(isliving(AM))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes things dust when a supermatter crystal runs into them as well. While this probably won't be the case with the main engine supermatter, it could come into play if a supermatter crystal starts moving around...
Also, provides some examine text to show that the crystal can be wrenched down, since it isn't really clear and not something you're generally going to experiment with.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Really, a supermatter crystal running into you and you being fine is just a weird interaction that doesn't feel quite right. This is more where it's at. Note that if an SM (in particular, a shard) runs into a window, it will destroy it, which should encourage you to anchor your shards before they start bouncing all over the place.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

https://github.com/ParadiseSS13/Paradise/assets/89928798/5bd0f82c-c44d-4454-ad6a-eb7e596e3334
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: You will now be dusted if an SM crystal bumps itself into you. Watch out!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
