### PR TITLE
Fixes some issues with revs

### DIFF
--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -1,10 +1,9 @@
-// To add a rev to the list of revolutionaries, make sure it's rev (with if(ticker.mode.name == "revolution)),
-// then call ticker.mode:add_revolutionary(_THE_PLAYERS_MIND_)
+// then call SSticker.mode.add_revolutionary(_THE_PLAYERS_MIND_)
 // nothing else needs to be done, as that proc will check if they are a valid target.
 // Just make sure the converter is a head before you call it!
-// To remove a rev (from brainwashing or w/e), call ticker.mode:remove_revolutionary(_THE_PLAYERS_MIND_),
+// To remove a rev (from brainwashing or w/e), call SSticker.mode.remove_revolutionary(_THE_PLAYERS_MIND_),
 // this will also check they're not a head, so it can just be called freely
-// If the game somtimes isn't registering a win properly, then ticker.mode.check_win() isn't being called somewhere.
+// If the game somtimes isn't registering a win properly, then SSticker.mode.check_win() isn't being called somewhere.
 
 #define REV_VICTORY 1
 #define STATION_VICTORY 2
@@ -243,10 +242,10 @@
 	var/comcount = 0
 	var/revcount = 0
 	var/loycount = 0
-	for(var/datum/mind/M in SSticker.mode:head_revolutionaries)
+	for(var/datum/mind/M in SSticker.mode.head_revolutionaries)
 		if(M.current && M.current.stat != DEAD)
 			foecount++
-	for(var/datum/mind/M in SSticker.mode:revolutionaries)
+	for(var/datum/mind/M in SSticker.mode.revolutionaries)
 		if(M.current && M.current.stat != DEAD)
 			revcount++
 
@@ -284,13 +283,13 @@
 	return dat
 
 /proc/is_revolutionary(mob/living/M)
-	return istype(M) && (M?.mind in SSticker?.mode?.revolutionaries)
+	return istype(M) && M?.mind?.has_antag_datum(/datum/antagonist/rev, FALSE)
 
 /proc/is_headrev(mob/living/M)
-	return istype(M) && (M?.mind in SSticker?.mode?.head_revolutionaries)
+	return istype(M) && M?.mind?.has_antag_datum(/datum/antagonist/rev/head)
 
 /proc/is_any_revolutionary(mob/living/M)
-	return is_revolutionary(M) || is_headrev(M)
+	return istype(M) && M?.mind?.has_antag_datum(/datum/antagonist/rev)
 
 #undef REV_VICTORY
 #undef STATION_VICTORY

--- a/code/game/objects/items/weapons/implants/implant_mindshield.dm
+++ b/code/game/objects/items/weapons/implants/implant_mindshield.dm
@@ -7,7 +7,7 @@
 	implant_state = "implant-nanotrasen"
 
 /obj/item/implant/mindshield/can_implant(mob/source, mob/user)
-	if(source.mind in SSticker.mode.head_revolutionaries)
+	if(source.mind.has_antag_datum(/datum/antagonist/rev/head))
 		source.visible_message("<span class='biggerdanger'>[source] seems to resist [src]!</span>",
 								"<span class='warning'>You feel something interfering with your mental conditioning, but you resist it!</span>")
 		return FALSE

--- a/code/game/objects/items/weapons/implants/implant_mindshield.dm
+++ b/code/game/objects/items/weapons/implants/implant_mindshield.dm
@@ -7,7 +7,7 @@
 	implant_state = "implant-nanotrasen"
 
 /obj/item/implant/mindshield/can_implant(mob/source, mob/user)
-	if(source.mind.has_antag_datum(/datum/antagonist/rev/head))
+	if(source.mind?.has_antag_datum(/datum/antagonist/rev/head))
 		source.visible_message("<span class='biggerdanger'>[source] seems to resist [src]!</span>",
 								"<span class='warning'>You feel something interfering with your mental conditioning, but you resist it!</span>")
 		return FALSE

--- a/code/modules/antagonists/revolutionary/team_revolution.dm
+++ b/code/modules/antagonists/revolutionary/team_revolution.dm
@@ -102,7 +102,7 @@
 	var/sec_diminish = (8 - sec) / 3 // 2 seccies = 2, 5 seccies = 1, 8 seccies = 0
 
 	var/potential = round(heads - sec_diminish) // more sec, increases. more heads, increases
-	var/how_many_more_headrevs = clamp(potential, clamp_at, head_revolutionaries - max_headrevs)
+	var/how_many_more_headrevs = clamp(potential, clamp_at, max_headrevs - head_revolutionaries)
 
 	return how_many_more_headrevs
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->Fixes some stylistic code choices with revs, including comments.

This also fixes an issue where only one headrev would spawn at the beginning of a rev round. Woops.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Style is good, requested by S34N.

## Testing
<!-- How did you test the PR, if at all? -->
Compiles, all changes work the same logically.
Headrevs can now spawn more than 1 at a time at roundstart.

## Changelog
:cl:
fix: Revolutions should no longer only start with one headrev.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
