### PR TITLE
feat: truncate the length of scrambled trinary speech

### DIFF
--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -64,7 +64,7 @@
 			capitalize = 0
 		scrambled_text += next
 		var/chance = rand(100)
-		if(join_override)
+		if(!isnull(join_override))
 			scrambled_text += join_override
 		else if(chance <= 5)
 			scrambled_text += ". "
@@ -274,7 +274,13 @@
 	colour = "trinary"
 	key = "5"
 	flags = RESTRICTED | WHITELISTED
-	syllables = list("02011","01222","10100","10210","21012","02011","21200","1002","2001","0002","0012","0012","000","120","121","201","220","10","11","0")
+	syllables = list("0", "1", "2")
+	space_chance = 0
+	join_override = ""
+
+/datum/language/trinary/scramble(input)
+	. = ..(copytext(input, 1, max(length(input) / 4, 2)))
+
 
 /datum/language/trinary/get_random_name()
 	var/new_name


### PR DESCRIPTION
## What Does This PR Do
This PR does several things to shorten the visual length of scrambled phrases spoken in trinary. It truncates the available syllables to the digits 0, 1, and 2; removes the word-joiner that may appear when scrambling text, removes the chance for spaces to be inserted, and reduces the input text by 75% before passing it to `/datum/language/proc/scramble`. A side-effect of all this is that punctuation should also not be inserted in the scrambled text based on the input, unless there's punctuation within the first 25% of the text.

## Why It's Good For The Game
Trinary is described as utilizing "machine-level" "sound encoding". This suggests that the speech is converted digitally, and digital encoding of data is--compared to human speech--very efficient. Based on some very quick research, a 60 minute audio cassette with a sample rate of 20KHz can store about 35MB, which translates to about 10,000Kb a second, which is about 1,670 words with an average of ~5 characters, assuming ASCII encoding.

What this means is that anything an IPC could realistically say in a conversation could, when translated to trinary, be expressed in a sound less than a second long. We don't go _that_ far, but we make each spoken phrase much shorter proportionally.

## Images of changes

The same message is spoken before and after the change, which is "This is a test of the emergency broadcast system."

Before:

![2023_07_26__17_21_09__Paradise Station 13](https://github.com/ParadiseSS13/Paradise/assets/59303604/66f779d0-1a24-47c2-b7ad-609c10cf982a)

After:

![2023_07_26__17_17_23__Paradise Station 13](https://github.com/ParadiseSS13/Paradise/assets/59303604/fb1bcd8c-b502-4bb0-b3d6-b2f36958fe59)

## Testing

## Changelog
:cl:
tweak: the text of spoken trinary is more compressed when heard by non-speakers
/:cl:
