### PR TITLE
Minor Chem Master tweaks

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -4,6 +4,9 @@
 #define MAX_UNITS_PER_PATCH 30 // Max amount of units in a patch
 #define MAX_CUSTOM_NAME_LEN 64 // Max length of a custom pill/condiment/whatever
 
+#define TRANSFER_TO_DISPOSAL 0
+#define TRANSFER_TO_BEAKER   1
+
 /obj/machinery/chem_master
 	name = "\improper ChemMaster 3000"
 	density = TRUE
@@ -15,7 +18,7 @@
 
 	var/obj/item/reagent_containers/beaker = null
 	var/obj/item/storage/pill_bottle/loaded_pill_bottle = null
-	var/mode = 0
+	var/mode = TRANSFER_TO_BEAKER
 	var/condi = FALSE
 	var/useramount = 30 // Last used amount
 	var/pillamount = 10
@@ -560,3 +563,6 @@
 #undef MAX_UNITS_PER_PILL
 #undef MAX_UNITS_PER_PATCH
 #undef MAX_CUSTOM_NAME_LEN
+
+#undef TRANSFER_TO_DISPOSAL
+#undef TRANSFER_TO_BEAKER

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -354,7 +354,7 @@
 				if("create_pill")
 					if(condi || !reagents.total_volume)
 						return
-					var/num = round(text2num(arguments["num"] || 1))
+					var/num = clamp(round(text2num(arguments["num"])), 0, MAX_MULTI_AMOUNT)
 					if(!num)
 						return
 					arguments["num"] = num
@@ -374,7 +374,7 @@
 				if("create_patch")
 					if(condi || !reagents.total_volume)
 						return
-					var/num = round(text2num(arguments["num"] || 1))
+					var/num = clamp(round(text2num(arguments["num"])), 0, MAX_MULTI_AMOUNT)
 					if(!num)
 						return
 					arguments["num"] = num
@@ -440,7 +440,7 @@
 				if("create_pill")
 					if(condi || !reagents.total_volume)
 						return
-					var/count = clamp(round(text2num(arguments["num"]) || 0), 0, MAX_MULTI_AMOUNT)
+					var/count = text2num(arguments["num"])
 					if(!count)
 						return
 
@@ -473,7 +473,7 @@
 				if("create_patch")
 					if(condi || !reagents.total_volume)
 						return
-					var/count = clamp(round(text2num(arguments["num"]) || 0), 0, MAX_MULTI_AMOUNT)
+					var/count = text2num(arguments["num"])
 					if(!count)
 						return
 


### PR DESCRIPTION
## What Does This PR Do
1)​ Makes Chem Masters transfer reagents back to the beaker rather than disposal, by default.
2)​ Fixes incorrect pill/patch naming when supplied an invalid target product amount (chem master would name the pills as if you were actually allowed to make 100 pills, rather than the valid maximum 20).

## Why It's Good For The Game
1)​​ Chemistry likely has the majority of Chem Master usage, and it sucks to accidentally trash some chems because you forgot to toggle the funny red button every dang shift
2)​ Bugs bad, especially when they mislead people into thinking they might have discovered an exploit or sumthin'

## Testing
Tested if creating pills with a valid product number still works as expected.
Tested if creating pills with an invalid product number clamps it to the expected minimum/maximum, supplying the appropriate volume in the default name.

## Changelog
:cl:
tweak: Chem Masters now transfer reagents back to the beaker by default
fix: Fixed Chem Masters naming pills/patches incorrectly sometimes
/:cl:
