### PR TITLE
cryo vetus slip nerf

### DIFF
--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -384,7 +384,7 @@
 
 	if(prob(50))
 		for(var/turf/simulated/floor/nearby_floor in oview(get_turf(src), (drops_core ? 2 : 1)))
-			nearby_floor.MakeSlippery(TURF_WET_PERMAFROST)
+			nearby_floor.MakeSlippery((drops_core? TURF_WET_PERMAFROST : TURF_WET_ICE), (drops_core? null : rand(10, 20 SECONDS)))
 
 		var/turf/simulated/T = get_turf(src)
 		if(istype(T))

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/ancient_robot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/ancient_robot.dm
@@ -529,7 +529,7 @@ Difficulty: Hard
 				T.ex_act(3)
 			if(mode == CRYO)
 				var/turf/simulated/S = get_turf(src)
-				S.MakeSlippery(TURF_WET_ICE)
+				S.MakeSlippery(TURF_WET_ICE, rand(10, 20 SECONDS))
 				for(var/turf/T in range (1, src))
 					new /obj/effect/snowcloud(T)
 					for(var/mob/living/carbon/C in T.contents)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Cryo vetus ice trails last much less time.
Cryo anomalies from vetus no longer apply perma frost (aka meaning no slips / magboots wont help you), and the ice trails last less time.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

The ammount of slipping cryo vetus did was a little much. This should make the terrain less hellish, as well as making no slips work as intended (bringing jump boots is still highly suggested)

## Testing
<!-- How did you test the PR, if at all? -->

confirmed vetus worked as I wanted

## Changelog
:cl:
fix: Cryo vetus is less hellish with ice duration, and no longer does permafrost ice, so no slips / magboots will work.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
