### PR TITLE
Adds more admin logging to roburgers

### DIFF
--- a/code/modules/food_and_drinks/food/foods/sandwiches.dm
+++ b/code/modules/food_and_drinks/food/foods/sandwiches.dm
@@ -69,6 +69,10 @@
 	list_reagents = list("nutriment" = 6, "nanomachines" = 10, "vitamin" = 1)
 	tastes = list("bun" = 4, "lettuce" = 2, "sludge" = 1)
 
+/obj/item/reagent_containers/food/snacks/roburger/Initialize(mapload)
+	. = ..()
+	message_admins("A [name] has been created at [ADMIN_COORDJMP(src)].")
+
 /obj/item/reagent_containers/food/snacks/xenoburger
 	name = "xenoburger"
 	desc = "Smells caustic and tastes like heresy."


### PR DESCRIPTION
## What Does This PR Do

Adds location logging to roburgers upon creation.

## Why It's Good For The Game

In short: faster+better grief prevention

In long: Roburgers are like chainsaws, it is statistically more likely they are made for griefing than for legit reasons. Even though this specific logging has no user attached to it, we still have the tools to see who did it based on this location.

## Images of changes

Added an extra article before the name

![image](https://github.com/ParadiseSS13/Paradise/assets/33333517/da23eb13-8772-4bfa-a4d0-d5d1aad0258c)


## Testing

1. Spawn these: `/obj/machinery/kitchen_machine/microwave`, `/obj/item/reagent_containers/food/snacks/bun`, `/obj/item/robot_parts/head`
2. Add the robot head and bun to microwave
3. Start cooking