### PR TITLE
Fixes some issues with command and sec job lists

### DIFF
--- a/code/__HELPERS/mob_helpers.dm
+++ b/code/__HELPERS/mob_helpers.dm
@@ -657,7 +657,7 @@ GLOBAL_LIST_INIT(do_after_once_tracker, list())
  * 	where active is defined as conscious (STAT = 0) and not an antag
 */
 /proc/check_active_security_force()
-	var/sec_positions = GLOB.security_positions - "Magistrate"
+	var/sec_positions = GLOB.full_security_positions
 	var/total = 0
 	var/active = 0
 	var/dead = 0

--- a/code/datums/cache/crew.dm
+++ b/code/datums/cache/crew.dm
@@ -27,7 +27,6 @@ GLOBAL_DATUM_INIT(crew_repository, /datum/repository/crew, new())
 		bold_jobs += GLOB.command_positions
 		bold_jobs += get_all_centcom_jobs()
 		bold_jobs += get_all_ERT_jobs()
-		bold_jobs += list("Nanotrasen Representative", "Blueshield", "Magistrate")
 
 	for(var/thing in GLOB.human_list)
 		var/mob/living/carbon/human/H = thing

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -41,7 +41,7 @@ GLOBAL_LIST_EMPTY(PDA_Manifest)
 			if(rank == "Captain" && heads.len != 1)
 				heads.Swap(1,  heads.len)
 
-		if(real_rank in GLOB.security_positions)
+		if(real_rank in GLOB.full_security_positions)
 			sec[++sec.len] = list("name" = name, "rank" = rank, "active" = isactive)
 			department = 1
 			if(depthead && sec.len != 1)

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -272,8 +272,7 @@
 	. = list()
 	for(var/thing in GLOB.human_list)
 		var/mob/living/carbon/human/player = thing
-		var/list/real_command_positions = GLOB.command_positions.Copy() - "Nanotrasen Representative"
-		if(player.stat != DEAD && player.mind && (player.mind.assigned_role in real_command_positions))
+		if(player.stat != DEAD && player.mind && (player.mind.assigned_role in GLOB.full_command_positions))
 			. |= player.mind
 
 
@@ -283,8 +282,7 @@
 /datum/game_mode/proc/get_all_heads()
 	. = list()
 	for(var/mob/player in GLOB.mob_list)
-		var/list/real_command_positions = GLOB.command_positions.Copy() - "Nanotrasen Representative"
-		if(player.mind && (player.mind.assigned_role in real_command_positions))
+		if(player.mind && (player.mind.assigned_role in GLOB.full_command_positions))
 			. |= player.mind
 
 //////////////////////////////////////////////
@@ -294,7 +292,7 @@
 	. = list()
 	for(var/thing in GLOB.human_list)
 		var/mob/living/carbon/human/player = thing
-		if(player.stat != DEAD && player.mind && (player.mind.assigned_role in GLOB.security_positions))
+		if(player.stat != DEAD && player.mind && (player.mind.assigned_role in GLOB.full_security_positions))
 			. |= player.mind
 
 ////////////////////////////////////////
@@ -304,7 +302,7 @@
 	. = list()
 	for(var/thing in GLOB.human_list)
 		var/mob/living/carbon/human/player = thing
-		if(player.mind && (player.mind.assigned_role in GLOB.security_positions))
+		if(player.mind && (player.mind.assigned_role in GLOB.full_security_positions))
 			. |= player.mind
 
 /datum/game_mode/proc/check_antagonists_topic(href, href_list[])

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -177,8 +177,7 @@
 /datum/game_mode/revolution/latespawn(mob/living/carbon/human/player)
 	..()
 	var/datum/mind/player_mind = player.mind
-	var/list/real_command_positions = GLOB.command_positions.Copy() - "Nanotrasen Representative"
-	if(player_mind && (player_mind.assigned_role in real_command_positions))
+	if(player_mind && (player_mind.assigned_role in GLOB.full_command_positions))
 		for(var/datum/mind/rev_mind in head_revolutionaries)
 			mark_for_death(rev_mind, player_mind)
 

--- a/code/game/jobs/job_globals.dm
+++ b/code/game/jobs/job_globals.dm
@@ -3,6 +3,7 @@ GLOBAL_LIST_INIT(station_departments, list(DEPARTMENT_COMMAND, DEPARTMENT_MEDICA
 											DEPARTMENT_SCIENCE, DEPARTMENT_SECURITY, DEPARTMENT_SUPPLY,
 											DEPARTMENT_SERVICE, DEPARTMENT_ASSISTANT))
 
+/// All roles that are within the command category
 GLOBAL_LIST_INIT(command_positions, list(
 	"Captain",
 	"Head of Personnel",
@@ -13,6 +14,16 @@ GLOBAL_LIST_INIT(command_positions, list(
 	"Nanotrasen Representative",
 	"Magistrate",
 	"Blueshield"
+))
+
+/// Only roles that are command of departments, for revolution and similar stuff
+GLOBAL_LIST_INIT(full_command_positions, list(
+	"Captain",
+	"Head of Personnel",
+	"Head of Security",
+	"Chief Engineer",
+	"Research Director",
+	"Chief Medical Officer",
 ))
 
 
@@ -58,9 +69,6 @@ GLOBAL_LIST_INIT(support_positions, list(
 	"Clown",
 	"Mime",
 	"Barber",
-	"Magistrate",
-	"Nanotrasen Representative",
-	"Blueshield",
 	"Explorer"
 ))
 
@@ -73,7 +81,7 @@ GLOBAL_LIST_INIT(supply_positions, list(
 
 GLOBAL_LIST_INIT(service_positions, (list("Head of Personnel") + (support_positions - supply_positions)))
 
-
+/// Roles that include any semblence of security, mostly for jobbans
 GLOBAL_LIST_INIT(security_positions, list(
 	"Head of Security",
 	"Warden",
@@ -82,6 +90,15 @@ GLOBAL_LIST_INIT(security_positions, list(
 	"Magistrate",
 	"Blueshield"
 ))
+
+/// Active security roles
+GLOBAL_LIST_INIT(full_security_positions, list(
+	"Head of Security",
+	"Warden",
+	"Detective",
+	"Security Officer"
+))
+
 
 
 GLOBAL_LIST_INIT(assistant_positions, list(

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -339,7 +339,7 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 					data["jobs_engineering"] = GLOB.engineering_positions
 					data["jobs_medical"] = GLOB.medical_positions
 					data["jobs_science"] = GLOB.science_positions
-					data["jobs_security"] = GLOB.security_positions
+					data["jobs_security"] = GLOB.full_security_positions
 					data["jobs_service"] = GLOB.service_positions
 					data["jobs_supply"] = GLOB.supply_positions - "Head of Personnel"
 					data["jobs_centcom"] = get_all_centcom_jobs() + get_all_ERT_jobs()

--- a/code/modules/events/event_procs.dm
+++ b/code/modules/events/event_procs.dm
@@ -93,7 +93,7 @@
 		if(M.mind.assigned_role in list("Chief Medical Officer", "Medical Doctor"))
 			active_with_role["Medical"]++
 
-		if(M.mind.assigned_role in GLOB.security_positions)
+		if(M.mind.assigned_role in GLOB.full_security_positions)
 			active_with_role["Security"]++
 
 		if(M.mind.assigned_role in list("Research Director", "Scientist"))

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -477,7 +477,7 @@
 	var/list/categorizedJobs = list(
 		"Command" = list(jobs = list(), titles = GLOB.command_positions, color = "#aac1ee"),
 		"Engineering" = list(jobs = list(), titles = GLOB.engineering_positions, color = "#ffd699"),
-		"Security" = list(jobs = list(), titles = GLOB.security_positions, color = "#ff9999"),
+		"Security" = list(jobs = list(), titles = GLOB.full_security_positions, color = "#ff9999"),
 		"Miscellaneous" = list(jobs = list(), titles = list(), color = "#ffffff", colBreak = 1),
 		"Synthetic" = list(jobs = list(), titles = GLOB.nonhuman_positions, color = "#ccffcc"),
 		"Support / Service" = list(jobs = list(), titles = GLOB.service_positions, color = "#cccccc"),

--- a/code/modules/world_topic/manifest.dm
+++ b/code/modules/world_topic/manifest.dm
@@ -5,7 +5,7 @@
 	var/list/positions = list()
 	var/list/set_names = list(
 		"heads" = GLOB.command_positions,
-		"sec" = GLOB.security_positions,
+		"sec" = GLOB.full_security_positions.Copy(),
 		"eng" = GLOB.engineering_positions,
 		"med" = GLOB.medical_positions,
 		"sci" = GLOB.science_positions,

--- a/code/modules/world_topic/manifest.dm
+++ b/code/modules/world_topic/manifest.dm
@@ -5,7 +5,7 @@
 	var/list/positions = list()
 	var/list/set_names = list(
 		"heads" = GLOB.command_positions,
-		"sec" = GLOB.full_security_positions.Copy(),
+		"sec" = GLOB.full_security_positions,
 		"eng" = GLOB.engineering_positions,
 		"med" = GLOB.medical_positions,
 		"sci" = GLOB.science_positions,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->Fixes some issues with command and sec job lists, along with tweaking some things. This is a followup to #21746 to address some of the changes. Since BS counted as a security job, he would show up in the joining menu, and on the manifest as security. We do not need more redshields. It also made magi + BS targets of the revolution, unlike NTRep, this fixes that. Rev targets are supposed to be the leaders of departments.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Its good that these roles count as jobbans now, but it shouldnt have made so many unnoticed miscellaneous changes. It also cuts down on having a role across multiple department showing up on manifest, join menu, and HOP's ID changer. 

## Testing
<!-- How did you test the PR, if at all? -->
Joined as blueshield and magi, saw myself in command and not on security's manifest. Messed around with some event testing, no runtimes.

## Changelog
:cl:
fix: Blueshield no longer shows up in the security section on the join menu and manifest
tweak: Magistrate no longer shows up in the security section on the join menu and manifest
tweak: Blueshield, Magistrate, and NTRep no longer shows up in the service section on the join menu and manifest
fix: Blueshield and Magistrate will no longer be revolutionary targets
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
