### PR TITLE
Buffs Rod of Asclepius

### DIFF
--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -287,8 +287,8 @@
 	if(ishuman(owner))
 		var/mob/living/carbon/human/H = owner
 		if(H.getBruteLoss() || H.getFireLoss() || H.getOxyLoss() || H.getToxLoss() || H.getBrainLoss() || H.getStaminaLoss() || H.getCloneLoss()) // Avoid counting burn wounds
-			H.adjustBruteLoss(-1.5)
-			H.adjustFireLoss(-1.5)
+			H.adjustBruteLoss(-1.5, robotic = TRUE)
+			H.adjustFireLoss(-1.5, robotic = TRUE)
 			H.adjustOxyLoss(-1.5)
 			H.adjustToxLoss(-1.5)
 			H.adjustBrainLoss(-1.5)

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -344,7 +344,7 @@
 			heal_points--
 	else if(isanimal(L))
 		var/mob/living/simple_animal/SM = L
-		if(SM.getBruteLoss()) // Scuffed; there's no `.getHealth()` for simple animals, they just use bruteloss
+		if(SM.health != SM.maxHealth)
 			SM.adjustHealth(-3.5)
 			force_particle = TRUE
 			if(prob(50)) // Animals are simpler

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -311,25 +311,9 @@
 	var/force_particle = FALSE
 
 	if(ishuman(L))
-		var/mob/living/carbon/human/H = L
-		if(H.getBruteLoss() || H.getFireLoss() || H.getOxyLoss() || H.getToxLoss() || H.getBrainLoss() || H.getStaminaLoss() || H.getCloneLoss()) // Avoid counting burn wounds
-			H.adjustBruteLoss(-3.5, robotic = TRUE)
-			H.adjustFireLoss(-3.5, robotic = TRUE)
-			H.adjustOxyLoss(-3.5)
-			H.adjustToxLoss(-3.5)
-			H.adjustBrainLoss(-3.5)
-			H.adjustStaminaLoss(-3.5)
-			H.adjustCloneLoss(-1)
-			heal_points--
-
-		for(var/obj/item/organ/external/E in H.bodyparts)
-			if(prob(10) && (E.status & (ORGAN_BROKEN | ORGAN_INT_BLEEDING | ORGAN_BURNT)) && !E.is_robotic())
-				E.mend_fracture()
-				E.fix_internal_bleeding()
-				E.fix_burn_wound()
-				heal_points--
+		heal_human(L)
 	else if(iscarbon(L))
-		if(L.health < L.maxHealth || L.getStaminaLoss()) // Carbons have no burn wounds nor brain damage
+		if(L.health < L.maxHealth || L.getStaminaLoss()) // Carbons have no burn wounds to worry about nor brain damage to heal
 			L.adjustBruteLoss(-3.5)
 			L.adjustFireLoss(-3.5)
 			L.adjustOxyLoss(-3.5)
@@ -352,6 +336,28 @@
 
 	if(starting_points < heal_points || force_particle)
 		new /obj/effect/temp_visual/heal(get_turf(L), COLOR_HEALING_GREEN)
+
+/datum/status_effect/hippocraticOath/proc/heal_human(mob/living/carbon/human/H)
+	if(H.getBruteLoss() || H.getFireLoss() || H.getOxyLoss() || H.getToxLoss() || H.getBrainLoss() || H.getStaminaLoss() || H.getCloneLoss()) // Avoid counting burn wounds
+		H.adjustBruteLoss(-3.5, robotic = TRUE)
+		H.adjustFireLoss(-3.5, robotic = TRUE)
+		H.adjustOxyLoss(-3.5)
+		H.adjustToxLoss(-3.5)
+		H.adjustBrainLoss(-3.5)
+		H.adjustStaminaLoss(-3.5)
+		H.adjustCloneLoss(-1)
+		heal_points--
+		if(!heal_points)
+			return
+
+	for(var/obj/item/organ/external/E in H.bodyparts)
+		if(prob(10) && (E.status & (ORGAN_BROKEN | ORGAN_INT_BLEEDING | ORGAN_BURNT)) && !E.is_robotic())
+			E.mend_fracture()
+			E.fix_internal_bleeding()
+			E.fix_burn_wound()
+			heal_points--
+			if(!heal_points)
+				return
 
 /obj/screen/alert/status_effect/regenerative_core
 	name = "Reinforcing Tendrils"

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -329,7 +329,7 @@
 				E.fix_burn_wound()
 				heal_points--
 	else if(iscarbon(L))
-		if(health != maxHealth || L.getStaminaLoss()) // Carbons have no burn wounds nor brain damage
+		if(L.health != L.maxHealth || L.getStaminaLoss()) // Carbons have no burn wounds nor brain damage
 			L.adjustBruteLoss(-3.5)
 			L.adjustFireLoss(-3.5)
 			L.adjustOxyLoss(-3.5)
@@ -338,7 +338,7 @@
 			L.adjustCloneLoss(-1)
 			heal_points--
 	else if(issilicon(L))
-		if(health != maxHealth)
+		if(L.health != L.maxHealth)
 			L.adjustBruteLoss(-3.5)
 			L.adjustFireLoss(-3.5)
 			heal_points--

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -286,8 +286,7 @@
 	// A servant of medicines stops at nothing to help others, let's give them an additional boost
 	if(ishuman(owner))
 		var/mob/living/carbon/human/H = owner
-
-		if(H.getBruteLoss() || H.getFireLoss() || H.getOxyLoss() || H.getToxLoss() || H.getBrainLoss() || H.getStaminaLoss() || H.getCloneLoss())
+		if(H.getBruteLoss() || H.getFireLoss() || H.getOxyLoss() || H.getToxLoss() || H.getBrainLoss() || H.getStaminaLoss() || H.getCloneLoss()) // Avoid counting burn wounds
 			H.adjustBruteLoss(-1.5)
 			H.adjustFireLoss(-1.5)
 			H.adjustOxyLoss(-1.5)
@@ -313,7 +312,7 @@
 
 	if(ishuman(L))
 		var/mob/living/carbon/human/H = L
-		if(H.getBruteLoss() || H.getFireLoss() || H.getOxyLoss() || H.getToxLoss() || H.getBrainLoss() || H.getStaminaLoss() || H.getCloneLoss())
+		if(H.getBruteLoss() || H.getFireLoss() || H.getOxyLoss() || H.getToxLoss() || H.getBrainLoss() || H.getStaminaLoss() || H.getCloneLoss()) // Avoid counting burn wounds
 			H.adjustBruteLoss(-3.5, robotic = TRUE)
 			H.adjustFireLoss(-3.5, robotic = TRUE)
 			H.adjustOxyLoss(-3.5)

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -330,12 +330,11 @@
 				E.fix_burn_wound()
 				heal_points--
 	else if(iscarbon(L))
-		if(L.getBruteLoss() || L.getFireLoss() || L.getOxyLoss() || L.getToxLoss() || L.getBrainLoss() || L.getStaminaLoss() || L.getCloneLoss())
+		if(health != maxHealth || L.getStaminaLoss()) // Carbons have no burn wounds nor brain damage
 			L.adjustBruteLoss(-3.5)
 			L.adjustFireLoss(-3.5)
 			L.adjustOxyLoss(-3.5)
 			L.adjustToxLoss(-3.5)
-			L.adjustBrainLoss(-3.5)
 			L.adjustStaminaLoss(-3.5)
 			L.adjustCloneLoss(-1)
 			heal_points--

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -299,7 +299,7 @@
 
 	// Regenerate points passively
 	if(heal_points < max_heal_points)
-		heal_points = min(heal_points += 3, max_heal_points)
+		heal_points = min(heal_points + 3, max_heal_points)
 
 	// The main course: heal everyone around you!
 	for(var/mob/living/L in view(7, owner))

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -302,7 +302,7 @@
 
 	// The main course: heal everyone around you!
 	for(var/mob/living/L in view(7, owner))
-		if(heal_points <= 0)
+		if(!heal_points)
 			break
 		heal(L)
 
@@ -350,7 +350,7 @@
 			if(prob(50)) // Animals are simpler
 				heal_points--
 
-	if(starting_points != heal_points || force_particle)
+	if(starting_points < heal_points || force_particle)
 		new /obj/effect/temp_visual/heal(get_turf(L), COLOR_HEALING_GREEN)
 
 /obj/screen/alert/status_effect/regenerative_core

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -293,18 +293,18 @@
 			H.adjustToxLoss(-1.5)
 			H.adjustBrainLoss(-1.5)
 			H.adjustStaminaLoss(-1.5)
-			H.adjustCloneLoss(-0.5) // Because apparently clone damage is the bastion of all health
+			H.adjustCloneLoss(-0.5)
 			new /obj/effect/temp_visual/heal(get_turf(H), COLOR_HEALING_GREEN)
 
 	// Regenerate points passively
 	if(heal_points < max_heal_points)
 		heal_points = min(heal_points + 3, max_heal_points)
 
-	// The main course: heal everyone around you!
+	// The main course: heal everyone around you with the points we just gained!
 	for(var/mob/living/L in view(7, owner))
+		heal(L)
 		if(!heal_points)
 			break
-		heal(L)
 
 /datum/status_effect/hippocraticOath/proc/heal(mob/living/L)
 	var/starting_points = heal_points

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -339,7 +339,7 @@
 			L.adjustCloneLoss(-1)
 			heal_points--
 	else if(issilicon(L))
-		if(L.getBruteLoss() || L.getFireLoss())
+		if(health != maxHealth)
 			L.adjustBruteLoss(-3.5)
 			L.adjustFireLoss(-3.5)
 			heal_points--

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -329,7 +329,7 @@
 				E.fix_burn_wound()
 				heal_points--
 	else if(iscarbon(L))
-		if(L.health != L.maxHealth || L.getStaminaLoss()) // Carbons have no burn wounds nor brain damage
+		if(L.health < L.maxHealth || L.getStaminaLoss()) // Carbons have no burn wounds nor brain damage
 			L.adjustBruteLoss(-3.5)
 			L.adjustFireLoss(-3.5)
 			L.adjustOxyLoss(-3.5)
@@ -338,13 +338,13 @@
 			L.adjustCloneLoss(-1)
 			heal_points--
 	else if(issilicon(L))
-		if(L.health != L.maxHealth)
+		if(L.health < L.maxHealth)
 			L.adjustBruteLoss(-3.5)
 			L.adjustFireLoss(-3.5)
 			heal_points--
 	else if(isanimal(L))
 		var/mob/living/simple_animal/SM = L
-		if(SM.health != SM.maxHealth)
+		if(SM.health < SM.maxHealth)
 			SM.adjustHealth(-3.5)
 			force_particle = TRUE
 			if(prob(50)) // Animals are simpler

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -309,8 +309,7 @@
 		heal(L)
 
 /datum/status_effect/hippocraticOath/proc/heal(mob/living/L)
-	if(L.health < L.maxHealth)
-		new /obj/effect/temp_visual/heal(get_turf(L), COLOR_HEALING_GREEN)
+	var/starting_points = heal_points
 
 	if(iscarbon(L))
 		L.adjustBruteLoss(-3.5)
@@ -339,6 +338,9 @@
 		SM.adjustHealth(-3.5)
 		if(prob(50)) // Animals are simpler
 			heal_points--
+
+	if(starting_points != heal_points)
+		new /obj/effect/temp_visual/heal(get_turf(L), COLOR_HEALING_GREEN)
 
 /obj/screen/alert/status_effect/regenerative_core
 	name = "Reinforcing Tendrils"

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -311,7 +311,25 @@
 /datum/status_effect/hippocraticOath/proc/heal(mob/living/L)
 	var/starting_points = heal_points
 
-	if(iscarbon(L))
+	if(ishuman(L))
+		var/mob/living/carbon/human/H = L
+		if(H.getBruteLoss() || H.getFireLoss() || H.getOxyLoss() || H.getToxLoss() || H.getBrainLoss() || H.getStaminaLoss() || H.getCloneLoss())
+			H.adjustBruteLoss(-3.5, robotic = TRUE)
+			H.adjustFireLoss(-3.5, robotic = TRUE)
+			H.adjustOxyLoss(-3.5)
+			H.adjustToxLoss(-3.5)
+			H.adjustBrainLoss(-3.5)
+			H.adjustStaminaLoss(-3.5)
+			H.adjustCloneLoss(-1)
+			heal_points--
+
+		for(var/obj/item/organ/external/E in H.bodyparts)
+			if(prob(10) && (E.status & (ORGAN_BROKEN | ORGAN_INT_BLEEDING | ORGAN_BURNT)) && !E.is_robotic())
+				E.mend_fracture()
+				E.fix_internal_bleeding()
+				E.fix_burn_wound(update_health = FALSE)
+				heal_points--
+	else if(iscarbon(L))
 		if(L.getBruteLoss() || L.getFireLoss() || L.getOxyLoss() || L.getToxLoss() || L.getBrainLoss() || L.getStaminaLoss() || L.getCloneLoss())
 			L.adjustBruteLoss(-3.5)
 			L.adjustFireLoss(-3.5)
@@ -319,17 +337,8 @@
 			L.adjustToxLoss(-3.5)
 			L.adjustBrainLoss(-3.5)
 			L.adjustStaminaLoss(-3.5)
-			L.adjustCloneLoss(-1) // Because apparently clone damage is the bastion of all health
+			L.adjustCloneLoss(-1)
 			heal_points--
-
-		if(ishuman(L))
-			var/mob/living/carbon/human/H = L
-			for(var/obj/item/organ/external/E in H.bodyparts)
-				if(prob(10) && (E.status & (ORGAN_BROKEN | ORGAN_INT_BLEEDING | ORGAN_BURNT)) && !E.is_robotic())
-					E.mend_fracture()
-					E.fix_internal_bleeding()
-					E.fix_burn_wound(update_health = FALSE)
-					heal_points--
 	else if(issilicon(L))
 		if(L.getBruteLoss() || L.getFireLoss())
 			L.adjustBruteLoss(-3.5)
@@ -337,7 +346,7 @@
 			heal_points--
 	else if(isanimal(L))
 		var/mob/living/simple_animal/SM = L
-		if(SM.getBruteLoss()) // Scuffed; there's no `.getHealth()` for simple animals, they just use bruteloss as health
+		if(SM.getBruteLoss()) // Scuffed; there's no `.getHealth()` for simple animals, they just use bruteloss
 			SM.adjustHealth(-3.5)
 			if(prob(50)) // Animals are simpler
 				heal_points--

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -310,6 +310,7 @@
 
 /datum/status_effect/hippocraticOath/proc/heal(mob/living/L)
 	var/starting_points = heal_points
+	var/force_particle = FALSE
 
 	if(ishuman(L))
 		var/mob/living/carbon/human/H = L
@@ -348,10 +349,11 @@
 		var/mob/living/simple_animal/SM = L
 		if(SM.getBruteLoss()) // Scuffed; there's no `.getHealth()` for simple animals, they just use bruteloss
 			SM.adjustHealth(-3.5)
+			force_particle = TRUE
 			if(prob(50)) // Animals are simpler
 				heal_points--
 
-	if(starting_points != heal_points)
+	if(starting_points != heal_points || force_particle)
 		new /obj/effect/temp_visual/heal(get_turf(L), COLOR_HEALING_GREEN)
 
 /obj/screen/alert/status_effect/regenerative_core

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -305,7 +305,6 @@
 	for(var/mob/living/L in view(7, owner))
 		if(heal_points <= 0)
 			break
-
 		heal(L)
 
 /datum/status_effect/hippocraticOath/proc/heal(mob/living/L)

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -265,67 +265,81 @@
 	H.remove_hud_from(owner)
 
 /datum/status_effect/hippocraticOath/tick()
+	// Death transforms you into a snake after a short grace period
 	if(owner.stat == DEAD)
 		if(deathTick < 4)
