### PR TITLE
Adds Fragmentation Grenades to the Uplink

### DIFF
--- a/code/datums/uplink_items/uplink_general.dm
+++ b/code/datums/uplink_items/uplink_general.dm
@@ -368,13 +368,26 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/storage/box/syndie_kit/c4
 	cost = 4
 
-
 /datum/uplink_item/explosives/syndicate_minibomb
 	name = "Syndicate Minibomb"
 	desc = "The minibomb is a grenade with a five-second fuse."
 	reference = "SMB"
 	item = /obj/item/grenade/syndieminibomb
 	cost = 6
+
+/datum/uplink_item/explosives/frag_grenade
+	name = "Fragmentation Grenade"
+	desc = "A frag grenade. Upon detonation, releases shrapnel that can embed in nearby victims."
+	reference = "FG"
+	item = /obj/item/grenade/frag
+	cost = 2
+
+/datum/uplink_item/explosives/frag_grenade_pack
+	name = "Pack of 5 Fragmentation Grenades"
+	desc = "A box of 5 frag grenades. Upon detonation, releases shrapnel that can embed in nearby victims. And it seems you'll have a LOT of victims."
+	reference = "FGP"
+	item = /obj/item/grenade/frag
+	cost = 8
 
 /datum/uplink_item/explosives/pizza_bomb
 	name = "Pizza Bomb"

--- a/code/datums/uplink_items/uplink_general.dm
+++ b/code/datums/uplink_items/uplink_general.dm
@@ -386,7 +386,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	name = "Pack of 5 Fragmentation Grenades"
 	desc = "A box of 5 frag grenades. Upon detonation, releases shrapnel that can embed in nearby victims. And it seems you'll have a LOT of victims."
 	reference = "FGP"
-	item = /obj/item/grenade/frag
+	item = /obj/item/storage/box/syndie_kit/frag_grenades
 	cost = 8
 
 /datum/uplink_item/explosives/pizza_bomb

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -196,6 +196,13 @@
 	for(var/I in 1 to 5)
 		new /obj/item/grenade/plastic/c4(src)
 
+/obj/item/storage/box/syndie_kit/frag_grenades
+	name = "pack of fragmentation grenades"
+
+/obj/item/storage/box/syndie_kit/frag_grenades/populate_contents()
+	for(var/I in 1 to 5)
+		new /obj/item/grenade/frag(src)
+
 /obj/item/storage/box/syndie_kit/throwing_weapons
 	name = "boxed throwing kit"
 	can_hold = list(/obj/item/throwing_star, /obj/item/restraints/legcuffs/bola/tactical)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds Fragmentation Grenades and a 5-Pack-Combo-Deal of Frags to the Uplink. 
Singular = `2TC`
5-Pack = `8TC`

## Why It's Good For The Game
Anti-personnel grenades are good. They dont breach the floor and cause minimal structural damage. This gives antagonists a nice way to cause Medbay/Bridge Hobo chaos if they need to get a target from a crowded room.

## Testing
1. Bombed some skrell.
2. Loaded test server.
3. Bombed more skrell from the uplink.

## Changelog
:cl:
add: Added frags to the uplink.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
