### PR TITLE
kills off last_bumped, jank reduction

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -15,7 +15,6 @@
 
 	var/list/blood_DNA
 	var/blood_color
-	var/last_bumped = 0
 	var/pass_flags = 0
 	var/germ_level = GERM_LEVEL_AMBIENT // The higher the germ level, the more germ on the atom.
 	var/simulated = TRUE //filter for actions - used by lighting overlays

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -105,9 +105,6 @@
 			return
 		if(isliving(AM))
 			var/mob/living/M = AM
-			if(world.time - M.last_bumped <= 10)
-				return	//Can bump-open one airlock per second. This is to prevent shock spam.
-			M.last_bumped = world.time
 			if(M.restrained() && !check_access(null))
 				return
 			if(M.mob_size > MOB_SIZE_TINY)
@@ -117,9 +114,6 @@
 	if(ismecha(AM))
 		var/obj/mecha/mecha = AM
 		if(density)
-			if(mecha.occupant)
-				if(world.time - mecha.occupant.last_bumped <= 10)
-					return
 			if(mecha.occupant && allowed(mecha.occupant) || check_access_list(mecha.operation_req_access))
 				if(HAS_TRAIT(src, TRAIT_CMAGGED))
 					cmag_switch(FALSE, mecha.occupant)

--- a/code/game/objects/structures/aliens.dm
+++ b/code/game/objects/structures/aliens.dm
@@ -160,8 +160,6 @@
 		return
 	var/mob/living/carbon/C = user
 	if(C.get_int_organ(/obj/item/organ/internal/alien/hivenode))
-		if(world.time - C.last_bumped <= 60)
-			return
 		if(!C.handcuffed)
 			operate()
 		return

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -128,8 +128,6 @@
 		return
 	if(ismob(user))
 		var/mob/M = user
-		if(world.time - user.last_bumped <= 60)
-			return //NOTE do we really need that?
 		if(M.client)
 			if(iscarbon(M))
 				var/mob/living/carbon/C = M


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Kills off a var on all atoms, last bumped
Reduces jank on xeno doors even further (i ded plz optimize memory)

## Why It's Good For The Game
I had a stroke earlier when I realized that none of the xeno doors I were clicking were opening, I then remembered it was because I slightly grazed an airlock earlier.
Last bumped is the silliest of vars, preventing you from using doors if you open an airlock by bumping on it, fuck this so much. it exists to fix a problem that shouldn't have been there in the first place AND DID NOT FIX THAT PROBLEM (this is related to the exploit I fixed earlier)
the only issue with this right now is that you can cheese open airlocks by bumping into them rather than just clicking on them, qwerty should have fixed that in a pr of his so I do not really care.

## Testing
Bumped into airlocks, things (mostly) worked fine with the exception of the shock thing

## Changelog
:cl:
tweak: You can open airlocks slightly faster, you no longer need to wait 6 seconds to open a xeno door if you touch an airlock
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
