### PR TITLE
Fixes a rare runtime with the clingtacle

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -117,9 +117,11 @@
 /obj/item/gun/proc/shoot_live_shot(mob/living/user, atom/target, pointblank = FALSE, message = TRUE)
 	if(recoil)
 		shake_camera(user, recoil + 1, recoil)
-
-	var/muzzle_range = chambered.muzzle_flash_range
-	var/muzzle_strength = chambered.muzzle_flash_strength
+	var/muzzle_range
+	var/muzzle_strength
+	if(chambered)
+		muzzle_range = chambered.muzzle_flash_range
+		muzzle_strength = chambered.muzzle_flash_strength
 	var/muzzle_flash_time = 0.2 SECONDS
 	if(suppressed)
 		playsound(user, fire_sound, 10, TRUE, ignore_walls = FALSE, extrarange = SILENCED_SOUND_EXTRARANGE, falloff_distance = 0)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -117,12 +117,11 @@
 /obj/item/gun/proc/shoot_live_shot(mob/living/user, atom/target, pointblank = FALSE, message = TRUE)
 	if(recoil)
 		shake_camera(user, recoil + 1, recoil)
-	var/muzzle_range
-	var/muzzle_strength
-	if(chambered)
-		muzzle_range = chambered.muzzle_flash_range
-		muzzle_strength = chambered.muzzle_flash_strength
+
+	var/muzzle_range = chambered?.muzzle_flash_range
+	var/muzzle_strength = chambered?.muzzle_flash_strength
 	var/muzzle_flash_time = 0.2 SECONDS
+
 	if(suppressed)
 		playsound(user, fire_sound, 10, TRUE, ignore_walls = FALSE, extrarange = SILENCED_SOUND_EXTRARANGE, falloff_distance = 0)
 		muzzle_range *= 0.5


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Checks if the gun fired actually has bullets that can influence the muzzle flash.
This runtimed on a cling tentacle because those things are guns too, but have no chambered ammo or muzzle flash.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Runtimes bad
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Fired the clingtacle a bunch at a dummy, nothing runtimed and the tentacle behaved as expected
<!-- How did you test the PR, if at all? -->

## Changelog
NPFC

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
