### PR TITLE
Fixes cyborgs being perfect surgeons

### DIFF
--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -191,7 +191,7 @@
 	/// Do we require any of the needed chems, or all of them?
 	var/require_all_chems = TRUE
 	/// Whether silicons ignore any probabilities (and are therefore "perfect" surgeons)
-	var/silicons_obey_prob = FALSE
+	var/silicons_ignore_prob = FALSE
 	/// How many times this step has been automatically repeated.
 	var/times_repeated = 0
 
@@ -359,7 +359,7 @@
 
 	var/step_result
 
-	if((prob(prob_success) || isrobot(user) && !silicons_obey_prob) && chem_check_result && !try_to_fail)
+	if((prob(prob_success) || silicons_ignore_prob && isrobot(user)) && chem_check_result && !try_to_fail)
 		step_result = end_step(user, target, target_zone, tool, surgery)
 	else
 		step_result = fail_step(user, target, target_zone, tool, surgery)

--- a/strings/tips.txt
+++ b/strings/tips.txt
@@ -62,7 +62,7 @@ As a Cyborg, you are immune to most forms of stunning, and excel at almost every
 As a Cyborg, you are impervious to fires and heat. If you are rogue, you can release plasma fires everywhere and walk through them without a care in the world!
 As a Cyborg, you are extremely vulnerable to EMPs as EMPs both stun you and damage you. The ion rifle in the armory or a traitor with an EMP kit can kill you in seconds.
 As an Engineering Cyborg, you can attach air alarm/fire alarm/APC frames to walls by using your magnetic gripper.
-As a Medical Cyborg, you can partially perform surgery, as you cannot replace organs, but you cannot fail any surgery steps.
+As a Medical Cyborg, the Hydrocodone in your Cyborg you can perform most surgery procedures even in the field with the help of your cyborg hypospray's Hydrocodone and roller bed rack module.
 As a Janitor Cyborg, you are the bane of all slaughter demons. Cleaning up blood stains will severely hinder them.
 As the Chief Engineer, you can rename areas or create entirely new ones using your station blueprints.
 As the Chief Engineer, your hardsuit is significantly better than everybody else's. It has the best features of both engineering and atmospherics hardsuits, boasting nigh-invulnerability to radiation and all atmospheric conditions. It even has a built in jet-pack!


### PR DESCRIPTION
## What Does This PR Do
Fixes a typo/oversight which let borgs keep their perfect surgery success rate after #18325 claimed they wouldn't.

## Why It's Good For The Game
False advertisement bad, I assume this change was consciously approved along with the rest of the PR, so I'm fixing the lack of it.

## Testing
- Spawned in as a Cyborg
- Applied roller bed rack module to floor
- Applied Skrell to rolled bed
- Repeatedly applied laser scalpel to Skrell in a surgery procedure, starting it and canceling it after a few steps
- Noticed the occasional surgery step failure as intended
- Kept going until Skrell dead
- Declared success

## Changelog
:cl:
fix: Cyborgs are no longer perfect surgeons by default
/:cl:
