### PR TITLE
Cult Revive rune can be used on living

### DIFF
--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -585,12 +585,27 @@ structure_check() searches for nearby cultist structures required for the invoca
 	invocation = "Pasnar val'keriam usinar. Savrae ines amutan. Yam'toth remium il'tarat!" //Depends on the name of the user - see below
 	icon_state = "revive"
 	var/static/sacrifices_used = -SOULS_TO_REVIVE // Cultists get one "free" revive
+	allow_excess_invokers = TRUE
 
 /obj/effect/rune/raise_dead/examine(mob/user)
 	. = ..()
 	if(iscultist(user) || user.stat == DEAD)
 		. += "<b>Sacrifices unrewarded:</b><span class='cultitalic'> [length(GLOB.sacrificed) - sacrifices_used]</span>"
 		. += "<b>Sacrifice cost per ressurection:</b><span class='cultitalic> [SOULS_TO_REVIVE]</span>"
+
+/obj/effect/rune/raise_dead/proc/revive_alive(mob/living/target)
+	target.visible_message("<span class='warning'>Dark magic begins to surround [target], regenerating their body.</span>")
+	if(!do_after(target, 10 SECONDS, FALSE, target, allow_moving = FALSE, progress = TRUE))
+		target.visible_message("<span class='warning'>Dark magic silently disappears.</span>")
+		return FALSE
+	target.revive()
+	return TRUE
+
+/obj/effect/rune/raise_dead/proc/revive_dead(mob/living/target)
+	target.revive()
+	if(target.ghost_can_reenter())
+		target.grab_ghost()
+	return TRUE
 
 /obj/effect/rune/raise_dead/invoke(list/invokers)
 	var/turf/T = get_turf(src)
@@ -599,13 +614,19 @@ structure_check() searches for nearby cultist structures required for the invoca
 	var/mob/living/user = invokers[1]
 	if(rune_in_use)
 		return
-
 	rune_in_use = TRUE
+	var/diff = length(GLOB.sacrificed) - SOULS_TO_REVIVE - sacrifices_used
+	var/revived_from_dead = FALSE
+	if(diff < 0)
+		to_chat(user, "<span class='cult'>Your cult must carry out [abs(diff)] more sacrifice\s before it can revive another cultist!</span>")
+		fail_invoke()
+		return
 	for(var/mob/living/M in T.contents)
-		if(iscultist(M) && (M.stat == DEAD || !M.client || M.client.is_afk()))
-			potential_revive_mobs |= M
+		if(!iscultist(M))
+			continue
+		potential_revive_mobs |= M
 	if(!length(potential_revive_mobs))
-		to_chat(user, "<span class='cultitalic'>There are no dead cultists on the rune!</span>")
+		to_chat(user, "<span class='cultitalic'>There are no cultists on the rune!</span>")
 		log_game("Raise Dead rune failed - no cultists to revive")
 		fail_invoke()
 		return
@@ -617,17 +638,23 @@ structure_check() searches for nearby cultist structures required for the invoca
 		fail_invoke()
 		return
 
-	..()
-	if(mob_to_revive.stat == DEAD)
-		var/diff = length(GLOB.sacrificed) - SOULS_TO_REVIVE - sacrifices_used
-		if(diff < 0)
-			to_chat(user, "<span class='cult'>Your cult must carry out [abs(diff)] more sacrifice\s before it can revive another cultist!</span>")
+	if(mob_to_revive.stat != DEAD && length(invokers) < 2)
+		to_chat(user, "<span class='cultitalic'>You need at least two cultists to heal cultist!</span>")
+		log_game("Raise Dead rune failed - not enough cultists to heal alive")
+		fail_invoke()
+		return
+
+	if(mob_to_revive.stat != DEAD)
+		if(!revive_alive(mob_to_revive))
 			fail_invoke()
 			return
-		sacrifices_used += SOULS_TO_REVIVE
-		mob_to_revive.revive()
-		if(mob_to_revive.ghost_can_reenter())
-			mob_to_revive.grab_ghost()
+	else
+		if(!revive_dead(mob_to_revive))
+			fail_invoke()
+			return
+		revived_from_dead = TRUE
+	..()
+	sacrifices_used += SOULS_TO_REVIVE
 
 	if(!mob_to_revive.get_ghost() && (!mob_to_revive.client || mob_to_revive.client.is_afk()))
 		set waitfor = FALSE
@@ -642,7 +669,11 @@ structure_check() searches for nearby cultist structures required for the invoca
 		else
 			fail_invoke()
 			return
-
+	if(!revived_from_dead)
+		mob_to_revive.visible_message("<span class='warning'>[mob_to_revive] draws in a huge breath, red light shining from [mob_to_revive.p_their()] eyes.</span>", \
+								"<span class='cultlarge'>All your injuries are now gone!</span>")
+		rune_in_use = FALSE
+		return
 	SEND_SOUND(mob_to_revive, sound('sound/ambience/antag/bloodcult.ogg'))
 	to_chat(mob_to_revive, "<span class='cultlarge'>\"PASNAR SAVRAE YAM'TOTH. Arise.\"</span>")
 	mob_to_revive.visible_message("<span class='warning'>[mob_to_revive] draws in a huge breath, red light shining from [mob_to_revive.p_their()] eyes.</span>", \

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -581,7 +581,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 //Rite of Resurrection: Requires a dead or inactive cultist. When reviving the dead, you can only perform one revival for every three sacrifices your cult has carried out.
 /obj/effect/rune/raise_dead
 	cultist_name = "Revive"
-	cultist_desc = "requires a dead, mindless, or inactive cultist placed upon the rune. For each three bodies sacrificed to the dark patron, one body will be mended and their mind awoken"
+	cultist_desc = "requires a dead, alive, mindless, or inactive cultist placed upon the rune. For each three bodies sacrificed to the dark patron, one body will be mended and their mind awoken. Mending living cultist requires two cultists at the rune"
 	invocation = "Pasnar val'keriam usinar. Savrae ines amutan. Yam'toth remium il'tarat!" //Depends on the name of the user - see below
 	icon_state = "revive"
 	var/static/sacrifices_used = -SOULS_TO_REVIVE // Cultists get one "free" revive


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
This PR allows you to activate Revive rune on living cultist if there is at least two invokers to regenerate their body.
Activating rune on living starts 10 seconds do_after and revives only after that.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Did you know you actually can heal IBs, burn wounds and such as cult by just using its magic? All you need is cut your cult buddy to death and then use the Revive rune. Honestly, i did not know that until someone told me that in code chat and we decided that making Revive rune actually abailable to use on living would be cool. Thats why we are here.

## Testing
<!-- How did you test the PR, if at all? -->
Compiled, draw rune, clicked it with multiple options.

## Changelog
:cl:
tweak: Revive rune now can be used on living cultist to heal their wounds, it requires cultist to stand still for 10 seconds and at least two cultists to start process.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
