### PR TITLE
[s] You can't escape a curse.

### DIFF
--- a/code/modules/surgery/organs/mmi_holder.dm
+++ b/code/modules/surgery/organs/mmi_holder.dm
@@ -16,6 +16,9 @@
 	// To supersede the over-writing of the MMI's name from `insert`
 	update_from_mmi()
 	target.thought_bubble_image = "thought_bubble_machine"
+	if(ishuman(target) && istype(stored_mmi?.held_brain, /obj/item/organ/internal/brain/cluwne))
+		var/mob/living/carbon/human/H = target
+		H.makeCluwne() //No matter where you go, no matter what you do, you cannot escape
 
 /obj/item/organ/internal/brain/mmi_holder/remove(mob/living/user, special = 0)
 	if(!special)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Fixes being able to bypass a curse via irc

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Escaping curses is bad.

## Testing
<!-- How did you test the PR, if at all? -->

Confirmed: 

- You can not escape a curse
- You can however irc someone without cursing them randomly.

## Changelog
:cl:
fix: Fixed being able to avoid magical curses via a metal body.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
