### PR TITLE
Gutlunches now spawn on lavaland.

### DIFF
--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -642,6 +642,15 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark/awaystart) //Without this away mission
 	mobtype = /mob/living/simple_animal/hostile/asteroid/goldgrub
 	icon_state = "questionmark"
 
+/obj/effect/landmark/mob_spawner/gutlunch
+	mobtype = /mob/living/simple_animal/hostile/asteroid/gutlunch
+	icon_state = "questionmark"
+
+/obj/effect/landmark/mob_spawner/gutlunch/Initialize(mapload)
+	if(prob(5))
+		mobtype = /mob/living/simple_animal/hostile/asteroid/gutlunch/gubbuck
+	. = ..()
+
 // Damage tiles
 /obj/effect/landmark/damageturf
 	icon_state = "damaged"

--- a/code/game/turfs/simulated/floor/asteroid_floors.dm
+++ b/code/game/turfs/simulated/floor/asteroid_floors.dm
@@ -181,7 +181,7 @@ GLOBAL_LIST_INIT(megafauna_spawn_list, list(/mob/living/simple_animal/hostile/me
 	mob_spawn_list = list(/obj/effect/landmark/mob_spawner/goliath = 50, /obj/structure/spawner/lavaland/goliath = 3,
 		/obj/effect/landmark/mob_spawner/watcher = 40, /obj/structure/spawner/lavaland = 2,
 		/obj/effect/landmark/mob_spawner/legion = 30, /obj/structure/spawner/lavaland/legion = 3,
-		SPAWN_MEGAFAUNA = 6, /obj/effect/landmark/mob_spawner/goldgrub = 10)
+		SPAWN_MEGAFAUNA = 6, /obj/effect/landmark/mob_spawner/goldgrub = 10, /obj/effect/landmark/mob_spawner/gutlunch = 4)
 
 	data_having_type = /turf/simulated/floor/plating/asteroid/airless/cave/volcanic/has_data
 	turf_type = /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Gutlunches (and more rarely gubbucks) can now spawn on lavaland.
They are a non-hostile fauna, previously found in ash walker den.

Spawn chance is currently at four, I'd prefer to see it in game first to (possibly) adjust it.
There is also 5% (more than regular "rare" mobs) chance for it to become a gubbuck - they effectively are the same, just smaller and colorful.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
More diversity for Lavaland fauna - having something that only _HOPES_ you die is pretty sweet after going through hordes of stuff that _ACTUALLY_ kills you!
This also makes sense lore wise on many levels!

1. We now know how did ashies get theirs.
2. It makes sense for scavenger fauna to develop on a murder planet.
3. It makes sense for non-violent fauna to develop on any planet.

okay that was only three... anyways!

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![obraz](https://github.com/ParadiseSS13/Paradise/assets/108196626/88317220-becc-4765-b4df-ad55aa70e6e2)
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
observed, saw a couple on observer menu. Re-generated LL a couple times to get data for spawn chance - it's a long and inconsistent process however.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Gutlunches can now be naturally found in lavaland wastes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
