### PR TITLE
false alarm now sounds the sirens

### DIFF
--- a/code/modules/events/false_alarm.dm
+++ b/code/modules/events/false_alarm.dm
@@ -31,8 +31,8 @@
 	)
 
 	var/list/major_fake_events = list(
-		list("Confirmed outbreak of level 3-X biohazard aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert", 'sound/AI/outbreak3.ogg'),
-		list("Confirmed outbreak of level 3-S biohazard aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert", 'sound/AI/outbreak3.ogg'),
+		list("Confirmed outbreak of level 3-X biohazard aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert", 'sound/AI/outbreak3.ogg', 'sound/effects/siren-spooky.ogg'),
+		list("Confirmed outbreak of level 3-S biohazard aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert", 'sound/AI/outbreak3.ogg', 'sound/effects/siren-spooky.ogg'),
 		list("Confirmed outbreak of level 5 biohazard aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert", 'sound/AI/outbreak5.ogg')
 	)
 
@@ -41,6 +41,6 @@
 		GLOB.minor_announcement.Announce(event[1], listgetindex(event, 2), listgetindex(event, 3))
 	else
 		event = pick_n_take(major_fake_events)
-		GLOB.major_announcement.Announce(event[1], listgetindex(event, 2), listgetindex(event, 3))
+		GLOB.major_announcement.Announce(event[1], listgetindex(event, 2), listgetindex(event, 3), new_sound2 = listgetindex(event, 4))
 
 	message_admins("False Alarm: [event[1]]")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
fixes #21502
adds an extra arg so it properly plays the sirens

## Why It's Good For The Game
these are fully false alarms, not kinda false alarms 

## Testing
i had to trigger the event like 30 times to test this thing

## Changelog
:cl:
fix: Sirens are triggered on false alarm events
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
