### PR TITLE
Fixes a couple issues with random costume spawners

### DIFF
--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -430,7 +430,6 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark/awaystart) //Without this away mission
 	. = ..()
 	new /obj/item/clothing/suit/chickensuit(src.loc)
 	new /obj/item/clothing/head/chicken(src.loc)
-	new /obj/item/reagent_containers/food/snacks/egg(src.loc)
 	return INITIALIZE_HINT_QDEL
 
 /obj/effect/landmark/costume/gladiator/Initialize(mapload)

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -550,7 +550,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark/awaystart) //Without this away mission
 	new /obj/item/clothing/suit/holidaypriest(src.loc)
 	return INITIALIZE_HINT_QDEL
 
-/obj/effect/landmark/costume/marisawizard/fake/Initialize(mapload)
+/obj/effect/landmark/costume/marisa_fakewizard/Initialize(mapload)
 	. = ..()
 	new /obj/item/clothing/head/wizard/marisa/fake(src.loc)
 	new/obj/item/clothing/suit/wizrobe/marisa/fake(src.loc)


### PR DESCRIPTION
## What Does This PR Do
- Fixes random costume landmark spawners sometimes spawning nothing due to unnecessary subtyping resulting in an accidental subtype that had nothing defined on it
- Removes the random extra egg that spawned with the chicken costume, resulting in eggs showing up in some undesirable locations

## Why It's Good For The Game
More costumes good, less non-costumes bundled with costumes spawning in places that cause issues also good

## Testing
It compiles, chicken suit no longer spawns with an egg, no more empty `/landmark/costume` subtypes should exist

## Changelog
:cl:
fix: Fixed random costume spawners sometimes spawning nothing
del: Chicken costume spawner no longer spawns an additional egg
/:cl: