### PR TITLE
pulse lasers no longer have shenaigins that cause the floor to breach

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -131,12 +131,6 @@
 		our_rpd.delete_all_pipes(user, src)
 
 /turf/bullet_act(obj/item/projectile/Proj)
-	if(istype(Proj, /obj/item/projectile/beam/pulse))
-		src.ex_act(2)
-	..()
-	return FALSE
-
-/turf/bullet_act(obj/item/projectile/Proj)
 	if(istype(Proj, /obj/item/projectile/bullet/gyro))
 		explosion(src, -1, 0, 2)
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Removes a bullet act from walls, that caused pulse lasers to ex_act it _before the pulse laser hit it_. This caused the wall to turn into plating often, causing the pulse laser to hit the floor instead, leading to the tile being spaced.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Ever wondered why pulse lasers turned the floor to space? So did I. I wanted to make the shotgun ammo not do that. But as I went to adjust the pulse lasers, I noticed: Walls shouldn't be spaced by pulse lasers to begin with, they *should* break, but not space.

Queue some breakpoints later, I found bullet_act on walls, called ex_act(2) on itself if it got hit by a pulse laser. Amazing. I presume this was from pre-object damage.

I'll call this a tweak, and if people *really* want, I'll only make it apply to shotgun pulse lasers, though a double call like that is a bit silly.

## Testing
<!-- How did you test the PR, if at all? -->
shot a bunch of pulse lasers without breaking the floors.

## Changelog
:cl:
tweak: Pulse lasers no longer call ex_act twice on walls, so walls no longer get spaced when hit by a pulse laser, only break.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
