### PR TITLE
Prevents blood from attempting to dry if said blood no longer exists

### DIFF
--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -44,7 +44,7 @@ GLOBAL_LIST_EMPTY(splatter_cache)
 		//weightless blood cannot dry
 		return
 
-	if(!.)
+	if(!. && !QDELETED(src))
 		dry_timer = addtimer(CALLBACK(src, PROC_REF(dry)), DRYING_TIME * (amount+1), TIMER_STOPPABLE)
 
 /obj/effect/decal/cleanable/blood/Destroy()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Prevents blood from attempting to dry if the blood tile no longer exists

## Why It's Good For The Game
We don't need to waste a timer slot on something that doesn't exist

## Testing
I'm not entirely sure how to reproduce this, but src will only be null in this case if it is being qdeleted, therefore it is most likely being qdeleted
## Changelog
Hopefully not playerfacing

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
