### PR TITLE
[s] Holoparasite Can No Longer Manifest in Stealth Boxes

### DIFF
--- a/code/_onclick/hud/guardian_hud.dm
+++ b/code/_onclick/hud/guardian_hud.dm
@@ -53,6 +53,9 @@
 		if(istype(summoner_loc, /obj/machinery/atmospherics))
 			to_chat(G, "<span class='warning'>You can not manifest while in these pipes!</span>")
 			return
+		if(istype(summoner_loc, /obj/structure/closet/cardboard/agent))
+			to_chat(G, "<span class='warning'>You can not manifest while your Stealth Implant is active!</span>")
+			return
 		if(G.loc == G.summoner)
 			G.Manifest()
 

--- a/code/_onclick/hud/guardian_hud.dm
+++ b/code/_onclick/hud/guardian_hud.dm
@@ -54,7 +54,7 @@
 			to_chat(G, "<span class='warning'>You can not manifest while in these pipes!</span>")
 			return
 		if(istype(summoner_loc, /obj/structure/closet/cardboard/agent))
-			to_chat(G, "<span class='warning'>You can not manifest while your Stealth Implant is active!</span>")
+			to_chat(G, "<span class='warning'>You can not manifest while inside an active Stealth Implant!</span>")
 			return
 		if(G.loc == G.summoner)
 			G.Manifest()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Prevents Holoparas from being able to Manifest while their user in a Stealth Implant

## Why It's Good For The Game
We removed Contortionist + Holopara for a reason.

This is the same issue.

## Testing
Tested manifesting while in the Stealth Implant Box
(god this was the first time I had to multikey for testing, pain pain pain)

## Changelog
:cl:
tweak: prevents Holoparasites from Manifesting inside Stealth Boxes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
