### PR TITLE
Fixes 9000+ runtimes with the camera bug because I'm an idiot

### DIFF
--- a/code/datums/components/sticky.dm
+++ b/code/datums/components/sticky.dm
@@ -105,8 +105,9 @@
 		qdel(parent)
 		return
 
+	// Cancel out these signals, if they even still exist. Just to be safe
 	UnregisterSignal(attached_to, list(COMSIG_HUMAN_MELEE_UNARMED_ATTACKBY, COMSIG_PARENT_EXAMINE, COMSIG_PARENT_QDELETING, COMSIG_MOVABLE_MOVED))
-	// cancel out these signals, if they even still exist
+
 	var/turf/T = get_turf(source)
 	if(!T)
 		T = get_turf(parent)

--- a/code/datums/components/sticky.dm
+++ b/code/datums/components/sticky.dm
@@ -76,7 +76,7 @@
 
 
 	I.invisibility = initial(I.invisibility)
-	UnregisterSignal(attached_to, list(COMSIG_HUMAN_MELEE_UNARMED_ATTACKBY, COMSIG_PARENT_EXAMINE))
+	UnregisterSignal(attached_to, list(COMSIG_HUMAN_MELEE_UNARMED_ATTACKBY, COMSIG_PARENT_EXAMINE, COMSIG_PARENT_QDELETING, COMSIG_MOVABLE_MOVED))
 	STOP_PROCESSING(SSobj, src)
 	attached_to = null
 	return COMPONENT_CANCEL_ATTACK_CHAIN
@@ -105,6 +105,8 @@
 		qdel(parent)
 		return
 
+	UnregisterSignal(attached_to, list(COMSIG_HUMAN_MELEE_UNARMED_ATTACKBY, COMSIG_PARENT_EXAMINE, COMSIG_PARENT_QDELETING, COMSIG_MOVABLE_MOVED))
+	// cancel out these signals, if they even still exist
 	var/turf/T = get_turf(source)
 	if(!T)
 		T = get_turf(parent)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->Fixes an oversight where taking a camera bug off something then moving it, would make it runtime. It didnt have any effect on the game, but holy SHIT, did it spam runtime logs.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->BUGS VERY BAD

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
<!-- How did you test the PR, if at all? -->
Loaded in, put a camera bug on myself, took the camera bug off, moved around. Switched to a new body, pulled by old body around. No runtimes!

## Changelog
:cl:
fix: Fixes a bug causing moving anything that had a camera bug removed it to runtime constantly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
