### PR TITLE
Adds article override to make examine text more consistent

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -738,3 +738,11 @@
 /proc/strip_html_tags(the_text)
 	var/static/regex/html_replacer = regex("<\[^>]*>", "g")
 	return html_replacer.Replace(the_text, "")
+
+/proc/starts_with_vowel(text)
+	var/start_char = copytext(text, 1, 2)
+	switch(lowertext(start_char))
+		if("a", "e", "i", "o", "u")
+			return TRUE
+		else
+			return FALSE

--- a/code/modules/mob/living/carbon/human/human_examine.dm
+++ b/code/modules/mob/living/carbon/human/human_examine.dm
@@ -56,10 +56,15 @@
 		msg += "!"    //omit the species when examining
 	else if(displayed_species == "Slime People") //snowflakey because Slime People are defined as a plural
 		msg += ", a<b><font color='[examine_color]'> slime person</font></b>!"
-	else if(displayed_species == "Unathi") //DAMN YOU, VOWELS
-		msg += ", a<b><font color='[examine_color]'> unathi</font></b>!"
 	else
-		msg += ", a<b><font color='[examine_color]'> [lowertext(displayed_species)]</font></b>!"
+		// do all this extra stuff because byond's text macros get confused by whatever comes between the species name and the article,
+		// so we can't just do \a
+		var/article_override = dna?.species.article_override
+		var/article = article_override
+		if(!article_override)
+			article = starts_with_vowel(displayed_species) ? "an" : "a"
+
+		msg += ", [article]<b><font color='[examine_color]'> [lowertext(displayed_species)]</font></b>!"
 
 	return msg
 

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -1,6 +1,9 @@
 /datum/species
 	var/name                     // Species name.
 	var/name_plural 			// Pluralized name (since "[name]s" is not always valid)
+	/// Article to use when referring to an individual of the species, if pronunciation is different from expected.
+	/// Because it's unathi's turn to be special snowflakes.
+	var/article_override
 	var/icobase = 'icons/mob/human_races/r_human.dmi'    // Normal icon set.
 
 	/// Minimum age this species can have

--- a/code/modules/mob/living/carbon/human/species/unathi.dm
+++ b/code/modules/mob/living/carbon/human/species/unathi.dm
@@ -1,6 +1,7 @@
 /datum/species/unathi
 	name = "Unathi"
 	name_plural = "Unathi"
+	article_override = "a"  // it's pronounced "you-nah-thee"
 	icobase = 'icons/mob/human_races/r_lizard.dmi'
 	language = "Sinta'unathi"
 	tail = "sogtail"
@@ -106,6 +107,7 @@
 /datum/species/unathi/ashwalker
 	name = "Ash Walker"
 	name_plural = "Ash Walkers"
+	article_override = null
 
 	blurb = "These reptillian creatures appear to be related to the Unathi, but seem significantly less evolved. \
 	They roam the wastes of Lavaland, worshipping a dead city and capturing unsuspecting miners."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes articles on examine more consistent, fixing (for example) `a ash walker`, while making one less snowflake check for unathi (did you know they're pronounced "you-nah-thee"? I didn't until 20 minutes ago).
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Better grammar, especially in examine bodies, is good. This change means we won't have to worry about special-casing any other species down the line in this check.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
![image](https://github.com/ParadiseSS13/Paradise/assets/89928798/e649ebb8-a69c-46a6-b1c6-49f59d941de6)

<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Ash walkers will now use the proper article in their examine text.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
