### PR TITLE
Debug spawn now returns when you don't give a string to spawn, instead of freezing your game

### DIFF
--- a/code/modules/admin/misc_admin_procs.dm
+++ b/code/modules/admin/misc_admin_procs.dm
@@ -699,6 +699,9 @@ GLOBAL_VAR_INIT(nologevent, 0)
 	if(!check_rights(R_SPAWN))
 		return
 
+	if(!object)
+		return
+
 	var/list/types = typesof(/atom)
 	var/list/matches = new()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
If you press enter while giving no string to look for to spawn, the game would give you a list of every single atom. This can easily freeze your game for 30+ seconds, giving you some good time to think about what you just did.

Also adds logging to the verb.

TODO:
- [x]  Add logging

Edit: it already logged things, but these logs didn't appear in my chat for some reason?
`	log_admin("[key_name(usr)] spawned [chosen] at ([usr.x],[usr.y],[usr.z])")`

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
I don't want to sit in the time-out of shame
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Tried giving no spawn path, didn't break on me
<!-- How did you test the PR, if at all? -->

## Changelog
NPFC

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
