### PR TITLE
Adds two requests consoles to the kitchen on Cerestation/Farragus

### DIFF
--- a/_maps/map_files/cerestation/cerestation.dmm
+++ b/_maps/map_files/cerestation/cerestation.dmm
@@ -38539,6 +38539,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
+"eFW" = (
+/obj/machinery/requests_console{
+	department = "Kitchen";
+	departmentType = 2;
+	name = "Kitchen Requests Console";
+	pixel_x = -30
+	},
+/turf/simulated/floor/plasteel/freezer,
+/area/station/service/kitchen)
 "eGe" = (
 /obj/structure/table,
 /obj/item/soap,
@@ -81350,6 +81359,12 @@
 /obj/machinery/smartfridge/foodcart{
 	dir = 4
 	},
+/obj/machinery/requests_console{
+	department = "Kitchen";
+	departmentType = 2;
+	name = "Kitchen Requests Console";
+	pixel_x = -30
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
@@ -117134,7 +117149,7 @@ hpJ
 uzY
 baH
 ogl
-ogl
+eFW
 bbK
 btd
 mgV


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Title. closes  #21797
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
They lacked request consoles, they should have request consoles.
## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
Before
![image](https://github.com/ParadiseSS13/Paradise/assets/96908085/38b59542-7a72-40cf-9240-181da439ce5a)

After
![image](https://github.com/ParadiseSS13/Paradise/assets/96908085/27cd580b-ff36-45ba-a72f-9f014d9010f5)

## Testing
<!-- How did you test the PR, if at all? -->
Compiled, checked if they existed.
## Changelog
:cl:
add: Added two request consoles to the kitchen on Cerestation/Farragus
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
