### PR TITLE
Fixing examining logic

### DIFF
--- a/code/__DEFINES/mob_defines.dm
+++ b/code/__DEFINES/mob_defines.dm
@@ -309,3 +309,28 @@
 
 #define MAX_EYE_BLURRY_FILTER_SIZE 2
 #define EYE_BLUR_TO_FILTER_SIZE_MULTIPLIER 0.005
+
+/proc/bodypart_name_to_clothing_bitflag(bodypart_name)
+	switch(bodypart_name)
+		if("head")
+			return HEAD
+		if("chest")
+			return UPPER_TORSO
+		if("groin")
+			return LOWER_TORSO
+		if("l_arm")
+			return ARM_LEFT
+		if("l_hand")
+			return HAND_LEFT
+		if("r_arm")
+			return ARM_RIGHT
+		if("r_hand")
+			return HAND_RIGHT
+		if("r_leg")
+			return LEG_RIGHT
+		if("r_foot")
+			return FOOT_RIGHT
+		if("l_leg")
+			return LEG_LEFT
+		if("l_foot")
+			return FOOT_LEFT

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -853,7 +853,6 @@
 				if(H.w_uniform.sprite_sheets[H.dna.species.name] && icon_exists(H.w_uniform.sprite_sheets[H.dna.species.name], "[basecolor]_d_s"))
 					item_color = item_color == "[basecolor]" ? "[basecolor]_d" : "[basecolor]"
 					usr.update_inv_w_uniform()
-
 			else
 				if(H.w_uniform.sprite_sheets["Human"] && icon_exists(H.w_uniform.sprite_sheets["Human"], "[basecolor]_d_s"))
 					item_color = item_color == "[basecolor]" ? "[basecolor]_d" : "[basecolor]"
@@ -863,6 +862,12 @@
 
 	else
 		to_chat(usr, "<span class='notice'>You cannot roll down the uniform!</span>")
+	if(item_color == "[basecolor]")
+		body_parts_covered = initial(body_parts_covered)
+	else
+		body_parts_covered &= ~UPPER_TORSO
+		body_parts_covered &= ~LOWER_TORSO
+		body_parts_covered &= ~ARMS
 
 /obj/item/clothing/under/verb/removetie()
 	set name = "Remove Accessory"

--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -216,7 +216,7 @@
 	msg += "<span class='warning'>"
 
 	// Stuff at the start of the block
-	msg += examine_start_damage_block()
+	msg += examine_start_damage_block(skipgloves, skipsuitstorage, skipjumpsuit, skipshoes, skipmask, skipears, skipeyes, skipface)
 
 	// Show how badly they're damaged
 	msg += examine_damage_flavor()

--- a/code/modules/mob/living/carbon/human/human_examine.dm
+++ b/code/modules/mob/living/carbon/human/human_examine.dm
@@ -79,57 +79,84 @@
 		is_destroyed["[organ_data["descriptor"]]"] = 1
 
 		var/obj/item/organ/external/E = bodyparts_by_name[organ_tag]
+		var/bodypart_clothing_bitflag = bodypart_name_to_clothing_bitflag(organ_tag)
 		if(!E)
 			wound_flavor_text["[organ_tag]"] = "<b>[p_they(TRUE)] [p_are()] missing [p_their()] [organ_descriptor].</b>\n"
-		else
-			if(!ismachineperson(src))
-				if(E.is_robotic())
-					wound_flavor_text["[E.limb_name]"] = "[p_they(TRUE)] [p_have()] a robotic [E.name]!\n"
+			continue
 
-				else if(E.status & ORGAN_SPLINTED)
-					wound_flavor_text["[E.limb_name]"] = "[p_they(TRUE)] [p_have()] a splint on [p_their()] [E.name]!\n"
+		if((bodypart_clothing_bitflag & HEAD))
+			if(skip_mask)
+				continue
+			var/obj/item/clothing/mask/current_mask = wear_mask
+			if(istype(current_mask) && (current_mask.body_parts_covered & bodypart_clothing_bitflag))
+				continue
 
