### PR TITLE
Fixes runtime with sound emotes

### DIFF
--- a/code/datums/emote.dm
+++ b/code/datums/emote.dm
@@ -237,9 +237,6 @@
  * Returns TRUE if the emote was able to be run (or failed successfully), or FALSE if the emote is unusable.
  */
 /datum/emote/proc/try_run_emote(mob/user, params, type_override, intentional = FALSE)
-	if(!can_run_emote(user, intentional = intentional))
-		return FALSE
-
 	// You can use this signal to block execution of emotes from components/other sources.
 	var/sig_res = SEND_SIGNAL(user, COMSIG_MOB_PREEMOTE, key, intentional)
 	switch(sig_res)

--- a/code/modules/mob/mob_emote.dm
+++ b/code/modules/mob/mob_emote.dm
@@ -28,14 +28,16 @@
 		return FALSE
 	var/silenced = FALSE
 	for(var/datum/emote/P in key_emotes)
+		// can this mob run the emote at all?
 		if(!P.can_run_emote(src, intentional))
 			continue
-		if(!P.check_cooldown(src, intentional))
-			// if an emote's on cooldown, don't spam them with messages of not being able to use it
-			silenced = TRUE
-			continue
-		if(P.try_run_emote(src, param, type_override, intentional))
-			return TRUE
+		else
+			if(!P.check_cooldown(src, intentional))
+				// if an emote's on cooldown, don't spam them with messages of not being able to use it
+				silenced = TRUE
+				continue
+			if(P.try_run_emote(src, param, type_override, intentional))
+				return TRUE
 	if(intentional && !silenced && !force_silence)
 		to_chat(src, "<span class='notice'>Unusable emote '[emote_key]'. Say *help for a list.</span>")
 	return FALSE

--- a/code/modules/mob/mob_emote.dm
+++ b/code/modules/mob/mob_emote.dm
@@ -31,13 +31,12 @@
 		// can this mob run the emote at all?
 		if(!P.can_run_emote(src, intentional))
 			continue
-		else
-			if(!P.check_cooldown(src, intentional))
-				// if an emote's on cooldown, don't spam them with messages of not being able to use it
-				silenced = TRUE
-				continue
-			if(P.try_run_emote(src, param, type_override, intentional))
-				return TRUE
+		if(!P.check_cooldown(src, intentional))
+			// if an emote's on cooldown, don't spam them with messages of not being able to use it
+			silenced = TRUE
+			continue
+		if(P.try_run_emote(src, param, type_override, intentional))
+			return TRUE
 	if(intentional && !silenced && !force_silence)
 		to_chat(src, "<span class='notice'>Unusable emote '[emote_key]'. Say *help for a list.</span>")
 	return FALSE

--- a/code/modules/mob/mob_emote.dm
+++ b/code/modules/mob/mob_emote.dm
@@ -28,6 +28,8 @@
 		return FALSE
 	var/silenced = FALSE
 	for(var/datum/emote/P in key_emotes)
+		if(!P.can_run_emote(src, intentional))
+			continue
 		if(!P.check_cooldown(src, intentional))
 			// if an emote's on cooldown, don't spam them with messages of not being able to use it
 			silenced = TRUE


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes a runtime where emotes with the get_sound datum overridden would runtime when mobs that can't even run the emote tried to run it (Eg. Cat calling the *bark emote)
Fixes: #18023
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Runtime bad
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Be a gorilla
Attempt to use the *sneeze emote, no runtime occurs
Attempt to use the *ooga emote, ooga loudly with no runtimes
Return to monke
<!-- How did you test the PR, if at all? -->

## Changelog
No player facing changes.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
