### PR TITLE
feat: clicking on wallmaps prompts to open webmap

### DIFF
--- a/code/game/objects/structures/signs.dm
+++ b/code/game/objects/structures/signs.dm
@@ -99,6 +99,10 @@
 /obj/structure/sign/double/map/right
 	icon_state = "map-right"
 
+/obj/structure/sign/double/map/attack_hand(mob/user)
+	if(user.client)
+		user.client.webmap()
+
 /obj/structure/sign/securearea
 	name = "\improper SECURE AREA"
 	desc = "A warning sign which reads 'SECURE AREA'"


### PR DESCRIPTION
## What Does This PR Do
Allows clients to click on a wall map to prompt for opening the station's webmap. I'm not sure if this should go in attack_hand or attackby but this seems straightforward.

## Why It's Good For The Game
A diegetic action like interacting with a map is much more natural and intuitive than clicking on the Map button in the UI. It also allows for an IC explanation for players instead of trying to explain where the UI's "Map" button is in LOOC.

## Images of changes
No visual changes.

## Testing
Tested interacting with map on Box. Interaction doesn't work as a ghost but that's prooooooobably fine?

## Changelog
:cl:
add: interacting with station wall maps prompts players to open the webmap.
/:cl:
