### PR TITLE
IDs in your PDA no longer affect the color your radio chatter

### DIFF
--- a/code/modules/mob/living/carbon/human/human_mob.dm
+++ b/code/modules/mob/living/carbon/human/human_mob.dm
@@ -435,18 +435,10 @@
 
 // Get rank from ID, ID inside PDA, PDA, ID in wallet, etc.
 /mob/living/carbon/human/proc/get_authentification_rank(if_no_id = "No id", if_no_job = "No job")
-	var/obj/item/pda/pda = wear_id
-	if(istype(pda))
-		if(pda.id)
-			return pda.id.rank
-		else
-			return pda.ownrank
-	else
-		var/obj/item/card/id/id = get_idcard()
-		if(id)
-			return id.rank ? id.rank : if_no_job
-		else
-			return if_no_id
+	var/obj/item/card/id/id = wear_id.GetID()
+	if(istype(id))
+		return id.rank ? id.rank : if_no_job
+	return if_no_id
 
 //gets assignment from ID, PDA, Wallet, etc.
 //This should not be relied on for authentication, because PDAs show their owner's job, even if an ID is not inserted

--- a/code/modules/mob/living/carbon/human/human_mob.dm
+++ b/code/modules/mob/living/carbon/human/human_mob.dm
@@ -437,7 +437,7 @@
 /mob/living/carbon/human/proc/get_authentification_rank(if_no_id = "No id", if_no_job = "No job")
 	var/obj/item/card/id/id = wear_id.GetID()
 	if(istype(id))
-		return id.rank ? id.rank : if_no_job
+		return id.rank || if_no_job
 	return if_no_id
 
 //gets assignment from ID, PDA, Wallet, etc.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->IDs in your PDA can no longer affect the color of your radio chatter when your PDA is in your PDA slot. I really should have done this sooner, but its taken me so long to track down.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Unintended consequence and bug of #20251. I've seen players abuse this to figure out who someone is when they're using a voice changing mask, but their ID is in their PDA

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![image](https://github.com/ParadiseSS13/Paradise/assets/91113370/710ae176-408a-4bdd-9d90-8525f8886010)
![image](https://github.com/ParadiseSS13/Paradise/assets/91113370/34f44a4c-d79a-4bef-959d-c5f2afcf9cdf)


## Testing
<!-- How did you test the PR, if at all? -->
See above

## Changelog
:cl:
fix: IDs in your PDA no longer affect the color your radio chatter when your PDA is in your PDA slot
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
