### PR TITLE
Fixes custom_pain spamming your chat if you have multiple burn wounds/broken bones

### DIFF
--- a/code/modules/surgery/organs/pain.dm
+++ b/code/modules/surgery/organs/pain.dm
@@ -48,10 +48,10 @@
 	var/msg = "<span class='userdanger'>[message]</span>"
 
 	// Anti message spam checks
-	if(msg && ((msg != last_pain_message) || (world.time >= next_pain_time)))
+	if(msg && ((msg != last_pain_message) && (world.time >= next_pain_time)))
 		last_pain_message = msg
 		to_chat(src, msg)
-	next_pain_time = world.time + 100
+		next_pain_time = world.time + 10 SECONDS
 
 /mob/living/carbon/human/proc/handle_pain()
 	// not when sleeping


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes what seems like an indentation error + an operator error, causing custom_pain messages to have no cooldown at all.
There is one downside to this, and that is in the case of multiple burn wounds/bone breaks. When you have more than two, the messages will only cycle between two set limbs (probably decided in how the `bodyparts` list is set up), and you will not get any messages for the rest of the pain. Below is how it looks after walking for around ~10 seconds with 2 burn wounds:
![image](https://github.com/ParadiseSS13/Paradise/assets/108773801/fb7d4f3f-fbe1-4a06-9c5d-1857a4787976)
If it is preferred that there is indeed a message for each limb, I'll gladly take the step to refactor the custom pain message for burn wounds/broken bones to be handled on the limbs themselves, so the cooldowns can be handled separately.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Having multiple burn wounds/broken bones absolutely spams your chat if you walk around, this aims to improve it a bit.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Checked the amount of messages I got from having 4 burn wounds, it was significantly less than my test amount of 2 burn wounds that I took before this edit.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Fixes a scenario where multiple burn wounds or broken bones can absolutely spam your chat with pain messages
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
