### PR TITLE
fixes decap chance, makes it more like bone breaks

### DIFF
--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -191,6 +191,12 @@
 		brute *= brute_mod
 		burn *= burn_mod
 
+	//I would move the delimb check below fractures and burn wounds, but it would cause issues. As such we save the incoming damage here.
+	var/original_brute = brute
+	var/original_burn = burn
+	var/limb_brute = brute_dam
+	var/limb_burn = burn_dam
+
 	// See if bones need to break
 	check_fracture(brute)
 	// See if we need to inflict severe burns
@@ -268,9 +274,9 @@
 	//If limb took enough damage, try to cut or tear it off
 	if(owner)
 		if(sharp && !(limb_flags & CANNOT_DISMEMBER))
-			if(brute_dam >= max_damage && prob(brute))
+			if(limb_brute >= max_damage && prob(original_brute / 2))
 				droplimb(0, DROPLIMB_SHARP)
-			if(burn_dam >= max_damage && prob(burn))
+			if(limb_burn >= max_damage && prob(original_burn / 2))
 				droplimb(0, DROPLIMB_BURN)
 
 	if(owner_old)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Partially reverts #21295

Decap chance now uses the original incoming damage values, to avoid spreading strangeness, and can no longer decap on the hit that maxes out the limb damage, similar to bones, to avoid things like the syndicate chainsaw decaping 20% of the time on the second hit.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Doubled decap chance was bad. There was no 50% spread like the author indicated, said 50% spread *only* happens on the hit that maxes out a limb, when the damage left over is equal to half the weapons force. The 3rd esword hit meets that exact threshold, which is why the author was confused, I believe. 

Since we fix the strangeness involving this by checking values earlier, we make it like broken bones, in which the limb must be fully damaged before decaps can happen, to avoid things like having a 20% chance to decap on the second chainsaw hit to the head. Only the 3rd hit onward has a check.
Projectile decaps unaffected.

## Testing
<!-- How did you test the PR, if at all? -->
Smacked skrells with some sharp weapons, exporting the values to chat and making sure they were as expected.


## Changelog
:cl:
fix: Delimb chance is no longer double the intended value.
tweak: Delimbs can not happen on the hit that maxes the limb damage, same as bone breaks.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
