### PR TITLE
Adds a quick-expansion gibbing proc, applies it to lazarus and instagib rifle

### DIFF
--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -96,14 +96,20 @@
 	// u no we dead
 	return TRUE
 
-/mob/living/proc/delayed_gib()
+/mob/living/proc/delayed_gib(inflate_at_end = FALSE)
 	visible_message("<span class='danger'><b>[src]</b> starts convulsing violently!</span>", "You feel as if your body is tearing itself apart!")
 	Weaken(30 SECONDS)
 	do_jitter_animation(1000, -1) // jitter until they are gibbed
-	addtimer(CALLBACK(src, PROC_REF(gib)), rand(2 SECONDS, 10 SECONDS))
+	addtimer(CALLBACK(src, inflate_at_end ? PROC_REF(quick_explode_gib) : PROC_REF(gib)), rand(2 SECONDS, 10 SECONDS))
 
-/mob/living/carbon/proc/inflate_gib() // Plays an animation that makes mobs appear to inflate before finally gibbing
+/mob/living/proc/inflate_gib() // Plays an animation that makes mobs appear to inflate before finally gibbing
 	addtimer(CALLBACK(src, PROC_REF(gib), null, null, TRUE, TRUE), 25)
-	var/matrix/M = matrix()
+	var/matrix/M = transform
 	M.Scale(1.8, 1.2)
 	animate(src, time = 40, transform = M, easing = SINE_EASING)
+
+/mob/living/proc/quick_explode_gib()
+	addtimer(CALLBACK(src, PROC_REF(gib), null, null, TRUE, TRUE), 1)
+	var/matrix/M = transform
+	M.Scale(1.8, 1.2)
+	animate(src, time = 1, transform = M, easing = SINE_EASING)

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -172,7 +172,7 @@
 	if(isliving(target))
 		var/mob/living/L = target
 		L.visible_message("<span class='danger'>[L] explodes!</span>")
-		L.gib()
+		L.quick_explode_gib()
 
 /obj/item/projectile/beam/laser/detective
 	name = "energy revolver shot"

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -784,7 +784,7 @@
 				if(M.getBruteLoss() + M.getFireLoss() + M.getCloneLoss() >= 150)
 					if(ischangeling(M))
 						return
-					M.delayed_gib()
+					M.delayed_gib(TRUE)
 					return
 				if(!M.ghost_can_reenter())
 					M.visible_message("<span class='warning'>[M] twitches slightly, but is otherwise unresponsive!</span>")

--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -35,7 +35,7 @@
 
 /datum/reagent/minttoxin/on_mob_life(mob/living/M)
 	if(HAS_TRAIT(M, TRAIT_FAT))
-		M.gib()
+		M.inflate_gib()
 	return ..()
 
 /datum/reagent/slimejelly


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds an expansion gibbing proc, a very short (single tick) animation that shows the victim expanding before exploding. Should add a bit more flavor to people getting gibbed in explosive ways.
Also adds the slow inflating gib (currently used in airtank suicide) to the minttoxin gib.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
It's a little bit of fun, and makes up for the fact we don't have the old explosion animation anymore. 
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

https://github.com/ParadiseSS13/Paradise/assets/89928798/49249ba5-407a-47b0-bd90-538435b73eee


<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Blew a bunch of things up
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Some things now cause you to look like you're blowing up for a moment before you gib.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
