### PR TITLE
Hotfix for buckling runtime

### DIFF
--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -150,7 +150,7 @@
 			M.visible_message("<span class='warning'>[user] buckles [M] to [src]!</span>",\
 				"<span class='warning'>[user] buckles you to [src]!</span>",\
 				"<span class='italics'>You hear metal clanking.</span>")
-		M?.pulledby.stop_pulling()
+		M.pulledby?.stop_pulling()
 
 /atom/movable/proc/user_unbuckle_mob(mob/living/buckled_mob, mob/user)
 	var/mob/living/M = unbuckle_mob(buckled_mob)


### PR DESCRIPTION
## What Does This PR Do
Hotfix for a runtime that occurs when buckling players
## Why It's Good For The Game
Prevents a runtime error from occurring. 
## Images
![Discord_W3Fo9SviJP](https://github.com/ParadiseSS13/Paradise/assets/116982774/74a56a4e-d098-428f-a206-fbd6e605e2b7)
## Testing
Pulled and buckled mob and checked for runtime.
## Changelog
NPFC