-				else if(!E.properly_attached)
-					wound_flavor_text["[E.limb_name]"] = "[p_their(TRUE)] [E.name] is barely attached!\n"
+		if(((bodypart_clothing_bitflag & ARMS) || (bodypart_clothing_bitflag & LEGS) || (bodypart_clothing_bitflag & UPPER_TORSO) || (bodypart_clothing_bitflag & LOWER_TORSO)))
+			if(skip_jumpsuit)
+				continue
+			if(!isnull(w_uniform) && (w_uniform.body_parts_covered & bodypart_clothing_bitflag))
+				continue
 
-				else if(E.status & ORGAN_BURNT)
-					wound_flavor_text["[E.limb_name]"] = "[p_their(TRUE)] [E.name] is badly burnt!\n"
+		if((bodypart_clothing_bitflag & HANDS))
+			if(skip_gloves)
+				continue
+			var/obj/item/clothing/gloves/current_gloves = gloves
+			if(istype(current_gloves) && (current_gloves.body_parts_covered & bodypart_clothing_bitflag))
+				continue
 
-			if(E.open)
-				if(E.is_robotic())
-					msg += "<b>The maintenance hatch on [p_their()] [ignore_limb_branding(E.limb_name)] is open!</b>\n"
-				else
-					msg += "<b>[p_their(TRUE)] [ignore_limb_branding(E.limb_name)] has an open incision!</b>\n"
+		if((bodypart_clothing_bitflag & FEET))
+			if(skip_shoes)
+				continue
+			var/obj/item/clothing/shoes/current_shoes = shoes
+			if(istype(current_shoes) && (current_shoes.body_parts_covered & bodypart_clothing_bitflag))
+				continue
 
-			for(var/obj/item/I in E.embedded_objects)
-				msg += "<b>[p_they(TRUE)] [p_have()] \a [bicon(I)] [I] embedded in [p_their()] [E.name]!</b>\n"
+		if(!ismachineperson(src))
+			if(E.is_robotic())
+				wound_flavor_text["[E.limb_name]"] = "[p_they(TRUE)] [p_have()] a robotic [E.name]!\n"
+
+			else if(E.status & ORGAN_SPLINTED)
+				wound_flavor_text["[E.limb_name]"] = "[p_they(TRUE)] [p_have()] a splint on [p_their()] [E.name]!\n"
+
+			else if(!E.properly_attached)
+				wound_flavor_text["[E.limb_name]"] = "[p_their(TRUE)] [E.name] is barely attached!\n"
+
+			else if(E.status & ORGAN_BURNT)
+				wound_flavor_text["[E.limb_name]"] = "[p_their(TRUE)] [E.name] is badly burnt!\n"
+
+		if(E.open)
+			if(E.is_robotic())
+				msg += "<b>The maintenance hatch on [p_their()] [ignore_limb_branding(E.limb_name)] is open!</b>\n"
+			else
+				msg += "<b>[p_their(TRUE)] [ignore_limb_branding(E.limb_name)] has an open incision!</b>\n"
+
+		for(var/obj/item/I in E.embedded_objects)
+			msg += "<b>[p_they(TRUE)] [p_have()] \a [bicon(I)] [I] embedded in [p_their()] [E.name]!</b>\n"
 
 	//Handles the text strings being added to the actual description.
 	//If they have something that covers the limb, and it is not missing, put flavortext.  If it is covered but bleeding, add other flavortext.
-	var/obj/item/clothing/mask/current_mask = wear_mask
-	var/obj/item/clothing/gloves/current_gloves = gloves
-	var/obj/item/clothing/shoes/current_shoes = shoes
-	if(wound_flavor_text["head"] && (is_destroyed["head"] || (!skip_mask && (!istype(current_mask) || !(current_mask.body_parts_covered & HEAD)))))
+
+	if(wound_flavor_text["head"])
 		msg += wound_flavor_text["head"]
-	if(wound_flavor_text["chest"] && !skip_jumpsuit && (isnull(w_uniform) || !(w_uniform.body_parts_covered & UPPER_TORSO))) //No need.  A missing chest gibs you.
+	if(wound_flavor_text["chest"])
 		msg += wound_flavor_text["chest"]
-	if(wound_flavor_text["groin"] && (is_destroyed["groin"] || (!skip_jumpsuit && (isnull(w_uniform) || !(w_uniform.body_parts_covered & LOWER_TORSO)))))
+	if(wound_flavor_text["groin"])
 		msg += wound_flavor_text["groin"]
-	if(wound_flavor_text["l_arm"] && (is_destroyed["left arm"] || (!skip_jumpsuit && (isnull(w_uniform) || !(w_uniform.body_parts_covered & ARM_LEFT)))))
+	if(wound_flavor_text["l_arm"])
 		msg += wound_flavor_text["l_arm"]
-	if(wound_flavor_text["l_hand"] && (is_destroyed["left hand"] || (!skip_gloves && (!istype(current_gloves) || !(current_gloves.body_parts_covered & HANDS)))))
+	if(wound_flavor_text["l_hand"])
 		msg += wound_flavor_text["l_hand"]
-	if(wound_flavor_text["r_arm"] && (is_destroyed["right arm"] || (!skip_jumpsuit && (isnull(w_uniform) || !(w_uniform.body_parts_covered & ARM_RIGHT)))))
+	if(wound_flavor_text["r_arm"])
 		msg += wound_flavor_text["r_arm"]
-	if(wound_flavor_text["r_hand"] && (is_destroyed["right hand"] || (!skip_gloves && (!istype(current_gloves) || !(current_gloves.body_parts_covered & HANDS)))))
+	if(wound_flavor_text["r_hand"])
 		msg += wound_flavor_text["r_hand"]
-	if(wound_flavor_text["l_leg"] && (is_destroyed["left leg"] || (!skip_jumpsuit && (isnull(w_uniform) || !(w_uniform.body_parts_covered & LEG_LEFT)))))
+	if(wound_flavor_text["l_leg"])
 		msg += wound_flavor_text["l_leg"]
-	if(wound_flavor_text["r_hand"] && (is_destroyed["right hand"] || (!skip_shoes && (!istype(current_shoes) || !(current_shoes.body_parts_covered & FEET)))))
+	if(wound_flavor_text["r_hand"])
 		msg += wound_flavor_text["l_foot"]
-	if(wound_flavor_text["r_leg"] && (is_destroyed["right leg"] || (!skip_jumpsuit && (isnull(w_uniform) || !(w_uniform.body_parts_covered & LEG_RIGHT)))))
+	if(wound_flavor_text["r_leg"])
 		msg += wound_flavor_text["r_leg"]
-	if(wound_flavor_text["r_hand"] && (is_destroyed["right hand"] || (!skip_shoes && (!istype(current_shoes) || !(current_shoes.body_parts_covered & FEET)))))
+	if(wound_flavor_text["r_hand"])
 		msg += wound_flavor_text["r_foot"]
 	return msg
 

--- a/code/modules/mob/living/carbon/human/human_examine.dm
+++ b/code/modules/mob/living/carbon/human/human_examine.dm
@@ -91,7 +91,8 @@
 			if(istype(current_mask) && (current_mask.body_parts_covered & bodypart_clothing_bitflag))
 				continue
 
