### PR TITLE
ensure only slimes can bubble and pop

### DIFF
--- a/code/datums/keybindings/emote_keybinds.dm
+++ b/code/datums/keybindings/emote_keybinds.dm
@@ -534,11 +534,11 @@
 	name = "Rattle"
 
 /datum/keybinding/emote/carbon/human/bubble
-	linked_emote = /datum/emote/living/carbon/human/bubble
+	linked_emote = /datum/emote/living/carbon/human/slime/bubble
 	name = "Bubble"
 
 /datum/keybinding/emote/carbon/human/pop
-	linked_emote = /datum/emote/living/carbon/human/pop
+	linked_emote = /datum/emote/living/carbon/human/slime/pop
 	name = "Pop"
 
 /datum/keybinding/emote/carbon/human/monkey/can_use(client/C, mob/M)

--- a/code/datums/keybindings/emote_keybinds.dm
+++ b/code/datums/keybindings/emote_keybinds.dm
@@ -509,8 +509,8 @@
 	linked_emote = /datum/emote/living/carbon/human/creak
 	name = "Creak"
 
-/datum/keybinding/emote/carbon/human/squish
-	linked_emote = /datum/emote/living/carbon/human/squish
+/datum/keybinding/emote/carbon/human/slime/squish
+	linked_emote = /datum/emote/living/carbon/human/slime/squish
 	name = "Squish"
 
 /datum/keybinding/emote/carbon/human/howl

--- a/code/modules/mob/living/carbon/human/human_emote.dm
+++ b/code/modules/mob/living/carbon/human/human_emote.dm
@@ -625,17 +625,10 @@
 	species_type_whitelist_typecache = list(/datum/species/diona)
 	sound = "sound/voice/dionatalk1.ogg"
 
-/datum/emote/living/carbon/human/squish
-	key = "squish"
-	key_third_person = "squishes"
-	message = "squishes."
-	message_param = "squishes at %t."
-	emote_type = EMOTE_SOUND
-	age_based = TRUE
-	// Credit to DrMinky (freesound.org) for the sound.
-	sound = "sound/effects/slime_squish.ogg"
+/datum/emote/living/carbon/human/slime
 
-/datum/emote/living/carbon/human/squish/can_run_emote(mob/user, status_check, intentional)
+
+/datum/emote/living/carbon/human/slime/can_run_emote(mob/user, status_check, intentional)
 	. = ..()
 	if(!.)
 		return FALSE
@@ -648,7 +641,17 @@
 				return TRUE
 	return FALSE
 
-/datum/emote/living/carbon/human/bubble
+/datum/emote/living/carbon/human/slime/squish
+	key = "squish"
+	key_third_person = "squishes"
+	message = "squishes."
+	message_param = "squishes at %t."
+	emote_type = EMOTE_SOUND
+	age_based = TRUE
+	// Credit to DrMinky (freesound.org) for the sound.
+	sound = "sound/effects/slime_squish.ogg"
+
+/datum/emote/living/carbon/human/slime/bubble
 	key = "bubble"
 	key_third_person = "bubbles"
 	message = "bubbles."
@@ -660,7 +663,7 @@
 	// https://freesound.org/people/audiolarx/sounds/263945/
 	sound = 'sound/effects/mob_effects/slime_bubble.ogg'
 
-/datum/emote/living/carbon/human/pop
+/datum/emote/living/carbon/human/slime/pop
 	key = "pop"
 	key_third_person = "pops"
 	message = "makes a popping sound."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fix #22014, ensuring that the checks that had previously been applied to slimepeople *squish were also applied for the new emotes.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Humans shouldn't be able to *bubble, unless they have rabies that is.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
![image](https://github.com/ParadiseSS13/Paradise/assets/89928798/bd1fe999-a666-419a-be8b-fd52646c8f77)

<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Fixes non-slimes being able to *bubble and *pop
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