-			deathTick += 1
-		else
-			owner.visible_message("<span class='notice'>[owner]'s soul is absorbed into the rod, relieving the previous snake of its duty.</span>")
-			var/mob/living/simple_animal/hostile/retaliate/poison/snake/healSnake = new(owner.loc)
-			var/list/chems = list("bicaridine", "perfluorodecalin", "kelotane")
-			healSnake.poison_type = pick(chems)
-			healSnake.name = "Asclepius's Snake"
-			healSnake.real_name = "Asclepius's Snake"
-			healSnake.desc = "A mystical snake previously trapped upon the Rod of Asclepius, now freed of its burden. Unlike the average snake, its bites contain chemicals with minor healing properties."
-			new /obj/effect/decal/cleanable/ash(owner.loc)
-			new /obj/item/rod_of_asclepius(owner.loc)
-			qdel(owner)
-	else
-		if(ishuman(owner))
-			var/mob/living/carbon/human/itemUser = owner
-			//Because a servant of medicines stops at nothing to help others, lets keep them on their toes and give them an additional boost.
-			if(itemUser.health < itemUser.maxHealth)
-				new /obj/effect/temp_visual/heal(get_turf(itemUser), COLOR_HEALING_GREEN)
-			itemUser.adjustBruteLoss(-1.5)
-			itemUser.adjustFireLoss(-1.5)
-			itemUser.adjustToxLoss(-1.5)
-			itemUser.adjustOxyLoss(-1.5)
-			itemUser.adjustStaminaLoss(-1.5)
-			itemUser.adjustBrainLoss(-1.5)
-			itemUser.adjustCloneLoss(-0.5) //Becasue apparently clone damage is the bastion of all health
-		if(heal_points < max_heal_points)
-			heal_points = min(heal_points += 3, max_heal_points)
-		//Heal all those around you, unbiased
-		for(var/mob/living/L in view(7, owner))
-			if(heal_points <= 0)
-				break
-			if(L.health < L.maxHealth)
-				new /obj/effect/temp_visual/heal(get_turf(L), COLOR_HEALING_GREEN)
-			if(iscarbon(L))
-				L.adjustBruteLoss(-3.5)
-				L.adjustFireLoss(-3.5)
-				L.adjustToxLoss(-3.5)
-				L.adjustOxyLoss(-3.5)
-				L.adjustStaminaLoss(-3.5)
-				L.adjustBrainLoss(-3.5)
-				L.adjustCloneLoss(-1) //Becasue apparently clone damage is the bastion of all health
-				heal_points--
-				if(ishuman(L))
-					var/mob/living/carbon/human/H = L
-					for(var/obj/item/organ/external/E in H.bodyparts)
-						if(prob(10))
-							E.mend_fracture()
-							E.fix_internal_bleeding()
-							E.fix_burn_wound(update_health = FALSE)
-							heal_points--
-			else if(issilicon(L))
-				L.adjustBruteLoss(-3.5)
-				L.adjustFireLoss(-3.5)
-				heal_points--
-			else if(isanimal(L))
-				var/mob/living/simple_animal/SM = L
-				SM.adjustHealth(-3.5)
-				if(prob(50))
-					heal_points -- // Animals are simpler
+			deathTick++
+			return
+
+		owner.visible_message("<span class='notice'>[owner]'s soul is absorbed into the rod, relieving the previous snake of its duty.</span>")
+		var/mob/living/simple_animal/hostile/retaliate/poison/snake/healSnake = new(owner.loc)
+		var/list/chems = list("bicaridine", "perfluorodecalin", "kelotane")
+		healSnake.poison_type = pick(chems)
+		healSnake.name = "Asclepius's Snake"
+		healSnake.real_name = "Asclepius's Snake"
+		healSnake.desc = "A mystical snake previously trapped upon the Rod of Asclepius, now freed of its burden. Unlike the average snake, its bites contain chemicals with minor healing properties."
+		new /obj/effect/decal/cleanable/ash(owner.loc)
+		new /obj/item/rod_of_asclepius(owner.loc)
+		qdel(owner)
+		return
+
+	// A servant of medicines stops at nothing to help others, let's give them an additional boost
+	if(ishuman(owner))
+		var/mob/living/carbon/human/H = owner
+
+		if(H.health < H.maxHealth)
+			new /obj/effect/temp_visual/heal(get_turf(H), COLOR_HEALING_GREEN)
+
+		H.adjustBruteLoss(-1.5)
+		H.adjustFireLoss(-1.5)
+		H.adjustToxLoss(-1.5)
+		H.adjustOxyLoss(-1.5)
+		H.adjustStaminaLoss(-1.5)
+		H.adjustBrainLoss(-1.5)
+		H.adjustCloneLoss(-0.5) // Because apparently clone damage is the bastion of all health
+
+	// Regenerate points passively
+	if(heal_points < max_heal_points)
+		heal_points = min(heal_points += 3, max_heal_points)
+
+	// The main course: heal everyone around you!
+	for(var/mob/living/L in view(7, owner))
+		if(heal_points <= 0)
+			break
+
+		heal(L)
+
+/datum/status_effect/hippocraticOath/proc/heal(mob/living/L)
+	if(L.health < L.maxHealth)
+		new /obj/effect/temp_visual/heal(get_turf(L), COLOR_HEALING_GREEN)
+
+	if(iscarbon(L))
+		L.adjustBruteLoss(-3.5)
+		L.adjustFireLoss(-3.5)
+		L.adjustToxLoss(-3.5)
+		L.adjustOxyLoss(-3.5)
+		L.adjustStaminaLoss(-3.5)
+		L.adjustBrainLoss(-3.5)
+		L.adjustCloneLoss(-1) // Because apparently clone damage is the bastion of all health
+		heal_points--
+
+		if(ishuman(L))
+			var/mob/living/carbon/human/H = L
+			for(var/obj/item/organ/external/E in H.bodyparts)
+				if(prob(10))
+					E.mend_fracture()
+					E.fix_internal_bleeding()
+					E.fix_burn_wound(update_health = FALSE)
+					heal_points--
+	else if(issilicon(L))
+		L.adjustBruteLoss(-3.5)
+		L.adjustFireLoss(-3.5)
+		heal_points--
+	else if(isanimal(L))
+		var/mob/living/simple_animal/SM = L
+		SM.adjustHealth(-3.5)
+		if(prob(50)) // Animals are simpler
+			heal_points--
 
 /obj/screen/alert/status_effect/regenerative_core
 	name = "Reinforcing Tendrils"

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -287,16 +287,15 @@
 	if(ishuman(owner))
 		var/mob/living/carbon/human/H = owner
 
