### PR TITLE
fixes a to_chat runtime, lints now throw an error if a to_chat proc lacks a target argument

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -317,9 +317,6 @@
 		return
 	ui_interact(user)
 
-#warn REMOVE AFTER THIS WORKS
-	to_chat("this is for debugging")
-
 /obj/machinery/chem_dispenser/AltClick(mob/user)
 	if(!is_drink || !Adjacent(user))
 		return

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -313,9 +313,12 @@
 	if(stat & BROKEN)
 		return
 	if(!anchored)
-		to_chat("<span class='warning'>[src] must be anchored first!</span>")
+		to_chat(user, "<span class='warning'>[src] must be anchored first!</span>")
 		return
 	ui_interact(user)
+
+#warn REMOVE AFTER THIS WORKS
+	to_chat("this is for debugging")
 
 /obj/machinery/chem_dispenser/AltClick(mob/user)
 	if(!is_drink || !Adjacent(user))

--- a/tools/ci/check_grep.sh
+++ b/tools/ci/check_grep.sh
@@ -45,11 +45,6 @@ if grep -P --exclude='__byond_version_compat.dm' '(\.proc\/)|(CALLBACK\(.*proc\/
     echo "ERROR: Outdated proc reference use detected in code, please use proc reference helpers."
     st=1
 fi;
-# Check for to_chat procs lacking proper arguments
-if grep -P '\to_chat("/' code/**/*.dm; then
-	echo "ERROR: to_chat proc called without a target argument. Please add a target argument so it properly displays in game."
-	st=1
-fi;
 nl='
 '
 nl=$'\n'

--- a/tools/ci/check_grep.sh
+++ b/tools/ci/check_grep.sh
@@ -45,6 +45,11 @@ if grep -P --exclude='__byond_version_compat.dm' '(\.proc\/)|(CALLBACK\(.*proc\/
     echo "ERROR: Outdated proc reference use detected in code, please use proc reference helpers."
     st=1
 fi;
+# Check for to_chat procs lacking proper arguments
+if grep -P '(\to_chat("\)' code/**/*.dm; then
+	echo "ERROR: to_chat proc called without a target argument. Please add a target argument so it properly displays in game."
+	st=1
+fi;
 nl='
 '
 nl=$'\n'

--- a/tools/ci/check_grep.sh
+++ b/tools/ci/check_grep.sh
@@ -46,7 +46,7 @@ if grep -P --exclude='__byond_version_compat.dm' '(\.proc\/)|(CALLBACK\(.*proc\/
     st=1
 fi;
 # Check for to_chat procs lacking proper arguments
-if grep -P '(\to_chat("\)' code/**/*.dm; then
+if grep -P '\to_chat("/' code/**/*.dm; then
 	echo "ERROR: to_chat proc called without a target argument. Please add a target argument so it properly displays in game."
 	st=1
 fi;

--- a/tools/ci/check_grep2.py
+++ b/tools/ci/check_grep2.py
@@ -16,7 +16,7 @@ IGNORE_515_PROC_MARKER_FILENAME = "__byond_version_compat.dm"
 CHECK_515_PROC_MARKER_RE = re.compile(r"\.proc/")
 def check_515_proc_syntax(lines):
     for idx, line in enumerate(lines):
-        if CHECK_515_PROC_MARKER_RE.match(line):
+        if CHECK_515_PROC_MARKER_RE.search(line):
             return Failure(idx + 1, "Outdated proc reference use detected in code. Please use proc reference helpers.")
 
 
@@ -92,6 +92,11 @@ def check_proc_args_with_var_prefix(lines):
         if PROC_ARGS_WITH_VAR_PREFIX_RE.match(line):
             return Failure(idx + 1, "Changed files contains a proc argument starting with 'var'.")
 
+TO_CHAT_WITH_NO_USER_ARG_RE = re.compile(r"to_chat\(\"")
+def check_to_chats_have_a_user_arguement(lines):
+    for idx, line in enumerate(lines):
+        if TO_CHAT_WITH_NO_USER_ARG_RE.search(line):
+            return Failure(idx + 1, "Changed files contains a to_chat() procedure without a user argument.")
 
 CODE_CHECKS = [
     check_space_indentation,
@@ -99,6 +104,7 @@ CODE_CHECKS = [
     check_trailing_newlines,
     check_global_vars,
     check_proc_args_with_var_prefix,
+    check_to_chats_have_a_user_arguement,
 ]
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
fixes a to_chat runtime
adds a check to check_grep.py to make sure that to_chat procs have a target argument 
fixes the .proc/ checker not working

## Why It's Good For The Game
this stuff happens and is bad, to_chat procs should have a target and it happens enough where the author should know something is wrong if they forgot to add one.

## Testing
it works, wish there was an documented way for new contributors to know how to run these on local
## Changelog
:cl:
fix: you are now notified that you cannot use chemical dispensers while they're unanchored 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
