### PR TITLE
Warn user during open airlock repair attempts

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1149,7 +1149,8 @@ GLOBAL_LIST_EMPTY(airlock_emissive_underlays)
 					"<span class='notice'>You [welded ? "weld the airlock shut":"unweld the airlock"].</span>")
 				update_icon()
 		else if(obj_integrity < max_integrity)
-			if(icon_state != "closed")
+			// Only attempt repairs if the door is solid (albeit closed)
+			if(!density)
 				to_chat(user, "<span class='warning'>The airlock must be closed for repairs.</span>")
 				return
 			user.visible_message("<span class='notice'>[user] is welding the airlock.</span>", \

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1149,6 +1149,9 @@ GLOBAL_LIST_EMPTY(airlock_emissive_underlays)
 					"<span class='notice'>You [welded ? "weld the airlock shut":"unweld the airlock"].</span>")
 				update_icon()
 		else if(obj_integrity < max_integrity)
+			if(icon_state != "closed")
+				to_chat(user, "<span class='warning'>The airlock must be closed for repairs.</span>")
+				return
 			user.visible_message("<span class='notice'>[user] is welding the airlock.</span>", \
 				"<span class='notice'>You begin repairing the airlock...</span>", \
 				"<span class='italics'>You hear welding.</span>")


### PR DESCRIPTION
## What Does This PR Do
This commit adds a check for non-closed airlocks during the repair logic, and returns the user a warning message that airlocks must be closed for repairs to work. This avoids the animation cycle of an interrupted repair attempt, and clarifies that repairs cannot be attempted in this state.

## Why It's Good For The Game
Fixes #13724, clarifying to a user why an airlock repair is not possible in this state.

## Images of changes
![image](https://github.com/ParadiseSS13/Paradise/assets/998920/816d6022-f8aa-4bc6-8ff8-49464768e216)

## Testing
* Damage an airlock to the point it needs repairs
* Attempt repairs whilst airlock is **not** closed, and observe no animation cycle and a warning message
* Attempt repairs whilst airlock is closed, and repairs work as normal

## Changelog
:cl:
fix: Non-closed airlocks no longer animate a failed repair cycle, and warn the user of their inability to be repaired.
/:cl: