### PR TITLE
Renames traitor+vampire & traitor+changeling in the code

### DIFF
--- a/code/game/gamemodes/changeling/traitor_chan.dm
+++ b/code/game/gamemodes/changeling/traitor_chan.dm
@@ -1,5 +1,5 @@
 /datum/game_mode/traitor/changeling
-	name = "traitor+changeling"
+	name = "traitor_changeling"
 	config_tag = "traitorchan"
 	traitors_possible = 3 //hard limit on traitors if scaling is turned off
 	restricted_jobs = list("Cyborg")

--- a/code/game/gamemodes/vampire/traitor_vamp.dm
+++ b/code/game/gamemodes/vampire/traitor_vamp.dm
@@ -1,5 +1,5 @@
 /datum/game_mode/traitor/vampire
-	name = "traitor+vampire"
+	name = "traitor_vampire"
 	config_tag = "traitorvamp"
 	traitors_possible = 3 //hard limit on traitors if scaling is turned off
 	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Blueshield", "Nanotrasen Representative", "Magistrate", "Internal Affairs Agent", "Nanotrasen Navy Officer", "Special Operations Officer", "Solar Federation General")


### PR DESCRIPTION
## What Does This PR Do
Renames traitor+changeling & traitor+vampire in the code, so that they log in the database as `traitor_changeling` and `traitor_vampire` instead.

## Why It's Good For The Game
If we for example wanted to make an API to query a gamemode based on the gamemode's name, having a + in the gamemode name is bad practice, as + is interpreted as a space (see [here](https://en.wikipedia.org/wiki/Query_string)) and you'd need some special snowflake code to handle this, which isn't ideal.

I can write a script to update local DB's if wanted, though I don't think anybody uses this and Affected has agreed to just update it manually for the live server. You can update your DB using the following SQL:

UPDATE round SET game_mode='traitor_changeling' WHERE game_mode='traitor+changeling';
UPDATE round SET game_mode='traitor_vampire' WHERE game_mode='traitor+vampire';

## Testing
I renamed and tested if it logs correctly locally.