### PR TITLE
Significantly reduce volume of disposals machinery when processing a ton of items

### DIFF
--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -1,4 +1,5 @@
 #define SAFETY_COOLDOWN 100
+#define SOUND_COOLDOWN (0.5 SECONDS)
 
 /obj/machinery/recycler
 	name = "recycler"
@@ -139,7 +140,7 @@
 			playsound(loc, 'sound/machines/buzz-sigh.ogg', 50, 0)
 			AM.forceMove(loc)
 
-	if(items_recycled && sound && (last_consumption_sound + 0.5 SECONDS) < world.time)
+	if(items_recycled && sound && (last_consumption_sound + SOUND_COOLDOWN) < world.time)
 		playsound(loc, item_recycle_sound, 100, 0)
 		last_consumption_sound = world.time
 
@@ -246,3 +247,5 @@
 /obj/item/paper/recycler
 	name = "paper - 'garbage duty instructions'"
 	info = "<h2>New Assignment</h2> You have been assigned to collect garbage from trash bins, located around the station. The crewmembers will put their trash into it and you will collect the said trash.<br><br>There is a recycling machine near your closet, inside maintenance; use it to recycle the trash for a small chance to get useful minerals. Then deliver these minerals to cargo or engineering. You are our last hope for a clean station, do not screw this up!"
+
+#undef SOUND_COOLDOWN

--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -19,6 +19,8 @@
 	var/item_recycle_sound = 'sound/machines/recycler.ogg'
 	/// For admin fun, var edit always_gib to TRUE (1)
 	var/always_gib = FALSE
+	/// The last time we played a consumption sound.
+	var/last_consumption_sound
 
 /obj/machinery/recycler/Initialize(mapload)
 	. = ..()
@@ -137,8 +139,9 @@
 			playsound(loc, 'sound/machines/buzz-sigh.ogg', 50, 0)
 			AM.forceMove(loc)
 
-	if(items_recycled && sound)
+	if(items_recycled && sound && (last_consumption_sound + 0.5 SECONDS) < world.time)
 		playsound(loc, item_recycle_sound, 100, 0)
+		last_consumption_sound = world.time
 
 /obj/machinery/recycler/proc/recycle_item(obj/item/I)
 	I.forceMove(loc)

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -6,6 +6,8 @@
 // Can hold items and human size things, no other draggables
 // Toilets are a type of disposal bin for small objects only and work on magic. By magic, I mean torque rotation
 #define SEND_PRESSURE 0.05*ONE_ATMOSPHERE
+/// How frequently disposals can make sounds, to prevent huge sound stacking
+#define DISPOSAL_SOUND_COOLDOWN (0.1 SECONDS)
 
 /obj/machinery/disposal
 	name = "disposal unit"
@@ -464,7 +466,7 @@
 		H.tomail = 1
 
 	sleep(10)
-	if(last_sound + 0.1 SECONDS < world.time)
+	if(last_sound + DISPOSAL_SOUND_COOLDOWN < world.time)
 		playsound(src, 'sound/machines/disposalflush.ogg', 50, 0, 0)
 		last_sound = world.time
 	sleep(5) // wait for animation to finish
@@ -499,7 +501,7 @@
 /obj/machinery/disposal/proc/expel(obj/structure/disposalholder/H)
 
 	var/turf/target
-	if(last_sound + 0.1 SECONDS < world.time)
+	if(last_sound + DISPOSAL_SOUND_COOLDOWN < world.time)
 		playsound(src, 'sound/machines/hiss.ogg', 50, 0, 0)
 		last_sound = world.time
 
@@ -846,7 +848,7 @@
 		else						// otherwise limit to 10 tiles
 			target = get_ranged_target_turf(T, direction, 10)
 
-		if(last_sound + 0.1 SECONDS < world.time)
+		if(last_sound + DISPOSAL_SOUND_COOLDOWN < world.time)
 			playsound(src, 'sound/machines/hiss.ogg', 50, 0, 0)
 			last_sound = world.time
 
@@ -864,7 +866,7 @@
 
 	else	// no specified direction, so throw in random direction
 
-		if(last_sound + 0.1 SECONDS < world.time)
+		if(last_sound + DISPOSAL_SOUND_COOLDOWN < world.time)
 			playsound(src, 'sound/machines/hiss.ogg', 50, 0, 0)
 			last_sound = world.time
 		if(H)
@@ -1414,7 +1416,7 @@
 	if(animation)
 		flick("outlet-open", src)
 		var/play_sound = FALSE
-		if(last_sound + 0.1 SECONDS < world.time)
+		if(last_sound + DISPOSAL_SOUND_COOLDOWN < world.time)
 			play_sound = TRUE
 			last_sound = world.time
 		if(play_sound)

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -464,7 +464,7 @@
 		H.tomail = 1
 
 	sleep(10)
-	if(last_sound < world.time + 1)
+	if(last_sound + 0.1 SECONDS < world.time)
 		playsound(src, 'sound/machines/disposalflush.ogg', 50, 0, 0)
 		last_sound = world.time
 	sleep(5) // wait for animation to finish
@@ -499,7 +499,10 @@
 /obj/machinery/disposal/proc/expel(obj/structure/disposalholder/H)
 
 	var/turf/target
-	playsound(src, 'sound/machines/hiss.ogg', 50, 0, 0)
+	if(last_sound + 0.1 SECONDS < world.time)
+		playsound(src, 'sound/machines/hiss.ogg', 50, 0, 0)
+		last_sound = world.time
+
 	if(H) // Somehow, someone managed to flush a window which broke mid-transit and caused the disposal to go in an infinite loop trying to expel null, hopefully this fixes it
 		for(var/atom/movable/AM in H)
 			target = get_offset_target_turf(src.loc, rand(5)-rand(5), rand(5)-rand(5))
@@ -733,6 +736,8 @@
 	plane = FLOOR_PLANE
 	layer = DISPOSAL_PIPE_LAYER				// slightly lower than wires and other pipes
 	base_icon_state	// initial icon state on map
+	/// The last time a sound was played from this
+	var/last_sound
 
 	// new pipe, set the icon_state as on map
 /obj/structure/disposalpipe/Initialize(mapload)
@@ -841,7 +846,10 @@
 		else						// otherwise limit to 10 tiles
 			target = get_ranged_target_turf(T, direction, 10)
 
-		playsound(src, 'sound/machines/hiss.ogg', 50, 0, 0)
+		if(last_sound + 0.1 SECONDS < world.time)
+			playsound(src, 'sound/machines/hiss.ogg', 50, 0, 0)
+			last_sound = world.time
+
 		if(H)
 			for(var/atom/movable/AM in H)
 				AM.forceMove(T)
@@ -856,7 +864,9 @@
 
 	else	// no specified direction, so throw in random direction
 
-		playsound(src, 'sound/machines/hiss.ogg', 50, 0, 0)
+		if(last_sound + 0.1 SECONDS < world.time)
+			playsound(src, 'sound/machines/hiss.ogg', 50, 0, 0)
+			last_sound = world.time
 		if(H)
 			for(var/atom/movable/AM in H)
 				target = get_offset_target_turf(T, rand(5)-rand(5), rand(5)-rand(5))
@@ -1378,6 +1388,8 @@
 	var/turf/target	// this will be where the output objects are 'thrown' to.
 	var/obj/structure/disposalpipe/trunk/linkedtrunk
 	var/mode = FALSE // Is the maintenance panel open? Different than normal disposal's mode
+	/// The last time a sound was played
+	var/last_sound
 
 /obj/structure/disposaloutlet/Initialize(mapload)
 	. = ..()
@@ -1401,9 +1413,15 @@
 /obj/structure/disposaloutlet/proc/expel(animation = TRUE)
 	if(animation)
 		flick("outlet-open", src)
-		playsound(src, 'sound/machines/warning-buzzer.ogg', 50, 0, 0)
+		var/play_sound = FALSE
+		if(last_sound + 0.1 SECONDS < world.time)
+			play_sound = TRUE
+			last_sound = world.time
+		if(play_sound)
+			playsound(src, 'sound/machines/warning-buzzer.ogg', 50, 0, 0)
 		sleep(20)	//wait until correct animation frame
-		playsound(src, 'sound/machines/hiss.ogg', 50, 0, 0)
+		if(play_sound)
+			playsound(src, 'sound/machines/hiss.ogg', 50, 0, 0)
 	for(var/atom/movable/AM in contents)
 		AM.forceMove(loc)
 		AM.pipe_eject(dir)

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -502,7 +502,7 @@
 
 	var/turf/target
 	if(last_sound + DISPOSAL_SOUND_COOLDOWN < world.time)
-		playsound(src, 'sound/machines/hiss.ogg', 50, 0, 0)
+		playsound(src, 'sound/machines/hiss.ogg', 50, 0, FALSE)
 		last_sound = world.time
 
 	if(H) // Somehow, someone managed to flush a window which broke mid-transit and caused the disposal to go in an infinite loop trying to expel null, hopefully this fixes it
@@ -849,7 +849,7 @@
 			target = get_ranged_target_turf(T, direction, 10)
 
 		if(last_sound + DISPOSAL_SOUND_COOLDOWN < world.time)
-			playsound(src, 'sound/machines/hiss.ogg', 50, 0, 0)
+			playsound(src, 'sound/machines/hiss.ogg', 50, 0, FALSE)
 			last_sound = world.time
 
 		if(H)
@@ -867,7 +867,7 @@
 	else	// no specified direction, so throw in random direction
 
 		if(last_sound + DISPOSAL_SOUND_COOLDOWN < world.time)
-			playsound(src, 'sound/machines/hiss.ogg', 50, 0, 0)
+			playsound(src, 'sound/machines/hiss.ogg', 50, 0, FALSE)
 			last_sound = world.time
 		if(H)
 			for(var/atom/movable/AM in H)
@@ -1420,10 +1420,10 @@
 			play_sound = TRUE
 			last_sound = world.time
 		if(play_sound)
-			playsound(src, 'sound/machines/warning-buzzer.ogg', 50, 0, 0)
+			playsound(src, 'sound/machines/warning-buzzer.ogg', 50, 0, FALSE)
 		sleep(20)	//wait until correct animation frame
 		if(play_sound)
-			playsound(src, 'sound/machines/hiss.ogg', 50, 0, 0)
+			playsound(src, 'sound/machines/hiss.ogg', 50, 0, FALSE)
 	for(var/atom/movable/AM in contents)
 		AM.forceMove(loc)
 		AM.pipe_eject(dir)

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -317,7 +317,9 @@
 		H.destinationTag = 1
 
 	sleep(10)
-	playsound(src, 'sound/machines/disposalflush.ogg', 50, 0, 0)
+	if(last_sound + 0.1 SECONDS < world.time)
+		playsound(src, 'sound/machines/disposalflush.ogg', 50, 0, 0)
+		last_sound = world.time
 	sleep(5) // wait for animation to finish
 
 	H.init(src)	// copy the contents of disposer to holder

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -317,7 +317,7 @@
 		H.destinationTag = 1
 
 	sleep(10)
-	if(last_sound + 0.1 SECONDS < world.time)
+	if(last_sound + DISPOSAL_SOUND_COOLDOWN < world.time)
 		playsound(src, 'sound/machines/disposalflush.ogg', 50, 0, 0)
 		last_sound = world.time
 	sleep(5) // wait for animation to finish

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -318,7 +318,7 @@
 
 	sleep(10)
 	if(last_sound + DISPOSAL_SOUND_COOLDOWN < world.time)
-		playsound(src, 'sound/machines/disposalflush.ogg', 50, 0, 0)
+		playsound(src, 'sound/machines/disposalflush.ogg', 50, 0, FALSE)
 		last_sound = world.time
 	sleep(5) // wait for animation to finish
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds a short cooldown on the recycler when it consumes items, as well as disposals machinery processing items in general, preventing them from playing a ton of overlapping sounds at once.

It also fixes some checks that were already there but inverted (read: broken).
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
When stuff has piled up in cargo disposals and someone finally pulls the lever, any poor sap close to the recycler will have their ears destroyed. This isn't really great, [as funny as it can be](https://cdn.discordapp.com/attachments/145700319819464704/1129853880008724550/2023-07-15_21-15-27.mp4) (VOLUME WARNING)
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Spawned 100 pieces of paper, put them through disposals, my ears felt fine afterwards.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Recyclers and disposals are now a lot quieter when processing a ton of items at once.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
