### PR TITLE
Fixes cyborg bolting so it is no longer instant. Again.

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_mob.dm
+++ b/code/modules/mob/living/silicon/robot/robot_mob.dm
@@ -1598,6 +1598,6 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 		to_chat(src, "<span class='warning'>You can only use this emote when you're out of charge.</span>")
 
 /mob/living/silicon/robot/can_instant_lockdown()
-	if(emagged || faction_check_mob(src, "syndicate"))
+	if(emagged || ("syndicate" in src.faction))
 		return TRUE
 	return FALSE

--- a/code/modules/mob/living/silicon/robot/robot_mob.dm
+++ b/code/modules/mob/living/silicon/robot/robot_mob.dm
@@ -1598,6 +1598,6 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 		to_chat(src, "<span class='warning'>You can only use this emote when you're out of charge.</span>")
 
 /mob/living/silicon/robot/can_instant_lockdown()
-	if(emagged || ("syndicate" in src.faction))
+	if(emagged || ("syndicate" in faction))
 		return TRUE
 	return FALSE


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes it so that cyborgs can no longer instantly bolt doors, unless emagged or malfunctioning, as intended in #22084
fixes: #22278
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
It'll work completely, for sure this time, I swear.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Be a cyborg
Try and bolt a door, it takes 3 seconds
Add the "syndicate" faction to my faction list
Bolting is now instant
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Cyborgs can no longer instantly bolt doors unless emagged or malfunctioning.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
