### PR TITLE
Fixes some issues with lava, acid, orbiters, and chameleon projectors

### DIFF
--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -90,14 +90,12 @@
 
 /obj/item/chameleon/proc/eject_all()
 	for(var/atom/movable/A in active_dummy)
-		A.loc = active_dummy.loc
-		if(ismob(A))
-			var/mob/M = A
-			M.reset_perspective(null)
+		A.forceMove(active_dummy.loc)
 
 /obj/effect/dummy/chameleon
 	name = ""
 	desc = ""
+	resistance_flags = INDESTRUCTIBLE | FREEZE_PROOF
 	density = FALSE
 	anchored = TRUE
 	var/can_move = TRUE
@@ -111,7 +109,7 @@
 	overlays = new_overlays
 	underlays = new_underlays
 	dir = O.dir
-	M.loc = src
+	M.forceMove(src)
 	master = C
 	master.active_dummy = src
 
@@ -132,6 +130,12 @@
 	master.disrupt()
 
 /obj/effect/dummy/chameleon/attack_alien()
+	master.disrupt()
+
+/obj/effect/dummy/chameleon/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume, global_overlay)
+	master.disrupt() // things like plasmafires, lava, bonfires will disrupt it
+
+/obj/effect/dummy/chameleon/acid_act()
 	master.disrupt()
 
 /obj/effect/dummy/chameleon/ex_act(severity) //no longer bomb-proof
@@ -197,7 +201,7 @@
 	disrupt(user)
 
 /obj/item/borg_chameleon/attack_self(mob/living/silicon/robot/syndicate/saboteur/user)
-	if(user && user.cell && user.cell.charge >  activationCost)
+	if(user && user.cell && user.cell.charge > activationCost)
 		if(isturf(user.loc))
 			toggle(user)
 		else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->Fixes #12006 (it responds to both lava, fire, and acid now). Also fixes orbiters failing to follow someone in a chameleon projector when they activate it. (this was an issue with direct loc editing, instead of moving). 

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Bugs are bad, the acid part wasn't explicitly stated in the issue, but I found it also by looking at the resistance flags, since effects are by default, lava, acid, and fire resistant.

## Testing
<!-- How did you test the PR, if at all? -->
Activated the chame projector, ghosts could follow me. The chame projector could be disrupted by lava, fire, and acid.

## Changelog
:cl:
fix: Orbiting a chameleon projector user as a ghost should be much more consistent.
fix: Chameleon projectors respond properly to lava, acid, and fire.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
