### PR TITLE
Adds the Prototype Freedom Implant

### DIFF
--- a/code/datums/uplink_items/uplink_general.dm
+++ b/code/datums/uplink_items/uplink_general.dm
@@ -659,7 +659,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/implants/protofreedom
 	name = "Prototype Freedom Bio-chip"
-	desc = "A bio-chip injected into the body and later activated manually to break out of any restraints or grabs. Can be activated up to 4 times."
+	desc = "A prototype bio-chip injected into the body and later activated manually to break out of any restraints or grabs. Can only be activated a singular time."
 	reference = "PFI"
 	item = /obj/item/implanter/freedom/prototype
 	cost = 2

--- a/code/datums/uplink_items/uplink_general.dm
+++ b/code/datums/uplink_items/uplink_general.dm
@@ -657,6 +657,13 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/implanter/freedom
 	cost = 5
 
+/datum/uplink_item/implants/protofreedom
+	name = "Prototype Freedom Bio-chip"
+	desc = "A bio-chip injected into the body and later activated manually to break out of any restraints or grabs. Can be activated up to 4 times."
+	reference = "PFI"
+	item = /obj/item/implanter/freedom/prototype
+	cost = 2
+
 /datum/uplink_item/implants/storage
 	name = "Storage Bio-chip"
 	desc = "A bio-chip injected into the body, and later activated at the user's will. It will open a small subspace pocket capable of storing two items."

--- a/code/game/objects/items/weapons/implants/implant_freedom.dm
+++ b/code/game/objects/items/weapons/implants/implant_freedom.dm
@@ -35,3 +35,22 @@
 	name = "bio-chip case - 'Freedom'"
 	desc = "A glass case containing a freedom bio-chip."
 	implant_type = /obj/item/implant/freedom
+
+/obj/item/implant/freedom/prototype
+	name = "prototype freedom bio-chip"
+	desc = "Use this to escape from those evil Red Shirts. Works only once!"
+	icon_state = "freedom"
+	item_color = "r"
+	origin_tech = "combat=5;magnets=3;biotech=3;syndicate=1"
+	uses = 1
+	implant_data = /datum/implant_fluff/protofreedom
+	implant_state = "implant-syndicate"
+
+/obj/item/implanter/freedom/prototype
+	name = "bio-chip implanter (proto-freedom)"
+	implant_type = /obj/item/implant/freedom/prototype
+
+/obj/item/implantcase/freedom/prototype
+	name = "bio-chip case - 'Proto-Freedom'"
+	desc = "A glass case containing a prototype freedom bio-chip."
+	implant_type = /obj/item/implant/freedom/prototype

--- a/code/game/objects/items/weapons/implants/implantfluff.dm
+++ b/code/game/objects/items/weapons/implants/implantfluff.dm
@@ -69,6 +69,12 @@
 	notes = "A bio-chip that is illegal in many systems. It is notoriously known for allowing users to grotesquely fracture bones and over-exert joints in order to slip out of the tightest of restraints."
 	function = "Uses a mixture of cybernetic nanobots, bone regrowth chemicals, and radio signals to quickly break the user out of restraints."
 
+/datum/implant_fluff/protofreedom
+	name = "Cybersun Industries X-92 Quick Escape Bio-chip"
+	life = "Destroyed after 1 use."
+	notes = "A bio-chip that is illegal in many systems. This is the early prototype version of the RX-92. It's significantly cheaper than it's newer version."
+	function = "Uses a mixture of cheap cybernetic nanobots, bone regrowth chemicals, and radio signals to quickly break the user out of restraints."
+
 /datum/implant_fluff/health
 	name = "Nanotrasen Health Bio-chip"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds a cheap one-use Freedoms implant for Traitors/Operatives.

Cost: `2TC`

## Why It's Good For The Game
Freedoms get you lethal'd. Its kinda in Space Law to allow Security to BLAST you for freedoms. But sometimes, you want ONE try to get away before getting blasted. `5TC` is a fairly steep price to pay for getting blasted with red beams afterwards.

This makes it so it hits less hard to your wallets without being insanely OP.

## Testing
1. I can break these cuffs.
2. You cant break those cu-
3. You can, but only once.

## Changelog
:cl:
add: Adds the one-use prototype freedom implant.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
