### PR TITLE
sliding puzzle chests have an item in them again

### DIFF
--- a/code/modules/ruins/lavalandruin_code/puzzle.dm
+++ b/code/modules/ruins/lavalandruin_code/puzzle.dm
@@ -254,7 +254,7 @@
 
 //Ruin version
 /obj/effect/sliding_puzzle/lavaland
-	reward_type = /obj/structure/closet/crate/necropolis
+	reward_type = /obj/structure/closet/crate/necropolis/tendril
 
 /obj/effect/sliding_puzzle/lavaland/dispense_reward()
 	if(prob(25))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
fixes #22115

## Why It's Good For The Game
Put in the wrong typepath by mistake, not entirely sure it isn't just the default anyways, you don't call parent on populate contents 


## Testing
still not doing a sliding puzzle

## Changelog
:cl:
fix: sliding puzzle chests have an item in them again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
