### PR TITLE
Floodlights can now only be turned on if they are anchored

### DIFF
--- a/code/game/machinery/floodlight.dm
+++ b/code/game/machinery/floodlight.dm
@@ -72,7 +72,7 @@
 			to_chat(user, "<span class='warning'>[src] hardly glows at all! Seems like the <b>power cell is empty</b>.</span>")
 			return
 		if(!anchored)
-			visible_message("<span class='warning'>[src] must be anchored first!</span>")
+			to_chat(user, "<span class='warning'>[src] must be anchored first!</span>")
 			return
 		on = TRUE
 		to_chat(user, "<span class='notice'>You turn on the light.</span>")

--- a/code/game/machinery/floodlight.dm
+++ b/code/game/machinery/floodlight.dm
@@ -71,6 +71,9 @@
 		if(cell.charge <= 0)
 			to_chat(user, "<span class='warning'>[src] hardly glows at all! Seems like the <b>power cell is empty</b>.</span>")
 			return
+		if(!anchored)
+			visible_message("<span class='warning'>[src] must be anchored first!</span>")
+			return
 		on = TRUE
 		to_chat(user, "<span class='notice'>You turn on the light.</span>")
 		set_light(brightness_on)
@@ -140,6 +143,10 @@
 	. = TRUE
 	if(!I.tool_use_check(user, 0))
 		return
+	if(anchored)
+		on = FALSE
+		set_light(0)
+		update_icon(UPDATE_ICON_STATE)
 	default_unfasten_wrench(user, I)
 
 /obj/machinery/floodlight/extinguish_light(force = FALSE)

--- a/code/game/machinery/floodlight.dm
+++ b/code/game/machinery/floodlight.dm
@@ -144,9 +144,7 @@
 	if(!I.tool_use_check(user, 0))
 		return
 	if(anchored)
-		on = FALSE
-		set_light(0)
-		update_icon(UPDATE_ICON_STATE)
+		extinguish_light()
 	default_unfasten_wrench(user, I)
 
 /obj/machinery/floodlight/extinguish_light(force = FALSE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Floodlights can now only be turned on if they are anchored to the ground.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Running around with a lit floodlight in maints is silly, also it can really steamroll an unprepared shadow demon. There's some more here that I really can't remember off of the top of my head right now.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Tried to turn an unanchored floodlight on, could do it when I wrenched it down
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: you can now only turn on a floodlight if it's wrenched down
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
