### PR TITLE
Fixes a runtime with gasp emote

### DIFF
--- a/code/modules/mob/living/carbon/human/human_emote.dm
+++ b/code/modules/mob/living/carbon/human/human_emote.dm
@@ -163,9 +163,9 @@
 	volume = 100
 
 /datum/emote/living/carbon/human/gasp/get_sound(mob/user)
-	var/mob/living/carbon/human/H = user
 	if(!ishuman(user))
 		return
+	var/mob/living/carbon/human/H = user
 
 	if(H.is_muzzled())
 		// If you're muzzled you're not making noise

--- a/code/modules/mob/living/carbon/human/human_emote.dm
+++ b/code/modules/mob/living/carbon/human/human_emote.dm
@@ -164,6 +164,9 @@
 
 /datum/emote/living/carbon/human/gasp/get_sound(mob/user)
 	var/mob/living/carbon/human/H = user
+	if(!ishuman(user))
+		return
+
 	if(H.is_muzzled())
 		// If you're muzzled you're not making noise
 		return


### PR DESCRIPTION
## What Does This PR Do
This fixes a runtime that occurs when a non-human uses the gasp emote.

![runtime-gasp](https://github.com/ParadiseSS13/Paradise/assets/116982774/443d3f5d-c481-44e6-90be-8270d2bd9c84)
## Why It's Good For The Game
Prevents a runtime error from occurring.
## Testing
Spawned is a cyborg and emoted, checked for runtime.
Spawned in a a human species and emoted, checked for proper function and runtime.
## Changelog
NPFC