### PR TITLE
fixes people not being unbuckled from stuff if they're being pulled

### DIFF
--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -375,7 +375,6 @@
 			M.start_pulling(t)
 	else
 		. = step(pulling, get_dir(pulling.loc, A))
-	return
 
 /mob/proc/update_gravity(has_gravity)
 	return

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -374,7 +374,7 @@
 		if(M)
 			M.start_pulling(t)
 	else
-		step(pulling, get_dir(pulling.loc, A))
+		. = step(pulling, get_dir(pulling.loc, A))
 	return
 
 /mob/proc/update_gravity(has_gravity)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -370,12 +370,12 @@
 		var/mob/M = pulling
 		var/atom/movable/t = M.pulling
 		M.stop_pulling()
-		step(pulling, get_dir(pulling.loc, A))
+		. = step(pulling, get_dir(pulling.loc, A)) // we set the return value to step here, if we don't having someone buckled in to a chair and being pulled won't let them be unbuckeled
 		if(M)
 			M.start_pulling(t)
 	else
 		step(pulling, get_dir(pulling.loc, A))
-	return TRUE
+	return
 
 /mob/proc/update_gravity(has_gravity)
 	return


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
fixes people not being unbuckled from stuff if they're being pulled (eg a chair)

## Why It's Good For The Game
Bugfix, kind of an issue if you're an antag or sec

## Testing
Compiled, ran, and tied down a skrell

## Changelog
:cl:
fix: Pulled people can be unbuckled from objects
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
