### PR TITLE
drops the price of the syndicate ai module significantly

### DIFF
--- a/code/datums/uplink_items/uplink_general.dm
+++ b/code/datums/uplink_items/uplink_general.dm
@@ -666,7 +666,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "When used with an upload console, this module allows you to upload priority laws to an artificial intelligence. Be careful with their wording, as artificial intelligences may look for loopholes to exploit."
 	reference = "HAI"
 	item = /obj/item/aiModule/syndicate
-	cost = 60
+	cost = 15
 
 /datum/uplink_item/device_tools/powersink
 	name = "Power Sink"

--- a/code/game/objects/items/weapons/AI_modules.dm
+++ b/code/game/objects/items/weapons/AI_modules.dm
@@ -418,7 +418,7 @@ AI MODULES
 	var/newFreeFormLaw = ""
 	desc = "A hacked AI law module: '<freeform>'"
 	icon_state = "syndicate"
-	origin_tech = "programming=5;materials=5;syndicate=5"
+	origin_tech = "programming=5;materials=5;syndicate=2"
 
 /obj/item/aiModule/syndicate/attack_self(mob/user as mob)
 	..()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Drops the price of the syndicate ai module from 60 tc to 15 tc (also the syndi tech cuz you know whyyyyy)

## Why It's Good For The Game
so, I'm just assuming people do not actually know what this item does.
Although in admin logs it suggests this is a zeroth law, this is an ion law, ion laws can be cleared using a reset board, this item is not good. it is not 12 tc legacy good, it is still probably not good for 3 tc considering you can just use a freeform module. it is somewhat easier to use, but not 60 tc easier to use.

To explain how fucking awful this item is, the hacker kit, the bundle themed around hacking, does not have this item in it because it literally just does nothing. 

also this is the most sane change i've made in the past 72 hours and my brain no longer hurts

## Testing
My map cut off first time testing this
thanks dm

## Changelog
:cl:
tweak: syndicate ai module now costs 15 tc from 60 tc
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
