### PR TITLE
Stops holoparasites from resting

### DIFF
--- a/code/game/gamemodes/miniantags/guardian/guardian.dm
+++ b/code/game/gamemodes/miniantags/guardian/guardian.dm
@@ -56,6 +56,15 @@
 /mob/living/simple_animal/hostile/guardian/can_buckle()
 	return FALSE
 
+/mob/living/simple_animal/hostile/guardian/rest()
+	return
+
+/mob/living/simple_animal/hostile/guardian/lay_down()
+	set_body_position(STANDING_UP)
+
+/mob/living/simple_animal/hostile/guardian/stand_up(instant, work_when_dead)
+	set_body_position(STANDING_UP)
+
 /mob/living/simple_animal/hostile/guardian/med_hud_set_health()
 	if(summoner)
 		var/image/holder = hud_list[HEALTH_HUD]


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Title. Also makes every call of `lay_down` and `stand_up` to instantly upright the holopara, in case of adminbus
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
It's a not very noticable thing if a holoparasite rests, and it can cause confusion and makes people think the holopara is rooted for some reason
Resolves #21086
Resolves #9794
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Tried to rest as a holopara, but nothing happened
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: holoparasites now can't rest anymore
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
