### PR TITLE
Makes Auto Surgeons Single-Use + Adds Advanced Auto Surgeon

### DIFF
--- a/code/modules/surgery/organs/autosurgeon.dm
+++ b/code/modules/surgery/organs/autosurgeon.dm
@@ -2,22 +2,27 @@
 
 /obj/item/autosurgeon
 	name = "autosurgeon"
-	desc = "A device that automatically inserts an implant or organ into the user without the hassle of extensive surgery. It has a screwdriver slot for removing accidentally added items."
+	desc = "A device that automatically inserts an implant or organ into the user without the hassle of extensive surgery. This autosurgeon is single-use."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "autoimplanter"
 	item_state = ""
 	w_class = WEIGHT_CLASS_SMALL
-	var/uses = INFINITE
+	var/uses = 1
 
 /obj/item/autosurgeon/attack_self_tk(mob/user)
 	return //stops TK fuckery
 
 /obj/item/autosurgeon/organ
 	name = "implant autosurgeon"
-	desc = "A device that automatically inserts an implant or organ into the user without the hassle of extensive surgery. It has a slot to insert implants or organs and a screwdriver slot for removing accidentally added items."
+	desc = "A device that automatically inserts an implant or organ into the user without the hassle of extensive surgery. It has a slot to insert implants or organs and a screwdriver slot for removing accidentally added items. This autosurgeon is single-use."
 	var/organ_type = /obj/item/organ/internal
 	var/starting_organ
 	var/obj/item/organ/internal/storedorgan
+
+/obj/item/autosurgeon/organ/admin
+	name = "advanced autosurgeon"
+	desc = "A device that automatically inserts an implant or organ into the user without the hassle of extensive surgery. It has a screwdriver slot for removing accidentally added items. This one can be used multiple times!"
+	uses = INFINITE
 
 /obj/item/autosurgeon/organ/syndicate
 	name = "suspicious implant autosurgeon"
@@ -77,10 +82,6 @@
 		to_chat(user, "<span class='notice'>You remove [storedorgan] from [src].</span>")
 		I.play_tool_sound(src)
 		storedorgan = null
-		if(uses != INFINITE)
-			uses--
-		if(!uses)
-			desc = "[initial(desc)] Looks like it's been used up."
 	return TRUE
 
 /obj/item/autosurgeon/organ/syndicate/laser_arm


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes all ICly-obtainable Auto Surgeons single-use.

Adds an Advanced Auto Surgeon for infinite use if admins need it.

Removing organs from the Auto Surgeon doesnt use up a use anymore.

## Why It's Good For The Game
I want these items to be more useable for uplinks/items/events without having to fear Robotics using it to give out SUPER fast full implant suites. Watching Robotics/Medbay get one of these from Traders/dropped by Nukies/etc is very very rough to see. The Crew shouldnt really have access to an infinite tool that allows for bypassing surgery.

You can now also remove an implant from the auto surgeon and insert anything into it for shenanigans, instead of it removing a use. I dunno why this was there, frankly.

## Testing
Smacked myself with a buncha auto surgeons.

## Changelog
:cl:
add: Added Advanced Auto Surgeon
tweak: Tweaked all basic Auto Surgeons to be single-use.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
