### PR TITLE
Better autonamed camera init performance

### DIFF
--- a/code/game/machinery/camera/camera_presets.dm
+++ b/code/game/machinery/camera/camera_presets.dm
@@ -33,29 +33,17 @@
 	upgradeXRay()
 	upgradeMotion()
 
-// AUTONAME
-
-/obj/machinery/camera/autoname
-	var/number = 0 //camera number in area
-
 // This camera type automatically sets it's name to whatever the area that it's in is called.
 /obj/machinery/camera/autoname/Initialize(mapload)
-	number = 1
-	var/area/A = get_area(src)
-	if(!A)
-		number = rand(1, 100)
-		c_tag = "Unknown #[number]"
+	var/static/list/autonames_in_areas = list()
+
+	var/area/camera_area = get_area(src)
+	if(!camera_area)
+		c_tag = "Unknown #[rand(1, 100)]"
 		stack_trace("Camera with tag [c_tag] was spawned without an area, please report this to your nearest coder.")
 		return ..()
 
-	for(var/obj/machinery/camera/autoname/C in A.contents)
-		if(C == src)
-			continue
-		if(C.number)
-			number = max(number, C.number + 1)
-
-	c_tag = "[sanitize(A.name)] #[number]"
-
+	c_tag = "[sanitize(camera_area.name)] #[++autonames_in_areas[camera_area]]" // increase the number, then print it (this is what ++ before does)
 	return ..() // We do this here so the camera is not added to the cameranet until it has a name.
 
 // CHECKS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->ports BeeStation/BeeStation-Hornet/pull/9540. Refactors the cameras' init for ***the micro-optimizations***

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Better init times

## Testing
<!-- How did you test the PR, if at all? -->
Cerestation (the station with the most auto-named cameras), all autonamed cameras were named correctly. Spawned some autoname cameras manually, turned out like before.

## Changelog
No player facing changes

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
