### PR TITLE
No more accidental put baton on table/in backpack

### DIFF
--- a/code/game/objects/items/weapons/storage/storage_base.dm
+++ b/code/game/objects/items/weapons/storage/storage_base.dm
@@ -533,6 +533,8 @@
 		var/obj/item/hand_labeler/labeler = I
 		if(labeler.mode)
 			return FALSE
+	if(user.a_intent != INTENT_HELP && !isliving(loc)) // Stops you from putting your baton in the storage on accident
+		return FALSE
 	. = TRUE //no afterattack
 	if(isrobot(user))
 		return //Robots can't interact with storage items.

--- a/code/game/objects/items/weapons/storage/storage_base.dm
+++ b/code/game/objects/items/weapons/storage/storage_base.dm
@@ -533,7 +533,7 @@
 		var/obj/item/hand_labeler/labeler = I
 		if(labeler.mode)
 			return FALSE
-	if(user.a_intent != INTENT_HELP && !isliving(loc)) // Stops you from putting your baton in the storage on accident
+	if(user.a_intent != INTENT_HELP && issimulatedturf(loc)) // Stops you from putting your baton in the storage on accident
 		return FALSE
 	. = TRUE //no afterattack
 	if(isrobot(user))

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -225,7 +225,7 @@
 	if(isrobot(user))
 		return
 
-	if(user.a_intent != INTENT_HARM && !(I.flags & ABSTRACT))
+	if(user.a_intent == INTENT_HELP && !(I.flags & ABSTRACT))
 		if(user.drop_item())
 			I.Move(loc)
 			var/list/click_params = params2list(params)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
This PR:
1: Changes putting items on the table logic. Now you will only put item on the table if your intent is HELP.
2: Changes putting items in storage items(such as backpacks). If its location is something living(like you), it will work like it works right now, any intent. If its location is something else(like floor), you will only put items in it on HELP intent. 

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
This logic already works with closets and its fine. There is a reason why your intent is not harm and you still not want to put your weapon on the table.
This logic already works with lockers and crates and i see no reason for other storage items and objects not work like that.
There is a lot of reasons you want to keep not harm intent and still not put item on the table / in the backpack

## Testing
<!-- How did you test the PR, if at all? -->
Compiled, tried putting items in backpack / on the table in various situations.

## Changelog
:cl:
tweak: You will only put items on the table with help intent now.
tweak: You will only put items in the backpack(or other storage item) with help intent if the backpack is on the floor(table, closet).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
