### PR TITLE
makes plushies return a qdel hint

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -550,7 +550,7 @@
 
 /obj/item/toy/plushie/Destroy()
 	QDEL_NULL(grenade)
-	..()
+	return ..()
 
 /obj/item/toy/plushie/attackby(obj/item/I, mob/living/user, params)
 	if(I.sharp)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
adds a missing return to plush destroy

## Why It's Good For The Game
Errors that show up and don't actually matter are bad, destroy procs should be consistent across items for easier to understand code

## Testing
it is one(1) return addition

## Changelog
NPFC

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
