### PR TITLE
Guest pass can not be used on personal lockers. 

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
@@ -43,6 +43,10 @@
 		to_chat(user, "<span class='warning'>It appears to be broken.</span>")
 		return
 
+	if(istype(W, /obj/item/card/id/guest))
+		to_chat(user, "<span class='warning'>Invalid identification card.</span>")
+		return
+
 	var/obj/item/card/id/I = W
 	if(!I || !I.registered_name)
 		return
@@ -67,4 +71,4 @@
 			registered_name = I.registered_name
 			desc = "Owned by [I.registered_name]."
 	else
-		to_chat(user, "<span class='warning'>Access Denied</span>")
+		to_chat(user, "<span class='warning'>Access denied.</span>")


### PR DESCRIPTION
## What Does This PR Do
 This fixes https://github.com/ParadiseSS13/Paradise/issues/11001, an oversight that allows for the use of guest passes on personal lockers. 
## Why It's Good For The Game
It fixes a labeled oversight. It prevents personal lockers from being accessed so easily, through faking a name or from cloning access. 
## Testing
Created a guest pass.
Tested on a personal locker while wearing a regular ID and without an ID.
## Changelog
:cl:
tweak: Tweaked personal locker access to disallow the use of guest passes
/:cl: