### PR TITLE
Fixes a flowering kudzu runtime

### DIFF
--- a/code/game/objects/structures/aliens.dm
+++ b/code/game/objects/structures/aliens.dm
@@ -52,9 +52,12 @@
 	canSmoothWith = list(SMOOTH_GROUP_ALIEN_RESIN)
 	max_integrity = 200
 	var/resintype = null
+	var/is_alien = TRUE
 
 /obj/structure/alien/resin/Initialize(mapload)
 	air_update_turf(1)
+	if(!is_alien)
+		return ..()
 	for(var/obj/structure/alien/weeds/node/W in get_turf(src))
 		qdel(W)
 	if(locate(/obj/structure/alien/weeds) in get_turf(src))

--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -10,6 +10,7 @@
 	canSmoothWith = null
 	smoothing_flags = NONE
 	var/growth_time = 120 SECONDS
+	is_alien = FALSE
 
 /obj/structure/alien/resin/flower_bud_enemy/Initialize(mapload)
 	..()
@@ -18,9 +19,6 @@
 	anchors += locate(x + 2, y + 2, z)
 	anchors += locate(x - 2, y - 2, z)
 	anchors += locate(x + 2, y - 2, z)
-
-	for(var/obj/structure/alien/weeds/W in get_turf(src))
-		qdel(W)
 
 	for(var/turf/T in anchors)
 		var/datum/beam/B = Beam(T, "vine", time=INFINITY, maxdistance=5, beam_type=/obj/effect/ebeam/vine)

--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -11,13 +11,16 @@
 	smoothing_flags = NONE
 	var/growth_time = 120 SECONDS
 
-/obj/structure/alien/resin/flower_bud_enemy/New()
+/obj/structure/alien/resin/flower_bud_enemy/Initialize(mapload)
 	..()
 	var/list/anchors = list()
-	anchors += locate(x-2,y+2,z)
-	anchors += locate(x+2,y+2,z)
-	anchors += locate(x-2,y-2,z)
-	anchors += locate(x+2,y-2,z)
+	anchors += locate(x - 2, y + 2, z)
+	anchors += locate(x + 2, y + 2, z)
+	anchors += locate(x - 2, y - 2, z)
+	anchors += locate(x + 2, y - 2, z)
+
+	for(var/obj/structure/alien/weeds/W in get_turf(src))
+		qdel(W)
 
 	for(var/turf/T in anchors)
 		var/datum/beam/B = Beam(T, "vine", time=INFINITY, maxdistance=5, beam_type=/obj/effect/ebeam/vine)
@@ -37,13 +40,12 @@
 
 
 /obj/effect/ebeam/vine/Crossed(atom/movable/AM, oldloc)
-	if(isliving(AM))
-		var/mob/living/L = AM
-		if(!("vines" in L.faction))
-			L.adjustBruteLoss(5)
-			to_chat(L, "<span class='alert'>You cut yourself on the thorny vines.</span>")
-
-
+	if(!isliving(AM))
+		return
+	var/mob/living/L = AM
+	if(!("vines" in L.faction))
+		L.adjustBruteLoss(5)
+		to_chat(L, "<span class='alert'>You cut yourself on the thorny vines.</span>")
 
 /mob/living/simple_animal/hostile/venus_human_trap
 	name = "venus human trap"

--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -13,7 +13,7 @@
 	is_alien = FALSE
 
 /obj/structure/alien/resin/flower_bud_enemy/Initialize(mapload)
-	..()
+	. = ..()
 	var/list/anchors = list()
 	anchors += locate(x - 2, y + 2, z)
 	anchors += locate(x + 2, y + 2, z)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #21200
Removes the weird alien resin spawned due to inheritance bullshit
Also slightly refactors the surrounding code because it bothered me
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Runtimes bad, random alien resin bad
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Spawned in resin doors and walls, they didn't runtime
Spawned flowering pod, it didn't runtime and it flowered nicely
<!-- How did you test the PR, if at all? -->

## Changelog
NPFC

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
