### PR TITLE
Vampires now don't get toxin damage from drinking a wrong blood type

### DIFF
--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -50,7 +50,7 @@
 /datum/reagent/slimejelly/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
 	var/mob/living/carbon/C = M
-	if(M.get_blood_id() != id && !C.mind?.has_antag_datum(/datum/antagonist/vampire))  // no effect on slime people // and vampires
+	if(M.get_blood_id() != id && !C.mind?.has_antag_datum(/datum/antagonist/vampire))  // no effect on slime people or vampires
 		if(prob(10))
 			to_chat(M, "<span class='danger'>Your insides are burning!</span>")
 			update_flags |= M.adjustToxLoss(rand(2, 6) * REAGENTS_EFFECT_MULTIPLIER, FALSE) // avg 0.4 toxin per cycle, not unreasonable
@@ -70,9 +70,10 @@
 		B.update_icon()
 
 /datum/reagent/slimejelly/reaction_mob(mob/living/M, method, volume)
+	..()
 	if(method == REAGENT_INGEST && iscarbon(M) && M.mind?.has_antag_datum(/datum/antagonist/vampire))
 		M.reagents.remove_reagent("slimejelly", 1)
-		volume++ // Bit higher than base, wish it could be higher, but this stops slimes from gaming to get more blood out of their blood
+		volume++ // Bit higher than base, wish it could be higher, but if it was higher, slime vampires would get even more blood out of their slime jelly
 		M.set_nutrition(min(NUTRITION_LEVEL_WELL_FED, M.nutrition + 10))
 		M.blood_volume = min(M.blood_volume + round(volume, 0.1), BLOOD_VOLUME_NORMAL)
 

--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -72,7 +72,7 @@
 /datum/reagent/slimejelly/reaction_mob(mob/living/M, method, volume)
 	if(method == REAGENT_INGEST && iscarbon(M) && M.mind?.has_antag_datum(/datum/antagonist/vampire))
 		M.reagents.remove_reagent("slimejelly", 1)
-		volume += 1 // Bit higher than base, wish it could be higher, but this stops slimes from gaming to get more blood out of their blood
+		volume++ // Bit higher than base, wish it could be higher, but this stops slimes from gaming to get more blood out of their blood
 		M.set_nutrition(min(NUTRITION_LEVEL_WELL_FED, M.nutrition + 10))
 		M.blood_volume = min(M.blood_volume + round(volume, 0.1), BLOOD_VOLUME_NORMAL)
 

--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -52,7 +52,8 @@
 	var/mob/living/carbon/C = M
 	if(iscarbon(C) && C.mind?.has_antag_datum(/datum/antagonist/vampire))
 		M.set_nutrition(min(NUTRITION_LEVEL_WELL_FED, M.nutrition + 10))
-		M.blood_volume = min(M.blood_volume + REAGENTS_METABOLISM, BLOOD_VOLUME_NORMAL)
+		if(M.get_blood_id() != id)
+			M.blood_volume = min(M.blood_volume + REAGENTS_METABOLISM, BLOOD_VOLUME_NORMAL)
 		return ..() | update_flags
 
 	if(M.get_blood_id() != id)

--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -49,6 +49,9 @@
 
 /datum/reagent/slimejelly/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
+	var/mob/living/carbon/C = M
+	if(C.mind?.has_antag_datum(/datum/antagonist/vampire)) // no effect on vampires
+		return ..() | update_flags
 	if(M.get_blood_id() != id)  // no effect on slime people
 		if(prob(10))
 			to_chat(M, "<span class='danger'>Your insides are burning!</span>")
@@ -68,6 +71,12 @@
 		B.basecolor = color
 		B.update_icon()
 
+/datum/reagent/slimejelly/reaction_mob(mob/living/M, method, volume)
+	if(method == REAGENT_INGEST && iscarbon(M) && M.mind?.has_antag_datum(/datum/antagonist/vampire))
+		M.reagents.remove_reagent("slimejelly", 1)
+		volume += 1 // Bit higher than base, wish it could be higher, but this stops slimes from gaming to get more blood out of their blood
+		M.set_nutrition(min(NUTRITION_LEVEL_WELL_FED, M.nutrition + 10))
+		M.blood_volume = min(M.blood_volume + round(volume, 0.1), BLOOD_VOLUME_NORMAL)
 
 /datum/reagent/slimetoxin
 	name = "Mutation Toxin"

--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -50,7 +50,12 @@
 /datum/reagent/slimejelly/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
 	var/mob/living/carbon/C = M
-	if(M.get_blood_id() != id && !C.mind?.has_antag_datum(/datum/antagonist/vampire))  // no effect on slime people or vampires
+	if(iscarbon(C) && C.mind?.has_antag_datum(/datum/antagonist/vampire))
+		M.set_nutrition(min(NUTRITION_LEVEL_WELL_FED, M.nutrition + 10))
+		M.blood_volume = min(M.blood_volume + REAGENTS_METABOLISM, BLOOD_VOLUME_NORMAL)
+		return ..() | update_flags
+
+	if(M.get_blood_id() != id)
 		if(prob(10))
 			to_chat(M, "<span class='danger'>Your insides are burning!</span>")
 			update_flags |= M.adjustToxLoss(rand(2, 6) * REAGENTS_EFFECT_MULTIPLIER, FALSE) // avg 0.4 toxin per cycle, not unreasonable
@@ -68,14 +73,6 @@
 		var/obj/effect/decal/cleanable/blood/slime/B = new(T)
 		B.basecolor = color
 		B.update_icon()
-
-/datum/reagent/slimejelly/reaction_mob(mob/living/M, method, volume)
-	..()
-	if(method == REAGENT_INGEST && iscarbon(M) && M.mind?.has_antag_datum(/datum/antagonist/vampire))
-		M.reagents.remove_reagent("slimejelly", 1)
-		volume++ // Bit higher than base, wish it could be higher, but if it was higher, slime vampires would get even more blood out of their slime jelly
-		M.set_nutrition(min(NUTRITION_LEVEL_WELL_FED, M.nutrition + 10))
-		M.blood_volume = min(M.blood_volume + round(volume, 0.1), BLOOD_VOLUME_NORMAL)
 
 /datum/reagent/slimetoxin
 	name = "Mutation Toxin"

--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -50,9 +50,7 @@
 /datum/reagent/slimejelly/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
 	var/mob/living/carbon/C = M
-	if(C.mind?.has_antag_datum(/datum/antagonist/vampire)) // no effect on vampires
-		return ..() | update_flags
-	if(M.get_blood_id() != id)  // no effect on slime people
+	if(M.get_blood_id() != id && !C.mind?.has_antag_datum(/datum/antagonist/vampire))  // no effect on slime people // and vampires
 		if(prob(10))
 			to_chat(M, "<span class='danger'>Your insides are burning!</span>")
 			update_flags |= M.adjustToxLoss(rand(2, 6) * REAGENTS_EFFECT_MULTIPLIER, FALSE) // avg 0.4 toxin per cycle, not unreasonable

--- a/code/modules/reagents/chemistry/reagents/water.dm
+++ b/code/modules/reagents/chemistry/reagents/water.dm
@@ -120,6 +120,7 @@
 		var/mob/living/carbon/C = M
 		if(C.mind?.has_antag_datum(/datum/antagonist/vampire))
 			C.set_nutrition(min(NUTRITION_LEVEL_WELL_FED, C.nutrition + 10))
+			C.blood_volume = min(C.blood_volume + round(volume, 0.1), BLOOD_VOLUME_NORMAL)
 	..()
 
 /datum/reagent/blood/on_new(list/data)

--- a/code/modules/reagents/chemistry/reagents/water.dm
+++ b/code/modules/reagents/chemistry/reagents/water.dm
@@ -103,7 +103,7 @@
 	taste_description = "<span class='warning'>blood</span>"
 	taste_mult = 1.3
 
-/datum/reagent/blood/reaction_mob(mob/living/M, method=REAGENT_TOUCH, volume)
+/datum/reagent/blood/reaction_mob(mob/living/M, method = REAGENT_TOUCH, volume)
 	if(data && data["viruses"])
 		for(var/thing in data["viruses"])
 			var/datum/disease/D = thing

--- a/code/modules/reagents/chemistry/reagents_datum.dm
+++ b/code/modules/reagents/chemistry/reagents_datum.dm
@@ -72,7 +72,8 @@
 		if(can_become_addicted)
 			if(is_type_in_list(src, M.reagents.addiction_list))
 				to_chat(M, "<span class='notice'>You feel slightly better, but for how long?</span>") //sate_addiction handles this now, but kept this for the feed back.
-
+	if(C.mind?.has_antag_datum(/datum/antagonist/vampire))
+		return
 	var/mob/living/carbon/C = M
 	if(method == REAGENT_INGEST && istype(C) && C.get_blood_id() == id)
 		if(id == "blood" && !(data?["blood_type"] in get_safe_blood(C.dna?.blood_type)) || C.dna?.species.name != data?["species"] && (data?["species_only"] || C.dna?.species.own_species_blood))

--- a/code/modules/reagents/chemistry/reagents_datum.dm
+++ b/code/modules/reagents/chemistry/reagents_datum.dm
@@ -72,9 +72,9 @@
 		if(can_become_addicted)
 			if(is_type_in_list(src, M.reagents.addiction_list))
 				to_chat(M, "<span class='notice'>You feel slightly better, but for how long?</span>") //sate_addiction handles this now, but kept this for the feed back.
+	var/mob/living/carbon/C = M
 	if(C.mind?.has_antag_datum(/datum/antagonist/vampire))
 		return
-	var/mob/living/carbon/C = M
 	if(method == REAGENT_INGEST && istype(C) && C.get_blood_id() == id)
 		if(id == "blood" && !(data?["blood_type"] in get_safe_blood(C.dna?.blood_type)) || C.dna?.species.name != data?["species"] && (data?["species_only"] || C.dna?.species.own_species_blood))
 			C.reagents.add_reagent("toxin", volume * 0.5)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
If you're a vampire, you now no longer get toxins from drinking the wrong blood type. Also makes vampires able to drink slime jelly to regain hunger.

As a side effect, vampires can also use slime jelly to restore their own blood, regardless of being a slime.

TODO:
- [x] Make normal blood not kill you
- [x] Make slime jelly work as a blood substituent.

Fixes #19798
Fixes #21614
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
It's intended that drinking blood from blood bags and such will restore your hunger, it is however quite stupid and annoying if you instead get 100 u of toxin because you grabbed the wrong bloodbag.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Drank blood, didn't die a vomiting death
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Vampires can now drink all types of blood without dying of blood incompatability
tweak: Vampires can now drink slime jelly to restore hunger and blood level
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
