### PR TITLE
Dice bags no longer sound like pill bottles

### DIFF
--- a/code/game/objects/items/weapons/dice.dm
+++ b/code/game/objects/items/weapons/dice.dm
@@ -1,10 +1,11 @@
-/obj/item/storage/pill_bottle/dice
+/obj/item/storage/pill_bottle/dice //But why is this a pill bottle
 	name = "bag of dice"
 	desc = "Contains all the luck you'll ever need."
 	icon = 'icons/obj/dice.dmi'
 	icon_state = "dicebag"
 	can_hold = list(/obj/item/dice)
 	allow_wrap = FALSE
+	use_sound = "rustle"
 
 /obj/item/storage/pill_bottle/dice/populate_contents()
 	var/special_die = pick("1","2","fudge","00","100")


### PR DESCRIPTION
## What Does This PR Do
Fixes #21791 (Caused by #21634)

## Why It's Good For The Game
Do not swallow dice, they are not pills and will not fix your brain damage

## Images of changes
https://github.com/ParadiseSS13/Paradise/assets/55188452/9a1a48c2-9b0b-41ab-a220-31cda20051a6

## Testing
Spawned a dice bag
Alt clicked it
Correct sound plays
Rejoiced and basked in the glory

## Changelog
:cl:
fix: Dice bags no longer sound like pill bottles
/:cl: