### PR TITLE
morphs no longer get sent to nullspace

### DIFF
--- a/code/game/gamemodes/miniantags/morph/spells/pass_airlock.dm
+++ b/code/game/gamemodes/miniantags/morph/spells/pass_airlock.dm
@@ -42,6 +42,8 @@
 			to_chat(user, "<span class='warning'>You need to stay still to pass through [A]!</span>")
 		revert_cast(user)
 		return
+	if(QDELETED(A))
+		return
 
 	user.visible_message("<span class='warning'>[user] briefly opens [A] slightly and passes through!</span>", "<span class='sinister'>You slide through the open crack in [A].</span>")
 	user.forceMove(A.loc) // Move into the turf of the airlock


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
fixes #21936 

## Why It's Good For The Game
Morphs shouldn't get sent to nullspace

## Testing
passed a deleted airlock, did not get sent to nullspace

## Changelog
:cl:
fix: You no longer get nullspaced if you try and pass through a deleted airlock as a morph
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
