### PR TITLE
HOTFIX: 2 SM event runtimes, 2 instances of unintended behavior

### DIFF
--- a/code/modules/power/engines/supermatter/supermatter.dm
+++ b/code/modules/power/engines/supermatter/supermatter.dm
@@ -218,7 +218,7 @@
 	///amount of EER to ADD
 	var/power_additive = 0
 	/// A list of all previous events
-	var/list/last_events
+	var/list/last_events = list()
 	/// Time of next event
 	var/next_event_time
 	/// Run S-Class event? So we can only run one S-class event per round per crystal
@@ -587,7 +587,7 @@
 	//Transitions between one function and another, one we use for the fast inital startup, the other is used to prevent errors with fusion temperatures.
 	//Use of the second function improves the power gain imparted by using co2
 	if(power_changes)
-		power = max(power - min(((power / 500) ** 3) * powerloss_inhibitor, power * 0.83 * powerloss_inhibitor), 0)
+		power = max((power - min(((power / 500) ** 3) * powerloss_inhibitor, power * 0.83 * powerloss_inhibitor) + power_additive), 0)
 	//After this point power is lowered
 	//This wraps around to the begining of the function
 	//Handle high power zaps/anomaly generation
@@ -671,7 +671,6 @@
 		//Boom (Mind blown)
 		if(damage > explosion_point)
 			countdown()
-	power += power_additive
 	return 1
 
 /obj/machinery/atmospherics/supermatter_crystal/bullet_act(obj/item/projectile/Proj)
@@ -1213,7 +1212,6 @@
 		log_debug("Attempted supermatter event aborted due to incorrect path. Incorrect path type: [event.type].")
 		return
 	event.start_event()
-
 
 #undef HALLUCINATION_RANGE
 #undef GRAVITATIONAL_ANOMALY

--- a/code/modules/power/engines/supermatter/supermatter.dm
+++ b/code/modules/power/engines/supermatter/supermatter.dm
@@ -421,7 +421,7 @@
 
 	try_events()
 	if(power > 100)
-		sif(!has_been_powered)
+		if(!has_been_powered)
 			investigate_log("has been powered for the first time.", "supermatter")
 			message_admins("[src] has been powered for the first time [ADMIN_JMP(src)].")
 			has_been_powered = TRUE

--- a/code/modules/power/engines/supermatter/supermatter.dm
+++ b/code/modules/power/engines/supermatter/supermatter.dm
@@ -420,7 +420,11 @@
 		return
 
 	try_events()
-
+	if(power > 100)
+		sif(!has_been_powered)
+			investigate_log("has been powered for the first time.", "supermatter")
+			message_admins("[src] has been powered for the first time [ADMIN_JMP(src)].")
+			has_been_powered = TRUE
 	//We vary volume by power, and handle OH FUCK FUSION IN COOLING LOOP noises.
 	if(power)
 		soundloop.volume = clamp((50 + (power / 50)), 50, 100)

--- a/code/modules/power/engines/supermatter/supermatter_event.dm
+++ b/code/modules/power/engines/supermatter/supermatter_event.dm
@@ -155,7 +155,7 @@
 	name = "A-1"
 
 /datum/supermatter_event/alpha_tier/apc_short/on_start()
-	var/area/current_area = get_area(src)
+	var/area/current_area = get_area(supermatter)
 	var/obj/machinery/power/apc/A = current_area.get_apc()
 	A.apc_short()
 
@@ -163,9 +163,9 @@
 	name = "A-2"
 
 /datum/supermatter_event/alpha_tier/air_siphon/on_start()
-	var/area/current_area = get_area(src)
-	var/obj/machinery/alarm/engine/A = current_area.master_air_alarm
-	A.apply_mode(AALARM_MODE_SCRUBBING)
+	var/area/current_area = get_area(supermatter)
+	for(var/obj/machinery/alarm/A in current_area)
+		A.apply_mode(AALARM_MODE_OFF)
 
 /datum/supermatter_event/alpha_tier/gas_multiplier
 	name = "A-3"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR fixes 2 runtime errors that occured when SM events were called. This PR also changes class A-2 events to simply reset the air alarm, as opposed to the previously attempted custom settings. Finally, this PR fixes a several year old issue in which admins were not notified and a flag was not set if an engine was not powered with emitters.


## Why It's Good For The Game
Runtimes bad. Things acting wrong is bad. Oversights are also bad.

## Testing
Ensure events starts on emitter based and gas based SM designs.

## Changelog
:cl:
fix: Fixes 2 runtimes and some unintended behavior in SM events
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
