### PR TITLE
Prevents augmenting with non-limb robot_parts

### DIFF
--- a/code/modules/surgery/limb_augmentation.dm
+++ b/code/modules/surgery/limb_augmentation.dm
@@ -28,16 +28,17 @@
 /datum/surgery_step/augment/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/robot_parts/p = tool
 	if(p.part)
-		if(!(target_zone in p.part))
-			to_chat(user, "<span class='warning'>[tool] cannot be used to augment this limb!</span>")
-			return SURGERY_BEGINSTEP_ABORT
+		if(target_zone in p.part)
+			var/obj/item/organ/external/affected = target.get_organ(target_zone)
+			user.visible_message(
+				"[user] starts augmenting [affected] with [tool].",
+				"You start augmenting [affected] with [tool]."
+			)
+			return ..()
+	to_chat(user, "<span class='warning'>[tool] cannot be used to augment this limb!</span>")
+	return SURGERY_BEGINSTEP_ABORT
 
-	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message(
-		"[user] starts augmenting [affected] with [tool].",
-		"You start augmenting [affected] with [tool]."
-	)
-	return ..()
+
 
 /datum/surgery_step/augment/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/robot_parts/L = tool


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes a bug where you were able to start the augmenting step of augment limb with non-limb parts that are subtypes of robot_parts (Eg. armour plating, binary communication device)
Fixes: #11635
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Unintended behaviour.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Be a skrell
Start augment limb surgery on left arm
Perform first 3 steps
Attempt to augment using armour plating, does not work
Attempt to augment using robotic right arm, does not work
Attempt to augment using robotic left arm, works
Robot fish
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: You can no longer augment limbs with non-limb robot parts.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
