### PR TITLE
Fix blackbox manifest data for AIs.

### DIFF
--- a/code/controllers/subsystem/SSjobs.dm
+++ b/code/controllers/subsystem/SSjobs.dm
@@ -85,12 +85,10 @@ SUBSYSTEM_DEF(jobs)
 		if(job.barred_by_missing_limbs(player.client))
 			return FALSE
 
-		var/position_limit = job.total_positions
-		if(!latejoin)
-			position_limit = job.spawn_positions
+		var/available = latejoin ? job.is_position_available() : job.is_spawn_position_available()
 
-		if((job.current_positions < position_limit) || position_limit == -1)
-			Debug("Player: [player] is now Rank: [rank], JCP:[job.current_positions], JPL:[position_limit]")
+		if(available)
+			Debug("Player: [player] is now Rank: [rank], JCP:[job.current_positions], JTP:[job.total_positions], JSP:[job.spawn_positions]")
 			player.mind.assigned_role = rank
 			player.mind.role_alt_title = GetPlayerAltTitle(player, rank)
 
@@ -101,6 +99,7 @@ SUBSYSTEM_DEF(jobs)
 
 			unassigned -= player
 			job.current_positions++
+			SSblackbox.record_feedback("nested tally", "manifest", 1, list(rank, (latejoin ? "latejoin" : "roundstart")))
 			return 1
 
 	Debug("AR has failed, Player: [player], Rank: [rank]")
@@ -368,7 +367,7 @@ SUBSYSTEM_DEF(jobs)
 				if(player.client.prefs.active_character.GetJobDepartment(job, level) & job.flag)
 
 					// If the job isn't filled
-					if((job.current_positions < job.spawn_positions) || job.spawn_positions == -1)
+					if(job.is_spawn_position_available())
 						Debug("DO pass, Player: [player], Level:[level], Job:[job.title]")
 						Debug(" - Job Flag: [job.flag] Job Department: [player.client.prefs.active_character.GetJobDepartment(job, level)] Job Current Pos: [job.current_positions] Job Spawn Positions = [job.spawn_positions]")
 						AssignRole(player, job.title)
@@ -407,7 +406,7 @@ SUBSYSTEM_DEF(jobs)
 	log_debug("Dividing Occupations took [stop_watch(watch)]s")
 	return TRUE
 
-/datum/controller/subsystem/jobs/proc/AssignRank(mob/living/carbon/human/H, rank, joined_late = FALSE, log_to_db = TRUE)
+/datum/controller/subsystem/jobs/proc/AssignRank(mob/living/carbon/human/H, rank, joined_late = FALSE)
 	if(!H)
 		return null
 	var/datum/job/job = GetJob(rank)
@@ -448,9 +447,6 @@ SUBSYSTEM_DEF(jobs)
 	if(job.important_information)
 		to_chat(H, "<center><div class='userdanger' style='width: 80%'>[job.important_information]</div></center>")
 	to_chat(H, "<center><span class='green'>----------------</span><br><br></center>")
-
-	if(log_to_db)
-		SSblackbox.record_feedback("nested tally", "manifest", 1, list(rank, (joined_late ? "latejoin" : "roundstart")))
 
 	return H
 

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -144,6 +144,9 @@
 /datum/job/proc/is_position_available()
 	return (current_positions < total_positions) || (total_positions == -1)
 
+/datum/job/proc/is_spawn_position_available()
+	return (current_positions < spawn_positions) || (spawn_positions == -1)
+
 /datum/outfit/job
 	name = "Standard Gear"
 	collect_not_del = TRUE // we don't want anyone to lose their job shit

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -485,7 +485,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 						new_character.mind.add_antag_datum(/datum/antagonist/traitor)
 				//Add aliens.
 				else
-					SSjobs.AssignRank(new_character, new_character.mind.assigned_role, FALSE, FALSE)
+					SSjobs.AssignRank(new_character, new_character.mind.assigned_role, FALSE)
 					SSjobs.EquipRank(new_character, new_character.mind.assigned_role, 1)//Or we simply equip them.
 
 	//Announces the character on all the systems, based on the record.


### PR DESCRIPTION
## What Does This PR Do
This change does two things:

1. Moves the recording of manifest data for roundstart/latejoins from `AssignRank` to `AssignRole`, since `AssignRank` is not called during roundstart AI creation.
2. Updates `AssignRole` to use `is_position_available` for availability, instead of hardcoded logic based on `job.total_positions` (which is not used in AI job availability).

## Why It's Good For The Game
Before this, AI roundstart joins were not recorded, and AI latejoins would skip a stanza in `AssignRole`.

## Testing
Attempted to join as AI round start, latejoin with and without wiping previous core, aghosted to ensure AI role is not available from lobby. Checked manifest results in DB.

## Changelog
NPFC
