### PR TITLE
Krav Implant for Nuclear Operatives

### DIFF
--- a/code/datums/uplink_items/uplink_nuclear.dm
+++ b/code/datums/uplink_items/uplink_nuclear.dm
@@ -340,14 +340,6 @@
 
 // STEALTHY WEAPONS
 
-/datum/uplink_item/stealthy_weapons/combat_plus
-	name = "Combat Gloves Plus"
-	desc = "Combat gloves with installed nanochips that teach you Krav Maga when worn, great as a cheap backup weapon. Warning, the nanochips will override any other fighting styles such as CQC."
-	reference = "CGP"
-	item = /obj/item/clothing/gloves/color/black/krav_maga/combat
-	cost = 5
-	uplinktypes = list(UPLINK_TYPE_NUCLEAR, UPLINK_TYPE_SST)
-
 // EXPLOSIVES
 
 /datum/uplink_item/explosives/c4bag
@@ -516,6 +508,14 @@
 	uplinktypes = list(UPLINK_TYPE_NUCLEAR, UPLINK_TYPE_SST)
 
 // IMPLANTS
+
+/datum/uplink_item/implants/krav_implant
+	name = "Krav Maga Implant"
+	desc = "A biochip that teach you Krav Maga when implanted, great as a cheap backup weapon. Warning, the biochip will override any other fighting styles such as CQC."
+	reference = "KMI"
+	item = /obj/item/implanter/krav_maga
+	cost = 5
+	uplinktypes = list(UPLINK_TYPE_NUCLEAR, UPLINK_TYPE_SST)
 
 /datum/uplink_item/implants/uplink/nuclear
 	name = "Nuclear Uplink Bio-chip"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds the Krav Maga implant to the Nuclear Uplink.

It retains the `5TC` cost.

## Why It's Good For The Game
Once MOD Suits are in, the Combat Gloves Plus become VERY useless. This makes it so you can still go Krav Maga if you wish while in a MOD Suit.

## Testing
1. Beat the shit out of some skrell.
2. Load the game.
3. Spawn in Nuclear Uplink.
4. Get Krav Implanter from the Uplink.
5. Beat the shit out of some skrell.

## Changelog
:cl:
tweak: Changes the Combat Gloves Plus to a Krav Implanter for the Nuclear Uplink.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
