### PR TITLE
VIP lockers now get more spare gear.

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security_lockers.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security_lockers.dm
@@ -119,7 +119,14 @@
 	icon_opened = "hop_open"
 
 /obj/structure/closet/secure_closet/blueshield/populate_contents()
+	if(prob(50))
+		new /obj/item/storage/backpack/blueshield(src)
+	else
+		new /obj/item/storage/backpack/satchel_blueshield(src)
 	new /obj/item/storage/briefcase(src)
+	new /obj/item/storage/backpack/duffel/blueshield(src)
+	new /obj/item/radio/headset/heads/blueshield/alt(src)
+	new /obj/item/cartridge/hos(src)
 	new	/obj/item/storage/firstaid/adv(src)
 	new /obj/item/pinpointer/crew(src)
 	new /obj/item/flashlight/seclite(src)
@@ -137,6 +144,8 @@
 /obj/structure/closet/secure_closet/ntrep/populate_contents()
 	new /obj/item/book/manual/wiki/faxes(src)
 	new /obj/item/storage/briefcase(src)
+	new /obj/item/radio/headset/heads/ntrep (src)
+	new /obj/item/cartridge/supervisor(src)
 	new /obj/item/paicard(src)
 	new /obj/item/flash(src)
 	new /obj/item/storage/box/tapes(src)
@@ -257,6 +266,7 @@
 	new /obj/item/storage/secure/briefcase(src)
 	new /obj/item/flash(src)
 	new /obj/item/radio/headset/heads/magistrate(src)
+	new /obj/item/cartridge/supervisor(src)
 	new /obj/item/gavelblock(src)
 	new /obj/item/gavelhammer(src)
 	new /obj/item/clothing/accessory/medal/legal(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/security_lockers.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security_lockers.dm
@@ -119,10 +119,8 @@
 	icon_opened = "hop_open"
 
 /obj/structure/closet/secure_closet/blueshield/populate_contents()
-	if(prob(50))
-		new /obj/item/storage/backpack/blueshield(src)
-	else
-		new /obj/item/storage/backpack/satchel_blueshield(src)
+	new /obj/item/storage/backpack/blueshield(src)
+	new /obj/item/storage/backpack/satchel_blueshield(src)
 	new /obj/item/storage/briefcase(src)
 	new /obj/item/storage/backpack/duffel/blueshield(src)
 	new /obj/item/radio/headset/heads/blueshield/alt(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
- NTR's, Blue's and Magi's lockers now start with their PDA cartridges (Easy-Record DELUXE for NTR and Magi, R.O.B.U.S.T. DELUXE for Blue)
- Blue's and NTR's lockers now start with spare headsets, magi had one already apparently
- Blue's locker now starts with his duffel, his backpack and his satchel
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
- Cartridges and headsets - in case you loose your PDA/headset, you should be able to get them back. Currently, you either need to bother another head (HoS for blueshield-level comms and R.O.B.U.S.T. cartridge, captain for NTR-level comms), or can't get a replacement at all (easy-record cartridge)
- Gives blueshield bags, so you can swap between them, for drip.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Spawned in, checked every locker, stuff was there.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Blueshield, NT Representative and Magistrate now have spare PDA cartridges in their lockers.
tweak: Blueshield and NT Representative now have spare headsets in their lockers.
tweak: Blueshield now has a couple backpacks in their locker.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
