### PR TITLE
Fixes item plurals for kitchen equipment 

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
@@ -478,8 +478,8 @@
 			else
 				if(food.ingredient_name_plural)
 					name_overrides[display_name] = food.ingredient_name_plural
-				else
-					name_overrides[display_name] = "[name_overrides[display_name]]\s" //name_overrides[display_name] Will be set on the first time as the singular form
+				else if(items_counts[display_name] == 1) // Must only add "s" once or you get stuff like "eggsssss"
+					name_overrides[display_name] = "[name_overrides[display_name]]s" //name_overrides[display_name] Will be set on the first time as the singular form
 
 		items_counts[display_name]++
 


### PR DESCRIPTION
## What Does This PR Do
This fixes https://github.com/ParadiseSS13/Paradise/issues/19486, a bug that causes items inserted into kitchen machines to not pluralize properly. 
## Why It's Good For The Game
Prevents a spelling error from occurring.
## Images of changes
![JcNfHTpJpn](https://github.com/ParadiseSS13/Paradise/assets/116982774/5398351c-ad07-4aba-8dda-d86238b542c2)
## Testing
Put multiples of the same item into a kitchen machine and checked the behavior.
## Changelog
:cl:
spellcheck: Fixed kitchen machine plurals
/:cl: