### PR TITLE
Fixes mmis being unable to use mech actions

### DIFF
--- a/code/modules/mob/living/carbon/brain/carbon_brain.dm
+++ b/code/modules/mob/living/carbon/brain/carbon_brain.dm
@@ -50,6 +50,9 @@
 /mob/living/carbon/brain/blob_act(obj/structure/blob/B)
 	return
 
+/mob/living/carbon/brain/incapacitated(ignore_restraints = FALSE, ignore_grab = FALSE)
+	return FALSE
+
 /mob/living/carbon/brain/on_forcemove(atom/newloc)
 	if(container)
 		container.forceMove(newloc)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
fixes #18595

MMI brainmobs were always returning they were incapacitated; this caused all their clicks to fizzle before they got to the mecha actions. This pr makes it so that mmi brainmobs don't fail incapacitated checks, this probably also causes like a mild change with some niche but I'm not that concerned considering that it would succeed with robobrains so it's more consistency than anything. 

## Why It's Good For The Game
Bugs bad, let the poor brains go mine or something.

## Testing
Slammed my head into a wall for an hour trying to get stuff to work, eventually found out it was failing even earlier than the mech actions and worked backwards

## Changelog
:cl:
fix: MMIs can use mech actions again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
