### PR TITLE
lavaland sliding puzzles now spawn normal mining chests

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -70,17 +70,6 @@
 			new /obj/item/borg/upgrade/modkit/lifesteal(src)
 			new /obj/item/bedsheet/cult(src)
 
-/obj/structure/closet/crate/necropolis/puzzle
-	name = "puzzling chest"
-
-/obj/structure/closet/crate/necropolis/puzzle/populate_contents()
-	var/loot = rand(1,2)
-	switch(loot)
-		if(1)
-			new /obj/item/soulstone/anybody(src)
-		if(2)
-			new /obj/item/wisp_lantern(src)
-
 //KA modkit design discs
 /obj/item/disk/design_disk/modkit_disk
 	name = "\improper KA mod disk"

--- a/code/modules/ruins/lavalandruin_code/puzzle.dm
+++ b/code/modules/ruins/lavalandruin_code/puzzle.dm
@@ -254,7 +254,7 @@
 
 //Ruin version
 /obj/effect/sliding_puzzle/lavaland
-	reward_type = /obj/structure/closet/crate/necropolis/puzzle
+	reward_type = /obj/structure/closet/crate/necropolis
 
 /obj/effect/sliding_puzzle/lavaland/dispense_reward()
 	if(prob(25))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
lavaland sliding puzzles now spawn normal mining chests instead of a whisp lanter or soulstone

## Why It's Good For The Game
Right now this is the chest you get if you complete the sliding puzzle
```
/obj/structure/closet/crate/necropolis/puzzle/populate_contents()
    var/loot = rand(1,2)
    switch(loot)
        if(1)
            new /obj/item/soulstone/anybody(src)
        if(2)
            new /obj/item/wisp_lantern(src)
```
50/50 chance between literal thermals and a soulstone, a rather useless item for a miner. Just give them a varied pool rather than this


## Testing
I'm not doing a sliding puzzle, it compiled 

## Changelog
:cl:
tweak: lavaland sliding puzzles now spawn normal mining chests instead of a whisp lanter or soulstone
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
