### PR TITLE
You can't feed simplemobs with condiment bottles anymore

### DIFF
--- a/code/modules/food_and_drinks/food/condiment.dm
+++ b/code/modules/food_and_drinks/food/condiment.dm
@@ -46,7 +46,7 @@
 		return
 
 	if(M == user)
-		to_chat(user, "<span class='notice'>You swallow some of contents of [src].</span>")
+		to_chat(user, "<span class='notice'>You swallow some of the contents of [src].</span>")
 	else
 		user.visible_message("<span class='warning'>[user] attempts to feed [M] from [src].</span>")
 		if(!do_mob(user, M))

--- a/code/modules/food_and_drinks/food/condiment.dm
+++ b/code/modules/food_and_drinks/food/condiment.dm
@@ -41,6 +41,10 @@
 		to_chat(user, "<span class='warning'>None of [src] left, oh no!</span>")
 		return 0
 
+	if(!iscarbon(M)) // Non-carbons can't process reagents
+		to_chat(user, "<span class='warning'>You cannot find a way to feed [M].</span>")
+		return
+
 	if(M == user)
 		to_chat(M, "<span class='notice'>You swallow some of contents of \the [src].</span>")
 	else

--- a/code/modules/food_and_drinks/food/condiment.dm
+++ b/code/modules/food_and_drinks/food/condiment.dm
@@ -39,14 +39,14 @@
 
 	if(!reagents || !reagents.total_volume)
 		to_chat(user, "<span class='warning'>None of [src] left, oh no!</span>")
-		return 0
+		return FALSE
 
 	if(!iscarbon(M)) // Non-carbons can't process reagents
 		to_chat(user, "<span class='warning'>You cannot find a way to feed [M].</span>")
 		return
 
 	if(M == user)
-		to_chat(M, "<span class='notice'>You swallow some of contents of \the [src].</span>")
+		to_chat(user, "<span class='notice'>You swallow some of contents of [src].</span>")
 	else
 		user.visible_message("<span class='warning'>[user] attempts to feed [M] from [src].</span>")
 		if(!do_mob(user, M))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Removes the ability to feed simplemobs chemicals or drinks with condiment bottles (It does jack shit anyways)
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
It's a bug
Fixes #18915 
Also cleans up some surrounding code
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Tried to feed a guardian salt, to prepare it for when it's master would die, it failed :(
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: You can no longer feed simplemobs with condiment bottles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
