### PR TITLE
[Fix] Stealth implant boxes no longer drop cardboard when destroyed

### DIFF
--- a/code/game/objects/items/weapons/implants/implant_stealth.dm
+++ b/code/game/objects/items/weapons/implants/implant_stealth.dm
@@ -95,7 +95,8 @@
 	desc = "It's so normal that you didn't notice it before."
 	icon_state = "agentbox"
 	max_integrity = 1
-	move_speed_multiplier = 0.5 // You can move at normal walk speed while in this box.
+	move_speed_multiplier = 0.5 // You can move at run speed while in this box.
+	material_drop = null
 	/// UID of the person who summoned this box with an implant.
 	var/implant_user_UID
 	// This has to be a separate object and not just an image because the image will inherit the box's 0 alpha while it is stealthed.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Stealth implant boxes no longer drop cardboard when destroyed.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Fixes #21705
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Activated stealth implant to summon the box. Shot the box and destroyed it. Box did not drop cardboard.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Stealth implant boxes no longer drop cardboard when destroyed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
