### PR TITLE
Fixes an oversight with observers and ghosts

### DIFF
--- a/code/game/machinery/tcomms/nttc.dm
+++ b/code/game/machinery/tcomms/nttc.dm
@@ -257,6 +257,7 @@
 		else
 			job_class = all_jobs[rank]
 
+	tcm.pre_modify_name = tcm.sender_name
 	if(toggle_name_color)
 		var/new_name = "<span class=\"[job_class]\">[tcm.sender_name]</span>"
 		tcm.sender_name = new_name

--- a/code/game/machinery/tcomms/tcomms_base.dm
+++ b/code/game/machinery/tcomms/tcomms_base.dm
@@ -414,7 +414,7 @@ GLOBAL_LIST_EMPTY(tcomms_machines)
 		if(length(heard_gibberish))
 			for(var/M in heard_gibberish)
 				var/mob/R = M
-				R.hear_radio(tcm.message_pieces, tcm.verbage, part_a, part_b, tcm.sender, TRUE, follow_target=tcm.follow_target, , check_name_against = tcm.pre_modify_name)
+				R.hear_radio(tcm.message_pieces, tcm.verbage, part_a, part_b, tcm.sender, TRUE, follow_target=tcm.follow_target, check_name_against = tcm.pre_modify_name)
 
 	return TRUE
 

--- a/code/game/machinery/tcomms/tcomms_base.dm
+++ b/code/game/machinery/tcomms/tcomms_base.dm
@@ -204,6 +204,8 @@ GLOBAL_LIST_EMPTY(tcomms_machines)
 	var/reject = FALSE
 	/// Voice name if the person doesnt have a name (diona, alien, etc)
 	var/vname
+	/// sender_name before modify_message modifies it, because it introduces html tags.
+	var/pre_modify_name
 	/// List of all channels this can be sent or recieved on
 	var/list/zlevels = list()
 	/// Should this signal be re-broadcasted (Can be modified by NTTC, defaults to TRUE)
@@ -382,21 +384,21 @@ GLOBAL_LIST_EMPTY(tcomms_machines)
 		if(length(heard_masked))
 			for(var/M in heard_masked)
 				var/mob/R = M
-				R.hear_radio(tcm.message_pieces, tcm.verbage, part_a, part_b, tcm.sender, 0, tcm.sender_name, follow_target=tcm.follow_target)
+				R.hear_radio(tcm.message_pieces, tcm.verbage, part_a, part_b, tcm.sender, FALSE, tcm.sender_name, follow_target=tcm.follow_target, check_name_against = tcm.pre_modify_name)
 
 		/* --- Process all the mobs that heard the voice normally (understood) --- */
 
 		if(length(heard_normal))
 			for(var/M in heard_normal)
 				var/mob/R = M
-				R.hear_radio(tcm.message_pieces, tcm.verbage, part_a, part_b, tcm.sender, 0, tcm.sender_name, follow_target=tcm.follow_target)
+				R.hear_radio(tcm.message_pieces, tcm.verbage, part_a, part_b, tcm.sender, FALSE, tcm.sender_name, follow_target=tcm.follow_target, check_name_against = tcm.pre_modify_name)
 
 		/* --- Process all the mobs that heard the voice normally (did not understand) --- */
 
 		if(length(heard_voice))
 			for(var/M in heard_voice)
 				var/mob/R = M
-				R.hear_radio(tcm.message_pieces, tcm.verbage, part_a, part_b, tcm.sender,0, tcm.vname, follow_target=tcm.follow_target)
+				R.hear_radio(tcm.message_pieces, tcm.verbage, part_a, part_b, tcm.sender, FALSE, tcm.vname, follow_target=tcm.follow_target, check_name_against = tcm.pre_modify_name)
 
 		/* --- Process all the mobs that heard a garbled voice (did not understand) --- */
 			// Displays garbled message (ie "f*c* **u, **i*er!")
@@ -404,7 +406,7 @@ GLOBAL_LIST_EMPTY(tcomms_machines)
 		if(length(heard_garbled))
 			for(var/M in heard_garbled)
 				var/mob/R = M
-				R.hear_radio(tcm.message_pieces, tcm.verbage, part_a, part_b, tcm.sender, 1, tcm.vname, follow_target=tcm.follow_target)
+				R.hear_radio(tcm.message_pieces, tcm.verbage, part_a, part_b, tcm.sender, TRUE, tcm.vname, follow_target=tcm.follow_target, check_name_against = tcm.pre_modify_name)
 
 
 		/* --- Complete gibberish. Usually happens when there's a compressed message --- */
@@ -412,7 +414,7 @@ GLOBAL_LIST_EMPTY(tcomms_machines)
 		if(length(heard_gibberish))
 			for(var/M in heard_gibberish)
 				var/mob/R = M
-				R.hear_radio(tcm.message_pieces, tcm.verbage, part_a, part_b, tcm.sender, 1, follow_target=tcm.follow_target)
+				R.hear_radio(tcm.message_pieces, tcm.verbage, part_a, part_b, tcm.sender, TRUE, follow_target=tcm.follow_target, , check_name_against = tcm.pre_modify_name)
 
 	return TRUE
 

--- a/code/modules/mob/dead/observer/observer_say.dm
+++ b/code/modules/mob/dead/observer/observer_say.dm
@@ -9,8 +9,16 @@
 /mob/dead/observer/handle_track(message, verb = "says", mob/speaker = null, speaker_name, atom/follow_target, hard_to_hear)
 	return "[speaker_name] ([ghost_follow_link(follow_target, ghost=src)])"
 
-/mob/dead/observer/handle_speaker_name(mob/speaker = null, vname, hard_to_hear)
+/mob/dead/observer/handle_speaker_name(mob/speaker = null, vname, hard_to_hear, check_name_against)
 	var/speaker_name = ..()
-	if(speaker && (speaker_name != speaker.real_name) && !isAI(speaker) && !isAutoAnnouncer(speaker)) //Announce computer and various stuff that broadcasts doesn't use it's real name but AI's can't pretend to be other mobs.
-		speaker_name = "[speaker.real_name] ([speaker_name])"
+	if(!speaker)
+		return speaker_name
+	//Announce computer and various stuff that broadcasts doesn't use it's real name but AI's can't pretend to be other mobs.
+	if(isAI(speaker) || isAutoAnnouncer(speaker))
+		return speaker_name
+	if(!check_name_against)
+		check_name_against = speaker_name
+	if(check_name_against == speaker.real_name)
+		return speaker_name
+	speaker_name = "[speaker.real_name] ([speaker_name])"
 	return speaker_name

--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -121,7 +121,7 @@
 			playsound_local(source, speech_sound, sound_vol, 1, sound_frequency)
 
 
-/mob/proc/hear_radio(list/message_pieces, verb = "says", part_a, part_b, mob/speaker = null, hard_to_hear = 0, vname = "", atom/follow_target, radio_freq)
+/mob/proc/hear_radio(list/message_pieces, verb = "says", part_a, part_b, mob/speaker = null, hard_to_hear = 0, vname = "", atom/follow_target, check_name_against)
 	if(!client)
 		return
 
@@ -137,7 +137,7 @@
 	if(!follow_target)
 		follow_target = speaker
 
-	var/speaker_name = handle_speaker_name(speaker, vname, hard_to_hear)
+	var/speaker_name = handle_speaker_name(speaker, vname, hard_to_hear, check_name_against)
 	track = handle_track(message, verb, speaker, speaker_name, follow_target, hard_to_hear)
 
 	if(!can_hear())

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -731,7 +731,7 @@
 		parrot_hear(html_decode(multilingual_to_message(message_pieces)))
 	..()
 
-/mob/living/simple_animal/parrot/hear_radio(list/message_pieces, verb = "says", part_a, part_b, mob/speaker = null, hard_to_hear = 0, atom/follow_target)
+/mob/living/simple_animal/parrot/hear_radio(list/message_pieces, verb = "says", part_a, part_b, mob/speaker = null, hard_to_hear = 0, atom/follow_target, check_name_against)
 	if(speaker != src && prob(50))
 		parrot_hear(html_decode(multilingual_to_message(message_pieces)))
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->Ghosts will now not see duplicate names if the user's real name matches with their shown name.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Fixes a bug that was caused by NTTC configurations

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![image](https://github.com/ParadiseSS13/Paradise/assets/91113370/e22ef5df-bfa9-450e-af92-1011aa49d314)
(The bottom line used to say [Common] Zack Woodworth (Zack Woodworth (No id)) (follow) says, "Test")

![image](https://github.com/ParadiseSS13/Paradise/assets/91113370/7eb68b28-445e-4303-b994-f61c3ca0112d)
Works with any type of voice changer

## Testing
<!-- How did you test the PR, if at all? -->
See above, and tested with a variety of voice changers

## Changelog
:cl:
fix: Observers should no longer see duplicated names in radio chat when someone has the correct name
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
