### PR TITLE
Adds the Assistant's formal uniform to the loadout Menu

### DIFF
--- a/code/modules/client/preference/loadout/loadout_uniform.dm
+++ b/code/modules/client/preference/loadout/loadout_uniform.dm
@@ -334,6 +334,11 @@
 	description = "A sleek black turtleneck paired with some khakis (WARNING DOES NOT HAVE SUIT SENSORS)"
 	path = /obj/item/clothing/under/syndicate/tacticool
 
+/datum/gear/uniform/suit/assistantformal
+	display_name = "Assistant's Formal Uniform"
+	description = "Formal attire fit for an Assistant"
+	path = /obj/item/clothing/under/misc/assistantformal
+
 /datum/gear/uniform/suit/redhawaiianshirt
 	display_name = "Red Hawaiian T-Shirt"
 	description = "A nice t-shirt to remind about warm beaches. This one is red."

--- a/code/modules/client/preference/loadout/loadout_uniform.dm
+++ b/code/modules/client/preference/loadout/loadout_uniform.dm
@@ -336,7 +336,7 @@
 
 /datum/gear/uniform/suit/assistantformal
 	display_name = "Assistant's Formal Uniform"
-	description = "Formal attire fit for an Assistant"
+	description = "Formal attire fit for an Assistant."
 	path = /obj/item/clothing/under/misc/assistantformal
 
 /datum/gear/uniform/suit/redhawaiianshirt


### PR DESCRIPTION
Took three whole hours, I'm finally a coder. time to do coder things and.. I dunno, cry in a corner

## What Does This PR Do
this PR takes the Assistant's Formal Uniform, usually only found in the maintance tunnels, and adds it to the Loadout menu for people to start with from round start

## Why It's Good For The Game
its a fun little piece of clothing that I feel goes unappreciated a lot of the time

## Testing
-Booted up private server
-Looked through Loadout menu
-Found Assistant's Formal Uniform
-Equipped it and joined the round
-Assistant's formal uniform appeared on my character
-Tears of joy

## Changelog
:cl:
add: Added Assistant's Formal Uniform to the Loadout menu
/:cl: