### PR TITLE
Allows for easier pulling onto beds and chairs, buckling someone stops anyone currently pulling them.

### DIFF
--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -150,7 +150,7 @@
 			M.visible_message("<span class='warning'>[user] buckles [M] to [src]!</span>",\
 				"<span class='warning'>[user] buckles you to [src]!</span>",\
 				"<span class='italics'>You hear metal clanking.</span>")
-		M.pulledby.stop_pulling()
+		M?.pulledby.stop_pulling()
 
 /atom/movable/proc/user_unbuckle_mob(mob/living/buckled_mob, mob/user)
 	var/mob/living/M = unbuckle_mob(buckled_mob)

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -150,6 +150,7 @@
 			M.visible_message("<span class='warning'>[user] buckles [M] to [src]!</span>",\
 				"<span class='warning'>[user] buckles you to [src]!</span>",\
 				"<span class='italics'>You hear metal clanking.</span>")
+		M.pulledby.stop_pulling()
 
 /atom/movable/proc/user_unbuckle_mob(mob/living/buckled_mob, mob/user)
 	var/mob/living/M = unbuckle_mob(buckled_mob)

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -26,6 +26,11 @@ LINEN BINS
 	var/list/nightmare_messages = list("black")
 	var/comfort = 0.5
 
+/obj/item/bedsheet/attack_hand(mob/user)
+	if(isturf(loc) && user.Move_Pulled(src)) // make sure its on the ground first, prevents a speed exploit
+		return
+	return ..()
+
 /obj/item/bedsheet/attack_self(mob/user as mob)
 	user.drop_item()
 	if(layer == initial(layer))

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -30,6 +30,11 @@
 	. = ..()
 	. += "<span class='notice'>Click dragging someone to a bed will buckle them in. Functions just like a chair except you can walk over them.</span>"
 
+/obj/structure/bed/attack_hand(mob/user)
+	if(user.Move_Pulled(src))
+		return
+	return ..()
+
 /obj/structure/bed/psych
 	name = "psych bed"
 	desc = "For prime comfort during psychiatric evaluations."

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -84,6 +84,11 @@
 		return
 	. = ..()
 
+/obj/structure/chair/attack_hand(mob/user)
+	if(user.Move_Pulled(src))
+		return
+	return ..()
+
 /obj/structure/chair/attack_tk(mob/user as mob)
 	if(!anchored || has_buckled_mobs() || !isturf(user.loc))
 		..()

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -375,7 +375,7 @@
 			M.start_pulling(t)
 	else
 		step(pulling, get_dir(pulling.loc, A))
-	return
+	return TRUE
 
 /mob/proc/update_gravity(has_gravity)
 	return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->Clicking on a bed/bedsheet/chair when pulling something, will pull the person onto the tile. This is similar to clicking turfs around you to move something. If you're not pulling something, it acts normally. Buckling someone down, will also stop anyone currently pulling them, this minimizes "scuffed-ness" when clicking multiple times on a chair. (This doesn't already have any balance implications, since you already can't start pulling or continue pulling someone that is buckled.)

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Makes it easier to click on stuff for quality of life, clicking on tiny pixels around chairs is annoying

## Testing
<!-- How did you test the PR, if at all? -->
Spawned a skrell, clicked on a chair, bed, and bedsheet, the skrell moved on top. I buckled them, and I was no longer pulling them.

## Changelog
:cl:
tweak: Beds, bedsheets, and chairs can now be clicked on to move the thing you're pulling on top of the bed/chair/etc.
fix: Buckling someone will properly end anyone currently pulling them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
