### PR TITLE
Tweaks species specific traitor items

### DIFF
--- a/code/datums/uplink_items/uplink_traitor.dm
+++ b/code/datums/uplink_items/uplink_traitor.dm
@@ -319,7 +319,6 @@
 	item = /obj/item/pen/sleepy/love
 	cost = 20
 	species = list("Skrell")
-	surplus = 0
 
 //Vox
 /datum/uplink_item/species_restricted/spikethrower

--- a/code/datums/uplink_items/uplink_traitor.dm
+++ b/code/datums/uplink_items/uplink_traitor.dm
@@ -319,7 +319,7 @@
 	item = /obj/item/pen/sleepy/love
 	cost = 20
 	species = list("Skrell")
-
+	surplus = 0
 
 //Vox
 /datum/uplink_item/species_restricted/spikethrower
@@ -329,6 +329,7 @@
 	item = /obj/item/gun/energy/spikethrower
 	cost = 60
 	species = list("Vox")
+	surplus = 0
 
 //IPC:
 //Positonic supercharge implant: stims, 3 uses, IPC adrenals
@@ -339,6 +340,7 @@
 	item = /obj/item/implanter/supercharge
 	cost = 40
 	species = list("Machine")
+	surplus = 0
 
 
 //plasmeme
@@ -349,6 +351,7 @@
 	item = /obj/item/fireproofing_injector
 	cost = 25
 	species = list("Plasmaman")
+	surplus = 0
 
 
 // -------------------------------------

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -145,6 +145,9 @@
 	reagents.add_reagent("ketamine", 100)
 
 /obj/item/pen/sleepy/love
+	name = "fancy pen"
+	desc = "A fancy metal pen. An inscription on one side reads, \"L.L. - L.R.\""
+	icon_state = "fancypen"
 	container_type = DRAINABLE //cannot be refilled, love can be extracted for use in other items with syringe
 	origin_tech = "engineering=4;syndicate=2"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
The plasmaman fireproof injector and the IPC supercharge implant can no longer be found in surplus crates.
The Skrell love injecting pen has had its sprite and appearance changed to that of the fancy pen, to make it appear different then the sleepy pen.

## Why It's Good For The Game
Randomly getting items you cannot use due to species locks is bad game design. The love pen is now visually distinct, preventing people from thinking they just overdosed a target on ketamine, when in fact they made them feel all warm and cuddly. 

## Testing
Spawn surplus crates, confirm no overcharge implants or fireproofing injectors were given.
Confirm pen sprite and appearance was properly updated.

## Changelog
:cl:
fix: You can no longer get species exclusive traitor items from surplus crates.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
