### PR TITLE
Alert messages for AdvancedToolUser checks

### DIFF
--- a/code/game/machinery/airlock_control/airlock_controllers.dm
+++ b/code/game/machinery/airlock_control/airlock_controllers.dm
@@ -81,6 +81,7 @@
 
 /obj/machinery/airlock_controller/attack_hand(mob/user)
 	if(!user.IsAdvancedToolUser())
+		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
 		return FALSE
 	ui_interact(user)
 

--- a/code/game/objects/items/weapons/dna_injector.dm
+++ b/code/game/objects/items/weapons/dna_injector.dm
@@ -117,6 +117,7 @@
 		return FALSE
 
 	if(!user.IsAdvancedToolUser())
+		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
 		return FALSE
 
 	var/attack_log = "injected with the Isolated [name]"

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -27,6 +27,7 @@
 
 /obj/item/restraints/handcuffs/attack(mob/living/carbon/C, mob/user)
 	if(!user.IsAdvancedToolUser())
+		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
 		return
 
 	if(!istype(C))


### PR DESCRIPTION
## What Does This PR Do
This adds in some user warning messages when a check is performed on handcuffs, DNA injectors, and airlock controls, if the mob can not use it due to not being an advanced tool user. 
## Why It's Good For The Game
This will alert the players if they can not complete a certain action or use an item due to not being eligible, mostly likely because they are a mob like a monkey. This brings these specific items up to speed with other items that perform the same check and display the same message. 
## Testing
Spawned in and took control of a monkey. 
Tested DNA Injectors, Airlock Controls, and Handcuffs and checked to see if the appropriate error message was displayed.
## Changelog
:cl:
add: Added some warning messages when ineligible to use certain items.
/:cl:
