### PR TITLE
Buffs cryogenic anomalies

### DIFF
--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -378,6 +378,9 @@
 	for(var/turf/T in oview(get_turf(src), 7))
 		turf_targets += T
 
+	for(var/mob/living/carbon/human/H in view(get_turf(src), 3))
+		shootAt(H)
+
 	for(var/I in 1 to rand(1, 3))
 		var/turf/target = pick(turf_targets)
 		shootAt(target)
@@ -404,6 +407,8 @@
 		return
 	var/obj/item/projectile/temp/basilisk/O = new /obj/item/projectile/temp/basilisk(T)
 	playsound(get_turf(src), 'sound/weapons/taser2.ogg', 75, TRUE)
+	O.original = target
+	O.stun = 0.5 SECONDS
 	O.current = T
 	O.yo = U.y - T.y
 	O.xo = U.x - T.x

--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -407,8 +407,9 @@
 		return
 	var/obj/item/projectile/temp/basilisk/O = new /obj/item/projectile/temp/basilisk(T)
 	playsound(get_turf(src), 'sound/weapons/taser2.ogg', 75, TRUE)
+	if(drops_core)
+		O.stun = 0.5 SECONDS
 	O.original = target
-	O.stun = 0.5 SECONDS
 	O.current = T
 	O.yo = U.y - T.y
 	O.xo = U.x - T.x


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Title. Cryogenic anomalies now shoot at people who are close to them directly in addition to shooting at random angles around them. Their projectiles now also stun you for half a second, making you drop what's in your hand and freeze in place for a moment.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Cryogenic anomalies are pretty weak if you wear internals. This'll add at least a little threat to approaching one without appropriate cold protection.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Loaded in and got frozen by an anomaly
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Cryogenic anomalies are now more dangerous
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
