### PR TITLE
Adds the welding goggles to the autolathe

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -106,6 +106,14 @@
 	build_path = /obj/item/clothing/head/welding
 	category = list("initial","Tools")
 
+/datum/design/welding_goggles
+	name = "Welding Goggles"
+	id = "welding_goggles"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 1750, MAT_GLASS = 400)
+	build_path = /obj/item/clothing/glasses/welding
+	category = list("initial","Tools")
+
 /datum/design/cable_coil
 	name = "Cable Coil"
 	id = "cable_coil"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds the welding goggles to the autolathe
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
We've had annoyed and confused people asking where the fuck to find these things, because it's currently a 50/50 split across all maps if mappers actually mapped them in. This clears that confusion and makes it an alternative to the welding helmet for the same price.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Made some welding goggles and helmets, shit didn't runtime
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: You can now craft welding goggles at the autolathe
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
