### PR TITLE
Pizza bomb now behaves as expected when alt+clicked

### DIFF
--- a/code/modules/food_and_drinks/food/foods/pizza.dm
+++ b/code/modules/food_and_drinks/food/foods/pizza.dm
@@ -446,6 +446,9 @@
 		return
 	return ..()
 
+/obj/item/pizzabox/pizza_bomb/AltClick(mob/user)
+	attack_self(user)
+
 /obj/item/pizzabox/pizza_bomb/attack_self(mob/user)
 	if(disarmed)
 		to_chat(user, "<span class='notice'>[src] is disarmed.</span>")


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
You can now alt+click a pizza bomb box like any other pizza box and it will still allow you to set the time/explode.
Fixes: #22299
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Bug bad
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Be a pizza addicted skrell
Open pizza bomb box by alt+clicking.
Set the timer to 1.
Open pizza bomb box again by alt+clicking
There's now skrell all over the walls.

<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Pizza bomb now behaves as expected again when alt+clicked.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
