### PR TITLE
Engineer Scanner Goggles on Radiation Mode Prevent SM Hallucinations/Singulo Staring

### DIFF
--- a/code/modules/clothing/glasses/engine_goggles.dm
+++ b/code/modules/clothing/glasses/engine_goggles.dm
@@ -14,6 +14,8 @@
 	origin_tech = "materials=3;magnets=3;engineering=3;plasmatech=3"
 	active_on_equip = FALSE
 
+	var/active_on_equip_rad = FALSE
+
 	var/list/modes = list(MODE_NONE = MODE_MESON, MODE_MESON = MODE_TRAY, MODE_TRAY = MODE_RAD, MODE_RAD = MODE_NONE)
 	var/mode = MODE_NONE
 	var/range = 1
@@ -42,10 +44,10 @@
 	if(mode == MODE_RAD)
 		if(!HAS_TRAIT_FROM(user, SM_HALLUCINATION_IMMUNE, "meson_glasses[UID()]"))
 			ADD_TRAIT(user, SM_HALLUCINATION_IMMUNE, "meson_glasses[UID()]")
-		active_on_equip = TRUE
+		active_on_equip_rad = TRUE
 	else
 		REMOVE_TRAIT(user, SM_HALLUCINATION_IMMUNE, "meson_glasses[UID()]")
-		active_on_equip = FALSE
+		active_on_equip_rad = FALSE
 
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user

--- a/code/modules/clothing/glasses/engine_goggles.dm
+++ b/code/modules/clothing/glasses/engine_goggles.dm
@@ -29,6 +29,14 @@
 	STOP_PROCESSING(SSobj, src)
 	return ..()
 
+/obj/item/clothing/glasses/meson/engine/equipped(mob/user, slot, initial)
+	. = ..()
+	if(active_on_equip && mode == MODE_MESON && slot == slot_glasses)
+		ADD_TRAIT(user, TRAIT_MESON_VISION, "meson_glasses[UID()]")
+
+	if(active_on_equip_rad && mode == MODE_RAD && slot == slot_glasses)
+		ADD_TRAIT(user, SM_HALLUCINATION_IMMUNE, "meson_glasses[UID()]")
+
 /obj/item/clothing/glasses/meson/engine/proc/toggle_mode(mob/user, voluntary)
 	mode = modes[mode]
 	to_chat(user, "<span class='[voluntary ? "notice" : "warning"]'>[voluntary ? "You turn the goggles" : "The goggles turn"] [mode ? "to [mode] mode" : "off"][voluntary ? "." : "!"]</span>")

--- a/code/modules/clothing/glasses/engine_goggles.dm
+++ b/code/modules/clothing/glasses/engine_goggles.dm
@@ -39,6 +39,14 @@
 		REMOVE_TRAIT(user, TRAIT_MESON_VISION, "meson_glasses[UID()]")
 		active_on_equip = FALSE
 
+	if(mode == MODE_RAD)
+		if(!HAS_TRAIT_FROM(user, SM_HALLUCINATION_IMMUNE, "meson_glasses[UID()]"))
+			ADD_TRAIT(user, SM_HALLUCINATION_IMMUNE, "meson_glasses[UID()]")
+		active_on_equip = TRUE
+	else
+		REMOVE_TRAIT(user, SM_HALLUCINATION_IMMUNE, "meson_glasses[UID()]")
+		active_on_equip = FALSE
+
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		if(H.glasses == src)

--- a/code/modules/power/engines/singularity/singularity.dm
+++ b/code/modules/power/engines/singularity/singularity.dm
@@ -454,8 +454,8 @@
 		if(isbrain(M)) //Ignore brains
 			continue
 
-		if(HAS_TRAIT(M, TRAIT_MESON_VISION))
-			to_chat(M, "<span class='notice'>You look directly into [src], but your meson vision protects you!</span>")
+		if(HAS_TRAIT(M, TRAIT_MESON_VISION) || HAS_TRAIT(M, SM_HALLUCINATION_IMMUNE))
+			to_chat(M, "<span class='notice'>You look directly into [src], but remain unaffected!</span>")
 			return
 
 		M.Stun(6 SECONDS)

--- a/code/modules/power/engines/supermatter/supermatter.dm
+++ b/code/modules/power/engines/supermatter/supermatter.dm
@@ -242,7 +242,7 @@
 	. = ..()
 	var/mob/living/carbon/human/H = user
 	if(istype(H))
-		if(!HAS_TRAIT(H, TRAIT_MESON_VISION) && (get_dist(user, src) < HALLUCINATION_RANGE(power)))
+		if(!HAS_TRAIT(H, TRAIT_MESON_VISION) && !HAS_TRAIT(H, SM_HALLUCINATION_IMMUNE) && (get_dist(user, src) < HALLUCINATION_RANGE(power)))
 			. += "<span class='danger'>You get headaches just from looking at it.</span>"
 	. += "<span class='notice'>When actived by an item hitting this awe-inspiring feat of engineering, it emits radiation and heat. This is the basis of the use of the pseudo-perpetual energy source, the supermatter crystal.</span>"
 	. +="<span class='notice'>Any object that touches [src] instantly turns to dust, be it complex as a human or as simple as a metal rod. These bursts of energy can cause hallucinations if meson scanners are not worn near the crystal.</span>"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Allows Radiation Mode to protect against SM Hallucinations and the Singularity.

## Why It's Good For The Game
Why the mode that allows you to carefully avoid radiation doesnt also protect you against the most radioactive things on Station is a bit wild.

## Testing
1. Stared at code till I went crazy.
2. Stared at an SM till I didnt go crazy, cause the code works.

## Changelog
:cl:
tweak: Radiation Goggle Mode now prevents SM Hallucinations and Singulo Staring.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
