### PR TITLE
pizza boxes can be closed by alt clicking

### DIFF
--- a/code/modules/food_and_drinks/food/foods/pizza.dm
+++ b/code/modules/food_and_drinks/food/foods/pizza.dm
@@ -318,6 +318,12 @@
 		return
 	..()
 
+/obj/item/pizzabox/AltClick(mob/user)
+	..()
+	if(open)
+		open = FALSE
+		update_appearance(UPDATE_DESC|UPDATE_ICON)
+
 /obj/item/pizzabox/attack_self(mob/user)
 	if(boxes.len > 0)
 		return


### PR DESCRIPTION
## What Does This PR Do
Alt clicking pizza boxes now closes them

## Why It's Good For The Game
Before, once a pizza box was opened the pizza could be placed in and taken out but the box could not be shut again, thus, never to be stacked again. Allows the chef to collect cardboard for pizza boxes and ACTUALLY deliver stacked pizza orders.

## Testing
Tried alt clicking when boxes were stacked, when they were closed, checked that pizza wasn't affected somehow by the opening and or closing of the box. Stacked pizzas maintain being taken from the top. Checked the pizza bomb as well, no whacky side effects.

## Changelog
:cl:
tweak: Pizza boxes can now be closed by alt clicking them
/:cl:
