### PR TITLE
Fixes blumpkin juicing

### DIFF
--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -70,8 +70,8 @@
 		/obj/item/reagent_containers/food/snacks/grown/watermelon = list("watermelonjuice" = 0),
 		/obj/item/reagent_containers/food/snacks/watermelonslice = list("watermelonjuice" = 0),
 		/obj/item/reagent_containers/food/snacks/grown/berries/poison = list("poisonberryjuice" = 0),
+		/obj/item/reagent_containers/food/snacks/grown/pumpkin/blumpkin = list("blumpkinjuice" = 0), //order is important here as blumpkin is a subtype of pumpkin, if switched blumpkins will produce pumpkin juice
 		/obj/item/reagent_containers/food/snacks/grown/pumpkin = list("pumpkinjuice" = 0),
-		/obj/item/reagent_containers/food/snacks/grown/pumpkin/blumpkin = list("blumpkinjuice" = 0),
 		/obj/item/reagent_containers/food/snacks/grown/apple = list("applejuice" = 0),
 		/obj/item/reagent_containers/food/snacks/grown/grapes = list("grapejuice" = 0),
 		/obj/item/reagent_containers/food/snacks/grown/grapes/green = list("grapejuice" = 0),

--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -74,7 +74,6 @@
 		/obj/item/reagent_containers/food/snacks/grown/pumpkin = list("pumpkinjuice" = 0),
 		/obj/item/reagent_containers/food/snacks/grown/apple = list("applejuice" = 0),
 		/obj/item/reagent_containers/food/snacks/grown/grapes = list("grapejuice" = 0),
-		/obj/item/reagent_containers/food/snacks/grown/grapes/green = list("grapejuice" = 0),
 		/obj/item/reagent_containers/food/snacks/grown/pineapple = list("pineapplejuice" = 0)
 	)
 


### PR DESCRIPTION
## What Does This PR Do
Fixes #20841 where juicing a blumpkin produces pumpkin juice instead of blumpkin juice.

## Why It's Good For The Game
Juicing one type of fruit/vegetable should not produce juice from another fruit/vegetable.

## Testing
Juiced a blumpkin and checked the contents of the container.

## Changelog
:cl:
fix: blumpkins now produce the right juice when juiced in a grinder
/:cl:
