### PR TITLE
Fixes a runtime when a crew monitor is used

### DIFF
--- a/code/modules/mob/living/carbon/human/human_mob.dm
+++ b/code/modules/mob/living/carbon/human/human_mob.dm
@@ -435,7 +435,7 @@
 
 // Get rank from ID, ID inside PDA, PDA, ID in wallet, etc.
 /mob/living/carbon/human/proc/get_authentification_rank(if_no_id = "No id", if_no_job = "No job")
-	var/obj/item/card/id/id = wear_id.GetID()
+	var/obj/item/card/id/id = wear_id?.GetID()
 	if(istype(id))
 		return id.rank || if_no_job
 	return if_no_id


### PR DESCRIPTION
## What Does This PR Do
Fixes a runtime that happens when the crew monitor tracks a crew member with sensors but without an ID.
## Why It's Good For The Game
Prevents a a few hundred runtime errors from being generated during a round.
## Images 
![ApplicationFrameHost_OViUYRoPCN](https://github.com/ParadiseSS13/Paradise/assets/116982774/bab78a5a-d058-427c-a2e7-8eeb329daa0a)
## Testing
Used crew monitor to check to see if a runtime error occurred.
Tested ID behavior if in ID slot and PDA.
## Changelog
NPFC
