### PR TITLE
Removes unused slime jelly bloodcrawl interaction

### DIFF
--- a/code/game/objects/effects/decals/Cleanable/alien_blood.dm
+++ b/code/game/objects/effects/decals/Cleanable/alien_blood.dm
@@ -46,9 +46,6 @@
 	bloodiness = MAX_SHOE_BLOODINESS
 	alpha = BLOOD_SPLATTER_ALPHA_SLIME
 
-/obj/effect/decal/cleanable/blood/slime/can_bloodcrawl_in()
-	return FALSE
-
 /obj/effect/decal/cleanable/blood/slime/dry()
 	return
 


### PR DESCRIPTION
## What Does This PR Do
Removes two lines of nonfunctional code about not being able to bloodcrawl in slime jelly.
Fixes #17317

## Why It's Good For The Game
Nonfunctional code that runs counter to Balance Team decision might cause confusion in the future.

## Testing
Loaded up local server, spawned in a slaughter demon and several slimes. Inhabited demon and attacked and ate a few slimes. Confirmed that I could bloodcrawl inside the slime jelly puddles as well as slime jelly footprints.

## Changelog
No player facing changes.
