### PR TITLE
fix issues on sechud record examines

### DIFF
--- a/code/modules/mob/living/carbon/human/human_examine.dm
+++ b/code/modules/mob/living/carbon/human/human_examine.dm
@@ -167,6 +167,8 @@
 							if(LAZYLEN(R.fields["comments"])) //if the commentlist is present
 								var/list/comments = R.fields["comments"]
 								commentLatest = LAZYACCESS(comments, comments.len) //get the latest entry from the comment log
+								if(islist(commentLatest))
+									commentLatest = "[commentLatest["header"]]: [commentLatest["text"]]"
 							else
 								commentLatest = "No entries." //If present but without entries (=target is recognized crew)
 

--- a/code/modules/mob/living/carbon/human/human_mob.dm
+++ b/code/modules/mob/living/carbon/human/human_mob.dm
@@ -760,7 +760,10 @@
 								read = 1
 								if(LAZYLEN(R.fields["comments"]))
 									for(var/c in R.fields["comments"])
-										to_chat(usr, c)
+										if(islist(c))
+											to_chat(usr, "[c["header"]]: [c["text"]]")
+										else
+											to_chat(usr, c)
 								else
 									to_chat(usr, "<span class='warning'>No comments found</span>")
 								if(hasHUD(usr, EXAMINE_HUD_SECURITY_WRITE))


### PR DESCRIPTION
## What Does This PR Do
Fixes two issues related to the fact that manual and automatic sec record entries are different data types. This ensures records are shown properly either for viewing manual entries on examine, or viewing the entire comment log in chat via sechud. This is pretty obviously shotgun surgery and a bad code smell but I'm not fiddling with the internals of console record data representations.

I believe this also partially addresses #20761, but does not resolve all the issues mentioned there.

## Why It's Good For The Game
This seems scuffed and probably results in miscommunication among sec officers when it comes to e.g. figuring out why someone might be set to arrest. Also seeing "`/list`" in public-facing examine test makes me cringe.

## Images of changes
Before:
![2023_07_31__23_25_19__ C__Users_warriorstar_iCloudDrive_Screenshots_2023_07_31_2023_07_31__23_14_46__c](https://github.com/ParadiseSS13/Paradise/assets/59303604/85452267-651b-4be4-bf05-7c4a6a9ac134)

After:
![2023_07_31__23_31_34__Paradise Station 13](https://github.com/ParadiseSS13/Paradise/assets/59303604/be810041-f6df-49d3-b508-dae1b8b671ba)

## Testing
Set self to arrest, and then added manual sec record entry, then examined myself with sechud, followed by pressing "View comment log".
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: sechuds now more reliably display security records on examine
/:cl:
