### PR TITLE
C4 now properly explodes when an assembly is attached.

### DIFF
--- a/code/game/objects/items/weapons/explosives.dm
+++ b/code/game/objects/items/weapons/explosives.dm
@@ -10,7 +10,7 @@
 	toolspeed = 1
 	var/atom/target = null
 	var/image_overlay = null
-	var/obj/item/assembly_holder/nadeassembly = null
+	var/obj/item/assembly/nadeassembly = null
 	var/assemblyattacher
 
 /obj/item/grenade/plastic/Initialize(mapload)
@@ -23,8 +23,8 @@
 	return ..()
 
 /obj/item/grenade/plastic/attackby(obj/item/I, mob/user, params)
-	if(!nadeassembly && istype(I, /obj/item/assembly_holder))
-		var/obj/item/assembly_holder/A = I
+	if(!nadeassembly && istype(I, /obj/item/assembly))
+		var/obj/item/assembly/A = I
 		if(!user.unEquip(I))
 			return ..()
 		nadeassembly = A

--- a/code/game/objects/items/weapons/explosives.dm
+++ b/code/game/objects/items/weapons/explosives.dm
@@ -71,7 +71,7 @@
 	if(isobserver(AM))
 		to_chat(user, "<span class='warning'>Your hand just phases through [AM]!</span>")
 		return
-	to_chat(user, "<span class='notice'>You start planting [src]. [nadeassembly == null ? "The timer is set to [det_time]..." : ""]</span>")
+	to_chat(user, "<span class='notice'>You start planting [src].[isnull(nadeassembly) ? " The timer is set to [det_time]..." : ""]</span>")
 
 	if(do_after(user, 50 * toolspeed, target = AM))
 		if(!user.unEquip(src))

--- a/code/game/objects/items/weapons/explosives.dm
+++ b/code/game/objects/items/weapons/explosives.dm
@@ -71,7 +71,7 @@
 	if(isobserver(AM))
 		to_chat(user, "<span class='warning'>Your hand just phases through [AM]!</span>")
 		return
-	to_chat(user, "<span class='notice'>You start planting [src]. The timer is set to [det_time]...</span>")
+	to_chat(user, "<span class='notice'>You start planting [src]. [nadeassembly == null ? "The timer is set to [det_time]..." : ""]</span>")
 
 	if(do_after(user, 50 * toolspeed, target = AM))
 		if(!user.unEquip(src))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Simplifies attaching an assembly to C4. You can now directly attach an assembly (Eg. Mousetrap, remote signalling device) to C4 instead of having to create an assemblyholder (Eg. Remote signalling device attached to an igniter.) Also fixes a bug where C4 would not explode when an assembly was attached to it.
Fixes: #22129
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Be a skrell with C4.
Have a remote signalling device and attach it to a piece of C4.
Attach the C4 to an airlock and signal the frequency.
It detonates.
Attach an armed mousetrap to a C4.
Step on it.
Smells like gunpowder tastes like fish.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Assemblies like the remote signalling device or mousetrap can now directly be attached to C4.
fix: C4 now explode when the attached assembly is activated.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
