### PR TITLE
Added the Armored Suit Jacket to both the Uplink and as maint loot

### DIFF
--- a/code/datums/uplink_items/uplink_general.dm
+++ b/code/datums/uplink_items/uplink_general.dm
@@ -744,6 +744,13 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/clothing/suit/jacket/syndicatebomber
 	cost = 1
 
+/datum/uplink_item/badass/tpsuit
+	name = "Syndicate Two-Piece Suit"
+	desc = "A snappy two-piece suit that any self-respecting Syndicate agent should wear. Perfect for professionals trying to go undetected, but moderately armored with experimental nanoweave in case things do get loud. Comes with two cashmere-lined pockets for maximum style and comfort."
+	reference = "SUIT"
+	item = /obj/item/clothing/suit/storage/lawyer/blackjacket/armored
+	cost = 1
+
 /datum/uplink_item/bundles_TC
 	category = "Bundles and Telecrystals"
 	surplus = 0

--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -160,8 +160,9 @@
 				/obj/item/storage/secure/briefcase/syndie = 2,
 				/obj/item/storage/fancy/cigarettes/cigpack_syndicate = 2,
 				/obj/item/storage/pill_bottle/fakedeath = 2,
-				/obj/item/clothing/suit/jacket/syndicatebomber = 5,
-				"" = 60 // This should be a decently high number for chances where no loot will spawn
+				/obj/item/clothing/suit/jacket/syndicatebomber = 4,
+				/obj/item/clothing/suit/storage/lawyer/blackjacket/armored = 2, // More armored than bomber and has pockets, so it is rarer
+				"" = 58 // This should be a decently high number for chances where no loot will spawn
 				)
 
 /obj/effect/spawner/lootdrop/maintenance/two


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Added the Armored Suit Jacket from the Payday, Bond and Professional bundle to the Uplink for 1 TC, as well as a rare maint loot drop (Rarer than the Syndicate Bomber Jacket as requested by Rurik).

## Why It's Good For The Game
Locking a drippy armored suit behind the RNG lootbox that is Bundles is kind of sad, and with the Syndicate Bomber Jacket being in I thought I might offer a more formal alternative.

While the suit has more armor and suit pockets, it still shouldn't be too unbalanced (According to code comments it is just roundstart Security armor levels of protection). Am willing to bump it to 2 TC if it overshadows the Bomber Jacket too much.

## Images of changes

![Uplink](https://github.com/ParadiseSS13/Paradise/assets/108938550/f342b4da-c2e8-45f6-a7b7-e3f59e2a26b3)
![Drip](https://github.com/ParadiseSS13/Paradise/assets/108938550/b9270682-2d9f-48dd-975e-b1a208fe1ed2)

## Testing
Loaded into a local server, traitored myself. Saw the suit jacket inside the Uplink and bought it with 1 TC. Then ran around maintenance until I found an armored suit spawn.

## Changelog
:cl:
add: Added the armoured suit jacket into the Uplink as the Syndicate Two-Piece Suit
add: Added the armoured suit jacket into the maintenance loot pool
/:cl: