### PR TITLE
fixes a runtime if your hand gets cut off

### DIFF
--- a/code/modules/surgery/organs/subtypes/standard_organs.dm
+++ b/code/modules/surgery/organs/subtypes/standard_organs.dm
@@ -205,6 +205,8 @@
 
 /obj/item/organ/external/hand/proc/update_hand_missing()
 	// we need to come back to this once the hand is actually removed/dead
+	if(!owner) // Rather not have this trigger on already remove limbs
+		return
 	addtimer(CALLBACK(owner, TYPE_PROC_REF(/mob/living/carbon/human, update_hands_hud), 0))
 
 /obj/item/organ/external/hand/right


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
fixes a null.hudused runtime from detaching a hand
source will be null if you input null into a timer send
```
/mob/living/carbon/proc/update_hands_hud()
	if(!hud_used)
		return
	var/obj/screen/inventory/R = hud_used.inv_slots[slot_r_hand]
	R?.update_icon()
	var/obj/screen/inventory/L = hud_used.inv_slots[slot_l_hand]
	L?.update_icon()
```
remember to sanity check your timer sends

## Why It's Good For The Game
runtimes bad

