### PR TITLE
Add missing UpdateButtonIcon() calls for Modsuits

### DIFF
--- a/code/modules/mod/mod_actions.dm
+++ b/code/modules/mod/mod_actions.dm
@@ -49,6 +49,7 @@
 	if(!ready && left_click)
 		ready = TRUE
 		button_icon_state = "activate-ready"
+		UpdateButtonIcon()
 		addtimer(CALLBACK(src, PROC_REF(reset_ready)), 3 SECONDS)
 		return
 	var/obj/item/mod/control/mod = target
@@ -59,6 +60,7 @@
 /datum/action/item_action/mod/activate/proc/reset_ready()
 	ready = FALSE
 	button_icon_state = initial(button_icon_state)
+	UpdateButtonIcon()
 
 /datum/action/item_action/mod/module
 	name = "Toggle Module"


### PR DESCRIPTION
## What Does This PR Do
This PR adds some missing `UpdateButtonIcon()` calls from https://github.com/tgstation/tgstation/pull/63836

## Why It's Good For The Game
Fixes #22161, updating UI buttons on interactions where required.

## Testing
* Wear a modsuit
* Interact with the "Activate MODsuit" button, and have the button react to interactions.

## Changelog
:cl:
fix: MODsuit button UI interactions now update the icon if required.
/:cl: