### PR TITLE
item actions can be used while horizontal

### DIFF
--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -137,7 +137,7 @@
 
 //Presets for item actions
 /datum/action/item_action
-	check_flags = AB_CHECK_RESTRAINED|AB_CHECK_STUNNED|AB_CHECK_LYING|AB_CHECK_CONSCIOUS
+	check_flags = AB_CHECK_RESTRAINED|AB_CHECK_STUNNED|AB_CHECK_HANDS_BLOCKED|AB_CHECK_CONSCIOUS
 	var/use_itemicon = TRUE
 
 /datum/action/item_action/New(Target, custom_icon, custom_icon_state)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Item action usability now checks for handblocked over being horizontal (This probably removes some jank, not entirely sure what)

## Why It's Good For The Game
To be entirely honest not being able to do this post crawling feels incredibly weird. I would like to be able to turn on my internals while lying down, thank you very much. There might be some weirdness with like the jump boots that i'll look at tomorrow but this probably should be alright and have minimal impact outside of QOL.

## Testing
Turned on my internals while on the ground

## Changelog
:cl:
tweak: item actions can be used while horizontal
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
