### PR TITLE
adds burn wound surgery

### DIFF
--- a/code/modules/surgery/abstract_steps.dm
+++ b/code/modules/surgery/abstract_steps.dm
@@ -292,13 +292,32 @@
 		to_chat(user, "<span class='warning'>The bones in [target]'s [parse_zone(affected)] look fully intact, they don't need mending.</span>")
 	return FALSE
 
-/// Proxy surgery step to allow healing bleeding and mending bones.
+/datum/surgery/intermediate/treat_burns
+	name = "Burns (abstract)"
+	desc = "An intermediate surgery to treat burn wounds while a patient is undergoing another procedure."
+	steps = list(/datum/surgery_step/treat_burns)
+	possible_locs = list(BODY_ZONE_CHEST, BODY_ZONE_HEAD, BODY_ZONE_PRECISE_GROIN, BODY_ZONE_L_ARM, BODY_ZONE_R_ARM, BODY_ZONE_L_LEG, BODY_ZONE_R_LEG, BODY_ZONE_PRECISE_R_HAND, BODY_ZONE_PRECISE_L_HAND, BODY_ZONE_PRECISE_R_FOOT, BODY_ZONE_PRECISE_L_FOOT)
+
+/datum/surgery/intermediate/treat_burns/can_start(mob/user, mob/living/carbon/target)
+	. = ..()
+	if(!.)
+		return FALSE
+	var/mob/living/carbon/human/H = target
+	var/obj/item/organ/external/affected = H.get_organ(user.zone_selected)
+	if(affected.status & ORGAN_BURNT)
+		return TRUE
+	else
+		to_chat(user, "<span class='warning'>The skin on [target]'s [parse_zone(affected)] seem to be in perfect condition, it doesn't need treatment.</span>")
+	return FALSE
+
+/// Proxy surgery step to allow healing bleeding, bones, and burns.
 /// Should be added into surgeries just after the first three standard steps.
 /datum/surgery_step/proxy/open_organ
-	name = "mend internal bleeding or mend bone (proxy)"
+	name = "mend internal bleeding, mend bone, or mend burns (proxy)"
 	branches = list(
 		/datum/surgery/intermediate/bleeding,
-		/datum/surgery/intermediate/mendbone
+		/datum/surgery/intermediate/mendbone,
+		/datum/surgery/intermediate/treat_burns
 	)
 
 /// Mend IB without healing bones

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -33,6 +33,17 @@
 	possible_locs = list(BODY_ZONE_CHEST, BODY_ZONE_HEAD, BODY_ZONE_PRECISE_GROIN, BODY_ZONE_L_ARM, BODY_ZONE_R_ARM, BODY_ZONE_L_LEG, BODY_ZONE_R_LEG, BODY_ZONE_PRECISE_R_HAND, BODY_ZONE_PRECISE_L_HAND, BODY_ZONE_PRECISE_R_FOOT, BODY_ZONE_PRECISE_L_FOOT)
 	requires_organic_bodypart = TRUE
 
+/datum/surgery/treat_burns
+	name = "Burns"
+	steps = list(
+		/datum/surgery_step/generic/cut_open,
+		/datum/surgery_step/generic/clamp_bleeders,
+		/datum/surgery_step/generic/retract_skin,
+		/datum/surgery_step/proxy/open_organ,
+		/datum/surgery_step/generic/cauterize
+	)
+	possible_locs = list(BODY_ZONE_CHEST, BODY_ZONE_HEAD, BODY_ZONE_PRECISE_GROIN, BODY_ZONE_L_ARM, BODY_ZONE_R_ARM, BODY_ZONE_L_LEG, BODY_ZONE_R_LEG, BODY_ZONE_PRECISE_R_HAND, BODY_ZONE_PRECISE_L_HAND, BODY_ZONE_PRECISE_R_FOOT, BODY_ZONE_PRECISE_L_FOOT)
+
 /datum/surgery/bleeding/can_start(mob/user, mob/living/carbon/target)
 	. = ..()
 	if(!.)
@@ -50,7 +61,6 @@
 	if(!(affected.status & ORGAN_DEAD) && !(affected.status & ORGAN_BURNT))
 		return FALSE
 	return TRUE
-
 
 /datum/surgery_step/fix_vein
 	name = "mend internal bleeding"
@@ -101,6 +111,69 @@
 
 	return SURGERY_STEP_RETRY
 
+/datum/surgery_step/fix_vein/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	var/obj/item/organ/external/affected = target.get_organ(target_zone)
+	user.visible_message(
+		"<span class='warning'> [user]'s hand slips, smearing [tool] in the incision in [target]'s [affected.name]!</span>",
+		"<span class='warning'> Your hand slips, smearing [tool] in the incision in [target]'s [affected.name]!</span>"
+	)
+	affected.receive_damage(5, 0)
+
+	return SURGERY_STEP_RETRY
+
+/datum/surgery_step/treat_burns
+	name = "mend burns"
+	allowed_tools = list(
+		/obj/item/stack/medical/ointment/advanced = 100,
+		/obj/item/stack/medical/ointment = 90
+	)
+	can_infect = TRUE
+	blood_level = SURGERY_BLOODSPREAD_HANDS
+
+	time = 3.2 SECONDS
+
+/datum/surgery_step/treat_burns/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	var/obj/item/organ/external/affected = target.get_organ(target_zone)
+	if(!(affected.status & ORGAN_BURNT))
+		to_chat(user, "<span class='warning'>The skin on [target]'s [parse_zone(affected)] seem to be in perfect condition, it doesn't need treatment.</span>")
+		return SURGERY_BEGINSTEP_SKIP
+
+	user.visible_message(
+		"[user] starts to treat affected tissue in [target]'s [affected.name] with \the [tool].",
+		"You start to treat affected tissue in [target]'s [affected.name] with \the [tool]."
+	)
+	target.custom_pain("The pain in your [affected.name] is unbearable!")
+
+	return ..()
+
+/datum/surgery_step/treat_burns/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	var/obj/item/organ/external/affected = target.get_organ(target_zone)
+	var/obj/item/stack/stack = tool
+
+	stack.use(1)
+	affected.fix_burn_wound()
+	affected.germ_level = 0
+	target.update_body()
+
+	user.visible_message(
+		"<span class='notice'> [user] finishes treating affected tissue in [target]'s [affected.name]</span>",
+		"<span class='notice'> You finish treating affected tissue in [target]'s [affected.name] with \the [tool].</span>"
+	)
+
+	return SURGERY_STEP_CONTINUE
+
+/datum/surgery_step/treat_burns/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	var/obj/item/organ/external/affected = target.get_organ(target_zone)
+	var/obj/item/stack/stack = tool
+
+	stack.use(1)
+
+	user.visible_message(
+		"<span class='warning'> [user]'s hand slips, ineffectively treating [target]'s [affected.name] with the [tool]!</span>",
+		"<span class='warning'> Your hand slips, ineffectively treating [target]'s [affected.name] with the [tool]!</span>"
+	)
+
+	return SURGERY_STEP_RETRY
 /datum/surgery_step/fix_dead_tissue		//Debridement
 	name = "remove dead tissue"
 	allowed_tools = list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Makes curing burn wounds its own separate surgery requiring an advanced trauma kit or ointment.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
As discussed in discord, this brings burn wound surgery in line with the speed and ease of curing IB and broken bones. Debridement surgery is untouched and still cures burn wounds.

## Testing
<!-- How did you test the PR, if at all? -->
Tested the surgery itself and branching from organ manip successfully. 
## Changelog
:cl:
add: Burn wounds now have a separate surgery
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