-		if(((bodypart_clothing_bitflag & ARMS) || (bodypart_clothing_bitflag & LEGS) || (bodypart_clothing_bitflag & UPPER_TORSO) || (bodypart_clothing_bitflag & LOWER_TORSO)))
+		var/chest_groin_arms_legs_bitflag = ARMS | LEGS | UPPER_TORSO | LOWER_TORSO //is what covered by jumpsuit
+		if(bodypart_clothing_bitflag & chest_groin_arms_legs_bitflag)
 			if(skip_jumpsuit)
 				continue
 			if(!isnull(w_uniform) && (w_uniform.body_parts_covered & bodypart_clothing_bitflag))

--- a/code/modules/mob/living/carbon/human/human_examine.dm
+++ b/code/modules/mob/living/carbon/human/human_examine.dm
@@ -84,7 +84,7 @@
 			wound_flavor_text["[organ_tag]"] = "<b>[p_they(TRUE)] [p_are()] missing [p_their()] [organ_descriptor].</b>\n"
 			continue
 
-		if((bodypart_clothing_bitflag & HEAD))
+		if(bodypart_clothing_bitflag & HEAD)
 			if(skip_mask)
 				continue
 			var/obj/item/clothing/mask/current_mask = wear_mask
@@ -98,14 +98,14 @@
 			if(!isnull(w_uniform) && (w_uniform.body_parts_covered & bodypart_clothing_bitflag))
 				continue
 
-		if((bodypart_clothing_bitflag & HANDS))
+		if(bodypart_clothing_bitflag & HANDS)
 			if(skip_gloves)
 				continue
 			var/obj/item/clothing/gloves/current_gloves = gloves
 			if(istype(current_gloves) && (current_gloves.body_parts_covered & bodypart_clothing_bitflag))
 				continue
 
-		if((bodypart_clothing_bitflag & FEET))
+		if(bodypart_clothing_bitflag & FEET)
 			if(skip_shoes)
 				continue
 			var/obj/item/clothing/shoes/current_shoes = shoes

--- a/code/modules/mob/living/carbon/human/human_examine.dm
+++ b/code/modules/mob/living/carbon/human/human_examine.dm
@@ -106,29 +106,31 @@
 
 	//Handles the text strings being added to the actual description.
 	//If they have something that covers the limb, and it is not missing, put flavortext.  If it is covered but bleeding, add other flavortext.
-	if(wound_flavor_text["head"] && (is_destroyed["head"] || (!skip_mask && !(wear_mask && istype(wear_mask, /obj/item/clothing/mask/gas)))))
+	var/obj/item/clothing/mask/current_mask = wear_mask
+	var/obj/item/clothing/gloves/current_gloves = gloves
+	var/obj/item/clothing/shoes/current_shoes = shoes
+	if(wound_flavor_text["head"] && (is_destroyed["head"] || (!skip_mask && (!istype(current_mask) || !(current_mask.body_parts_covered & HEAD)))))
 		msg += wound_flavor_text["head"]
-	if(wound_flavor_text["chest"] && !w_uniform && !skip_jumpsuit) //No need.  A missing chest gibs you.
+	if(wound_flavor_text["chest"] && !skip_jumpsuit && (isnull(w_uniform) || !(w_uniform.body_parts_covered & UPPER_TORSO))) //No need.  A missing chest gibs you.
 		msg += wound_flavor_text["chest"]
-	if(wound_flavor_text["l_arm"] && (is_destroyed["left arm"] || (!w_uniform && !skip_jumpsuit)))
-		msg += wound_flavor_text["l_arm"]
-	if(wound_flavor_text["l_hand"] && (is_destroyed["left hand"] || (!gloves && !skip_gloves)))
-		msg += wound_flavor_text["l_hand"]
-	if(wound_flavor_text["r_arm"] && (is_destroyed["right arm"] || (!w_uniform && !skip_jumpsuit)))
-		msg += wound_flavor_text["r_arm"]
-	if(wound_flavor_text["r_hand"] && (is_destroyed["right hand"] || (!gloves && !skip_gloves)))
-		msg += wound_flavor_text["r_hand"]
-	if(wound_flavor_text["groin"] && (is_destroyed["groin"] || (!w_uniform && !skip_jumpsuit)))
+	if(wound_flavor_text["groin"] && (is_destroyed["groin"] || (!skip_jumpsuit && (isnull(w_uniform) || !(w_uniform.body_parts_covered & LOWER_TORSO)))))
 		msg += wound_flavor_text["groin"]
-	if(wound_flavor_text["l_leg"] && (is_destroyed["left leg"] || (!w_uniform && !skip_jumpsuit)))
+	if(wound_flavor_text["l_arm"] && (is_destroyed["left arm"] || (!skip_jumpsuit && (isnull(w_uniform) || !(w_uniform.body_parts_covered & ARM_LEFT)))))
+		msg += wound_flavor_text["l_arm"]
+	if(wound_flavor_text["l_hand"] && (is_destroyed["left hand"] || (!skip_gloves && (!istype(current_gloves) || !(current_gloves.body_parts_covered & HANDS)))))
+		msg += wound_flavor_text["l_hand"]
+	if(wound_flavor_text["r_arm"] && (is_destroyed["right arm"] || (!skip_jumpsuit && (isnull(w_uniform) || !(w_uniform.body_parts_covered & ARM_RIGHT)))))
+		msg += wound_flavor_text["r_arm"]
+	if(wound_flavor_text["r_hand"] && (is_destroyed["right hand"] || (!skip_gloves && (!istype(current_gloves) || !(current_gloves.body_parts_covered & HANDS)))))
+		msg += wound_flavor_text["r_hand"]
+	if(wound_flavor_text["l_leg"] && (is_destroyed["left leg"] || (!skip_jumpsuit && (isnull(w_uniform) || !(w_uniform.body_parts_covered & LEG_LEFT)))))
 		msg += wound_flavor_text["l_leg"]
-	if(wound_flavor_text["l_foot"]&& (is_destroyed["left foot"] || (!shoes && !skip_shoes)))
+	if(wound_flavor_text["r_hand"] && (is_destroyed["right hand"] || (!skip_shoes && (!istype(current_shoes) || !(current_shoes.body_parts_covered & FEET)))))
 		msg += wound_flavor_text["l_foot"]
-	if(wound_flavor_text["r_leg"] && (is_destroyed["right leg"] || (!w_uniform && !skip_jumpsuit)))
+	if(wound_flavor_text["r_leg"] && (is_destroyed["right leg"] || (!skip_jumpsuit && (isnull(w_uniform) || !(w_uniform.body_parts_covered & LEG_RIGHT)))))
 		msg += wound_flavor_text["r_leg"]
-	if(wound_flavor_text["r_foot"]&& (is_destroyed["right foot"] || (!shoes  && !skip_shoes)))
+	if(wound_flavor_text["r_hand"] && (is_destroyed["right hand"] || (!skip_shoes && (!istype(current_shoes) || !(current_shoes.body_parts_covered & FEET)))))
 		msg += wound_flavor_text["r_foot"]
-
 	return msg
 
 /mob/living/carbon/human/examine_extra_damage_flavor()

--- a/code/modules/mob/living/carbon/human/human_examine.dm
+++ b/code/modules/mob/living/carbon/human/human_examine.dm
@@ -72,6 +72,7 @@
 	var/msg = ""
 	var/list/wound_flavor_text = list()
 	var/list/is_destroyed = list()
+	var/skip_bodyparts = 0
 	for(var/organ_tag in dna.species.has_limbs)
 
 		var/list/organ_data = dna.species.has_limbs[organ_tag]
@@ -81,7 +82,21 @@
 		var/obj/item/organ/external/E = bodyparts_by_name[organ_tag]
 		var/bodypart_clothing_bitflag = bodypart_name_to_clothing_bitflag(organ_tag)
 		if(!E)
