### PR TITLE
Makes building on chasms take a screwdriver

### DIFF
--- a/code/game/turfs/simulated/floor/chasm.dm
+++ b/code/game/turfs/simulated/floor/chasm.dm
@@ -54,13 +54,17 @@
 	if(istype(C, /obj/item/stack/rods))
 		var/obj/item/stack/rods/R = C
 		var/obj/structure/lattice/L = locate(/obj/structure/lattice, src)
+		var/obj/item/O = user.get_inactive_hand()
 		if(!L)
-			if(R.use(1))
-				to_chat(user, "<span class='notice'>You construct a lattice.</span>")
-				playsound(src, 'sound/weapons/genhit.ogg', 50, 1)
-				ReplaceWithLattice()
+			if(isscrewdriver(O))
+				if(R.use(1))
+					to_chat(user, "<span class='notice'>You construct a lattice.</span>")
+					playsound(src, 'sound/weapons/genhit.ogg', 50, 1)
+					ReplaceWithLattice()
+				else
+					to_chat(user, "<span class='warning'>You need one rod to build a lattice.</span>")
 			else
-				to_chat(user, "<span class='warning'>You need one rod to build a lattice.</span>")
+				to_chat(user, "<span class='warning'>You need to hold a screwdriver in your other hand to secure this lattice.</span>")
 			return
 	if(istype(C, /obj/item/stack/tile/plasteel))
 		var/obj/structure/lattice/L = locate(/obj/structure/lattice, src)

--- a/code/game/turfs/simulated/floor/chasm.dm
+++ b/code/game/turfs/simulated/floor/chasm.dm
@@ -59,7 +59,7 @@
 			if(isscrewdriver(O))
 				if(R.use(1))
 					to_chat(user, "<span class='notice'>You construct a lattice.</span>")
-					playsound(src, 'sound/weapons/genhit.ogg', 50, 1)
+					playsound(src, 'sound/weapons/genhit.ogg', 50, TRUE)
 					ReplaceWithLattice()
 				else
 					to_chat(user, "<span class='warning'>You need one rod to build a lattice.</span>")

--- a/code/game/turfs/simulated/floor/chasm.dm
+++ b/code/game/turfs/simulated/floor/chasm.dm
@@ -56,7 +56,7 @@
 		var/obj/structure/lattice/L = locate(/obj/structure/lattice, src)
 		var/obj/item/O = user.get_inactive_hand()
 		if(!L)
-			if(isscrewdriver(O))
+			if(O?.tool_behaviour == TOOL_SCREWDRIVER)
 				if(R.use(1))
 					to_chat(user, "<span class='notice'>You construct a lattice.</span>")
 					playsound(src, 'sound/weapons/genhit.ogg', 50, TRUE)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
As it says on the tin. To build over a chasm you now need a screwdriver in the offhand for the rod stage.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Presently, if Lavaland rolls chasms, the labor camp is completely useless as prisoners can just... build out willy nilly. This makes it so you need the most basic of tools to build across chasms - screwdrivers fit in boxes so miners shouldn't have issues with using them and they can still build over to labor camp if they feel so inclined.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![image](https://github.com/ParadiseSS13/Paradise/assets/71326864/25382ddc-4818-47b3-9fa3-7282cb3a57b5)

## Testing
<!-- How did you test the PR, if at all? -->
See above. Almost made a silly mistake and made it consume the rod even if it failed.

## Changelog
:cl:
tweak: Building across chasms now takes a screwdriver in the off-hand.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
