### PR TITLE
Adds the Syndicate "Big Brother" Obfuscation Suit

### DIFF
--- a/code/datums/uplink_items/uplink_traitor.dm
+++ b/code/datums/uplink_items/uplink_traitor.dm
@@ -409,11 +409,20 @@
 /datum/uplink_item/stealthy_tools/voice_modulator
 	name = "Chameleon Voice Modulator Mask"
 	desc = "A syndicate tactical mask equipped with chameleon technology and a sound modulator for disguising your voice. \
-			While the mask is active, your voice will sound unrecognizable to others"
+			While the mask is active, your voice will sound unrecognizable to others."
 	reference = "CVMM"
 	item = /obj/item/clothing/mask/gas/voice_modulator/chameleon
 	cost = 5
 	excludefrom = list(UPLINK_TYPE_NUCLEAR, UPLINK_TYPE_SST)
+
+/datum/uplink_item/stealthy_tools/silicon_cham_suit
+	name = "Silicon Obfuscation Suit"
+	desc = "A syndicate tactical suit equipped with the latest in anti-silicon technology and, allegedly, biological technology learned from the Changeling Hivemind. \
+			While this suit is worn, you will be unable to be tracked or seen by on-Station AI."
+	reference = "SCS"
+	item = /obj/item/clothing/under/syndicate/silicon_cham
+	cost = 15
+	excludefrom = list(UPLINK_TYPE_NUCLEAR)
 
 /datum/uplink_item/stealthy_weapons/sleepy_pen
 	name = "Sleepy Pen"

--- a/code/datums/uplink_items/uplink_traitor.dm
+++ b/code/datums/uplink_items/uplink_traitor.dm
@@ -416,7 +416,7 @@
 	excludefrom = list(UPLINK_TYPE_NUCLEAR, UPLINK_TYPE_SST)
 
 /datum/uplink_item/stealthy_tools/silicon_cham_suit
-	name = "Silicon Obfuscation Suit"
+	name = "\"Big Brother\" Obfuscation Suit"
 	desc = "A syndicate tactical suit equipped with the latest in anti-silicon technology and, allegedly, biological technology learned from the Changeling Hivemind. \
 			While this suit is worn, you will be unable to be tracked or seen by on-Station AI."
 	reference = "SCS"

--- a/code/datums/uplink_items/uplink_traitor.dm
+++ b/code/datums/uplink_items/uplink_traitor.dm
@@ -421,7 +421,7 @@
 			While this suit is worn, you will be unable to be tracked or seen by on-Station AI."
 	reference = "SCS"
 	item = /obj/item/clothing/under/syndicate/silicon_cham
-	cost = 15
+	cost = 20
 	excludefrom = list(UPLINK_TYPE_NUCLEAR)
 
 /datum/uplink_item/stealthy_weapons/sleepy_pen

--- a/code/datums/uplink_items/uplink_traitor.dm
+++ b/code/datums/uplink_items/uplink_traitor.dm
@@ -419,7 +419,7 @@
 	name = "\"Big Brother\" Obfuscation Suit"
 	desc = "A syndicate tactical suit equipped with the latest in anti-silicon technology and, allegedly, biological technology learned from the Changeling Hivemind. \
 			While this suit is worn, you will be unable to be tracked or seen by on-Station AI."
-	reference = "SCS"
+	reference = "BBOS"
 	item = /obj/item/clothing/under/syndicate/silicon_cham
 	cost = 20
 	excludefrom = list(UPLINK_TYPE_NUCLEAR)

--- a/code/modules/antagonists/traitor/contractor/items/contractor_kit.dm
+++ b/code/modules/antagonists/traitor/contractor/items/contractor_kit.dm
@@ -30,6 +30,7 @@
 		/obj/item/multitool/ai_detect,
 		/obj/item/encryptionkey/binary,
 		/obj/item/jammer,
