### PR TITLE
Radio Jammer can no longer jam across z-levels

### DIFF
--- a/code/game/objects/items/devices/radio/radio_objects.dm
+++ b/code/game/objects/items/devices/radio/radio_objects.dm
@@ -364,6 +364,8 @@ GLOBAL_LIST_INIT(default_medbay_channels, list(
 	var/turf/position = get_turf(src)
 	for(var/J in GLOB.active_jammers)
 		var/obj/item/jammer/jammer = J
+		if(position.z != jammer.z)
+			break
 		if(get_dist(position, get_turf(jammer)) < jammer.range)
 			jammed = TRUE
 			break

--- a/code/game/objects/items/devices/radio/radio_objects.dm
+++ b/code/game/objects/items/devices/radio/radio_objects.dm
@@ -364,9 +364,10 @@ GLOBAL_LIST_INIT(default_medbay_channels, list(
 	var/turf/position = get_turf(src)
 	for(var/J in GLOB.active_jammers)
 		var/obj/item/jammer/jammer = J
-		if(position.z != jammer.z)
-			break
-		if(get_dist(position, get_turf(jammer)) < jammer.range)
+		var/position_jammer = get_turf(jammer)
+		if(!atoms_share_level(position, position_jammer))
+			continue
+		if(get_dist(position, position_jammer) < jammer.range)
 			jammed = TRUE
 			break
 


### PR DESCRIPTION
## What Does This PR Do
This fixes the radio jammer and stops it from being able to jam across z-levels.

## Why It's Good For The Game
This makes the jammer work as intended.

## Testing
Created an active jammer at the x,y coordinates of the bridge on a different z-level.
Tested radio on the bridge to see if comms were still jammed.

## Changelog
:cl:
fix: Fixed jammer's ability to jam comms across z-levels
/:cl: