### PR TITLE
Adds a new Fungal Growth event, makes fungus re-harvestable

### DIFF
--- a/code/game/objects/effects/decals/Cleanable/misc_cleanables.dm
+++ b/code/game/objects/effects/decals/Cleanable/misc_cleanables.dm
@@ -288,12 +288,6 @@
 		. += "<span class='notice'>There's enough here to scrape into a beaker.</span>"
 
 /obj/effect/decal/cleanable/fungus/on_scoop()
-
-	// can you feel your heart burning?
-	// can you feel the struggle within?
-	// the fear within me is beyond anything your soul can make.
-	// you can't kill me in a way that matters
-
 	alpha = 128
 	no_scoop = TRUE
 

--- a/code/game/objects/effects/decals/Cleanable/misc_cleanables.dm
+++ b/code/game/objects/effects/decals/Cleanable/misc_cleanables.dm
@@ -283,7 +283,7 @@
 /obj/effect/decal/cleanable/fungus/examine(mob/user)
 	. = ..()
 	if(no_scoop)
-		. += "<span class='notice'>There's really not a lot here, you probably couldn't harvest anything if you tried.</span>"
+		. += "<span class='notice'>There's not a lot here, you probably wouldn't be able to harvest anything useful.</span>"
 	else
 		. += "<span class='notice'>There's a good bit here, it looks like you could scrape some off into a beaker.</span>"
 

--- a/code/game/objects/effects/decals/Cleanable/misc_cleanables.dm
+++ b/code/game/objects/effects/decals/Cleanable/misc_cleanables.dm
@@ -277,6 +277,36 @@
 	icon_state = "flour"
 	color = "#D5820B"
 	scoop_reagents = list("fungus" = 10)
+	no_clear = TRUE
+	var/timer_id
+
+/obj/effect/decal/cleanable/fungus/examine(mob/user)
+	. = ..()
+	if(no_scoop)
+		. += "<span class='notice'>There's really not a lot here, you probably couldn't harvest anything if you tried.</span>"
+	else
+		. += "<span class='notice'>There's a good bit here, it looks like you could scrape some off into a beaker.</span>"
+
+/obj/effect/decal/cleanable/fungus/on_scoop()
+
+	// can you feel your heart burning?
+	// can you feel the struggle within?
+	// the fear within me is beyond anything your soul can make.
+	// you can't kill me in a way that matters
+
+	alpha = 128
+	no_scoop = TRUE
+
+	timer_id = addtimer(CALLBACK(src, PROC_REF(recreate)), rand(5 MINUTES, 10 MINUTES), TIMER_STOPPABLE)
+
+/obj/effect/decal/cleanable/fungus/Destroy()
+	. = ..()
+	deltimer(timer_id)
+
+/obj/effect/decal/cleanable/fungus/proc/recreate()
+	alpha = 255
+	reagents.add_reagent_list(scoop_reagents)
+	no_scoop = FALSE
 
 /obj/effect/decal/cleanable/confetti //PARTY TIME!
 	name = "confetti"

--- a/code/game/objects/effects/decals/Cleanable/misc_cleanables.dm
+++ b/code/game/objects/effects/decals/Cleanable/misc_cleanables.dm
@@ -285,7 +285,7 @@
 	if(no_scoop)
 		. += "<span class='notice'>There's not a lot here, you probably wouldn't be able to harvest anything useful.</span>"
 	else
-		. += "<span class='notice'>There's a good bit here, it looks like you could scrape some off into a beaker.</span>"
+		. += "<span class='notice'>There's enough here to scrape into a beaker.</span>"
 
 /obj/effect/decal/cleanable/fungus/on_scoop()
 

--- a/code/game/objects/effects/effects.dm
+++ b/code/game/objects/effects/effects.dm
@@ -125,6 +125,7 @@
 			to_chat(user, "<span class='notice'>[I] is full!</span>")
 			return
 		to_chat(user, "<span class='notice'>You scoop [src] into [I]!</span>")
+		on_scoop()
 		reagents.trans_to(I, reagents.total_volume)
 		if(!reagents.total_volume && !no_clear) //scooped up all of it
 			qdel(src)
@@ -144,3 +145,6 @@
 /obj/effect/decal/blob_act(obj/structure/blob/B)
 	if(B && B.loc == loc)
 		qdel(src)
+
+/obj/effect/decal/proc/on_scoop()
+	return

--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -7,6 +7,7 @@
 #define ASSIGNMENT_MEDICAL "Medical"
 #define ASSIGNMENT_SCIENTIST "Scientist"
 #define ASSIGNMENT_SECURITY "Security"
+#define ASSIGNMENT_CHEMIST "Chemist"
 
 GLOBAL_LIST_INIT(severity_to_string, list(EVENT_LEVEL_MUNDANE = "Mundane", EVENT_LEVEL_MODERATE = "Moderate", EVENT_LEVEL_MAJOR = "Major"))
 GLOBAL_LIST_EMPTY(event_last_fired)
@@ -141,6 +142,7 @@ GLOBAL_LIST_EMPTY(event_last_fired)
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Vermin Infestation",/datum/event/infestation, 		100,	list(ASSIGNMENT_JANITOR = 100)),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Sentience",			/datum/event/sentience,			50),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Wallrot",			/datum/event/wallrot, 			0,		list(ASSIGNMENT_ENGINEER = 30, ASSIGNMENT_GARDENER = 50)),
+		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Fungus Growth",		/datum/event/wallrot/fungus, 	50, 	list(ASSIGNMENT_CHEMIST = 50)),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Koi School",		/datum/event/carp_migration/koi,		80),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Camera Failure",	/datum/event/camera_failure,		100, list(ASSIGNMENT_ENGINEER = 10)),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Fake Virus",		/datum/event/fake_virus,		50),
@@ -218,3 +220,4 @@ GLOBAL_LIST_EMPTY(event_last_fired)
 #undef ASSIGNMENT_MEDICAL
 #undef ASSIGNMENT_SCIENTIST
 #undef ASSIGNMENT_SECURITY
+#undef ASSIGNMENT_CHEMIST

--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -142,7 +142,7 @@ GLOBAL_LIST_EMPTY(event_last_fired)
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Vermin Infestation",/datum/event/infestation, 		100,	list(ASSIGNMENT_JANITOR = 100)),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Sentience",			/datum/event/sentience,			50),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Wallrot",			/datum/event/wallrot, 			0,		list(ASSIGNMENT_ENGINEER = 30, ASSIGNMENT_GARDENER = 50)),
-		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Fungus Growth",		/datum/event/wallrot/fungus, 	50, 	list(ASSIGNMENT_CHEMIST = 50)),
+		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Fungal Growth",		/datum/event/wallrot/fungus, 	50, 	list(ASSIGNMENT_CHEMIST = 50)),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Koi School",		/datum/event/carp_migration/koi,		80),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Camera Failure",	/datum/event/camera_failure,		100, list(ASSIGNMENT_ENGINEER = 10)),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Fake Virus",		/datum/event/fake_virus,		50),

--- a/code/modules/events/wallrot.dm
+++ b/code/modules/events/wallrot.dm
@@ -1,29 +1,44 @@
 /datum/event/wallrot/start()
 	INVOKE_ASYNC(src, PROC_REF(spawn_wallrot))
 
+/datum/event/wallrot/proc/apply_to_turf(turf/T)
+	var/turf/simulated/wall/W = T
+	W.rot()
+
+/datum/event/wallrot/proc/is_valid_candidate(turf/T)
+	return TRUE
+
 /datum/event/wallrot/proc/spawn_wallrot()
 	var/turf/simulated/wall/center = null
 
 	// 100 attempts
 	for(var/i in 0 to 100)
 		var/turf/candidate = locate(rand(1, world.maxx), rand(1, world.maxy), level_name_to_num(MAIN_STATION))
-		if(iswallturf(candidate))
+		if(iswallturf(candidate) && is_valid_candidate(candidate))
 			center = candidate
 			break
 
 	if(!center)
 		return
 	// Make sure at least one piece of wall rots!
-	center.rot()
+	apply_to_turf(center)
 
 	// Have a chance to rot lots of other walls.
 	var/rotcount = 0
 	var/actual_severity = severity * rand(5, 10)
 	for(var/turf/simulated/wall/W in range(5, center))
 		if(prob(50))
-			W.rot()
+			apply_to_turf(W)
 			rotcount++
 
 			// Only rot up to severity walls
 			if(rotcount >= actual_severity)
 				break
+
+/datum/event/wallrot/fungus
+
+/datum/event/wallrot/fungus/is_valid_candidate(turf/T)
+	return istype(get_area(T), /area/maintenance)
+
+/datum/event/wallrot/fungus/apply_to_turf(turf/T)
+	new /obj/effect/decal/cleanable/fungus(T)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds a new mundane event, Fungus Growth, which causes fungus tiles to grow on maintenance tiles. 

Fungus is also now re-harvestable after some time (between 5-10 minutes).
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Spacecillin is now more useful than ever with germs and infections becoming more prevalent (hello, burn wounds), but most chemists won't be producing it since fungus is pretty uncommon. This adds a little bit of life to maintenance (maybe there's some new fungus popping up), while also making it a bit more consistent to get -- assuming, of course, the event rolls. It also allows you to farm the fungus that does currently exist, though you'll have to know the spots where it spawns on maps to do so effectively.
Of course, if it pops up in unsightly spots, it can be cleaned off with soap or other common cleaning tools.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Triggered the event, spawned some fungus among us. Scooped it off, examined it.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
add: A new event, "Fungal Growth", which causes space fungus to randomly pop up in maintenance.
tweak: Space fungus now regrows some time after being scooped up.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
