### PR TITLE
Fixes some issues with the ERT manager

### DIFF
--- a/code/modules/admin/verbs/pray.dm
+++ b/code/modules/admin/verbs/pray.dm
@@ -64,7 +64,7 @@
 				SEND_SOUND(X, sound('sound/effects/adminhelp.ogg'))
 
 /proc/ERT_Announce(text, mob/Sender, repeat_warning)
-	var/msg = sanitizeSafe(text, MAX_MESSAGE_LEN)
+	var/msg = sanitizeSafe(text)
 	var/insert_this = list(list(
 		"time" = station_time_timestamp(),
 		"sender_real_name" = "[Sender.real_name ? Sender.real_name : Sender.name]",

--- a/code/modules/admin/verbs/pray.dm
+++ b/code/modules/admin/verbs/pray.dm
@@ -64,12 +64,12 @@
 				SEND_SOUND(X, sound('sound/effects/adminhelp.ogg'))
 
 /proc/ERT_Announce(text, mob/Sender, repeat_warning)
-	var/msg = sanitize(copytext(text, 1, MAX_MESSAGE_LEN))
+	var/msg = sanitizeSafe(text, MAX_MESSAGE_LEN)
 	var/insert_this = list(list(
 		"time" = station_time_timestamp(),
 		"sender_real_name" = "[Sender.real_name ? Sender.real_name : Sender.name]",
 		"sender_uid" = Sender.UID(),
-		"message" = msg))
+		"message" = html_decode(msg)))
 	GLOB.ert_request_messages.Insert(1, insert_this) // insert it to the top of the list
 	msg = "<span class='adminnotice'><b><font color=orange>ERT REQUEST: </font>[key_name(Sender, 1)] ([ADMIN_PP(Sender,"PP")]) ([ADMIN_VV(Sender,"VV")]) ([ADMIN_TP(Sender,"TP")]) ([ADMIN_SM(Sender,"SM")]) ([admin_jump_link(Sender)]) ([ADMIN_BSA(Sender,"BSA")]) (<A HREF='?_src_=holder;ErtReply=[Sender.UID()]'>RESPOND</A>):</b> [msg]</span>"
 	if(repeat_warning)

--- a/code/modules/security_levels/keycard_authentication.dm
+++ b/code/modules/security_levels/keycard_authentication.dm
@@ -117,7 +117,7 @@
 	. = TRUE
 	switch(action)
 		if("ert")
-			ert_reason = stripped_input(usr, "Reason for ERT Call:", "", "")
+			ert_reason = input(usr, "Reason for ERT Call:", "", "") // we strip this later in ERT_Announce
 		if("reset")
 			reset()
 		if("triggerevent")

--- a/code/modules/tgui/modules/ert_manager.dm
+++ b/code/modules/tgui/modules/ert_manager.dm
@@ -104,13 +104,15 @@
 				slots_list += "paranormal: [paranormal_slots]"
 			if(cyborg_slots > 0)
 				slots_list += "cyborg: [cyborg_slots]"
-			D.silent = params["silent"]
+
+			var/silenced = text2bool(params["silent"])
+			D.silent = silenced
 
 			var/slot_text = english_list(slots_list)
 			notify_ghosts("An ERT is being dispatched. Type: [ert_type]. Open positions: [slot_text]")
-			message_admins("[key_name_admin(usr)] dispatched a [params["silent"] ? "silent " : ""][ert_type] ERT. Slots: [slot_text]", 1)
-			log_admin("[key_name(usr)] dispatched a [params["silent"] ? "silent " : ""][ert_type] ERT. Slots: [slot_text]")
-			if(!params["silent"])
+			message_admins("[key_name_admin(usr)] dispatched a [silenced ? "silent " : ""][ert_type] ERT. Slots: [slot_text]", 1)
+			log_admin("[key_name(usr)] dispatched a [silenced ? "silent " : ""][ert_type] ERT. Slots: [slot_text]")
+			if(!silenced)
 				GLOB.major_announcement.Announce("Attention, [station_name()]. We are attempting to assemble an ERT. Standby.", "ERT Protocol Activated")
 			trigger_armed_response_team(D, commander_slots, security_slots, medical_slots, engineering_slots, janitor_slots, paranormal_slots, cyborg_slots, cyborg_security)
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->ERTs are now properly silenced, reviewing ERT requests will also not have a bunch of garbled text in them now if the user used an html-viable character, and instead they will be turned into spaces.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Unintended things bad

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
Proper looking safe text rendering, by removing the text instead of just encoding it
![image](https://github.com/ParadiseSS13/Paradise/assets/91113370/c391c89a-eda0-4b19-ab5c-f92aa16f443a)

## Testing
<!-- How did you test the PR, if at all? -->
See above, silencing worked properly between toggles. Tested the safety of the sanitize input using exploits, all worked as intended.

## Changelog
:cl:
fix: ERTs are no longer always silent if an admin clicks a button
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
