### PR TITLE
Makes ash walkers breathe a small bit of oxygen

### DIFF
--- a/code/modules/surgery/organs/subtypes/unathi_organs.dm
+++ b/code/modules/surgery/organs/subtypes/unathi_organs.dm
@@ -30,4 +30,4 @@
 	icon = 'icons/obj/species_organs/unathi.dmi'
 
 /obj/item/organ/internal/lungs/unathi/ash_walker
-	safe_oxygen_min = 0 // can breathe on lavaland
+	safe_oxygen_min = 4 // 4x as efficient as regular Unathi, can comfortably breathe on lavaland


### PR DESCRIPTION
## What Does This PR Do
Title. The precise amount is ~30% of the amount of oxygen available to them on lavaland, so they should still be able to breathe very comfortably.

## Why It's Good For The Game
The problem lies in two points:
- While in crit, you start taking respiratory damage (as well as from other sources, like a certain species of lavaland mushrooms). This normally isn't a big problem, because most species that can take respiratory damage also breathe, which with enough of the required gas, provides resp. damage healing.
- Ash walkers don't breathe any gases to heal from.

This makes any respiratory damage they take basically permanent, which I hardly buy is an intended side-effect of letting ash walkers exist safe from lavaland's low pressure. Making ash walkers need a small bit of oxygen should also nerf their resistance to space (respiratory damage is honestly space's main killer), and in general makes more sense for them as organic beings.

## Testing
Spawned in as an ashie on lavaland, made sure I don't start suffocating immediately.
Gave myself enough brute/burn damage to knock me into crit, and waited a bit to amass some resp. damage. Healed the brute/burn damage and checked to see I can breathe off the respiratory damage from crit as opposed to it becoming a permanent max HP reduction.

## Changelog
:cl:
tweak: Ash walkers now breathe a small amount of oxygen.
fix: Ash walkers' respiratory damage is no longer semi-permanent.
/:cl: