### PR TITLE
Buffs the Battlemage Armor, deletes Battlemage Armor charges

### DIFF
--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -475,7 +475,7 @@
 //Weapons and Armors
 /datum/spellbook_entry/item/battlemage
 	name = "Battlemage Armor"
-	desc = "An ensorceled spaceproof suit of protective yet light armor, protected by a powerful shield. The shield can completely negate three attacks before needing to recharge."
+	desc = "An ensorceled spaceproof suit of protective yet light armor, protected by a powerful shield. The shield can completely negate 15 attacks before permanently failing."
 	item_path = /obj/item/storage/box/wizard/hardsuit
 	limit = 1
 	category = "Weapons and Armors"

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -475,17 +475,10 @@
 //Weapons and Armors
 /datum/spellbook_entry/item/battlemage
 	name = "Battlemage Armour"
-	desc = "An ensorceled suit of armour, protected by a powerful shield. The shield can completely negate sixteen attacks before being permanently depleted. Despite appearance it is NOT spaceproof."
+	desc = "An ensorceled suit of protective yet light armour, protected by a powerful shield. The shield can completely negate three attacks at a time before needing to recharge. The armor is also spaceproof."
 	item_path = /obj/item/storage/box/wizard/hardsuit
 	limit = 1
 	category = "Weapons and Armors"
-
-/datum/spellbook_entry/item/battlemage_charge
-	name = "Battlemage Armour Charges"
-	desc = "A powerful defensive rune, it will grant eight additional charges to a suit of battlemage armour."
-	item_path = /obj/item/wizard_armour_charge
-	category = "Weapons and Armors"
-	cost = 1
 
 /datum/spellbook_entry/item/mjolnir
 	name = "Mjolnir"

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -474,8 +474,8 @@
 
 //Weapons and Armors
 /datum/spellbook_entry/item/battlemage
-	name = "Battlemage Armour"
-	desc = "An ensorceled suit of protective yet light armour, protected by a powerful shield. The shield can completely negate three attacks at a time before needing to recharge. The armor is also spaceproof."
+	name = "Battlemage Armor"
+	desc = "An ensorceled suit of protective yet light armor, protected by a powerful shield. The shield can completely negate three attacks at a time before needing to recharge. The armor is also spaceproof."
 	item_path = /obj/item/storage/box/wizard/hardsuit
 	limit = 1
 	category = "Weapons and Armors"

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -475,7 +475,7 @@
 //Weapons and Armors
 /datum/spellbook_entry/item/battlemage
 	name = "Battlemage Armor"
-	desc = "An ensorceled suit of protective yet light armor, protected by a powerful shield. The shield can completely negate three attacks at a time before needing to recharge. The armor is also spaceproof."
+	desc = "An ensorceled spaceproof suit of protective yet light armor, protected by a powerful shield. The shield can completely negate three attacks before needing to recharge."
 	item_path = /obj/item/storage/box/wizard/hardsuit
 	limit = 1
 	category = "Weapons and Armors"

--- a/code/modules/clothing/suits/wiz_robe.dm
+++ b/code/modules/clothing/suits/wiz_robe.dm
@@ -189,16 +189,10 @@
 	desc = "Not all wizards are afraid of getting up close and personal."
 	icon_state = "hardsuit-wiz"
 	item_state = "wiz_hardsuit"
-	///How many shields regen per recharge cycle
-	recharge_rate = 1
 	///The amount of charges the suit currently has
-	current_charges = 3
+	current_charges = 15
 	///The max number of charges the suit can hold
-	max_charges = 3
-	///How long between each recharge
-	recharge_cooldown = 5 SECONDS
-	///How long after being hit the shields can begin recharging
-	recharge_delay = 10 SECONDS
+	max_charges = 15
 	shield_state = "shield-red"
 	shield_on = "shield-red"
 	min_cold_protection_temperature = SPACE_SUIT_MIN_TEMP_PROTECT
@@ -212,8 +206,10 @@
 /obj/item/clothing/suit/space/hardsuit/shielded/wizard/arch
 	desc = "For the arch wizard in need of additional protection."
 	recharge_rate = 5
-	recharge_cooldown = 0
+	recharge_cooldown = 0 SECONDS
+	current_charges = 15
 	max_charges = 15
+	recharge_delay = 1 SECONDS
 	min_cold_protection_temperature = SPACE_SUIT_MIN_TEMP_PROTECT
 	max_heat_protection_temperature = SPACE_SUIT_MAX_TEMP_PROTECT
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/shielded/wizard/arch

--- a/code/modules/clothing/suits/wiz_robe.dm
+++ b/code/modules/clothing/suits/wiz_robe.dm
@@ -186,25 +186,27 @@
 
 /obj/item/clothing/suit/space/hardsuit/shielded/wizard
 	name = "battlemage armor"
-	desc = "Not all wizards are afraid of getting up close and personal. Not spaceproof despite its appearance."
+	desc = "Not all wizards are afraid of getting up close and personal. Spaceproof."
 	icon_state = "hardsuit-wiz"
 	item_state = "wiz_hardsuit"
-	recharge_rate = 0
-	current_charges = 15
-	recharge_cooldown = INFINITY
+	recharge_rate = 1
+	current_charges = 3
+	max_charges = 3
+	recharge_cooldown = 50
+	recharge_delay = 100
 	shield_state = "shield-red"
 	shield_on = "shield-red"
-	min_cold_protection_temperature = ARMOR_MIN_TEMP_PROTECT
-	max_heat_protection_temperature = ARMOR_MAX_TEMP_PROTECT
+	min_cold_protection_temperature = SPACE_SUIT_MIN_TEMP_PROTECT
+	max_heat_protection_temperature = SPACE_SUIT_MAX_TEMP_PROTECT
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/shielded/wizard
-	armor = list(MELEE = 20, BULLET = 10, LASER = 10, ENERGY = 10, BOMB = 10, RAD = 10, FIRE = INFINITY, ACID = INFINITY)
+	armor = list(MELEE = 35, BULLET = 50, LASER = 20, ENERGY = 10, BOMB = 25, RAD = 50, FIRE = INFINITY, ACID = INFINITY)
 	slowdown = 0
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	magical = TRUE
 
 /obj/item/clothing/suit/space/hardsuit/shielded/wizard/arch
 	desc = "For the arch wizard in need of additional protection."
-	recharge_rate = 1
+	recharge_rate = 5
 	recharge_cooldown = 0
 	max_charges = 15
 	min_cold_protection_temperature = SPACE_SUIT_MIN_TEMP_PROTECT
@@ -217,9 +219,9 @@
 	icon_state = "hardsuit0-wiz"
 	item_state = "wiz_helm"
 	item_color = "wiz"
-	min_cold_protection_temperature = ARMOR_MIN_TEMP_PROTECT
-	max_heat_protection_temperature = ARMOR_MAX_TEMP_PROTECT
-	armor = list(MELEE = 20, BULLET = 10, LASER = 10, ENERGY = 10, BOMB = 10, RAD = 10, FIRE = INFINITY, ACID = INFINITY)
+	min_cold_protection_temperature = SPACE_SUIT_MIN_TEMP_PROTECT
+	max_heat_protection_temperature = SPACE_SUIT_MAX_TEMP_PROTECT
+	armor = list(MELEE = 35, BULLET = 50, LASER = 20, ENERGY = 10, BOMB = 25, RAD = 50, FIRE = INFINITY, ACID = INFINITY)
 	actions_types = list() //No inbuilt light
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	magical = TRUE
@@ -231,18 +233,3 @@
 	desc = "A truly protective helmet."
 	min_cold_protection_temperature = SPACE_HELM_MIN_TEMP_PROTECT
 	max_heat_protection_temperature = SPACE_HELM_MAX_TEMP_PROTECT
-
-/obj/item/wizard_armour_charge
-	name = "battlemage shield charges"
-	desc = "A powerful rune that will increase the number of hits a suit of battlemage armour can take before failing.."
-	icon = 'icons/effects/effects.dmi'
-	icon_state = "electricity2"
-
-/obj/item/wizard_armour_charge/afterattack(obj/item/clothing/suit/space/hardsuit/shielded/wizard/W, mob/user)
-	. = ..()
-	if(!istype(W))
-		to_chat(user, "<span class='warning'>The rune can only be used on battlemage armour!</span>")
-		return
-	W.current_charges += 8
-	to_chat(user, "<span class='notice'>You charge [W]. It can now absorb [W.current_charges] hits.</span>")
-	qdel(src)

