### PR TITLE
Bureaucratic error event tweaks

### DIFF
--- a/code/modules/events/bureaucratic_error.dm
+++ b/code/modules/events/bureaucratic_error.dm
@@ -27,7 +27,7 @@
 	var/list/affected_jobs = list() // For logging
 	var/list/jobs = SSjobs.occupations.Copy()
 	var/datum/job/overflow
-	var/overflow_amount = rand(1, 3)
+	var/overflow_amount = pick(1, 2)
 	var/errors = 0
 	while(errors < overflow_amount)
 		var/random_change = pick(-2, -1, 1, 2)

--- a/code/modules/events/bureaucratic_error.dm
+++ b/code/modules/events/bureaucratic_error.dm
@@ -41,4 +41,4 @@
 		errors++
 	log_and_message_admins(affected_jobs.Join(".\n"))
 	for(var/mob/M as anything in GLOB.dead_mob_list)
-		to_chat(M, "<span class='deadsay'><b>Bureaucratic Error:</b> The following job slots have changed: [affected_jobs.Join(", ")].</span>")
+		to_chat(M, "<span class='deadsay'><b>Bureaucratic Error:</b> The following job slots have changed: \n[affected_jobs.Join(",\n ")].</span>")

--- a/code/modules/events/bureaucratic_error.dm
+++ b/code/modules/events/bureaucratic_error.dm
@@ -8,6 +8,7 @@
 		/datum/job/rd,
 		/datum/job/hos,
 		/datum/job/ai,
+		/datum/job/cyborg,
 		/datum/job/captain,
 		/datum/job/hop,
 		/datum/job/nanotrasenrep,
@@ -20,16 +21,16 @@
 	)
 
 /datum/event/bureaucratic_error/announce()
-	GLOB.major_announcement.Announce("A recent bureaucratic error in the Human Resources Department may result in personnel shortages in some departments and redundant staffing in others.", "Paperwork Mishap Alert")
+	GLOB.major_announcement.Announce("A recent bureaucratic error in the Human Resources Department may result in personnel shortages in some departments and redundant staffing in others. Contact your local HoP to solve this issue.", "Paperwork Mishap Alert")
 
 /datum/event/bureaucratic_error/start()
 	var/list/affected_jobs = list() // For logging
 	var/list/jobs = SSjobs.occupations.Copy()
 	var/datum/job/overflow
-	var/overflow_amount = rand(1, 6)
+	var/overflow_amount = rand(1, 3)
 	var/errors = 0
-	while(errors <= overflow_amount)
-		var/random_change = pick(-1, 1)
+	while(errors < overflow_amount)
+		var/random_change = pick(-2, -1, 1, 2)
 		overflow = pick_n_take(jobs)
 		if(overflow.admin_only)
 			continue

--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -144,7 +144,7 @@ GLOBAL_LIST_EMPTY(event_last_fired)
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Koi School",		/datum/event/carp_migration/koi,		80),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Camera Failure",	/datum/event/camera_failure,		100, list(ASSIGNMENT_ENGINEER = 10)),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Fake Virus",		/datum/event/fake_virus,		50),
-		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Bureaucratic Error",/datum/event/bureaucratic_error,					80, TRUE),
+		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Bureaucratic Error",/datum/event/bureaucratic_error,					40, TRUE),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Disease Outbreak",	/datum/event/disease_outbreak, 			50,		list(ASSIGNMENT_MEDICAL = 25), TRUE)
 	)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
**Tweaks**
Decreased the event weight from 80 to 40.
Number of jobs affected is now 2 (6 -> 2).
Number of job slots affected has been increased by one (+-1 -> +-2).
Added a "Contact your local HoP to solve this issue" line to the event announcement.
Gave some line breaks to the message ghosts receive.

**Fixes**
The number of jobs being affected is now correct (caused by giving the var/error the value of 0 without making the necessary adjustments during the initial PR reviews, thus increasing the limit of affected jobs by one)
Cyborg job has been included into the event blacklist.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
The event weight i initially gave  was too much from what i intended (which is for an event that a player would see once in a while). With this new weight, the chances for it to trigger during the round will be approximately 15%.

Having to deal with fewer jobs with more noticeable changes is easier than a big list with imperceptible changes, thus making life easier for HoPs.


## Testing
<!-- How did you test the PR, if at all? -->
- Triggered the event multiple times and verified the changes.
## Changelog
:cl:
tweak: The bureaucratic error event weight has been decreased
tweak: Bureaucratic error: number of jobs affected (decreased) number of slots affected (increased)
fix: Cyborg job is no longer affected by the bureaucratic error event
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
