### PR TITLE
Refactors some old area initialization code to improve performance

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -138,21 +138,15 @@
 	return powernet
 
 /area/proc/reg_in_areas_in_z()
-	if(contents.len)
-		var/list/areas_in_z = GLOB.space_manager.areas_in_z
-		var/z
-		for(var/i in 1 to contents.len)
-			var/atom/thing = contents[i]
-			if(!thing)
-				continue
-			z = thing.z
-			break
-		if(!z)
-			WARNING("No z found for [src]")
-			return
-		if(!areas_in_z["[z]"])
-			areas_in_z["[z]"] = list()
-		areas_in_z["[z]"] += src
+	if(!length(contents)) // if its nullspaced or something, I guess
+		return
+	if(!z)
+		WARNING("No z found for [src]")
+		return
+	var/list/areas_in_z = GLOB.space_manager.areas_in_z
+	if(!areas_in_z["[z]"])
+		areas_in_z["[z]"] = list()
+	areas_in_z["[z]"] += src
 
 /area/proc/get_cameras()
 	var/list/cameras = list()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->Basically ports tgstation/tgstation/pull/48910. This decreases init times by 0.05 seconds on average from my testing on JUST cyberiad (what an insane increase, I know). It is likely way more factoring in lavaland and space ruins.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Performance is good

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
Testing on cyberiad (no lavaland, no space z levels or ruins)
Old
![image](https://github.com/ParadiseSS13/Paradise/assets/91113370/99ddf962-3c44-4986-8b58-2c1b55b6d57a)

New
![image](https://github.com/ParadiseSS13/Paradise/assets/91113370/dc0efd33-1252-4df3-bebf-796fea73006d)

Testing on a prod-like environment
Old
![image](https://github.com/ParadiseSS13/Paradise/assets/91113370/f696ecd4-1fa7-4d06-8267-be2a8bde218c)

New
![image](https://github.com/ParadiseSS13/Paradise/assets/91113370/a46d9a9a-228a-448e-9d4e-1bbb9862a845)


## Testing
<!-- How did you test the PR, if at all? -->
See above

## Changelog
nothing player facing

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
