### PR TITLE
Adds Basic Observer Outfits for Admin/Testing Use

### DIFF
--- a/code/datums/outfits/outfit_admin.dm
+++ b/code/datums/outfits/outfit_admin.dm
@@ -1372,7 +1372,7 @@
 	uniform = /obj/item/clothing/under/plasmaman/assistant
 	head = /obj/item/clothing/head/helmet/space/plasmaman/assistant
 	mask = /obj/item/clothing/mask/breath
-	belt =/obj/item/tank/internals/plasmaman/belt/full
+	belt = /obj/item/tank/internals/plasmaman/belt/full
 	back = /obj/item/storage/backpack/satchel
 	shoes = /obj/item/clothing/shoes/black
 	backpack_contents = list(

--- a/code/datums/outfits/outfit_admin.dm
+++ b/code/datums/outfits/outfit_admin.dm
@@ -1380,4 +1380,4 @@
 
 	mask = /obj/item/clothing/mask/breath/vox
 	belt = /obj/item/tank/internals/emergency_oxygen/double/vox
-	box = /obj/item/storage/box/survival_vox = 1
+	box = /obj/item/storage/box/survival_vox

--- a/code/datums/outfits/outfit_admin.dm
+++ b/code/datums/outfits/outfit_admin.dm
@@ -1361,8 +1361,8 @@
 	uniform = /obj/item/clothing/under/costume/tourist_suit
 	back = /obj/item/storage/backpack/satchel
 	shoes = /obj/item/clothing/shoes/black
+	box = /obj/item/storage/box/survival
 	backpack_contents = list(
-		/obj/item/storage/box/survival = 1,
 		/obj/item/implanter/dust = 1
 		)
 
@@ -1373,23 +1373,11 @@
 	head = /obj/item/clothing/head/helmet/space/plasmaman/assistant
 	mask = /obj/item/clothing/mask/breath
 	belt = /obj/item/tank/internals/plasmaman/belt/full
-	back = /obj/item/storage/backpack/satchel
-	shoes = /obj/item/clothing/shoes/black
-	backpack_contents = list(
-		/obj/item/storage/box/survival_plasmaman = 1,
-		/obj/item/implanter/dust = 1
-		)
+	box = /obj/item/storage/box/survival_plasmaman
 
 /datum/outfit/admin/observer/vox
 	name = "Observer (Vox)"
 
-	uniform = /obj/item/clothing/under/costume/tourist_suit
 	mask = /obj/item/clothing/mask/breath/vox
 	belt = /obj/item/tank/internals/emergency_oxygen/double/vox
-	back = /obj/item/storage/backpack/satchel
-	shoes = /obj/item/clothing/shoes/black
-	backpack_contents = list(
-		/obj/item/storage/box/survival_vox = 1,
-		/obj/item/implanter/dust = 1
-		)
-
+	box = /obj/item/storage/box/survival_vox = 1

--- a/code/datums/outfits/outfit_admin.dm
+++ b/code/datums/outfits/outfit_admin.dm
@@ -1354,3 +1354,38 @@
 	if(istype(I))
 		apply_to_card(I, H, list(ACCESS_CLOWN), "Emergency Response Clown")
 	H.sec_hud_set_ID()
+
+/datum/outfit/admin/observer
+	name = "Observer"
+
+	uniform = /obj/item/clothing/under/costume/tourist_suit
+	back = /obj/item/storage/backpack/satchel
+	shoes = /obj/item/clothing/shoes/black
+	backpack_contents = list(/obj/item/storage/box/survival = 1)
+
+	implants = list(/obj/item/implant/dust)
+
+/datum/outfit/admin/observer/plasmaman
+	name = "Observer (Plasma)"
+
+	uniform = /obj/item/clothing/under/plasmaman/assistant
+	head = /obj/item/clothing/head/helmet/space/plasmaman/assistant
+	mask = /obj/item/clothing/mask/breath
+	belt =/obj/item/tank/internals/plasmaman/belt/full
+	back = /obj/item/storage/backpack/satchel
+	shoes = /obj/item/clothing/shoes/black
+	backpack_contents = list(/obj/item/storage/box/survival_plasmaman = 1)
+
+	implants = list(/obj/item/implant/dust)
+
+/datum/outfit/admin/observer/vox
+	name = "Observer (Vox)"
+
+	uniform = /obj/item/clothing/under/costume/tourist_suit
+	mask = /obj/item/clothing/mask/breath/vox
+	belt = /obj/item/tank/internals/emergency_oxygen/double/vox
+	back = /obj/item/storage/backpack/satchel
+	shoes = /obj/item/clothing/shoes/black
+	backpack_contents = list(/obj/item/storage/box/survival_vox = 1)
+
+	implants = list(/obj/item/implant/dust)

--- a/code/datums/outfits/outfit_admin.dm
+++ b/code/datums/outfits/outfit_admin.dm
@@ -1361,9 +1361,10 @@
 	uniform = /obj/item/clothing/under/costume/tourist_suit
 	back = /obj/item/storage/backpack/satchel
 	shoes = /obj/item/clothing/shoes/black
-	backpack_contents = list(/obj/item/storage/box/survival = 1)
-
-	implants = list(/obj/item/implant/dust)
+	backpack_contents = list(
+		/obj/item/storage/box/survival = 1,
+		/obj/item/implanter/dust = 1
+		)
 
 /datum/outfit/admin/observer/plasmaman
 	name = "Observer (Plasma)"
@@ -1374,9 +1375,10 @@
 	belt =/obj/item/tank/internals/plasmaman/belt/full
 	back = /obj/item/storage/backpack/satchel
 	shoes = /obj/item/clothing/shoes/black
-	backpack_contents = list(/obj/item/storage/box/survival_plasmaman = 1)
-
-	implants = list(/obj/item/implant/dust)
+	backpack_contents = list(
+		/obj/item/storage/box/survival_plasmaman = 1,
+		/obj/item/implanter/dust = 1
+		)
 
 /datum/outfit/admin/observer/vox
 	name = "Observer (Vox)"
@@ -1386,6 +1388,8 @@
 	belt = /obj/item/tank/internals/emergency_oxygen/double/vox
 	back = /obj/item/storage/backpack/satchel
 	shoes = /obj/item/clothing/shoes/black
-	backpack_contents = list(/obj/item/storage/box/survival_vox = 1)
+	backpack_contents = list(
+		/obj/item/storage/box/survival_vox = 1,
+		/obj/item/implanter/dust = 1
+		)
 
-	implants = list(/obj/item/implant/dust)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds a bare-bones outfit for spawning people in on the Live server OR for testing when needed. Can simply click "o" to jump down to "Observer" and pick the appropriate outfit!

## Why It's Good For The Game
Having an easy-to-get-to outfit for Admins to spawn people in as for the Admin Zone/testing stuff on Live is nice. This outfit has no ID and no headset, so you can just let dchat peeps go about and do whatever testing/stupidity you want.

Also comes with a dust implanter so that when you die/if you want to go back to dchat, you can.

Comes in Human Standard, Vox, and Plasmaman flavor!

## Testing
1. Spawned in a human, dressed em.
2. Spawned in a vox, dressed em.
3. Spawned in a plasmeme, dressed em.

## Changelog
:cl:
add: Added basic observer outfits for admin use.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
