### PR TITLE
Keycard Authenticator now has 20 seconds to swipe, but requires 2 different people.

### DIFF
--- a/code/modules/security_levels/keycard_authentication.dm
+++ b/code/modules/security_levels/keycard_authentication.dm
@@ -8,7 +8,8 @@
 	var/event
 	var/swiping = FALSE // on swiping screen?
 	var/confirm_delay = 20 SECONDS // time allowed for a second person to confirm a swipe.
-	var/busy = FALSE // Busy when waiting for authentication or an event request has been sent from this device. So someone on the other end can't just close the ERT menu while someone is typing
+	/// True when a request is sent from another device. So someone on the other end can't just close the ERT menu while someone is typing
+	var/busy = FALSE
 	var/obj/machinery/keycard_auth/event_source
 	var/mob/triggered_by
 	var/mob/confirmed_by
@@ -202,6 +203,7 @@
 
 /obj/machinery/keycard_auth/proc/remind_admins(old_reason, the_triggerer) // im great at naming variables
 	if(GLOB.ert_request_answered)
+		GLOB.ert_request_answered = FALSE // For ERT requests that may come later
 		return
 	ERT_Announce(old_reason, the_triggerer, repeat_warning = TRUE)
 

--- a/code/modules/security_levels/keycard_authentication.dm
+++ b/code/modules/security_levels/keycard_authentication.dm
@@ -7,13 +7,11 @@
 	var/active = FALSE // This gets set to TRUE on all devices except the one where the initial request was made.
 	var/event
 	var/swiping = FALSE // on swiping screen?
-	var/list/ert_chosen = list()
-	var/confirmed = FALSE // This variable is set by the device that confirms the request.
-	var/confirm_delay = 5 SECONDS // time allowed for a second person to confirm a swipe.
-	var/busy = FALSE // Busy when waiting for authentication or an event request has been sent from this device.
+	var/confirm_delay = 20 SECONDS // time allowed for a second person to confirm a swipe.
+	var/busy = FALSE // Busy when waiting for authentication or an event request has been sent from this device. So someone on the other end can't just close the ERT menu while someone is typing
 	var/obj/machinery/keycard_auth/event_source
-	var/mob/event_triggered_by
-	var/mob/event_confirmed_by
+	var/mob/triggered_by
+	var/mob/confirmed_by
 	var/ert_reason
 
 	anchored = TRUE
@@ -27,7 +25,7 @@
 /obj/machinery/keycard_auth/update_icon_state()
 	. = ..()
 
-	if(event_triggered_by || event_source)
+	if(triggered_by || event_source)
 		icon_state = "auth_on"
 	else
 		icon_state = "auth_off"
@@ -36,37 +34,42 @@
 	. = ..()
 	underlays.Cut()
 
-	if(event_triggered_by || event_source)
+	if(triggered_by || event_source)
 		underlays += emissive_appearance(icon, "auth_lightmask")
 
 
-/obj/machinery/keycard_auth/attack_ai(mob/user as mob)
+/obj/machinery/keycard_auth/attack_ai(mob/user)
 	to_chat(user, "<span class='warning'>The station AI is not to interact with these devices.</span>")
 	return
 
-/obj/machinery/keycard_auth/attackby(obj/item/W as obj, mob/user as mob, params)
+/obj/machinery/keycard_auth/attackby(obj/item/W, mob/user, params)
 	if(stat & (NOPOWER|BROKEN))
 		to_chat(user, "This device is not powered.")
 		return
 	if(istype(W, /obj/item/card/id) || istype(W, /obj/item/pda))
-		if(check_access(W))
-			if(active)
-				//This is not the device that made the initial request. It is the device confirming the request.
-				if(event_source)
-					event_source.confirmed = TRUE
-					event_source.event_confirmed_by = usr
-					SStgui.update_uis(event_source)
-					SStgui.update_uis(src)
-			else if(swiping)
-				if(event == "Emergency Response Team" && !ert_reason)
-					to_chat(user, "<span class='warning'>Supply a reason for calling the ERT first!</span>")
-					return
-				event_triggered_by = usr
-				SStgui.update_uis(src)
-				broadcast_request() //This is the device making the initial event request. It needs to broadcast to other devices
-		else
+		if(!check_access(W))
 			to_chat(user, "<span class='warning'>Access denied.</span>")
-		return
+			return
+		if(user == event_source?.triggered_by)
+			to_chat(user, "<span class='warning'>Identical body-signature detected. Access denied.</span>")
+			return
+		if(active)
+			//This is not the device that made the initial request. It is the device confirming the request.
+			if(!event_source)
+				return
+			event_source.confirmed_by = user
+			SStgui.update_uis(event_source)
+			SStgui.update_uis(src)
+			event_source.confirm_and_trigger()
+			reset()
+			return
+		if(swiping)
+			if(event == "Emergency Response Team" && !ert_reason)
+				to_chat(user, "<span class='warning'>Supply a reason for calling the ERT first!</span>")
+				return
+			triggered_by = user
+			SStgui.update_uis(src)
+			broadcast_request() //This is the device making the initial event request. It needs to broadcast to other devices
 	return ..()
 
 /obj/machinery/keycard_auth/power_change()
@@ -97,8 +100,8 @@
 	data["event"] = active && event_source && event_source.event ? event_source.event : event
 	data["ertreason"] = active && event_source && event_source.ert_reason ? event_source.ert_reason : ert_reason
 	data["isRemote"] = active ? TRUE : FALSE
-	data["hasSwiped"] = event_triggered_by ? TRUE : FALSE
-	data["hasConfirm"] = event_confirmed_by || (active && event_source && event_source.event_confirmed_by) ? TRUE : FALSE
+	data["hasSwiped"] = triggered_by ? TRUE : FALSE
+	data["hasConfirm"] = confirmed_by || (active && event_source && event_source.confirmed_by) ? TRUE : FALSE
 	return data
 
 /obj/machinery/keycard_auth/ui_act(action, params)
@@ -126,10 +129,10 @@
 	active = FALSE
 	event = null
 	swiping = FALSE
-	confirmed = FALSE
+	busy = FALSE
 	event_source = null
-	event_triggered_by = null
-	event_confirmed_by = null
+	triggered_by = null
+	confirmed_by = null
 	set_light(0)
 	update_icon()
 
@@ -137,39 +140,32 @@
 	update_icon()
 	set_light(1, LIGHTING_MINIMUM_POWER)
 	for(var/obj/machinery/keycard_auth/KA in GLOB.machines)
-		if(KA == src) continue
-		KA.reset()
-		spawn()
-			KA.receive_request(src)
+		if(KA == src)
+			continue
+		KA.receive_request(src)
 
-	sleep(confirm_delay)
-	if(confirmed)
-		confirmed = FALSE
-		trigger_event(event)
-		log_game("[key_name(event_triggered_by)] triggered and [key_name(event_confirmed_by)] confirmed event [event]")
-		message_admins("[key_name_admin(event_triggered_by)] triggered and [key_name_admin(event_confirmed_by)] confirmed event [event]", 1)
+	addtimer(CALLBACK(src, PROC_REF(reset)), confirm_delay)
+
+/obj/machinery/keycard_auth/proc/confirm_and_trigger()
+	trigger_event(event)
+	log_game("[key_name(triggered_by)] triggered and [key_name(confirmed_by)] confirmed event [event]")
+	message_admins("[key_name_admin(triggered_by)] triggered and [key_name_admin(confirmed_by)] confirmed event [event]", 1)
+
 	reset()
 
 /obj/machinery/keycard_auth/proc/receive_request(obj/machinery/keycard_auth/source)
 	if(stat & (BROKEN|NOPOWER))
 		return
+	reset()
 
 	set_light(1, LIGHTING_MINIMUM_POWER)
-
 	event_source = source
 	busy = TRUE
 	active = TRUE
 	SStgui.update_uis(src)
 	update_icon()
 
-	sleep(confirm_delay)
-
-	event_source = null
-	update_icon()
-	active = FALSE
-	busy = FALSE
-
-	set_light(0)
+	addtimer(CALLBACK(src, PROC_REF(reset)), confirm_delay)
 
 /obj/machinery/keycard_auth/proc/trigger_event()
 	switch(event)
@@ -195,16 +191,19 @@
 			for(var/client/C in GLOB.admins)
 				if(check_rights(R_EVENT, 0, C.mob))
 					fullmin_count++
-			if(fullmin_count)
-				GLOB.ert_request_answered = TRUE
-				ERT_Announce(ert_reason , event_triggered_by, 0)
-				ert_reason = null
-				SSblackbox.record_feedback("nested tally", "keycard_auths", 1, list("ert", "called"))
-				spawn(3000)
-					if(!GLOB.ert_request_answered)
-						ERT_Announce(ert_reason , event_triggered_by, 1)
-			else
+			if(!fullmin_count)
 				trigger_armed_response_team(new /datum/response_team/amber) // No admins? No problem. Automatically send a code amber ERT.
+				return
+
+			ERT_Announce(ert_reason, triggered_by, repeat_warning = FALSE)
+			SSblackbox.record_feedback("nested tally", "keycard_auths", 1, list("ert", "called"))
+			addtimer(CALLBACK(src, PROC_REF(remind_admins), ert_reason, triggered_by), 5 MINUTES)
+			ert_reason = null
+
+/obj/machinery/keycard_auth/proc/remind_admins(old_reason, the_triggerer) // im great at naming variables
+	if(GLOB.ert_request_answered)
+		return
+	ERT_Announce(old_reason, the_triggerer, repeat_warning = TRUE)
 
 /obj/machinery/keycard_auth/proc/is_ert_blocked()
 	return SSticker.mode && SSticker.mode.ert_disabled


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->Keycard Authenticator now has 20 seconds to swipe, but requires 2 different people. Also refactors a ton of the old code, along with fixing a bug where admins would not be notified if an ERT request wasn't responded to in 5 minutes. It checks by mob, so clings cant cause any shenanigans with it.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->These things are kind of frustrating, sometimes you just miss your chance to swipe and you gotta redo it all over again. To trade this off to prevent abuse, you can no longer swipe at 2 different keycard auths to get red/ert/whatever. You shouldn't be able to do it anyways, but sometimes mistakes are made in mapping.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
This is what happens if you try to run over and swipe at another one.
![image](https://github.com/ParadiseSS13/Paradise/assets/91113370/d9634a7d-f412-4180-99a8-3416fb182cad)


## Testing
<!-- How did you test the PR, if at all? -->
Did a ton of swiping, running around, and waiting 5 minutes for the admin reminder

## Changelog
:cl:
tweak: Keycard Authenticators now give 20 seconds to swipe
tweak: Keycard Authenticators now require 2 different people for confirmation.
fix: Admins will now get a proper reminder 5 minutes after an ERT request, if they have not already answered.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
