### PR TITLE
HOTFIX: event B3 no longer nukes the SM

### DIFF
--- a/code/modules/power/engines/supermatter/supermatter_event.dm
+++ b/code/modules/power/engines/supermatter/supermatter_event.dm
@@ -141,7 +141,7 @@
 	name = "B-3"
 
 /datum/supermatter_event/bravo_tier/power_additive/on_start()
-	supermatter.power_additive = 2000
+	supermatter.power += 3000
 
 //A class events
 /datum/supermatter_event/alpha_tier

--- a/code/modules/power/engines/supermatter/supermatter_event.dm
+++ b/code/modules/power/engines/supermatter/supermatter_event.dm
@@ -142,6 +142,7 @@
 
 /datum/supermatter_event/bravo_tier/power_additive/on_start()
 	supermatter.power += 3000
+	duration = 10 SECONDS
 
 //A class events
 /datum/supermatter_event/alpha_tier


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Changes Event b3 to be a EER spike of 3000, as opposed to detonation of a small nuclear warhead inside the Sm chamber.

## Why It's Good For The Game
Sm nuking on a B 3 class event is not intended. Fixes a rather severe issue

## Testing
Setup Co2 SM, confirm engine does not detonate while under 5k EER.

## Changelog
:cl:
fix: Event B3 now functions as intended
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
