### PR TITLE
fixes cell doors not closing when they should

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -21660,7 +21660,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/machinery/door/window/reinforced/normal{
+/obj/machinery/door/window/brigdoor{
 	dir = 2;
 	id = "Cell 2";
 	name = "Cell 2";
@@ -25550,7 +25550,7 @@
 	},
 /area/security/prison/cell_block)
 "brl" = (
-/obj/machinery/door/window/reinforced/normal{
+/obj/machinery/door/window/brigdoor{
 	dir = 2;
 	id = "Cell 3";
 	name = "Cell 3";
@@ -29210,7 +29210,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/window/reinforced/normal{
+/obj/machinery/door/window/brigdoor{
 	dir = 1;
 	id = "Cell 5";
 	name = "Cell 5";
@@ -33537,7 +33537,7 @@
 	},
 /area/security/brig)
 "bHX" = (
-/obj/machinery/door/window/reinforced/normal{
+/obj/machinery/door/window/brigdoor{
 	dir = 8;
 	id = "Cell 1";
 	name = "Cell 1";
@@ -35076,7 +35076,7 @@
 	},
 /area/security/prison/cell_block)
 "bLG" = (
-/obj/machinery/door/window/reinforced/normal{
+/obj/machinery/door/window/brigdoor{
 	dir = 2;
 	id = "Cell 4";
 	name = "Cell 4";
@@ -86849,7 +86849,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
 "lmR" = (
-/obj/machinery/door/window/reinforced/normal{
+/obj/machinery/door/window/brigdoor{
 	dir = 1;
 	id = "Cell 6";
 	name = "Cell 6";

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -50480,7 +50480,7 @@
 	},
 /area/engine/engineering)
 "dym" = (
-/obj/machinery/door/window/reinforced/normal{
+/obj/machinery/door/window/brigdoor{
 	dir = 8;
 	id = "Cell 1";
 	name = "Cell 1";
@@ -56516,7 +56516,7 @@
 /turf/simulated/floor/plasteel,
 /area/security/prison/cell_block/A)
 "grL" = (
-/obj/machinery/door/window/reinforced/normal{
+/obj/machinery/door/window/brigdoor{
 	dir = 8;
 	id = "Cell 3";
 	name = "Cell 3";
@@ -61998,7 +61998,7 @@
 	},
 /area/engine/controlroom)
 "iTF" = (
-/obj/machinery/door/window/reinforced/reversed{
+/obj/machinery/door/window/brigdoor{
 	dir = 4;
 	id = "Cell 2";
 	name = "Cell 2";
@@ -74316,7 +74316,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/machinery/door/window/reinforced/normal{
+/obj/machinery/door/window/brigdoor{
 	id = "Cell 5";
 	name = "Cell 5";
 	req_access_txt = "2";
@@ -87224,7 +87224,7 @@
 	},
 /area/medical/medbay)
 "viR" = (
-/obj/machinery/door/window/reinforced/normal{
+/obj/machinery/door/window/brigdoor{
 	id = "Cell 4";
 	name = "Cell 4";
 	req_access_txt = "2";

--- a/_maps/map_files/cerestation/cerestation.dmm
+++ b/_maps/map_files/cerestation/cerestation.dmm
@@ -27321,7 +27321,7 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/office)
 "cLE" = (
-/obj/machinery/door/window/reinforced/normal{
+/obj/machinery/door/window/brigdoor{
 	dir = 2;
 	id = "Cell 6";
 	name = "Cell 6";
@@ -60076,7 +60076,7 @@
 	},
 /area/crew_quarters/sleep)
 "lUn" = (
-/obj/machinery/door/window/reinforced/normal{
+/obj/machinery/door/window/brigdoor{
 	dir = 2;
 	id = "Cell 8";
 	name = "Cell 8";
@@ -88211,7 +88211,7 @@
 	},
 /area/hallway/secondary/entry/south)
 "vvl" = (
-/obj/machinery/door/window/reinforced/normal{
+/obj/machinery/door/window/brigdoor{
 	dir = 2;
 	id = "Cell 7";
 	name = "Cell 7";

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -55712,7 +55712,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/machinery/door/window/reinforced/normal{
+/obj/machinery/door/window/brigdoor{
 	dir = 1;
 	id = "Cell 1";
 	name = "Cell 1";
@@ -63622,7 +63622,7 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/east)
 "eSm" = (
-/obj/machinery/door/window/reinforced/normal{
+/obj/machinery/door/window/brigdoor{
 	dir = 1;
 	id = "Cell 3";
 	name = "Cell 3";
@@ -67319,7 +67319,7 @@
 /area/security/permabrig)
 "gXR" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/window/reinforced/normal{
+/obj/machinery/door/window/brigdoor{
 	dir = 2;
 	id = "Cell 4";
 	name = "Cell 4";
@@ -85582,7 +85582,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/machinery/door/window/reinforced/normal{
+/obj/machinery/door/window/brigdoor{
 	dir = 2;
 	id = "Cell 2";
 	name = "Cell 2";
@@ -92304,7 +92304,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/window/reinforced/normal{
+/obj/machinery/door/window/brigdoor{
 	id = "Cell 5";
 	name = "Cell 5";
 	req_access_txt = "2";


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
fixes #21879
Brig cell doors now use the proper path so they close/open when a cell timer ends/starts

## Why It's Good For The Game
Cell doors should close/open when a timer starts/expires

## Images of changes
You won't see anything playerfacing mapping wise

## Testing
Found out cerestation just straight up doesn't have a cell 5

## Changelog
:cl:
fix: Cell doors once again close when they should when using a cell timer
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
