### PR TITLE
Allows White Terrors to force open powered doors.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/white.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/white.dm
@@ -23,6 +23,7 @@
 	melee_damage_lower = 5
 	melee_damage_upper = 15
 	spider_tier = TS_TIER_2
+	spider_opens_doors = 2
 	loudspeaker = TRUE
 	web_type = /obj/structure/spider/terrorweb/white
 


### PR DESCRIPTION

## What Does This PR Do
Grants white terror spiders the ability to force open powered doors.

## Why It's Good For The Game
White terrors are a tad weak. After the intial blitzkrieg they basically lose a lot of relevance as every door is shut and every vent is welded. This should slightly alleviate this problem.

Also definitely not because of a recent round where I was stuck in one room for ten minutes because all the doors were closed and all the reds were dead.

## Testing
Created white terror, became white terror, forced door open, bit things.

## Changelog
:cl:
tweak: Gives White Terrors the ability to open doors.
/:cl: