### PR TITLE
Debridement surgery no longer requires mitocholide

### DIFF
--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -147,7 +147,8 @@
 	name = "treat necrosis"
 	allowed_tools = list(
 		/obj/item/stack/medical/ointment/advanced = 100,
-		/obj/item/stack/medical/ointment = 90
+		/obj/item/stack/medical/ointment = 90,
+		/obj/item/stack/medical/ointment/aloe = 90
 	)
 
 	can_infect = FALSE

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -147,8 +147,7 @@
 	name = "treat necrosis"
 	allowed_tools = list(
 		/obj/item/stack/medical/ointment/advanced = 100,
-		/obj/item/stack/medical/bruise_pack = 90,
-		/obj/item/stack/medical/bruise_pack/improvised = 65
+		/obj/item/stack/medical/ointment = 90
 	)
 
 	can_infect = FALSE
@@ -165,8 +164,8 @@
 		return SURGERY_BEGINSTEP_SKIP
 
 	user.visible_message(
-		"[user] starts to wrap affected tissue in [target]'s [affected.name] with \the [tool].",
-		"You start to wrap affected tissue in [target]'s [affected.name] with \the [tool]."
+		"[user] starts to treat affected tissue in [target]'s [affected.name] with \the [tool].",
+		"You start to treat affected tissue in [target]'s [affected.name] with \the [tool]."
 	)
 	target.custom_pain("Something in your [affected.name] is causing you a lot of pain!")
 	return ..()
@@ -184,8 +183,8 @@
 	target.update_body()
 
 	user.visible_message(
-		"<span class='notice'> [user] finishes wrapping affected tissue in [target]'s [affected.name]</span>",
-		"<span class='notice'> You finish wrapping affected tissue in [target]'s [affected.name] with \the [tool].</span>"
+		"<span class='notice'> [user] finishes treating affected tissue in [target]'s [affected.name]</span>",
+		"<span class='notice'> You finish treating affected tissue in [target]'s [affected.name] with \the [tool].</span>"
 	)
 
 	return SURGERY_STEP_CONTINUE
@@ -198,8 +197,8 @@
 	stack.use(1)
 
 	user.visible_message(
-		"<span class='warning'> [user]'s hand slips, ineffectively wrapping [target]'s [affected.name] with the [tool]!</span>",
-		"<span class='warning'> Your hand slips, ineffectively wrapping [target]'s [affected.name] with the [tool]!</span>"
+		"<span class='warning'> [user]'s hand slips, ineffectively treating [target]'s [affected.name] with the [tool]!</span>",
+		"<span class='warning'> Your hand slips, ineffectively treating [target]'s [affected.name] with the [tool]!</span>"
 	)
 
 	//no damage or anything, just wastes medicine


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Debridement surgery no longer requires mitocholide for the last step. It now requires either an advanced burn kit, ointment/aloe (at 100%, 90% chance of success each).
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
With the addition of burn wounds, debridement surgery has become a common task for doctors.

Unfortunately, mitocholide is not always available. This can be due to lowpop staffing, chemists not doing their job, or an antag trying to perform ghetto surgery without access to the chem fridge (this is a big point, because the private chemistry fridge is ID locked on several maps. If the antag doesn't have medical access, they literally cannot acquire mitocholide without convincing somebody to fork it over).

Mitocholide will remain important for fixing necrotic organs, so its role in lazarus reagent revivals is no less prominent.
## Testing
<!-- How did you test the PR, if at all? -->
Did a lot of surgery on a skrell, both successful and unsuccessful steps work properly.
## Changelog
:cl:
tweak: Debridement surgery no longer requires mitocholide, instead needing adv burnkits or ointment/aloe
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
