### PR TITLE
allows view_runtimes to access the mc stuff easier

### DIFF
--- a/code/datums/statclick.dm
+++ b/code/datums/statclick.dm
@@ -18,7 +18,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/statclick)
 	var/class
 
 /obj/effect/statclick/debug/Click()
-	if(!is_admin(usr) || !target)
+	if(!check_rights(R_DEBUG|R_VIEWRUNTIMES)|| !target)
 		return
 	if(!class)
 		if(istype(target, /datum/controller/subsystem))

--- a/code/datums/statclick.dm
+++ b/code/datums/statclick.dm
@@ -18,7 +18,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/statclick)
 	var/class
 
 /obj/effect/statclick/debug/Click()
-	if(!check_rights(R_DEBUG|R_VIEWRUNTIMES)|| !target)
+	if(!check_rights(R_DEBUG|R_VIEWRUNTIMES) || !target)
 		return
 	if(!class)
 		if(istype(target, /datum/controller/subsystem))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
view_runtime right holders no longer need to right click on debug stats and vv them to access globals/controllers

## Why It's Good For The Game
we can already do it this is just easier

## Testing
don't wanna set up a db but it's handled the same somewhere else so it should work just fine