### PR TITLE
Morgue trays now can't move while in no gravity

### DIFF
--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -208,7 +208,7 @@
  */
 /obj/structure/m_tray
 	name = "morgue tray"
-	desc = "Apply corpse before closing. May float away in no-gravity."
+	desc = "Apply corpse before closing.
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "morgue_tray"
 	density = TRUE

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -208,7 +208,7 @@
  */
 /obj/structure/m_tray
 	name = "morgue tray"
-	desc = "Apply corpse before closing.
+	desc = "Apply corpse before closing."
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "morgue_tray"
 	density = TRUE

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -274,6 +274,9 @@
 		var/atom/movable/mover = caller
 		. = . || mover.checkpass(PASSTABLE)
 
+/obj/structure/m_tray/Process_Spacemove(movement_dir)
+	return TRUE
+
 /*
  * Crematorium
  */
@@ -538,6 +541,9 @@ GLOBAL_LIST_EMPTY(crematoriums)
 		connected.connected = null
 	connected = null
 	return ..()
+
+/obj/structure/c_tray/Process_Spacemove(movement_dir)
+	return TRUE
 
 // Crematorium switch
 /obj/machinery/crema_switch


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes morgue and cremator trays moving while in 0g
Fixes #20014 
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Bug bad
PR kills bug
PR good
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
Before:
![image](https://github.com/ParadiseSS13/Paradise/assets/108773801/e77dc098-7eb0-4c06-bae6-51a8b87bf602)
After:
![image](https://github.com/ParadiseSS13/Paradise/assets/108773801/ace99e50-bdf7-4016-ad0e-1203493a0260)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
See images
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Morgue and crematorium trays now really can't move while in no grav
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
