### PR TITLE
terror spiders can now pull non dense objects at normal speed

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
@@ -473,4 +473,4 @@ GLOBAL_LIST_EMPTY(ts_infected_list)
 /mob/living/simple_animal/hostile/poison/terror_spider/movement_delay()
 	. = ..()
 	if(pulling && !ismob(pulling) && pulling.density)
-		. += 6 // drastic move speed penalty for dragging anything that is not a mob
+		. += 6 // Drastic move speed penalty for dragging anything that is not a mob or a non dense object

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
@@ -472,5 +472,5 @@ GLOBAL_LIST_EMPTY(ts_infected_list)
 
 /mob/living/simple_animal/hostile/poison/terror_spider/movement_delay()
 	. = ..()
-	if(pulling && !ismob(pulling))
+	if(pulling && !ismob(pulling) && pulling.density)
 		. += 6 // drastic move speed penalty for dragging anything that is not a mob


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
terror spiders can now pull non dense objects at normal speed

## Why It's Good For The Game
it's not a problem if a spider drags a gun away, it is a problem if they are pulling a locker, rather than hurting everything let's be more selective 

## Testing
pulled a locker, pulled a welder

## Changelog
:cl:
tweak: terror spiders can now pull non dense objects at normal speed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
