### PR TITLE
Fixes drunk brawling combo counter

### DIFF
--- a/code/modules/martial_arts/martial.dm
+++ b/code/modules/martial_arts/martial.dm
@@ -64,16 +64,13 @@
 		return MARTIAL_ARTS_CANNOT_USE
 	if(combo_timer)
 		deltimer(combo_timer)
-/*
-	if(last_hit + COMBO_ALIVE_TIME < world.time)
-		reset_combos()
-*/
+
 	combo_timer = addtimer(CALLBACK(src, PROC_REF(reset_combos)), COMBO_ALIVE_TIME, TIMER_UNIQUE | TIMER_STOPPABLE)
-	streak += intent_to_streak(step)
-	var/mob/living/carbon/human/owner = locateUID(owner_UID)
-	owner?.hud_used.combo_display.update_icon(ALL, streak)
 
 	if(HAS_COMBOS)
+		streak += intent_to_streak(step)
+		var/mob/living/carbon/human/owner = locateUID(owner_UID)
+		owner?.hud_used.combo_display.update_icon(ALL, streak)
 		return check_combos(step, user, target)
 	return FALSE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
prevents martial arts that dont have combos from getting combo counters

## Why It's Good For The Game
![image](https://github.com/ParadiseSS13/Paradise/assets/69320440/27ebcc3a-6c21-4987-a7d9-432cb84cf2f9)
this is bad

## Testing
drunk booze
punched skrell
sleeping carp learnt
punched skrell

## Changelog
:cl:
fix: Martial arts without combos wont get a combo counter
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
