### PR TITLE
Abstract items can be shown

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -26,7 +26,6 @@
 
 ///Whether or not this atom shows screentips when hovered over
 #define NO_SCREENTIPS			32768
-#define FORCE_VISIBLE			65536	// It forces item to be visible on examine even if it is abstract
 
 // Update flags for [/atom/proc/update_appearance]
 /// Update the atom's name

--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -26,6 +26,7 @@
 
 ///Whether or not this atom shows screentips when hovered over
 #define NO_SCREENTIPS			32768
+#define FORCE_VISIBLE			65536	// It forces item to be visible on examine even if it is abstract
 
 // Update flags for [/atom/proc/update_appearance]
 /// Update the atom's name

--- a/code/game/gamemodes/cult/blood_magic.dm
+++ b/code/game/gamemodes/cult/blood_magic.dm
@@ -397,7 +397,7 @@
 
 /obj/item/melee/blood_magic/customised_abstract_text()
 	if(!ishuman(loc))
-		return ""
+		return
 	var/mob/living/carbon/human/owner = loc
 	return "<span class='warning'>[owner.p_their(TRUE)] [owner.l_hand == src ? "left hand" : "right hand"] is burning in blood-red fire.</span>\n"
 

--- a/code/game/gamemodes/cult/blood_magic.dm
+++ b/code/game/gamemodes/cult/blood_magic.dm
@@ -399,7 +399,7 @@
 	if(!ishuman(loc))
 		return
 	var/mob/living/carbon/human/owner = loc
-	return "<span class='warning'>[owner.p_their(TRUE)] [owner.l_hand == src ? "left hand" : "right hand"] is burning in blood-red fire.</span>\n"
+	return "<span class='warning'>[owner.p_their(TRUE)] [owner.l_hand == src ? "left hand" : "right hand"] is burning in blood-red fire.</span>"
 
 /obj/item/melee/blood_magic/attack_self(mob/living/user)
 	afterattack(user, user, TRUE)

--- a/code/game/gamemodes/cult/blood_magic.dm
+++ b/code/game/gamemodes/cult/blood_magic.dm
@@ -395,6 +395,12 @@
 			source.UpdateButtonIcon()
 	return ..()
 
+/obj/item/melee/blood_magic/customised_abstract_text()
+	if(!ishuman(loc))
+		return ""
+	var/mob/living/carbon/human/owner = loc
+	return "<span class='warning'>[owner.p_their(TRUE)] [owner.l_hand == src ? "left hand" : "right hand"] is burning in blood-red fire.</span>\n"
+
 /obj/item/melee/blood_magic/attack_self(mob/living/user)
 	afterattack(user, user, TRUE)
 

--- a/code/game/gamemodes/wizard/godhand.dm
+++ b/code/game/gamemodes/wizard/godhand.dm
@@ -25,7 +25,7 @@
 
 /obj/item/melee/touch_attack/customised_abstract_text()
 	if(!ishuman(loc))
-		return ""
+		return
 	var/mob/living/carbon/human/owner = loc
 	return "<span class='warning'>[owner.p_their(TRUE)] [owner.l_hand == src ? "left hand" : "right hand"] is burning in magic fire.</span>\n"
 

--- a/code/game/gamemodes/wizard/godhand.dm
+++ b/code/game/gamemodes/wizard/godhand.dm
@@ -27,7 +27,7 @@
 	if(!ishuman(loc))
 		return
 	var/mob/living/carbon/human/owner = loc
-	return "<span class='warning'>[owner.p_their(TRUE)] [owner.l_hand == src ? "left hand" : "right hand"] is burning in magic fire.</span>\n"
+	return "<span class='warning'>[owner.p_their(TRUE)] [owner.l_hand == src ? "left hand" : "right hand"] is burning in magic fire.</span>"
 
 /obj/item/melee/touch_attack/attack(mob/target, mob/living/carbon/user)
 	if(!iscarbon(user)) //Look ma, no hands

--- a/code/game/gamemodes/wizard/godhand.dm
+++ b/code/game/gamemodes/wizard/godhand.dm
@@ -23,6 +23,12 @@
 		attached_spell.UnregisterSignal(attached_spell.action.owner, COMSIG_MOB_WILLINGLY_DROP)
 	return ..()
 
+/obj/item/melee/touch_attack/customised_abstract_text()
+	if(!ishuman(loc))
+		return ""
+	var/mob/living/carbon/human/owner = loc
+	return "<span class='warning'>[owner.p_their(TRUE)] [owner.l_hand == src ? "left hand" : "right hand"] is burning in magic fire.</span>\n"
+
 /obj/item/melee/touch_attack/attack(mob/target, mob/living/carbon/user)
 	if(!iscarbon(user)) //Look ma, no hands
 		return

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -154,7 +154,7 @@ GLOBAL_DATUM_INIT(welding_sparks, /mutable_appearance, mutable_appearance('icons
 		in_storage = TRUE
 
 /obj/item/proc/customised_abstract_text()
-	return ""
+	return
 
 /obj/item/proc/determine_move_resist()
 	switch(w_class)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -153,6 +153,7 @@ GLOBAL_DATUM_INIT(welding_sparks, /mutable_appearance, mutable_appearance('icons
 	if(isstorage(loc)) //marks all items in storage as being such
 		in_storage = TRUE
 
+// this proc is used to add text for items with ABSTRACT flag after default examine text
 /obj/item/proc/customised_abstract_text()
 	return
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -153,6 +153,9 @@ GLOBAL_DATUM_INIT(welding_sparks, /mutable_appearance, mutable_appearance('icons
 	if(isstorage(loc)) //marks all items in storage as being such
 		in_storage = TRUE
 
+/obj/item/proc/customised_abstract_text()
+	return ""
+
 /obj/item/proc/determine_move_resist()
 	switch(w_class)
 		if(WEIGHT_CLASS_TINY)

--- a/code/game/objects/items/weapons/holy_weapons.dm
+++ b/code/game/objects/items/weapons/holy_weapons.dm
@@ -122,6 +122,12 @@
 	damtype = BURN
 	attack_verb = list("punched", "cross countered", "pummeled")
 
+/obj/item/nullrod/godhand/customised_abstract_text()
+	if(!ishuman(loc))
+		return ""
+	var/mob/living/carbon/human/owner = loc
+	return "<span class='warning'>[owner.p_their(TRUE)] [owner.l_hand == src ? "left hand" : "right hand"] is burning in holy fire.</span>\n"
+
 /obj/item/nullrod/staff
 	name = "red holy staff"
 	desc = "It has a mysterious, protective aura."
@@ -421,9 +427,15 @@
 	desc = "Particularly twisted deities grant gifts of dubious value."
 	icon_state = "arm_blade"
 	item_state = "arm_blade"
-	flags = ABSTRACT | NODROP | FORCE_VISIBLE
+	flags = ABSTRACT | NODROP
 	w_class = WEIGHT_CLASS_HUGE
 	sharp = TRUE
+
+/obj/item/nullrod/armblade/customised_abstract_text()
+	if(!ishuman(loc))
+		return ""
+	var/mob/living/carbon/human/owner = loc
+	return "<span class='warning'>[owner.p_their(TRUE)] [owner.l_hand == src ? "left arm" : "right arm"] has been turned into a grotesque meat-blade.</span>\n"
 
 /obj/item/nullrod/armblade/mining
 	flags = NODROP

--- a/code/game/objects/items/weapons/holy_weapons.dm
+++ b/code/game/objects/items/weapons/holy_weapons.dm
@@ -126,7 +126,7 @@
 	if(!ishuman(loc))
 		return
 	var/mob/living/carbon/human/owner = loc
-	return "<span class='warning'>[owner.p_their(TRUE)] [owner.l_hand == src ? "left hand" : "right hand"] is burning in holy fire.</span>\n"
+	return "<span class='warning'>[owner.p_their(TRUE)] [owner.l_hand == src ? "left hand" : "right hand"] is burning in holy fire.</span>"
 
 /obj/item/nullrod/staff
 	name = "red holy staff"
@@ -435,7 +435,7 @@
 	if(!ishuman(loc))
 		return
 	var/mob/living/carbon/human/owner = loc
-	return "<span class='warning'>[owner.p_their(TRUE)] [owner.l_hand == src ? "left arm" : "right arm"] has been turned into a grotesque meat-blade.</span>\n"
+	return "<span class='warning'>[owner.p_their(TRUE)] [owner.l_hand == src ? "left arm" : "right arm"] has been turned into a grotesque meat-blade.</span>"
 
 /obj/item/nullrod/armblade/mining
 	flags = NODROP

--- a/code/game/objects/items/weapons/holy_weapons.dm
+++ b/code/game/objects/items/weapons/holy_weapons.dm
@@ -124,7 +124,7 @@
 
 /obj/item/nullrod/godhand/customised_abstract_text()
 	if(!ishuman(loc))
-		return ""
+		return
 	var/mob/living/carbon/human/owner = loc
 	return "<span class='warning'>[owner.p_their(TRUE)] [owner.l_hand == src ? "left hand" : "right hand"] is burning in holy fire.</span>\n"
 
@@ -433,7 +433,7 @@
 
 /obj/item/nullrod/armblade/customised_abstract_text()
 	if(!ishuman(loc))
-		return ""
+		return
 	var/mob/living/carbon/human/owner = loc
 	return "<span class='warning'>[owner.p_their(TRUE)] [owner.l_hand == src ? "left arm" : "right arm"] has been turned into a grotesque meat-blade.</span>\n"
 

--- a/code/game/objects/items/weapons/holy_weapons.dm
+++ b/code/game/objects/items/weapons/holy_weapons.dm
@@ -421,7 +421,7 @@
 	desc = "Particularly twisted deities grant gifts of dubious value."
 	icon_state = "arm_blade"
 	item_state = "arm_blade"
-	flags = ABSTRACT | NODROP
+	flags = ABSTRACT | NODROP | FORCE_VISIBLE
 	w_class = WEIGHT_CLASS_HUGE
 	sharp = TRUE
 

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -751,7 +751,7 @@
 
 /obj/item/pyro_claws/customised_abstract_text()
 	if(!ishuman(loc))
-		return ""
+		return
 	var/mob/living/carbon/human/owner = loc
 	return "<span class='warning'>[owner.p_they(TRUE)] [owner.p_have(FALSE)] energy claws extending [owner.p_their(FALSE)] wrists.</span>\n"
 

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -726,7 +726,7 @@
 	lefthand_file = 'icons/mob/inhands/weapons_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons_righthand.dmi'
 	icon_state = "pyro_claws"
-	flags = ABSTRACT | NODROP | DROPDEL | FORCE_VISIBLE
+	flags = ABSTRACT | NODROP | DROPDEL
 	force = 22
 	damtype = BURN
 	armour_penetration_percentage = 50
@@ -748,6 +748,12 @@
 /obj/item/pyro_claws/Destroy()
 	STOP_PROCESSING(SSobj, src)
 	return ..()
+
+/obj/item/pyro_claws/customised_abstract_text()
+	if(!ishuman(loc))
+		return ""
+	var/mob/living/carbon/human/owner = loc
+	return "<span class='warning'>[owner.p_they(TRUE)] have energy claws extending [owner.p_their(FALSE)] wrists.</span>\n"
 
 /obj/item/pyro_claws/process()
 	lifetime -= 2 SECONDS

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -753,7 +753,7 @@
 	if(!ishuman(loc))
 		return ""
 	var/mob/living/carbon/human/owner = loc
-	return "<span class='warning'>[owner.p_they(TRUE)] have energy claws extending [owner.p_their(FALSE)] wrists.</span>\n"
+	return "<span class='warning'>[owner.p_they(TRUE)] [owner.p_have(FALSE)] energy claws extending [owner.p_their(FALSE)] wrists.</span>\n"
 
 /obj/item/pyro_claws/process()
 	lifetime -= 2 SECONDS

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -753,7 +753,7 @@
 	if(!ishuman(loc))
 		return
 	var/mob/living/carbon/human/owner = loc
-	return "<span class='warning'>[owner.p_they(TRUE)] [owner.p_have(FALSE)] energy claws extending [owner.p_their(FALSE)] wrists.</span>\n"
+	return "<span class='warning'>[owner.p_they(TRUE)] [owner.p_have(FALSE)] energy claws extending [owner.p_their(FALSE)] wrists.</span>"
 
 /obj/item/pyro_claws/process()
 	lifetime -= 2 SECONDS

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -726,7 +726,7 @@
 	lefthand_file = 'icons/mob/inhands/weapons_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons_righthand.dmi'
 	icon_state = "pyro_claws"
-	flags = ABSTRACT | NODROP | DROPDEL
+	flags = ABSTRACT | NODROP | DROPDEL | FORCE_VISIBLE
 	force = 22
 	damtype = BURN
 	armour_penetration_percentage = 50

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -164,7 +164,7 @@
 	if(!ishuman(loc))
 		return
 	var/mob/living/carbon/human/owner = loc
-	return "<span class='warning'>[owner.p_their(TRUE)] [owner.l_hand == src ? "left arm" : "right arm"] has been turned into a grotesque meat-blade.</span>\n"
+	return "<span class='warning'>[owner.p_their(TRUE)] [owner.l_hand == src ? "left arm" : "right arm"] has been turned into a grotesque meat-blade.</span>"
 
 /***************************************\
 |***********COMBAT TENTACLES*************|
@@ -211,7 +211,7 @@
 	if(!ishuman(loc))
 		return
 	var/mob/living/carbon/human/owner = loc
-	return "<span class='warning'>[owner.p_their(TRUE)] [owner.l_hand == src ? "left arm" : "right arm"] has been turned into a grotesque tentacle.</span>\n"
+	return "<span class='warning'>[owner.p_their(TRUE)] [owner.l_hand == src ? "left arm" : "right arm"] has been turned into a grotesque tentacle.</span>"
 
 /obj/item/gun/magic/tentacle/Initialize(mapload, silent, new_parent_action)
 	. = ..()

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -127,7 +127,7 @@
 	desc = "A grotesque blade made of bone and flesh that cleaves through people like a hot knife through butter."
 	icon_state = "arm_blade"
 	item_state = "arm_blade"
-	flags = ABSTRACT | NODROP | DROPDEL | FORCE_VISIBLE
+	flags = ABSTRACT | NODROP | DROPDEL
 	w_class = WEIGHT_CLASS_HUGE
 	sharp = TRUE
 	force = 25
@@ -160,6 +160,12 @@
 		var/obj/machinery/computer/C = target
 		C.attack_alien(user) //muh copypasta
 
+/obj/item/melee/arm_blade/customised_abstract_text()
+	if(!ishuman(loc))
+		return ""
+	var/mob/living/carbon/human/owner = loc
+	return "<span class='warning'>[owner.p_their(TRUE)] [owner.l_hand == src ? "left arm" : "right arm"] has been turned into a grotesque meat-blade.</span>\n"
+
 /***************************************\
 |***********COMBAT TENTACLES*************|
 \***************************************/
@@ -190,7 +196,7 @@
 	righthand_file = 'icons/mob/inhands/weapons_righthand.dmi'
 	icon_state = "tentacle"
 	item_state = "tentacle"
-	flags = ABSTRACT | NODROP | NOBLUDGEON | DROPDEL | FORCE_VISIBLE
+	flags = ABSTRACT | NODROP | NOBLUDGEON | DROPDEL
 	w_class = WEIGHT_CLASS_HUGE
 	ammo_type = /obj/item/ammo_casing/magic/tentacle
 	fire_sound = 'sound/effects/splat.ogg'
@@ -200,6 +206,12 @@
 	throw_range = 0
 	throw_speed = 0
 	var/datum/action/changeling/weapon/parent_action
+
+/obj/item/gun/magic/tentacle/customised_abstract_text()
+	if(!ishuman(loc))
+		return ""
+	var/mob/living/carbon/human/owner = loc
+	return "<span class='warning'>[owner.p_their(TRUE)] [owner.l_hand == src ? "left arm" : "right arm"] has been turned into a grotesque tentacle.</span>\n"
 
 /obj/item/gun/magic/tentacle/Initialize(mapload, silent, new_parent_action)
 	. = ..()

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -127,7 +127,7 @@
 	desc = "A grotesque blade made of bone and flesh that cleaves through people like a hot knife through butter."
 	icon_state = "arm_blade"
 	item_state = "arm_blade"
-	flags = ABSTRACT | NODROP | DROPDEL
+	flags = ABSTRACT | NODROP | DROPDEL | FORCE_VISIBLE
 	w_class = WEIGHT_CLASS_HUGE
 	sharp = TRUE
 	force = 25
@@ -190,7 +190,7 @@
 	righthand_file = 'icons/mob/inhands/weapons_righthand.dmi'
 	icon_state = "tentacle"
 	item_state = "tentacle"
-	flags = ABSTRACT | NODROP | NOBLUDGEON | DROPDEL
+	flags = ABSTRACT | NODROP | NOBLUDGEON | DROPDEL | FORCE_VISIBLE
 	w_class = WEIGHT_CLASS_HUGE
 	ammo_type = /obj/item/ammo_casing/magic/tentacle
 	fire_sound = 'sound/effects/splat.ogg'

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -162,7 +162,7 @@
 
 /obj/item/melee/arm_blade/customised_abstract_text()
 	if(!ishuman(loc))
-		return ""
+		return
 	var/mob/living/carbon/human/owner = loc
 	return "<span class='warning'>[owner.p_their(TRUE)] [owner.l_hand == src ? "left arm" : "right arm"] has been turned into a grotesque meat-blade.</span>\n"
 
@@ -209,7 +209,7 @@
 
 /obj/item/gun/magic/tentacle/customised_abstract_text()
 	if(!ishuman(loc))
-		return ""
+		return
 	var/mob/living/carbon/human/owner = loc
 	return "<span class='warning'>[owner.p_their(TRUE)] [owner.l_hand == src ? "left arm" : "right arm"] has been turned into a grotesque tentacle.</span>\n"
 

--- a/code/modules/antagonists/vampire/vampire_powers/hemomancer_powers.dm
+++ b/code/modules/antagonists/vampire/vampire_powers/hemomancer_powers.dm
@@ -70,7 +70,7 @@
 
 /obj/item/vamp_claws/customised_abstract_text()
 	if(!ishuman(loc))
-		return ""
+		return
 	var/mob/living/carbon/human/owner = loc
 	return "<span class='warning'>[owner.p_they(TRUE)] [owner.p_have(FALSE)] bloodied claws extending [owner.p_their(FALSE)] wrists.</span>\n"
 

--- a/code/modules/antagonists/vampire/vampire_powers/hemomancer_powers.dm
+++ b/code/modules/antagonists/vampire/vampire_powers/hemomancer_powers.dm
@@ -44,7 +44,7 @@
 	righthand_file = 'icons/mob/inhands/weapons_righthand.dmi'
 	icon_state = "vamp_claws"
 	w_class = WEIGHT_CLASS_BULKY
-	flags = ABSTRACT | NODROP | DROPDEL
+	flags = ABSTRACT | NODROP | DROPDEL | FORCE_VISIBLE
 	force = 10
 	armour_penetration_flat = 20
 	sharp = TRUE

--- a/code/modules/antagonists/vampire/vampire_powers/hemomancer_powers.dm
+++ b/code/modules/antagonists/vampire/vampire_powers/hemomancer_powers.dm
@@ -44,7 +44,7 @@
 	righthand_file = 'icons/mob/inhands/weapons_righthand.dmi'
 	icon_state = "vamp_claws"
 	w_class = WEIGHT_CLASS_BULKY
-	flags = ABSTRACT | NODROP | DROPDEL | FORCE_VISIBLE
+	flags = ABSTRACT | NODROP | DROPDEL
 	force = 10
 	armour_penetration_flat = 20
 	sharp = TRUE
@@ -67,6 +67,12 @@
 		parent_spell.UnregisterSignal(parent_spell.action.owner, COMSIG_MOB_WILLINGLY_DROP)
 		parent_spell = null
 	return ..()
+
+/obj/item/vamp_claws/customised_abstract_text()
+	if(!ishuman(loc))
+		return ""
+	var/mob/living/carbon/human/owner = loc
+	return "<span class='warning'>[owner.p_they(TRUE)] [owner.p_have(FALSE)] bloodied claws extending [owner.p_their(FALSE)] wrists.</span>\n"
 
 /obj/item/vamp_claws/afterattack(atom/target, mob/user, proximity)
 	if(!proximity)

--- a/code/modules/antagonists/vampire/vampire_powers/hemomancer_powers.dm
+++ b/code/modules/antagonists/vampire/vampire_powers/hemomancer_powers.dm
@@ -72,7 +72,7 @@
 	if(!ishuman(loc))
 		return
 	var/mob/living/carbon/human/owner = loc
-	return "<span class='warning'>[owner.p_they(TRUE)] [owner.p_have(FALSE)] bloodied claws extending from [owner.p_their(FALSE)] wrists.</span>\n"
+	return "<span class='warning'>[owner.p_they(TRUE)] [owner.p_have(FALSE)] bloodied claws extending from [owner.p_their(FALSE)] wrists.</span>"
 
 /obj/item/vamp_claws/afterattack(atom/target, mob/user, proximity)
 	if(!proximity)

--- a/code/modules/antagonists/vampire/vampire_powers/hemomancer_powers.dm
+++ b/code/modules/antagonists/vampire/vampire_powers/hemomancer_powers.dm
@@ -72,7 +72,7 @@
 	if(!ishuman(loc))
 		return
 	var/mob/living/carbon/human/owner = loc
-	return "<span class='warning'>[owner.p_they(TRUE)] [owner.p_have(FALSE)] bloodied claws extending [owner.p_their(FALSE)] wrists.</span>\n"
+	return "<span class='warning'>[owner.p_they(TRUE)] [owner.p_have(FALSE)] bloodied claws extending from [owner.p_their(FALSE)] wrists.</span>\n"
 
 /obj/item/vamp_claws/afterattack(atom/target, mob/user, proximity)
 	if(!proximity)

--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -125,6 +125,8 @@
 	// All the things wielded/worn that can be reasonably described with a common template:
 	var/list/message_parts = examine_visible_clothing(skipgloves, skipsuitstorage, skipjumpsuit, skipshoes, skipmask, skipears, skipeyes, skipface)
 
+	var/list/abstract_items = list()
+
 	for(var/parts in message_parts)
 		var/action = parts[1]
 		var/obj/item/item = parts[2]
@@ -134,20 +136,23 @@
 		if(length(parts) >= 5)
 			accessories = parts[5]
 
-		if(item && !((item.flags & ABSTRACT) && !(item.flags & FORCE_VISIBLE)))
-			var/item_words = item.name
-			if(item.blood_DNA)
-				item_words = "[item.blood_color != "#030303" ? "blood-stained" : "oil-stained"] [item_words]"
-			var/submsg = "[p_they(TRUE)] [action] [bicon(item)] \a [item_words]"
-			if(accessories)
-				submsg += " with [accessories]"
-			if(limb_name)
-				submsg += " [preposition] [p_their()] [limb_name]"
-			if(item.blood_DNA)
-				submsg = "<span class='warning'>[submsg]!</span>\n"
+		if(item)
+			if(item.flags & ABSTRACT)
+				abstract_items.Add(item)
 			else
-				submsg = "[submsg].\n"
-			msg += submsg
+				var/item_words = item.name
+				if(item.blood_DNA)
+					item_words = "[item.blood_color != "#030303" ? "blood-stained" : "oil-stained"] [item_words]"
+				var/submsg = "[p_they(TRUE)] [action] [bicon(item)] \a [item_words]"
+				if(accessories)
+					submsg += " with [accessories]"
+				if(limb_name)
+					submsg += " [preposition] [p_their()] [limb_name]"
+				if(item.blood_DNA)
+					submsg = "<span class='warning'>[submsg]!</span>\n"
+				else
+					submsg = "[submsg].\n"
+				msg += submsg
 		else
 			// add any extra info on the limbs themselves
 			msg += examine_handle_individual_limb(limb_name)
@@ -169,6 +174,9 @@
 			msg += "<span class='warning'>[p_they(TRUE)] [p_are()] [bicon(legcuffed)] ensnared in a beartrap!</span>\n"
 		else
 			msg += "<span class='warning'>[p_they(TRUE)] [p_are()] [bicon(legcuffed)] legcuffed!</span>\n"
+
+	for(var/obj/item/abstract_item in abstract_items)
+		msg += abstract_item.customised_abstract_text()
 
 	//Jitters
 	switch(AmountJitter())

--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -138,7 +138,7 @@
 
 		if(item)
 			if(item.flags & ABSTRACT)
-				abstract_items.Add(item)
+				abstract_items |= item
 			else
 				var/item_words = item.name
 				if(item.blood_DNA)

--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -176,7 +176,10 @@
 			msg += "<span class='warning'>[p_they(TRUE)] [p_are()] [bicon(legcuffed)] legcuffed!</span>\n"
 
 	for(var/obj/item/abstract_item in abstract_items)
-		msg += abstract_item.customised_abstract_text()
+		var/text = abstract_item.customised_abstract_text()
+		if(!text)
+			continue
+		msg += "[text]\n"
 
 	//Jitters
 	switch(AmountJitter())

--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -134,7 +134,7 @@
 		if(length(parts) >= 5)
 			accessories = parts[5]
 
-		if(item && !(item.flags & ABSTRACT))
+		if(item && !((item.flags & ABSTRACT) && !(item.flags & FORCE_VISIBLE)))
 			var/item_words = item.name
 			if(item.blood_DNA)
 				item_words = "[item.blood_color != "#030303" ? "blood-stained" : "oil-stained"] [item_words]"

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -488,7 +488,7 @@
 	if(!ishuman(loc))
 		return
 	var/mob/living/carbon/human/owner = loc
-	return "<span class='warning'>[owner.p_their(TRUE)] [owner.l_hand == src ? "left arm" : "right arm"] is covered in metal.</span>\n"
+	return "<span class='warning'>[owner.p_their(TRUE)] [owner.l_hand == src ? "left arm" : "right arm"] is covered in metal.</span>"
 
 /obj/item/shield/v1_arm/emp_act(severity)
 	if(disabled)

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -484,6 +484,11 @@
 	var/disabled = FALSE
 	var/force_when_disabled = 5 //still basically a metal pipe, just hard to move
 
+/obj/item/shield/v1_arm/customised_abstract_text()
+	if(!ishuman(loc))
+		return
+	var/mob/living/carbon/human/owner = loc
+	return "<span class='warning'>[owner.p_their(TRUE)] [owner.l_hand == src ? "left arm" : "right arm"] is covered in metal.</span>\n"
 
 /obj/item/shield/v1_arm/emp_act(severity)
 	if(disabled)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
This PR adds customised_abstract_text() proc for /obj/item which is only called in examine proc when item is abstract. 
It allows us to show that there is something instead of not showing anything when they have an armblade.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Do you see this huge bloody arm blade this changeling made of their arm? Uh, you dont? well ummm.. now you do. 
Items that have physical form like armblade should be shown on examine

## Testing
<!-- How did you test the PR, if at all? -->
Compiled, looked at changeling

## Images
![image](https://github.com/ParadiseSS13/Paradise/assets/61080616/3036ea97-7dcb-4578-bb8d-5c0e5af9ac5d)

## Changelog
:cl:
tweak: Abstract weapons(armblade, vampire claws, tentackle) that have physical form are now shown on examine with unuqie text
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
