### PR TITLE
Chem Dispensers no longer work while unanchored

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -187,6 +187,8 @@
 		return
 	if(stat & (NOPOWER|BROKEN))
 		return
+	if(!anchored)
+		return
 
 	. = TRUE
 	switch(actions)
@@ -309,6 +311,9 @@
 
 /obj/machinery/chem_dispenser/attack_hand(mob/user)
 	if(stat & BROKEN)
+		return
+	if(!anchored)
+		visible_message("<span class='warning'>[src] must be anchored first!</span>")
 		return
 	ui_interact(user)
 

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -313,7 +313,7 @@
 	if(stat & BROKEN)
 		return
 	if(!anchored)
-		visible_message("<span class='warning'>[src] must be anchored first!</span>")
+		to_chat("<span class='warning'>[src] must be anchored first!</span>")
 		return
 	ui_interact(user)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Chem dispensers now need to be anchored in order to be used.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Requiring the dispenser to be anchored prevents on the fly chem mixing and low prep smoke bombs that previously required little effort for the user
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


## Testing
Tried to use an anchored chem dispenser: Worked
Tried to use an unanchored chem dispenser: Did not work
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Chem dispensers must be anchored to use
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
