### PR TITLE
Adds delta alarm to mixer

### DIFF
--- a/code/datums/looping_sounds/looping_sound.dm
+++ b/code/datums/looping_sounds/looping_sound.dm
@@ -137,4 +137,5 @@
 	mid_length = 80
 	decrease_to_amount = 10
 	decrease_by_amount = 5
+	direct = TRUE
 	channel = CHANNEL_DELTA_ALARM

--- a/code/modules/client/preference/preferences.dm
+++ b/code/modules/client/preference/preferences.dm
@@ -88,6 +88,7 @@ GLOBAL_LIST_INIT(special_role_times, list( //minimum age (in days) for accounts 
 		"1017" = 100, // CHANNEL_ENGINE
 		"1016" = 100, // CHANNEL_FIREALARM
 		"1015" = 100, // CHANNEL_ASH_STORM
+		"1014" = 100, // CHANNEL_DELTA_ALARM
 	)
 	/// The volume mixer save timer handle. Used to debounce the DB call to save, to avoid spamming.
 	var/volume_mixer_saving = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds the delta alarm to the sound mixer. The alarm itself was added in https://github.com/ParadiseSS13/Paradise/pull/21174. 
Also, fixes some weirdness that would sometimes occur while changing a slider with a decreasing sound added in the aforementioned PR.

If we're concerned about sound mixer bloat, I can also convert this to a pref toggle.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
I've heard a few people complaining about how shrill the sound effect is, particularly after listening to it for a long time. It's cool and atmospheric, and it does indeed get quieter on its own, but it'd be really nice if it could be quieted a bit more (or silenced outright, for people who want that).

Also, the channel was still coded in, it was just never added. I think that might have been an oversight?
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
![image](https://github.com/ParadiseSS13/Paradise/assets/89928798/f23b640c-6c3a-463e-8764-8967ee669604)
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: The delta alarm now has a slider in the volume mixer.
fix: Changing a sound slider with a decreasing, looping sound will now not make it suddenly very loud for a loop.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
