### PR TITLE
Adds Check for Circuit Boards Having Components

### DIFF
--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -112,8 +112,7 @@
 					icon_state = "box_2"
 					state = 3
 					components = list()
-					if(circuit.req_components)
-						req_components = circuit.req_components.Copy()
+					req_components = circuit.req_components?.Copy()
 					update_namelist()
 					update_req_desc()
 				else
@@ -1081,4 +1080,5 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/economy/merch
 	board_type = "machine"
 	req_components = list(
+							/obj/item/stock_parts/matter_bin = 1,
 							/obj/item/stack/cable_coil = 1)

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -1075,7 +1075,7 @@ to destroy them and players will be able to make replacements.
 							/obj/item/stack/sheet/glass = 1)
 
 /obj/item/circuitboard/merch
-	board_name = "Merchandise Computer Circuit Board"
+	board_name = "Nanotrasen Merchandise Vendor"
 	icon_state = "generic"
 	build_path = /obj/machinery/economy/merch
 	board_type = "machine"

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -52,6 +52,7 @@
 // update description of required components remaining
 /obj/machinery/constructable_frame/proc/update_req_desc()
 	if(!req_components || !req_component_names)
+		desc = "Does not require any more components."
 		return
 
 	var/hasContent = 0
@@ -111,7 +112,8 @@
 					icon_state = "box_2"
 					state = 3
 					components = list()
-					req_components = circuit.req_components.Copy()
+					if(circuit.req_components)
+						req_components = circuit.req_components.Copy()
 					update_namelist()
 					update_req_desc()
 				else
@@ -1074,7 +1076,9 @@ to destroy them and players will be able to make replacements.
 							/obj/item/stack/sheet/glass = 1)
 
 /obj/item/circuitboard/merch
-	name = "Merchandise Computer Circuitboard"
+	board_name = "Merchandise Computer Circuit Board"
 	icon_state = "generic"
 	build_path = /obj/machinery/economy/merch
 	board_type = "machine"
+	req_components = list(
+							/obj/item/stack/cable_coil = 1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Adds a check to determine if circuit boards have components required.
Adds a single cable coil to the components required to make the Nanotrasen Merchandise Vendor.
Returns a description of "Does not require any more components." if a circuit board has no components required.
Changes the variable "name" to "board_name" of /obj/item/circuitboard/merch.
Fixes #22141 

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Fixes a runtime error.
Future proofs for boards that may not have components.

## Testing
<!-- How did you test the PR, if at all? -->
Spawned in, constructed Nanotrasen Merchandise Vendor with cable coil.
Tested with board that did not require components, and confirmed no runtime occurred.
Tested with Soda Fountain at the same time to confirm full functionality

## Changelog
:cl:
tweak: Changed required component for the Merchandise Computer Circuit Board to require one cable coil and one matter bin as component
spellcheck: Changed Merchandise Computer Circuitboard to Merchandise Computer Circuit Board as per #22141
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
