### PR TITLE
Fix: stop magic staff recharging while already at max charge

### DIFF
--- a/code/modules/projectiles/guns/magic.dm
+++ b/code/modules/projectiles/guns/magic.dm
@@ -74,7 +74,7 @@
 	if(charge_tick >= recharge_rate)
 		charge_tick = 0
 		charges++
-		return 1
+		return TRUE
 	else
 		return 0
 

--- a/code/modules/projectiles/guns/magic.dm
+++ b/code/modules/projectiles/guns/magic.dm
@@ -66,7 +66,7 @@
 
 /obj/item/gun/magic/process()
 	// Don't start recharging until we lose a charge
-	if (charges >= max_charges)
+	if(charges >= max_charges)
 		charge_tick = 0
 		return 0
 

--- a/code/modules/projectiles/guns/magic.dm
+++ b/code/modules/projectiles/guns/magic.dm
@@ -65,12 +65,18 @@
 
 
 /obj/item/gun/magic/process()
-	charge_tick++
-	if(charge_tick < recharge_rate || charges >= max_charges)
+	// Don't start recharging until we lose a charge
+	if (charges >= max_charges)
+		charge_tick = 0
 		return 0
-	charge_tick = 0
-	charges++
-	return 1
+
+	charge_tick++
+	if(charge_tick >= recharge_rate)
+		charge_tick = 0
+		charges++
+		return 1
+	else
+		return 0
 
 /obj/item/gun/magic/update_icon_state()
 	return

--- a/code/modules/projectiles/guns/magic.dm
+++ b/code/modules/projectiles/guns/magic.dm
@@ -76,7 +76,7 @@
 		charges++
 		return TRUE
 	else
-		return 0
+		return FALSE
 
 /obj/item/gun/magic/update_icon_state()
 	return

--- a/code/modules/projectiles/guns/magic.dm
+++ b/code/modules/projectiles/guns/magic.dm
@@ -68,7 +68,7 @@
 	// Don't start recharging until we lose a charge
 	if(charges >= max_charges)
 		charge_tick = 0
-		return 0
+		return FALSE
 
 	charge_tick++
 	if(charge_tick >= recharge_rate)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Makes staffs actually have the number of max charges they're supposed to

## Why It's Good For The Game

This makes the value of `max_charges` on a `/gun/magic` item more accurate. Before, `max_charges = 1` would actually mean two charges, because you'd accumulate infinite increases to `charge_tick` that would then immediately refill the charge when lost.

## Testing
<!-- How did you test the PR, if at all? -->

Spawned and fired a bunch of staffs

## Changelog
:cl:
fix: Magic staffs now have the correct number of max charges in practice
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
