### PR TITLE
Fixes a runtime with having no ears and explosions

### DIFF
--- a/code/modules/mob/living/carbon/human/human_mob.dm
+++ b/code/modules/mob/living/carbon/human/human_mob.dm
@@ -253,8 +253,8 @@
 				brute_loss = 30 * (2 - round(bomb_armor * 0.01, 0.05))
 				burn_loss = brute_loss				//Damage gets reduced from 120 to up to 60 combined brute+burn
 			if(ears && check_ear_prot() < HEARING_PROTECTION_TOTAL)
-				Deaf(2 MINUTES)
 				ears.receive_damage(30)
+			Deaf(2 MINUTES)
 			Weaken(stuntime)
 			KnockDown(stuntime * 3) //Up to 15 seconds of knockdown
 
@@ -263,8 +263,8 @@
 			if(bomb_armor)
 				brute_loss = 15 * (2 - round(bomb_armor * 0.01, 0.05)) //Reduced from 30 to up to 15
 			if(ears && check_ear_prot() < HEARING_PROTECTION_TOTAL)
-				Deaf(1 MINUTES)
 				ears.receive_damage(15)
+			Deaf(1 MINUTES)
 			KnockDown(10 SECONDS - bomb_armor) //Between no knockdown to 10 seconds of knockdown depending on bomb armor
 			valid_limbs = list("l_hand", "l_foot", "r_hand", "r_foot")
 			limb_loss_chance = 25

--- a/code/modules/mob/living/carbon/human/human_mob.dm
+++ b/code/modules/mob/living/carbon/human/human_mob.dm
@@ -252,7 +252,7 @@
 			if(bomb_armor)
 				brute_loss = 30 * (2 - round(bomb_armor * 0.01, 0.05))
 				burn_loss = brute_loss				//Damage gets reduced from 120 to up to 60 combined brute+burn
-			if(check_ear_prot() < HEARING_PROTECTION_TOTAL)
+			if(ears && check_ear_prot() < HEARING_PROTECTION_TOTAL)
 				Deaf(2 MINUTES)
 				ears.receive_damage(30)
 			Weaken(stuntime)
@@ -262,7 +262,7 @@
 			brute_loss = 30
 			if(bomb_armor)
 				brute_loss = 15 * (2 - round(bomb_armor * 0.01, 0.05)) //Reduced from 30 to up to 15
-			if(check_ear_prot() < HEARING_PROTECTION_TOTAL)
+			if(ears && check_ear_prot() < HEARING_PROTECTION_TOTAL)
 				Deaf(1 MINUTES)
 				ears.receive_damage(15)
 			KnockDown(10 SECONDS - bomb_armor) //Between no knockdown to 10 seconds of knockdown depending on bomb armor


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
If you have no ears, for example by being a slimeperson, and are bombed with heavy or light explosions, the code tries to damage your ears that you don't have, causing runtimes.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Runtimes bad
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Bombed a slime with light explosions, didn't get the runtime that live had
<!-- How did you test the PR, if at all? -->

## Changelog
NPFC

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
