### PR TITLE
Buffs Malf AIs

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai_mob.dm
+++ b/code/modules/mob/living/silicon/ai/ai_mob.dm
@@ -1378,7 +1378,7 @@ GLOBAL_LIST_INIT(ai_verbs_default, list(
 		to_chat(src, "<span class='danger'>Hack aborted. [apc] is no longer responding to our systems.</span>")
 		SEND_SOUND(src, sound('sound/machines/buzz-sigh.ogg'))
 	else
-		malf_picker.processing_time += 10
+		malf_picker.processing_time += 15
 
 		apc.malfai = parent || src
 		apc.malfhack = TRUE


### PR DESCRIPTION
## What Does This PR Do
Increases the CPU time gained from hacking APCs to 15 from 10.

## Why It's Good For The Game
Considering the time expenditure and risk of being caught, APC hacking is a bit sad in its reward. This should hopefully remedy the issue.

## Testing
 - Spawned in
 - Became AI
 - Malf'd
 - APCs give 15 points now
 - August 28 Plasmafire Incident

## Changelog
:cl:
tweak: Buffed Malf AI, hacking APCs gives 15 points now
/:cl: