### PR TITLE
Allows engiborgs to pick up igniters

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -32,7 +32,8 @@
 		/obj/item/tank,
 		/obj/item/circuitboard,
 		/obj/item/stack/tile/light,
-		/obj/item/stack/ore/bluespace_crystal
+		/obj/item/stack/ore/bluespace_crystal,
+		/obj/item/assembly/igniter
 	)
 
 	//Item currently being held.


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Allows cyborg magnetic grippers to be able to pick up igniters.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
There are 3 things that this actually allows borgs to do, and that is repair the cremator if it is destroyed.
Anything you can do otherwise with the igniter, like making sparks, is already something a borg can do just fine. If they wanted to make bomb assemblies with these, they would still need actual humanoid hands to do so. 
Also they can build ORMs now
Oh, and malf borgs can construct stunprods, at the cost of their ziptie module
This is just some QOL for borgs, so they don't need a humanoid to put in the igniter for them.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Became an engiborg, picked up an igniter.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Engiborgs can now pick up igniters
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
