### PR TITLE
adds homing projectiles and a new wizard spell, homing toolbox

### DIFF
--- a/code/datums/spells/wizard_spells.dm
+++ b/code/datums/spells/wizard_spells.dm
@@ -358,6 +358,16 @@
 
 	return TRUE
 
+/obj/effect/proc_holder/spell/fireball/toolbox
+	name = "Homing Toolbox"
+	desc = "This spell summons and throws a magical homing toolbox at your opponent."
+	sound = 'sound/weapons/smash.ogg'
+	fireball_type = /obj/item/projectile/homing/magic/toolbox
+	invocation = "ROBUSTIO!"
+
+	selection_activated_message		= "<span class='notice'>Your prepare to cast your homing toolbox! <B>Left-click to cast at a target!</B></span>"
+	selection_deactivated_message	= "<span class='notice'>You unrobust your toolbox...for now.</span>"
+
 /obj/effect/proc_holder/spell/aoe/repulse
 	name = "Repulse"
 	desc = "This spell throws everything around the user away."

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -137,6 +137,12 @@
 	spell_type = /obj/effect/proc_holder/spell/fireball
 	category = "Offensive"
 
+/datum/spellbook_entry/summon_toolbox
+	name = "Homing Toolbox"
+	spell_type = /obj/effect/proc_holder/spell/fireball/toolbox
+	category = "Offensive"
+	cost = 1
+
 /datum/spellbook_entry/fleshtostone
 	name = "Flesh to Stone"
 	spell_type = /obj/effect/proc_holder/spell/touch/flesh_to_stone

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -561,7 +561,6 @@ emp_act
 		if(((throwingdatum ? throwingdatum.speed : I.throw_speed) >= EMBED_THROWSPEED_THRESHOLD) || I.embedded_ignore_throwspeed_threshold)
 			if(can_embed(I))
 				if(prob(I.embed_chance) && !HAS_TRAIT(src, TRAIT_PIERCEIMMUNE))
-					throw_alert("embeddedobject", /obj/screen/alert/embeddedobject)
 					var/obj/item/organ/external/L = pick(bodyparts)
 					L.add_embedded_object(I)
 					I.add_mob_blood(src)//it embedded itself in you, of course it's bloody!

--- a/code/modules/projectiles/projectile/homing_projectiles.dm
+++ b/code/modules/projectiles/projectile/homing_projectiles.dm
@@ -1,0 +1,52 @@
+/obj/item/projectile/homing
+	name = "smart bullet"
+	icon_state = "bullet"
+	var/homing_active = TRUE
+
+/obj/item/projectile/homing/pixel_move(trajectory_multiplier)
+	. = ..()
+	if(!homing_active)
+		return
+
+	var/turf/current_turf = get_turf(src)
+	var/turf/target_turf = get_turf(original)
+	if(current_turf == target_turf)
+		homing_active = FALSE
+		return
+
+	if(!current_turf || !target_turf)
+		return
+
+	var/dx = target_turf.x - current_turf.x
+	var/dy = target_turf.y - current_turf.y
+	var/angle = ATAN2(dy, dx)
+	set_angle(angle)
+
+/obj/item/projectile/homing/magic
+	name = "bolt of nothing"
+	icon_state = "energy"
+	damage = 0
+	damage_type = OXY
+	nodamage = 1
+	armour_penetration_percentage = 100
+	flag = MAGIC
+
+/obj/item/projectile/homing/magic/toolbox
+	name = "magic toolbox"
+	icon = 'icons/obj/storage.dmi'
+	icon_state = "toolbox_default"
+	hitsound = 'sound/weapons/smash.ogg'
+	damage = 30
+	damage_type = BRUTE
+
+/obj/item/projectile/homing/magic/toolbox/on_range()
+	. = ..()
+	new /obj/item/storage/toolbox(get_turf(src))
+
+/obj/item/projectile/homing/magic/toolbox/on_hit(atom/target, blocked, hit_zone)
+	. = ..()
+	var/obj/item/storage/toolbox/T = new /obj/item/storage/toolbox(get_turf(src))
+	if(ishuman(target))
+		var/mob/living/carbon/human/H = target
+		var/obj/item/organ/external/E = pick(H.bodyparts)
+		E.add_embedded_object(T)

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -871,6 +871,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 		forceMove(T)
 
 /obj/item/organ/external/proc/add_embedded_object(obj/item/I)
+	owner.throw_alert("embeddedobject", /obj/screen/alert/embeddedobject)
 	embedded_objects += I
 	I.forceMove(owner)
 	RegisterSignal(I, COMSIG_MOVABLE_MOVED, PROC_REF(remove_embedded_object))

--- a/paradise.dme
+++ b/paradise.dme
@@ -2402,6 +2402,7 @@
 #include "code\modules\projectiles\projectile\bullets.dm"
 #include "code\modules\projectiles\projectile\energy_projectiles.dm"
 #include "code\modules\projectiles\projectile\force.dm"
+#include "code\modules\projectiles\projectile\homing_projectiles.dm"
 #include "code\modules\projectiles\projectile\magic_projectiles.dm"
 #include "code\modules\projectiles\projectile\reusable.dm"
 #include "code\modules\projectiles\projectile\special_projectiles.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
adds support for future homing projectiles, projectiles that redirect themselves towards their target as they fly.

adds a new wizard spell, homing toolbox. fires out a toolbox similar to the fireball spell. the projectile does 30 damage, ignores armour and embeds a toolbox in the target on hit. costs 1 spellpoint. honestly might be better as a staff/wand rather than a spell itself. up for change there.

## Why It's Good For The Game
fun wizard spell, adds future support for new features.

## Images of changes
[dreamseeker_cxIUkxOdmf.webm](https://github.com/ParadiseSS13/Paradise/assets/69320440/110785f8-89b6-4aab-861c-f4ab39813bff)

![image](https://github.com/ParadiseSS13/Paradise/assets/69320440/b4bb14cc-802b-492a-85a0-864c8186cb50)

## Testing
compiled, made the video and image above, and checked it was in the spellbook.

## Changelog
:cl:
add: new wizard spell, homing toolbox
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
