### PR TITLE
Blood pool now tries cardinal move if diagonal is blocked

### DIFF
--- a/code/datums/spells/ethereal_jaunt.dm
+++ b/code/datums/spells/ethereal_jaunt.dm
@@ -102,11 +102,35 @@
 		return
 	var/turf/newLoc = get_step(src,direction)
 	setDir(direction)
+	movedelay = world.time + movespeed
 	if(can_move(newLoc))
 		forceMove(newLoc)
-	else
+		return
+	if(!IS_DIR_DIAGONAL(direction))
 		to_chat(user, "<span class='warning'>Something is blocking the way!</span>")
-	movedelay = world.time + movespeed
+		return
+	var/turf/possible_1
+	var/turf/possible_2
+	switch(direction)
+		if(NORTHEAST)
+			possible_1 = get_step(src, NORTH)
+			possible_2 = get_step(src, EAST)
+		if(NORTHWEST)
+			possible_1 = get_step(src, NORTH)
+			possible_2 = get_step(src, WEST)
+		if(SOUTHEAST)
+			possible_1 = get_step(src, SOUTH)
+			possible_2 = get_step(src, EAST)
+		if(SOUTHWEST)
+			possible_1 = get_step(src, SOUTH)
+			possible_2 = get_step(src, WEST)
+	if(can_move(possible_1))
+		forceMove(possible_1)
+		return
+	if(can_move(possible_2))
+		forceMove(possible_2)
+		return
+	to_chat(user, "<span class='warning'>Something is blocking the way!</span>")
 
 /obj/effect/dummy/spell_jaunt/proc/can_move(turf/T)
 	if(T.flags & NOJAUNT)

--- a/code/datums/spells/ethereal_jaunt.dm
+++ b/code/datums/spells/ethereal_jaunt.dm
@@ -109,21 +109,8 @@
 	if(!IS_DIR_DIAGONAL(direction))
 		to_chat(user, "<span class='warning'>Something is blocking the way!</span>")
 		return
-	var/turf/possible_1
-	var/turf/possible_2
-	switch(direction)
-		if(NORTHEAST)
-			possible_1 = get_step(src, NORTH)
-			possible_2 = get_step(src, EAST)
-		if(NORTHWEST)
-			possible_1 = get_step(src, NORTH)
-			possible_2 = get_step(src, WEST)
-		if(SOUTHEAST)
-			possible_1 = get_step(src, SOUTH)
-			possible_2 = get_step(src, EAST)
-		if(SOUTHWEST)
-			possible_1 = get_step(src, SOUTH)
-			possible_2 = get_step(src, WEST)
+	var/turf/possible_1 = get_step(src, turn(direction, 45))
+	var/turf/possible_2 = get_step(src, turn(direction, -45))
 	if(can_move(possible_1))
 		forceMove(possible_1)
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
This PR tweaks relaymove proc of blood pool(hemomancer spell). Previously if you try to move diagonally and turf to the diagonal direction is blocked, you would not move at all and you will get message "Something is blocking the way!".
After this PR if diagonal move is blocked, you will try to move in cardinal directions which are parts of diagonal movement like it works with default walk. (you try to move diagonally into the wall, you move in parallel with wall instead)

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Unexpected behaviour of blood pool move is not cool, blood pooling into a door before this PR was really hard, you need to stand accurate at the door and only then move into, now you can just bumb it as default walk.

## Testing
<!-- How did you test the PR, if at all? -->
Compiled, tried blood pooling

## Changelog
:cl:
tweak: Blood pool movement now tries to move in cardinal directions if diagonal movement is blocked.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
