### PR TITLE
Flashbangs are now affected by pressure like sound.

### DIFF
--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -56,8 +56,9 @@
 				M.Confused(status_duration * 2)
 
 		// Bang
-		if(bang)
-			var/ear_safety = M.check_ear_prot()
+		if(!bang)
+			return
+		var/ear_safety = M.check_ear_prot()
 			//Atmosphere affects sound
 			var/pressure_factor = 1
 			var/datum/gas_mixture/hearer_env = source_turf.return_air()

--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -40,7 +40,7 @@
 /proc/bang(turf/T, atom/A, range = 7, flash = TRUE, bang = TRUE)
 
 	// Flashing mechanic
-	var/source_turf = get_turf(A)
+	var/turf/source_turf = get_turf(A)
 	for(var/mob/living/M in hearers(range, T))
 		if(M.stat == DEAD)
 			continue
@@ -56,18 +56,34 @@
 				M.Confused(status_duration * 2)
 
 		// Bang
-		var/ear_safety = M.check_ear_prot()
 		if(bang)
+			var/ear_safety = M.check_ear_prot()
+			//Atmosphere affects sound
+			var/pressure_factor = 1
+			var/datum/gas_mixture/hearer_env = source_turf.return_air()
+			var/datum/gas_mixture/source_env = T.return_air()
+
+			if(hearer_env && source_env)
+				var/pressure = min(hearer_env.return_pressure(), source_env.return_pressure())
+				if(pressure < ONE_ATMOSPHERE - 10) //-10 KPA as a nice soft zone before we start losing power
+					pressure_factor = max((pressure - SOUND_MINIMUM_PRESSURE)/(ONE_ATMOSPHERE - SOUND_MINIMUM_PRESSURE), 0)
+			else //space
+				pressure_factor = 0
+
+			if(distance <= 1)
+				pressure_factor = max(pressure_factor, 0.15) //touching the source of the sound
+
 			if(source_turf == mobturf) // Holding on person or being exactly where lies is significantly more dangerous and voids protection
 				M.KnockDown(10 SECONDS)
+				M.Deaf(15 SECONDS)
 			if(!ear_safety)
-				M.KnockDown(status_duration)
-				M.Deaf(30 SECONDS)
+				M.KnockDown(status_duration * pressure_factor)
+				M.Deaf(30 SECONDS * pressure_factor)
 				if(iscarbon(M))
 					var/mob/living/carbon/C = M
 					var/obj/item/organ/internal/ears/ears = C.get_int_organ(/obj/item/organ/internal/ears)
 					if(istype(ears))
-						ears.receive_damage(5)
+						ears.receive_damage(5 * pressure_factor)
 						if(ears.damage >= 15)
 							to_chat(M, "<span class='warning'>Your ears start to ring badly!</span>")
 							if(prob(ears.damage - 5))

--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -67,7 +67,7 @@
 		if(hearer_env && source_env)
 			var/pressure = min(hearer_env.return_pressure(), source_env.return_pressure())
 			if(pressure < ONE_ATMOSPHERE - 10) //-10 KPA as a nice soft zone before we start losing power
-				pressure_factor = max((pressure - SOUND_MINIMUM_PRESSURE)/(ONE_ATMOSPHERE - SOUND_MINIMUM_PRESSURE), 0)
+				pressure_factor = max((pressure - SOUND_MINIMUM_PRESSURE) / (ONE_ATMOSPHERE - SOUND_MINIMUM_PRESSURE), 0)
 		else //space
 			pressure_factor = 0
 

--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -59,35 +59,37 @@
 		if(!bang)
 			return
 		var/ear_safety = M.check_ear_prot()
-			//Atmosphere affects sound
-			var/pressure_factor = 1
-			var/datum/gas_mixture/hearer_env = source_turf.return_air()
-			var/datum/gas_mixture/source_env = T.return_air()
+		//Atmosphere affects sound
+		var/pressure_factor = 1
+		var/datum/gas_mixture/hearer_env = source_turf.return_air()
+		var/datum/gas_mixture/source_env = T.return_air()
 
-			if(hearer_env && source_env)
-				var/pressure = min(hearer_env.return_pressure(), source_env.return_pressure())
-				if(pressure < ONE_ATMOSPHERE - 10) //-10 KPA as a nice soft zone before we start losing power
-					pressure_factor = max((pressure - SOUND_MINIMUM_PRESSURE)/(ONE_ATMOSPHERE - SOUND_MINIMUM_PRESSURE), 0)
-			else //space
-				pressure_factor = 0
+		if(hearer_env && source_env)
+			var/pressure = min(hearer_env.return_pressure(), source_env.return_pressure())
+			if(pressure < ONE_ATMOSPHERE - 10) //-10 KPA as a nice soft zone before we start losing power
+				pressure_factor = max((pressure - SOUND_MINIMUM_PRESSURE)/(ONE_ATMOSPHERE - SOUND_MINIMUM_PRESSURE), 0)
+		else //space
+			pressure_factor = 0
 
-			if(distance <= 1)
-				pressure_factor = max(pressure_factor, 0.15) //touching the source of the sound
+		if(distance <= 1)
+			pressure_factor = max(pressure_factor, 0.15) //touching the source of the sound
 
-			if(source_turf == mobturf) // Holding on person or being exactly where lies is significantly more dangerous and voids protection
-				M.KnockDown(10 SECONDS)
-				M.Deaf(15 SECONDS)
-			if(!ear_safety)
-				M.KnockDown(status_duration * pressure_factor)
-				M.Deaf(30 SECONDS * pressure_factor)
-				if(iscarbon(M))
-					var/mob/living/carbon/C = M
-					var/obj/item/organ/internal/ears/ears = C.get_int_organ(/obj/item/organ/internal/ears)
-					if(istype(ears))
-						ears.receive_damage(5 * pressure_factor)
-						if(ears.damage >= 15)
-							to_chat(M, "<span class='warning'>Your ears start to ring badly!</span>")
-							if(prob(ears.damage - 5))
-								to_chat(M, "<span class='warning'>You can't hear anything!</span>")
-						else if(ears.damage >= 5)
-							to_chat(M, "<span class='warning'>Your ears start to ring!</span>")
+		if(source_turf == mobturf) // Holding on person or being exactly where lies is significantly more dangerous and voids protection
+			M.KnockDown(10 SECONDS)
+			M.Deaf(15 SECONDS)
+		if(ear_safety)
+			return
+		M.KnockDown(status_duration * pressure_factor)
+		M.Deaf(30 SECONDS * pressure_factor)
+		if(!iscarbon(M))
+			return
+		var/mob/living/carbon/C = M
+		var/obj/item/organ/internal/ears/ears = C.get_int_organ(/obj/item/organ/internal/ears)
+		if(istype(ears))
+			ears.receive_damage(5 * pressure_factor)
+			if(ears.damage >= 15)
+				to_chat(M, "<span class='warning'>Your ears start to ring badly!</span>")
+				if(prob(ears.damage - 5))
+					to_chat(M, "<span class='warning'>You can't hear anything!</span>")
+			else if(ears.damage >= 5)
+				to_chat(M, "<span class='warning'>Your ears start to ring!</span>")


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Flashbangs bang is now affected by pressure. Less pressure = quieter = shorter status effect. If you or the flashbang is in space and you are not on / beside it, you will be unable to hear it, and unaffected. Flash of the flashbang is unaffected.
Flashbangs now deafen people for a shorter amount of time if on the same tile when they have hearing protection.
Re-orders flashbang code so bang related stuff is ran only if bang is called.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Realism is good, if you can't hear a flashbang, you should not be affected by it. Also makes lower pressure environments interesting, with the bangs being weaker.
Also makes sense that if a flashbang knocks you down on the same tile, it should deafen you for a bit too.

## Testing
<!-- How did you test the PR, if at all? -->

Lots of flashbanging in various pressures.

## Changelog
:cl:
tweak: Flashbangs bang is now affected by pressure.
tweak: Flashbangs that go off on the same tile of you will deafen you now for 15 seconds even if you have full ear protection.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