+			if(bodypart_clothing_bitflag & skip_bodyparts)
+				continue
 			wound_flavor_text["[organ_tag]"] = "<b>[p_they(TRUE)] [p_are()] missing [p_their()] [organ_descriptor].</b>\n"
+			if(bodypart_clothing_bitflag & ARM_LEFT)
+				skip_bodyparts |= HAND_LEFT
+				wound_flavor_text["l_hand"] = null
+			if(bodypart_clothing_bitflag & ARM_RIGHT)
+				skip_bodyparts |= HAND_RIGHT
+				wound_flavor_text["r_hand"] = null
+			if(bodypart_clothing_bitflag & LEG_LEFT)
+				skip_bodyparts |= FOOT_LEFT
+				wound_flavor_text["l_foot"] = null
+			if(bodypart_clothing_bitflag & LEG_RIGHT)
+				skip_bodyparts |= FOOT_RIGHT
+				wound_flavor_text["r_foot"] = null
 			continue
 
 		if(bodypart_clothing_bitflag & HEAD)
@@ -137,28 +152,17 @@
 	//Handles the text strings being added to the actual description.
 	//If they have something that covers the limb, and it is not missing, put flavortext.  If it is covered but bleeding, add other flavortext.
 
-	if(wound_flavor_text["head"])
-		msg += wound_flavor_text["head"]
-	if(wound_flavor_text["chest"])
-		msg += wound_flavor_text["chest"]
-	if(wound_flavor_text["groin"])
-		msg += wound_flavor_text["groin"]
-	if(wound_flavor_text["l_arm"])
-		msg += wound_flavor_text["l_arm"]
-	if(wound_flavor_text["l_hand"])
-		msg += wound_flavor_text["l_hand"]
-	if(wound_flavor_text["r_arm"])
-		msg += wound_flavor_text["r_arm"]
-	if(wound_flavor_text["r_hand"])
-		msg += wound_flavor_text["r_hand"]
-	if(wound_flavor_text["l_leg"])
-		msg += wound_flavor_text["l_leg"]
-	if(wound_flavor_text["r_hand"])
-		msg += wound_flavor_text["l_foot"]
-	if(wound_flavor_text["r_leg"])
-		msg += wound_flavor_text["r_leg"]
-	if(wound_flavor_text["r_hand"])
-		msg += wound_flavor_text["r_foot"]
+	msg += wound_flavor_text["head"]
+	msg += wound_flavor_text["chest"]
+	msg += wound_flavor_text["groin"]
+	msg += wound_flavor_text["l_arm"]
+	msg += wound_flavor_text["l_hand"]
+	msg += wound_flavor_text["r_arm"]
+	msg += wound_flavor_text["r_hand"]
+	msg += wound_flavor_text["l_leg"]
+	msg += wound_flavor_text["l_foot"]
+	msg += wound_flavor_text["r_leg"]
+	msg += wound_flavor_text["r_foot"]
 	return msg
 
 /mob/living/carbon/human/examine_extra_damage_flavor()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
This PR fixes examining wounds logic
Previously
1. It did not use its own proc args, they just were not transfered when we called the proc
2. It did check just for existing jumpsuit, not for it `body_parts_covered` flags
3. same for gloves, feets; mask had even weirder logic
4. rolling up and down jumpsuit did not change any of `body_parts_covered` flags

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Bugs bad, being able to see crit burn through ERT hardsuit and not being able to see crit burn through rolled down jumpsuit is bad

## Testing
<!-- How did you test the PR, if at all? -->
Compiled, did critical burn, examined myself multiple times

## Changelog
:cl:
tweak: Rolling down and up jumpsuit now affects if you can see chest, lower body, arms on examine
fix: Examining injured now checks if you cant see body parts
fix: Examining now will show robotic limbs only if you can see them(jumpsuit + gloves fully hides metal arm+hand)
fix: If person is missing full arm(leg), this wont be splitted into two messages(arm+hand/leg+feet)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
