### PR TITLE
Fix: Typos with a crowbar and a sign Fixes #22033

### DIFF
--- a/code/game/objects/structures/signs.dm
+++ b/code/game/objects/structures/signs.dm
@@ -187,7 +187,7 @@
 
 /obj/structure/sign/greencross
 	name = "medbay"
-	desc = "The Intergalactic symbol of Medical institutions. You'll probably get help here.'"
+	desc = "The Intergalactic symbol of Medical institutions. You'll probably get help here."
 	icon_state = "greencross"
 
 /obj/structure/sign/goldenplaque

--- a/code/modules/customitems/item_defines.dm
+++ b/code/modules/customitems/item_defines.dm
@@ -158,7 +158,7 @@
 
 /obj/item/crowbar/fluff/zelda_creedy_1 // Zomgponies: Griffin Rowley
 	name = "Zelda's Crowbar"
-	desc = "A pink crow bar that has an engraving that reads, 'To Zelda. Love always, Dawn'"
+	desc = "A pink crowbar that has an engraving that reads, 'To Zelda. Love always, Dawn'"
 	icon = 'icons/obj/custom_items.dmi'
 	icon_state = "zeldacrowbar"
 	item_state = "crowbar"


### PR DESCRIPTION
Fix: Typos with a crowbar and a sign
 Fixes #22033

![grenncrossFix](https://github.com/ParadiseSS13/Paradise/assets/107350270/5df54a92-6efe-473b-a429-0bc67b135274)
![crowbarFix](https://github.com/ParadiseSS13/Paradise/assets/107350270/be088bc9-bbf8-4688-bd65-392de4c1979a)
