### PR TITLE
tweak: Better stacks

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -514,6 +514,7 @@ GLOBAL_LIST_INIT(brass_recipes, list (
 	throw_range = 3
 	turf_type = /turf/simulated/floor/clockwork
 	table_type = /obj/structure/table/reinforced/brass
+	dynamic_icon_state = TRUE
 
 /obj/item/stack/tile/brass/narsie_act()
 	new /obj/item/stack/sheet/runed_metal(loc, amount)

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -52,14 +52,16 @@
 	update_icon(UPDATE_ICON_STATE)
 
 /obj/item/stack/update_icon_state()
-	. = ..()
 	if(!dynamic_icon_state)
-		return
-	var/temp_amount = get_amount()
-	if(temp_amount > 1)
-		icon_state = "[initial(icon_state)]_[min(temp_amount, 3)]" //2 if amount is 2, 3 if more.
-		return
-	icon_state = initial(icon_state)
+		return ..()
+	if(amount <= (max_amount * (1/3)))
+		icon_state = initial(icon_state)
+		return ..()
+	if (amount <= (max_amount * (2/3)))
+		icon_state = "[initial(icon_state)]_2"
+		return ..()
+	icon_state = "[initial(icon_state)]_3"
+	return ..()
 
 /obj/item/stack/Crossed(obj/O, oldloc)
 	if(amount >= max_amount || ismob(loc)) // Prevents unnecessary call. Also prevents merging stack automatically in a mob's inventory

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -52,16 +52,14 @@
 	update_icon(UPDATE_ICON_STATE)
 
 /obj/item/stack/update_icon_state()
+	. = ..()
 	if(!dynamic_icon_state)
-		return ..()
-	if(amount <= (max_amount * (1/3)))
+		return
+	var/state = CEILING((amount/max_amount) * 3, 1)
+	icon_state = "[initial(icon_state)]_[state]"
+	if(state <= 1)
 		icon_state = initial(icon_state)
-		return ..()
-	if (amount <= (max_amount * (2/3)))
-		icon_state = "[initial(icon_state)]_2"
-		return ..()
-	icon_state = "[initial(icon_state)]_3"
-	return ..()
+		return
 
 /obj/item/stack/Crossed(obj/O, oldloc)
 	if(amount >= max_amount || ismob(loc)) // Prevents unnecessary call. Also prevents merging stack automatically in a mob's inventory

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -59,7 +59,6 @@
 	icon_state = "[initial(icon_state)]_[state]"
 	if(state <= 1)
 		icon_state = initial(icon_state)
-		return
 
 /obj/item/stack/Crossed(obj/O, oldloc)
 	if(amount >= max_amount || ismob(loc)) // Prevents unnecessary call. Also prevents merging stack automatically in a mob's inventory

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -56,9 +56,11 @@
 	if(!dynamic_icon_state)
 		return
 	var/state = CEILING((amount/max_amount) * 3, 1)
-	icon_state = "[initial(icon_state)]_[state]"
 	if(state <= 1)
 		icon_state = initial(icon_state)
+		return
+
+	icon_state = "[initial(icon_state)]_[state]"
 
 /obj/item/stack/Crossed(obj/O, oldloc)
 	if(amount >= max_amount || ismob(loc)) // Prevents unnecessary call. Also prevents merging stack automatically in a mob's inventory


### PR DESCRIPTION
## What Does This PR Do
Now stacks change icon_state every third of amount.
If we have max amount = 50 in stack. We got:
1: 1-16
2: 17-33
3: 34-50
No more 1-2-3.

## Why It's Good For The Game
Stacks displaying a more accurate amount

## Images of changes
Only code

## Testing
Placed almost all stacks
![image](https://github.com/ParadiseSS13/Paradise/assets/69762909/bd8871fa-bed4-4b28-b5d9-0f53ff06641f)

## Changelog
:cl:
tweak: Stacks now work on the principle of 1/3
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
