### PR TITLE
Gives flares the same attack sounds and attack message as lighters.

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -195,6 +195,8 @@
 	on = FALSE
 	force = initial(force)
 	damtype = initial(damtype)
+	hitsound = initial(hitsound)
+	attack_verb = initial(attack_verb)
 	update_brightness()
 
 /obj/item/flashlight/flare/attack_self(mob/user)
@@ -213,6 +215,8 @@
 		if(produce_heat)
 			force = on_damage
 			damtype = "fire"
+			hitsound = 'sound/items/welder.ogg'
+			attack_verb = list("burnt", "singed")
 		START_PROCESSING(SSobj, src)
 
 /obj/item/flashlight/flare/decompile_act(obj/item/matter_decompiler/C, mob/user)


### PR DESCRIPTION
## What Does This PR Do
Gives flares the same attack sounds and attack description as lighters.

## Why It's Good For The Game
Currently flares use a whack sound and a fairly generic "attacked" verb in it's attack message.  Since flares only do damage when they're turned on and do burn damage, it's more appropriate for them to use a different sound and message.

## Testing
Hit things with flares.

## Changelog
:cl:
tweak: Flares now use the same attack sounds and attack message as lighters.
/:cl:
