### PR TITLE
The Bureaucratic Error can now no longer open or close security job slots

### DIFF
--- a/code/modules/events/bureaucratic_error.dm
+++ b/code/modules/events/bureaucratic_error.dm
@@ -13,7 +13,10 @@
 		/datum/job/nanotrasenrep,
 		/datum/job/blueshield,
 		/datum/job/judge,
-		/datum/job/chaplain
+		/datum/job/chaplain,
+		/datum/job/officer,
+		/datum/job/detective,
+		/datum/job/warden
 	)
 
 /datum/event/bureaucratic_error/announce()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Blacklists secoff, det and warden from the aforementioned event.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
HOP can't touch em anymore, so if your det slot changes by -1, you don't have a detective anymore. Same goes for warden.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Compiled.
I trust in the code that adding three datums to it will not break it.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Bureaucratic error event can now no longer open or close Secoff, Detective or warden job slots.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
