### PR TITLE
Increases the amount of N2O that atmos starts with

### DIFF
--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -230,7 +230,7 @@
 
 /turf/simulated/floor/engine/n20
 	name = "\improper N2O floor"
-	sleeping_agent = 6000
+	sleeping_agent = 60000
 	oxygen = 0
 	nitrogen = 0
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Multiplies the amount of N2O that atmos starts with by 10.
(Sorry for the amount of files and lines edited)
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Alright, let's crunch some numbers:
CO2:
9 x 50.000 = 450.000 moles of CO2
Plasma:
9 x 70.000 = 630.000 moles of Plasma
O2 & N2:
9 x 100.000 = 900.000 moles of N2 & O2
N2O:
9 x 6000 = 54.000 moles of N2O

Slight discrepancy here. N2O is very interesting because it has a high heat capacity, and is able to keep the EER down very well, with the downside of dissolving into N2 and O2 at 1400 Kelvin.

This PR makes the atmos storage start with 540.000 moles of N2O, slightly more than CO2, but still less than every other gas tank.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
It's literally adding a single "0"
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: The roundstart amount of N2O of atmos has been increased by tenfold
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
