### PR TITLE
Fix two typos.

### DIFF
--- a/code/controllers/subsystem/SSjobs.dm
+++ b/code/controllers/subsystem/SSjobs.dm
@@ -534,6 +534,7 @@ SUBSYSTEM_DEF(jobs)
 		// Key: name | Value: Amount
 		var/datum/job/J = GetJob(job)
 		if(!J)
+			stack_trace("`[job]` not found while setting max slots. Check for misspellings or alternate titles")
 			continue
 		J.total_positions = text2num(joblist[job])
 		J.spawn_positions = text2num(joblist[job])

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/clown.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/clown.dm
@@ -43,7 +43,7 @@
 	mob_biotypes = MOB_ORGANIC
 	response_help = "honks the"
 	speak = list("Honk!")
-	speak_emote = list("sqeaks")
+	speak_emote = list("squeaks")
 	emote_see = list("honks")
 	maxHealth = 100
 	health = 100

--- a/config/example/config.toml
+++ b/config/example/config.toml
@@ -409,7 +409,7 @@ job_slot_amounts = [
 	{name = "Research Director", lowpop = 1, highpop = 1},
 	{name = "Chief Medical Officer", lowpop = 1, highpop = 1},
 	# Engineering
-	{name = "Atmospheric Technician", lowpop = 3, highpop = 4},
+	{name = "Life Support Specialist", lowpop = 3, highpop = 4},
 	{name = "Station Engineer", lowpop = 5, highpop = 6},
 	# Medical
 	{name = "Chemist", lowpop = 2, highpop = 2},
@@ -417,7 +417,7 @@ job_slot_amounts = [
 	{name = "Medical Doctor", lowpop = 5, highpop = 6},
 	{name = "Virologist", lowpop = 1, highpop = 1},
 	# Science
-	{name = "Robotocist", lowpop = 2, highpop = 2},
+	{name = "Roboticist", lowpop = 2, highpop = 2},
 	{name = "Scientist", lowpop = 6, highpop = 7},
 	# Security
 	{name = "Detective", lowpop = 1, highpop = 1},

--- a/config/example/config.toml
+++ b/config/example/config.toml
@@ -423,13 +423,13 @@ job_slot_amounts = [
 	{name = "Detective", lowpop = 1, highpop = 1},
 	{name = "Security Officer", lowpop = 8, highpop = 9},
 	{name = "Warden", lowpop = 1, highpop = 1},
+	{name = "Internal Affairs Agent", lowpop = 2, highpop = 2},
 	# Service
 	{name = "Bartender", lowpop = 1, highpop = 1},
 	{name = "Botanist", lowpop = 2, highpop = 2},
 	{name = "Chaplain", lowpop = 1, highpop = 1},
 	{name = "Chef", lowpop = 1, highpop = 1},
 	{name = "Janitor", lowpop = 1, highpop = 2},
-	{name = "Lawyer", lowpop = 2, highpop = 2},
 	{name = "Librarian", lowpop = 1, highpop = 1},
 	# Cargo/Supply
 	{name = "Quartermaster", lowpop = 1, highpop = 1},


### PR DESCRIPTION
## What Does This PR Do
Fixes a typo in an emote string but more importantly fixes two job map names in the TOML config.

## Why It's Good For The Game
If these names in the TOML config aren't as specified they won't be properly applied to the job datums. Roboticist for obvious reasons and Atmospheric Technician because alt job titles don't work here.