### PR TITLE
Adds a period to two flower descriptions. Fixes #22029

### DIFF
--- a/code/modules/hydroponics/grown/flowers.dm
+++ b/code/modules/hydroponics/grown/flowers.dm
@@ -43,7 +43,7 @@
 /obj/item/reagent_containers/food/snacks/grown/poppy/lily
 	seed = /obj/item/seeds/poppy/lily
 	name = "lily"
-	desc = "A beautiful white flower"
+	desc = "A beautiful white flower."
 	icon_state = "lily"
 	tastes = list("lily" = 1)
 	filling_color = "#C7BBAD"
@@ -63,7 +63,7 @@
 /obj/item/reagent_containers/food/snacks/grown/poppy/geranium
 	seed = /obj/item/seeds/poppy/geranium
 	name = "geranium"
-	desc = "A beautiful purple flower"
+	desc = "A beautiful purple flower."
 	icon_state = "geranium"
 	tastes = list("geranium" = 1)
 	filling_color = "#A463FB"


### PR DESCRIPTION
## What Does This PR Do
Fixes #22029 

## Why It's Good For The Game
Two random flowers missing periods in their descriptions made the game literally unplayable for at least 60% of the playerbase. I'm sure many will be happy to see this change.

## Testing
Loaded in. Spawned flowers. They have periods in their descriptions now.

## Changelog
:cl:
spellcheck: Adds periods to two flower descriptions. Fixes #22029 
/:cl: