### PR TITLE
Prevents radios from working in certain admin areas

### DIFF
--- a/code/game/machinery/tcomms/tcomms_core.dm
+++ b/code/game/machinery/tcomms/tcomms_core.dm
@@ -26,11 +26,7 @@
 	var/link_password
 	/// What tab of the UI were currently on
 	var/ui_tab = UI_TAB_CONFIG
-	/// Areas in which every radio message will be ignored
-	var/list/blacklisted_areas = list(
-		/area/adminconstruction,
-		/area/tdome,
-	)
+
 
 /**
   * Initializer for the core.
@@ -100,11 +96,6 @@
 		return FALSE
 	// Kill the signal if its on a z-level that isnt reachable
 	if(!zlevel_reachable(tcm.source_level))
-		return FALSE
-
-	if(is_type_in_list(get_area(tcm.radio), blacklisted_areas))
-		// add a debug log so people testing things won't be fighting against a "broken" radio for too long.
-		log_debug("Radio message from [tcm.sender] was used in restricted area [get_area(tcm.radio)].")
 		return FALSE
 
 	// Now we can run NTTC

--- a/code/game/machinery/tcomms/tcomms_core.dm
+++ b/code/game/machinery/tcomms/tcomms_core.dm
@@ -26,6 +26,11 @@
 	var/link_password
 	/// What tab of the UI were currently on
 	var/ui_tab = UI_TAB_CONFIG
+	/// Areas in which every radio message will be ignored
+	var/list/blacklisted_areas = list(
+		/area/adminconstruction,
+		/area/tdome,
+	)
 
 /**
   * Initializer for the core.
@@ -95,6 +100,10 @@
 		return FALSE
 	// Kill the signal if its on a z-level that isnt reachable
 	if(!zlevel_reachable(tcm.source_level))
+		return FALSE
+
+	if(is_type_in_list(get_area(tcm.radio), blacklisted_areas))
+		log_debug("Radio message was muted in restricted area")
 		return FALSE
 
 	// Now we can run NTTC

--- a/code/game/machinery/tcomms/tcomms_core.dm
+++ b/code/game/machinery/tcomms/tcomms_core.dm
@@ -103,7 +103,8 @@
 		return FALSE
 
 	if(is_type_in_list(get_area(tcm.radio), blacklisted_areas))
-		log_debug("Radio message was muted in restricted area")
+		// add a debug log so people testing things won't be fighting against a "broken" radio for too long.
+		log_debug("Radio message from [tcm.sender] was used in restricted area [get_area(tcm.radio)].")
 		return FALSE
 
 	// Now we can run NTTC

--- a/code/game/machinery/tcomms/tcomms_core.dm
+++ b/code/game/machinery/tcomms/tcomms_core.dm
@@ -27,7 +27,6 @@
 	/// What tab of the UI were currently on
 	var/ui_tab = UI_TAB_CONFIG
 
-
 /**
   * Initializer for the core.
   *

--- a/code/game/objects/items/devices/radio/radio_objects.dm
+++ b/code/game/objects/items/devices/radio/radio_objects.dm
@@ -58,6 +58,8 @@ GLOBAL_LIST_INIT(default_medbay_channels, list(
 	var/obj/item/encryptionkey/syndicate/syndiekey = null
 	/// How many times this is disabled by EMPs
 	var/disable_timer = 0
+	/// Areas in which this radio cannot send messages
+	var/static/list/blacklisted_areas = list(/area/adminconstruction, /area/tdome)
 
 	flags = CONDUCT
 	slot_flags = SLOT_BELT
@@ -262,6 +264,11 @@ GLOBAL_LIST_INIT(default_medbay_channels, list(
 	else
 		connection = radio_connection
 		channel = null
+
+	if(is_type_in_list(get_area(src), blacklisted_areas))
+		// add a debug log so people testing things won't be fighting against a "broken" radio for too long.
+		log_debug("Radio message from [src] was used in restricted area [get_area(src)].")
+		return
 	if(!istype(connection))
 		return
 	if(!connection)
@@ -359,6 +366,11 @@ GLOBAL_LIST_INIT(default_medbay_channels, list(
 
 	if(!M.IsVocal())
 		return 0
+
+	if(is_type_in_list(get_area(src), blacklisted_areas))
+		// add a debug log so people testing things won't be fighting against a "broken" radio for too long.
+		log_debug("Radio message from [src] was used in restricted area [get_area(src)].")
+		return FALSE
 
 	var/jammed = FALSE
 	var/turf/position = get_turf(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Prevents radios from working in certain admin areas.
Admins can always vv the radios to work if they want to (or just move elsewhere), so it hopefully shouldn't matter too much.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Players using the radio in admin testing or the thunderdome (or just having death implants triggered) sometimes causes some bleed-over into the station, prompting weird reactions. This isn't really ideal and creates some ick-ock situations. This should hopefully fix that.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


## Testing
![image](https://github.com/ParadiseSS13/Paradise/assets/89928798/4fcc1e6a-0c27-41f3-87c9-1b499b924001)
![image](https://github.com/ParadiseSS13/Paradise/assets/89928798/1ca9c265-51f0-4cb6-ba5c-c39701bcc388)

<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Radios now no longer work in certain admin areas.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
