### PR TITLE
makes the lavaland theme log sound more rational

### DIFF
--- a/code/controllers/subsystem/non_firing/SSmapping.dm
+++ b/code/controllers/subsystem/non_firing/SSmapping.dm
@@ -41,7 +41,7 @@ SUBSYSTEM_DEF(mapping)
 
 /datum/controller/subsystem/mapping/Initialize()
 	lavaland_theme = pick(/turf/simulated/floor/plating/lava/smooth/lava_land_surface, /turf/simulated/floor/plating/lava/smooth/lava_land_surface/plasma, /turf/simulated/floor/chasm/straight_down/lava_land_surface)
-	log_startup_progress("We feel like [lavaland_theme] today...") //We load this first. In the event some nerd ever makes a surface map, and we don't have it in lavaland in the event lavaland is disabled.
+	log_startup_progress("We're in the mood for [initial(lavaland_theme.name)] today...") //We load this first. In the event some nerd ever makes a surface map, and we don't have it in lavaland in the event lavaland is disabled.
 	cave_theme = pick(BLOCKED_BURROWS, CLASSIC_CAVES, DEADLY_DEEPROCK)
 	log_startup_progress("We feel like [cave_theme] today...")
 	// Load all Z level templates


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
makes the lavaland theme log sound more rational
Before:
``"We feel like /turf/simulated/floor/plating/lava/smooth/lava_land_surface/plasma today..."``
After:
``"We're in the mood for liquid plasma today..."``

## Why It's Good For The Game
Same vibe, significantly less fucked up execution 

## Images of changes
Crazy? I was crazy once. They locked me in a turf, a uninitialized turf, an uninitialized turf with string typepaths, and uninitialized turfs with string typepaths make me crazy

## Testing
Looked at the thing in game

## Changelog
:cl:
tweak: Lavaland theme log now displays name vs typepath
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
