### PR TITLE
makes sm events not chain together in rare cases

### DIFF
--- a/code/modules/power/engines/supermatter/supermatter.dm
+++ b/code/modules/power/engines/supermatter/supermatter.dm
@@ -239,7 +239,6 @@
 	if(is_main_engine)
 		GLOB.main_supermatter_engine = src
 	soundloop = new(list(src), TRUE)
-	make_next_event_time()
 
 /obj/machinery/atmospherics/supermatter_crystal/Destroy()
 	if(warp)
@@ -422,9 +421,7 @@
 	try_events()
 	if(power > 100)
 		if(!has_been_powered)
-			investigate_log("has been powered for the first time.", "supermatter")
-			message_admins("[src] has been powered for the first time [ADMIN_JMP(src)].")
-			has_been_powered = TRUE
+			enable_for_the_first_time()
 	//We vary volume by power, and handle OH FUCK FUSION IN COOLING LOOP noises.
 	if(power)
 		soundloop.volume = clamp((50 + (power / 50)), 50, 100)
@@ -687,9 +684,7 @@
 		if(power_changes) //This needs to be here I swear
 			power += Proj.damage * bullet_energy
 			if(!has_been_powered)
-				investigate_log("has been powered for the first time.", "supermatter")
-				message_admins("[src] has been powered for the first time [ADMIN_JMP(src)].")
-				has_been_powered = TRUE
+				enable_for_the_first_time()
 	else if(takes_damage)
 		damage += Proj.damage * bullet_energy
 	return FALSE
@@ -1216,6 +1211,12 @@
 		log_debug("Attempted supermatter event aborted due to incorrect path. Incorrect path type: [event.type].")
 		return
 	event.start_event()
+
+/obj/machinery/atmospherics/supermatter_crystal/proc/enable_for_the_first_time()
+	investigate_log("has been powered for the first time.", "supermatter")
+	message_admins("[src] has been powered for the first time [ADMIN_JMP(src)].")
+	has_been_powered = TRUE
+	make_next_event_time()
 
 #undef HALLUCINATION_RANGE
 #undef GRAVITATIONAL_ANOMALY

--- a/code/modules/power/engines/supermatter/supermatter.dm
+++ b/code/modules/power/engines/supermatter/supermatter.dm
@@ -1184,7 +1184,7 @@
 		fake_time += rand(2 MINUTES, 10 MINUTES)
 	else if(fake_time > 15 MINUTES && prob(30))
 		fake_time -= rand(2 MINUTES, 10 MINUTES)
-	next_event_time += fake_time
+	next_event_time = fake_time + world.time
 
 /obj/machinery/atmospherics/supermatter_crystal/proc/try_events()
 	if(has_been_powered == FALSE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
makes sm events not chain together in rare cases, sm event timer only starts ticking after the sm is set up

## Why It's Good For The Game
Events chaining together because nobody set up the SM is generally bad, getting an event right after you set it up is bad

## Testing
Compiled, took a look at the SM to make sure the events functioned

## Changelog
:cl:
tweak: makes sm events not chain together in rare cases, sm event timer only starts ticking after the sm is set up
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
