### PR TITLE
Attempts to stop an atmos runtime from happening

### DIFF
--- a/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
@@ -152,11 +152,14 @@
 		air2.merge(filtered_out)
 		air3.merge(removed)
 
-	parent2.update = 1
+	if(parent2)
+		parent2.update = 1
 
-	parent3.update = 1
+	if(parent3)
+		parent3.update = 1
 
-	parent1.update = 1
+	if(parent1)
+		parent1.update = 1
 
 	return 1
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds some sanity checks so hopefully this won't happen more
![image](https://github.com/ParadiseSS13/Paradise/assets/108773801/7d225477-6e73-4abd-bd79-a4017a6f4866)
This kept being called on a filter, and my assumption is that because it has no third outlet, it'll runtime because there is no third outlet to update.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Runtimes are bad, especially when there's 4000 of them
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Fucked around a bit with filters, they worked as expected and didn't runtime
<!-- How did you test the PR, if at all? -->

## Changelog
NPFC

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
