### PR TITLE
Vomit no longer stuns

### DIFF
--- a/code/datums/diseases/advance/symptoms/vomit.dm
+++ b/code/datums/diseases/advance/symptoms/vomit.dm
@@ -103,4 +103,4 @@ Bonus
 	level = 4
 
 /datum/symptom/vomit/projectile/Vomit(mob/living/carbon/M)
-	M.vomit(6,0,1,5,1)
+	M.vomit(6,0,FALSE,5,1)

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -203,12 +203,12 @@
 			return
 		if(teleports < 6)
 			to_chat(M, "<span class='warning'>You feel a bit sick!</span>")
-			M.vomit(lost_nutrition = 15, blood = 0, stun = 0, distance = 0, message = 1)
+			M.vomit(lost_nutrition = 15, blood = 0, should_confuse = FALSE, distance = 0, message = 1)
 			M.Weaken(2 SECONDS)
 		else
 			to_chat(M, "<span class='danger'>You feel really sick!</span>")
 			M.adjustBruteLoss(rand(0, teleports * 2))
-			M.vomit(lost_nutrition = 30, blood = 0, stun = 0, distance = 0, message = 1)
+			M.vomit(lost_nutrition = 30, blood = 0, should_confuse = FALSE, distance = 0, message = 1)
 			M.Weaken(6 SECONDS)
 
 /datum/status_effect/pacifism

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -125,13 +125,13 @@
 		if(blood)
 			if(T)
 				add_splatter_floor(T)
-			if(stun)
+			if(should_confuse)
 				adjustBruteLoss(3)
 		else
 			if(T)
 				T.add_vomit_floor()
 			adjust_nutrition(-lost_nutrition)
-			if(stun)
+			if(should_confuse)
 				adjustToxLoss(-3)
 
 		T = get_step(T, dir)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -94,7 +94,7 @@
 	return FALSE
 
 
-/mob/living/carbon/proc/vomit(lost_nutrition = 10, blood = 0, should_confuse = 1, distance = 0, message = 1)
+/mob/living/carbon/proc/vomit(lost_nutrition = 10, blood = 0, should_confuse = TRUE, distance = 0, message = 1)
 	. = TRUE
 
 	if(stat == DEAD || ismachineperson(src)) // Dead people and IPCs do not vomit particulates

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -94,23 +94,23 @@
 	return FALSE
 
 
-/mob/living/carbon/proc/vomit(lost_nutrition = 10, blood = 0, stun = 1, distance = 0, message = 1)
+/mob/living/carbon/proc/vomit(lost_nutrition = 10, blood = 0, should_confuse = 1, distance = 0, message = 1)
 	. = TRUE
 
 	if(stat == DEAD || ismachineperson(src)) // Dead people and IPCs do not vomit particulates
 		return FALSE
 
-	if(stun)
+	if(should_confuse)
 		if(blood)
 			KnockDown(10 SECONDS)
 		AdjustConfused(8 SECONDS)
-		Slowed(8 SECONDS)
+		Slowed(8 SECONDS, 1)
 
 	if(!blood && nutrition < 100) // Nutrition vomiting while already starving
 		if(message)
 			visible_message("<span class='warning'>[src] dry heaves!</span>", \
 							"<span class='userdanger'>You try to throw up, but there's nothing in your stomach!</span>")
-		if(stun)
+		if(should_confuse)
 			KnockDown(20 SECONDS)
 			AdjustConfused(20 SECONDS)
 		return

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -101,14 +101,16 @@
 		return FALSE
 
 	if(stun)
-		Stun(8 SECONDS)
+		AdjustConfused(8 SECONDS)
+		Slowed(8 SECONDS)
 
 	if(!blood && nutrition < 100) // Nutrition vomiting while already starving
 		if(message)
 			visible_message("<span class='warning'>[src] dry heaves!</span>", \
 							"<span class='userdanger'>You try to throw up, but there's nothing in your stomach!</span>")
 		if(stun)
-			Weaken(20 SECONDS)
+			KnockDown(20 SECONDS)
+			AdjustConfused(20 SECONDS)
 		return
 
 	if(message)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -101,6 +101,8 @@
 		return FALSE
 
 	if(stun)
+		if(blood)
+			KnockDown(10 SECONDS)
 		AdjustConfused(8 SECONDS)
 		Slowed(8 SECONDS)
 

--- a/code/modules/mob/living/carbon/human/human_life.dm
+++ b/code/modules/mob/living/carbon/human/human_life.dm
@@ -739,7 +739,7 @@
 		if(getToxLoss() >= 45 && nutrition > 20)
 			lastpuke ++
 			if(lastpuke >= 25) // about 25 second delay I guess
-				vomit(20, 0, 1, 0, 1)
+				vomit(20, 0, TRUE, 0, 1)
 				adjustToxLoss(-3)
 				lastpuke = 0
 

--- a/code/modules/reagents/chemistry/reagents/drugs.dm
+++ b/code/modules/reagents/chemistry/reagents/drugs.dm
@@ -262,7 +262,7 @@
 			if(prob(20))
 				if(ishuman(M))
 					var/mob/living/carbon/human/H = M
-					H.vomit(lost_nutrition = 0, blood = TRUE, stun = FALSE)
+					H.vomit(lost_nutrition = 0, blood = TRUE, should_confuse = FALSE)
 				M.KnockDown(1 SECONDS)
 			else
 				update_flags |= M.adjustStaminaLoss(10, FALSE)

--- a/code/modules/reagents/chemistry/reagents/drugs.dm
+++ b/code/modules/reagents/chemistry/reagents/drugs.dm
@@ -586,7 +586,7 @@
 		var/mob/living/carbon/human/H = M
 		H.physiology.stun_mod /= tenacity
 		H.physiology.stamina_mod /= tenacity
-		H.vomit(blood = TRUE, stun = FALSE) // just a visual, very gritty. don't do drugs kids
+		H.vomit(blood = TRUE, should_confuse = FALSE) // just a visual, very gritty. don't do drugs kids
 		H.LoseBreath(10 SECONDS) // procs 5 times, mostly a visual thing. damage could stack to cause a slowdown.
 		H.Confused(10 SECONDS)
 

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -855,7 +855,7 @@
 	if(volume < 20)
 		if(prob(10))
 			to_chat(H, "<span class='warning>You cough up some congealed blood.</span>")
-			H.vomit(blood = TRUE, stun = FALSE) //mostly visual
+			H.vomit(blood = TRUE, should_confuse = FALSE) //mostly visual
 		else if(prob(10))
 			var/overdose_message = pick("Your vision is tinted red for a moment.", "You can hear your heart beating.")
 			to_chat(H, "<span class='warning'>[overdose_message]</span>")
@@ -863,7 +863,7 @@
 		if(prob(10))
 			to_chat(H, "<span class='danger'>You choke on congealed blood!</span>")
 			H.AdjustLoseBreath(2 SECONDS)
-			H.vomit(blood = TRUE, stun = FALSE)
+			H.vomit(blood = TRUE, should_confuse = FALSE)
 		else if(prob(10))
 			var/overdose_message = pick("You're seeing red!", "Your heartbeat thunders in your ears!", "Your veins writhe under your skin!")
 			to_chat(H, "<span class='danger'>[overdose_message]</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
This PR removes stun from vomit proc, instead it confuses and slowdowns you, if its blood vomit(IB), it knockouts you.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Random stuns while two IBs, random stuns while toxin damage is bad.

Having no random stuns is good for me so i think this PR should be fine.

## Testing
<!-- How did you test the PR, if at all? -->
Compiled, got damage

## Changelog
:cl:
tweak: Vomit no longer stuns, instead it makes you Confused and Knockouts you if its vomit from IB.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
