### PR TITLE
Fixes the Timestop spell

### DIFF
--- a/code/datums/spells/conjure.dm
+++ b/code/datums/spells/conjure.dm
@@ -28,7 +28,7 @@
 			targets -= T
 	playsound(get_turf(src), cast_sound, 50, 1)
 
-	if(!delay || do_after(user, delay, target = user))
+	if(delay <= 0 || do_after(user, delay, target = user))
 		for(var/i=0,i<summon_amt,i++)
 			if(!targets.len)
 				break

--- a/code/datums/spells/conjure.dm
+++ b/code/datums/spells/conjure.dm
@@ -28,7 +28,7 @@
 			targets -= T
 	playsound(get_turf(src), cast_sound, 50, 1)
 
-	if(do_after(user, delay, target = user))
+	if(!delay || do_after(user, delay, target = user))
 		for(var/i=0,i<summon_amt,i++)
 			if(!targets.len)
 				break

--- a/code/datums/spells/wizard_spells.dm
+++ b/code/datums/spells/wizard_spells.dm
@@ -225,10 +225,12 @@
 	invocation_type = "shout"
 	cooldown_min = 100
 	summon_amt = 1
+	delay = 0
 	action_icon_state = "time"
 
 	summon_type = list(/obj/effect/timestop/wizard)
 	aoe_range = 0
+
 
 /obj/effect/proc_holder/spell/aoe/conjure/carp
 	name = "Summon Carp"


### PR DESCRIPTION
## What Does This PR Do
Fixes the Timestop spell. It now works every time you cast it, including when stamcritted.

Much credit to QwertyToForty for basically holding my hand through the process.

## Why It's Good For The Game
The Timestop spell is wacky. It randomly refuses to fire and straight up won't work if you're in stamcrit. This should fix that.

## Testing
Loaded in, became wiz, used spell, it works. Shot beepsky, it works even as he beats my ass.

## Changelog
:cl:
fix: Fixed timestop. It now works every time, including when stamina critted.
/:cl: