### PR TITLE
Removes old lines of code mentioning genetic_damage, fixes text misleading to receiving "genetic_damage".

### DIFF
--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -448,7 +448,6 @@
 			to_chat(owner, "<span class='danger'>We collapse in exhaustion.</span>")
 			owner.Weaken(6 SECONDS)
 			owner.emote("gasp")
-	cling.genetic_damage += stacks
 	cling = null
 
 /datum/status_effect/panacea

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -1,5 +1,4 @@
 #define LING_FAKEDEATH_TIME					40 SECONDS
-#define LING_DEAD_GENETIC_DAMAGE_HEAL_CAP	50	//The lowest value of genetic_damage handle_changeling() can take it to while dead.
 #define LING_ABSORB_RECENT_SPEECH			8	//The amount of recent spoken lines to gain on absorbing a mob
 
 GLOBAL_LIST_INIT(possible_changeling_IDs, list("Alpha","Beta","Gamma","Delta","Epsilon","Zeta","Eta","Theta","Iota","Kappa","Lambda","Mu","Nu","Xi","Omicron","Pi","Rho","Sigma","Tau","Upsilon","Phi","Chi","Psi","Omega"))

--- a/code/modules/antagonists/changeling/datum_changeling.dm
+++ b/code/modules/antagonists/changeling/datum_changeling.dm
@@ -183,7 +183,7 @@
 	var/mob/living/carbon/human/H = owner.current
 	if(H.stat == DEAD)
 		chem_charges = clamp(0, chem_charges + chem_recharge_rate - chem_recharge_slowdown, chem_storage * 0.5)
-	else // Not dead? no chem
+	else
 		chem_charges = clamp(0, chem_charges + chem_recharge_rate - chem_recharge_slowdown, chem_storage)
 	update_chem_charges_ui(H)
 

--- a/code/modules/antagonists/changeling/datum_changeling.dm
+++ b/code/modules/antagonists/changeling/datum_changeling.dm
@@ -36,8 +36,6 @@
 	var/sting_range = 2
 	/// The changeling's identifier when speaking in the hivemind, i.e. "Mr. Delta 123".
 	var/changelingID = "Changeling"
-	/// The current amount of genetic damage incurred from power use.
-	var/genetic_damage = 0
 	/// If the changeling is in the process of absorbing someone.
 	var/is_absorbing = FALSE
 	/// The amount of points available to purchase changeling abilities.
@@ -185,10 +183,8 @@
 	var/mob/living/carbon/human/H = owner.current
 	if(H.stat == DEAD)
 		chem_charges = clamp(0, chem_charges + chem_recharge_rate - chem_recharge_slowdown, chem_storage * 0.5)
-		genetic_damage = directional_bounded_sum(genetic_damage, -1, LING_DEAD_GENETIC_DAMAGE_HEAL_CAP, 0)
-	else // Not dead? no chem/genetic_damage caps.
+	else // Not dead? no chem
 		chem_charges = clamp(0, chem_charges + chem_recharge_rate - chem_recharge_slowdown, chem_storage)
-		genetic_damage = max(0, genetic_damage - 1)
 	update_chem_charges_ui(H)
 
 /datum/antagonist/changeling/proc/update_chem_charges_ui(mob/living/carbon/human/H = owner.current)

--- a/code/modules/antagonists/changeling/powers/lesserform.dm
+++ b/code/modules/antagonists/changeling/powers/lesserform.dm
@@ -20,7 +20,6 @@
 		return FALSE
 
 	H.visible_message("<span class='warning'>[H] transforms!</span>")
-	cling.genetic_damage = 30
 	to_chat(H, "<span class='warning'>Our genes cry out!</span>")
 	H.monkeyize()
 

--- a/code/modules/antagonists/changeling/powers/strained_muscles.dm
+++ b/code/modules/antagonists/changeling/powers/strained_muscles.dm
@@ -4,7 +4,7 @@
 /datum/action/changeling/strained_muscles
 	name = "Strained Muscles"
 	desc = "We evolve the ability to reduce the acid buildup in our muscles, allowing us to move much faster."
-	helptext = "The strain will use up our chemicals faster over time, and is not sustainable. Causes slight genetic damage to our genome. Can not be used in lesser form."
+	helptext = "The strain will use up our chemicals faster over time, and is not sustainable. Can not be used in lesser form."
 	button_icon_state = "strained_muscles"
 	chemical_cost = 0
 	dna_cost = 1


### PR DESCRIPTION
## What Does This PR Do
This PR removes unnecessary code which has no functionality nor use anymore.
Removes code mentioning genetic_damage from 5 files.
Removes the mention of genetic damage from the description of the ability Strained Muscles.

## Why It's Good For The Game
Removes unrequired lines of code, likely removing the possbility of errors within in the code.

## Images of changes
Old:
![image](https://github.com/ParadiseSS13/Paradise/assets/142694283/a73ca193-46a6-42a7-9cf1-74665563604b)

New:
![changeling1](https://github.com/ParadiseSS13/Paradise/assets/142694283/408c81ac-1dc9-4bcc-b2e5-b8e01b151ac9)


## Testing
Tested via Testserver, everything is functional.

![changeling](https://github.com/ParadiseSS13/Paradise/assets/142694283/c863ed47-19d9-4640-85ca-d88378207258)



## Changelog
:cl:
del: Removed genetic_damage from the changeling code as it is not used anymore.
/:cl:
