### PR TITLE
[s] Disposals now checks for density before expelling

### DIFF
--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -795,7 +795,10 @@
 
 		H.forceMove(P)
 	else			// if wasn't a pipe, then set loc to turf
-		H.forceMove(T)
+		if (is_blocked_turf(T))
+			H.forceMove(src.loc)
+		else
+			H.forceMove(T)
 		return null
 
 	return P

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -795,8 +795,8 @@
 
 		H.forceMove(P)
 	else			// if wasn't a pipe, then set loc to turf
-		if (is_blocked_turf(T))
-			H.forceMove(src.loc)
+		if(is_blocked_turf(T))
+			H.forceMove(loc)
 		else
 			H.forceMove(T)
 		return null


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
When an unconnected disposals pipe tries to expel someone, it first checks for dense objects on the tile in front of it: If there is a dense objects on the tile in front of it, it will instead expel you on the tile with the pipe.
Fixes: #13249
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Currently you are able to bypass any door/window/non-turf dense object by placing an unconnected disposals trunk/pipe in front of it and getting into a chute, this PR aims to fix that.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Be a skrell with and RPD and tools
Point a disposals trunk into an airlock and add a chute to enter the trunk.
Enter the trunk.
Get thrown out of the trunk on the side of the airlock I started on, and not behind it.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Disposals now checks for density before expelling
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
