### PR TITLE
Revolutionaries now have a grace periods from attacks after beating deconversion

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -699,6 +699,8 @@
 #define COMSIG_HUMAN_PARRY "human_parry"
 ///From mob/living/carbon/human/do_suicide()
 #define COMSIG_HUMAN_SUICIDE_ACT "human_suicide_act"
+///From mob/living/carbon/human/attackedby(): (mob/living/carbon/human/attacker). Also found on species/disarm and species/harm
+#define COMSIG_HUMAN_ATTACKED "human_attacked"
 
 // /datum/species signals
 

--- a/code/__DEFINES/status_effects.dm
+++ b/code/__DEFINES/status_effects.dm
@@ -56,6 +56,8 @@
 
 #define STATUS_EFFECT_DRILL_PAYBACK /datum/status_effect/drill_payback // Slight antistun and healing, along with visual effect. Works only in range of the vault, and for 30 seconds after it ends.
 
+#define STATUS_EFFECT_REVOLUTION_PROTECT /datum/status_effect/rev_protection
+
 /////////////
 // DEBUFFS //
 /////////////

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -641,3 +641,8 @@
 /datum/status_effect/thrall_net/on_remove()
 	. = ..()
 	vamp = null
+
+/datum/status_effect/rev_protection
+	// revs are paralyzed for 10 seconds when they're deconverted, same duration
+	duration = 10 SECONDS
+	alert_type = null

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -646,3 +646,20 @@
 	// revs are paralyzed for 10 seconds when they're deconverted, same duration
 	duration = 10 SECONDS
 	alert_type = null
+
+/datum/status_effect/rev_protection/on_apply()
+	RegisterSignal(owner, COMSIG_HUMAN_ATTACKED, PROC_REF(on_human_attackby))
+	return ..()
+
+/datum/status_effect/rev_protection/proc/on_human_attackby(mob/living/carbon/human/victim, mob/living/carbon/human/attacker)
+	SIGNAL_HANDLER
+	if(!(attacker.a_intent in list(INTENT_DISARM, INTENT_HARM)))
+		return
+	if(!is_any_revolutionary(attacker)) // protect from non-revs. Revs dont care about deconverted people
+		to_chat(attacker, "<span class='biggerdanger'>[owner] was just deconverted! You don't feel like harming them!</span>")
+		attacker.changeNext_move(CLICK_CD_MELEE)
+		return COMPONENT_CANCEL_ATTACK_CHAIN
+
+/datum/status_effect/rev_protection/on_remove()
+	UnregisterSignal(owner, COMSIG_HUMAN_ATTACKED)
+	. = ..()

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -259,7 +259,7 @@
 //////////////////////////////////////////////////////////////////////////////
 //Deals with players being converted from the revolution (Not a rev anymore)//  // Modified to handle borged MMIs.  Accepts another var if the target is being borged at the time  -- Polymorph.
 //////////////////////////////////////////////////////////////////////////////
-/datum/game_mode/proc/remove_revolutionary(datum/mind/rev_mind , beingborged)
+/datum/game_mode/proc/remove_revolutionary(datum/mind/rev_mind, beingborged, activate_protection)
 	var/remove_head = FALSE
 	var/mob/revolutionary = rev_mind.current
 	if(beingborged && (rev_mind in head_revolutionaries))
@@ -277,11 +277,16 @@
 				"<span class='userdanger'>The frame's firmware detects and deletes your neural reprogramming! You remember nothing[remove_head ? "." : " but the name of the one who flashed you."]</span>")
 			message_admins("[key_name_admin(rev_mind.current)] [ADMIN_QUE(rev_mind.current,"?")] ([ADMIN_FLW(rev_mind.current,"FLW")]) has been borged while being a [remove_head ? "leader" : " member"] of the revolution.")
 		else
