### PR TITLE
Fixes pills being put into patch packs via the ChemMaster

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -456,7 +456,7 @@
 						P.icon_state = "pill[pillsprite]"
 						reagents.trans_to(P, amount_per_pill)
 						// Load the pills in the bottle if there's one loaded
-						if(istype(loaded_pill_bottle) && length(loaded_pill_bottle.contents) < loaded_pill_bottle.storage_slots)
+						if(istype(loaded_pill_bottle) && loaded_pill_bottle.can_be_inserted(P, TRUE))
 							P.forceMove(loaded_pill_bottle)
 				if("create_pill_multiple")
 					if(condi || !reagents.total_volume)
@@ -492,7 +492,7 @@
 							P.instant_application = TRUE
 							P.icon_state = "bandaid_med"
 						// Load the patches in the bottle if there's one loaded
-						if(istype(loaded_pill_bottle, /obj/item/storage/pill_bottle/patch_pack) && length(loaded_pill_bottle.contents) < loaded_pill_bottle.storage_slots)
+						if(istype(loaded_pill_bottle) && loaded_pill_bottle.can_be_inserted(P, TRUE))
 							P.forceMove(loaded_pill_bottle)
 				if("create_patch_multiple")
 					if(condi || !reagents.total_volume)


### PR DESCRIPTION
## What Does This PR Do
This fixes a bug that allows players to insert pills into patch packs using the ChemMaster 3000.

## Why It's Good For The Game
Patch packs should not be able to hold pills.

## Images of changes
### **Before**
![dreamseeker_pc08JnkhZT](https://github.com/ParadiseSS13/Paradise/assets/116982774/1014e954-2831-46e4-b294-a2db51c678aa)

### **After**
![dreamseeker_mwXs3HrGyO](https://github.com/ParadiseSS13/Paradise/assets/116982774/48c3b29f-5521-4cc5-a635-272bf7011ac4)

## Testing
Tested to see if pills could not be put into patch packs.
Tested to see if patches could not be put into pill bottles.
Tested to see if patches and pills could still be put in their intended containers.

## Changelog
:cl: Burza and CinnamonSnowball
fix: Fixed item checking for pills and patches when inserting into containers with ChemMaster
/:cl: