### PR TITLE
Empty trashbags can now fit inside backpacks.

### DIFF
--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -23,6 +23,31 @@
 	use_to_pickup = 1
 	slot_flags = SLOT_BELT
 
+/obj/item/storage/bag/trash/proc/update_weight()
+	if(!length(contents))
+		w_class = WEIGHT_CLASS_NORMAL
+		return
+
+	w_class = WEIGHT_CLASS_BULKY
+
+/obj/item/storage/bag/trash/remove_from_storage(obj/item/I, atom/new_location)
+	. = ..()
+	update_weight()
+
+/obj/item/storage/bag/trash/can_be_inserted(obj/item/I, stop_messages = FALSE)
+	if(isstorage(loc) && !istype(loc, /obj/item/storage/backpack/holding))
+		to_chat(usr, "<span class='warning'>You can't seem to fit [I] into [src].</span>")
+		return FALSE
+	. = ..()
+
+/obj/item/storage/bag/trash/Initialize(mapload)
+	. = ..()
+	update_weight()
+
+/obj/item/storage/bag/trash/handle_item_insertion(obj/item/I, prevent_warning)
+	. = ..()
+	update_weight()
+
 // -----------------------------
 //          Trash bag
 // -----------------------------

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -23,24 +23,6 @@
 	use_to_pickup = 1
 	slot_flags = SLOT_BELT
 
-/obj/item/storage/bag/trash/remove_from_storage(obj/item/I, atom/new_location)
-	. = ..()
-	update_weight()
-
-/obj/item/storage/bag/trash/can_be_inserted(obj/item/I, stop_messages = FALSE)
-	if(isstorage(loc) && !istype(loc, /obj/item/storage/backpack/holding))
-		to_chat(usr, "<span class='warning'>You can't seem to fit [I] into [src].</span>")
-		return FALSE
-	. = ..()
-
-/obj/item/storage/bag/trash/Initialize(mapload)
-	. = ..()
-	update_weight()
-
-/obj/item/storage/bag/trash/handle_item_insertion(obj/item/I, prevent_warning)
-	. = ..()
-	update_weight()
-
 // -----------------------------
 //          Trash bag
 // -----------------------------
@@ -66,6 +48,24 @@
 		return
 
 	w_class = WEIGHT_CLASS_BULKY
+
+/obj/item/storage/bag/trash/remove_from_storage(obj/item/I, atom/new_location)
+	. = ..()
+	update_weight()
+
+/obj/item/storage/bag/trash/can_be_inserted(obj/item/I, stop_messages = FALSE)
+	if(isstorage(loc) && !istype(loc, /obj/item/storage/backpack/holding))
+		to_chat(usr, "<span class='warning'>You can't seem to fit [I] into [src].</span>")
+		return FALSE
+	. = ..()
+
+/obj/item/storage/bag/trash/Initialize(mapload)
+	. = ..()
+	update_weight()
+
+/obj/item/storage/bag/trash/handle_item_insertion(obj/item/I, prevent_warning)
+	. = ..()
+	update_weight()
 
 /obj/item/storage/bag/trash/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] puts [src] over [user.p_their()] head and starts chomping at the insides! Disgusting!</span>")

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -23,13 +23,6 @@
 	use_to_pickup = 1
 	slot_flags = SLOT_BELT
 
-/obj/item/storage/bag/trash/proc/update_weight()
-	if(!length(contents))
-		w_class = WEIGHT_CLASS_NORMAL
-		return
-
-	w_class = WEIGHT_CLASS_BULKY
-
 /obj/item/storage/bag/trash/remove_from_storage(obj/item/I, atom/new_location)
 	. = ..()
 	update_weight()
@@ -66,6 +59,13 @@
 	max_combined_w_class = 30
 	can_hold = list() // any
 	cant_hold = list(/obj/item/disk/nuclear)
+
+/obj/item/storage/bag/trash/proc/update_weight()
+	if(!length(contents))
+		w_class = WEIGHT_CLASS_NORMAL
+		return
+
+	w_class = WEIGHT_CLASS_BULKY
 
 /obj/item/storage/bag/trash/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] puts [src] over [user.p_their()] head and starts chomping at the insides! Disgusting!</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
While empty, trashbags can fit into backpacks. However while holding items, they cannot.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Currently trashbags have a weight class of bulky, while being.. trashbags, something that (while empty) really isn't all that large, meaning janitors need to carry around empty trashbags in their hands constantly, or need to use the jani car/t, or a bluespace bag, both having frustrating downsides, mainly being the need to constantly drag/drive something around, thats really prone to being stolen, or needing a high tech level from rnd. 
Not to mention if you're a janitor ert, you often do not have time/the ability to obtain such items.

## Testing
<!-- How did you test the PR, if at all? -->
I tried to put the trashbags(bluespace and non) in various storage compartments while full of cigar butts and empty, making sure that it acted how i expected. 
And it did indeed act how i expected.
## Changelog
:cl:
tweak: The trashbag(of holding) now fits inside backpacks and the sort while empty, However not while holding items. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
