### PR TITLE
If you get facehugged and nested, you are now able to ghost

### DIFF
--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -540,6 +540,30 @@ so as to remain in compliance with the most up-to-date laws."
 	var/mob/dead/observer/G = usr
 	G.reenter_corpse()
 
+/obj/screen/alert/ghost
+	name = "Ghost"
+	desc = "Would you like to ghost? You will be notified when your body is removed from the nest."
+	icon_state = "template"
+	timeout = 5 MINUTES // longer than any infection should be
+
+/obj/screen/alert/ghost/Initialize(mapload)
+	. = ..()
+	var/image/I = image('icons/mob/mob.dmi', icon_state = "ghost", layer = FLOAT_LAYER, dir = SOUTH)
+	I.layer = FLOAT_LAYER
+	I.plane = FLOAT_PLANE
+	overlays += I
+
+/obj/screen/alert/ghost/Click()
+	var/mob/living/carbon/human/infected_user = usr
+	if(!istype(infected_user) || infected_user.stat == DEAD)
+		infected_user.clear_alert("ghost_nest")
+		return
+	var/obj/item/clothing/mask/facehugger/hugger_mask = infected_user.wear_mask
+	if(!istype(hugger_mask) || !(locate(/obj/item/organ/internal/body_egg/alien_embryo) in infected_user.internal_organs) || hugger_mask.sterile)
+		infected_user.clear_alert("ghost_nest")
+		return
+	infected_user.ghostize(TRUE)
+
 /obj/screen/alert/notify_action
 	name = "Body created"
 	desc = "A body was created. You can enter it."

--- a/code/game/objects/structures/stool_bed_chair_nest/alien_nests.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/alien_nests.dm
@@ -9,6 +9,7 @@
 	var/image/nest_overlay
 	comfort = 0
 	flags = NODECONSTRUCT
+	var/ghost_timer
 
 /obj/structure/bed/nest/Initialize(mapload)
 	. = ..()
@@ -32,7 +33,7 @@
 				M.visible_message("<span class='warning'>[M.name] struggles to break free from the gelatinous resin!</span>",\
 					"<span class='notice'>You struggle to break free from the gelatinous resin... (Stay still for two minutes.)</span>",\
 					"<span class='italics'>You hear squelching...</span>")
-				if(!do_after(M, 1200, target = src))
+				if(!do_after(M, 120 SECONDS, target = src))
 					if(M && M.buckled)
 						to_chat(M, "<span class='warning'>You fail to escape \the [src]!</span>")
 					return
@@ -46,7 +47,7 @@
 			add_fingerprint(user)
 
 /obj/structure/bed/nest/user_buckle_mob(mob/living/M, mob/living/user)
-	if (!ismob(M) || (get_dist(src, user) > 1) || (M.loc != loc) || user.incapacitated() || M.buckled)
+	if(!istype(M) || (get_dist(src, user) > 1) || (M.loc != loc) || user.incapacitated() || M.buckled)
 		return
 
 	if(M.get_int_organ(/obj/item/organ/internal/alien/hivenode))
@@ -64,7 +65,16 @@
 		M.visible_message("<span class='notice'>[user.name] secretes a thick vile goo, securing [M.name] into [src]!</span>",\
 			"<span class='danger'>[user.name] drenches you in a foul-smelling resin, trapping you in [src]!</span>",\
 			"<span class='italics'>You hear squelching...</span>")
+	ghost_timer = addtimer(CALLBACK(src, PROC_REF(ghost_check)), 15 SECONDS, TIMER_UNIQUE|TIMER_STOPPABLE)
 
+/obj/structure/bed/nest/proc/ghost_check()
+	if(!length(buckled_mobs))
+		return
+	for(var/mob/living/carbon/human/buckled_mob in buckled_mobs)
+		var/obj/item/clothing/mask/facehugger/hugger_mask = buckled_mob.wear_mask
+		if(istype(hugger_mask) && !hugger_mask.sterile && (locate(/obj/item/organ/internal/body_egg/alien_embryo) in buckled_mob.internal_organs))
+			buckled_mob.throw_alert("ghost_nest", /obj/screen/alert/ghost)
+			to_chat(buckled_mob, "<span class='ghostalert'>You may now ghost, you keep respawnability in this state. You will be alerted when you're removed from the nest.</span>")
 
 /obj/structure/bed/nest/post_buckle_mob(mob/living/M)
 	M.pixel_y = 0
@@ -77,6 +87,9 @@
 	M.pixel_y = M.get_standard_pixel_y_offset()
 	M.layer = initial(M.layer)
 	cut_overlay(nest_overlay)
+	deltimer(ghost_timer)
+	M.clear_alert("ghost_nest")
+	M.notify_ghost_cloning("You have been unbuckled from an alien nest! Click that alert to re-enter your body.", source = src)
 
 /obj/structure/bed/nest/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
 	switch(damage_type)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
If you get facehugged and put in a alien nest, you are now able to ghost after 15 seconds, you will be alerted when you get removed from the nest.
Got a tad bit more testing to do just to make sure you can't cheese this.

## Why It's Good For The Game
I've been noticing more and more people suiciding when they get caught by a xeno. The xenos don't like this because larva need to be able to bite living carbons in order to evolve faster, but I'd say this is more a result of xenos making you wait 3 or so minutes whenever you end up caught by one more than anything. This should generally reduce the salt around xenos and allow them to be actually examined as a midround rather than anecdote hell.

I also just think not being forced to wait for a few minute is a good thing

## Testing
got xeno'd and returned to and from my body, then deleted the nest to make sure the second alert showed up

## Changelog
:cl:
tweak: If you end up as xeno prey in a xeno nest, you can now ghost after 15 seconds
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
