### PR TITLE
Thermite tweak

### DIFF
--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -3,8 +3,6 @@
 	name = "station"
 	var/wet = 0
 	var/image/wet_overlay = null
-
-	var/thermite = 0
 	oxygen = MOLES_O2STANDARD
 	nitrogen = MOLES_N2STANDARD
 	var/to_be_destroyed = 0 //Used for fire, if a melting temperature was reached, it will be destroyed

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -18,7 +18,7 @@
 	var/damage_cap = 100 //Wall will break down to girders if damage reaches this point
 
 	var/global/damage_overlays[8]
-	var/melting = FALSE
+	var/melting = FALSE //TRUE if wall is currently being melted with thermite
 
 	opacity = TRUE
 	density = TRUE
@@ -278,9 +278,7 @@
 		return
 
 	melting = TRUE
-	while(TRUE)
-		if(!reagents.get_reagent_amount("thermite"))
-			break
+	while(reagents.get_reagent_amount("thermite") > 0)
 		reagents.remove_reagent("thermite", 5)
 		if(damage_cap - damage <= 30)
 			burn_down()

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -294,7 +294,8 @@
 		sleep(1 SECONDS)
 	if(iswallturf(src))
 		melting = FALSE
-	if(O)	qdel(O)
+	if(O)
+		qdel(O)
 	return
 
 //Interactions

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -18,6 +18,7 @@
 	var/damage_cap = 100 //Wall will break down to girders if damage reaches this point
 
 	var/global/damage_overlays[8]
+	var/melting = FALSE
 
 	opacity = TRUE
 	density = TRUE
@@ -246,9 +247,8 @@
 	ChangeTurf(/turf/simulated/floor)
 
 /turf/simulated/wall/proc/thermitemelt(mob/user as mob, speed)
-	var/wait = 20 SECONDS
-	if(speed)
-		wait = speed
+	if(melting)
+		return
 	if(istype(sheet_type, /obj/item/stack/sheet/mineral/diamond))
 		return
 
@@ -261,16 +261,40 @@
 	O.density = TRUE
 	O.layer = 5
 
-	src.ChangeTurf(/turf/simulated/floor/plating)
-
-	var/turf/simulated/floor/F = src
-	F.burn_tile()
-	F.icon_state = "plating"
 	if(user)
 		to_chat(user, "<span class='warning'>The thermite starts melting through the wall.</span>")
 
-	spawn(wait)
+	if(speed)
+		melting = TRUE
+		while(speed > 0)
+			playsound(src, 'sound/items/welder.ogg', 100, TRUE)
+			speed = max(0, speed - 1 SECONDS)
+			sleep(1)
+		burn_down()
+		var/turf/simulated/floor/F = src
+		F.burn_tile()
+		F.icon_state = "plating"
 		if(O)	qdel(O)
+		return
+
+	melting = TRUE
+	while(TRUE)
+		if(!reagents.get_reagent_amount("thermite"))
+			break
+		reagents.remove_reagent("thermite", 5)
+		if(damage_cap - damage <= 30)
+			burn_down()
+
+			var/turf/simulated/floor/F = src
+			F.burn_tile()
+			F.icon_state = "plating"
+			break
+		take_damage(30)
+		playsound(src, 'sound/items/welder.ogg', 100, TRUE)
+		sleep(1 SECONDS)
+	if(iswallturf(src))
+		melting = FALSE
+	if(O)	qdel(O)
 	return
 
 //Interactions
@@ -345,7 +369,7 @@
 
 /turf/simulated/wall/welder_act(mob/user, obj/item/I)
 	. = TRUE
-	if(thermite && I.use_tool(src, user, volume = I.tool_volume))
+	if(reagents.get_reagent_amount("thermite") && I.use_tool(src, user, volume = I.tool_volume))
 		thermitemelt(user)
 		return
 	if(rotting)

--- a/code/game/turfs/simulated/walls_reinforced.dm
+++ b/code/game/turfs/simulated/walls_reinforced.dm
@@ -73,7 +73,7 @@
 		return ..()
 
 /turf/simulated/wall/r_wall/welder_act(mob/user, obj/item/I)
-	if(thermite && I.use_tool(src, user, volume = I.tool_volume))
+	if(reagents.get_reagent_amount("thermite") && I.use_tool(src, user, volume = I.tool_volume))
 		thermitemelt(user)
 		return TRUE
 	if(!(d_state in list(RWALL_COVER, RWALL_SUPPORT_RODS, RWALL_CUT_COVER)))

--- a/code/modules/reagents/chemistry/reagents/pyrotechnic.dm
+++ b/code/modules/reagents/chemistry/reagents/pyrotechnic.dm
@@ -209,7 +209,6 @@
 		if(!S.reagents)
 			S.create_reagents(volume)
 		S.reagents.add_reagent("thermite", volume)
-		S.thermite = TRUE
 		if(S.active_hotspot)
 			S.reagents.temperature_reagents(S.active_hotspot.temperature, 10, 300)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
This PR changes thermite melting logic. Now melting time and melting progress is on thermite volume. Now it uses 100 units to melt r wall and 20 units to melt default wall. Melting r wall is 20 seconds, melting basic wall is 4 seconds.
When you start melting, it doesnt remove the wall, instead it is damaging it every second, making welder sound.

This does not affect T4, it still melts wall in 3 seconds(or whatever its time is)

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
I really dont like the idea of 3chem reagent being able to melt everything in one drop. This PR forces you to at least get MORE thermite to melt r walls, making raiding shit like AI sat harder. 

## Testing
<!-- How did you test the PR, if at all? -->
Compiled, thermitted

## Changelog
:cl:
tweak: Thermite now requires volume to melt walls. 20 units to basic metal wall, 100 units to reinforced wall. Its melting time now is also based on wall type and its health. Every second thermite applies 30 damage to a wall and uses 5u of it. Thermite now is also making welding sounds every second instead of melting wall silently.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
