### PR TITLE
[s] Lowers xenomorph acid damage on living mobs

### DIFF
--- a/code/datums/spells/alien_spells/corrosive_acid_spit.dm
+++ b/code/datums/spells/alien_spells/corrosive_acid_spit.dm
@@ -20,10 +20,10 @@
 	if(!plasma_check(200, user))
 		to_chat(user, "<span class='noticealien'>You don't have enough plasma to perform this action!</span>")
 		return
-	var/acid_damage_modifier = 2
+	var/acid_damage_modifier = 100
 	if(isliving(target))
-		acid_damage_modifier = 1
-	if(target.acid_act(100 * acid_damage_modifier, 50 * acid_damage_modifier))
+		acid_damage_modifier = 50
+	if(target.acid_act(2 * acid_damage_modifier, acid_damage_modifier))
 		visible_message("<span class='alertalien'>[user] vomits globs of vile stuff all over [target]. It begins to sizzle and melt under the bubbling mess of acid!</span>")
 		add_attack_logs(user, target, "Applied corrosive acid") // Want this logged
 		user.add_plasma(-200)

--- a/code/datums/spells/alien_spells/corrosive_acid_spit.dm
+++ b/code/datums/spells/alien_spells/corrosive_acid_spit.dm
@@ -20,12 +20,10 @@
 	if(!plasma_check(200, user))
 		to_chat(user, "<span class='noticealien'>You don't have enough plasma to perform this action!</span>")
 		return
-	if(isliving(target) && target.acid_act(100, 50)) // If we don't do this, naked humans/simplemobs get absolutely nuked
-		visible_message("<span class='alertalien'>[user] vomits globs of vile stuff all over [target]. It begins to sizzle and melt under the bubbling mess of acid!</span>")
-		add_attack_logs(user, target, "Applied corrosive acid") // Want this logged
-		user.add_plasma(-200)
-		return ..() // Otherwise it would apply more acid damage afterwards
-	if(target.acid_act(200, 100))
+	var/acid_damage_modifier = 1
+	if(isliving(target))
+		acid_damage_modifier = 0.5
+	if(target.acid_act(200 * acid_damage_modifier, 100 * acid_damage_modifier))
 		visible_message("<span class='alertalien'>[user] vomits globs of vile stuff all over [target]. It begins to sizzle and melt under the bubbling mess of acid!</span>")
 		add_attack_logs(user, target, "Applied corrosive acid") // Want this logged
 		user.add_plasma(-200)

--- a/code/datums/spells/alien_spells/corrosive_acid_spit.dm
+++ b/code/datums/spells/alien_spells/corrosive_acid_spit.dm
@@ -20,10 +20,10 @@
 	if(!plasma_check(200, user))
 		to_chat(user, "<span class='noticealien'>You don't have enough plasma to perform this action!</span>")
 		return
-	var/acid_damage_modifier = 1
+	var/acid_damage_modifier = 2
 	if(isliving(target))
-		acid_damage_modifier = 0.5
-	if(target.acid_act(200 * acid_damage_modifier, 100 * acid_damage_modifier))
+		acid_damage_modifier = 1
+	if(target.acid_act(100 * acid_damage_modifier, 50 * acid_damage_modifier))
 		visible_message("<span class='alertalien'>[user] vomits globs of vile stuff all over [target]. It begins to sizzle and melt under the bubbling mess of acid!</span>")
 		add_attack_logs(user, target, "Applied corrosive acid") // Want this logged
 		user.add_plasma(-200)

--- a/code/datums/spells/alien_spells/corrosive_acid_spit.dm
+++ b/code/datums/spells/alien_spells/corrosive_acid_spit.dm
@@ -20,6 +20,11 @@
 	if(!plasma_check(200, user))
 		to_chat(user, "<span class='noticealien'>You don't have enough plasma to perform this action!</span>")
 		return
+	if(isliving(target) && target.acid_act(100, 50)) // If we don't do this, naked humans/simplemobs get absolutely nuked
+		visible_message("<span class='alertalien'>[user] vomits globs of vile stuff all over [target]. It begins to sizzle and melt under the bubbling mess of acid!</span>")
+		add_attack_logs(user, target, "Applied corrosive acid") // Want this logged
+		user.add_plasma(-200)
+		return ..() // Otherwise it would apply more acid damage afterwards
 	if(target.acid_act(200, 100))
 		visible_message("<span class='alertalien'>[user] vomits globs of vile stuff all over [target]. It begins to sizzle and melt under the bubbling mess of acid!</span>")
 		add_attack_logs(user, target, "Applied corrosive acid") // Want this logged

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -166,14 +166,13 @@ GLOBAL_DATUM_INIT(acid_overlay, /mutable_appearance, mutable_appearance('icons/e
 ///the obj's reaction when touched by acid
 /obj/acid_act(acidpwr, acid_volume)
 	if(!(resistance_flags & UNACIDABLE) && acid_volume)
-
 		if(!acid_level)
 			SSacid.processing[src] = src
 			add_overlay(GLOB.acid_overlay, TRUE)
 		var/acid_cap = acidpwr * 300 //so we cannot use huge amounts of weak acids to do as well as strong acids.
 		if(acid_level < acid_cap)
 			acid_level = min(acid_level + acidpwr * acid_volume, acid_cap)
-		return 1
+		return TRUE
 
 ///the proc called by the acid subsystem to process the acid that's on the obj
 /obj/proc/acid_processing()

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -323,7 +323,7 @@ emp_act
 			chest_clothes = wear_suit
 		if(chest_clothes)
 			if(!(chest_clothes.resistance_flags & UNACIDABLE))
-				chest_clothes.acid_act(acidpwr, acid_volume)
+				chest_clothes.acid_act(2 * acidpwr, 2 * acid_volume)
 				update_inv_w_uniform()
 				update_inv_wear_suit()
 			else

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -323,7 +323,7 @@ emp_act
 			chest_clothes = wear_suit
 		if(chest_clothes)
 			if(!(chest_clothes.resistance_flags & UNACIDABLE))
-				chest_clothes.acid_act(2 * acidpwr, 2 * acid_volume)
+				chest_clothes.acid_act(acidpwr, acid_volume)
 				update_inv_w_uniform()
 				update_inv_wear_suit()
 			else


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Title. Xenomorph acid now does less damage to living mobs.
In return, any acid on the chest (As far as I know, only xenomorphs and probably acid foam/acid smoke can actually touch this) has doubled strength and is applied twice. This means that the maximum acid damage is doubled, and it will reach the maximum damage faster.
Naked humans take 120 burn damage and 60 brute damage from this acid.
Humans with no headgear take 40 burn damage and 20 brute damage.
Fixes #12901 
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Fixes a bug and makes coming into the melee range of xenos slightly more interesting and fair. 
Some other testing:
- Skrell in security officer outfit: jumpsuit & protective vest melted in about 25 seconds, helmet and others in about 30 seconds
- Skrell in HOS outfit: same numbers for the helmet and others, armored jacket didn't seem to melt due to high acid armor
- Any MODsuit seems to be immune to this acidmelting of xenos
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
See the section in `Why it's good for the game`
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Acid melts (jump)suits twice as fast now
tweak: xenomorph human acid damage has been reduced
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
