### PR TITLE
Adds Signalers to the Investigate Round Objects Verb

### DIFF
--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -42,6 +42,7 @@ GLOBAL_LIST_EMPTY(remote_signalers)
 	if(usr) // sometimes (like when a prox sensor sends a signal) there is no usr
 		invoking_ckey = usr.key
 	GLOB.lastsignalers.Add("[SQLtime()] <b>:</b> [invoking_ckey] used [src] @ location ([T.x],[T.y],[T.z]) <b>:</b> [format_frequency(frequency)]/[code]")
+	investigate_log("[SQLtime()] <b>:</b> [invoking_ckey] used [src] @ location ([T.x],[T.y],[T.z]) <b>:</b> [format_frequency(frequency)]/[code]", "signalers")
 
 /obj/item/assembly/signaler/proc/signal_callback()
 	pulse(1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Tracks all signalers in the Investigate Round Objects verb.

Funnily enough, this isnt tracked in bombs, so we'll track it in its own area. This makes finding out who blew up things easier.

## Why It's Good For The Game
Only having the last 10 signalers to check is very wacky - I for one would rather see all signalers.

## Testing
Clicked a buncha signalers.

## Changelog
:cl:
add: Added logging for signalers to the investigate verb.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