+		/obj/item/clothing/under/syndicate/silicon_cham,
 		/obj/item/implanter/freedom,
 	)
 

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -35,7 +35,8 @@
 	var/species_disguise = null
 	var/magical = FALSE
 	var/dyeable = FALSE
-	var/blockTracking // Do we block AI tracking?
+	/// Do we block AI tracking?
+	var/blockTracking
 	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/clothing/update_icon_state()

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -35,6 +35,7 @@
 	var/species_disguise = null
 	var/magical = FALSE
 	var/dyeable = FALSE
+	var/blockTracking // Do we block AI tracking?
 	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/clothing/update_icon_state()
@@ -371,7 +372,6 @@
 	icon = 'icons/obj/clothing/hats.dmi'
 	body_parts_covered = HEAD
 	slot_flags = SLOT_HEAD
-	var/blockTracking // Do we block AI tracking?
 	var/HUDType = null
 
 	var/vision_flags = 0

--- a/code/modules/clothing/under/syndicate_jumpsuits.dm
+++ b/code/modules/clothing/under/syndicate_jumpsuits.dm
@@ -35,3 +35,22 @@
 	icon_state = "tactical_suit"
 	item_state = "bl_suit"
 	item_color = "tactical_suit"
+
+/obj/item/clothing/under/syndicate/silicon_cham
+	name = "tactical turtleneck"
+	desc = "A non-descript and slightly suspicious looking turtleneck with digital camouflage cargo pants. <b>This one has extra cybernetic modifications.</b>"
+	blockTracking = TRUE
+
+/obj/item/clothing/under/syndicate/silicon_cham/equipped(mob/user, slot, initial)
+	. = ..()
+	if(slot == slot_w_uniform)
+		ADD_TRAIT(user, TRAIT_AI_UNTRACKABLE, "silicon_cham[UID()]")
+		user.invisibility = SEE_INVISIBLE_LIVING
+		to_chat(user, "<span class='notice'>You feel a slight shiver as the cybernetic obfuscators activate.</span>")
+
+/obj/item/clothing/under/syndicate/silicon_cham/dropped(mob/user)
+	. = ..()
+	if(user)
+		REMOVE_TRAIT(user, TRAIT_AI_UNTRACKABLE, "silicon_cham[UID()]")
+		user.invisibility = initial(user.invisibility)
+		to_chat(user, "<span class='notice'>You feel a slight shiver as the cybernetic obfuscators deactivate.</span>")

--- a/code/modules/mob/living/carbon/human/human_mob.dm
+++ b/code/modules/mob/living/carbon/human/human_mob.dm
@@ -1812,15 +1812,19 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 	if(wear_id)
 		var/obj/item/card/id/id = wear_id.GetID()
 		if(istype(id) && id.is_untrackable())
-			return 0
+			return FALSE
 	if(wear_pda)
 		var/obj/item/card/id/id = wear_pda.GetID()
 		if(istype(id) && id.is_untrackable())
-			return 0
+			return FALSE
 	if(istype(head, /obj/item/clothing/head))
 		var/obj/item/clothing/head/hat = head
 		if(hat.blockTracking)
-			return 0
+			return FALSE
+	if(w_uniform)
+		var/obj/item/clothing/under/uniform = w_uniform
+		if(uniform.blockTracking)
+			return FALSE
 
 	return ..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds the "Big Brother" Obfuscation Suit to the Uplink for Agents for `20TC`.

This suit prevents all tracking from AI cameras as well as makes the user invisible to the AI (just like Changeling Cham Skin).

It is unable to be purchased by Nuclear Operatives. It has been added to the Contractor Starter Bundle's possible rolls.

## Why It's Good For The Game
This is a reversal of the Radio Jammer. Instead of hiding everyone ELSE talking, this hides the user.

## Testing
1. Ensured Traits added/removed properly.
2. Ensured the AI could not track the user of the suit when the suit was being worn.
3. Ensured the AI could not see the user of the suit when the suit was being worn.

## Changelog
:cl:
add: Added the Syndicate "Big Brother" Obfuscation Suit to the Traitor Uplink.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
