### PR TITLE
Fixes Camera Bugs not working

### DIFF
--- a/code/game/objects/items/devices/camera_bug.dm
+++ b/code/game/objects/items/devices/camera_bug.dm
@@ -17,6 +17,7 @@
 	name = "invasive camera utility"
 	desc = "How did this get here?! Please report this as a bug to github"
 	power_state = NO_POWER_USE
+	requires_power = FALSE
 	silent_console = TRUE
 
 /obj/item/camera_bug/Initialize(mapload)


### PR DESCRIPTION
## What Does This PR Do
Fixes #20999 and Fixes #22146

## Why It's Good For The Game
Items should work

## Testing
1. Gave myself a camera bug from the uplink
4. Used it while the original room had/didnt have power
3. Spawned the ruin that has a camera bug
4. Used it while the original room had/didnt have power

## Changelog
:cl:
fix: Camera bugs will no longer occasionally not work.
/:cl: