### PR TITLE
Adjusts the Supermatter Sliver layer to be above the supermatter

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -743,7 +743,8 @@
 		target_cryopod = safepick(free_cryopods)
 		if(target_cryopod.check_occupant_allowed(person_to_cryo))
 			var/turf/T = get_turf(person_to_cryo)
-			var/obj/effect/portal/cryo = new /obj/effect/portal(T, null, null, 40)
+			var/obj/effect/portal/SP = new /obj/effect/portal(T, null, null, 40, FALSE)
+			SP.name = "NT SSD Teleportation Portal"
 			target_cryopod.take_occupant(person_to_cryo, 1)
 			return 1
 	return 0

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -743,8 +743,7 @@
 		target_cryopod = safepick(free_cryopods)
 		if(target_cryopod.check_occupant_allowed(person_to_cryo))
 			var/turf/T = get_turf(person_to_cryo)
-			var/obj/effect/portal/SP = new /obj/effect/portal(T, null, null, 40)
-			SP.name = "NT SSD Teleportation Portal"
+			var/obj/effect/portal/cryo = new /obj/effect/portal(T, null, null, 40)
 			target_cryopod.take_occupant(person_to_cryo, 1)
 			return 1
 	return 0

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -22,6 +22,8 @@
 	var/one_use = FALSE // Does this portal go away after one teleport?
 	/// The time after which the effects should play again. Too many effects can lag the server
 	var/effect_cooldown = 0
+	///Whether or not portal use will cause sparks
+	var/trigger_sparks = TRUE
 
 /obj/effect/portal/New(loc, turf/_target, obj/creation_object = null, lifespan = 300, mob/creation_mob = null)
 	..()
@@ -44,7 +46,8 @@
 	if(!QDELETED(O))
 		O.portal_destroyed(src)
 	target = null
-	do_sparks(5, 0, loc)
+	if(trigger_sparks)
+		do_sparks(5, 0, loc)
 	return ..()
 
 /obj/effect/portal/singularity_pull()
@@ -142,7 +145,8 @@
 
 /obj/effect/portal/proc/invalid_teleport()
 	visible_message("<span class='warning'>[src] flickers and fails due to bluespace interference!</span>")
-	do_sparks(5, 0, loc)
+	if(trigger_sparks)
+		do_sparks(5, 0, loc)
 	qdel(src)
 
 #define UNSTABLE_TIME_DELAY 2 SECONDS
@@ -190,5 +194,10 @@
 	failchance = 0
 	precision = 0
 	ignore_tele_proof_area_setting = TRUE
+
+/obj/effect/portal/cryo
+	name = "NT SSD Teleportation Portal"
+	desc = "A portal capable of sending SSD crew straight to cryo storage."
+	trigger_sparks = FALSE
 
 #undef EFFECT_COOLDOWN

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -23,9 +23,8 @@
 	/// The time after which the effects should play again. Too many effects can lag the server
 	var/effect_cooldown = 0
 	///Whether or not portal use will cause sparks
-	var/trigger_sparks = TRUE
-
-/obj/effect/portal/New(loc, turf/_target, obj/creation_object = null, lifespan = 300, mob/creation_mob = null)
+	var/create_sparks = TRUE
+/obj/effect/portal/New(loc, turf/_target, obj/creation_object = null, lifespan = 300, mob/creation_mob = null, create_sparks = TRUE)
 	..()
 
 	GLOB.portals += src
@@ -46,7 +45,7 @@
 	if(!QDELETED(O))
 		O.portal_destroyed(src)
 	target = null
-	if(trigger_sparks)
+	if(create_sparks)
 		do_sparks(5, 0, loc)
 	return ..()
 
@@ -145,7 +144,7 @@
 
 /obj/effect/portal/proc/invalid_teleport()
 	visible_message("<span class='warning'>[src] flickers and fails due to bluespace interference!</span>")
-	if(trigger_sparks)
+	if(create_sparks)
 		do_sparks(5, 0, loc)
 	qdel(src)
 
@@ -194,10 +193,5 @@
 	failchance = 0
 	precision = 0
 	ignore_tele_proof_area_setting = TRUE
-
-/obj/effect/portal/cryo
-	name = "NT SSD Teleportation Portal"
-	desc = "A portal capable of sending SSD crew straight to cryo storage."
-	trigger_sparks = FALSE
 
 #undef EFFECT_COOLDOWN


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adjusts the sliver layer slightly above that of the supermatter. Fixes #21404
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
You shouldn't need to alt+click the supermatter tile to realize that the sliver is under it. Adjusting the layer allows for visibility and use.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://github.com/ParadiseSS13/Paradise/assets/107899953/c8c120cb-2cb1-4956-8cdc-31a6a6380362)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Cut a sliver off, could see it above the SM.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: The Supermatter Sliver is now visible above the SM.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
