### PR TITLE
Fixes single pill/patch creation in Chem Masters

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -354,10 +354,13 @@
 				if("create_pill")
 					if(condi || !reagents.total_volume)
 						return
-					var/num = clamp(round(text2num(arguments["num"])), 0, MAX_MULTI_AMOUNT)
+
+					var/num = arguments["num"] || 1 // Multi puts a string in `num`, single leaves it null
+					num = clamp(round(text2num(num)), 0, MAX_MULTI_AMOUNT)
 					if(!num)
 						return
 					arguments["num"] = num
+
 					var/amount_per_pill = clamp(reagents.total_volume / num, 0, MAX_UNITS_PER_PILL)
 					var/default_name = "[reagents.get_master_reagent_name()] ([amount_per_pill]u)"
 					var/pills_text = num == 1 ? "new pill" : "[num] new pills"
@@ -374,10 +377,13 @@
 				if("create_patch")
 					if(condi || !reagents.total_volume)
 						return
-					var/num = clamp(round(text2num(arguments["num"])), 0, MAX_MULTI_AMOUNT)
+
+					var/num = arguments["num"] || 1 // Multi puts a string in `num`, single leaves it null
+					num = clamp(round(text2num(num)), 0, MAX_MULTI_AMOUNT)
 					if(!num)
 						return
 					arguments["num"] = num
+
 					var/amount_per_patch = clamp(reagents.total_volume / num, 0, MAX_UNITS_PER_PATCH)
 					var/default_name = "[reagents.get_master_reagent_name()] ([amount_per_patch]u)"
 					var/patches_text = num == 1 ? "new patch" : "[num] new patches"


### PR DESCRIPTION
## What Does This PR Do
Fixes single pill/patch creation buttons doing absolutely nothing due to early-returning thanks to an arguments list property that is never set for those buttons
I broke this on accident in #21904 because the way the code did it previously was undocumented and baked into a one-liner; still, probably should've caught it in more rigorous testing, totally my b
(also, Chem Master UI code is horrible)

## Why It's Good For The Game
Bugs be gone

## Testing
Tried to make a singular pill, confirmed success
Tried to make 1 pill in a multi number prompt, confirmed result was the same as above
Tried to make 0 pills in a multi number prompt, confirmed machine aborts successfully

## Changelog
:cl:
fix: Fixed Chem Masters' singular pill/patch creation buttons not working
/:cl:
