### PR TITLE
Adds a hardened plus nutriment implant for Syndicate Officer

### DIFF
--- a/code/game/jobs/job/syndicate_jobs.dm
+++ b/code/game/jobs/job/syndicate_jobs.dm
@@ -42,6 +42,10 @@
 		/obj/item/implant/dust
 	)
 
+	cybernetic_implants = list(
+		/obj/item/organ/internal/cyberimp/chest/nutriment/plus/hardened
+	)
+
 /datum/outfit/job/syndicateofficer/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
 	if(visualsOnly)


### PR DESCRIPTION
## What Does This PR Do
This gives the Syndicate Officer a Hardened Nutriment Pump Implant Plus.
## Why It's Good For The Game
Syndicate officers should not need to experience starvation. 
## Testing
Joined as Syndicate Officer and checked for appropriate implant. 
## Changelog
:cl:
add: Added hardened nutriment pump plus implant to Syndicate Officer
/:cl:
