### PR TITLE
Fixes some issues with keycard authenticators

### DIFF
--- a/code/modules/security_levels/keycard_authentication.dm
+++ b/code/modules/security_levels/keycard_authentication.dm
@@ -187,17 +187,19 @@
 			atom_say("ERT request transmitted!")
 			GLOB.command_announcer.autosay("ERT request transmitted. Reason: [ert_reason]", name, follow_target_override = src)
 			print_centcom_report(ert_reason, station_time_timestamp() + " ERT Request")
+			SSblackbox.record_feedback("nested tally", "keycard_auths", 1, list("ert", "called"))
 
 			var/fullmin_count = 0
 			for(var/client/C in GLOB.admins)
 				if(check_rights(R_EVENT, 0, C.mob))
 					fullmin_count++
 			if(!fullmin_count)
-				trigger_armed_response_team(new /datum/response_team/amber) // No admins? No problem. Automatically send a code amber ERT.
+				// No admins? No problem. Automatically send a code amber ERT.
+				INVOKE_ASYNC(GLOBAL_PROC, GLOBAL_PROC_REF(trigger_armed_response_team), new /datum/response_team/amber)
+				ert_reason = null
 				return
 
 			ERT_Announce(ert_reason, triggered_by, repeat_warning = FALSE)
-			SSblackbox.record_feedback("nested tally", "keycard_auths", 1, list("ert", "called"))
 			addtimer(CALLBACK(src, PROC_REF(remind_admins), ert_reason, triggered_by), 5 MINUTES)
 			ert_reason = null
 

--- a/code/modules/security_levels/keycard_authentication.dm
+++ b/code/modules/security_levels/keycard_authentication.dm
@@ -169,7 +169,7 @@
 	addtimer(CALLBACK(src, PROC_REF(reset)), confirm_delay)
 
 /obj/machinery/keycard_auth/proc/trigger_event()
-	SHOULD_NOT_SLEEP(TRUE) // exploits related to ERT spawning can come up here related to ERT spawning if this sleeps
+	SHOULD_NOT_SLEEP(TRUE) // trigger_armed_response_team sleeps, which can cause issues for procs that call trigger_event(). We want to avoid that
 	switch(event)
 		if("Red Alert")
 			INVOKE_ASYNC(GLOBAL_PROC, GLOBAL_PROC_REF(set_security_level), SEC_LEVEL_RED)

--- a/code/modules/security_levels/keycard_authentication.dm
+++ b/code/modules/security_levels/keycard_authentication.dm
@@ -169,6 +169,7 @@
 	addtimer(CALLBACK(src, PROC_REF(reset)), confirm_delay)
 
 /obj/machinery/keycard_auth/proc/trigger_event()
+	SHOULD_NOT_SLEEP(TRUE) // exploits related to ERT spawning can come up here related to ERT spawning if this sleeps
 	switch(event)
 		if("Red Alert")
 			set_security_level(SEC_LEVEL_RED)

--- a/code/modules/security_levels/keycard_authentication.dm
+++ b/code/modules/security_levels/keycard_authentication.dm
@@ -172,7 +172,7 @@
 	SHOULD_NOT_SLEEP(TRUE) // exploits related to ERT spawning can come up here related to ERT spawning if this sleeps
 	switch(event)
 		if("Red Alert")
-			set_security_level(SEC_LEVEL_RED)
+			INVOKE_ASYNC(GLOBAL_PROC, GLOBAL_PROC_REF(set_security_level), SEC_LEVEL_RED)
 		if("Grant Emergency Maintenance Access")
 			make_maint_all_access()
 		if("Revoke Emergency Maintenance Access")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->Fixes #22055. ERT without admins online will also be properly tallied on the blackbox.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Nasty bug

## Testing
<!-- How did you test the PR, if at all? -->
2 Clients on a server, called ERT while both were de-admined, could only call 1 instead of spamming it. Changed alert to red alert without any problems with the async.

## Changelog
:cl:
fix: ERT calling when no admins are online is more consistent with normal ERTs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
