### PR TITLE
fixes surplus crates

### DIFF
--- a/code/datums/uplink_items/uplink_traitor.dm
+++ b/code/datums/uplink_items/uplink_traitor.dm
@@ -541,19 +541,19 @@
 
 /datum/uplink_item/bundles_TC/surplus_crate
 	name = "Syndicate Surplus Crate"
-	desc = "A crate containing 50 telecrystals worth of random syndicate leftovers."
+	desc = "A crate containing 250 telecrystals worth of random syndicate leftovers."
 	reference = "SYSC"
 	cost = 100
 	item = /obj/item/storage/box/syndie_kit/bundle
 	excludefrom = list(UPLINK_TYPE_NUCLEAR, UPLINK_TYPE_SST)
-	var/crate_value = 50
+	var/crate_value = 250
 
 /datum/uplink_item/bundles_TC/surplus_crate/super
 	name = "Syndicate Super Surplus Crate"
-	desc = "A crate containing 125 telecrystals worth of random syndicate leftovers."
+	desc = "A crate containing 625 telecrystals worth of random syndicate leftovers."
 	reference = "SYSS"
 	cost = 200
-	crate_value = 125
+	crate_value = 625
 
 /datum/uplink_item/bundles_TC/surplus_crate/spawn_item(turf/loc, obj/item/uplink/U)
 	var/obj/structure/closet/crate/C = new(loc)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
adjusts surplus crates for inflation
fixes #22057

## Why It's Good For The Game
bugs are bad

## Testing
checked the numbers on my 90 pound calculator

## Changelog
:cl:
fix: surplus crates give the proper amount of items
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
