### PR TITLE
/obj/structure/alien/egg/grown has a prox timer now

### DIFF
--- a/code/game/objects/structures/aliens.dm
+++ b/code/game/objects/structures/aliens.dm
@@ -480,6 +480,8 @@
 		obj_integrity = integrity_failure
 	else if(status != GROWN)
 		addtimer(CALLBACK(src, PROC_REF(grow)), rand(MIN_GROWTH_TIME, MAX_GROWTH_TIME))
+	if(status == GROWN)
+		AddComponent(/datum/component/proximity_monitor)
 
 /obj/structure/alien/egg/attack_alien(mob/living/carbon/alien/user)
 	return attack_hand(user)


### PR DESCRIPTION
## What Does This PR Do
/obj/structure/alien/egg/grown now has a prox timer
Fixes #21594 

## Why It's Good For The Game
Bugfix good

## Testing
spawned /obj/structure/alien/egg/grown, walked near it, owch!

## Changelog
:cl:
fix: alien eggs that are created as grown on creation will facehug people who walk near them again
/:cl: