### PR TITLE
Fixed Trick Revolver, Added Trick minibomb

### DIFF
--- a/code/datums/uplink_items/uplink_traitor.dm
+++ b/code/datums/uplink_items/uplink_traitor.dm
@@ -44,7 +44,7 @@
 
 /datum/uplink_item/jobspecific/trick_grenade
 	name = "Trick Grenade"
-	desc = "Syndicate Minibomb with glue ejectors that will stick it into the user's hands on activation."
+	desc = "Syndicate Minibomb with glue ejectors that will stick it to the user's hands on activation."
 	reference = "CGN"
 	item = /obj/item/storage/box/syndie_kit/fake_minibomb
 	cost = 1

--- a/code/datums/uplink_items/uplink_traitor.dm
+++ b/code/datums/uplink_items/uplink_traitor.dm
@@ -47,7 +47,7 @@
 	desc = "Syndicate Minibomb with glue ejectors that will stick it to the user's hands on activation."
 	reference = "CGN"
 	item = /obj/item/storage/box/syndie_kit/fake_minibomb
-	cost = 1
+	cost = 5
 	job = list("Clown")
 
 //mime

--- a/code/datums/uplink_items/uplink_traitor.dm
+++ b/code/datums/uplink_items/uplink_traitor.dm
@@ -49,6 +49,7 @@
 	item = /obj/item/storage/box/syndie_kit/fake_minibomb
 	cost = 1
 	job = list("Clown")
+
 //mime
 /datum/uplink_item/jobspecific/caneshotgun
 	name = "Cane Shotgun and Assassination Shells"

--- a/code/datums/uplink_items/uplink_traitor.dm
+++ b/code/datums/uplink_items/uplink_traitor.dm
@@ -41,6 +41,14 @@
 	item = /obj/item/storage/box/syndie_kit/fake_revolver
 	cost = 1
 	job = list("Clown")
+
+/datum/uplink_item/jobspecific/trick_grenade
+	name = "Trick Grenade"
+	desc = "Syndicate Minibomb with glue ejectors that will stick bomb to user's hand on activation."
+	reference = "CGN"
+	item = /obj/item/storage/box/syndie_kit/fake_minibomb
+	cost = 1
+	job = list("Clown")
 //mime
 /datum/uplink_item/jobspecific/caneshotgun
 	name = "Cane Shotgun and Assassination Shells"

--- a/code/datums/uplink_items/uplink_traitor.dm
+++ b/code/datums/uplink_items/uplink_traitor.dm
@@ -44,7 +44,7 @@
 
 /datum/uplink_item/jobspecific/trick_grenade
 	name = "Trick Grenade"
-	desc = "Syndicate Minibomb with glue ejectors that will stick bomb to user's hand on activation."
+	desc = "Syndicate Minibomb with glue ejectors that will stick it into the user's hands on activation."
 	reference = "CGN"
 	item = /obj/item/storage/box/syndie_kit/fake_minibomb
 	cost = 1

--- a/code/game/objects/items/weapons/grenades/syndieminibomb.dm
+++ b/code/game/objects/items/weapons/grenades/syndieminibomb.dm
@@ -21,6 +21,6 @@
 /obj/item/grenade/syndieminibomb/fake/attack_self(mob/user)
 	if(!active)
 		flags |= NODROP
-		to_chat(user, "<span class='danger'>As you activate the bomb, it emits super glue and sticks to your hand.</span>")
+		to_chat(user, "<span class='userdanger'>As you activate the bomb, it emits a substance that sticks to your hand! It won't come off!</span>")
 		to_chat(user, "<span class='sans'>Uh oh.</span>")
 	. = ..()

--- a/code/game/objects/items/weapons/grenades/syndieminibomb.dm
+++ b/code/game/objects/items/weapons/grenades/syndieminibomb.dm
@@ -16,7 +16,7 @@
 /obj/item/grenade/syndieminibomb/fake/examine(mob/user)
 	. = ..()
 	if(HAS_TRAIT(user, TRAIT_CLUMSY))
-		. += "<span class='sans'>There is small glue ejectors all over the bomb.</span>"
+		. += "<span class='sans'>There are small glue ejectors all over the bomb.</span>"
 
 /obj/item/grenade/syndieminibomb/fake/attack_self(mob/user)
 	if(!active)

--- a/code/game/objects/items/weapons/grenades/syndieminibomb.dm
+++ b/code/game/objects/items/weapons/grenades/syndieminibomb.dm
@@ -10,3 +10,17 @@
 	update_mob()
 	explosion(loc, 1, 2, 4, flame_range = 2)
 	qdel(src)
+
+/obj/item/grenade/syndieminibomb/fake
+
+/obj/item/grenade/syndieminibomb/fake/examine(mob/user)
+	. = ..()
+	if(HAS_TRAIT(user, TRAIT_CLUMSY))
+		. += "<span class='sans'>There is small glue ejectors all over the bomb.</span>"
+
+/obj/item/grenade/syndieminibomb/fake/attack_self(mob/user)
+	if(!active)
+		flags |= NODROP
+		to_chat(user, "<span class='danger'>As you activate the bomb, it emits super glue and sticks to your hand.</span>")
+		to_chat(user, "<span class='sans'>Uh oh.</span>")
+	. = ..()

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -240,11 +240,17 @@
 		new /obj/item/ammo_casing/shotgun/assassination(src)
 	new /obj/item/gun/projectile/revolver/doublebarrel/improvised/cane(src)
 
+/obj/item/storage/box/syndie_kit/fake_minibomb
+	name = "trick minibomb kit"
+
+/obj/item/storage/box/syndie_kit/fake_minibomb/populate_contents()
+	new /obj/item/grenade/syndieminibomb/fake(src)
+
 /obj/item/storage/box/syndie_kit/fake_revolver
 	name = "trick revolver kit"
 
 /obj/item/storage/box/syndie_kit/fake_revolver/populate_contents()
-	new /obj/item/toy/russian_revolver/trick_revolver(src)
+	new /obj/item/gun/projectile/revolver/fake(src)
 
 /obj/item/storage/box/syndie_kit/mimery
 	name = "advanced mimery kit"

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -100,7 +100,7 @@
 
 /obj/item/gun/projectile/revolver/fake/process_fire(atom/target, mob/living/carbon/human/user, message, params, zone_override, bonus_spread)
 	var/zone = "chest"
-	if(!user.has_organ("head"))
+	if(user.has_organ("head"))
 		zone = "head"
 	add_fingerprint(user)
 	if(!chambered)

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -96,7 +96,7 @@
 /obj/item/gun/projectile/revolver/fake/examine(mob/user)
 	. = ..()
 	if(HAS_TRAIT(user, TRAIT_CLUMSY))
-		. += "<span class='sans'>Its mechanism looks like it shoots backwards.</span>"
+		. += "<span class='sans'>Its mechanism seems to shoot backwards.</span>"
 
 /obj/item/gun/projectile/revolver/fake/process_fire(atom/target, mob/living/carbon/human/user, message, params, zone_override, bonus_spread)
 	var/zone = "chest"

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -111,7 +111,7 @@
 		return
 	process_chamber()
 	update_icon()
-	playsound(src, 'sound/weapons/gunshots/gunshot_strong.ogg', 50, 1)
+	playsound(src, 'sound/weapons/gunshots/gunshot_strong.ogg', 50, TRUE)
 	user.visible_message("<span class='danger'>[src] goes off!</span>")
 	to_chat(user, "<span class='danger'>[src] did look pretty dodgey!</span>")
 	SEND_SOUND(user, sound('sound/misc/sadtrombone.ogg')) //HONK

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -91,6 +91,34 @@
 	. = ..()
 	. += "[get_ammo(0,0)] of those are live rounds."
 
+/obj/item/gun/projectile/revolver/fake
+
+/obj/item/gun/projectile/revolver/fake/examine(mob/user)
+	. = ..()
+	if(HAS_TRAIT(user, TRAIT_CLUMSY))
+		. += "<span class='sans'>Its mechanism looks like it shoots backwards.</span>"
+
+/obj/item/gun/projectile/revolver/fake/process_fire(atom/target, mob/living/carbon/human/user, message, params, zone_override, bonus_spread)
+	var/zone = "chest"
+	if(!user.has_organ("head"))
+		zone = "head"
+	add_fingerprint(user)
+	if(!chambered)
+		shoot_with_empty_chamber(user)
+		return
+	if(!chambered.fire(target = user, user = user, params = params, distro = null, quiet = suppressed, zone_override = zone, spread = 0, firer_source_atom = src))
+		shoot_with_empty_chamber(user)
+		return
+	process_chamber()
+	update_icon()
+	playsound(src, 'sound/weapons/gunshots/gunshot_strong.ogg', 50, 1)
+	user.visible_message("<span class='danger'>[src] goes off!</span>")
+	to_chat(user, "<span class='danger'>[src] did look pretty dodgey!</span>")
+	SEND_SOUND(user, sound('sound/misc/sadtrombone.ogg')) //HONK
+	user.apply_damage(300, BRUTE, zone, sharp = TRUE, used_weapon = "Self-inflicted gunshot wound to the [zone].")
+	user.bleed(BLOOD_VOLUME_NORMAL)
+	user.death() // Just in case
+
 /obj/item/gun/projectile/revolver/fingergun //Summoned by the Finger Gun spell, from advanced mimery traitor item
 	name = "\improper finger gun"
 	desc = "Bang bang bang!"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
This PR
1: Moves trick revolver from subtype of russian revolver to subtype of actual 357 revolver. Now it acts the same as default revolver whatever you do with it, but if you try shoot, you will die.

2: Makes trick revolver bring recognisable with clumsy trait. If you examine it with clumsy, you will see "Its mechanism looks like it shots backwards."

3: Adds Trick minibomb. That is minibomb as actual one, but once you activate it, it will gain NODROP flag makes it impossible to throw at target. If you examine it with clumsy gene, you will see text "There is small glue ejectors all over the bomb."
After activating the bomb, you will see text "As you activate the bomb, it emits super glue and sticks to your hand." and "Uh oh."

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Trick revolver supposed to looks like real one, but its nature of being subtype of russian revolver makes it not acting like real one. Making trick revolver harder to identify is good by my sight.

Adding more trick uplink items is good, trick bomb sounds fun(for me).

Making clown being able to identify clown uplink fake items is cool for me.

## Testing
<!-- How did you test the PR, if at all? -->
Compiled, tested shooting revolver and throwing nade

## Changelog
:cl:
add: Trick Minibomb - Clown uplink item for 1 TC which is actual syndicate minibomb, but once you activate it, you cant throw it away. Clowns(or others with clumsy gene) can identify it.
tweak: Trick Revolver - Now clowns(or others with clumsy gene) can identify it.
fix: Trick Revolver - It now acts like a real revolver in every way except shooting. Its harder to identify, no more "Has 4 rounds remaining."
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