+			var/class = activate_protection ? "biggerdanger" : "userdanger" // biggerdanger only shows up when protection happens (usually in a red-flood of combat text)
 			revolutionary.visible_message(
-				"<span class='userdanger'>[rev_mind.current] looks like [rev_mind.current.p_they()] just remembered [rev_mind.current.p_their()] real allegiance!</span>",
-				"<span class='userdanger'>You have been brainwashed! You are no longer a revolutionary! Your memory is hazy from the time you were a rebel... the only thing you remember is the name of the one who brainwashed you...</span>")
+				"<span class='[class]'>[rev_mind.current] looks like [rev_mind.current.p_they()] just remembered [rev_mind.current.p_their()] real allegiance!</span>",
+				"<span class='[class]'>You have been brainwashed! You are no longer a revolutionary! Your memory is hazy from the time you were a rebel... the only thing you remember is the name of the one who brainwashed you...</span>")
 			rev_mind.current.Paralyse(10 SECONDS)
 		update_rev_icons_removed(rev_mind)
+		if(activate_protection && isliving(revolutionary))
+			var/mob/living/living_rev = revolutionary
+			living_rev.apply_status_effect(STATUS_EFFECT_REVOLUTION_PROTECT)
+		return TRUE
 
 /////////////////////////////////////
 //Adds the rev hud to a new convert//
@@ -454,3 +459,12 @@
 	dat += "<HR>"
 
 	return dat
+
+/proc/is_revolutionary(mob/living/M)
+	return istype(M) && (M?.mind in SSticker?.mode?.revolutionaries)
+
+/proc/is_headrev(mob/living/M)
+	return istype(M) && (M?.mind in SSticker?.mode?.head_revolutionaries)
+
+/proc/is_any_revolutionary(mob/living/M)
+	return is_revolutionary(M) || is_headrev(M)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -511,7 +511,7 @@ emp_act
 							KnockDown(10 SECONDS)
 							AdjustConfused(30 SECONDS)
 						if(mind && prob(I.force + ((100 - health) / 2)) && src != user && I.damtype == BRUTE)
-							SSticker.mode.remove_revolutionary(mind)
+							SSticker.mode.remove_revolutionary(mind, activate_protection = TRUE)
 
 					if(bloody)//Apply blood
 						if(wear_mask)
@@ -739,6 +739,12 @@ emp_act
 /mob/living/carbon/human/water_act(volume, temperature, source, method = REAGENT_TOUCH)
 	. = ..()
 	dna.species.water_act(src, volume, temperature, source, method)
+
+/mob/living/carbon/human/attackby(obj/item/I, mob/user, params)
+	if((user.a_intent in list(INTENT_DISARM, INTENT_HARM)) && try_protection(user))
+		user.changeNext_move(CLICK_CD_MELEE)
+		return TRUE
+	return ..()
 
 /mob/living/carbon/human/is_eyes_covered(check_glasses = TRUE, check_head = TRUE, check_mask = TRUE)
 	if(check_glasses && glasses && (glasses.flags_cover & GLASSESCOVERSEYES))

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -741,8 +741,7 @@ emp_act
 	dna.species.water_act(src, volume, temperature, source, method)
 
 /mob/living/carbon/human/attackby(obj/item/I, mob/user, params)
-	if((user.a_intent in list(INTENT_DISARM, INTENT_HARM)) && try_protection(user))
-		user.changeNext_move(CLICK_CD_MELEE)
+	if(SEND_SIGNAL(src, COMSIG_HUMAN_ATTACKED, user) & COMPONENT_CANCEL_ATTACK_CHAIN)
 		return TRUE
 	return ..()
 

--- a/code/modules/mob/living/carbon/human/human_mob.dm
+++ b/code/modules/mob/living/carbon/human/human_mob.dm
@@ -2172,8 +2172,3 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 	)
 
 	AddComponent(/datum/component/deadchat_control/cardinal_movement, mode, inputs, cooldown)
-
-/mob/living/carbon/human/proc/try_protection(mob/living/carbon/human/user)
-	if(has_status_effect(STATUS_EFFECT_REVOLUTION_PROTECT) && !is_any_revolutionary(user)) // protect from non-revs. Revs dont care about deconverted people
-		to_chat(user, "<span class='biggerdanger'>[src] was just deconverted! You don't feel like harming them!</span>")
-		return TRUE

--- a/code/modules/mob/living/carbon/human/human_mob.dm
+++ b/code/modules/mob/living/carbon/human/human_mob.dm
@@ -2172,3 +2172,8 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 	)
 
 	AddComponent(/datum/component/deadchat_control/cardinal_movement, mode, inputs, cooldown)
+
+/mob/living/carbon/human/proc/try_protection(mob/living/carbon/human/user)
+	if(has_status_effect(STATUS_EFFECT_REVOLUTION_PROTECT) && !is_any_revolutionary(user)) // protect from non-revs. Revs dont care about deconverted people
+		to_chat(user, "<span class='biggerdanger'>[src] was just deconverted! You don't feel like harming them!</span>")
+		return TRUE

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -509,7 +509,7 @@
 	if(target.check_block())
 		target.visible_message("<span class='warning'>[target] blocks [user]'s attack!</span>")
 		return FALSE
-	if(target.try_protection(user))
+	if(SEND_SIGNAL(target, COMSIG_HUMAN_ATTACKED, user) & COMPONENT_CANCEL_ATTACK_CHAIN)
 		return FALSE
 	if(attacker_style && attacker_style.harm_act(user, target) == TRUE)
 		return TRUE
@@ -559,7 +559,7 @@
 	if(target.check_block())
 		target.visible_message("<span class='warning'>[target] blocks [user]'s disarm attempt!</span>")
 		return FALSE
-	if(target.try_protection(user))
+	if(SEND_SIGNAL(target, COMSIG_HUMAN_ATTACKED, user) & COMPONENT_CANCEL_ATTACK_CHAIN)
 		return FALSE
 	if(target.absorb_stun(0))
 		target.visible_message("<span class='warning'>[target] is not affected by [user]'s disarm attempt!</span>")

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -509,6 +509,8 @@
 	if(target.check_block())
 		target.visible_message("<span class='warning'>[target] blocks [user]'s attack!</span>")
 		return FALSE
+	if(target.try_protection(user))
+		return FALSE
 	if(attacker_style && attacker_style.harm_act(user, target) == TRUE)
 		return TRUE
 	else
@@ -556,6 +558,8 @@
 		return FALSE
 	if(target.check_block())
 		target.visible_message("<span class='warning'>[target] blocks [user]'s disarm attempt!</span>")
+		return FALSE
+	if(target.try_protection(user))
 		return FALSE
 	if(target.absorb_stun(0))
 		target.visible_message("<span class='warning'>[target] is not affected by [user]'s disarm attempt!</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->When a non-head rev is deconverted by beating in the head, the message will be much bigger. They will also be granted a 10 second grace period from being attacked from someone on disarm/harm intent. You can still use help and grab intent on them. I settled on 10 seconds because when revs are deconverted, they are paralyzed for 10 seconds (paralyze is basically sleeping them, they can't see or move, and are forced to the ground.) The one exception to this is revolutionaries, they can still harm their ex-comrades. Idea from Qwerty.<br><br>
I particularly chose disarm and harm intent, and left help and grab intent because disarm and harm are the COMBAT intents, which people use when fighting. The others are left so if you still want to stab them, you can kind of, or automender them. 

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Revs is an awesome concept, but in the end it just ends up a ton of murderboning, especially when it is difficult to notice deconversions. Hopefully this will help cut down on the murderbone.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
(The blue text is normal-size text)
![image](https://github.com/ParadiseSS13/Paradise/assets/91113370/fdcbe3ba-6024-4e0a-84f1-6624af21790a)


## Testing
<!-- How did you test the PR, if at all? -->
Beating skrells in the head on all 4 intents with a knife, couldnt hurt them on disarm + harm intent, but could on the other intents. Deconverted skrells, and tried to punch and disarm them with empty hands, and failed.

## Changelog
:cl:
tweak: Revolutionaries now have a grace periods from attacks (on harm and disarm intent) after a beating deconversion
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