-		if(H.health < H.maxHealth)
+		if(H.getBruteLoss() || H.getFireLoss() || H.getOxyLoss() || H.getToxLoss() || H.getBrainLoss() || H.getStaminaLoss() || H.getCloneLoss())
+			H.adjustBruteLoss(-1.5)
+			H.adjustFireLoss(-1.5)
+			H.adjustOxyLoss(-1.5)
+			H.adjustToxLoss(-1.5)
+			H.adjustBrainLoss(-1.5)
+			H.adjustStaminaLoss(-1.5)
+			H.adjustCloneLoss(-0.5) // Because apparently clone damage is the bastion of all health
 			new /obj/effect/temp_visual/heal(get_turf(H), COLOR_HEALING_GREEN)
-
-		H.adjustBruteLoss(-1.5)
-		H.adjustFireLoss(-1.5)
-		H.adjustToxLoss(-1.5)
-		H.adjustOxyLoss(-1.5)
-		H.adjustStaminaLoss(-1.5)
-		H.adjustBrainLoss(-1.5)
-		H.adjustCloneLoss(-0.5) // Because apparently clone damage is the bastion of all health
 
 	// Regenerate points passively
 	if(heal_points < max_heal_points)

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -312,32 +312,35 @@
 	var/starting_points = heal_points
 
 	if(iscarbon(L))
-		L.adjustBruteLoss(-3.5)
-		L.adjustFireLoss(-3.5)
-		L.adjustToxLoss(-3.5)
-		L.adjustOxyLoss(-3.5)
-		L.adjustStaminaLoss(-3.5)
-		L.adjustBrainLoss(-3.5)
-		L.adjustCloneLoss(-1) // Because apparently clone damage is the bastion of all health
-		heal_points--
+		if(L.getBruteLoss() || L.getFireLoss() || L.getOxyLoss() || L.getToxLoss() || L.getBrainLoss() || L.getStaminaLoss() || L.getCloneLoss())
+			L.adjustBruteLoss(-3.5)
+			L.adjustFireLoss(-3.5)
+			L.adjustOxyLoss(-3.5)
+			L.adjustToxLoss(-3.5)
+			L.adjustBrainLoss(-3.5)
+			L.adjustStaminaLoss(-3.5)
+			L.adjustCloneLoss(-1) // Because apparently clone damage is the bastion of all health
+			heal_points--
 
 		if(ishuman(L))
 			var/mob/living/carbon/human/H = L
 			for(var/obj/item/organ/external/E in H.bodyparts)
-				if(prob(10))
+				if(prob(10) && (E.status & (ORGAN_BROKEN | ORGAN_INT_BLEEDING | ORGAN_BURNT)) && !E.is_robotic())
 					E.mend_fracture()
 					E.fix_internal_bleeding()
 					E.fix_burn_wound(update_health = FALSE)
 					heal_points--
 	else if(issilicon(L))
-		L.adjustBruteLoss(-3.5)
-		L.adjustFireLoss(-3.5)
-		heal_points--
+		if(L.getBruteLoss() || L.getFireLoss())
+			L.adjustBruteLoss(-3.5)
+			L.adjustFireLoss(-3.5)
+			heal_points--
 	else if(isanimal(L))
 		var/mob/living/simple_animal/SM = L
-		SM.adjustHealth(-3.5)
-		if(prob(50)) // Animals are simpler
-			heal_points--
+		if(SM.getBruteLoss()) // Scuffed; there's no `.getHealth()` for simple animals, they just use bruteloss as health
+			SM.adjustHealth(-3.5)
+			if(prob(50)) // Animals are simpler
+				heal_points--
 
 	if(starting_points != heal_points)
 		new /obj/effect/temp_visual/heal(get_turf(L), COLOR_HEALING_GREEN)

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -328,7 +328,7 @@
 			if(prob(10) && (E.status & (ORGAN_BROKEN | ORGAN_INT_BLEEDING | ORGAN_BURNT)) && !E.is_robotic())
 				E.mend_fracture()
 				E.fix_internal_bleeding()
-				E.fix_burn_wound(update_health = FALSE)
+				E.fix_burn_wound()
 				heal_points--
 	else if(iscarbon(L))
 		if(L.getBruteLoss() || L.getFireLoss() || L.getOxyLoss() || L.getToxLoss() || L.getBrainLoss() || L.getStaminaLoss() || L.getCloneLoss())


### PR DESCRIPTION
## What Does This PR Do
-​ Makes Rod of Asclepius Hippocratic Oath buff no longer waste heal points on completely healthy targets
-​ Allows the Oath to heal robotic limbs (it could already heal silicons)
-​ Makes the Oath's heal particles more accurate
-​ Refactors and cleans up the Oath's code a bit

## Why It's Good For The Game
The current state of the Rod is pathetic. Only a few seconds after activating it, you've already wasted all of your points trying to heal yourself, remove IBs/fractures/burn wounds from your already perfect condition limbs, and other healthy people nearby. This results in the rod only ever really healing you, *very rarely* leaving enough points for healing anybody else.

The change to allow it to heal robotic limbs is just logical consistency with it healing silicons; don't see a reason why it shouldn't.

## Testing
Spawned in as an IPC, spawned an extra mouse, unathi, cyborg, and alien drone (humanoid, not the simplemob). Activated the Rod of Asclepius, possessed the unathi, grabbed a surgical saw and gave each entity a few whacks. Confirmed the Rod can heal everyone without running out of juice in 2 seconds, and without any runtimes. Confirmed it still eventually runs out of juice if there's too many mobs to treat.

## Changelog
:cl:
tweak: Rod of Asclepius no longer attempts to heal healthy targets, wasting healing points
add: Rod of Asclepius can now heal robotic limbs
fix: Rod of Asclepius's healing particles are now more accurate
/:cl: