### PR TITLE
Gives Vampires Stronger Night Vision at 500 Blood

### DIFF
--- a/code/modules/antagonists/vampire/vamp_datum.dm
+++ b/code/modules/antagonists/vampire/vamp_datum.dm
@@ -22,7 +22,7 @@
 									/datum/vampire_passive/vision = 100,
 									/obj/effect/proc_holder/spell/vampire/self/specialize = 150,
 									/datum/vampire_passive/regen = 200,
-									/datum/vampire_passive/adv_vision = 500)
+									/datum/vampire_passive/vision/adv_vision = 500)
 
 	/// list of the peoples UIDs that we have drained, and how much blood from each one
 	var/list/drained_humans = list()

--- a/code/modules/antagonists/vampire/vamp_datum.dm
+++ b/code/modules/antagonists/vampire/vamp_datum.dm
@@ -22,7 +22,7 @@
 									/datum/vampire_passive/vision = 100,
 									/obj/effect/proc_holder/spell/vampire/self/specialize = 150,
 									/datum/vampire_passive/regen = 200,
-									/datum/vampire_passive/vision/adv_vision = 500)
+									/datum/vampire_passive/vision/advanced = 500)
 
 	/// list of the peoples UIDs that we have drained, and how much blood from each one
 	var/list/drained_humans = list()

--- a/code/modules/antagonists/vampire/vamp_datum.dm
+++ b/code/modules/antagonists/vampire/vamp_datum.dm
@@ -66,15 +66,13 @@
 
 /datum/antagonist/vampire/proc/force_add_ability(path)
 	var/spell = new path(owner)
+	powers += spell
 	if(istype(spell, /obj/effect/proc_holder/spell))
 		owner.AddSpell(spell)
 	if(istype(spell, /datum/vampire_passive))
 		var/datum/vampire_passive/passive = spell
 		passive.owner = owner.current
 		passive.on_apply(src)
-	powers += spell
-	if(istype(spell, /datum/vampire_passive/vision))
-		owner.current.update_sight() // Life updates conditionally, so we need to update sight here in case the vamp gets new vision based on his powers. Maybe one day refactor to be more OOP and on the vampire's ability datum.
 
 /datum/antagonist/vampire/proc/get_ability(path)
 	for(var/datum/power as anything in powers)

--- a/code/modules/antagonists/vampire/vamp_datum.dm
+++ b/code/modules/antagonists/vampire/vamp_datum.dm
@@ -73,7 +73,8 @@
 		passive.owner = owner.current
 		passive.on_apply(src)
 	powers += spell
-	owner.current.update_sight() // Life updates conditionally, so we need to update sight here in case the vamp gets new vision based on his powers. Maybe one day refactor to be more OOP and on the vampire's ability datum.
+	if(istype(spell, /datum/vampire_passive/vision))
+		owner.current.update_sight() // Life updates conditionally, so we need to update sight here in case the vamp gets new vision based on his powers. Maybe one day refactor to be more OOP and on the vampire's ability datum.
 
 /datum/antagonist/vampire/proc/get_ability(path)
 	for(var/datum/power as anything in powers)

--- a/code/modules/antagonists/vampire/vamp_datum.dm
+++ b/code/modules/antagonists/vampire/vamp_datum.dm
@@ -21,7 +21,8 @@
 									/obj/effect/proc_holder/spell/vampire/glare = 0,
 									/datum/vampire_passive/vision = 100,
 									/obj/effect/proc_holder/spell/vampire/self/specialize = 150,
-									/datum/vampire_passive/regen = 200)
+									/datum/vampire_passive/regen = 200,
+									/datum/vampire_passive/adv_vision = 500)
 
 	/// list of the peoples UIDs that we have drained, and how much blood from each one
 	var/list/drained_humans = list()

--- a/code/modules/antagonists/vampire/vampire_powers/umbrae_powers.dm
+++ b/code/modules/antagonists/vampire/vampire_powers/umbrae_powers.dm
@@ -325,5 +325,8 @@
 	if(!V.bloodusable || owner.stat == DEAD)
 		V.remove_ability(src)
 
