### PR TITLE
buffs the mind batterer

### DIFF
--- a/code/__DEFINES/status_effects.dm
+++ b/code/__DEFINES/status_effects.dm
@@ -174,6 +174,3 @@
 // Basically variants with differing effect times to their parent datums, nothing special
 
 #define STATUS_EFFECT_PACIFIED_BATTERER /datum/status_effect/pacifism/batterer
-
-#define STATUS_EFFECT_CLINGTENTACLE_BATTERER /datum/status_effect/cling_tentacle/batterer
-

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -294,10 +294,6 @@
 /datum/status_effect/cling_tentacle/on_remove()
 	REMOVE_TRAIT(owner, TRAIT_IMMOBILIZED, "[id]")
 
-/datum/status_effect/cling_tentacle/batterer
-	id = "cling_tentacle_batterer"
-	alert_type = null
-	duration = 7 SECONDS
 // start of `living` level status procs.
 
 /**


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Confusion buffed from 30 seconds to 45 seconds
batterer now recharges a use every 20 seconds
batterer no longer works on mobs with no clients

## Why It's Good For The Game
Alright now that the batters in, it's clear this item is not very good. This was stuff I wanted to do in the original pr that I held off on so it would get merged. I would really prefer to not give it knockdown if someone is (pretty likely) thinking to suggest that.
But yeah, more consistent confused and recharge is really what this item needs to be somewhat viable

also I don't think NPCs/ssd people should get brain damaged you know. seems a little fucked up to me

## Testing
battered a skrell a bunch

## Changelog
:cl:
fix: mind batterer no longer affects clientless mobs
tweak: mind batterer confuse lasts longer
tweak: mind batterer recharges over time
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
