### PR TITLE
Disposals now instantly shoot you out rather than having a delay

### DIFF
--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -1429,10 +1429,9 @@
 		AM.pipe_eject(dir)
 		if(isdrone(AM) || istype(AM, /mob/living/silicon/robot/syndicate/saboteur)) //Drones keep smashing windows from being fired out of chutes. Bad for the station. ~Z
 			return
-		spawn(5)
-			if(QDELETED(AM))
-				return
-			AM.throw_at(target, 3, 1)
+		if(QDELETED(AM))
+			return
+		AM.throw_at(target, 3, 1)
 
 /obj/structure/disposaloutlet/screwdriver_act(mob/living/user, obj/item/I)
 	add_fingerprint(user)

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -1427,10 +1427,13 @@
 	for(var/atom/movable/AM in contents)
 		AM.forceMove(loc)
 		AM.pipe_eject(dir)
-		if(isdrone(AM) || istype(AM, /mob/living/silicon/robot/syndicate/saboteur)) //Drones keep smashing windows from being fired out of chutes. Bad for the station. ~Z
-			return
 		if(QDELETED(AM))
 			return
+		if(isliving(AM))
+			var/mob/living/mob_to_immobilize = AM
+			if(isdrone(mob_to_immobilize) || istype(mob_to_immobilize, /mob/living/silicon/robot/syndicate/saboteur)) //Drones keep smashing windows from being fired out of chutes. Bad for the station. ~Z
+				return
+			mob_to_immobilize.Immobilize(1 SECONDS)
 		AM.throw_at(target, 3, 1)
 
 /obj/structure/disposaloutlet/screwdriver_act(mob/living/user, obj/item/I)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Disposals now instantly shoot you out rather than having a delay
Adds a 1 second immobilize to reduce further cheese after being shot out by a disposal outlet
## Why It's Good For The Game
This is weird and frankly pretty janky, it's gotten to the point where a good amount of maps have quarter tile windows around the recycler so you can't cheese emmaged recycler stuff as easy, you can still cheese past it so here's a better solution. Adds a 1 second immobilize to reduce further cheese

Also it's just weird to get thrown AFTER you're out of the tile with the disposal outlet

## Testing
oh no emmaged recycler

## Changelog
:cl:
tweak: Disposal outlets shoot you out instantly, Adds a 1 second immobilize after being shot out by a disposals outlet
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
