### PR TITLE
Gives the blueshield security comms roundstart.

### DIFF
--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -139,7 +139,7 @@
 /obj/item/encryptionkey/heads/blueshield
 	name = "Blueshield's Encryption Key"
 	icon_state = "com_cypherkey"
-	channels = list("Command" = 1)
+	channels = list("Command" = 1, "Security" = 1)
 
 /*
 /obj/item/encryptionkey/headset_mine


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Gives the blueshield access security comms.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
I've started a topic on the forums here: https://www.paradisestation.org/forum/topic/24207-balance-blueshield-and-security-comms/ and feedback was rather positive.

tl;dr, it would GREATLY help blueshield do their job, as believe me or not, command does a poor job at communicating threats to you.
If blueshields use them to validhunt, I advise pressing "F1" and choosing "adminhelp". It's a player issue, not a code issue.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![obraz](https://github.com/ParadiseSS13/Paradise/assets/108196626/d3ef28e8-3aec-4d3a-98f0-a3edb93edcf1)
![obraz](https://github.com/ParadiseSS13/Paradise/assets/108196626/b91f8646-5f4d-4e95-bb22-d2c01b375706)
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Spawned in, used my comms, seemed to work.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
add: Blueshield now spawns with security comms.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
