### PR TITLE
The stealth implant's box cooldown now begins when the box is dismissed or destroyed

### DIFF
--- a/code/game/objects/items/weapons/implants/implant_stealth.dm
+++ b/code/game/objects/items/weapons/implants/implant_stealth.dm
@@ -35,13 +35,9 @@
 			recall_box_animation()
 		return
 	// Box closing from here on out.
-	if(on_cooldown)
-		return FALSE
 	if(!isturf(owner.loc)) //Don't let the player use this to escape mechs/welded closets.
 		to_chat(owner, "<span class='warning'>You need more space to activate this implant!</span>")
 		return
-	addtimer(VARSET_CALLBACK(src, on_cooldown, FALSE), 10 SECONDS)
-	on_cooldown = TRUE
 	owner.playsound_local(owner, 'sound/misc/box_deploy.ogg', 50, TRUE)
 	spawn_box()
 
@@ -61,6 +57,22 @@
 	INVOKE_ASYNC(box, TYPE_PROC_REF(/obj/structure/closet/cardboard/agent, go_invisible), 1.7 SECONDS)
 	box.create_fake_box()
 	owner.forceMove(box)
+	RegisterSignal(box, COMSIG_PARENT_QDELETING, PROC_REF(start_cooldown))
+
+/datum/action/item_action/agent_box/proc/start_cooldown(datum/source)
+	SIGNAL_HANDLER
+	on_cooldown = TRUE
+	addtimer(CALLBACK(src, PROC_REF(end_cooldown)), 10 SECONDS)
+	UpdateButtonIcon()
+
+/datum/action/item_action/agent_box/proc/end_cooldown()
+	on_cooldown = FALSE
+	UpdateButtonIcon()
+
+/datum/action/item_action/agent_box/IsAvailable()
+	if(..() && !on_cooldown)
+		return TRUE
+	return FALSE
 
 /datum/action/item_action/agent_box/proc/recall_box_animation()
 	var/image/fake_box = image('icons/obj/cardboard_boxes.dmi', owner, "agentbox", ABOVE_MOB_LAYER)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
The stealth implant's box cooldown now begins when the box is dismissed or destroyed.

Cooldown is 10 seconds (unchanged).
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
 The current cooldown is very inconsequential, as it starts when you SUMMON the box (press the action button). Which means you can summon the box, run into combat 10 seconds later, get shot and immediately summon another one, and run off. This will add a bit more counter-play to the stealth implant.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
* Summoned the stealth implant box, then dismissed it with the action button. It went on cooldown.
* Summoned the stealth implant box, was shot and had the box destroyed. It also went on cooldown.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
balance: The stealth implant's box cooldown now begins when the box is dismissed or destroyed, instead of starting when it was summoned.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
