### PR TITLE
Improves PDA logging, fixes message monitoring console input issues

### DIFF
--- a/code/game/machinery/computer/message_monitor.dm
+++ b/code/game/machinery/computer/message_monitor.dm
@@ -400,7 +400,8 @@
 
 					//Select Your Name
 					if("Sender")
-						customsender 	= clean_input("Please enter the sender's name.")
+						customsender 	= input("Please enter the sender's name.")
+						customsender	= trim_strip_html_properly(customsender)
 
 					//Select Receiver
 					if("Recepient")
@@ -419,11 +420,13 @@
 
 					//Enter custom job
 					if("RecJob")
-						customjob	 	= clean_input("Please enter the sender's job.")
+						customjob	 	= input("Please enter the sender's job.")
+						customjob		= trim_strip_html_properly(customjob)
 
 					//Enter message
 					if("Message")
-						custommessage	= clean_input("Please enter your message.")
+						custommessage	= input("Please enter your message.")
+						custommessage	= trim_strip_html_properly(custommessage)
 
 					//Send message
 					if("Send")

--- a/code/game/machinery/computer/message_monitor.dm
+++ b/code/game/machinery/computer/message_monitor.dm
@@ -424,7 +424,6 @@
 					//Enter message
 					if("Message")
 						custommessage	= clean_input("Please enter your message.")
-						custommessage	= sanitize(copytext(custommessage, 1, MAX_MESSAGE_LEN))
 
 					//Send message
 					if("Send")
@@ -454,11 +453,13 @@
 							if(P.owner == customsender)
 								PDARec = P
 								break
+
+						var/sender_identity
 						//Sender isn't faking as someone who exists
 						if(isnull(PDARec))
 							src.linkedServer.send_pda_message("[customrecepient.owner]", "[customsender]","[custommessage]")
 							recipient_messenger.notify("<b>Message from [customsender] ([customjob]), </b>\"[custommessage]\" (<a href='?src=[UID()];choice=Message;target=\ref[src]'>Reply</a>)")
-							log_pda("(PDA: [customsender]) sent \"[custommessage]\" to [customrecepient.owner]", usr)
+							sender_identity = customsender
 						//Sender is faking as someone who exists
 						else
 							src.linkedServer.send_pda_message("[customrecepient.owner]", "[PDARec.owner]","[custommessage]")
@@ -468,7 +469,12 @@
 								recipient_messenger.conversations.Add("\ref[PDARec]")
 
 							recipient_messenger.notify("<b>Message from [PDARec.owner] ([customjob]), </b>\"[custommessage]\" (<a href='?src=[recipient_messenger.UID()];choice=Message;target=\ref[PDARec]'>Reply</a>)")
-							log_pda("(PDA: [PDARec.owner]) sent \"[custommessage]\" to [customrecepient.owner]", usr)
+							sender_identity = PDARec.owner
+
+						// Logging
+						log_pda("(PDA: [sender_identity]) sent \"[custommessage]\" to [customrecepient.owner]", usr)
+						investigate_log("PDA Message - Custom Name: \"[sender_identity]\", Custom Job: \"[customjob]\", Real Sender: \"[key_name(usr)]\" ([ADMIN_PP(usr,"PP")]) -> [customrecepient.owner] ([ADMIN_VV(customrecepient, "VV")]), Message: \"[custommessage]\"", "pda")
+
 						var/log_message = "sent PDA message \"[custommessage]\" using [src] as [customsender] ([customjob])"
 						var/receiver
 						if(ishuman(customrecepient.loc))

--- a/code/modules/pda/messenger.dm
+++ b/code/modules/pda/messenger.dm
@@ -185,7 +185,7 @@
 		useMS.send_pda_message("[P.owner]","[pda.owner]","[t]")
 		tnote.Add(list(list("sent" = 1, "owner" = "[P.owner]", "job" = "[P.ownjob]", "message" = "[html_decode(t)]", "target" = "[P.UID()]")))
 		PM.tnote.Add(list(list("sent" = 0, "owner" = "[pda.owner]", "job" = "[pda.ownjob]", "message" = "[html_decode(t)]", "target" = "[pda.UID()]")))
-		pda.investigate_log("<span class='game say'>PDA Message - <span class='name'>[U.key] - [pda.owner]</span> -> <span class='name'>[P.owner]</span>: <span class='message'>[t]</span></span>", "pda")
+		pda.investigate_log("<span class='game say'>PDA Message - <span class='name'>[pda.owner] ([U.key] [ADMIN_PP(U, "PP")])</span> -> <span class='name'>[P.owner]</span> ([ADMIN_VV(P, "VV")]), Message: <span class='message'>\"[t]\"</span></span>", "pda")
 
 		// Show it to ghosts
 		for(var/mob/M in GLOB.dead_mob_list)


### PR DESCRIPTION
## What Does This PR Do

1. Adds investigation logging to the message monitoring console
2. Adds admin shortcuts to the  investigation pda logs
3. Fixes a sanitisation issue on the message monitoring console
4. Fixes inputs not having a max length

please do not smite me for not keeping this PR more atomic

## Why It's Good For The Game

1. Currently, it takes us 5+ clicks to figure out who sent a funny n-word message from the message monitoring console, this greatly cuts down on it
2. The shortcuts just make our life easier
3. Apparently, the custom admin message didn't sanitise properly, I fixed that one as well
4. There was no sanitisation / max length in the custom sender and custom job fields, meaning you could have inserted the entire bee movie script there

## Images of changes

Admin buttons, proper ckey logging. The PP buttons open the sender's PP, the VV opens the target PDA (not its owner, as the owner can be null):

![image](https://github.com/ParadiseSS13/Paradise/assets/33333517/0670076e-421e-465e-832f-3f5ca87904ee)

Max length is now enforced and inputs sanitise properly:

![image](https://github.com/ParadiseSS13/Paradise/assets/33333517/87628e1b-87b2-471d-9dee-9280c5d9ee23)

## Testing

1. Spawn in as the RD
2. Get the message monitoring console code from your table
3. Log into the message monitoring console by clicking on Unauthenticated
5. Click on Send Admin Message
6. Send a message
7. Use the investigate-round-objects verb and check the pda category

## Changelog
:cl:
tweak: Improved PDA logging for investigations.
fix: Fixed some sanitisation issues on the message monitoring console.
/:cl:
