### PR TITLE
Slowdown is no longer affected by zero G

### DIFF
--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -272,8 +272,6 @@
 /datum/species/proc/movement_delay(mob/living/carbon/human/H)
 	. = 0	//We start at 0.
 
-	if(!has_gravity(H))
-		return
 	if(!IS_HORIZONTAL(H))
 		if(HAS_TRAIT(H, TRAIT_GOTTAGOFAST))
 			. -= 1


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Slowdown is no longer affected by zero G

## Why It's Good For The Game
So, zero gravity combat is and has been an issue.
Painslow is very important in combat and many weapons rely on it, from most of the weapons that tots have access to, to the disabler that security players use. In this game, if things get bad and you can't catch up, things will continue to get worse unless you actively act to make them get better. The most fun you can have in this game is trying to make best of a bad situation.
Zero G combat fucking blows.
Zero G makes every weapon feel like a taser in the worst way, you either did basically nothing to someone or they're in front of you completely stunned. The most consistent way to deal with someone in zero G is to ignore them and then attack them in a place where you can actually slow them. Space turtlers are just... bad, no way around it. Space combat will be a lot more interesting when shit can actually go south without fully hitting the bottom.

There has also been a cry to make space more dangerous and, oh boy, this does that, prepare to start dying if you have no suit on. An entire sec team rushing into vault EVA with no suit will no longer have a very fun time.

not entirely sure what to do jetpacks, antags dont really have an easy way to get em on the run but sec does, maybe I'll just have it reduce the slowdown, or maybe touches to it just won't be needed.

## Testing
I died very fast and got very cold, then I booted up my testserver
## Changelog
:cl:
tweak: Slowdown is no longer affected by zero G
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