-/datum/vampire_passive/xray
+/datum/vampire_passive/vision/xray
 	gain_desc = "You can now see through walls, incase you hadn't noticed."
+	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
+	see_in_dark = 8
+	vision_flags = SEE_TURFS|SEE_MOBS|SEE_OBJS

--- a/code/modules/antagonists/vampire/vampire_powers/vampire_powers.dm
+++ b/code/modules/antagonists/vampire/vampire_powers/vampire_powers.dm
@@ -267,12 +267,13 @@
 	vision_flags = SEE_MOBS
 
 /datum/vampire_passive/vision/full
+	gain_desc = "Your vampiric vision has reached its full strength!"
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
 	see_in_dark = 8
 	vision_flags = SEE_MOBS
 
 /datum/vampire_passive/full
-	gain_desc = "You have reached your full potential. You are no longer weak to the effects of anything holy and your vision has improved greatly."
+	gain_desc = "You have reached your full potential. You are no longer weak to the effects of anything holy."
 
 /obj/effect/proc_holder/spell/vampire/raise_vampires
 	name = "Raise Vampires"

--- a/code/modules/antagonists/vampire/vampire_powers/vampire_powers.dm
+++ b/code/modules/antagonists/vampire/vampire_powers/vampire_powers.dm
@@ -45,6 +45,7 @@
 	return ..()
 
 /datum/vampire_passive/proc/on_apply(datum/antagonist/vampire/V)
+	owner.update_sight() // Life updates conditionally, so we need to update sight here in case the vamp gets new vision based on his powers. Maybe one day refactor to be more OOP and on the vampire's ability datum.
 	return
 
 /obj/effect/proc_holder/spell/vampire/self/rejuvenate
@@ -263,13 +264,13 @@
 /datum/vampire_passive/vision/advanced
 	gain_desc = "Your vampiric vision now allows you to see everything in the dark!"
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
-	see_in_dark = 5
+	see_in_dark = 3
 	vision_flags = SEE_MOBS
 
 /datum/vampire_passive/vision/full
 	gain_desc = "Your vampiric vision has reached its full strength!"
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
-	see_in_dark = 8
+	see_in_dark = 6
 	vision_flags = SEE_MOBS
 
 /datum/vampire_passive/full

--- a/code/modules/antagonists/vampire/vampire_powers/vampire_powers.dm
+++ b/code/modules/antagonists/vampire/vampire_powers/vampire_powers.dm
@@ -256,9 +256,20 @@
 
 /datum/vampire_passive/vision
 	gain_desc = "Your vampiric vision has improved."
+	var/lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
+	var/see_in_dark = 1
+	var/vision_flags = SEE_MOBS
 
-/datum/vampire_passive/adv_vision
+/datum/vampire_passive/vision/advanced
 	gain_desc = "Your vampiric vision now allows you to see everything in the dark!"
+	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
+	see_in_dark = 5
+	vision_flags = SEE_MOBS
+
+/datum/vampire_passive/vision/full
+	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
+	see_in_dark = 8
+	vision_flags = SEE_MOBS
 
 /datum/vampire_passive/full
 	gain_desc = "You have reached your full potential. You are no longer weak to the effects of anything holy and your vision has improved greatly."

--- a/code/modules/antagonists/vampire/vampire_powers/vampire_powers.dm
+++ b/code/modules/antagonists/vampire/vampire_powers/vampire_powers.dm
@@ -258,7 +258,7 @@
 	gain_desc = "Your vampiric vision has improved."
 
 /datum/vampire_passive/adv_vision
-	gain_desc = "Your vampiric vision now allows you to see in the dark!"
+	gain_desc = "Your vampiric vision now allows you to see everything in the dark!"
 
 /datum/vampire_passive/full
 	gain_desc = "You have reached your full potential. You are no longer weak to the effects of anything holy and your vision has improved greatly."

--- a/code/modules/antagonists/vampire/vampire_powers/vampire_powers.dm
+++ b/code/modules/antagonists/vampire/vampire_powers/vampire_powers.dm
@@ -257,6 +257,9 @@
 /datum/vampire_passive/vision
 	gain_desc = "Your vampiric vision has improved."
 
+/datum/vampire_passive/adv_vision
+	gain_desc = "Your vampiric vision now allows you to see in the dark!"
+
 /datum/vampire_passive/full
 	gain_desc = "You have reached your full potential. You are no longer weak to the effects of anything holy and your vision has improved greatly."
 

--- a/code/modules/antagonists/vampire/vampire_subclasses.dm
+++ b/code/modules/antagonists/vampire/vampire_subclasses.dm
@@ -31,7 +31,7 @@
 							/obj/effect/proc_holder/spell/vampire/shadow_boxing = 800)
 	fully_powered_abilities = list(/datum/vampire_passive/full,
 								/obj/effect/proc_holder/spell/vampire/self/eternal_darkness,
-								/datum/vampire_passive/xray)
+								/datum/vampire_passive/vision/xray)
 
 /datum/vampire_subclass/hemomancer
 	name = "hemomancer"
@@ -105,6 +105,6 @@
 							/obj/effect/proc_holder/spell/vampire/self/eternal_darkness,
 							/obj/effect/proc_holder/spell/vampire/hysteria,
 							/obj/effect/proc_holder/spell/vampire/raise_vampires,
-							/datum/vampire_passive/xray)
+							/datum/vampire_passive/vision/xray)
 	improved_rejuv_healing = TRUE
 	thrall_cap = 150 // can thrall high pop

--- a/code/modules/antagonists/vampire/vampire_subclasses.dm
+++ b/code/modules/antagonists/vampire/vampire_subclasses.dm
@@ -30,6 +30,7 @@
 							/obj/effect/proc_holder/spell/vampire/vamp_extinguish = 600,
 							/obj/effect/proc_holder/spell/vampire/shadow_boxing = 800)
 	fully_powered_abilities = list(/datum/vampire_passive/full,
+								/datum/vampire_passive/vision/full,
 								/obj/effect/proc_holder/spell/vampire/self/eternal_darkness,
 								/datum/vampire_passive/vision/xray)
 
@@ -42,6 +43,7 @@
 							/obj/effect/proc_holder/spell/vampire/predator_senses = 600,
 							/obj/effect/proc_holder/spell/vampire/blood_eruption = 800)
 	fully_powered_abilities = list(/datum/vampire_passive/full,
+								/datum/vampire_passive/vision/full,
 								/obj/effect/proc_holder/spell/vampire/self/blood_spill)
 
 /datum/vampire_subclass/gargantua
@@ -53,6 +55,7 @@
 							/obj/effect/proc_holder/spell/vampire/self/overwhelming_force = 600,
 							/obj/effect/proc_holder/spell/fireball/demonic_grasp = 800)
 	fully_powered_abilities = list(/datum/vampire_passive/full,
+								/datum/vampire_passive/vision/full,
 								/obj/effect/proc_holder/spell/vampire/charge)
 	improved_rejuv_healing = TRUE
 
@@ -69,6 +72,7 @@
 							/obj/effect/proc_holder/spell/vampire/self/share_damage = 800)
 	fully_powered_abilities = list(/datum/vampire_passive/full,
 								/obj/effect/proc_holder/spell/vampire/hysteria,
+								/datum/vampire_passive/vision/full,
 								/datum/vampire_passive/increment_thrall_cap/three)
 
 
@@ -100,6 +104,7 @@
 							/obj/effect/proc_holder/spell/fireball/demonic_grasp,
 							/obj/effect/proc_holder/spell/vampire/shadow_boxing,
 							/datum/vampire_passive/full,
+							/datum/vampire_passive/vision/full,
 							/obj/effect/proc_holder/spell/vampire/self/blood_spill,
 							/obj/effect/proc_holder/spell/vampire/charge,
 							/obj/effect/proc_holder/spell/vampire/self/eternal_darkness,

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -940,6 +940,7 @@ It'll return null if the organ doesn't correspond, so include null checks when u
 	if(V)
 		for(var/datum/vampire_passive/vision/buffs as anything in V.powers)
 			H.sight = buffs.vision_flags
+			to_chat(H, "<span class='danger'>THIS IS A TEST 1</span>")
 			H.see_in_dark += buffs.see_in_dark
 			H.lighting_alpha = buffs.lighting_alpha
 

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -938,9 +938,8 @@ It'll return null if the organ doesn't correspond, so include null checks when u
 
 	var/datum/antagonist/vampire/V = H.mind?.has_antag_datum(/datum/antagonist/vampire)
 	if(V)
-		for(var/datum/vampire_passive/vision/buffs as anything in V.powers)
+		for(var/datum/vampire_passive/vision/buffs in V.powers)
 			H.sight = buffs.vision_flags
-			to_chat(H, "<span class='danger'>THIS IS A TEST 1</span>")
 			H.see_in_dark += buffs.see_in_dark
 			H.lighting_alpha = buffs.lighting_alpha
 

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -938,22 +938,9 @@ It'll return null if the organ doesn't correspond, so include null checks when u
 
 	var/datum/antagonist/vampire/V = H.mind?.has_antag_datum(/datum/antagonist/vampire)
 	if(V)
-		if(V.get_ability(/datum/vampire_passive/xray))
-			H.sight |= SEE_TURFS|SEE_MOBS|SEE_OBJS
-			H.see_in_dark += 8
-			H.lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
-		else if(V.get_ability(/datum/vampire_passive/full))
-			H.sight |= SEE_MOBS
-			H.see_in_dark += 8
-			H.lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
-		else if(V.get_ability(/datum/vampire_passive/adv_vision))
-			H.sight |= SEE_MOBS
-			H.see_in_dark += 5
-			H.lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
-		else if(V.get_ability(/datum/vampire_passive/vision))
-			H.sight |= SEE_MOBS
-			H.see_in_dark += 1 // base of 2, 2+1 is 3
-			H.lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
+		H.sight |= V.get_ability(/datum/vampire_passive/vision)
+		H.see_in_dark += 8
+		H.lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
 
 	// my glasses, I can't see without my glasses
 	if(H.glasses)

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -938,9 +938,10 @@ It'll return null if the organ doesn't correspond, so include null checks when u
 
 	var/datum/antagonist/vampire/V = H.mind?.has_antag_datum(/datum/antagonist/vampire)
 	if(V)
-		H.sight |= V.get_ability(/datum/vampire_passive/vision)
-		H.see_in_dark += 8
-		H.lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
+		for(var/datum/vampire_passive/vision/buffs as anything in V.powers)
+			H.sight = buffs.vision_flags
+			H.see_in_dark += buffs.see_in_dark
+			H.lighting_alpha = buffs.lighting_alpha
 
 	// my glasses, I can't see without my glasses
 	if(H.glasses)

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -939,7 +939,7 @@ It'll return null if the organ doesn't correspond, so include null checks when u
 	var/datum/antagonist/vampire/V = H.mind?.has_antag_datum(/datum/antagonist/vampire)
 	if(V)
 		for(var/datum/vampire_passive/vision/buffs in V.powers)
-			H.sight = buffs.vision_flags
+			H.sight |= buffs.vision_flags
 			H.see_in_dark += buffs.see_in_dark
 			H.lighting_alpha = buffs.lighting_alpha
 

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -946,6 +946,10 @@ It'll return null if the organ doesn't correspond, so include null checks when u
 			H.sight |= SEE_MOBS
 			H.see_in_dark += 8
 			H.lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
+		else if(V.get_ability(/datum/vampire_passive/adv_vision))
+			H.sight |= SEE_MOBS
+			H.see_in_dark += 5
+			H.lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
 		else if(V.get_ability(/datum/vampire_passive/vision))
 			H.sight |= SEE_MOBS
 			H.see_in_dark += 1 // base of 2, 2+1 is 3


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Extends Vampire Night Vision from `3` to `7` tiles once they reach 500 blood.

## Why It's Good For The Game
For a creature that attacks from the darkness, you have absolute PISS poor night vision until you reach Full Power.

This gives Vampires a slight bonus when they reach 500 blood.

## Testing
1. Ran around in the dark at various blood levels.

## Changelog
:cl:
add: Adds Advanced Vampire Night Vision at 500 Blood as a passive.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
