### PR TITLE
Fix Plushie Path in spacebar, it cause other PR's to fail map check.

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/spacebar.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/spacebar.dmm
@@ -374,11 +374,11 @@
 	pixel_y = -3
 	},
 /obj/item/clothing/suit/hgpirate,
-/obj/item/toy/carpplushie/gold,
 /obj/item/reagent_containers/food/drinks/cans/beer/sleepy_beer,
 /obj/item/clothing/gloves/ring/gold,
 /obj/item/id_decal/gold,
 /obj/item/screwdriver,
+/obj/item/toy/plushie/carpplushie/gold,
 /turf/simulated/floor/plating/asteroid/airless,
 /area/space/nearstation)
 "eG" = (


### PR DESCRIPTION
## What Does This PR Do
Fix plushie carp path

## Why It's Good For The Game
it create issues, issues bad


## Testing
open map editor and placed plushie back

## Changelog
:cl:
fix: Fix gold carp plushie path for spacebar space ruin.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
