### PR TITLE
AI in mech now uses mech cell instead of area power

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai_life.dm
+++ b/code/modules/mob/living/silicon/ai/ai_life.dm
@@ -142,7 +142,7 @@
 	var/turf/T = get_turf(src)
 	var/area/A = get_area(src)
 	if(controlled_mech)
-		return !(controlled_mech.get_charge() > 0)
+		return controlled_mech.get_charge() <= 0
 	return (!A.powernet.equipment_powered && A.requires_power || isspaceturf(T)) && !isitem(loc)
 
 /mob/living/silicon/ai/rejuvenate()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
When an AI controls a mech, either through an AI beacon or with the Mech Domination power, they are no longer dependant on the area the mech is standing in being powered by an APC; Instead, the cell inside the mech is used to check if the AI has powered or not.
Fixes: #11968
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
It doesn't make sense that the AI should need a separate power source to be powered when inside of a mech.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Be a malfunctioning AI
Use the mech domination power on a Durand
Enter an unpowered area, I remain functional as normal
Set the power of the Durand's cell to 0
I cease functioning as normal
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: AI controlling a mech now uses the mech cell for power instead of the area's APC.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
