### PR TITLE
Fixes #21976 Nonhumans now have red blood again

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -680,8 +680,8 @@
 				var/mob/living/carbon/human/H = src
 				if(H.dna.species.blood_color)
 					existing_trail.color = H.dna.species.blood_color
-				else
-					existing_trail.color = "#A10808"
+			else
+				existing_trail.color = "#A10808"
 
 /mob/living/carbon/human/makeTrail(turf/T)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Fixes nonhumans having white blood instead of red, caused by an accidental tab in the code by https://github.com/ParadiseSS13/Paradise/pull/21863
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Fiixes https://github.com/ParadiseSS13/Paradise/issues/21976
## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
BEFORE
![old blood](https://github.com/ParadiseSS13/Paradise/assets/77684085/1903d68c-f577-4c23-9106-2284bb5a4ed5)

AFTER
![after the fix](https://github.com/ParadiseSS13/Paradise/assets/77684085/f5c3080a-e4fd-4d81-bd05-afc9bd7ddc86)

## Testing
<!-- How did you test the PR, if at all? -->
- Beat Ian multiple times until he bleeds
- Drag him around and notice the trail color
## Changelog
:cl:
fix: Nonhumans now have red blood again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
