### PR TITLE
Fixes gland dispenser access

### DIFF
--- a/code/game/gamemodes/miniantags/abduction/machinery/dispenser.dm
+++ b/code/game/gamemodes/miniantags/abduction/machinery/dispenser.dm
@@ -62,6 +62,9 @@
 	if(..())
 		return
 
+	if(!isabductor(ui.user))
+		return
+
 	switch(action)
 		if("dispense")
 			var/gland_id = text2num(params["gland_id"])

--- a/code/game/gamemodes/miniantags/abduction/machinery/dispenser.dm
+++ b/code/game/gamemodes/miniantags/abduction/machinery/dispenser.dm
@@ -71,6 +71,9 @@
 			return TRUE
 
 /obj/machinery/abductor/gland_dispenser/attack_hand(mob/user)
+	if(!isabductor(user))
+		to_chat(user, "<span class='warning'>You don't understand any of the alien writing!</span>")
+		return
 	ui_interact(user)
 
 /obj/machinery/abductor/gland_dispenser/attackby(obj/item/W, mob/user, params)


### PR DESCRIPTION
## What Does This PR Do
Fixes https://github.com/ParadiseSS13/Paradise/issues/22289, an oversight created when gland dispensers were moved to TGUI.
## Why It's Good For The Game
We don't need players grabbing organs from the dispenser that could spawn on Lavaland.
## Testing
Tested dispenser access as non-abductor.
Tested dispenser access as abductor.
## Changelog
:cl:
fix: Fixed gland dispenser access
/:cl: