### PR TITLE
Attempts to allow for timers attached to no objects to be diagnosed

### DIFF
--- a/code/controllers/subsystem/SStimer.dm
+++ b/code/controllers/subsystem/SStimer.dm
@@ -547,6 +547,8 @@ SUBSYSTEM_DEF(timer)
 	if (callBack.object == GLOBAL_PROC)
 		. = "GLOBAL_PROC"
 	else
+		if(isnull(callBack.object))
+			CRASH("this timer is attached to no object, the attempted proc to call was [callBack.delegate]")
 		. = "[callBack.object.type]"
 
 GLOBAL_LIST_EMPTY(timers_by_type)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Throws an error along with whatever proc a timer was trying to call if there's no object attached to it

## Why It's Good For The Game
ok so we've been getting an absolute mass of runtimes like this: ``Runtime in SStimer.dm,550: Cannot read null.type``
it's attached to a subsystem so this pretty much gives us zero help in figuring out what exactly is causing the issue. If the object is null now, we'll get the proc it was trying to call and then will be able to work backwards from there 

## Testing
We don't know what's causing the issue, so I can't really think of a way to test this

## Changelog
NPFC

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
