### PR TITLE
Fix error in check_grep trailing newline test.

### DIFF
--- a/tools/ci/check_grep2.py
+++ b/tools/ci/check_grep2.py
@@ -71,11 +71,8 @@ def check_mixed_indentation(lines):
 
 
 def check_trailing_newlines(lines):
-    if not lines:
-        return
-
-    last_line = [x for x in lines][-1]
-    if not last_line.endswith("\n"):
+    lines = [x for x in lines]
+    if lines and not lines[-1].endswith("\n"):
         return Failure(len(lines), "Missing a trailing newline")
 
 


### PR DESCRIPTION
## What Does This PR Do
This fixes check_grep2 to properly handle errors for files missing trailing newlines. `lines` here is actually an `io.TextIOWrapper`, which has an `__iter__` but no `__len__`, so we have to be kind of clumsy here for the sake of satisfying the same API as the other error checks and returning a line number in the error message.

## Why It's Good For The Game
CI should now fail properly for files that contain no trailing newline.

## Testing
Tested on the same commit that failed at https://github.com/ParadiseSS13/Paradise/actions/runs/5959649385.

## Changelog
NPFC
