### PR TITLE
Remote signaler tweaks

### DIFF
--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -31,6 +31,7 @@ GLOBAL_LIST_EMPTY(remote_signalers)
 	. += "<span class='notice'>Alt+Click to send a signal.</span>"
 
 /obj/item/assembly/signaler/AltClick(mob/user)
+	to_chat(user, "<span class='notice'>You activate [src].</span>")
 	activate()
 
 /obj/item/assembly/signaler/attackby(obj/item/W, mob/user, params)
@@ -58,7 +59,6 @@ GLOBAL_LIST_EMPTY(remote_signalers)
 
 /obj/item/assembly/signaler/proc/signal_callback()
 	pulse(1)
-	to_chat(usr, "You have sent the signal.")
 	visible_message("[bicon(src)] *beep* *beep*")
 
 // Activation pre-runner, handles cooldown and calls signal(), invoked from ui_act()

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -40,7 +40,7 @@ GLOBAL_LIST_EMPTY(remote_signalers)
 		if(secured && signaler2.secured)
 			code = signaler2.code
 			frequency = signaler2.frequency
-			to_chat(user, "You transfer the frequency and code to the [src].")
+			to_chat(user, "You transfer the frequency and code to [src].")
 	return ..()
 
 /// Called from activate(), actually invokes the signal on other signallers in the world

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -39,7 +39,7 @@ GLOBAL_LIST_EMPTY(remote_signalers)
 			code = signaler2.code
 			frequency = signaler2.frequency
 			to_chat(user, "You transfer the frequency and code to the [signaler2.name].")
-	..()
+	return ..()
 
 /// Called from activate(), actually invokes the signal on other signallers in the world
 /obj/item/assembly/signaler/proc/signal()

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -2,10 +2,10 @@ GLOBAL_LIST_EMPTY(remote_signalers)
 
 /obj/item/assembly/signaler
 	name = "remote signaling device"
-	desc = "Used to remotely activate devices. Allows for syncing when using a signaler on another. Alt+Click to send a signal."
+	desc = "Used to remotely activate devices. Allows for syncing when using a signaler on another."
 	icon_state = "signaller"
 	item_state = "signaler"
-	materials = list(MAT_METAL=400, MAT_GLASS=120)
+	materials = list(MAT_METAL = 400, MAT_GLASS = 120)
 	origin_tech = "magnets=1;bluespace=1"
 	wires = WIRE_RECEIVE | WIRE_PULSE | WIRE_RADIO_PULSE | WIRE_RADIO_RECEIVE
 	secured = TRUE
@@ -28,6 +28,7 @@ GLOBAL_LIST_EMPTY(remote_signalers)
 /obj/item/assembly/signaler/examine(mob/user)
 	. = ..()
 	. += "The power light is [receiving ? "on" : "off"]"
+	. += "<span class='notice'>Alt+Click to send a signal.</span>"
 
 /obj/item/assembly/signaler/AltClick(mob/user)
 	activate()
@@ -38,7 +39,7 @@ GLOBAL_LIST_EMPTY(remote_signalers)
 		if(secured && signaler2.secured)
 			code = signaler2.code
 			frequency = signaler2.frequency
-			to_chat(user, "You transfer the frequency and code to the [signaler2.name].")
+			to_chat(user, "You transfer the frequency and code to the [src].")
 	return ..()
 
 /// Called from activate(), actually invokes the signal on other signallers in the world
@@ -57,6 +58,7 @@ GLOBAL_LIST_EMPTY(remote_signalers)
 
 /obj/item/assembly/signaler/proc/signal_callback()
 	pulse(1)
+	to_chat(usr, "You have sent the signal.")
 	visible_message("[bicon(src)] *beep* *beep*")
 
 // Activation pre-runner, handles cooldown and calls signal(), invoked from ui_act()

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -2,7 +2,7 @@ GLOBAL_LIST_EMPTY(remote_signalers)
 
 /obj/item/assembly/signaler
 	name = "remote signaling device"
-	desc = "Used to remotely activate devices."
+	desc = "Used to remotely activate devices. Allows for syncing when using a signaler on another. Alt+Click to send a signal."
 	icon_state = "signaller"
 	item_state = "signaler"
 	materials = list(MAT_METAL=400, MAT_GLASS=120)
@@ -28,6 +28,18 @@ GLOBAL_LIST_EMPTY(remote_signalers)
 /obj/item/assembly/signaler/examine(mob/user)
 	. = ..()
 	. += "The power light is [receiving ? "on" : "off"]"
+
+/obj/item/assembly/signaler/AltClick(mob/user)
+	activate()
+
+/obj/item/assembly/signaler/attackby(obj/item/W, mob/user, params)
+	if(issignaler(W))
+		var/obj/item/assembly/signaler/signaler2 = W
+		if(secured && signaler2.secured)
+			code = signaler2.code
+			frequency = signaler2.frequency
+			to_chat(user, "You transfer the frequency and code to the [signaler2.name].")
+	..()
 
 /// Called from activate(), actually invokes the signal on other signallers in the world
 /obj/item/assembly/signaler/proc/signal()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
You can now send a signal with ALT+CLICK.
You can now transfer the code/frequency by using a signaler on another (based on https://github.com/tgstation/tgstation/pull/23340).
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
I judge it to be good quality of life additions to the game, allowing for you to set multiple signallers more easily.

## Testing
<!-- How did you test the PR, if at all? -->
- Tested by using the signal with the new shortcut
- Did transfer the settings multiple times and tested it with an airlock
## Changelog
:cl:
tweak: Remote signaler: you can now send a signal with ALT+CLICK
tweak: Remote signaler: You can now transfer the code/frequency by using a signaler on another
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
