### PR TITLE
A healthy addition of debug verbs

### DIFF
--- a/code/__DEFINES/MC.dm
+++ b/code/__DEFINES/MC.dm
@@ -91,6 +91,7 @@
 /datum/controller/subsystem/timer/##X/New(){\
 	NEW_SS_GLOBAL(SS##X);\
 	PreInit();\
+	ss_id="timer_[#X]";\
 }\
 /datum/controller/subsystem/timer/##X/fire() {..() /*just so it shows up on the profiler*/} \
 /datum/controller/subsystem/timer/##X

--- a/code/controllers/subsystem/SStimer.dm
+++ b/code/controllers/subsystem/SStimer.dm
@@ -335,6 +335,17 @@ SUBSYSTEM_DEF(timer)
 	second_queue = alltimers
 	bucket_count = new_bucket_count
 
+/datum/controller/subsystem/timer/Shutdown()
+	if(type != /datum/controller/subsystem/timer)
+		// Yes this is a hack but I dont want this running on inherited children of this SS
+		return
+
+	// Sort it first
+	var/list/sorted = sortTim(GLOB.timers_by_type, GLOBAL_PROC_REF(cmp_numeric_dsc), TRUE)
+
+	// DOOMP EET
+	var/timer_json_file = file("[GLOB.log_directory]/timers.json")
+	WRITE_FILE(timer_json_file, json_encode(sorted))
 
 /datum/controller/subsystem/timer/Recover()
 	second_queue |= SStimer.second_queue

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -285,12 +285,14 @@ GLOBAL_LIST_INIT(admin_verbs_maintainer, list(
 		if(holder.rights & R_MAINTAINER)
 			verbs += GLOB.admin_verbs_maintainer
 		if(holder.rights & R_VIEWRUNTIMES)
+			// TODO - Make a viewruntimes list at this point - its getting silly
 			verbs += /client/proc/view_runtimes
 			verbs += /client/proc/cmd_display_del_log
 			verbs += /client/proc/cmd_display_del_log_simple
 			verbs += /client/proc/toggledebuglogs
 			verbs += /client/proc/debug_variables /*allows us to -see- the variables of any instance in the game. +VAREDIT needed to modify*/
 			verbs += /client/proc/ss_breakdown
+			verbs += /client/proc/show_gc_queues
 			spawn(1) // This setting exposes the profiler for people with R_VIEWRUNTIMES. They must still have it set in cfg/admin.txt
 				control_freak = 0
 

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -835,6 +835,51 @@ GLOBAL_PROTECT(AdminProcCallSpamPrevention)
 
 	usr << browse(dat, "window=simpledellog")
 
+/client/proc/show_gc_queues()
+	set name = "View GC Queue"
+	set category = "Debug"
+	set desc = "Shows the list of whats currently in a GC queue"
+
+	if(!check_rights(R_DEBUG|R_VIEWRUNTIMES))
+		return
+
+	// Get the amount of queues
+	var/queue_count = length(SSgarbage.queues)
+	var/list/selectable_queues = list()
+	// Setup choices
+	for(var/i in 1 to queue_count)
+		selectable_queues["Queue #[i] ([length(SSgarbage.queues[i])] item\s)"] = i
+
+	// Ask the user
+	var/choice = input(usr, "Select a GC queue. Note that the queue lookup may lag the server.", "GC Queue") as null|anything in selectable_queues
+	if(!choice)
+		return
+
+	// Get our target
+	var/list/target_queue = SSgarbage.queues[selectable_queues[choice]].Copy()
+	message_admins(length(target_queue))
+	var/list/queue_counts = list()
+
+	// Iterate that target and see whats what
+	for(var/queue_entry in target_queue)
+		var/datum/D = locate(queue_entry[1])
+		if(istype(D))
+			if(!queue_counts[D.type])
+				queue_counts[D.type] = 0
+
+			queue_counts[D.type]++
+
+	// Sort it the right way
+	var/list/sorted = sortTim(queue_counts, GLOBAL_PROC_REF(cmp_numeric_dsc), TRUE)
+
+	// And make a nice little menu
+	var/list/text = list("<h1>Current status of [choice]</h1>", "<ul>")
+	for(var/key in sorted)
+		text += "<li>[key] - [sorted[key]]</li>"
+
+	text += "</ul>"
+	usr << browse(text.Join(), "window=gcqueuestatus")
+
 /client/proc/cmd_admin_toggle_block(mob/M, block)
 	if(!check_rights(R_SPAWN))
 		return

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -856,8 +856,7 @@ GLOBAL_PROTECT(AdminProcCallSpamPrevention)
 		return
 
 	// Get our target
-	var/list/target_queue = SSgarbage.queues[selectable_queues[choice]].Copy()
-	message_admins(length(target_queue))
+	var/list/target_queue = SSgarbage.queues[selectable_queues[choice]]
 	var/list/queue_counts = list()
 
 	// Iterate that target and see whats what

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -862,11 +862,13 @@ GLOBAL_PROTECT(AdminProcCallSpamPrevention)
 	// Iterate that target and see whats what
 	for(var/queue_entry in target_queue)
 		var/datum/D = locate(queue_entry[1])
-		if(istype(D))
-			if(!queue_counts[D.type])
-				queue_counts[D.type] = 0
+		if(!istype(D))
+			continue
 
-			queue_counts[D.type]++
+		if(!queue_counts[D.type])
+			queue_counts[D.type] = 0
+
+		queue_counts[D.type]++
 
 	// Sort it the right way
 	var/list/sorted = sortTim(queue_counts, GLOBAL_PROC_REF(cmp_numeric_dsc), TRUE)


### PR DESCRIPTION
## What Does This PR Do
Adds a new debug verb and timer loggin.

#### Debug GC Queue

There is a new verb, `Debug GC Queue`, which does what it says on the tin.

You are presented with a list of the GC queues
![image](https://github.com/ParadiseSS13/Paradise/assets/25063394/c28dcb57-a2a0-4613-aa1e-2db70f88abf0)

You can then see exactly whats in the queue, and how many of that there are
![image](https://github.com/ParadiseSS13/Paradise/assets/25063394/613a60c2-8aaf-41ea-bf4d-3a4337fc50c2)

#### Timer Log
Again, does what it says on the tin. Writes a `.json` file after each round with all the timers made that round.
![image](https://github.com/ParadiseSS13/Paradise/assets/25063394/396724ac-a339-492f-8687-7d6c8633f3a2)

## Why It's Good For The Game
Means I can work on solving this
![image](https://github.com/ParadiseSS13/Paradise/assets/25063394/e666d507-4de0-4dd5-80b5-7fd5871d6a0d)

And this
![DCXVw7gvMF](https://github.com/ParadiseSS13/Paradise/assets/25063394/37331ef2-d410-4832-9cce-9076ef9f0369)

## Images of changes
See above

## Testing
See above

## Changelog
NPFC