### PR TITLE
Fix Spacebar airless docking, and change ammount of cable stacks.

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/spacebar.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/spacebar.dmm
@@ -27,12 +27,12 @@
 /turf/simulated/floor/plating,
 /area/ruin/space/powered)
 "ag" = (
-/turf/simulated/floor/plating/asteroid/airless,
+/turf/simulated/floor/plating/asteroid/ancient,
 /area/ruin/space/powered)
 "ah" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/plating/asteroid/airless,
+/turf/simulated/floor/plating/asteroid/ancient,
 /area/space/nearstation)
 "ai" = (
 /turf/simulated/mineral,
@@ -139,7 +139,7 @@
 /area/ruin/space/powered/bar)
 "aI" = (
 /obj/effect/decal/remains/human,
-/turf/simulated/floor/plating/asteroid/airless,
+/turf/simulated/floor/plating/asteroid/ancient,
 /area/space/nearstation)
 "aJ" = (
 /turf/simulated/wall,
@@ -226,7 +226,7 @@
 /obj/item/scalpel,
 /obj/structure/table,
 /obj/item/wirecutters,
-/turf/simulated/floor/plating/asteroid/airless,
+/turf/simulated/floor/plating/asteroid/ancient,
 /area/space/nearstation)
 "aZ" = (
 /obj/item/radio/beacon,
@@ -283,7 +283,7 @@
 /area/ruin/space/powered/bar)
 "bh" = (
 /obj/item/stack/ore/glass,
-/turf/simulated/floor/plating/asteroid/airless,
+/turf/simulated/floor/plating/asteroid/ancient,
 /area/space/nearstation)
 "bi" = (
 /obj/machinery/teleport/station,
@@ -291,7 +291,7 @@
 /area/ruin/space/powered/bar)
 "bj" = (
 /obj/item/stack/ore/glass,
-/turf/simulated/floor/plating/asteroid/airless,
+/turf/simulated/floor/plating/asteroid/ancient,
 /area/ruin/space/powered)
 "bk" = (
 /turf/simulated/floor/plasteel{
@@ -329,7 +329,7 @@
 /area/ruin/space/powered)
 "bq" = (
 /obj/machinery/light,
-/turf/simulated/floor/plating/asteroid/airless,
+/turf/simulated/floor/plating/asteroid/ancient,
 /area/ruin/space/powered)
 "br" = (
 /turf/template_noop,
@@ -373,11 +373,17 @@
 /obj/item/id_decal/gold,
 /obj/item/screwdriver,
 /obj/item/toy/plushie/carpplushie/gold,
-/turf/simulated/floor/plating/asteroid/airless,
+/turf/simulated/floor/plating/asteroid/ancient,
+/area/space/nearstation)
+"eC" = (
+/obj/item/stack/ore/bluespace_crystal/refined,
+/turf/simulated/floor/plating/asteroid/ancient,
 /area/space/nearstation)
 "eG" = (
 /obj/effect/landmark/damageturf,
-/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil{
+	amount = 1
+	},
 /turf/simulated/floor/plating,
 /area/ruin/space/powered/bar)
 "fg" = (
@@ -389,9 +395,9 @@
 /area/ruin/space/powered/bar)
 "gy" = (
 /obj/item/stack/cable_coil{
-	amount = 5
+	amount = 1
 	},
-/turf/simulated/floor/plating/asteroid/airless,
+/turf/simulated/floor/plating/asteroid/ancient,
 /area/space/nearstation)
 "gM" = (
 /obj/structure/marker_beacon/dock_marker/collision,
@@ -455,7 +461,7 @@
 /area/ruin/space/powered/bar)
 "lS" = (
 /obj/item/restraints/handcuffs/cable/red,
-/turf/simulated/floor/plating/asteroid/airless,
+/turf/simulated/floor/plating/asteroid/ancient,
 /area/space/nearstation)
 "mb" = (
 /obj/structure/table/wood,
@@ -465,7 +471,10 @@
 "mu" = (
 /obj/structure/bed/roller,
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/plating/asteroid/airless,
+/turf/simulated/floor/plating/asteroid/ancient,
+/area/space/nearstation)
+"oJ" = (
+/turf/simulated/floor/plating/asteroid/ancient,
 /area/space/nearstation)
 "pb" = (
 /obj/item/stack/tile/mineral,
@@ -486,7 +495,7 @@
 /obj/machinery/atmospherics/portable/canister/air{
 	filled = 1
 	},
-/turf/simulated/floor/plating/asteroid/airless,
+/turf/simulated/floor/plating/asteroid/ancient,
 /area/ruin/space/powered)
 "rQ" = (
 /obj/structure/chair/stool{
@@ -551,7 +560,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/plating/asteroid/airless,
+/turf/simulated/floor/plating/asteroid/ancient,
 /area/ruin/space/powered)
 "wy" = (
 /obj/effect/landmark/damageturf,
@@ -692,7 +701,7 @@
 	dir = 1
 	},
 /obj/item/stack/ore/glass,
-/turf/simulated/floor/plating/asteroid/airless,
+/turf/simulated/floor/plating/asteroid/ancient,
 /area/ruin/space/powered)
 "FY" = (
 /obj/machinery/reagentgrinder,
@@ -702,9 +711,9 @@
 "Gv" = (
 /obj/item/pickaxe,
 /obj/item/stack/cable_coil{
-	amount = 5
+	amount = 1
 	},
-/turf/simulated/floor/plating/asteroid/airless,
+/turf/simulated/floor/plating/asteroid/ancient,
 /area/space/nearstation)
 "Gz" = (
 /turf/simulated/wall/mineral/iron,
@@ -732,7 +741,7 @@
 /obj/item/shovel{
 	pixel_x = -5
 	},
-/turf/simulated/floor/plating/asteroid/airless,
+/turf/simulated/floor/plating/asteroid/ancient,
 /area/ruin/space/powered)
 "Kp" = (
 /obj/effect/decal/cleanable/blood,
@@ -743,7 +752,9 @@
 /area/ruin/space/powered/bar)
 "KM" = (
 /obj/effect/landmark/damageturf,
-/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil{
+	amount = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -756,7 +767,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/plating/asteroid/airless,
+/turf/simulated/floor/plating/asteroid/ancient,
 /area/ruin/space/powered)
 "Lh" = (
 /obj/structure/table/wood,
@@ -770,7 +781,7 @@
 /area/space/nearstation)
 "Lu" = (
 /obj/effect/decal/cleanable/blood/writing,
-/turf/simulated/floor/plating/asteroid/airless,
+/turf/simulated/floor/plating/asteroid/ancient,
 /area/space/nearstation)
 "Ly" = (
 /obj/machinery/door_control{
@@ -809,7 +820,7 @@
 /area/ruin/space/powered/bar)
 "Nl" = (
 /obj/item/pickaxe,
-/turf/simulated/floor/plating/asteroid/airless,
+/turf/simulated/floor/plating/asteroid/ancient,
 /area/ruin/space/powered)
 "Np" = (
 /obj/item/stack/ore/bluespace_crystal/refined,
@@ -819,7 +830,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/plating/asteroid/airless,
+/turf/simulated/floor/plating/asteroid/ancient,
 /area/ruin/space/powered)
 "NE" = (
 /obj/structure/closet/secure_closet/bar{
@@ -841,7 +852,7 @@
 /area/ruin/space/powered/bar)
 "Ow" = (
 /obj/item/stack/ore/glass/basalt,
-/turf/simulated/floor/plating/asteroid/airless,
+/turf/simulated/floor/plating/asteroid/ancient,
 /area/ruin/space/powered)
 "Pr" = (
 /obj/structure/chair/stool,
@@ -860,7 +871,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/plating/asteroid/airless,
+/turf/simulated/floor/plating/asteroid/ancient,
 /area/ruin/space/powered)
 "QU" = (
 /obj/effect/landmark/damageturf,
@@ -890,7 +901,7 @@
 /area/ruin/space/powered/bar)
 "UA" = (
 /obj/structure/glowshroom,
-/turf/simulated/floor/plating/asteroid/airless,
+/turf/simulated/floor/plating/asteroid/ancient,
 /area/space/nearstation)
 "UO" = (
 /obj/effect/spawner/random_spawners/cobweb_right_rare,
@@ -919,7 +930,9 @@
 /obj/machinery/light_construct/small{
 	dir = 8
 	},
-/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil{
+	amount = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -2181,7 +2194,7 @@ bb
 bb
 am
 ab
-ac
+oJ
 ab
 ab
 ab
@@ -2233,7 +2246,7 @@ bk
 bk
 QY
 gy
-ac
+oJ
 mu
 ab
 ab
@@ -2339,7 +2352,7 @@ am
 ab
 Gv
 ab
-ac
+oJ
 ab
 ab
 ad
@@ -2365,7 +2378,7 @@ ab
 ab
 ab
 ee
-ac
+oJ
 ab
 am
 av
@@ -2390,7 +2403,7 @@ bk
 am
 ab
 ab
-Np
+eC
 ab
 ab
 ad
@@ -2441,7 +2454,7 @@ bk
 qZ
 am
 ab
-ac
+oJ
 ab
 ab
 ad
@@ -2470,7 +2483,7 @@ ac
 ab
 ab
 ab
-ac
+oJ
 QY
 as
 as

--- a/config/example/config.toml
+++ b/config/example/config.toml
@@ -584,7 +584,7 @@ redis_connstring = "redis://127.0.0.1/"
 # Whether to load the lavaland Z-level.
 enable_lavaland = true
 # Globally enable and disable placing of all ruins, including lavaland ruins and lavaland tendrils.
-enable_space_ruins = false
+enable_space_ruins = true
 # Minimum number of extra zlevels to generate and fill with ruins
 minimum_zlevels = 2
 # Maximum number of extra zlevels to generate and fill with ruins

--- a/config/example/config.toml
+++ b/config/example/config.toml
@@ -584,7 +584,7 @@ redis_connstring = "redis://127.0.0.1/"
 # Whether to load the lavaland Z-level.
 enable_lavaland = true
 # Globally enable and disable placing of all ruins, including lavaland ruins and lavaland tendrils.
-enable_space_ruins = true
+enable_space_ruins = false
 # Minimum number of extra zlevels to generate and fill with ruins
 minimum_zlevels = 2
 # Maximum number of extra zlevels to generate and fill with ruins


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Replace airless asteroid sand with air filled one + fix cables to not spawn as 30 but 1 (as it was intended to do).

## Why It's Good For The Game
people reported it, so i just fix this issues, less painfull to play.

## Images of changes
_(remember to add photo)_

## Testing
Compiled, gone on test server to place template because it crashed on private (didn't crash on test server) it work.

## Changelog
:cl:
tweak: Changed inside airless tiles to have oxygen.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
