### PR TITLE
Cyborgs and Drones dust when interacting with Supermatter Slivers

### DIFF
--- a/code/game/objects/items/theft_items.dm
+++ b/code/game/objects/items/theft_items.dm
@@ -186,8 +186,8 @@
 	else if(istype(I, /obj/item/scalpel/supermatter) || istype(I, /obj/item/nuke_core_container/supermatter)) // we don't want it to dust
 		return
 	else
-		if(issilicon(usr))
-			to_chat(user, "<span class='danger'>You try to touch [src] with one of your modules. Error!</span>")
+		if(issilicon(user))
+			to_chat(user, "<span class='userdanger'>You try to touch [src] with one of your modules. Error!</span>")
 			radiation_pulse(user, 500, 2)
 			playsound(src, 'sound/effects/supermatter.ogg', 50, TRUE)
 			user.dust()

--- a/code/game/objects/items/theft_items.dm
+++ b/code/game/objects/items/theft_items.dm
@@ -186,6 +186,13 @@
 	else if(istype(I, /obj/item/scalpel/supermatter) || istype(I, /obj/item/nuke_core_container/supermatter)) // we don't want it to dust
 		return
 	else
+		if(issilicon(usr))
+			to_chat(user, "<span class='danger'>You try to touch [src] with one of your modules. Error!</span>")
+			radiation_pulse(user, 500, 2)
+			playsound(src, 'sound/effects/supermatter.ogg', 50, TRUE)
+			user.dust()
+			qdel(src)
+			return
 		to_chat(user, "<span class='danger'>As it touches [src], both [src] and [I] burst into dust!</span>")
 		radiation_pulse(user, 100)
 		playsound(src, 'sound/effects/supermatter.ogg', 50, TRUE)


### PR DESCRIPTION
## What Does This PR Do
Fixes: #21316 where modules were deleted from drones and cyborgs who interacted with Supermatter Slivers instead of dusting them.

## Why It's Good For The Game
Cyborgs and Drones that interact with Supermatter Slivers should be dusted while interacting with a sliver with one of their modules.

## Images of changes
![dreamseeker_O2Jw14eRha](https://github.com/ParadiseSS13/Paradise/assets/116982774/dbcf2a55-8092-4537-8df0-4b5360b34fcb)


## Testing
Spawned in Supermatter Slivers. 
Tested multiple modules on both Drones and Cyborgs.
Checked for dusting.

Tested with regular mobs using tools.
Checked to make sure they didn't dust.

## Changelog
:cl:
fix: Cyborgs and Drones dusting when using modules
/:cl: