### PR TITLE
PDAs Change Icon With Unread Messages Again

### DIFF
--- a/code/modules/pda/app.dm
+++ b/code/modules/pda/app.dm
@@ -40,8 +40,8 @@
 		pda.play_ringtone()
 
 	if(blink && !(src in pda.notifying_programs))
-		pda.update_icon(UPDATE_OVERLAYS)
 		pda.notifying_programs |= src
+		pda.update_icon(UPDATE_OVERLAYS)
 
 /datum/data/pda/proc/unnotify()
 	if(src in pda.notifying_programs)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Fixes #21893 - PDA Icons flash again after receiving messages.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Bug bad, flashing PDA good.

## Testing
<!-- How did you test the PR, if at all? -->
Sent PDA a message, observed flashing, observed flashing stopping when looking at messages.

## Changelog
:cl:
fix: PDAs flash when receiving messages again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
