### PR TITLE
Sharp items can cut wires, conduct items not always shock you

### DIFF
--- a/code/modules/power/cables/cable.dm
+++ b/code/modules/power/cables/cable.dm
@@ -106,6 +106,9 @@ By design, d1 is the smallest direction and d2 is the highest
 		var/obj/item/toy/crayon/C = W
 		cable_color(C.colourName)
 
+	else if((W.flags & CONDUCT) && W.sharp)
+		wirecutter_act(user, W)
+
 	add_fingerprint(user)
 
 /obj/structure/cable/multitool_act(mob/user, obj/item/I)

--- a/code/modules/power/cables/cable.dm
+++ b/code/modules/power/cables/cable.dm
@@ -106,7 +106,7 @@ By design, d1 is the smallest direction and d2 is the highest
 		var/obj/item/toy/crayon/C = W
 		cable_color(C.colourName)
 
-	else if((W.flags & CONDUCT) && W.sharp)
+	else if(W.sharp)
 		wirecutter_act(user, W)
 
 	add_fingerprint(user)

--- a/code/modules/power/cables/cable.dm
+++ b/code/modules/power/cables/cable.dm
@@ -106,10 +106,6 @@ By design, d1 is the smallest direction and d2 is the highest
 		var/obj/item/toy/crayon/C = W
 		cable_color(C.colourName)
 
-	else
-		if(W.flags & CONDUCT)
-			shock(user, 50, 0.7)
-
 	add_fingerprint(user)
 
 /obj/structure/cable/multitool_act(mob/user, obj/item/I)

--- a/code/modules/power/cables/cable.dm
+++ b/code/modules/power/cables/cable.dm
@@ -88,28 +88,37 @@ By design, d1 is the smallest direction and d2 is the highest
 	if(T.transparent_floor || T.intact)
 		to_chat(user, "<span class='danger'>You can't interact with something that's under the floor!</span>")
 		return
+	add_fingerprint(user)
 
-	else if(istype(W, /obj/item/stack/cable_coil))
+	if(istype(W, /obj/item/stack/cable_coil))
 		var/obj/item/stack/cable_coil/coil = W
 		if(coil.get_amount() < 1)
 			to_chat(user, "<span class='warning'>Not enough cable!</span>")
 			return
 		coil.cable_join(src, user)
+		return
 
-	else if(istype(W, /obj/item/rcl))
+	if(istype(W, /obj/item/rcl))
 		var/obj/item/rcl/R = W
 		if(R.loaded)
 			R.loaded.cable_join(src, user)
 			R.is_empty(user)
+		return
 
-	else if(istype(W, /obj/item/toy/crayon))
+	if(istype(W, /obj/item/toy/crayon))
 		var/obj/item/toy/crayon/C = W
 		cable_color(C.colourName)
+		return
 
-	else if(W.sharp)
+	if(W.sharp)
 		wirecutter_act(user, W)
+		return
 
-	add_fingerprint(user)
+	if((user.a_intent == INTENT_HARM) && (W.flags & CONDUCT))
+		if(!shock(user, 50, 0.7))
+			return
+		user.do_attack_animation(src, used_item=W)
+		user.visible_message("<span class='danger'>[user] has hit [src] with [W]!</span>", "<span class='danger'>You hit [src] with [W]!</span>")
 
 /obj/structure/cable/multitool_act(mob/user, obj/item/I)
 	. = TRUE
@@ -132,7 +141,7 @@ By design, d1 is the smallest direction and d2 is the highest
 		return
 	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
 		return
-	if(shock(user, 50))
+	if((I.flags & CONDUCT) && shock(user, 50))
 		return
 	user.visible_message("[user] cuts the cable.", "<span class='notice'>You cut the cable.</span>")
 	investigate_log("was cut by [key_name(usr, 1)] in [get_area(user)]([T.x], [T.y], [T.z] - [ADMIN_JMP(T)])","wires")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
This PR changes object interaction with cables.
Sharp items can cut wires now. If sharp item is conduct, you can be shocked.
Clicking cables with non harm intent wont shock you now. If you click cable with conduct item and harm intend, you can be shocked.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Touching cables with conduct items without damaging isolation should not shock you, same as it doesnt shock you when you touch cables with hands. There is also no possible interaction between, lets say, wrench and cable. You cant damage, hit or remove it so when you click cable with wrench, it is missclick which will get you shocked today.
I dont like hurting players for missclicks, adding interaction with sharp items instead sounds cool to me.

## Testing
<!-- How did you test the PR, if at all? -->
Compiled, touched cables with various items

## Changelog
:cl:
tweak: Cables now can shock you if you click it with harm intent and conduct item.
tweak: You can cut wires with any sharp items now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
