### PR TITLE
Removes Stun Arm from Safety Override, Adds Proto Emitter

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -399,7 +399,7 @@
 		/obj/item/stack/sheet/rglass/cyborg
 	)
 	emag_modules = list(/obj/item/borg/stun, /obj/item/restraints/handcuffs/cable/zipties/cyborg, /obj/item/rcd/borg)
-	override_modules = list(/obj/item/rcd/borg, /obj/item/gun/energy/emitter/cyborg/proto)
+	override_modules = list(/obj/item/gun/energy/emitter/cyborg/proto)
 	malf_modules = list(/obj/item/gun/energy/emitter/cyborg)
 	special_rechargables = list(/obj/item/extinguisher, /obj/item/weldingtool/largetank/cyborg, /obj/item/gun/energy/emitter/cyborg)
 

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -16,6 +16,8 @@
 	var/list/basic_modules = list()
 	/// A list of modules the robot gets when emagged.
 	var/list/emag_modules = list()
+	/// A list of modules the robot gets when Safety Overridden.______qdel_list_wrapper(list/L)
+	var/list/override_modules = list()
 	/// A list of modules that the robot gets when malf AI buys it.
 	var/list/malf_modules = list()
 	/// A list of modules that require special recharge handling. Examples include things like flashes, sprays and welding tools.
@@ -43,6 +45,10 @@
 		basic_modules += I
 		basic_modules -= i
 
+	for(var/i in override_modules)
+		var/obj/item/I = new i(src)
+		override_modules += I
+		override_modules -= i
 	// Even though these are created here the robot won't be able to see and equip them until they actually get emagged/hacked.
 	for(var/i in emag_modules)
 		var/obj/item/I = new i(src)
@@ -59,7 +65,7 @@
 	special_rechargables += /obj/item/flash/cyborg
 
 	// This is done so we can loop through this list later and call cyborg_recharge() on the items while the borg is recharging.
-	var/all_modules = basic_modules | emag_modules | malf_modules
+	var/all_modules = basic_modules | override_modules | emag_modules | malf_modules
 	for(var/path in special_rechargables)
 		var/obj/item/I = locate(path) in all_modules
 		if(I) // If it exists, add the object reference.
@@ -80,6 +86,7 @@
 	// These can all contain actual objects, so we need to null them out.
 	QDEL_LIST_CONTENTS(modules)
 	QDEL_LIST_CONTENTS(basic_modules)
+	QDEL_LIST_CONTENTS(override_modules)
 	QDEL_LIST_CONTENTS(emag_modules)
 	QDEL_LIST_CONTENTS(malf_modules)
 	QDEL_LIST_CONTENTS(storages)
@@ -101,6 +108,7 @@
 /obj/item/robot_module/proc/remove_item_from_lists(item_or_item_type)
 	var/list/lists = list(
 		basic_modules,
+		override_modules,
 		emag_modules,
 		malf_modules,
 		storages,
@@ -170,7 +178,7 @@
 	return I
 
 /**
- * Builds the usable module list from the modules we have in `basic_modules`, `emag_modules` and `malf_modules`
+ * Builds the usable module list from the modules we have in `basic_modules`, `override_modules`, `emag_modules` and `malf_modules`
  */
 /obj/item/robot_module/proc/rebuild_modules()
 	var/mob/living/silicon/robot/R = loc
@@ -185,7 +193,11 @@
 	for(var/item in basic_modules)
 		add_module(item, FALSE)
 
-	if(R.emagged || R.weapons_unlock)
+	if(R.weapons_unlock)
+		for(var/item in override_modules)
+			add_module(item, FALSE)
+
+	if(R.emagged)
 		for(var/item in emag_modules)
 			add_module(item, FALSE)
 
@@ -387,6 +399,7 @@
 		/obj/item/stack/sheet/rglass/cyborg
 	)
 	emag_modules = list(/obj/item/borg/stun, /obj/item/restraints/handcuffs/cable/zipties/cyborg, /obj/item/rcd/borg)
+	override_modules = list(/obj/item/rcd/borg, /obj/item/gun/energy/emitter/cyborg/proto)
 	malf_modules = list(/obj/item/gun/energy/emitter/cyborg)
 	special_rechargables = list(/obj/item/extinguisher, /obj/item/weldingtool/largetank/cyborg, /obj/item/gun/energy/emitter/cyborg)
 

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -16,7 +16,7 @@
 	var/list/basic_modules = list()
 	/// A list of modules the robot gets when emagged.
 	var/list/emag_modules = list()
-	/// A list of modules the robot gets when Safety Overridden.______qdel_list_wrapper(list/L)
+	/// A list of modules the robot gets when Safety Overridden.
 	var/list/override_modules = list()
 	/// A list of modules that the robot gets when malf AI buys it.
 	var/list/malf_modules = list()

--- a/code/modules/projectiles/ammunition/energy_lens.dm
+++ b/code/modules/projectiles/ammunition/energy_lens.dm
@@ -299,7 +299,7 @@
 
 /obj/item/ammo_casing/energy/emitter/cyborg/proto // needed a slightly weaker ranged option to give to Safety Overriden borgs. The fire rate is about the same as an emitter if you put it on the ground.
 	e_cost = 500
-	delay = 3 SECONDS
+	delay = 2 SECONDS
 
 /obj/item/ammo_casing/energy/bsg
 	projectile_type = /obj/item/projectile/energy/bsg

--- a/code/modules/projectiles/ammunition/energy_lens.dm
+++ b/code/modules/projectiles/ammunition/energy_lens.dm
@@ -297,6 +297,10 @@
 	e_cost = 350 // about 42 shots on an engineering borg from a borging machine, Reads a lot better than it actually is because people miss shots and often your better abilities require charge as well
 	delay = 1 SECONDS
 
+/obj/item/ammo_casing/energy/emitter/cyborg/proto // needed a slightly weaker ranged option to give to Safety Overriden borgs. The fire rate is about the same as an emitter if you put it on the ground.
+	e_cost = 500
+	delay = 3 SECONDS
+
 /obj/item/ammo_casing/energy/bsg
 	projectile_type = /obj/item/projectile/energy/bsg
 	muzzle_flash_color = LIGHT_COLOR_DARKBLUE

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -273,6 +273,10 @@
 /obj/item/gun/energy/emitter/cyborg/emp_act()
 	return
 
+/obj/item/gun/energy/emitter/cyborg/proto
+	ammo_type = list(/obj/item/ammo_casing/energy/emitter/cyborg/proto)
+
+
 ////////Laser Tag////////////////////
 
 /obj/item/gun/energy/laser/tag


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Removes Stun Arm from the Safety Override for EngiBorgs.
Adds the Proto Emitter Gun to the Safety Override for EngiBorgs.

## Why It's Good For The Game
There is no reason for the Crew to be able to make pseudo-SecBorgs. We dont need more insta-stuns for Antags to deal with. This was discussed with GAs/HAs before being made, as we see this as an issue.

Given that some Antag Roboticists used this for evil, I gave them a ranged emitter that's slightly weaker than the Malf AI one.

## Testing
Tested the Safety Override on myself, it works.

## Changelog
:cl:
add: Added Proto Cyborg Emitter to the EngiBorg Safety Override.
del: Removed Stun Arm from the EngiBorg Safety Override.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
