### PR TITLE
Traitor chef can use traitor CQC, no multiple defensive stance actions

### DIFF
--- a/code/modules/martial_arts/cqc.dm
+++ b/code/modules/martial_arts/cqc.dm
@@ -40,9 +40,8 @@
 
 /datum/martial_art/cqc/teach(mob/living/carbon/human/H, make_temporary)
 	var/found = FALSE
-	for(var/datum/martial_art/M in H.mind.known_martial_arts)
-		if(istype(M, /datum/martial_art/cqc/under_siege))
-			M.remove(H)
+	for(var/datum/martial_art/cqc/under_siege/M in H.mind.known_martial_arts)
+		M.remove(H)
 	for(var/datum/action/D in H.actions)
 		if(istype(D, /datum/action/defensive_stance))
 			found = TRUE

--- a/code/modules/martial_arts/cqc.dm
+++ b/code/modules/martial_arts/cqc.dm
@@ -40,7 +40,16 @@
 
 /datum/martial_art/cqc/teach(mob/living/carbon/human/H, make_temporary)
 	var/datum/action/defensive_stance/defensive = new /datum/action/defensive_stance()
-	defensive.Grant(H)
+	var/found = FALSE
+	for(var/datum/martial_art/M in H.mind.known_martial_arts)
+		if(istype(M, /datum/martial_art/cqc/under_siege))
+			M.remove(H)
+	for(var/datum/action/D in H.actions)
+		if(istype(D, /datum/action/defensive_stance))
+			found = TRUE
+			break
+	if(!found)
+		defensive.Grant(H)
 	return ..()
 
 /datum/martial_art/cqc/remove(mob/living/carbon/human/H)

--- a/code/modules/martial_arts/cqc.dm
+++ b/code/modules/martial_arts/cqc.dm
@@ -39,7 +39,6 @@
 	return ..()
 
 /datum/martial_art/cqc/teach(mob/living/carbon/human/H, make_temporary)
-	var/datum/action/defensive_stance/defensive = new /datum/action/defensive_stance()
 	var/found = FALSE
 	for(var/datum/martial_art/M in H.mind.known_martial_arts)
 		if(istype(M, /datum/martial_art/cqc/under_siege))
@@ -49,6 +48,7 @@
 			found = TRUE
 			break
 	if(!found)
+		var/datum/action/defensive_stance/defensive = new /datum/action/defensive_stance()
 		defensive.Grant(H)
 	return ..()
 


### PR DESCRIPTION
## What Does This PR Do
If a chef learns CQC from the traitor item, he can use it outside of the kitchen. Multiple uses of CQC now doesn't add multiple defence stance actions
Fixes #21995 
## Why It's Good For The Game
Chef should be able to use CQC outside of kitchen when they purchase a CQC manual, multiple defensive stance icons unnecessary 
## Testing
Spawned in as chef, robusted things in the kitchen, made sure couldn't robust outside. Gave chef CQC, could robust where he pleases. Used multiple CQC manuals, didn't get multiple defensive stance icons, CQC still worked, multiple defence stance icons is not good

## Changelog
:cl:
fix: Using CQC manual as chef now allows you to use CQC outside of the kitchen
fix: Multiple uses of CQC manual don't give you multiple defensive stance actions
/:cl:
