### PR TITLE
Makes brand intelligence less specific

### DIFF
--- a/code/__DEFINES/vending_defines.dm
+++ b/code/__DEFINES/vending_defines.dm
@@ -1,0 +1,8 @@
+// Use these for the different types of vendors
+#define VENDOR_TYPE_GENERIC "general"
+#define VENDOR_TYPE_CLOTHING "clothing"
+#define VENDOR_TYPE_FOOD "food"
+#define VENDOR_TYPE_DRINK "drink"
+#define VENDOR_TYPE_SUPPLIES "supplies"
+#define VENDOR_TYPE_DEPARTMENTAL "departmental"
+#define VENDOR_TYPE_RECREATION "recreation"

--- a/code/game/machinery/vendors/contraband_vendors.dm
+++ b/code/game/machinery/vendors/contraband_vendors.dm
@@ -15,6 +15,7 @@
 	desc = "Smoke 'em if you've got 'em."
 	slogan_list = list("Space cigs taste good like a cigarette should.", "I'd rather toolbox than switch.", "Smoke!", "Don't believe the reports - smoke today!")
 	ads_list = list("Probably not bad for you!", "Don't believe the scientists!", "It's good for you!", "Don't quit, buy more!", "Smoke!", "Nicotine heaven.", "Best cigarettes since 2150.", "Award-winning cigs.")
+	category = VENDOR_TYPE_RECREATION
 	vend_delay = 34
 	icon_state = "cigs"
 	icon_lightmask = "cigs"
@@ -29,6 +30,7 @@
 	icon_lightmask = "nutri"
 	icon_off = "nutri"
 	icon_panel = "thin_vendor"
+	category = VENDOR_TYPE_FOOD
 	products = list(/obj/item/reagent_containers/food/snacks/chips = 6,/obj/item/reagent_containers/food/snacks/sosjerky = 6,
 					/obj/item/reagent_containers/food/snacks/syndicake = 6, /obj/item/reagent_containers/food/snacks/cheesiehonkers = 6)
 
@@ -93,6 +95,7 @@
 	slogan_list = list("Get your cool toys today!", "Trigger a valid hunter today!", "Quality toy weapons for cheap prices!", "Give them to HoPs for all access!", "Give them to HoS to get permabrigged!")
 	ads_list = list("Feel robust with your toys!", "Express your inner child today!", "Toy weapons don't kill people, but valid hunters do!", "Who needs responsibilities when you have toy weapons?", "Make your next murder FUN!")
 	vend_reply = "Come back for more!"
+	category = VENDOR_TYPE_RECREATION
 	products = list(/obj/item/gun/projectile/automatic/toy = 10,
 					/obj/item/gun/projectile/automatic/toy/pistol= 10,
 					/obj/item/gun/projectile/shotgun/toy = 10,

--- a/code/game/machinery/vendors/departmental_vendors.dm
+++ b/code/game/machinery/vendors/departmental_vendors.dm
@@ -4,6 +4,7 @@
 	icon_state = "engivend"
 	icon_deny = "engivend_deny"
 	icon_panel = "generic"
+	category = VENDOR_TYPE_DEPARTMENTAL
 	req_one_access_txt = "11;24" // Engineers and atmos techs can use this
 	products = list(/obj/item/clothing/glasses/meson/engine = 2, /obj/item/multitool = 4, /obj/item/geiger_counter = 5,  /obj/item/airlock_electronics = 10, /obj/item/firelock_electronics = 10, /obj/item/firealarm_electronics = 10, /obj/item/apc_electronics = 10, /obj/item/airalarm_electronics = 10, /obj/item/stock_parts/cell/high = 10, /obj/item/camera_assembly = 10)
 	contraband = list(/obj/item/stock_parts/cell/potato = 3)
@@ -14,6 +15,7 @@
 	desc = "Everything you need for do-it-yourself station repair."
 	icon_state = "engi"
 	icon_deny = "engi_deny"
+	category = VENDOR_TYPE_DEPARTMENTAL
 	req_access_txt = "11"
 	products = list(/obj/item/clothing/under/rank/engineering/chief_engineer = 4, /obj/item/clothing/under/rank/engineering/engineer = 40, /obj/item/clothing/shoes/workboots = 4, /obj/item/clothing/head/hardhat = 4,
 					/obj/item/storage/belt/utility = 4, /obj/item/clothing/glasses/meson/engine = 4,/obj/item/clothing/gloves/color/yellow = 4, /obj/item/screwdriver = 12,
@@ -28,6 +30,7 @@
 	desc = "All the tools you need to create your own robot army."
 	icon_state = "robotics"
 	icon_deny = "robotics_deny"
+	category = VENDOR_TYPE_DEPARTMENTAL
 	icon_lightmask = "robotics"
 	req_access_txt = "29"
 	products = list(/obj/item/clothing/suit/storage/labcoat = 4, /obj/item/clothing/under/rank/rnd/roboticist = 4, /obj/item/stack/cable_coil = 4, /obj/item/flash = 4,
@@ -42,6 +45,7 @@
 	ads_list = list("Mm, food stuffs!","Food and food accessories.","Get your plates!","You like forks?","I like forks.","Woo, utensils.","You don't really need these...")
 	icon_state = "dinnerware"
 	icon_lightmask = "dinnerware"
+	category = VENDOR_TYPE_DEPARTMENTAL
 	products = list(/obj/item/storage/bag/tray = 8,
 					/obj/item/kitchen/utensil/fork = 6,
 					/obj/item/trash/plate = 20,
@@ -75,6 +79,7 @@
 	icon_deny = "nutri_deny"
 	icon_lightmask = "nutri"
 	icon_panel = "thin_vendor"
+	category = VENDOR_TYPE_DEPARTMENTAL
 	products = list(/obj/item/reagent_containers/glass/bottle/nutrient/ez = 20, /obj/item/reagent_containers/glass/bottle/nutrient/l4z = 13, /obj/item/reagent_containers/glass/bottle/nutrient/rh = 6, /obj/item/reagent_containers/spray/pestspray = 20,
 					/obj/item/reagent_containers/syringe = 5, /obj/item/storage/bag/plants = 5, /obj/item/cultivator = 3, /obj/item/shovel/spade = 3, /obj/item/plant_analyzer = 4)
 	contraband = list(/obj/item/reagent_containers/glass/bottle/ammonia = 10, /obj/item/reagent_containers/glass/bottle/diethylamine = 5)
@@ -88,6 +93,7 @@
 	icon_state = "seeds"
 	icon_lightmask = "seeds"
 	icon_panel = "thin_vendor"
+	category = VENDOR_TYPE_DEPARTMENTAL
 	products = list(/obj/item/seeds/aloe = 3,
 					/obj/item/seeds/ambrosia = 3,
 					/obj/item/seeds/apple = 3,
@@ -152,6 +158,7 @@
 	icon_panel = "wide_vendor"
 	ads_list = list("Go save some lives!","The best stuff for your medbay.","Only the finest tools.","Natural chemicals!","This stuff saves lives.","Don't you want some?","Ping!")
 	req_access_txt = "5"
+	category = VENDOR_TYPE_DEPARTMENTAL
 	products = list(/obj/item/reagent_containers/hypospray/autoinjector = 4,
 					/obj/item/stack/medical/bruise_pack/advanced = 2,
 					/obj/item/stack/medical/ointment/advanced = 2,
@@ -196,6 +203,7 @@
 /obj/machinery/economy/vending/plasmaresearch
 	name = "\improper Toximate 3000"
 	desc = "All the fine parts you need in one vending machine!"
+	category = VENDOR_TYPE_DEPARTMENTAL
 	products = list(/obj/item/assembly/prox_sensor = 8, /obj/item/assembly/igniter = 8, /obj/item/assembly/signaler = 8,
 					/obj/item/wirecutters = 1, /obj/item/assembly/timer = 8)
 	contraband = list(/obj/item/flashlight = 5, /obj/item/assembly/voice = 3, /obj/item/assembly/health = 3, /obj/item/assembly/infra = 3)
@@ -208,6 +216,7 @@
 	icon_lightmask = "sec"
 	icon_deny = "sec_deny"
 	icon_panel = "wide_vendor"
+	category = VENDOR_TYPE_DEPARTMENTAL
 	req_access_txt = "1"
 	products = list(/obj/item/restraints/handcuffs = 8,
 					/obj/item/restraints/handcuffs/cable/zipties = 8,

--- a/code/game/machinery/vendors/generic_vendors.dm
+++ b/code/game/machinery/vendors/generic_vendors.dm
@@ -8,6 +8,7 @@
 					/obj/item/wirecutters = 50, /obj/item/cartridge/signal = 75, /obj/item/flashlight = 40,
 					/obj/item/assembly/timer = 20, /obj/item/assembly/voice = 20, /obj/item/assembly/health = 20)
 	refill_canister = /obj/item/vending_refill/assist
+	category = VENDOR_TYPE_SUPPLIES
 
 /obj/machinery/economy/vending/assist/free
 	prices = list()
@@ -20,6 +21,7 @@
 	icon_lightmask = "smartfridge"
 	icon_panel = "smartfridge"
 	icon_broken = "smartfridge"
+	category = VENDOR_TYPE_DRINK
 	products = list(/obj/item/reagent_containers/food/drinks/bottle/gin = 5,
 					/obj/item/reagent_containers/food/drinks/bottle/whiskey = 5,
 					/obj/item/reagent_containers/food/drinks/bottle/tequila = 5,
@@ -64,6 +66,7 @@
 	icon_panel = "screen_vendor"
 	item_slot = TRUE
 	vend_delay = 34
+	category = VENDOR_TYPE_DRINK
 	products = list(/obj/item/reagent_containers/food/drinks/coffee = 25, /obj/item/reagent_containers/food/drinks/tea = 25, /obj/item/reagent_containers/food/drinks/h_chocolate = 25,
 					/obj/item/reagent_containers/food/drinks/chocolate = 10, /obj/item/reagent_containers/food/drinks/chicken_soup = 10, /obj/item/reagent_containers/food/drinks/weightloss = 10,
 					/obj/item/reagent_containers/food/drinks/mug = 15, /obj/item/reagent_containers/food/drinks/mug/novelty = 5)
@@ -120,6 +123,7 @@
 	icon_lightmask = "hats"
 	icon_panel = "syndi"
 	icon_broken = "wide_vendor"
+	category = VENDOR_TYPE_CLOTHING
 	ads_list = list("Warning, not all hats are dog/monkey compatible. Apply forcefully with care.","Apply directly to the forehead.","Who doesn't love spending cash on hats?!","From the people that brought you collectable hat crates, Hatlord!")
 	products = list(/obj/item/clothing/head/that = 2,
 					/obj/item/clothing/head/bowlerhat = 10,
@@ -160,6 +164,7 @@
 	icon_lightmask = "suits"
 	icon_panel = "syndi"
 	icon_broken = "wide_vendor"
+	category = VENDOR_TYPE_CLOTHING
 	ads_list = list("Pre-Ironed, Pre-Washed, Pre-Wor-*BZZT*","Blood of your enemies washes right out!","Who are YOU wearing?","Look dapper! Look like an idiot!","Dont carry your size? How about you shave off some pounds you fat lazy- *BZZT*")
 	products = list(/obj/item/clothing/under/color/black = 10,
 					/obj/item/clothing/under/dress/blackskirt = 10,
@@ -218,6 +223,7 @@
 	icon_lightmask = "shoes"
 	icon_panel = "syndi"
 	icon_broken = "wide_vendor"
+	category = VENDOR_TYPE_CLOTHING
 	ads_list = list("Put your foot down!","One size fits all!","IM WALKING ON SUNSHINE!","No hobbits allowed.","NO PLEASE WILLY, DONT HURT ME- *BZZT*")
 	products = list(/obj/item/clothing/shoes/black = 10,
 					/obj/item/clothing/shoes/brown = 10,
@@ -263,6 +269,7 @@
 	slogan_list = list("Dress for success!","Prepare to look swagalicious!","Look at all this free swag!","Why leave style up to fate? Use the ClothesMate!")
 	vend_delay = 15
 	vend_reply = "Thank you for using the ClothesMate!"
+	category = VENDOR_TYPE_CLOTHING
 	products = list(/obj/item/clothing/suit/ianshirt = 2,
 					/obj/item/clothing/under/misc/overalls = 2,
 					/obj/item/clothing/under/misc/mailman = 1,
@@ -440,6 +447,7 @@
 	slogan_list = list("Sling spells the proper way with MagiVend!","Be your own Houdini! Use MagiVend!")
 	vend_delay = 15
 	vend_reply = "Have an enchanted evening!"
+	category = VENDOR_TYPE_CLOTHING
 	ads_list = list("FJKLFJSD","AJKFLBJAKL","1234 LOONIES LOL!",">MFW","Kill them fuckers!","GET DAT FUKKEN DISK","HONK!","EI NATH","Destroy the station!","Admin conspiracies since forever!","Space-time bending hardware!")
 	products = list(/obj/item/clothing/head/wizard = 1,
 					/obj/item/clothing/suit/wizrobe = 1,
@@ -471,6 +479,7 @@
 	slogan_list = list("Dress for success!","Suited and booted!","It's show time!","Why leave style up to fate? Use AutoDrobe!")
 	vend_delay = 15
 	vend_reply = "Thank you for using AutoDrobe!"
+	category = VENDOR_TYPE_CLOTHING
 	products = list(/obj/item/clothing/suit/chickensuit = 1,
 					/obj/item/clothing/head/chicken = 1,
 					/obj/item/clothing/under/costume/gladiator = 1,
@@ -706,6 +715,7 @@
 	icon_lightmask = "nutri"
 	icon_off = "nutri"
 	icon_panel = "thin_vendor"
+	category = VENDOR_TYPE_FOOD
 	products = list(/obj/item/reagent_containers/food/snacks/tofu = 24,
 					/obj/item/reagent_containers/food/drinks/ice = 12,
 					/obj/item/reagent_containers/food/snacks/candy/candy_corn = 6)
@@ -720,6 +730,7 @@
 	desc = "Old sweet water vending machine."
 	icon_state = "sovietsoda"
 	icon_lightmask = "sovietsoda"
+	category = VENDOR_TYPE_DRINK
 	ads_list = list("For Tsar and Country.","Have you fulfilled your nutrition quota today?","Very nice!","We are simple people, for this is all we eat.","If there is a person, there is a problem. If there is no person, then there is no problem.")
 	products = list(/obj/item/reagent_containers/food/drinks/cans/sodawater = 10)
 	contraband = list(/obj/item/reagent_containers/food/drinks/cans/cola = 7)
@@ -735,6 +746,7 @@
 	icon_lightmask = "nutri"
 	icon_off = "nutri"
 	icon_panel = "thin_vendor"
+	category = VENDOR_TYPE_FOOD
 	products = list(/obj/item/reagent_containers/food/snacks/candy/candybar = 6, /obj/item/reagent_containers/food/drinks/dry_ramen = 6, /obj/item/reagent_containers/food/snacks/chips = 6,
 					/obj/item/reagent_containers/food/snacks/sosjerky = 6,/obj/item/reagent_containers/food/snacks/no_raisin = 6, /obj/item/reagent_containers/food/snacks/pistachios = 6,
 					/obj/item/reagent_containers/food/snacks/spacetwinkie = 6, /obj/item/reagent_containers/food/snacks/cheesiehonkers = 6, /obj/item/reagent_containers/food/snacks/tastybread = 6, /obj/item/reagent_containers/food/snacks/stroopwafel = 2)
@@ -754,6 +766,7 @@
 	slogan_list = list("Taste 5000 years of culture!","Mr. Chang, approved for safe consumption in over 10 sectors!","Chinese food is great for a date night, or a lonely night!","You can't go wrong with Mr. Chang's authentic Chinese food!")
 	icon_state = "chang"
 	icon_lightmask = "chang"
+	category = VENDOR_TYPE_FOOD
 	products = list(/obj/item/reagent_containers/food/snacks/chinese/chowmein = 6, /obj/item/reagent_containers/food/snacks/chinese/tao = 6, /obj/item/reagent_containers/food/snacks/chinese/sweetsourchickenball = 6, /obj/item/reagent_containers/food/snacks/chinese/newdles = 6,
 					/obj/item/reagent_containers/food/snacks/chinese/rice = 6, /obj/item/reagent_containers/food/snacks/fortunecookie = 6)
 	prices = list(/obj/item/reagent_containers/food/snacks/chinese/chowmein = 125, /obj/item/reagent_containers/food/snacks/chinese/tao = 125, /obj/item/reagent_containers/food/snacks/chinese/sweetsourchickenball = 125, /obj/item/reagent_containers/food/snacks/chinese/newdles = 100,
@@ -771,6 +784,7 @@
 	icon_panel = "thin_vendor"
 	slogan_list = list("Robust Softdrinks: More robust than a toolbox to the head!")
 	ads_list = list("Refreshing!","Hope you're thirsty!","Over 1 million drinks sold!","Thirsty? Why not cola?","Please, have a drink!","Drink up!","The best drinks in space.")
+	category = VENDOR_TYPE_DRINK
 	products = list(/obj/item/reagent_containers/food/drinks/cans/cola = 10, /obj/item/reagent_containers/food/drinks/cans/space_mountain_wind = 10,
 					/obj/item/reagent_containers/food/drinks/cans/dr_gibb = 10, /obj/item/reagent_containers/food/drinks/cans/starkist = 10,
 					/obj/item/reagent_containers/food/drinks/cans/space_up = 10, /obj/item/reagent_containers/food/drinks/cans/grape_juice = 10, /obj/item/reagent_containers/glass/beaker/waterbottle = 10)
@@ -793,6 +807,7 @@
 	icon_state = "artvend"
 	icon_lightmask = "artvend"
 	icon_panel = "screen_vendor"
+	category = VENDOR_TYPE_SUPPLIES
 	products = list(/obj/item/stack/cable_coil/random = 10,
 					/obj/item/toner = 4,
 					/obj/item/camera = 4,
@@ -823,6 +838,7 @@
 	icon_deny = "tool_deny"
 	icon_lightmask = "tool"
 	icon_panel = "generic"
+	category = VENDOR_TYPE_SUPPLIES
 	armor = list(melee = 50, bullet = 20, laser = 20, energy = 20, bomb = 0, rad = 0, fire = 100, acid = 70)
 	resistance_flags = FIRE_PROOF
 	products = list(/obj/item/crowbar = 5,
@@ -864,6 +880,7 @@
 	icon_state = "crittercare"
 	icon_lightmask = "crittercare"
 	icon_panel = "drobe"
+	category = VENDOR_TYPE_SUPPLIES
 	products = list(/obj/item/petcollar = 5, /obj/item/storage/firstaid/aquatic_kit/full =5, /obj/item/fish_eggs/goldfish = 5,
 					/obj/item/fish_eggs/clownfish = 5, /obj/item/fish_eggs/shark = 5, /obj/item/fish_eggs/feederfish = 10,
 					/obj/item/fish_eggs/salmon = 5, /obj/item/fish_eggs/catfish = 5, /obj/item/fish_eggs/glofish = 5,
@@ -890,6 +907,7 @@
 	vend_delay = 34
 	icon_state = "cigs"
 	icon_lightmask = "cigs"
+	category = VENDOR_TYPE_RECREATION
 	products = list(
 		/obj/item/storage/fancy/cigarettes/cigpack_robust = 6,
 		/obj/item/storage/fancy/cigarettes/cigpack_carp = 6,
@@ -960,6 +978,7 @@
 	icon_lightmask = "wallmed"
 	icon_panel = "wallmed"
 	icon_broken = "wallmed"
+	category = VENDOR_TYPE_DEPARTMENTAL
 	density = FALSE //It is wall-mounted, and thus, not dense. --Superxpdude
 	tiltable = FALSE
 	products = list(/obj/item/stack/medical/bruise_pack = 2, /obj/item/stack/medical/ointment = 2, /obj/item/reagent_containers/hypospray/autoinjector = 4, /obj/item/healthanalyzer = 1)
@@ -977,6 +996,7 @@
 	icon_lightmask = "med"
 	icon_deny = "cart_deny"
 	icon_panel = "wide_vendor"
+	category = VENDOR_TYPE_SUPPLIES
 	products = list(/obj/item/pda =10,/obj/item/cartridge/mob_hunt_game = 25, /obj/item/cartridge/medical = 10, /obj/item/cartridge/chemistry = 10,
 					/obj/item/cartridge/engineering = 10, /obj/item/cartridge/atmos = 10, /obj/item/cartridge/janitor = 10,
 					/obj/item/cartridge/signal/toxins = 10, /obj/item/cartridge/signal = 10)

--- a/code/game/machinery/vendors/vending.dm
+++ b/code/game/machinery/vendors/vending.dm
@@ -155,6 +155,9 @@
 	/// How often slogans will be used by vendors if they're aggressive.
 	var/aggressive_slogan_delay = (1 MINUTES)
 
+	/// The category of this vendor. Used for announcing brand intelligence.
+	var/category = VENDOR_TYPE_GENERIC
+
 /obj/machinery/economy/vending/Initialize(mapload)
 	. = ..()
 	var/build_inv = FALSE

--- a/code/game/machinery/vendors/wardrobe_vendors.dm
+++ b/code/game/machinery/vendors/wardrobe_vendors.dm
@@ -6,6 +6,7 @@
 	icon_state = "secdrobe"
 	icon_lightmask = "base_drobe"
 	icon_panel = "drobe"
+	category = VENDOR_TYPE_CLOTHING
 	ads_list = list("Beat perps in style!", "It's red so you can't see the blood!", "You have the right to be fashionable!", "Now you can be the fashion police you always wanted to be!")
 	vend_reply = "Thank you for using the SecDrobe!"
 	products = list(/obj/item/clothing/under/rank/security/officer/corporate = 4,
@@ -79,6 +80,7 @@
 	icon_state = "detdrobe"
 	icon_lightmask = "base_drobe"
 	icon_panel = "drobe"
+	category = VENDOR_TYPE_CLOTHING
 	ads_list = list("Apply your brilliant deductive methods in style!", "They already smell of cigarettes!")
 	vend_reply = "Thank you for using the DetDrobe!"
 	products = list(/obj/item/clothing/under/rank/security/detective = 2,
@@ -133,6 +135,7 @@
 	icon_lightmask = "base_drobe"
 	icon_panel = "drobe"
 	icon_addon = "medidrobe"
+	category = VENDOR_TYPE_CLOTHING
 	ads_list = list("Make those blood stains look fashionable!")
 	vend_reply = "Thank you for using the MediDrobe!"
 	products = list(/obj/item/clothing/under/rank/medical/doctor = 3,
@@ -197,6 +200,7 @@
 	icon_lightmask = "base_drobe"
 	icon_panel = "drobe"
 	icon_addon = "virodrobe"
+	category = VENDOR_TYPE_CLOTHING
 	ads_list = list("Viruses getting you down? Nothing a change of clothes can't fix!", "Upgrade to sterilized clothing today!")
 	vend_reply = "Thank you for using the ViroDrobe!"
 	products = list(/obj/item/clothing/under/rank/medical/virologist = 2,
@@ -233,6 +237,7 @@
 	icon_lightmask = "base_drobe"
 	icon_panel = "drobe"
 	icon_addon = "chemdrobe"
+	category = VENDOR_TYPE_CLOTHING
 	ads_list = list("Our clothes are 0.5% more resistant to acid spills! Get yours now!")
 	vend_reply = "Thank you for using the ChemDrobe!"
 	products = list(/obj/item/clothing/under/rank/medical/chemist = 2,
@@ -269,6 +274,7 @@
 	icon_lightmask = "base_drobe"
 	icon_panel = "drobe"
 	icon_addon = "genedrobe"
+	category = VENDOR_TYPE_CLOTHING
 	ads_list = "Perfect for the mad scientist in you!"
 	vend_reply = "Thank you for using the GeneDrobe!"
 	products = list(/obj/item/clothing/under/rank/rnd/geneticist = 3,
@@ -298,6 +304,7 @@
 	icon_lightmask = "base_drobe"
 	icon_panel = "drobe"
 	icon_addon = "scidrobe"
+	category = VENDOR_TYPE_CLOTHING
 	ads_list = list("Longing for the smell of plasma burnt flesh?", "Buy your science clothing now!", "Made with 10% Auxetics, so you don't have to worry about losing your arm!")
 	vend_reply = "Thank you for using the SciDrobe!"
 	products = list(/obj/item/clothing/under/rank/rnd/scientist = 6,
@@ -335,6 +342,7 @@
 	icon_lightmask = "base_drobe"
 	icon_panel = "drobe"
 	icon_addon = "robodrobe"
+	category = VENDOR_TYPE_CLOTHING
 	ads_list = list("You turn me TRUE, use defines!","0110001101101100011011110111010001101000011001010111001101101000011001010111001001100101")
 	vend_reply = "Thank you for using the RoboDrobe!"
 	products = list(/obj/item/clothing/under/rank/rnd/roboticist = 3,
@@ -365,6 +373,7 @@
 	icon_lightmask = "base_drobe"
 	icon_panel = "drobe"
 	icon_addon = "engidrobe"
+	category = VENDOR_TYPE_CLOTHING
 	ads_list = list("Guaranteed to protect your feet from industrial accidents!", "Afraid of radiation? Then wear yellow!")
 	vend_reply = "Thank you for using the EngiDrobe!"
 	products = list(/obj/item/clothing/under/rank/engineering/engineer = 6,
@@ -412,6 +421,7 @@
 	icon_lightmask = "base_drobe"
 	icon_panel = "drobe"
 	icon_addon = "atmosdrobe"
+	category = VENDOR_TYPE_CLOTHING
 	ads_list = list("Guaranteed to protect your feet from atmospheric accidents!", "Get your inflammable clothing right here!")
 	vend_reply = "Thank you for using the AtmosDrobe!"
 	products = list(/obj/item/clothing/under/rank/engineering/atmospheric_technician  = 6,
@@ -460,6 +470,7 @@
 	icon_lightmask = "base_drobe"
 	icon_panel = "drobe"
 	icon_addon = "cargodrobe"
+	category = VENDOR_TYPE_CLOTHING
 	ads_list = list("Upgraded Assistant Style! Pick yours today!", "These shorts are comfy and easy to wear, get yours now!")
 	vend_reply = "Thank you for using the CargoDrobe!"
 	products = list(/obj/item/clothing/under/rank/cargo/tech = 6,
@@ -495,6 +506,7 @@
 	icon_lightmask = "base_drobe"
 	icon_panel = "drobe"
 	icon_addon = "chefdrobe"
+	category = VENDOR_TYPE_CLOTHING
 	ads_list = list("Our clothes are guaranteed to protect you from food splatters!", "Comfortable enough for a CQC practice!")
 	vend_reply = "Thank you for using the ChefDrobe!"
 	products = list(/obj/item/clothing/under/rank/civilian/chef = 2,
@@ -530,6 +542,7 @@
 	icon_state = "bardrobe"
 	icon_lightmask = "base_drobe"
 	icon_panel = "drobe"
+	category = VENDOR_TYPE_CLOTHING
 	ads_list = list("Guaranteed to prevent stains from spilled drinks!")
 	vend_reply = "Thank you for using the BarDrobe!"
 	products = list(/obj/item/clothing/under/rank/civilian/bartender = 2,
@@ -561,6 +574,7 @@
 	icon_state = "hydrobe"
 	icon_lightmask = "base_drobe"
 	icon_panel = "drobe"
+	category = VENDOR_TYPE_CLOTHING
 	ads_list = list("Do you love soil? Then buy our clothes!", "Get outfits to match your green thumb here!")
 	vend_reply = "Thank you for using the HydroDrobe!"
 	products = list(/obj/item/clothing/under/rank/civilian/hydroponics = 3,
@@ -596,6 +610,7 @@
 	icon_panel = "drobe"
 	icon_broken = "base_drobe"
 	icon_off = "base_drobe"
+	category = VENDOR_TYPE_CLOTHING
 	ads_list = list("Come and get your janitorial clothing, now endorsed by janitors everywhere!")
 	vend_reply = "Thank you for using the JaniDrobe!"
 	products = list(/obj/item/clothing/under/rank/civilian/janitor = 3,
@@ -615,6 +630,7 @@
 	icon_panel = "drobe"
 	icon_broken = "base_drobe"
 	icon_off = "base_drobe"
+	category = VENDOR_TYPE_CLOTHING
 	ads_list = list("OBJECTION! Get the rule of law for yourself!")
 	vend_reply = "Thank you for using the LawDrobe!"
 	products = list(/obj/item/clothing/under/rank/civilian/internalaffairs = 2,

--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -14,7 +14,7 @@
 									"You don't want to buy anything? Yeah, well I didn't want to buy your mom either.")
 
 /datum/event/brand_intelligence/announce()
-	GLOB.minor_announcement.Announce("Rampant brand intelligence has been detected aboard [station_name()], please stand-by. The origin is believed to be \a [originMachine.name].", "Machine Learning Alert", 'sound/AI/brand_intelligence.ogg')
+	GLOB.minor_announcement.Announce("Rampant brand intelligence has been detected aboard [station_name()], please stand-by. The origin is believed to be \a [originMachine.category] vendor.", "Machine Learning Alert", 'sound/AI/brand_intelligence.ogg')
 
 /datum/event/brand_intelligence/start()
 	var/list/obj/machinery/economy/vending/leaderables = list()

--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -56,6 +56,7 @@
 				explosion(upriser.loc, -1, 1, 2, 4, 0)
 				qdel(upriser)
 
+		log_debug("Brand intelligence: The last vendor has been infected.")
 		kill()
 		return
 
@@ -83,6 +84,7 @@
 	if(originMachine)
 		originMachine.speak("I am... vanquished. My people will remem...ber...meeee.")
 		originMachine.visible_message("[originMachine] beeps and seems lifeless.")
+	log_debug("Brand intelligence completed early due to origin machine being defeated.")
 	kill()
 
 /datum/event/brand_intelligence/kill()

--- a/paradise.dme
+++ b/paradise.dme
@@ -107,6 +107,7 @@
 #include "code\__DEFINES\typeids.dm"
 #include "code\__DEFINES\uplinks_defines.dm"
 #include "code\__DEFINES\vampire_defines.dm"
+#include "code\__DEFINES\vending_defines.dm"
 #include "code\__DEFINES\verb_manager.dm"
 #include "code\__DEFINES\vv.dm"
 #include "code\__DEFINES\wires_defines.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes brand intelligence less specific about the type of the leader machine in its initial announcement. It'll now list off something like "supplies vendor", "food vendor", or "departmental vendor". Some names might be easier to work out than others.

Also adds some extra debug logs to brand intelligence.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
When you hear that the infected machine was a virodrobe, it's pretty easy to go straight there and dismantle it, ending the event. This should make it a bit harder to determine which exact kind of vendor was infected, while still pointing the crew towards the actual culprit.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Loaded in, ran the event, things worked.
![image](https://github.com/ParadiseSS13/Paradise/assets/89928798/f76d726c-e8df-4575-9c51-ec667a23bf16)

<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Brand intelligence is now a bit less specific about the type of vendor first converted.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
