### PR TITLE
allows runtime access to view mc tabs

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -69,7 +69,6 @@ GLOBAL_LIST_INIT(admin_verbs_admin, list(
 	/client/proc/ccbdb_lookup_ckey,
 	/client/proc/view_instances,
 	/client/proc/start_vote,
-	/client/proc/toggle_mctabs,
 	/client/proc/ping_all_admins,
 	/client/proc/show_watchlist
 ))
@@ -295,6 +294,7 @@ GLOBAL_LIST_INIT(admin_verbs_maintainer, list(
 			verbs += /client/proc/debug_variables /*allows us to -see- the variables of any instance in the game. +VAREDIT needed to modify*/
 			verbs += /client/proc/ss_breakdown
 			verbs += /client/proc/show_gc_queues
+			verbs += /client/proc/toggle_mctabs
 			spawn(1) // This setting exposes the profiler for people with R_VIEWRUNTIMES. They must still have it set in cfg/admin.txt
 				control_freak = 0
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
fixes runtime access not being able to use the view mc tab verb (if it was set in the db directly they could) also we can hit f3 to view the stats directly
![yippie](https://github.com/ParadiseSS13/Paradise/assets/96800819/61fb2909-e283-467c-bd42-81fac5ae02e2)


## Why It's Good For The Game
bugs bad and i want to see the funny numbers

## Testing
I will not be setting up a db for this, this should work fine

## Changelog
:cl:
fix: [ADMIN] runtime access users can access mc tabs again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