--- a/code/modules/clothing/suits/wiz_robe.dm
+++ b/code/modules/clothing/suits/wiz_robe.dm
@@ -186,7 +186,7 @@
 
 /obj/item/clothing/suit/space/hardsuit/shielded/wizard
 	name = "battlemage armor"
-	desc = "Not all wizards are afraid of getting up close and personal. Spaceproof."
+	desc = "Not all wizards are afraid of getting up close and personal. It is spaceproof."
 	icon_state = "hardsuit-wiz"
 	item_state = "wiz_hardsuit"
 	recharge_rate = 1

--- a/code/modules/clothing/suits/wiz_robe.dm
+++ b/code/modules/clothing/suits/wiz_robe.dm
@@ -186,7 +186,7 @@
 
 /obj/item/clothing/suit/space/hardsuit/shielded/wizard
 	name = "battlemage armor"
-	desc = "Not all wizards are afraid of getting up close and personal. It is spaceproof."
+	desc = "Not all wizards are afraid of getting up close and personal."
 	icon_state = "hardsuit-wiz"
 	item_state = "wiz_hardsuit"
 	recharge_rate = 1

--- a/code/modules/clothing/suits/wiz_robe.dm
+++ b/code/modules/clothing/suits/wiz_robe.dm
@@ -189,10 +189,15 @@
 	desc = "Not all wizards are afraid of getting up close and personal."
 	icon_state = "hardsuit-wiz"
 	item_state = "wiz_hardsuit"
+	///How many shields regen per recharge cycle
 	recharge_rate = 1
+	///How many charges the shields start with
 	current_charges = 3
+	///The max number of charges the suit can hold
 	max_charges = 3
+	///How long between each recharge
 	recharge_cooldown = 5 SECONDS
+	///How long after being hit the shields can begin recharging
 	recharge_delay = 10 SECONDS
 	shield_state = "shield-red"
 	shield_on = "shield-red"

--- a/code/modules/clothing/suits/wiz_robe.dm
+++ b/code/modules/clothing/suits/wiz_robe.dm
@@ -191,7 +191,7 @@
 	item_state = "wiz_hardsuit"
 	///How many shields regen per recharge cycle
 	recharge_rate = 1
-	///How many charges the shields start with
+	///The amount of charges the suit currently has
 	current_charges = 3
 	///The max number of charges the suit can hold
 	max_charges = 3

--- a/code/modules/clothing/suits/wiz_robe.dm
+++ b/code/modules/clothing/suits/wiz_robe.dm
@@ -192,8 +192,8 @@
 	recharge_rate = 1
 	current_charges = 3
 	max_charges = 3
-	recharge_cooldown = 50
-	recharge_delay = 100
+	recharge_cooldown = 5 SECONDS
+	recharge_delay = 10 SECONDS
 	shield_state = "shield-red"
 	shield_on = "shield-red"
 	min_cold_protection_temperature = SPACE_SUIT_MIN_TEMP_PROTECT


### PR DESCRIPTION
## What Does This PR Do
Greatly improves Battlemage Armor, giving it Syndicate Hardsuit grade armor with a recharging shield, along with spaceproofing. 

EDIT: At the behest of the voices in my head and on the balance team, the shields no longer recharge and return to 15 charges. Armor and spaceproofing remain.

Also buffs Archmage Armor with an extremely rapid recharging shield for admeme use.

Removes the armor charges since they're still worthless and will never return or be loved.

## Why It's Good For The Game
Battlemage armor sucks. You get exactly 15 hits before your armor is now utterly worthless as its base armor values are terrible.

The charges to replenish this are also a complete scam and not worth it in the slightest. The suit not even being spaceproof is insult to injury.

Now, it should be a proper set of wizard power armor that makes wizards a good bit less squishy.

## Testing
Loaded in, donned battlemage armor. Jaunted to space, was fine. Let turrets shoot me before jaunting away, shield broke after 15 hits and never recharges.

## Changelog
:cl:
tweak: Buffed Battlemage Armor, increasing armor values and adding spaceproofing.
del: Deleted Battlemage Armor charges
/:cl: