### PR TITLE
Fixes Emagged Borgs Not Having Instant Bolt/Shock

### DIFF
--- a/code/_onclick/ai_onclick.dm
+++ b/code/_onclick/ai_onclick.dm
@@ -206,14 +206,8 @@
 /obj/machinery/door/airlock/AICtrlClick(mob/living/silicon/user) // Bolts doors
 	if(!ai_control_check(user))
 		return
-
-	if(istype(user, /mob/living/silicon/robot))
-		var/mob/living/silicon/robot/S = user
-		if(S.emagged || do_after(user, 3 SECONDS, target = src, allow_moving = TRUE))
-			toggle_bolt(user)
-			return
-
-	if(isAntag(user) || do_after(user, 3 SECONDS, target = src, allow_moving = TRUE))
+	var/mob/living/silicon/S = user
+	if(S.can_instant_lockdown() || do_after(user, 3 SECONDS, target = src, allow_moving = TRUE))
 		toggle_bolt(user)
 
 
@@ -225,15 +219,8 @@
 	if(isElectrified())
 		electrify(0, user, TRUE) // un-shock
 	else
-
-		if(istype(user, /mob/living/silicon/robot))
-			var/mob/living/silicon/robot/S = user
-			if(S.emagged || do_after(user, 3 SECONDS, target = src, allow_moving = TRUE))
-				electrify(-1, user, TRUE) // permanent shock + audio cue
-				playsound(loc, "sparks", 100, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
-				return
-
-		if(isAntag(user) || do_after(user, 3 SECONDS, target = src, allow_moving = TRUE))
+		var/mob/living/silicon/S = user
+		if(S.can_instant_lockdown() || do_after(user, 3 SECONDS, target = src, allow_moving = TRUE))
 			electrify(-1, user, TRUE) // permanent shock + audio cue
 			playsound(loc, "sparks", 100, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
 

--- a/code/_onclick/ai_onclick.dm
+++ b/code/_onclick/ai_onclick.dm
@@ -204,9 +204,15 @@
 	open_close(user)
 
 /obj/machinery/door/airlock/AICtrlClick(mob/living/silicon/user) // Bolts doors
-
 	if(!ai_control_check(user))
 		return
+
+	if(istype(user, /mob/living/silicon/robot))
+		var/mob/living/silicon/robot/S = user
+		if(S.emagged || do_after(user, 3 SECONDS, target = src, allow_moving = TRUE))
+			toggle_bolt(user)
+			return
+
 	if(isAntag(user) || do_after(user, 3 SECONDS, target = src, allow_moving = TRUE))
 		toggle_bolt(user)
 
@@ -219,6 +225,14 @@
 	if(isElectrified())
 		electrify(0, user, TRUE) // un-shock
 	else
+
+		if(istype(user, /mob/living/silicon/robot))
+			var/mob/living/silicon/robot/S = user
+			if(S.emagged || do_after(user, 3 SECONDS, target = src, allow_moving = TRUE))
+				electrify(-1, user, TRUE) // permanent shock + audio cue
+				playsound(loc, "sparks", 100, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
+				return
+
 		if(isAntag(user) || do_after(user, 3 SECONDS, target = src, allow_moving = TRUE))
 			electrify(-1, user, TRUE) // permanent shock + audio cue
 			playsound(loc, "sparks", 100, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)

--- a/code/_onclick/ai_onclick.dm
+++ b/code/_onclick/ai_onclick.dm
@@ -206,8 +206,7 @@
 /obj/machinery/door/airlock/AICtrlClick(mob/living/silicon/user) // Bolts doors
 	if(!ai_control_check(user))
 		return
-	var/mob/living/silicon/S = user
-	if(S.can_instant_lockdown() || do_after(user, 3 SECONDS, target = src, allow_moving = TRUE))
+	if(user.can_instant_lockdown() || do_after(user, 3 SECONDS, target = src, allow_moving = TRUE))
 		toggle_bolt(user)
 
 
@@ -219,8 +218,7 @@
 	if(isElectrified())
 		electrify(0, user, TRUE) // un-shock
 	else
-		var/mob/living/silicon/S = user
-		if(S.can_instant_lockdown() || do_after(user, 3 SECONDS, target = src, allow_moving = TRUE))
+		if(user.can_instant_lockdown() || do_after(user, 3 SECONDS, target = src, allow_moving = TRUE))
 			electrify(-1, user, TRUE) // permanent shock + audio cue
 			playsound(loc, "sparks", 100, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
 

--- a/code/modules/mob/living/silicon/robot/robot_mob.dm
+++ b/code/modules/mob/living/silicon/robot/robot_mob.dm
@@ -1596,3 +1596,8 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 		playsound(loc, 'sound/machines/buzz-two.ogg', 50, 0)
 	else
 		to_chat(src, "<span class='warning'>You can only use this emote when you're out of charge.</span>")
+
+/mob/living/silicon/robot/can_instant_lockdown()
+	if(emagged || faction_check_mob(src, "syndicate"))
+		return TRUE
+	return FALSE

--- a/code/modules/mob/living/silicon/silicon_mob.dm
+++ b/code/modules/mob/living/silicon/silicon_mob.dm
@@ -79,14 +79,7 @@
 	return ..()
 
 /mob/living/silicon/proc/can_instant_lockdown()
-
-	if(istype(src, /mob/living/silicon/robot)) // Checks for Borgs first, as antags could be placed in a cyborg and we dont want that overriding. You NEED `emagged` to insta-bolt/shock.
-		var/mob/living/silicon/robot/S = src
-		if(S.emagged)
-			return TRUE
-		return FALSE
-
-	if(isAntag(src)) // Checks for Malf AI/Syndie Borgs that are proper antags on their own.
+	if(isAntag(src))
 		return TRUE
 	return FALSE
 

--- a/code/modules/mob/living/silicon/silicon_mob.dm
+++ b/code/modules/mob/living/silicon/silicon_mob.dm
@@ -78,6 +78,18 @@
 	QDEL_NULL(aiCamera)
 	return ..()
 
+/mob/living/silicon/proc/can_instant_lockdown()
+
+	if(istype(src, /mob/living/silicon/robot)) // Checks for Borgs first, as antags could be placed in a cyborg and we dont want that overriding. You NEED `emagged` to insta-bolt/shock.
+		var/mob/living/silicon/robot/S = src
+		if(S.emagged)
+			return TRUE
+		return FALSE
+
+	if(isAntag(src)) // Checks for Malf AI/Syndie Borgs that are proper antags on their own.
+		return TRUE
+	return FALSE
+
 /mob/living/silicon/proc/get_radio()
 	return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Ensures emagged borgs, both malf and emaggedd, can instantly bolt/shock doors.

## Why It's Good For The Game
This was intended in the original PR #21491:

`This change makes it so if you want to ignore the funny menuing to lock a door down, you have a slight delay to do so. This will ONLY effect non-antagonist AI - so malf/emagged borgs/etc do not have to deal with this change.`

## Testing
1. Emagged myself as a cyborg.

## Changelog
:cl:
fix: Fixed emagged cyborgs not being able to instantly bolt/shock.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
