### PR TITLE
Robot Names Can No Longer Be 0 Characters Long

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/bot_construction.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot_construction.dm
@@ -30,12 +30,11 @@
 
 	else if(is_pen(W))
 		var/t = rename_interactive(user, W, prompt = "Enter new robot name")
-		if(!isnull(t))
-			if(length(t) > 0)
-				created_name = t
-				log_game("[key_name(user)] has renamed a robot to [t]")
-			else
-				to_chat(user, "The robot's name must have at least one character.")
+		if(length(t) > 0)
+			created_name = t
+			log_game("[key_name(user)] has renamed a robot to [t]")
+		else
+			to_chat(user, "The robot's name must have at least one character.")
 
 //Edbot Assembly
 
@@ -55,12 +54,11 @@
 
 	if(is_pen(W))
 		var/t = rename_interactive(user, W, prompt = "Enter new robot name")
-		if(!isnull(t))
-			if(length(t) > 0)
-				created_name = t
-				log_game("[key_name(user)] has renamed a robot to [t]")
-			else
-				to_chat(user, "The robot's name must have at least one character.")
+		if(length(t) > 0)
+			created_name = t
+			log_game("[key_name(user)] has renamed a robot to [t]")
+		else
+			to_chat(user, "The robot's name must have at least one character.")
 		return
 
 	switch(build_step)
@@ -306,12 +304,11 @@
 
 	else if(is_pen(W))
 		var/t = rename_interactive(user, W, prompt = "Enter new robot name")
-		if(!isnull(t))
-			if(length(t) > 0)
-				created_name = t
-				log_game("[key_name(user)] has renamed a robot to [t]")
-			else
-				to_chat(user, "The robot's name must have at least one character.")
+		if(length(t) > 0)
+			created_name = t
+			log_game("[key_name(user)] has renamed a robot to [t]")
+		else
+			to_chat(user, "The robot's name must have at least one character.")
 
 /obj/item/toolbox_tiles/sensor/update_icon_state()
 	icon_state = "[toolbox_color]toolbox_tiles_sensor"
@@ -390,12 +387,11 @@
 	..()
 	if(is_pen(I))
 		var/t = rename_interactive(user, I, prompt = "Enter new robot name")
-		if(!isnull(t))
-			if(length(t) > 0)
-				created_name = t
-				log_game("[key_name(user)] has renamed a robot to [t]")
-			else
-				to_chat(user, "The robot's name must have at least one character.")
+		if(length(t) > 0)
+			created_name = t
+			log_game("[key_name(user)] has renamed a robot to [t]")
+		else
+			to_chat(user, "The robot's name must have at least one character.")
 	else
 		switch(build_step)
 			if(0)
@@ -501,12 +497,11 @@
 
 	else if(is_pen(I))
 		var/t = rename_interactive(user, I, prompt = "Enter new robot name")
-		if(!isnull(t))
-			if(length(t) > 0)
-				created_name = t
-				log_game("[key_name(user)] has renamed a robot to [t]")
-			else
-				to_chat(user, "The robot's name must have at least one character.")
+		if(length(t) > 0)
+			created_name = t
+			log_game("[key_name(user)] has renamed a robot to [t]")
+		else
+			to_chat(user, "The robot's name must have at least one character.")
 
 //General Griefsky
 

--- a/code/modules/mob/living/simple_animal/bot/bot_construction.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot_construction.dm
@@ -31,8 +31,11 @@
 	else if(is_pen(W))
 		var/t = rename_interactive(user, W, prompt = "Enter new robot name")
 		if(!isnull(t))
-			created_name = t
-			log_game("[key_name(user)] has renamed a robot to [t]")
+			if(length(t) > 0)
+				created_name = t
+				log_game("[key_name(user)] has renamed a robot to [t]")
+			else
+				to_chat(user, "The robot's name must have at least one character.")
 
 //Edbot Assembly
 
@@ -53,8 +56,11 @@
 	if(is_pen(W))
 		var/t = rename_interactive(user, W, prompt = "Enter new robot name")
 		if(!isnull(t))
-			created_name = t
-			log_game("[key_name(user)] has renamed a robot to [t]")
+			if(length(t) > 0)
+				created_name = t
+				log_game("[key_name(user)] has renamed a robot to [t]")
+			else
+				to_chat(user, "The robot's name must have at least one character.")
 		return
 
 	switch(build_step)
@@ -301,8 +307,11 @@
 	else if(is_pen(W))
 		var/t = rename_interactive(user, W, prompt = "Enter new robot name")
 		if(!isnull(t))
-			created_name = t
-			log_game("[key_name(user)] has renamed a robot to [t]")
+			if(length(t) > 0)
+				created_name = t
+				log_game("[key_name(user)] has renamed a robot to [t]")
+			else
+				to_chat(user, "The robot's name must have at least one character.")
 
 /obj/item/toolbox_tiles/sensor/update_icon_state()
 	icon_state = "[toolbox_color]toolbox_tiles_sensor"
@@ -317,11 +326,6 @@
 		to_chat(user, "<span class='notice'>You add the robot arm to the odd looking toolbox assembly. Boop beep!</span>")
 		user.unEquip(src, 1)
 		qdel(src)
-	else if(is_pen(W))
-		var/t = rename_interactive(user, W, prompt = "Enter new robot name")
-		if(!isnull(t))
-			created_name = t
-			log_game("[key_name(user)] has renamed a robot to [t]")
 
 //Medbot Assembly
 /obj/item/storage/firstaid/attackby(obj/item/I, mob/user, params)
@@ -387,8 +391,11 @@
 	if(is_pen(I))
 		var/t = rename_interactive(user, I, prompt = "Enter new robot name")
 		if(!isnull(t))
-			created_name = t
-			log_game("[key_name(user)] has renamed a robot to [t]")
+			if(length(t) > 0)
+				created_name = t
+				log_game("[key_name(user)] has renamed a robot to [t]")
+			else
+				to_chat(user, "The robot's name must have at least one character.")
 	else
 		switch(build_step)
 			if(0)
@@ -495,8 +502,11 @@
 	else if(is_pen(I))
 		var/t = rename_interactive(user, I, prompt = "Enter new robot name")
 		if(!isnull(t))
-			created_name = t
-			log_game("[key_name(user)] has renamed a robot to [t]")
+			if(length(t) > 0)
+				created_name = t
+				log_game("[key_name(user)] has renamed a robot to [t]")
+			else
+				to_chat(user, "The robot's name must have at least one character.")
 
 //General Griefsky
 

--- a/code/modules/mob/living/simple_animal/bot/bot_construction.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot_construction.dm
@@ -30,7 +30,7 @@
 
 	else if(is_pen(W))
 		var/t = rename_interactive(user, W, prompt = "Enter new robot name")
-		if(length(t) > 0)
+		if(length(t))
 			created_name = t
 			log_game("[key_name(user)] has renamed a robot to [t]")
 		else
@@ -54,7 +54,7 @@
 
 	if(is_pen(W))
 		var/t = rename_interactive(user, W, prompt = "Enter new robot name")
-		if(length(t) > 0)
+		if(length(t))
 			created_name = t
 			log_game("[key_name(user)] has renamed a robot to [t]")
 		else
@@ -304,7 +304,7 @@
 
 	else if(is_pen(W))
 		var/t = rename_interactive(user, W, prompt = "Enter new robot name")
-		if(length(t) > 0)
+		if(length(t))
 			created_name = t
 			log_game("[key_name(user)] has renamed a robot to [t]")
 		else
@@ -387,7 +387,7 @@
 	..()
 	if(is_pen(I))
 		var/t = rename_interactive(user, I, prompt = "Enter new robot name")
-		if(length(t) > 0)
+		if(length(t))
 			created_name = t
 			log_game("[key_name(user)] has renamed a robot to [t]")
 		else
@@ -497,7 +497,7 @@
 
 	else if(is_pen(I))
 		var/t = rename_interactive(user, I, prompt = "Enter new robot name")
-		if(length(t) > 0)
+		if(length(t))
 			created_name = t
 			log_game("[key_name(user)] has renamed a robot to [t]")
 		else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #21841 - all robot names must now be at least 1 character long. Also fixed a bug that made the rename dialog pop up twice for floorbots.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Things not having names bad.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Tried giving empty names to the most popular robots, tried giving a normal name to a robot.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Robot names can no longer be 0 characters long
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
