### PR TITLE
Tweaks how splints work on healthy limbs

### DIFF
--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -482,19 +482,18 @@ Note that amputating the affected organ does in fact remove the infection from t
 	return "[tbrute][tburn]"
 
 /obj/item/organ/external/proc/update_splints()
-    if(!(status & ORGAN_SPLINTED))
-        owner.splinted_limbs -= src
-        return
-    if(owner.step_count >= splinted_count + SPLINT_LIFE)
-        status &= ~ORGAN_SPLINTED //oh no, we actually need surgery now!
-        owner.handle_splints()
-        if(status & ORGAN_BROKEN)
-            owner.visible_message(owner, "<span class='danger'>[owner] screams in pain as [owner.p_their()] splint pops off [owner.p_their()] [name]!</span>","<span class='userdanger'>You scream in pain as your splint pops off your [name]!</span>")
-            owner.emote("scream")
-            owner.Weaken(4 SECONDS) //Better feedback compared to stun() - We won't be just standing there menancingly
-            return
-        to_chat(owner, "<span class='notice'>Your splint harmlessly pops off your [name].</span>") //If we fixed our bones, a splint popping off shouldn't be painful and stun us.
-
+	if(!(status & ORGAN_SPLINTED))
+		owner.splinted_limbs -= src
+		return
+	if(owner.step_count >= splinted_count + SPLINT_LIFE)
+		status &= ~ORGAN_SPLINTED // Oh no, we actually need surgery now!
+		owner.handle_splints()
+		if(!(status & ORGAN_BROKEN))
+			to_chat(owner, "<span class='notice'>Your splint harmlessly pops off your [name].</span>") // If we fixed our bones, a splint popping off shouldn't be painful and stun us.
+			return
+		owner.visible_message("<span class='danger'>[owner] screams in pain as [owner.p_their()] splint pops off [owner.p_their()] [name]!</span>","<span class='userdanger'>You scream in pain as your splint pops off your [name]!</span>")
+		owner.emote("scream")
+		owner.Weaken(4 SECONDS) // Better feedback compared to stun() - We won't be just standing there menancingly
 
 /****************************************************
 			DISMEMBERMENT

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -489,7 +489,7 @@ Note that amputating the affected organ does in fact remove the infection from t
         status &= ~ORGAN_SPLINTED //oh no, we actually need surgery now!
         owner.handle_splints()
         if(status & ORGAN_BROKEN)
-            to_chat(owner, "<span class='danger'>[owner] screams in pain as [owner.p_their()] splint pops off their [name]!</span>","<span class='userdanger'>You scream in pain as your splint pops off your [name]!</span>") // Figure out how to_chat works nicely
+            owner.visible_message(owner, "<span class='danger'>[owner] screams in pain as [owner.p_their()] splint pops off [owner.p_their()] [name]!</span>","<span class='userdanger'>You scream in pain as your splint pops off your [name]!</span>")
             owner.emote("scream")
             owner.Weaken(4 SECONDS) //Better feedback compared to stun() - We won't be just standing there menancingly
             return

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -482,15 +482,18 @@ Note that amputating the affected organ does in fact remove the infection from t
 	return "[tbrute][tburn]"
 
 /obj/item/organ/external/proc/update_splints()
-	if(!(status & ORGAN_SPLINTED))
-		owner.splinted_limbs -= src
-		return
-	if(owner.step_count >= splinted_count + SPLINT_LIFE)
-		status &= ~ORGAN_SPLINTED //oh no, we actually need surgery now!
-		owner.visible_message("<span class='danger'>[owner] screams in pain as [owner.p_their()] splint pops off their [name]!</span>","<span class='userdanger'>You scream in pain as your splint pops off your [name]!</span>")
-		owner.emote("scream")
-		owner.Stun(4 SECONDS)
-		owner.handle_splints()
+    if(!(status & ORGAN_SPLINTED))
+        owner.splinted_limbs -= src
+        return
+    if(owner.step_count >= splinted_count + SPLINT_LIFE)
+        status &= ~ORGAN_SPLINTED //oh no, we actually need surgery now!
+        owner.handle_splints()
+        if(status & ORGAN_BROKEN)
+            to_chat(owner, "<span class='danger'>[owner] screams in pain as [owner.p_their()] splint pops off their [name]!</span>","<span class='userdanger'>You scream in pain as your splint pops off your [name]!</span>") // Figure out how to_chat works nicely
+            owner.emote("scream")
+            owner.Weaken(4 SECONDS) //Better feedback compared to stun() - We won't be just standing there menancingly
+            return
+        to_chat(owner, "<span class='notice'>Your splint harmlessly pops off your [name].</span>") //If we fixed our bones, a splint popping off shouldn't be painful and stun us.
 
 
 /****************************************************


### PR DESCRIPTION
## What Does This PR Do
Splints now no longer hardstun you when it pops off, as long as the limb it is on doesn't have a bone fracture.

Splints also now Weaken you when it pops off a limb with bone fractures.

## Why It's Good For The Game
Currently, if you use a splint on a healthy limb, or have your damaged limb fixed after you splint it but forget to remove the splint, it will pop off after a while and then hardstun you for four seconds.

While it makes sense for this to happen to limbs with bone fractures, making splints still punish you with a debilitating stun when you have either spent TC on a prototype nanite injector or went to Medbay to get your fractures fixed is... not ideal. That really seems like an oversight and this PR aims to fix that. The splint still pops off, but you won't get stunned for four seconds.

The change from Stun() to Weaken() was done so it would provide more feedback to the player - Now instead of you just standing there suddenly unable to move, you will go horizontal as well.

## Testing
Loaded up a local server
- Put splint on healthy skrell and walked around. Splint pops off with no screaming or Weakening.
- Put splint on left leg of skrell with broken right leg and walked around. Splint pops off with no screaming or Weakening.
- Put splint on left leg of skrell with IB in left leg and walked around. Splint pops off with no screaming or Weakening.
- Put splint on left leg of skrell with broken left leg and walked around. Splint pops off, skrell becomes horizontal and begins screaming in endless agony.

## Changelog
:cl:
Tweak: Splint now no longer stuns you when it pops off a healthy limb
Tweak: Splint popping off a limb with bone fractures now Weaken instead of Stun
/:cl:
