### PR TITLE
Improves /datum/component/sticky code

### DIFF
--- a/code/datums/components/sticky.dm
+++ b/code/datums/components/sticky.dm
@@ -9,11 +9,25 @@
 
 /datum/component/sticky/Initialize(_drop_on_attached_destroy = FALSE)
 	if(!isitem(parent))
-		stack_trace("/datum/component/sticky's parent is not an item, its [parent.type]")
 		return COMPONENT_INCOMPATIBLE
 
 	drop_on_attached_destroy = _drop_on_attached_destroy
+
+/datum/component/sticky/Destroy(force, silent)
+	if(QDELETED(parent)) // we dont want the falling off visible message if this component is getting destroyed because parent is getting destroyed
+		return
+	if(isitem(parent) && attached_to)
+		var/obj/item/I = parent
+		I.visible_message("<span class='notice'>[parent] falls off of [attached_to]</span>")
+	pick_up(parent)
+	move_to_the_thing(parent, get_turf(parent))
+	. = ..()
+
+/datum/component/sticky/RegisterWithParent()
 	RegisterSignal(parent, COMSIG_ITEM_PRE_ATTACK, PROC_REF(stick_to_it))
+
+/datum/component/sticky/UnregisterFromParent()
+	UnregisterSignal(parent, COMSIG_ITEM_PRE_ATTACK)
 
 /datum/component/sticky/proc/stick_to_it(obj/item/I, atom/target, mob/user, params)
 	SIGNAL_HANDLER
@@ -59,10 +73,10 @@
 /datum/component/sticky/proc/pick_up(atom/A, mob/living/carbon/human/user)
 	SIGNAL_HANDLER
 	if(!attached_to)
+		CRASH("/datum/component/sticky/proc/pick_up was called, but without an attached atom")
+	if(user && user.a_intent != INTENT_GRAB)
 		return
-	if(user.a_intent != INTENT_GRAB)
-		return
-	if(user.get_active_hand())
+	if(user && user.get_active_hand())
 		return
 	attached_to.cut_overlay(overlay, priority = TRUE)
 
@@ -70,8 +84,8 @@
 	I.pixel_x = initial(I.pixel_x)
 	I.pixel_y = initial(I.pixel_y)
 	move_to_the_thing(parent)
-	INVOKE_ASYNC(user, TYPE_PROC_REF(/mob, put_in_hands), I)
 	if(user)
+		INVOKE_ASYNC(user, TYPE_PROC_REF(/mob, put_in_hands), I)
 		to_chat(user, "<span class='notice'>You take [parent] off of [attached_to].</span>")
 
 
@@ -90,8 +104,7 @@
 /datum/component/sticky/proc/on_move(datum/source, oldloc, move_dir)
 	SIGNAL_HANDLER
 	if(!attached_to)
-		stack_trace("/datum/component/sticky was called on_move, but without an attached atom")
-		return
+		CRASH("/datum/component/sticky/proc/on_move was called, but without an attached atom")
 	move_to_the_thing(parent)
 
 /datum/component/sticky/process() // because sometimes the item can move inside something, like a crate
@@ -118,4 +131,6 @@
 		return // only items should be able to have the sticky component
 	if(!target)
 		target = get_turf(attached_to)
+	if(!target)
+		CRASH("/datum/component/sticky/proc/move_to_the_thing was called without a viable target")
 	INVOKE_ASYNC(I, TYPE_PROC_REF(/atom/movable, forceMove), target)

--- a/code/datums/components/sticky.dm
+++ b/code/datums/components/sticky.dm
@@ -20,7 +20,7 @@
 		I.visible_message("<span class='notice'>[parent] falls off of [attached_to]</span>")
 	pick_up(parent)
 	move_to_the_thing(parent, get_turf(parent))
-	. = ..()
+	return ..()
 
 /datum/component/sticky/RegisterWithParent()
 	RegisterSignal(parent, COMSIG_ITEM_PRE_ATTACK, PROC_REF(stick_to_it))

--- a/code/datums/components/sticky.dm
+++ b/code/datums/components/sticky.dm
@@ -17,7 +17,7 @@
 	// we dont want the falling off visible message if this component is getting destroyed because parent is getting destroyed
 	if(!QDELETED(parent) && isitem(parent) && attached_to)
 		var/obj/item/I = parent
-		I.visible_message("<span class='notice'>[parent] falls off of [attached_to]</span>")
+		I.visible_message("<span class='notice'>[parent] falls off of [attached_to].</span>")
 	pick_up(parent)
 	move_to_the_thing(parent, get_turf(parent))
 	return ..()

--- a/code/datums/components/sticky.dm
+++ b/code/datums/components/sticky.dm
@@ -14,9 +14,8 @@
 	drop_on_attached_destroy = _drop_on_attached_destroy
 
 /datum/component/sticky/Destroy(force, silent)
-	if(QDELETED(parent)) // we dont want the falling off visible message if this component is getting destroyed because parent is getting destroyed
-		return
-	if(isitem(parent) && attached_to)
+	// we dont want the falling off visible message if this component is getting destroyed because parent is getting destroyed
+	if(!QDELETED(parent) && isitem(parent) && attached_to)
 		var/obj/item/I = parent
 		I.visible_message("<span class='notice'>[parent] falls off of [attached_to]</span>")
 	pick_up(parent)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->Updates /datum/component/sticky's code to better fit our component standards, along with adding a destroy to help clean up. Adds several more errors too if somehow something goes wrong. Adds stuff for removing the item if the sticky component is deleted, or the parent is deleted. This shouldn't be happening often, but good code is safe code. It also means

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Requested by Steelslayer to move signals to RegisterWithParent, I fixed some other stuff too along the way

## Testing
<!-- How did you test the PR, if at all? -->
put a bunch of camera bugs on stuff, no runtimes. Crushed myself with a recycler, camera bug stayed, crushed myself with an emagged recycler, camera bug was destroyed along with the rest of my clothes

## Changelog
:cl:
fix: Camera bug hidden cameras will be properly destroyed when a person wearing one is sent into an emagged recycler
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
