### PR TITLE
Cyberiad: Fixes some minor issues (No conflicts version)

### DIFF
--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -29647,12 +29647,7 @@
 /turf/simulated/wall,
 /area/station/maintenance/disposal)
 "bCg" = (
-/obj/machinery/computer/security/telescreen/entertainment{
-	icon_state = "television";
-	icon_screen = "detective_tv";
-	name = "television";
-	desc = "A relic of a bygone age."
-	},
+/obj/machinery/computer/security/telescreen/entertainment/television,
 /turf/simulated/floor/carpet/royalblack,
 /area/station/maintenance/apmaint)
 "bCh" = (
@@ -67890,6 +67885,9 @@
 /obj/item/storage/fancy/rollingpapers,
 /obj/item/storage/box/matches,
 /obj/item/seeds/tobacco,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/station/security/permabrig)
 "hpR" = (
@@ -82766,7 +82764,6 @@
 /area/station/engineering/hardsuitstorage)
 "qLU" = (
 /obj/structure/table,
-/obj/item/key/janitor,
 /obj/item/key/janitor,
 /obj/item/grenade/chem_grenade/cleaner,
 /obj/item/grenade/chem_grenade/cleaner,


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Perma no longer has a pipe missing a vent.
Custodial office no longer has a duplicate pimpin'ride key.
Maintenance old television type is now correct.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Fixes https://github.com/ParadiseSS13/Paradise/issues/21768
Fixes https://github.com/ParadiseSS13/Paradise/issues/21113
Fixes the maintenance television being of the wrong path, causing its screen to change to the entertainment monitor one once a video camera was activated.
## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![vent](https://github.com/ParadiseSS13/Paradise/assets/77684085/29635890-3ecf-41e9-88d9-acc555d203b0)

![key](https://github.com/ParadiseSS13/Paradise/assets/77684085/c11152fe-6e4b-4db6-a023-8886f2de4e6d)

![television](https://github.com/ParadiseSS13/Paradise/assets/77684085/82103ef2-bd1d-4e9f-99e2-c9c1820d3159)

## Testing
<!-- How did you test the PR, if at all? -->
- compiled and verified the changes as one can see over images of changes
## Changelog
:cl:
fix: Cyberiad: perma no longer has a pipe missing a vent
fix: Cyberiad: custodial office no longer has a duplicate pimpin'ride key
fix: Cyberiad: maintenance old television type is now correct, no longer having issues with its screen
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
