### PR TITLE
NutrimentPump

### DIFF
--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -316,7 +316,7 @@
 
 /obj/item/organ/internal/cyberimp/chest/nutriment
 	name = "Nutriment pump implant"
-	desc = "This implant will synthesize a small amount of nutriment and pump it directly into your bloodstream, when you are starving."
+	desc = "This implant will synthesize a small amount of nutriment and pump it directly into your bloodstream when you are starving."
 	icon_state = "chest_implant"
 	implant_color = "#00AA00"
 	var/hunger_threshold = NUTRITION_LEVEL_STARVING
@@ -366,7 +366,7 @@
 
 /obj/item/organ/internal/cyberimp/chest/nutriment/plus
 	name = "Nutriment pump implant PLUS"
-	desc = "This implant will synthesize a small amount of nutriment and pump it directly into your bloodstream, when you are hungry."
+	desc = "This implant will synthesize a small amount of nutriment and pump it directly into your bloodstream when you are hungry."
 	icon_state = "chest_implant"
 	implant_color = "#006607"
 	hunger_threshold = NUTRITION_LEVEL_HUNGRY

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -316,7 +316,7 @@
 
 /obj/item/organ/internal/cyberimp/chest/nutriment
 	name = "Nutriment pump implant"
-	desc = "This implant will synthesize a small amount of nutriment and pump it directly into your bloodstream when you are starving."
+	desc = "This implant will synthesize a small amount of nutriment and pumps it directly into your bloodstream when you are starving."
 	icon_state = "chest_implant"
 	implant_color = "#00AA00"
 	var/hunger_threshold = NUTRITION_LEVEL_STARVING

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -316,7 +316,7 @@
 
 /obj/item/organ/internal/cyberimp/chest/nutriment
 	name = "Nutriment pump implant"
-	desc = "This implant will synthesize a small amount of nutriment and pump it directly into your bloodstrean, when you are starving."
+	desc = "This implant will synthesize a small amount of nutriment and pump it directly into your bloodstream, when you are starving."
 	icon_state = "chest_implant"
 	implant_color = "#00AA00"
 	var/hunger_threshold = NUTRITION_LEVEL_STARVING

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -366,7 +366,7 @@
 
 /obj/item/organ/internal/cyberimp/chest/nutriment/plus
 	name = "Nutriment pump implant PLUS"
-	desc = "This implant will synthesize a small amount of nutriment and pump it directly into your bloodstream when you are hungry."
+	desc = "This implant will synthesize a small amount of nutriment and pumps it directly into your bloodstream when you are hungry."
 	icon_state = "chest_implant"
 	implant_color = "#006607"
 	hunger_threshold = NUTRITION_LEVEL_HUNGRY

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -316,7 +316,7 @@
 
 /obj/item/organ/internal/cyberimp/chest/nutriment
 	name = "Nutriment pump implant"
-	desc = "This implant with synthesize and pump into your bloodstream a small amount of nutriment when you are starving."
+	desc = "This implant will synthesize a small amount of nutriment and pump it directly into your bloodstrean, when you are starving."
 	icon_state = "chest_implant"
 	implant_color = "#00AA00"
 	var/hunger_threshold = NUTRITION_LEVEL_STARVING
@@ -366,7 +366,7 @@
 
 /obj/item/organ/internal/cyberimp/chest/nutriment/plus
 	name = "Nutriment pump implant PLUS"
-	desc = "This implant will synthesize a small amount of nutriment and pump it into your bloodstream when you are hungry."
+	desc = "This implant will synthesize a small amount of nutriment and pump it directly into your bloodstream, when you are hungry."
 	icon_state = "chest_implant"
 	implant_color = "#006607"
 	hunger_threshold = NUTRITION_LEVEL_HUNGRY

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -372,6 +372,7 @@
 	hunger_threshold = NUTRITION_LEVEL_HUNGRY
 	poison_amount = 10
 	origin_tech = "materials=4;powerstorage=3;biotech=3"
+
 /obj/item/organ/internal/cyberimp/chest/nutriment/hardened
 	name = "hardened nutriment pump implant"
 	emp_proof = TRUE

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -366,18 +366,18 @@
 
 /obj/item/organ/internal/cyberimp/chest/nutriment/plus
 	name = "Nutriment pump implant PLUS"
-	desc = "This implant will synthesize and pump into your bloodstream a small amount of nutriment when you are hungry."
+	desc = "This implant will synthesize a small amount of nutriment and pump it into your bloodstream when you are hungry."
 	icon_state = "chest_implant"
 	implant_color = "#006607"
 	hunger_threshold = NUTRITION_LEVEL_HUNGRY
 	poison_amount = 10
 	origin_tech = "materials=4;powerstorage=3;biotech=3"
 /obj/item/organ/internal/cyberimp/chest/nutriment/hardened
-	name = "hardened nutrient pump implant"
+	name = "hardened nutriment pump implant"
 	emp_proof = TRUE
 
 /obj/item/organ/internal/cyberimp/chest/nutriment/plus/hardened
-	name = "hardened nutrient pump implant PLUS"
+	name = "hardened nutriment pump implant PLUS"
 	emp_proof = TRUE
 
 /obj/item/organ/internal/cyberimp/chest/reviver


### PR DESCRIPTION
## What Does This PR Do
Changes Nutriment item description and typo in name
 - Reworded description
- Changed nutrient to nutriment
Fixes #21569

## Why It's Good For The Game
Changed slightly confusing description wording and fixed a typo that led to the item not being properly searchable in certain menu's
## Testing
Loaded test server, spawned all versions of nutriment pumps and viewed their names and description with no issues.

## Changelog
:cl:
fix: Fixed nutriment pump typos
/:cl:
