### PR TITLE
The View GC queue verb is now available to those with the +DEBUG permission

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -179,6 +179,7 @@ GLOBAL_LIST_INIT(admin_verbs_debug, list(
 	/client/proc/timer_log,
 	/client/proc/debug_timers,
 	/client/proc/force_verb_bypass,
+	/client/proc/show_gc_queues
 	))
 GLOBAL_LIST_INIT(admin_verbs_possess, list(
 	/proc/possess,


### PR DESCRIPTION
## What Does This PR Do
Adds `/client/proc/show_gc_queues` to the global `admin_verbs_debug` list so that it's available to those with the +DEBUG permission. Requested by AA.

## Changelog
:cl:
fix: The View GC queue verb is now available to those with the +DEBUG permission
/:cl: