### PR TITLE
Cyberiad: Maintenance & Service Rework [Part 3]

### DIFF
--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -62943,6 +62943,10 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
+"eCG" = (
+/mob/living/simple_animal/mouse,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "eDs" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -68176,6 +68180,12 @@
 	icon_state = "cmo"
 	},
 /area/station/maintenance/aft)
+"hvu" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "hvz" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -70361,7 +70371,7 @@
 "iIf" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/portable/canister/sleeping_agent{
-	filled = 0.1
+	filled = 0.01
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -70766,7 +70776,7 @@
 /area/station/maintenance/asmaint)
 "iYz" = (
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/mouse,
+/obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "iYO" = (
@@ -71827,6 +71837,9 @@
 "jHT" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/emergency,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "jIE" = (
@@ -76540,6 +76553,17 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/science/xenobiology)
+"mAb" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "mAq" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -85595,7 +85619,7 @@
 "rQm" = (
 /obj/effect/decal/warning_stripes/red/hollow,
 /obj/machinery/atmospherics/portable/canister/carbon_dioxide{
-	filled = 0.1
+	filled = 0.01
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -139231,7 +139255,7 @@ iaQ
 aEX
 vPH
 aBf
-aBf
+mAb
 aBf
 hAa
 bir
@@ -140002,7 +140026,7 @@ aGX
 sXm
 fQx
 aGY
-aGY
+eCG
 aOI
 sHt
 sHt
@@ -141026,7 +141050,7 @@ aaa
 aHN
 ove
 aGY
-aGY
+hvu
 buy
 cjD
 aGX

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -90,6 +90,10 @@
 /obj/effect/landmark/spawner/carp,
 /turf/space,
 /area/space)
+"abz" = (
+/obj/effect/spawner/random_spawners/wall_rusted_maybe,
+/turf/simulated/wall/r_wall,
+/area/station/security/detective)
 "abN" = (
 /turf/simulated/wall/r_wall,
 /area/station/security/permabrig)
@@ -750,6 +754,11 @@
 /obj/structure/fans/tiny,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
+"aes" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "aeu" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/decal/warning_stripes/north,
@@ -1154,24 +1163,9 @@
 /turf/simulated/floor/carpet,
 /area/station/command/office/hos)
 "afN" = (
-/obj/structure/chair/office/dark{
-	dir = 1
-	},
-/obj/effect/landmark/start/mime,
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plasteel{
-	icon_regular_floor = "yellowsiding";
-	icon_state = "tranquillite"
-	},
-/area/station/service/mime)
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/wood,
+/area/station/service/library)
 "afO" = (
 /turf/simulated/floor/plating/airless,
 /area/space/nearstation)
@@ -1291,19 +1285,17 @@
 	},
 /area/station/security/armory/secure)
 "agu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light{
-	dir = 1
+	dir = 8
 	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "bluered"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
+/turf/simulated/floor/plasteel,
 /area/station/public/dorms)
 "agD" = (
 /obj/structure/cable{
@@ -1565,6 +1557,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkredcorners"
@@ -1605,6 +1600,9 @@
 	c_tag = "Brig Main Hall East 1"
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkredcorners"
@@ -2011,6 +2009,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkredcorners"
 	},
@@ -2120,12 +2119,13 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -2143,6 +2143,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
+"ajb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "ajg" = (
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/simple/hidden,
@@ -2235,6 +2242,11 @@
 	icon_state = "redfull"
 	},
 /area/station/security/permabrig)
+"ajB" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/mouse,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "ajF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 5
@@ -2246,7 +2258,9 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkredcorners"
@@ -2370,6 +2384,9 @@
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkredcorners"
@@ -2410,6 +2427,11 @@
 	icon_state = "darkredcorners"
 	},
 /area/station/security/brig)
+"akc" = (
+/obj/structure/table,
+/obj/item/toy/figure/griffin,
+/turf/simulated/floor/carpet/black,
+/area/station/maintenance/fore)
 "akd" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -2514,7 +2536,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/sortjunction/reversed{
+	name = "Detective";
+	sort_type_txt = "24"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkredcorners"
 	},
@@ -2581,6 +2606,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -2658,6 +2686,10 @@
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -2845,16 +2877,16 @@
 /area/station/security/brig)
 "alb" = (
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkredcorners"
@@ -3588,15 +3620,20 @@
 	name = "old sink";
 	pixel_y = 28
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
 "amL" = (
-/obj/machinery/shower{
+/obj/structure/morgue{
 	dir = 8
 	},
-/obj/structure/curtain/open/shower,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
+/obj/effect/landmark/spawner/rev,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/station/security/detective)
 "amM" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -3717,6 +3754,16 @@
 	},
 /turf/simulated/floor/carpet,
 /area/station/command/office/hos)
+"anc" = (
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/obj/item/bikehorn/rubberducky,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "and" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -5042,50 +5089,78 @@
 	},
 /area/station/command/office/hos)
 "apY" = (
-/obj/structure/bed,
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 6
 	},
-/turf/simulated/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
 /area/station/maintenance/fore)
 "apZ" = (
-/obj/item/storage/secure/safe{
-	pixel_y = 25
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/plating,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/catwalk,
 /area/station/maintenance/fore)
 "aqb" = (
-/obj/item/storage/secure/safe{
-	pixel_y = 25
+/obj/machinery/door/airlock/engineering{
+	name = "Fore Starboard Solar Access";
+	req_access_txt = "10"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/fore)
+/area/station/maintenance/auxsolarstarboard)
 "aqc" = (
-/obj/effect/spawner/random_spawners/wall_rusted_maybe,
-/turf/simulated/wall,
+/obj/machinery/atmospherics/unary/tank/air{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
 /area/station/maintenance/fore)
 "aqd" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/station/security/range)
 "aqn" = (
-/obj/item/flag/sec,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
-"aqq" = (
-/obj/item/soap,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
-"aqr" = (
-/obj/structure/toilet{
-	dir = 8
+/obj/machinery/door/airlock/glass{
+	name = "Chapel Office";
+	req_access_txt = "22"
 	},
-/obj/machinery/light/small{
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/service/chapel/office)
+"aqq" = (
+/obj/structure/toilet{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
+"aqr" = (
+/obj/structure/table,
+/obj/item/storage/box/bodybags,
+/obj/item/clothing/gloves/color/latex,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/station/security/detective)
 "aqu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -5394,6 +5469,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -5601,6 +5679,9 @@
 /obj/item/radio/intercom/department/security{
 	pixel_y = 25
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkredcorners"
@@ -5746,31 +5827,32 @@
 /turf/simulated/floor/plating,
 /area/station/security/evidence)
 "arR" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/wall,
-/area/station/maintenance/fore)
-"arS" = (
-/obj/item/toy/pet_rock,
-/obj/machinery/door_control{
-	id = "secmaintdorm1";
-	name = "Door Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_x = 25;
-	specialfunctions = 4
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
+/area/station/maintenance/electrical)
+"arS" = (
+/obj/item/storage/toolbox/emergency,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/station/maintenance/fore)
 "arT" = (
-/obj/item/toy/plushie/deer,
-/obj/machinery/door_control{
-	id = "secmaintdorm2";
-	name = "Door Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_x = 25;
-	specialfunctions = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet/red,
+/area/station/service/library)
 "arU" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -5796,11 +5878,14 @@
 /turf/space,
 /area/station/engineering/solar/auxport)
 "asc" = (
-/obj/effect/spawner/random_barrier/obstruction,
+/obj/structure/falsewall,
 /turf/simulated/floor/plating,
-/area/station/maintenance/fore)
+/area/station/maintenance/fsmaint)
 "asf" = (
 /obj/effect/spawner/random_barrier/possibly_welded_airlock,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
 "asg" = (
@@ -5997,13 +6082,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/item/radio/intercom{
 	name = "south bump";
 	pixel_y = -28
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -6395,12 +6482,12 @@
 	},
 /area/station/security/evidence)
 "atq" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -6409,29 +6496,30 @@
 /turf/simulated/floor/plasteel,
 /area/station/security/lobby)
 "atr" = (
-/obj/machinery/door/airlock{
-	id_tag = "secmaintdorm1";
-	name = "Room 1"
-	},
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
 "ats" = (
-/obj/machinery/door/airlock{
-	id_tag = "secmaintdorm2";
-	name = "Room 2"
+/obj/effect/spawner/window/reinforced/tinted,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
 "att" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/girder,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
 "atu" = (
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 8
-	},
-/obj/machinery/atmospherics/portable/canister/air{
-	filled = 0.1
+/obj/machinery/door/airlock/maintenance{
+	name = "Detective Maintenance";
+	req_access_txt = "4";
+	security_level = 1
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
@@ -6440,11 +6528,12 @@
 /turf/simulated/floor/plasteel,
 /area/station/security/processing)
 "atw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 6
+/obj/structure/weightmachine/stacklifter,
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "caution"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
+/area/station/public/dorms)
 "atx" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -6499,6 +6588,9 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkredcorners"
@@ -6514,6 +6606,9 @@
 /obj/item/radio/intercom{
 	name = "south bump";
 	pixel_y = -28
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -6593,12 +6688,13 @@
 /turf/simulated/floor/plating,
 /area/station/security/permabrig)
 "atT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/structure/sign/vacuum/external{
+/obj/machinery/status_display{
 	pixel_x = 32
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/station/security/detective)
 "atY" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/glasses/sunglasses{
@@ -6875,10 +6971,20 @@
 	},
 /area/station/security/evidence)
 "auK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
+/obj/machinery/computer/security/wooden_tv{
+	network = list("SS13","Research Outpost","Mining Outpost")
+	},
+/obj/machinery/button/windowtint{
+	id = "Detective";
+	pixel_x = 8;
+	pixel_y = 24;
+	req_access_txt = "4"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/carpet,
+/area/station/security/detective)
 "auL" = (
 /obj/item/kirbyplants,
 /turf/simulated/floor/plasteel{
@@ -7044,28 +7150,25 @@
 	},
 /area/station/security/evidence)
 "auZ" = (
-/obj/machinery/light/small{
+/obj/structure/chair/stool{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
+/turf/simulated/floor/carpet,
+/area/station/security/detective)
 "ava" = (
+/obj/effect/decal/warning_stripes/northeastcorner,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/fore)
-"avb" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fore)
 "avc" = (
-/obj/item/toy/figure/crew/secofficer,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/fore)
+/obj/structure/weightmachine/weightlifter,
+/turf/simulated/floor/plasteel{
+	icon_state = "caution"
+	},
+/area/station/public/dorms)
 "avd" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -7554,6 +7657,17 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "redcorner"
@@ -7576,11 +7690,6 @@
 /turf/simulated/wall,
 /area/station/maintenance/fore)
 "awn" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -7608,15 +7717,10 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -7630,12 +7734,6 @@
 /turf/simulated/floor/plasteel,
 /area/station/security/brig)
 "awC" = (
-/obj/structure/chair,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
@@ -7647,48 +7745,39 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/machinery/camera{
-	c_tag = "Brig Prisoner Processing East";
-	dir = 8;
-	pixel_y = -22
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "redcorner"
-	},
+/turf/simulated/floor/plasteel,
 /area/station/security/processing)
 "awD" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
-"awE" = (
 /obj/structure/table,
-/obj/item/toy/figure/griffin,
+/obj/structure/extinguisher_cabinet{
+	name = "south bump";
+	pixel_y = -30
+	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/fore)
+/area/station/maintenance/electrical)
 "awF" = (
-/obj/structure/chair/stool{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/plasteel,
+/area/station/public/dorms)
 "awG" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
 /area/station/security/detective)
 "awH" = (
-/obj/structure/table,
-/obj/item/dice/d20,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/starboard/east)
 "awI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -7797,8 +7886,17 @@
 /turf/simulated/wall/r_wall,
 /area/station/security/execution)
 "axe" = (
-/turf/simulated/wall,
-/area/station/security/detective)
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Secure Gate";
+	name = "Security Blast Door"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/prison/cell_block/A)
 "axh" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -8129,9 +8227,12 @@
 	},
 /area/station/security/processing)
 "axQ" = (
-/obj/item/radio/intercom{
-	name = "south bump";
-	pixel_y = -28
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "redcorner"
@@ -8148,68 +8249,33 @@
 	},
 /area/station/security/processing)
 "axS" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "redcorner"
 	},
 /area/station/security/processing)
 "axU" = (
-/obj/machinery/alarm{
-	dir = 8;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/structure/table,
 /obj/item/restraints/handcuffs,
 /obj/item/taperecorder,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "redcorner"
+	},
+/area/station/security/processing)
+"axW" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/station/security/processing)
-"axV" = (
-/obj/machinery/atmospherics/portable/canister/air,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
-"axW" = (
-/obj/structure/rack{
-	dir = 1
-	},
-/obj/item/radio{
-	pixel_x = 5
-	},
-/obj/item/reagent_containers/food/drinks/mug/sec,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
-"axX" = (
-/obj/structure/sign/poster/contraband/random{
-	pixel_y = 32
-	},
-/obj/structure/rack{
-	dir = 1
-	},
-/obj/item/storage/fancy/donut_box,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
+/area/station/hallway/primary/starboard/west)
 "axY" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/table,
-/obj/item/taperecorder,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
+/obj/machinery/light,
+/turf/simulated/floor/wood,
+/area/station/maintenance/fsmaint)
 "axZ" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -8217,35 +8283,49 @@
 	},
 /area/station/security/lobby)
 "aya" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random_spawners/wall_rusted_maybe,
-/turf/simulated/wall,
-/area/station/maintenance/fore)
-"ayb" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
-"ayc" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
-"ayd" = (
-/obj/structure/rack{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
 	},
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
-"ayf" = (
-/obj/structure/table,
-/obj/item/toy/figure/crew/hos,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
-"ayg" = (
-/obj/structure/table,
-/obj/item/toy/figure/owl,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/service/chapel)
+"ayb" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkredcorners"
+	},
+/area/station/security/brig)
+"ayc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/starboard/east)
+"ayd" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/public/dorms)
 "ayj" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
@@ -8257,9 +8337,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
-	},
-/obj/machinery/door_timer/cell_5{
-	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkredcorners"
@@ -8294,10 +8371,13 @@
 /turf/simulated/floor/plasteel,
 /area/station/security/processing)
 "ayr" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel,
-/area/station/security/prison/cell_block/A)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/security/interrogation)
 "ays" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -8577,59 +8657,50 @@
 /area/station/security/processing)
 "aza" = (
 /turf/simulated/wall/r_wall,
-/area/station/security/processing)
+/area/station/security/interrogation)
 "azc" = (
-/obj/structure/cable,
-/obj/effect/spawner/window/reinforced/polarized{
-	id = "Interrogation"
+/obj/machinery/crema_switch{
+	pixel_x = 24
 	},
-/turf/simulated/floor/plating,
-/area/station/security/interrogation)
-"azd" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Interrogation";
-	req_access_txt = "63"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "Interrogation"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/security/interrogation)
-"azl" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
+/turf/simulated/floor/plasteel{
+	icon_state = "cult"
+	},
+/area/station/service/chapel/office)
+"azl" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralcorner"
+	},
+/area/station/public/dorms)
 "azm" = (
-/obj/structure/rack{
-	dir = 1
+/obj/structure/table/wood,
+/obj/machinery/firealarm{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
 	},
-/obj/item/clothing/suit/fire/firefighter,
-/obj/item/tank/internals/oxygen,
-/obj/item/clothing/mask/gas,
-/obj/item/extinguisher,
-/obj/item/clothing/head/hardhat/red,
-/obj/item/clothing/glasses/meson,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
+/obj/item/clothing/suit/soldiercoat,
+/obj/item/clothing/under/costume/soldieruniform,
+/obj/item/clothing/head/stalhelm,
+/obj/machinery/newscaster{
+	name = "north bump";
+	pixel_y = 28
+	},
+/turf/simulated/floor/wood,
+/area/station/service/clown)
 "azn" = (
-/obj/structure/chair/stool{
-	dir = 1
+/obj/machinery/computer/cryopod{
+	pixel_y = 30
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/fore)
+/turf/simulated/floor/plasteel{
+	icon_state = "whitegreenfull"
+	},
+/area/station/public/sleep)
 "azq" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -8886,20 +8957,23 @@
 	},
 /area/station/security/prison/cell_block/A)
 "azL" = (
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 8
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
+/obj/machinery/ai_status_display{
+	pixel_y = 32
+	},
+/turf/simulated/floor/wood,
+/area/station/service/library)
 "azM" = (
-/obj/machinery/light/small{
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
-/obj/machinery/atmospherics/binary/pump/on{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/starboard/west)
 "azN" = (
 /obj/structure/closet/secure_closet/brig{
 	id = "Cell 2";
@@ -8956,11 +9030,21 @@
 	},
 /area/station/security/lobby)
 "azS" = (
-/obj/structure/chair/stool/bar{
+/obj/effect/spawner/random_spawners/wall_rusted_maybe,
+/turf/simulated/wall,
+/area/station/maintenance/electrical)
+"azT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
-/turf/simulated/floor/wood,
-/area/station/maintenance/abandonedbar)
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fore)
 "azU" = (
 /obj/structure/sign/electricshock,
 /turf/simulated/wall,
@@ -8984,72 +9068,55 @@
 	},
 /area/station/security/brig)
 "azW" = (
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 5";
-	name = "Cell 5 Locker"
-	},
-/obj/machinery/camera{
-	c_tag = "Brig Cell 5";
-	dir = 9
-	},
-/obj/effect/decal/cleanable/cobweb2,
-/turf/simulated/floor/plasteel,
-/area/station/security/prison/cell_block/A)
-"azX" = (
-/obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/station/security/interrogation)
+"azX" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/starboard/east)
 "azY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "Processing"
 	},
 /obj/structure/cable{
-	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "0-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/button/windowtint{
-	dir = 4;
-	id = "Interrogation";
-	name = "interrogation tint control";
-	pixel_x = -24;
-	req_access_txt = "63"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/security/interrogation)
-"azZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/security/interrogation)
-"aAa" = (
-/obj/effect/landmark/spawner/nukedisc_respawn,
 /turf/simulated/floor/plating,
+/area/station/security/prison/cell_block/A)
+"azZ" = (
+/obj/structure/sign/vacuum/external{
+	pixel_x = 32
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/station/maintenance/fore)
-"aAb" = (
-/obj/structure/chair/stool/bar{
+"aAa" = (
+/obj/machinery/camera{
+	c_tag = "Dormitories West";
 	dir = 4
 	},
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutralcorner"
 	},
+/area/station/public/dorms)
+"aAb" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/table/wood,
+/obj/item/stack/spacecash/c50,
+/turf/simulated/floor/wood,
 /area/station/maintenance/abandonedbar)
-"aAc" = (
-/obj/structure/grille/broken,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
 "aAd" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -9058,9 +9125,18 @@
 /turf/simulated/wall,
 /area/station/maintenance/abandonedbar)
 "aAg" = (
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
-/area/station/maintenance/abandonedbar)
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/station/security/detective)
 "aAm" = (
 /turf/simulated/wall/r_wall,
 /area/station/legal/courtroom)
@@ -9127,46 +9203,44 @@
 	},
 /area/station/security/lobby)
 "aAA" = (
-/obj/machinery/power/treadmill{
-	dir = 8
-	},
-/obj/structure/cable/yellow,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/machinery/treadmill_monitor{
-	id = "Cell 5";
-	pixel_y = -32
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel,
-/area/station/security/prison/cell_block/A)
-"aAB" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/security/interrogation)
-"aAC" = (
-/obj/machinery/light_switch{
-	dir = 1;
-	name = "south bump";
-	pixel_y = -24
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/machinery/button/windowtint{
+	dir = 4;
+	id = "Interrogation";
+	name = "interrogation tint control";
+	pixel_x = -24;
+	req_access_txt = "63"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/station/security/interrogation)
+"aAB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "black";
+	dir = 1
+	},
+/area/station/hallway/primary/starboard/east)
+"aAC" = (
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "Detective"
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/detective)
 "aAE" = (
 /obj/machinery/light{
 	dir = 8
@@ -9222,11 +9296,10 @@
 	},
 /area/station/legal/lawoffice)
 "aAJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
+/obj/structure/table/wood,
+/obj/item/storage/box/characters,
+/turf/simulated/floor/wood,
+/area/station/service/library)
 "aAK" = (
 /obj/machinery/atmospherics/binary/valve/open{
 	dir = 4
@@ -9234,15 +9307,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
 "aAL" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	name = "south bump";
-	pixel_y = -24
+/obj/effect/spawner/random_spawners/blood_often,
+/obj/item/mounted/frame/apc_frame,
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken5"
 	},
-/obj/structure/chair/stool/bar{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
 /area/station/maintenance/abandonedbar)
 "aAM" = (
 /obj/machinery/camera{
@@ -9303,11 +9372,12 @@
 /turf/simulated/floor/plating,
 /area/station/security/prison/cell_block/A)
 "aAQ" = (
-/obj/structure/chair/stool{
-	dir = 8
+/obj/machinery/economy/vending/detdrobe,
+/obj/machinery/light,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
+/area/station/security/detective)
 "aAR" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -9337,17 +9407,6 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/fore)
 "aAV" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -9367,97 +9426,158 @@
 	},
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkredcorners"
 	},
 /area/station/security/prison/cell_block/A)
 "aAY" = (
-/obj/effect/landmark/burnturf,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
-"aAZ" = (
+/obj/effect/decal/warning_stripes/white/hollow,
+/obj/structure/cable/yellow,
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel,
-/area/station/security/prison/cell_block/A)
-"aBb" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/security/prison/cell_block/A)
-"aBc" = (
-/obj/structure/table/wood,
-/obj/item/deck/cards,
-/turf/simulated/floor/wood,
-/area/station/maintenance/abandonedbar)
-"aBd" = (
-/obj/structure/chair/wood/wings{
+/area/station/maintenance/fsmaint)
+"aAZ" = (
+/obj/structure/chair{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/abandonedbar)
-"aBe" = (
-/obj/structure/chair/wood/wings{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/alarm{
+	dir = 4;
+	name = "west bump";
+	pixel_x = -24
 	},
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
-/area/station/maintenance/abandonedbar)
-"aBf" = (
-/obj/structure/chair/wood/wings{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/station/maintenance/abandonedbar)
-"aBg" = (
-/turf/simulated/floor/wood,
-/area/station/maintenance/abandonedbar)
-"aBh" = (
-/obj/item/stack/tile/wood,
-/turf/simulated/floor/plating,
-/area/station/maintenance/abandonedbar)
-"aBi" = (
-/obj/structure/table/reinforced,
-/obj/item/taperecorder,
-/obj/item/flashlight/lamp,
-/obj/item/wirecutters/security,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/station/security/interrogation)
-"aBj" = (
-/obj/structure/table/wood,
-/obj/item/trash/candle,
+"aBb" = (
+/obj/structure/table/reinforced,
+/obj/item/wirecutters/security,
+/obj/item/taperecorder,
+/obj/item/flashlight/lamp,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/security/interrogation)
+"aBc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 6
+	},
 /turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
+"aBd" = (
+/obj/item/poster/random_contraband,
+/obj/item/stack/cable_coil/white,
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "vault"
+	},
+/area/station/maintenance/fsmaint)
+"aBe" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkredcorners"
+	},
+/area/station/security/prison/cell_block/A)
+"aBf" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
+"aBg" = (
+/turf/simulated/floor/wood,
 /area/station/maintenance/abandonedbar)
+"aBh" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	autolink_id = "barmaint_vent"
+	},
+/obj/machinery/airlock_controller/air_cycler{
+	pixel_x = 25;
+	req_access_txt = "13";
+	vent_link_id = "barmaint_vent";
+	ext_door_link_id = "barmaint_door_ext";
+	int_door_link_id = "barmaint_door_int";
+	ext_button_link_id = "barmaint_btn_ext";
+	int_button_link_id = "barmaint_btn_int"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
+"aBi" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Electrical Maintenance";
+	req_access_txt = "11"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/electrical)
+"aBj" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	name = "south bump";
+	pixel_y = -24
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "cult"
+	},
+/area/station/service/chapel/office)
 "aBm" = (
 /obj/item/stack/rods,
 /turf/space,
@@ -9467,81 +9587,79 @@
 /turf/simulated/floor/plating,
 /area/station/legal/courtroom)
 "aBo" = (
-/obj/structure/chair{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/security/interrogation)
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/wood,
+/area/station/service/clown)
 "aBp" = (
-/obj/structure/chair{
-	dir = 8
+/obj/machinery/power/apc{
+	name = "south bump";
+	pixel_y = -24
 	},
-/obj/machinery/alarm{
-	dir = 8;
-	name = "east bump";
-	pixel_x = 24
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "neutralcorner"
 	},
-/area/station/security/interrogation)
+/area/station/public/dorms)
 "aBq" = (
-/obj/machinery/space_heater,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
-"aBr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
 	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralcorner"
+	},
+/area/station/public/dorms)
+"aBr" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance/two,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
 "aBs" = (
 /turf/simulated/wall,
 /area/station/security/interrogation)
 "aBt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
-"aBu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/girder,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
 "aBv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/universal,
-/turf/simulated/wall,
-/area/station/maintenance/fore)
+/obj/structure/cult/archives,
+/turf/simulated/floor/plasteel{
+	icon_state = "cult"
+	},
+/area/station/service/library)
 "aBw" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump Engineering";
+	pixel_x = -24;
+	shock_proof = 1
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/fore)
+/area/station/maintenance/auxsolarstarboard)
 "aBy" = (
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating/airless,
 /area/space/nearstation)
 "aBz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/obj/machinery/alarm{
+	name = "north bump";
+	pixel_y = 24
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/station/security/detective)
 "aBA" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -9627,13 +9745,6 @@
 	icon_state = "dark"
 	},
 /area/station/security/execution)
-"aBR" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics Maintenance";
-	req_access_txt = "12;24"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
 "aBS" = (
 /obj/structure/table/reinforced,
 /obj/item/flashlight/lamp,
@@ -9650,18 +9761,27 @@
 /turf/simulated/floor/plasteel/airless,
 /area/space/nearstation)
 "aBU" = (
-/obj/machinery/light_construct/small{
-	dir = 8
+/obj/structure/table/wood,
+/obj/item/storage/photo_album{
+	pixel_y = -10
 	},
-/obj/machinery/status_display{
-	layer = 4;
-	pixel_y = 32
+/obj/item/camera_film,
+/obj/item/camera_film,
+/obj/item/camera{
+	desc = "A one use - polaroid camera. 30 photos left.";
+	name = "detectives camera";
+	pictures_left = 30
 	},
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
+/obj/machinery/requests_console{
+	name = "Detective Requests Console";
+	pixel_y = -30;
+	department = "Detective";
+	departmentType = 5
 	},
-/area/station/maintenance/abandonedbar)
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/station/security/detective)
 "aBV" = (
 /turf/simulated/floor/wood{
 	broken = 1;
@@ -9669,21 +9789,20 @@
 	},
 /area/station/maintenance/abandonedbar)
 "aBW" = (
-/obj/structure/sink/kitchen{
-	pixel_y = 25
-	},
-/obj/machinery/light_construct/small{
-	dir = 4
-	},
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
-/area/station/maintenance/abandonedbar)
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/carpet/black,
+/area/station/service/chapel/office)
 "aBX" = (
-/obj/item/trash/liquidfood,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/light_switch{
+	name = "north bump";
+	pixel_y = 24
+	},
 /turf/simulated/floor/wood,
-/area/station/maintenance/abandonedbar)
+/area/station/service/clown)
 "aBY" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
@@ -9772,7 +9891,9 @@
 	},
 /area/station/legal/magistrate)
 "aCh" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
 "aCi" = (
@@ -9908,14 +10029,15 @@
 	},
 /area/station/hallway/primary/fore)
 "aCw" = (
-/obj/structure/bed,
-/obj/machinery/flasher{
-	id = "Cell 5";
-	pixel_y = -28
+/obj/machinery/light_switch{
+	dir = 1;
+	name = "south bump";
+	pixel_y = -24
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel,
-/area/station/security/prison/cell_block/A)
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/security/interrogation)
 "aCx" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -9923,10 +10045,19 @@
 	},
 /area/station/hallway/primary/fore)
 "aCz" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
+/obj/machinery/disposal,
+/obj/machinery/light_switch{
+	dir = 1;
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/station/security/detective)
 "aCB" = (
 /obj/docking_port/stationary{
 	dir = 4;
@@ -10000,59 +10131,53 @@
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "aCL" = (
-/obj/machinery/recharge_station,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/electrical)
-"aCM" = (
-/obj/item/shard,
-/obj/item/stack/rods,
-/obj/item/airlock_electronics,
-/turf/simulated/floor/plating{
-	dir = 9;
-	icon_regular_floor = "escape"
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Diner"
 	},
-/area/station/maintenance/abandonedbar)
-"aCN" = (
-/obj/effect/decal/cleanable/fungus,
-/turf/simulated/wall,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel,
+/area/station/service/bar)
+"aCM" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12";
+	name = "Old Bar Office"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/service/bar,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
 /area/station/maintenance/abandonedbar)
 "aCO" = (
-/obj/machinery/economy/vending/autodrobe,
+/obj/machinery/light_switch{
+	name = "north bump";
+	pixel_y = 24
+	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/abandonedbar)
-"aCP" = (
-/obj/effect/spawner/random_spawners/wall_rusted_always,
-/turf/simulated/wall,
-/area/station/maintenance/abandonedbar)
+/area/station/maintenance/electrical)
 "aCQ" = (
-/obj/structure/window/reinforced{
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/plating{
-	dir = 5;
-	icon_regular_floor = "escape"
-	},
-/area/station/maintenance/abandonedbar)
-"aCR" = (
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "escape"
+	icon_state = "dark"
 	},
-/area/station/maintenance/abandonedbar)
+/area/station/security/brig)
 "aCS" = (
-/obj/item/lighter/random,
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
+/obj/machinery/light,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralcorner"
 	},
-/area/station/maintenance/abandonedbar)
+/area/station/public/dorms)
 "aCU" = (
 /obj/item/stack/sheet/mineral/plasma{
 	amount = 10
@@ -10077,11 +10202,14 @@
 /turf/simulated/floor/wood,
 /area/station/maintenance/abandonedbar)
 "aCW" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/bottle/patron,
-/obj/item/storage/fancy/cigarettes/cigpack_shadyjims,
-/turf/simulated/floor/plating,
-/area/station/maintenance/abandonedbar)
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/station/service/library)
 "aCZ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light{
@@ -10229,11 +10357,6 @@
 	},
 /area/station/hallway/primary/fore)
 "aDo" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/alarm{
 	dir = 4;
@@ -10241,49 +10364,58 @@
 	pixel_x = -24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "rampbottom"
 	},
 /area/station/security/prison/cell_block/A)
-"aDp" = (
-/obj/structure/closet/crate,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/effect/spawner/lootdrop/maintenance/two,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
 "aDq" = (
-/obj/machinery/space_heater,
-/obj/structure/sign/poster/contraband/random{
-	pixel_x = -32
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/starboard/west)
 "aDr" = (
-/obj/structure/rack,
-/obj/item/poster/random_contraband,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
-"aDs" = (
-/turf/simulated/floor/plating,
-/area/station/maintenance/abandonedbar)
-"aDt" = (
-/obj/structure/table/wood,
-/obj/item/lipstick/random,
-/obj/structure/sign/poster/contraband/random{
-	pixel_x = -32
+/obj/effect/landmark/start/mime,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
 	},
-/obj/machinery/light_construct/small{
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/chair/office/dark,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/plasteel{
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
+	},
+/area/station/service/mime)
+"aDs" = (
+/obj/structure/chair/office/dark,
+/obj/item/radio/intercom{
+	name = "north bump";
+	pixel_y = 28
+	},
+/obj/effect/landmark/start/detective,
+/turf/simulated/floor/carpet,
+/area/station/security/detective)
+"aDt" = (
+/obj/structure/chair{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/abandonedbar)
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/plasteel,
+/area/station/public/dorms)
 "aDu" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -10437,29 +10569,38 @@
 	},
 /area/station/legal/magistrate)
 "aDV" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "escape"
+	icon_state = "dark"
 	},
-/area/station/maintenance/abandonedbar)
+/area/station/service/chapel)
 "aDW" = (
-/obj/structure/door_assembly,
-/turf/simulated/floor/plating,
-/area/station/maintenance/abandonedbar)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/station/security/detective)
 "aDX" = (
-/obj/item/shard{
-	icon_state = "small"
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/item/stack/rods,
-/turf/simulated/floor/plating{
-	dir = 4;
-	icon_regular_floor = "escape"
+/turf/simulated/floor/plasteel{
+	icon_state = "cult"
 	},
-/area/station/maintenance/abandonedbar)
+/area/station/service/chapel/office)
 "aDY" = (
-/obj/item/stack/tile/plasteel,
-/turf/simulated/floor/plating,
-/area/station/maintenance/abandonedbar)
+/obj/structure/table/wood,
+/obj/item/ashtray/bronze,
+/obj/item/storage/fancy/cigarettes/dromedaryco,
+/obj/item/radio/intercom/department/security{
+	pixel_x = -28
+	},
+/turf/simulated/floor/carpet,
+/area/station/security/detective)
 "aDZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -10471,10 +10612,6 @@
 	broken = 1;
 	icon_state = "wood-broken"
 	},
-/area/station/maintenance/abandonedbar)
-"aEc" = (
-/obj/machinery/economy/vending/boozeomat,
-/turf/simulated/floor/plating,
 /area/station/maintenance/abandonedbar)
 "aEd" = (
 /obj/structure/cable{
@@ -10502,12 +10639,9 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/fore)
 "aEi" = (
-/obj/machinery/economy/vending/cigarette,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "darkred"
-	},
-/area/station/hallway/primary/fore)
+/obj/machinery/economy/vending/boozeomat,
+/turf/simulated/floor/wood,
+/area/station/maintenance/abandonedbar)
 "aEj" = (
 /turf/simulated/wall,
 /area/station/hallway/primary/fore)
@@ -10518,55 +10652,35 @@
 "aEl" = (
 /turf/simulated/wall,
 /area/station/legal/courtroom)
-"aEm" = (
-/obj/structure/table/wood/poker,
-/obj/item/ashtray/bronze,
-/turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "darkred"
-	},
-/area/station/hallway/primary/fore)
 "aEn" = (
-/obj/structure/chair/office/dark,
-/obj/machinery/light{
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/landmark/start/detective,
-/turf/simulated/floor/carpet,
-/area/station/security/detective)
+/turf/simulated/floor/plasteel,
+/area/station/security/prison/cell_block/A)
 "aEo" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
+/obj/machinery/camera{
+	c_tag = "Brig Cell 5";
+	dir = 6
 	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/carpet,
-/area/station/security/detective)
+/obj/structure/bed,
+/turf/simulated/floor/plating,
+/area/station/security/prison/cell_block/A)
 "aEp" = (
-/obj/item/radio/intercom{
-	name = "east bump";
-	pixel_x = 28
+/obj/structure/closet/secure_closet/brig{
+	id = "Cell 4";
+	name = "Cell 4 Locker"
 	},
-/obj/machinery/computer/security/wooden_tv{
-	network = list("SS13","Research Outpost","Mining Outpost")
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
-/obj/machinery/button/windowtint{
-	id = "Detective";
-	pixel_x = -8;
-	pixel_y = 24;
-	req_access_txt = "4"
-	},
-/turf/simulated/floor/carpet,
-/area/station/security/detective)
+/obj/effect/decal/cleanable/cobweb2,
+/turf/simulated/floor/plasteel,
+/area/station/security/prison/cell_block/A)
 "aEq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -10575,25 +10689,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkredcorners"
 	},
 /area/station/security/prison/cell_block/A)
 "aEr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -10601,38 +10701,35 @@
 	},
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/structure/disposalpipe/segment,
+/obj/machinery/door_timer/cell_5{
+	pixel_x = -32
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkredcorners"
 	},
 /area/station/security/prison/cell_block/A)
 "aEs" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/door/airlock/external{
+	id_tag = "barmaint_door_ext";
+	locked = 1;
+	name = "External Access";
+	req_access_txt = "13"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/fore)
+/area/station/maintenance/fsmaint)
 "aEt" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Security Maintenance";
 	req_access_txt = "63";
 	security_level = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10641,57 +10738,43 @@
 	id_tag = "Secure Gate";
 	name = "Security Blast Door"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
-"aEu" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
 "aEv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
-"aEw" = (
-/obj/item/storage/toolbox/emergency,
-/obj/structure/table,
-/obj/machinery/light/small,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
-"aEx" = (
-/obj/item/storage/fancy/crayons,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
-"aEy" = (
-/obj/item/poster/random_contraband,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
-"aEz" = (
-/obj/structure/table/wood,
-/obj/structure/mirror{
-	pixel_x = -28
-	},
-/obj/item/storage/pill_bottle/random_drug_bottle,
-/turf/simulated/floor/plating,
-/area/station/maintenance/abandonedbar)
-"aEA" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+	icon_state = "dark"
 	},
-/area/station/security/detective)
+/area/station/maintenance/fore)
+"aEz" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "showroomfloor"
+	},
+/area/station/service/kitchen)
+"aEA" = (
+/obj/structure/table/wood,
+/obj/item/book/manual/wiki/sop_service,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/station/service/library)
 "aEC" = (
 /obj/structure/chair/stool{
 	dir = 1
@@ -10747,7 +10830,7 @@
 	},
 /area/station/maintenance/fpmaint2)
 "aEI" = (
-/obj/structure/chair/comfy/black,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
 "aEJ" = (
@@ -10789,79 +10872,50 @@
 /obj/effect/spawner/random_spawners/cobweb_left_frequent,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
-"aES" = (
-/obj/structure/chair/stool{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "whitecorner"
-	},
-/area/station/maintenance/abandonedbar)
 "aET" = (
 /obj/effect/spawner/random_spawners/cobweb_right_rare,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
 "aEU" = (
-/obj/item/shard{
-	icon_state = "medium"
-	},
-/turf/simulated/floor/plating{
-	dir = 10;
-	icon_regular_floor = "escape"
-	},
-/area/station/maintenance/abandonedbar)
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/electrical)
 "aEV" = (
-/obj/structure/window/reinforced{
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/electrical)
+"aEW" = (
+/obj/machinery/cryopod,
+/obj/machinery/light{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "escape"
-	},
-/area/station/maintenance/abandonedbar)
-"aEW" = (
-/obj/item/stack/rods,
-/turf/simulated/floor/plasteel{
-	icon_state = "escape"
-	},
-/area/station/maintenance/abandonedbar)
-"aEX" = (
-/obj/item/trash/pistachios,
-/obj/machinery/light_construct,
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
-/area/station/maintenance/abandonedbar)
-"aEY" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/station/maintenance/electrical)
-"aEZ" = (
-/obj/machinery/light,
-/obj/machinery/light_switch{
 	dir = 1;
-	name = "south bump";
-	pixel_y = -24
+	icon_state = "whitegreencorner"
 	},
+/area/station/public/sleep)
+"aEX" = (
+/obj/structure/girder,
 /turf/simulated/floor/plating,
-/area/station/maintenance/abandonedbar)
+/area/station/maintenance/fsmaint)
 "aFa" = (
-/obj/structure/sign/poster/contraband/random{
-	pixel_x = 32
-	},
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
-/area/station/maintenance/abandonedbar)
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel,
+/area/station/public/dorms)
 "aFb" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/condiment/saltshaker,
-/obj/item/reagent_containers/food/condiment/peppermill,
-/turf/simulated/floor/plating,
-/area/station/maintenance/abandonedbar)
+/obj/machinery/newscaster{
+	dir = 4;
+	name = "west bump";
+	pixel_x = -28
+	},
+/turf/simulated/floor/carpet/black,
+/area/station/service/chapel/office)
 "aFc" = (
 /obj/structure/chair/stool,
 /obj/structure/sign/poster/contraband/random{
@@ -10869,9 +10923,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
-"aFd" = (
-/turf/simulated/wall/r_wall,
-/area/station/maintenance/abandonedbar)
 "aFg" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -10913,10 +10964,11 @@
 	},
 /area/station/legal/magistrate)
 "aFn" = (
+/obj/structure/railing/cap/normal,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "neutralcorner"
 	},
-/area/station/security/interrogation)
+/area/station/public/dorms)
 "aFo" = (
 /obj/machinery/light_switch{
 	dir = 4;
@@ -11004,10 +11056,14 @@
 	},
 /area/station/legal/magistrate)
 "aFw" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
 	},
-/area/station/hallway/primary/fore)
+/obj/item/camera_film,
+/turf/simulated/floor/wood,
+/area/station/service/library)
 "aFx" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -11028,24 +11084,28 @@
 	},
 /area/station/hallway/primary/fore)
 "aFz" = (
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "Processing"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/effect/spawner/window/reinforced/polarized{
-	id = "Detective"
-	},
 /turf/simulated/floor/plating,
-/area/station/security/detective)
+/area/station/security/prison/cell_block/A)
 "aFA" = (
-/obj/structure/chair{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "darkred"
+	dir = 1;
+	icon_state = "green"
 	},
-/area/station/hallway/primary/fore)
+/area/station/hallway/primary/starboard/west)
 "aFB" = (
 /obj/structure/table/wood,
 /obj/item/book/manual/wiki/security_space_law,
@@ -11054,104 +11114,100 @@
 /area/station/security/detective)
 "aFC" = (
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 2;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet,
-/area/station/security/detective)
+/obj/machinery/power/treadmill{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/treadmill_monitor{
+	id = "Cell 5";
+	pixel_y = -32
+	},
+/turf/simulated/floor/plasteel,
+/area/station/security/prison/cell_block/A)
 "aFD" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp/green{
-	on = 0;
-	pixel_x = -3;
-	pixel_y = 8
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/item/storage/fancy/cigarettes/dromedaryco,
-/obj/item/ashtray/bronze,
-/obj/item/radio/intercom/department/security{
-	pixel_x = 28
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
 	},
-/turf/simulated/floor/carpet,
-/area/station/security/detective)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/plasteel,
+/area/station/security/prison/cell_block/A)
 "aFE" = (
-/obj/structure/cable,
-/obj/effect/spawner/window/reinforced/polarized{
-	id = "Detective"
+/turf/simulated/floor/plasteel{
+	icon_state = "darkredcorners"
 	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Secure Gate";
-	name = "Security Blast Door"
-	},
-/turf/simulated/floor/plating,
-/area/station/security/detective)
+/area/station/security/prison/cell_block/A)
 "aFF" = (
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/fore)
 "aFG" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security{
-	name = "Detective's Office";
-	req_access_txt = "4"
-	},
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Secure Gate";
-	name = "Security Blast Door"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+	dir = 8;
+	icon_state = "darkredcorners"
 	},
 /area/station/security/prison/cell_block/A)
 "aFH" = (
-/obj/structure/grille,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
+/obj/machinery/economy/vending/chinese,
+/turf/simulated/floor/carpet,
+/area/station/public/mrchangs)
 "aFI" = (
 /turf/simulated/wall,
 /area/station/public/arcade)
 "aFJ" = (
-/turf/simulated/wall/r_wall,
-/area/station/public/dorms)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
+	},
+/area/station/service/mime)
 "aFK" = (
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
-/area/station/public/dorms)
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/carpet,
+/area/station/public/mrchangs)
 "aFL" = (
 /turf/simulated/wall/r_wall,
 /area/station/security/evidence)
 "aFM" = (
-/obj/structure/sign/poster/contraband/random{
-	pixel_x = -32
-	},
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
-"aFN" = (
-/obj/item/toy/crayon/random,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/carpet,
+/area/station/public/mrchangs)
 "aFO" = (
-/obj/item/toy/crayon/spraycan,
-/obj/structure/table,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
-"aFP" = (
-/turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "purple"
+/obj/machinery/light{
+	dir = 1
 	},
-/area/station/maintenance/abandonedbar)
+/obj/structure/table,
+/obj/item/storage/firstaid/regular,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/public/dorms)
 "aFQ" = (
 /obj/machinery/camera{
 	c_tag = "Fore Port Solar Control";
@@ -11250,19 +11306,27 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
 "aGc" = (
-/obj/structure/mineral_door/wood{
-	name = "Abandoned Bar"
+/obj/structure/chair/comfy/black{
+	dir = 4
 	},
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/area/station/maintenance/abandonedbar)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/service/chapel)
 "aGd" = (
-/obj/effect/decal/cleanable/fungus,
-/obj/effect/spawner/random_spawners/wall_rusted_always,
-/turf/simulated/wall,
-/area/station/maintenance/abandonedbar)
+/obj/structure/toilet{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "aGe" = (
 /obj/structure/table,
 /obj/item/restraints/handcuffs/cable,
@@ -11373,90 +11437,38 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/fore)
-"aGy" = (
-/obj/structure/chair/stool{
+"aGz" = (
+/obj/machinery/power/smes,
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/electrical)
+"aGB" = (
+/obj/machinery/power/smes,
+/obj/structure/cable,
+/turf/simulated/floor/plating,
+/area/station/maintenance/electrical)
+"aGC" = (
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
+/obj/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet,
-/area/station/security/detective)
-"aGz" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/carpet,
-/area/station/security/detective)
-"aGA" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/camera{
-	c_tag = "Brig Detective's Office"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/station/security/detective)
-"aGB" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet,
-/area/station/security/detective)
-"aGC" = (
-/obj/machinery/economy/vending/detdrobe,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/station/security/detective)
+/turf/simulated/floor/wood,
+/area/station/service/library)
 "aGD" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/item/radio/intercom{
+	name = "south bump";
+	pixel_y = -28
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/station/security/detective)
-"aGE" = (
-/obj/machinery/status_display{
-	layer = 4;
-	pixel_y = 32
-	},
-/obj/machinery/computer/med_data,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/station/security/detective)
+/turf/simulated/floor/carpet,
+/area/station/public/mrchangs)
 "aGF" = (
 /obj/machinery/computer/secure_data,
 /turf/simulated/floor/plasteel{
@@ -11464,32 +11476,29 @@
 	},
 /area/station/security/detective)
 "aGG" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
+/area/station/service/chapel/office)
 "aGH" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
+/area/station/security/detective)
 "aGK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_x = 1;
+	pixel_y = 9
+	},
+/obj/item/pen,
+/turf/simulated/floor/wood,
+/area/station/service/library)
 "aGN" = (
 /turf/simulated/floor/carpet/arcade,
 /area/station/public/arcade)
@@ -11502,36 +11511,37 @@
 /area/station/maintenance/auxsolarstarboard)
 "aGU" = (
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
 	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/sign/vacuum/external{
-	pixel_y = 32
-	},
-/obj/machinery/power/solar_control{
-	name = "Fore Starboard Solar Control"
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarstarboard)
 "aGV" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/machinery/light_construct/small{
+	dir = 8
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/decal/cleanable/blood/old,
+/obj/item/chair/wood,
+/obj/effect/decal/remains/human{
+	desc = "This guy seemed to have died in terrible way! Half his remains are dust.";
+	name = "human remains"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/electrical)
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/station/maintenance/abandonedbar)
 "aGW" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 8
 	},
 /obj/machinery/atmospherics/portable/canister/air,
+/obj/effect/spawner/random_spawners/cobweb_right_frequent,
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarstarboard)
 "aGX" = (
@@ -11545,36 +11555,37 @@
 /turf/simulated/floor/carpet/arcade,
 /area/station/public/arcade)
 "aHb" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/turf/simulated/floor/wood,
+/area/station/public/mrchangs)
 "aHc" = (
-/obj/structure/rack,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "cautioncorner"
+	},
+/area/station/public/dorms)
 "aHd" = (
-/obj/item/toy/crayon/white,
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/chair/stool,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralcorner"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/area/station/public/dorms)
 "aHe" = (
-/obj/structure/sign/poster/contraband/random{
-	pixel_x = 32
-	},
-/obj/structure/chair/stool{
-	dir = 8
+/obj/structure/cable,
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "Processing"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/area/station/security/interrogation)
 "aHf" = (
-/obj/structure/table,
-/obj/item/poster/random_contraband,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Hydroponics";
+	req_access_txt = "35"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel,
+/area/station/service/hydroponics)
 "aHg" = (
 /obj/structure/sign/electricshock,
 /turf/simulated/wall/r_wall,
@@ -11768,37 +11779,32 @@
 "aHI" = (
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarstarboard)
 "aHJ" = (
 /obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/terminal,
-/obj/machinery/light/small{
-	dir = 4
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarstarboard)
 "aHK" = (
-/obj/structure/chair/stool{
-	dir = 1
+/obj/machinery/status_display{
+	pixel_y = -32
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/auxsolarstarboard)
+/turf/simulated/floor/plasteel{
+	icon_state = "caution"
+	},
+/area/station/public/dorms)
 "aHL" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/electrical)
+/area/station/maintenance/abandonedbar)
 "aHM" = (
 /obj/machinery/atmospherics/trinary/filter{
 	dir = 4
@@ -11810,13 +11816,29 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "aHO" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/plating,
+/obj/structure/railing/cap/reversed{
+	dir = 4
+	},
+/obj/effect/spawner/random_spawners/cobweb_left_rare,
+/turf/simulated/floor/plasteel{
+	icon_state = "black";
+	dir = 8
+	},
 /area/station/maintenance/fsmaint)
 "aHP" = (
-/obj/effect/decal/cleanable/fungus,
-/turf/simulated/wall,
-/area/station/maintenance/fsmaint)
+/obj/machinery/cryopod{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	name = "south bump";
+	pixel_y = -24
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whitegreencorner"
+	},
+/area/station/public/sleep)
 "aHQ" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
@@ -11846,92 +11868,60 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
 "aHW" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/carpet,
-/area/station/security/detective)
-"aHX" = (
-/obj/machinery/hologram/holopad,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/station/security/detective)
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/bottle/patron,
+/obj/item/storage/fancy/cigarettes/cigpack_shadyjims,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/station/maintenance/abandonedbar)
 "aHZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/station/security/detective)
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "aIb" = (
-/obj/structure/chair/stool{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+	icon_state = "neutralcorner"
 	},
-/area/station/security/detective)
+/area/station/public/dorms)
 "aIc" = (
 /turf/simulated/wall,
 /area/station/service/clown)
 "aId" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
-/area/station/maintenance/fore)
+/area/station/maintenance/electrical)
 "aIe" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/station/service/clown)
-"aIg" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Detective Maintenance";
-	req_access_txt = "4";
-	security_level = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
 "aIh" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/station/service/mime)
 "aIi" = (
-/obj/structure/rack{
-	dir = 1
+/obj/structure/railing/cap/reversed,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralcorner"
 	},
-/obj/item/storage/box/evidence,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
+/area/station/public/dorms)
 "aIl" = (
 /turf/simulated/wall,
 /area/station/legal/magistrate)
@@ -11951,10 +11941,6 @@
 /obj/effect/landmark/start/assistant,
 /turf/simulated/floor/carpet/arcade,
 /area/station/public/arcade)
-"aIq" = (
-/obj/effect/decal/cleanable/fungus,
-/turf/simulated/wall,
-/area/station/maintenance/fore)
 "aIr" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -11990,10 +11976,12 @@
 /turf/simulated/floor/carpet/arcade,
 /area/station/public/arcade)
 "aIv" = (
-/obj/structure/rack,
-/obj/item/tank/internals/air,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/area/station/public/arcade)
 "aIw" = (
 /obj/machinery/camera{
 	c_tag = "Fore Port Solar Access"
@@ -12006,61 +11994,95 @@
 	},
 /area/station/maintenance/fpmaint2)
 "aIA" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/machinery/power/terminal{
+	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
+/obj/structure/cable,
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarstarboard)
 "aIB" = (
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/structure/chair/stool{
+	dir = 8
 	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump Engineering";
-	pixel_x = -24;
-	shock_proof = 1
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarstarboard)
 "aIC" = (
-/obj/machinery/camera{
-	c_tag = "Fore Starboard Solars";
-	dir = 1
-	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/machinery/power/smes,
+/obj/structure/cable,
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarstarboard)
 "aID" = (
-/obj/structure/closet/wardrobe/mixed,
-/obj/item/clothing/shoes/jackboots,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/machinery/status_display{
+	pixel_y = 32
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralcorner"
+	},
+/area/station/public/dorms)
 "aIE" = (
-/obj/effect/spawner/window,
+/obj/structure/cable/blue{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/blue{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/blue{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/blue{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/blue{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/blue{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/blue{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/blue{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/blue,
+/obj/structure/cable/blue{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/effect/decal/warning_stripes/white/hollow,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "aIF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/firealarm{
+	name = "north bump";
+	pixel_y = 24
 	},
-/obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutralcorner"
 	},
-/turf/simulated/floor/plasteel,
 /area/station/public/dorms)
 "aIH" = (
 /turf/simulated/floor/wood{
@@ -12192,12 +12214,11 @@
 /turf/simulated/floor/carpet,
 /area/station/legal/courtroom)
 "aIY" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
+/turf/simulated/floor/plasteel,
+/area/station/public/dorms)
 "aIZ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -12248,11 +12269,10 @@
 /area/station/hallway/primary/fore)
 "aJh" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/plasteel,
 /area/station/hallway/primary/fore)
 "aJi" = (
 /obj/structure/cable{
@@ -12266,129 +12286,88 @@
 /turf/simulated/floor/carpet,
 /area/station/legal/courtroom)
 "aJj" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Chapel"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "darkred"
-	},
-/area/station/hallway/primary/fore)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel,
+/area/station/service/chapel)
 "aJk" = (
-/obj/item/folder/red{
-	pixel_y = 3
-	},
-/obj/item/hand_labeler,
-/obj/item/storage/box/evidence,
-/obj/structure/table/wood,
-/obj/item/radio/intercom/department/security{
-	pixel_y = -28
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/station/security/detective)
-"aJl" = (
-/obj/machinery/light_switch{
-	dir = 1;
-	name = "south bump";
-	pixel_y = -24
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/station/security/detective)
-"aJm" = (
-/obj/structure/table/wood,
-/obj/item/storage/photo_album{
-	pixel_y = -10
-	},
-/obj/item/camera_film,
-/obj/item/camera_film,
-/obj/item/camera{
-	desc = "A one use - polaroid camera. 30 photos left.";
-	name = "detectives camera";
-	pictures_left = 30
-	},
-/obj/machinery/requests_console{
-	name = "Detective Requests Console";
-	pixel_y = -30;
-	department = "Detective";
-	departmentType = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/station/security/detective)
-"aJn" = (
-/obj/machinery/alarm{
-	dir = 1;
-	name = "south bump";
-	pixel_y = -24
-	},
-/obj/structure/closet/secure_closet{
-	anchored = 1;
-	name = "Evidence Storage";
-	req_access_txt = "4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/station/security/detective)
-"aJo" = (
-/obj/machinery/newscaster/security_unit{
-	dir = 8;
-	name = "east bump";
-	pixel_x = 28
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/station/security/detective)
-"aJp" = (
+/obj/machinery/door/airlock/public/glass,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
-"aJq" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/pen,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
-"aJu" = (
-/obj/item/kirbyplants,
 /turf/simulated/floor/plasteel{
-	icon_state = "barber"
+	icon_state = "dark"
 	},
-/area/station/service/barber)
+/area/station/public/dorms)
+"aJl" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/machinery/flasher{
+	id = "Cell 5";
+	pixel_y = -28
+	},
+/turf/simulated/floor/plasteel,
+/area/station/security/prison/cell_block/A)
+"aJm" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/station/security/detective)
+"aJo" = (
+/obj/structure/chair/stool{
+	dir = 4
+	},
+/obj/effect/landmark/start/botanist,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/service/hydroponics)
+"aJq" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/security/interrogation)
+"aJu" = (
+/obj/machinery/light_construct/small{
+	dir = 4
+	},
+/turf/simulated/floor/wood{
+	broken = 1;
+	icon_state = "wood-broken"
+	},
+/area/station/maintenance/abandonedbar)
 "aJv" = (
 /obj/machinery/gameboard,
 /obj/structure/sign/poster/contraband/random{
@@ -12415,24 +12394,17 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/public/arcade)
-"aJD" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+"aJE" = (
+/obj/machinery/power/solar_control{
+	name = "Fore Starboard Solar Control";
+	dir = 4
 	},
-/obj/machinery/door/airlock/engineering{
-	name = "Fore Starboard Solar Access";
-	req_access_txt = "10"
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarstarboard)
-"aJE" = (
-/obj/structure/sign/poster/contraband/random{
-	pixel_x = -32
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
 "aJF" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -12450,9 +12422,13 @@
 /turf/simulated/floor/plasteel,
 /area/station/legal/courtroom)
 "aJH" = (
-/obj/structure/sign/electricshock,
-/turf/simulated/wall/r_wall,
-/area/station/maintenance/auxsolarstarboard)
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/landmark/start/assistant,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel,
+/area/station/public/dorms)
 "aJI" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plating,
@@ -12469,23 +12445,67 @@
 /turf/simulated/floor/plasteel,
 /area/station/legal/courtroom)
 "aJK" = (
-/obj/effect/decal/cleanable/cobweb2,
-/turf/simulated/floor/plating,
+/obj/item/stack/cable_coil/pink,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "vault"
+	},
 /area/station/maintenance/fsmaint)
 "aJL" = (
-/obj/machinery/economy/slot_machine,
-/obj/item/coin/iron,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/obj/structure/morgue{
+	dir = 8
+	},
+/obj/effect/landmark/spawner/rev,
+/turf/simulated/floor/plasteel{
+	icon_state = "cult"
+	},
+/area/station/service/chapel/office)
 "aJM" = (
-/obj/structure/closet/firecloset,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/security/brig)
 "aJN" = (
-/obj/item/coin/gold,
-/obj/effect/decal/cleanable/cobweb,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/station/service/bar)
 "aJO" = (
 /obj/item/garrote/improvised,
 /turf/simulated/floor/plating,
@@ -12554,22 +12574,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
 "aKg" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/fore)
+/obj/effect/spawner/random_spawners/fungus_maybe,
+/turf/simulated/wall,
+/area/station/public/dorms)
 "aKh" = (
 /obj/structure/chair/office/dark,
 /obj/effect/spawner/random_spawners/cobweb_right_rare,
@@ -12601,12 +12608,24 @@
 /turf/simulated/floor/carpet,
 /area/station/legal/courtroom)
 "aKm" = (
-/obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/wood,
 /area/station/service/clown)
 "aKn" = (
-/turf/simulated/floor/wood,
-/area/station/service/clown)
+/obj/machinery/door/window/reinforced/normal{
+	name = "Forensics Morgue";
+	req_access_txt = "4";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/station/security/detective)
 "aKo" = (
 /obj/structure/disposalpipe/junction{
 	dir = 1;
@@ -12687,34 +12706,34 @@
 	},
 /area/station/legal/magistrate)
 "aKy" = (
-/obj/item/kirbyplants,
-/turf/simulated/floor/plasteel{
-	icon_state = "darkred"
-	},
-/area/station/hallway/primary/fore)
-"aKz" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "bluecorner"
-	},
-/area/station/hallway/primary/fore)
-"aKA" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "darkred"
+	icon_state = "bluecorner"
 	},
 /area/station/hallway/primary/fore)
+"aKz" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
+"aKA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "green"
+	},
+/area/station/service/hydroponics)
 "aKB" = (
 /obj/structure/closet/secure_closet/detective,
 /obj/item/restraints/handcuffs,
@@ -12724,37 +12743,16 @@
 	},
 /area/station/security/detective)
 "aKC" = (
-/obj/machinery/photocopier,
-/obj/machinery/light,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/station/security/detective)
+/obj/structure/chair,
+/obj/effect/landmark/start/chaplain,
+/turf/simulated/floor/carpet/black,
+/area/station/service/chapel/office)
 "aKD" = (
-/obj/structure/filingcabinet/chestdrawer,
-/obj/machinery/ai_status_display{
-	pixel_y = -32
+/obj/structure/chair/wood{
+	dir = 8
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/station/security/detective)
-"aKE" = (
-/obj/structure/table,
-/obj/item/hand_labeler,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
-"aKH" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
+/turf/simulated/floor/wood,
+/area/station/public/mrchangs)
 "aKI" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -12762,22 +12760,30 @@
 /turf/simulated/floor/carpet/arcade,
 /area/station/public/arcade)
 "aKJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/structure/chair{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/station/maintenance/electrical)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/security/interrogation)
 "aKK" = (
 /obj/machinery/economy/arcade/claw,
 /turf/simulated/floor/carpet/arcade,
 /area/station/public/arcade)
 "aKM" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+/obj/structure/filingcabinet/chestdrawer,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/electrical)
+/area/station/security/detective)
 "aKN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -12786,79 +12792,114 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
 "aKP" = (
-/obj/machinery/atmospherics/meter,
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
-"aKQ" = (
-/obj/machinery/camera{
-	c_tag = "Holodeck West";
-	dir = 4
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "44"
 	},
-/turf/simulated/floor/plasteel,
-/area/station/public/dorms)
-"aKS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
-"aKT" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
+/area/station/maintenance/fore)
+"aKQ" = (
+/obj/machinery/camera{
+	c_tag = "Chapel Chaplain's Office"
 	},
-/obj/structure/cable{
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/station/service/chapel/office)
+"aKS" = (
+/obj/machinery/cryopod,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "whitegreen"
+	},
+/area/station/public/sleep)
+"aKT" = (
+/obj/machinery/computer/med_data,
+/obj/machinery/status_display{
+	layer = 4;
+	pixel_y = 32
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/station/security/detective)
+"aKU" = (
+/obj/effect/decal/warning_stripes/white/hollow,
+/obj/structure/cable/pink,
+/obj/structure/cable/pink{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/cable/pink{
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance/eight,
-/obj/effect/decal/cleanable/cobweb,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
-"aKU" = (
-/obj/structure/table,
-/obj/item/pen,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
-"aKV" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
+/obj/structure/cable/pink{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/pink{
+	d2 = 4;
+	icon_state = "1-4";
+	d1 = 1
+	},
+/obj/structure/cable/pink{
+	d2 = 8;
+	icon_state = "1-8";
+	d1 = 1
+	},
+/obj/structure/cable/pink{
+	d2 = 4;
+	icon_state = "2-4";
+	d1 = 2
+	},
+/obj/structure/cable/pink{
+	d2 = 8;
+	icon_state = "2-8";
+	d1 = 2
+	},
+/obj/structure/cable/pink{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/pink{
+	d2 = 8;
+	icon_state = "4-8";
+	d1 = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
+"aKV" = (
+/obj/machinery/light_switch{
+	name = "north bump";
+	pixel_y = 24
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/station/service/chapel/office)
 "aKW" = (
 /obj/effect/spawner/random_spawners/fungus_maybe,
 /turf/simulated/wall,
 /area/station/maintenance/fpmaint2)
 "aKX" = (
-/obj/structure/chair/stool{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/obj/item/lighter/random,
+/turf/simulated/floor/wood,
+/area/station/maintenance/abandonedbar)
 "aKY" = (
-/obj/structure/closet,
-/obj/item/coin/iron,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
-"aKZ" = (
-/obj/item/coin/gold,
-/obj/item/coin/iron,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/obj/structure/morgue{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "cult"
+	},
+/area/station/service/chapel/office)
 "aLb" = (
 /obj/machinery/status_display{
 	layer = 4;
@@ -12873,10 +12914,15 @@
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/pod_1)
 "aLc" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	name = "north bump";
+	pixel_y = 28
+	},
+/turf/simulated/floor/carpet,
+/area/station/public/mrchangs)
 "aLd" = (
 /turf/simulated/wall/r_wall,
 /area/station/hallway/secondary/entry)
@@ -12906,18 +12952,18 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
 "aLh" = (
+/obj/machinery/door/airlock/tranquillite{
+	name = "Mime's Office";
+	req_access_txt = "44"
+	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Detective";
-	req_access_txt = "4"
-	},
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "Detective"
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
 	},
-/area/station/security/detective)
+/area/station/service/mime)
 "aLi" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -13283,30 +13329,62 @@
 	},
 /area/station/legal/courtroom)
 "aMb" = (
-/obj/structure/cable{
-	d1 = 4;
+/obj/effect/decal/warning_stripes/white/hollow,
+/obj/structure/cable/green,
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/green{
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "0-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "1-2";
+	d1 = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "1-4";
+	d1 = 1
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "1-8";
+	d1 = 1
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "2-4";
+	d1 = 2
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "2-8";
+	d1 = 2
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "4-8";
+	d1 = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "aMc" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_x = -5;
+	pixel_y = 5;
+	name = "Petition Bin"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/item/pen,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
@@ -13315,51 +13393,33 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry)
 "aMe" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/electrical)
-"aMg" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Electrical Maintenance";
-	req_access_txt = "11"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkredcorners"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/electrical)
+/area/station/security/brig)
 "aMh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
 "aMi" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance/three,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "whitegreenfull"
+	},
+/area/station/public/sleep)
 "aMj" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance/two,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "vault"
+	},
+/area/station/maintenance/fsmaint)
 "aMk" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -13373,9 +13433,15 @@
 /turf/simulated/floor/plating,
 /area/station/security/lobby)
 "aMl" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/snacks/donut,
-/turf/simulated/floor/plating,
+/obj/item/stack/cable_coil/orange,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "vault"
+	},
 /area/station/maintenance/fsmaint)
 "aMn" = (
 /obj/machinery/door/airlock/maintenance{
@@ -13384,10 +13450,13 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "aMo" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 2;
+	pixel_y = 6
+	},
+/turf/simulated/floor/wood,
+/area/station/public/mrchangs)
 "aMp" = (
 /obj/item/radio/intercom{
 	name = "east bump";
@@ -13432,9 +13501,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
 "aMz" = (
-/obj/effect/spawner/random_spawners/wall_rusted_always,
-/turf/simulated/wall,
-/area/station/maintenance/fsmaint)
+/turf/simulated/floor/plasteel{
+	icon_state = "cult"
+	},
+/area/station/service/chapel/office)
 "aMA" = (
 /turf/simulated/wall,
 /area/station/maintenance/fpmaint)
@@ -13494,20 +13564,26 @@
 /turf/simulated/floor/carpet/arcade,
 /area/station/public/arcade)
 "aMK" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/railing/cap/normal{
+	dir = 8
 	},
-/obj/machinery/camera{
-	c_tag = "Fore Starboard Solar Access"
+/obj/effect/spawner/random_spawners/cobweb_right_rare,
+/turf/simulated/floor/plasteel{
+	icon_state = "black";
+	dir = 4
 	},
-/obj/structure/closet/emcloset,
-/turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "aML" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/universal,
-/obj/effect/spawner/random_barrier/obstruction,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "whitegreencorner"
+	},
+/area/station/public/sleep)
 "aMM" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -13659,34 +13735,77 @@
 /obj/machinery/atmospherics/portable/canister/air{
 	filled = 0.1
 	},
+/obj/effect/spawner/random_spawners/cobweb_right_frequent,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "aNh" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance/two,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/plasteel{
+	icon_state = "whitegreenfull"
+	},
+/area/station/public/sleep)
 "aNi" = (
-/mob/living/simple_animal/mouse,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/station/service/chapel/office)
 "aNj" = (
-/obj/structure/table,
+/obj/effect/decal/warning_stripes/white/hollow,
+/obj/structure/cable/orange,
+/obj/structure/cable/orange{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/cable/orange{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/orange{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/orange{
+	d2 = 2;
+	icon_state = "1-2";
+	d1 = 1
+	},
+/obj/structure/cable/orange{
+	d2 = 4;
+	icon_state = "1-4";
+	d1 = 1
+	},
+/obj/structure/cable/orange{
+	d2 = 8;
+	icon_state = "1-8";
+	d1 = 1
+	},
+/obj/structure/cable/orange{
+	d2 = 4;
+	icon_state = "2-4";
+	d1 = 2
+	},
+/obj/structure/cable/orange{
+	d2 = 8;
+	icon_state = "2-8";
+	d1 = 2
+	},
+/obj/structure/cable/orange{
+	d2 = 8;
+	icon_state = "4-8";
+	d1 = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "aNk" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/extinguisher_cabinet{
-	name = "east bump";
-	pixel_x = 27
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/electrical)
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/abandonedbar)
 "aNl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -13699,52 +13818,23 @@
 /turf/simulated/floor/carpet,
 /area/station/legal/courtroom)
 "aNm" = (
-/obj/machinery/power/port_gen/pacman,
-/turf/simulated/floor/plating,
-/area/station/maintenance/electrical)
-"aNn" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/landmark/burnturf,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/station/security/detective)
 "aNo" = (
 /turf/simulated/floor/mech_bay_recharge_floor,
 /area/station/maintenance/electrical)
 "aNp" = (
-/obj/machinery/mech_bay_recharge_port,
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/structure/reagent_dispensers/beerkeg,
+/obj/effect/spawner/random_spawners/cobweb_left_frequent,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/electrical)
-"aNq" = (
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/computer/mech_bay_power_console,
-/turf/simulated/floor/bluegrid,
-/area/station/maintenance/electrical)
-"aNr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/electrical)
-"aNs" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/station/maintenance/electrical)
+/area/station/maintenance/abandonedbar)
 "aNt" = (
 /obj/docking_port/mobile/pod{
 	id = "pod1";
@@ -13829,12 +13919,11 @@
 /turf/simulated/floor/plasteel,
 /area/station/legal/courtroom)
 "aNH" = (
-/obj/structure/chair/stool{
-	dir = 8
+/obj/machinery/atmospherics/unary/tank/air{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/station/maintenance/fore)
+/area/station/maintenance/fsmaint)
 "aNI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -13910,22 +13999,14 @@
 	icon_state = "bluecorner"
 	},
 /area/station/legal/courtroom)
-"aNQ" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/plasteel{
-	icon_state = "caution"
-	},
-/area/station/public/dorms)
 "aNR" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/curtain/open/shower{
+	icon_state = "closed"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/item/soap,
 /turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/area/station/maintenance/fore)
 "aNS" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -13949,23 +14030,15 @@
 	icon_state = "bluecorner"
 	},
 /area/station/hallway/primary/fore)
-"aNV" = (
-/obj/structure/chair/stool{
-	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
+"aOi" = (
+/obj/machinery/door/airlock{
+	name = "Crematorium";
+	req_access_txt = "27"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "caution"
+	icon_state = "cult"
 	},
-/area/station/public/dorms)
-"aOi" = (
-/obj/item/clothing/suit/officercoat,
-/obj/item/clothing/head/armyofficer,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/area/station/service/chapel/office)
 "aOj" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -13980,10 +14053,9 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/electrical)
 "aOl" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
@@ -14129,9 +14201,16 @@
 /turf/simulated/floor/plasteel,
 /area/station/legal/courtroom)
 "aOC" = (
-/obj/machinery/light/small,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/obj/structure/railing/cap/reversed{
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralcorner"
+	},
+/area/station/public/dorms)
 "aOD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
@@ -14145,25 +14224,34 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/port)
 "aOE" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/item/radio/intercom{
+	name = "south bump";
+	pixel_y = -28
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/turf/simulated/floor/plasteel,
+/area/station/security/processing)
 "aOF" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/simulated/floor/plating,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "vault"
+	},
 /area/station/maintenance/fsmaint)
 "aOG" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/public/dorms)
 "aOH" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
@@ -14172,38 +14260,27 @@
 /turf/simulated/wall,
 /area/station/public/dorms)
 "aOJ" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/machinery/bottler,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/station/maintenance/electrical)
+/area/station/maintenance/abandonedbar)
 "aOK" = (
-/obj/structure/table,
-/obj/item/clothing/gloves/color/fyellow,
-/obj/item/storage/toolbox/electrical,
-/obj/item/multitool,
-/obj/item/radio/intercom{
-	name = "east bump";
-	pixel_x = 28
+/turf/simulated/floor/plasteel{
+	icon_state = "black";
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/electrical)
+/area/station/hallway/primary/starboard/east)
 "aOL" = (
 /turf/simulated/floor/plating,
 /area/station/maintenance/electrical)
 "aOM" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/structure/closet/emcloset,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/station/maintenance/electrical)
+/area/station/maintenance/fsmaint)
 "aON" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -14288,12 +14365,13 @@
 /turf/space,
 /area/space/nearstation)
 "aOY" = (
-/obj/structure/chair/stool{
-	dir = 1
+/obj/machinery/power/apc{
+	name = "south bump";
+	pixel_y = -24
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/electrical)
 "aOZ" = (
 /obj/machinery/atmospherics/unary/tank/air{
 	dir = 8
@@ -14307,20 +14385,6 @@
 /obj/item/clothing/mask/face/fox,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fpmaint2)
-"aPb" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
 "aPc" = (
 /obj/effect/decal/cleanable/fungus,
 /turf/simulated/wall,
@@ -14376,14 +14440,14 @@
 /turf/simulated/wall,
 /area/station/maintenance/fpmaint)
 "aPk" = (
+/obj/machinery/economy/vending/cigarette,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/reagent_dispensers/water_cooler,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "caution"
-	},
+/turf/simulated/floor/wood,
 /area/station/public/dorms)
 "aPm" = (
 /turf/simulated/floor/plasteel,
@@ -14399,10 +14463,17 @@
 	},
 /area/station/maintenance/asmaint)
 "aPs" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/landmark/burnturf,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/obj/machinery/cryopod,
+/obj/machinery/alarm{
+	dir = 8;
+	name = "east bump";
+	pixel_x = 24
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "whitegreen"
+	},
+/area/station/public/sleep)
 "aPt" = (
 /obj/structure/chair/stool{
 	dir = 8
@@ -14541,33 +14612,21 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry)
 "aPK" = (
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "maint3";
-	name = "Blast Door"
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/area/station/maintenance/abandonedbar)
 "aPL" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "whitegreenfull"
 	},
 /area/station/public/sleep)
 "aPO" = (
-/obj/structure/sign/electricshock,
-/turf/simulated/wall,
-/area/station/maintenance/electrical)
-"aPP" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
+/obj/item/poster/random_contraband,
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "vault"
 	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
+/area/station/maintenance/fsmaint)
 "aPQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -14588,18 +14647,13 @@
 	},
 /area/station/hallway/secondary/entry)
 "aPS" = (
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/machinery/firealarm{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
 	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump Engineering";
-	pixel_y = 24;
-	shock_proof = 1
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/electrical)
+/turf/simulated/floor/carpet/red,
+/area/station/service/library)
 "aPT" = (
 /obj/machinery/alarm{
 	name = "north bump";
@@ -14688,16 +14742,13 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
 "aQk" = (
-/obj/machinery/status_display{
-	layer = 4;
-	pixel_x = -32
-	},
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
+/obj/structure/closet/masks,
+/obj/item/radio/intercom{
+	name = "north bump";
+	pixel_y = 28
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	dir = 4;
 	icon_state = "neutralcorner"
 	},
 /area/station/public/dorms)
@@ -14706,103 +14757,65 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
 "aQm" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/machinery/status_display{
+	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/public/dorms)
-"aQn" = (
-/obj/item/radio/intercom{
-	name = "north bump";
-	pixel_y = 28
-	},
-/obj/structure/disposalpipe/junction{
-	icon_state = "pipe-y"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
+	dir = 4;
 	icon_state = "neutralcorner"
 	},
 /area/station/public/dorms)
 "aQo" = (
-/obj/structure/chair,
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = 32
+/obj/structure/curtain/open/shower/security{
+	icon_state = "closed"
 	},
-/obj/effect/landmark/start/assistant,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "rampbottom";
+	dir = 8
 	},
-/area/station/public/dorms)
+/area/station/maintenance/fsmaint)
 "aQp" = (
-/obj/structure/chair,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/public/dorms)
-"aQr" = (
-/obj/machinery/status_display{
-	layer = 4;
-	pixel_y = 32
-	},
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/table,
-/obj/item/stack/tape_roll,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "bar"
+	},
+/area/station/public/dorms)
+"aQr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
 	},
 /area/station/public/dorms)
 "aQs" = (
-/obj/item/kirbyplants,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitecorner"
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
-/area/station/hallway/primary/starboard/west)
+/turf/simulated/floor/wood,
+/area/station/service/bar)
 "aQt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+/obj/item/storage/pill_bottle/dice,
+/obj/structure/table/wood,
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_y = 32
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	dir = 4;
 	icon_state = "neutralcorner"
 	},
 /area/station/public/dorms)
 "aQu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/public/dorms)
+/obj/structure/table/wood,
+/obj/item/kitchen/utensil/fork,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/wood,
+/area/station/service/bar)
 "aQw" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -14820,17 +14833,17 @@
 	},
 /area/station/hallway/secondary/entry)
 "aQA" = (
-/obj/machinery/economy/vending/snack,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "bluered"
+	dir = 4;
+	icon_state = "neutralcorner"
 	},
 /area/station/public/dorms)
 "aQC" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/obj/machinery/recharge_station,
 /turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/area/station/maintenance/electrical)
 "aQD" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/cable{
@@ -14843,57 +14856,74 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/fore)
 "aQE" = (
-/obj/machinery/economy/vending/wallmed{
-	name = "Emergency NanoMed";
-	pixel_y = 28
+/obj/structure/table/wood,
+/obj/item/deck/cards,
+/obj/machinery/camera{
+	c_tag = "Dormitories Centessssssssssssssr"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "cafeteria"
 	},
 /area/station/public/dorms)
 "aQG" = (
-/obj/machinery/newscaster{
-	name = "north bump";
-	pixel_y = 28
-	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "cafeteria"
 	},
 /area/station/public/dorms)
 "aQI" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "aQJ" = (
-/obj/machinery/atmospherics/portable/canister/air,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/carpet,
+/area/station/service/chapel)
 "aQL" = (
-/obj/structure/girder,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
-"aQM" = (
-/obj/structure/janitorialcart,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
-"aQN" = (
-/obj/structure/table/glass,
-/obj/item/pen,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
-"aQO" = (
-/obj/structure/table/glass,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "rampbottom"
+	},
+/area/station/hallway/primary/starboard/east)
+"aQM" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Chapel"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/service/chapel)
+"aQN" = (
+/obj/machinery/computer/HolodeckControl{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/public/dorms)
+"aQO" = (
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/station/service/library)
 "aQQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -14910,13 +14940,14 @@
 	},
 /area/station/hallway/primary/fore)
 "aQR" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/electrical)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/wood,
+/area/station/service/bar)
 "aQS" = (
 /obj/machinery/light{
 	dir = 4
@@ -14926,46 +14957,51 @@
 	},
 /area/station/hallway/primary/fore)
 "aQT" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Interrogation";
+	req_access_txt = "63"
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "Interrogation"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
-/obj/effect/landmark/spawner/nukedisc_respawn,
-/turf/simulated/floor/plating,
-/area/station/maintenance/electrical)
+/area/station/security/interrogation)
 "aQU" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/plating,
-/area/station/maintenance/electrical)
-"aQW" = (
-/obj/structure/table,
-/obj/item/camera_assembly,
-/obj/item/camera_assembly,
-/obj/item/assembly/prox_sensor{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/machinery/alarm{
-	dir = 8;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/machinery/light{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/electrical)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkredcorners"
+	},
+/area/station/security/brig)
+"aQW" = (
+/obj/structure/closet/secure_closet/bar{
+	req_access_txt = "25"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/station/maintenance/abandonedbar)
 "aQX" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -14977,12 +15013,6 @@
 	},
 /turf/space,
 /area/space)
-"aQY" = (
-/obj/structure/chair/stool{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/electrical)
 "aQZ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
@@ -15179,16 +15209,17 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
 "aRD" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/cryopod,
+/obj/machinery/firealarm{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "whitegreen"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/area/station/public/sleep)
 "aRE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -15205,50 +15236,27 @@
 	},
 /area/station/hallway/primary/fore)
 "aRG" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/structure/chair{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralcorner"
+	},
+/area/station/public/dorms)
 "aRI" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door_control{
-	id = "maint3";
-	name = "Blast Door Control C";
-	pixel_y = 24
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
-"aRJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
-"aRK" = (
-/obj/structure/table,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/obj/machinery/light_switch{
+	dir = 4;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/public/dorms)
 "aRL" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -15346,17 +15354,25 @@
 	},
 /area/station/hallway/secondary/entry)
 "aRX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
+/obj/structure/curtain/open/shower/security,
+/turf/simulated/floor/plasteel,
 /area/station/maintenance/fsmaint)
 "aRZ" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high/plus,
-/obj/item/stock_parts/cell/high/plus,
-/turf/simulated/floor/plating,
-/area/station/maintenance/electrical)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/camera{
+	c_tag = "Holodeck West";
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/public/dorms)
 "aSb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -15381,32 +15397,36 @@
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "aSe" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/structure/chair/sofa/left{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel,
+/obj/effect/landmark/start/assistant,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood,
 /area/station/public/dorms)
 "aSf" = (
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry)
 "aSg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/railing/cap/normal{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	icon_state = "black"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/area/station/public/dorms)
 "aSi" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+	dir = 6
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/turf/simulated/floor/plasteel{
+	icon_state = "cult"
+	},
+/area/station/service/chapel/office)
 "aSj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -15414,9 +15434,9 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry)
 "aSk" = (
-/obj/machinery/economy/vending/coffee,
+/obj/structure/closet/boxinggloves,
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	dir = 4;
 	icon_state = "neutralcorner"
 	},
 /area/station/public/dorms)
@@ -15426,19 +15446,12 @@
 /area/station/public/sleep)
 "aSm" = (
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "caution"
-	},
-/area/station/public/dorms)
+/turf/simulated/floor/wood,
+/area/station/public/pet_store)
 "aSn" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -15498,14 +15511,18 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
 "aSx" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel,
-/area/station/public/dorms)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/hydroponics/constructable,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "green"
+	},
+/area/station/service/hydroponics)
 "aSy" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -15521,48 +15538,15 @@
 "aSA" = (
 /turf/simulated/wall/r_wall,
 /area/station/service/expedition)
-"aSB" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "caution"
-	},
-/area/station/public/dorms)
 "aSC" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/station/ai_monitored/storage/eva)
 "aSD" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/public/dorms)
-"aSE" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "arrival"
-	},
-/area/station/public/dorms)
+/obj/effect/spawner/random_spawners/wall_rusted_maybe,
+/turf/simulated/wall,
+/area/station/maintenance/fore)
 "aSF" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -15574,24 +15558,11 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port)
 "aSG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/public/dorms)
+/turf/simulated/floor/carpet/black,
+/area/station/service/chapel/office)
 "aSH" = (
 /obj/machinery/atmospherics/binary/valve/open{
 	dir = 4
@@ -15610,15 +15581,22 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard/east)
 "aSJ" = (
+/obj/structure/railing/cap/normal{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "arrival"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/area/station/public/dorms)
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fsmaint)
 "aSK" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -15629,10 +15607,14 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
 "aSM" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "caution"
+/obj/machinery/door/airlock/public/glass{
+	name = "Mr. Chang's"
 	},
-/area/station/public/dorms)
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/wood,
+/area/station/public/mrchangs)
 "aSN" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -15640,15 +15622,19 @@
 	},
 /area/station/hallway/primary/fore)
 "aSP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
 /area/station/maintenance/fore)
 "aSR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/condiment/saltshaker,
+/obj/item/reagent_containers/food/condiment/peppermill,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
-/turf/simulated/floor/plasteel,
-/area/station/public/dorms)
+/turf/simulated/floor/plating,
+/area/station/maintenance/abandonedbar)
 "aSS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -15666,9 +15652,15 @@
 	},
 /area/station/hallway/primary/fore)
 "aSV" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard/east)
@@ -15701,18 +15693,12 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/ne)
 "aTe" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Holodeck Door"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "maint3";
-	name = "Blast Door"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/turf/simulated/floor/plasteel,
+/area/station/public/dorms)
 "aTf" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -15721,8 +15707,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
 "aTg" = (
-/obj/structure/grille/broken,
-/turf/simulated/floor/plating,
+/obj/structure/curtain/open/shower/security{
+	icon_state = "closed"
+	},
+/turf/simulated/floor/plasteel,
 /area/station/maintenance/fsmaint)
 "aTh" = (
 /obj/machinery/light/small{
@@ -15733,27 +15721,34 @@
 /area/station/maintenance/fpmaint2)
 "aTi" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/railing/cap/reversed{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "neutralcorner"
 	},
 /area/station/public/dorms)
 "aTj" = (
-/obj/machinery/power/terminal,
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/electrical)
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/station/service/bar)
 "aTk" = (
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/station/maintenance/electrical)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/station/service/kitchen)
 "aTl" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -15762,25 +15757,27 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/electrical)
 "aTm" = (
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/structure/chair/wood{
+	dir = 8
 	},
-/obj/machinery/light_switch{
-	dir = 1;
-	name = "south bump";
-	pixel_y = -24
+/obj/machinery/newscaster{
+	name = "north bump";
+	pixel_y = 28
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/electrical)
+/turf/simulated/floor/carpet,
+/area/station/public/mrchangs)
 "aTn" = (
-/obj/machinery/power/terminal,
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/machinery/door/airlock/maintenance{
+	name = "Chapel Maintenance";
+	req_access_txt = "12"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/electrical)
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "cult"
+	},
+/area/station/maintenance/fsmaint)
 "aTo" = (
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
@@ -15790,19 +15787,11 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry)
 "aTs" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 9
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/turf/simulated/floor/wood,
+/area/station/public/mrchangs)
 "aTt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -15889,40 +15878,31 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	dir = 4;
 	icon_state = "neutralcorner"
 	},
 /area/station/public/dorms)
 "aTE" = (
-/obj/structure/chair/sofa/corner{
-	dir = 4
+/obj/structure/window/reinforced{
+	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
+	dir = 1
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/station/public/dorms)
 "aTF" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "caution"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/area/station/public/dorms)
-"aTG" = (
-/obj/structure/chair/sofa/left,
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/wood,
-/area/station/public/dorms)
+/area/station/service/bar)
 "aTH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -15930,20 +15910,13 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard/east)
-"aTI" = (
-/obj/structure/chair/sofa,
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/effect/landmark/start/assistant,
-/turf/simulated/floor/wood,
-/area/station/public/dorms)
 "aTJ" = (
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "caution"
+/obj/structure/chair/stool{
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel,
 /area/station/public/dorms)
 "aTK" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -16004,10 +15977,15 @@
 /area/station/ai_monitored/storage/eva)
 "aTR" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
+	dir = 4
 	},
-/turf/simulated/floor/wood,
+/obj/machinery/door/window/classic/normal{
+	dir = 1;
+	name = "Boxing Arena"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/station/public/dorms)
 "aTS" = (
 /obj/structure/table/glass,
@@ -16079,9 +16057,11 @@
 	},
 /area/station/medical/reception)
 "aTX" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 6
+/obj/structure/sign/electricshock{
+	pixel_x = -32
 	},
+/obj/effect/spawner/random_spawners/cobweb_left_frequent,
+/obj/structure/janitorialcart,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "aTY" = (
@@ -16098,28 +16078,24 @@
 /turf/simulated/floor/plating,
 /area/station/medical/chemistry)
 "aTZ" = (
-/obj/structure/closet,
-/obj/effect/decal/cleanable/cobweb,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/turf/simulated/floor/plasteel{
+	icon_state = "cautioncorner"
+	},
+/area/station/public/dorms)
 "aUa" = (
-/obj/machinery/atmospherics/unary/tank/air{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/service/chapel)
 "aUb" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance/two,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
-"aUc" = (
-/obj/machinery/door/poddoor{
-	id_tag = "maint2"
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralcorner"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/area/station/public/dorms)
 "aUd" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -16128,59 +16104,55 @@
 	icon_state = "stairs-r"
 	},
 /area/station/public/dorms)
-"aUe" = (
-/obj/structure/closet,
-/obj/item/reagent_containers/food/drinks/cans/badminbrew,
-/obj/effect/landmark/spawner/nukedisc_respawn,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
 "aUf" = (
-/obj/effect/spawner/random_spawners/wall_rusted_always,
-/turf/simulated/wall,
-/area/station/maintenance/electrical)
+/obj/machinery/camera{
+	c_tag = "Chapel Crematorium";
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "cult"
+	},
+/area/station/service/chapel/office)
 "aUg" = (
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
-/obj/machinery/power/smes,
-/turf/simulated/floor/plating,
-/area/station/maintenance/electrical)
-"aUh" = (
-/obj/machinery/computer/monitor{
-	dir = 1;
-	name = "Backup Power Monitoring Console"
+/turf/simulated/floor/plasteel{
+	icon_state = "whitegreenfull"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable,
-/turf/simulated/floor/plating,
-/area/station/maintenance/electrical)
+/area/station/public/sleep)
 "aUi" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/closet/secure_closet{
+	anchored = 1;
+	name = "Evidence Storage";
+	req_access_txt = "4"
 	},
-/turf/simulated/wall,
-/area/station/maintenance/electrical)
+/obj/machinery/status_display{
+	pixel_y = -32
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/station/security/detective)
 "aUj" = (
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/machinery/economy/vending/wallmed{
+	name = "Emergency NanoMed";
+	pixel_y = 28
 	},
-/obj/machinery/power/smes,
-/turf/simulated/floor/plating,
-/area/station/maintenance/electrical)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/public/dorms)
 "aUk" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/warning_stripes/south,
@@ -16279,14 +16251,12 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/garden)
 "aUA" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/structure/punching_bag,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/turf/simulated/floor/plasteel{
+	icon_state = "caution"
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/wood,
-/area/station/service/clown)
+/area/station/public/dorms)
 "aUB" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -16315,19 +16285,12 @@
 	},
 /area/station/service/expedition)
 "aUG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "arrival"
-	},
-/area/station/public/dorms)
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/starboard/west)
 "aUH" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "darkbluefull"
@@ -16342,31 +16305,16 @@
 	},
 /area/station/public/dorms)
 "aUJ" = (
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "arrival"
-	},
-/area/station/public/dorms)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/electrical)
 "aUK" = (
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/beach/water{
-	icon_state = "seadeep"
-	},
-/area/station/public/dorms)
-"aUL" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/plasteel{
-	icon_state = "cult"
-	},
-/area/station/service/chapel/office)
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/starboard/east)
 "aUO" = (
 /obj/structure/table,
 /obj/item/roller{
@@ -16401,12 +16349,11 @@
 /turf/simulated/wall,
 /area/station/public/toilet)
 "aUR" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	dir = 8
-	},
-/obj/machinery/atmospherics/meter,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/obj/structure/table/wood,
+/obj/item/pen,
+/obj/item/reagent_containers/food/drinks/bottle/holywater,
+/turf/simulated/floor/carpet/black,
+/area/station/service/chapel/office)
 "aUS" = (
 /turf/simulated/wall,
 /area/station/service/bar)
@@ -16419,12 +16366,20 @@
 	},
 /area/station/public/dorms)
 "aUU" = (
-/obj/structure/chair/stool{
+/obj/machinery/camera{
+	c_tag = "Holodeck East";
 	dir = 1
 	},
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/obj/item/radio/intercom{
+	name = "south bump";
+	pixel_y = -28
+	},
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/public/dorms)
 "aUV" = (
 /obj/machinery/light{
 	dir = 8
@@ -16433,9 +16388,13 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry)
 "aUW" = (
-/obj/machinery/space_heater,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/mug,
+/obj/machinery/ai_status_display{
+	pixel_y = -32
+	},
+/turf/simulated/floor/wood,
+/area/station/public/mrchangs)
 "aUX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -16444,9 +16403,14 @@
 	},
 /area/station/service/chapel)
 "aUY" = (
-/obj/effect/decal/cleanable/fungus,
-/turf/simulated/wall,
-/area/station/maintenance/electrical)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/carpet,
+/area/station/service/chapel)
 "aUZ" = (
 /turf/space,
 /area/station/hallway/secondary/entry)
@@ -16569,36 +16533,16 @@
 	icon_state = "vault"
 	},
 /area/station/command/vault)
-"aVo" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/table/wood,
-/obj/item/instrument/eguitar,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/public/dorms)
 "aVp" = (
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
 	},
-/obj/structure/table/wood,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/public/dorms)
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "aVq" = (
-/obj/structure/chair/stool{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "caution"
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/plasteel,
 /area/station/public/dorms)
 "aVr" = (
 /turf/simulated/floor/plasteel{
@@ -16607,35 +16551,40 @@
 	},
 /area/station/service/expedition)
 "aVs" = (
-/obj/structure/window/reinforced{
+/obj/structure/railing/cap/normal{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
 	},
-/obj/structure/table/wood,
-/obj/item/instrument/piano_synth,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/public/dorms)
-"aVt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
-/area/station/public/dorms)
-"aVu" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "black";
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/area/station/maintenance/fsmaint)
+"aVt" = (
+/obj/structure/sign/chinese{
+	pixel_x = 32;
+	pixel_y = 32
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
 /area/station/public/dorms)
 "aVx" = (
 /obj/structure/table,
@@ -16662,20 +16611,12 @@
 	icon_state = "whitehall"
 	},
 /area/station/medical/reception)
-"aVz" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/station/public/dorms)
 "aVA" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/turf/simulated/floor/wood,
+/area/station/public/mrchangs)
 "aVE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -16732,10 +16673,6 @@
 	icon_state = "whitehall"
 	},
 /area/station/medical/reception)
-"aVJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
 "aVK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -16772,9 +16709,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
 "aVN" = (
-/obj/machinery/atmospherics/binary/valve,
+/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/area/station/public/pet_store)
 "aVO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/warning_stripes/west,
@@ -16783,11 +16720,13 @@
 	},
 /area/station/ai_monitored/storage/eva)
 "aVQ" = (
-/obj/machinery/door/poddoor{
-	id_tag = "maint1"
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/turf/simulated/floor/wood,
+/area/station/public/mrchangs)
 "aVR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/warning_stripes/east,
@@ -16795,18 +16734,6 @@
 	icon_state = "dark"
 	},
 /area/station/ai_monitored/storage/eva)
-"aVU" = (
-/obj/machinery/light,
-/obj/machinery/light_switch{
-	dir = 1;
-	name = "south bump";
-	pixel_y = -24
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/station/service/clown)
 "aVV" = (
 /turf/simulated/wall/mineral/titanium,
 /area/shuttle/arrival/station)
@@ -16820,14 +16747,13 @@
 /turf/simulated/floor/plating,
 /area/shuttle/arrival/station)
 "aWb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/structure/railing/cap/reversed{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/turf/simulated/floor/plasteel{
+	icon_state = "black"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/area/station/public/dorms)
 "aWc" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -16870,17 +16796,15 @@
 	},
 /area/station/security/checkpoint/secondary)
 "aWg" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/access_button{
+	autolink_id = "barmaint_btn_ext";
+	pixel_x = -25;
+	pixel_y = -25;
+	req_access_txt = "13"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/obj/structure/lattice/catwalk,
+/turf/space,
+/area/space/nearstation)
 "aWh" = (
 /obj/machinery/requests_console{
 	department = "Security";
@@ -17040,41 +16964,24 @@
 	icon_state = "vault"
 	},
 /area/station/command/vault)
-"aWA" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
 "aWB" = (
-/obj/structure/chair{
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/structure/chair{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	dir = 4;
 	icon_state = "neutralcorner"
 	},
 /area/station/public/dorms)
 "aWC" = (
-/obj/structure/chair/sofa/right{
-	dir = 4
+/obj/machinery/economy/vending/artvend,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutralcorner"
 	},
-/turf/simulated/floor/wood,
 /area/station/public/dorms)
 "aWD" = (
 /obj/structure/table/wood,
@@ -17088,10 +16995,13 @@
 /turf/simulated/floor/carpet,
 /area/station/public/dorms)
 "aWF" = (
-/obj/structure/chair/stool{
+/obj/machinery/light,
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/beach/water{
+	icon_state = "seadeep"
+	},
 /area/station/public/dorms)
 "aWG" = (
 /obj/structure/window/reinforced{
@@ -17102,21 +17012,13 @@
 	},
 /area/station/public/dorms)
 "aWH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/chair{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "arrival"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
+/turf/simulated/floor/plasteel,
 /area/station/public/dorms)
 "aWI" = (
 /obj/machinery/washing_machine,
@@ -17125,23 +17027,33 @@
 	},
 /area/station/medical/reception)
 "aWJ" = (
-/mob/living/simple_animal/crab/Coffee,
-/turf/simulated/floor/beach/water{
-	icon_state = "seadeep"
+/obj/machinery/light{
+	dir = 4
 	},
-/area/station/public/dorms)
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/maintenance/fsmaint)
 "aWK" = (
 /turf/simulated/floor/beach/water{
 	icon_state = "seadeep"
 	},
 /area/station/public/dorms)
 "aWL" = (
-/obj/structure/table,
-/obj/item/clothing/under/misc/swimsuit/red,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "arrival"
+/obj/structure/chair{
+	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
 /area/station/public/dorms)
 "aWM" = (
 /obj/structure/window/reinforced{
@@ -17152,13 +17064,16 @@
 	},
 /area/station/public/dorms)
 "aWP" = (
-/obj/structure/chair/stool{
-	dir = 4
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "caution"
+/obj/structure/chair/sofa/corner,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
+/turf/simulated/floor/wood,
 /area/station/public/dorms)
 "aWR" = (
 /obj/machinery/economy/vending/coffee,
@@ -17180,9 +17095,20 @@
 	},
 /area/station/medical/reception)
 "aWT" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "vault"
+/obj/structure/table,
+/obj/item/clothing/under/misc/swimsuit/red,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plasteel,
 /area/station/public/dorms)
 "aWU" = (
 /obj/structure/window/reinforced{
@@ -17193,11 +17119,18 @@
 	},
 /area/station/public/dorms)
 "aWV" = (
-/obj/item/stack/rods{
-	amount = 10
+/obj/machinery/access_button{
+	autolink_id = "secmaint_btn_int";
+	name = "interior access button";
+	pixel_x = 9;
+	pixel_y = -25;
+	req_access_txt = "13"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/maintenance/fore)
 "aWW" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -17220,74 +17153,21 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/public/toilet)
-"aXa" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
-"aXb" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
 "aXc" = (
-/obj/machinery/crema_switch{
-	pixel_y = -25
+/obj/structure/extinguisher_cabinet{
+	name = "west bump";
+	pixel_x = -27
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "cult"
-	},
+/turf/simulated/floor/carpet/black,
 /area/station/service/chapel/office)
 "aXd" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Crematorium Maintenance";
-	req_access_txt = "27"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "cult"
-	},
-/area/station/maintenance/fsmaint)
-"aXe" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "cult"
-	},
+/turf/simulated/floor/carpet/black,
 /area/station/service/chapel/office)
 "aXf" = (
 /turf/simulated/floor/plasteel{
@@ -17295,20 +17175,10 @@
 	},
 /area/station/public/dorms)
 "aXg" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	name = "south bump";
-	pixel_y = -24
+/obj/structure/chair{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "cult"
-	},
+/turf/simulated/floor/carpet/black,
 /area/station/service/chapel/office)
 "aXh" = (
 /obj/machinery/driver_button{
@@ -17322,30 +17192,25 @@
 	},
 /area/station/service/chapel)
 "aXi" = (
+/obj/machinery/economy/vending/cola,
 /turf/simulated/floor/plasteel{
-	icon_regular_floor = "yellowsiding";
-	icon_state = "tranquillite"
+	dir = 6;
+	icon_state = "caution"
 	},
-/area/station/service/mime)
+/area/station/public/dorms)
 "aXj" = (
-/obj/structure/morgue,
-/obj/machinery/camera{
-	c_tag = "Chapel Crematorium";
+/obj/structure/chair/wood/wings{
 	dir = 4
 	},
-/obj/effect/landmark/spawner/rev,
-/turf/simulated/floor/plasteel{
-	icon_state = "cult"
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
 	},
-/area/station/service/chapel/office)
+/turf/simulated/floor/wood,
+/area/station/service/bar)
 "aXk" = (
-/obj/machinery/alarm{
-	name = "north bump";
-	pixel_y = 24
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "cult"
-	},
+/obj/structure/table/wood,
+/obj/item/lighter/zippo/black,
+/turf/simulated/floor/carpet/black,
 /area/station/service/chapel/office)
 "aXl" = (
 /obj/machinery/door/poddoor{
@@ -17364,12 +17229,8 @@
 /turf/simulated/floor/plating/airless,
 /area/shuttle/arrival/station)
 "aXo" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "cult"
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/carpet/black,
 /area/station/service/chapel/office)
 "aXq" = (
 /obj/structure/cable{
@@ -17615,28 +17476,23 @@
 	icon_state = "vault"
 	},
 /area/station/command/vault)
-"aXW" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
 "aXX" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/obj/machinery/hydroponics/constructable,
+/obj/item/radio/intercom{
+	name = "south bump";
+	pixel_y = -28
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "green"
+	},
+/area/station/service/hydroponics)
 "aXY" = (
 /obj/structure/cable,
 /obj/structure/cable{
@@ -17689,6 +17545,7 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -17771,13 +17628,14 @@
 /turf/simulated/floor/plasteel,
 /area/station/medical/paramedic)
 "aYp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+/obj/item/radio/intercom{
+	name = "north bump";
+	pixel_y = 28
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "whitegreenfull"
+	icon_state = "grimy"
 	},
-/area/station/public/sleep)
+/area/station/service/chapel/office)
 "aYr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -17797,6 +17655,7 @@
 "aYx" = (
 /obj/structure/crematorium,
 /obj/effect/landmark/spawner/rev,
+/obj/effect/spawner/random_spawners/cobweb_right_rare,
 /turf/simulated/floor/plasteel{
 	icon_state = "cult"
 	},
@@ -17811,12 +17670,19 @@
 	},
 /area/station/service/chapel)
 "aYA" = (
-/obj/structure/table,
-/turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "vault"
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/bananalamp,
+/obj/item/reagent_containers/food/snacks/pie,
+/obj/machinery/alarm{
+	dir = 1;
+	name = "south bump";
+	pixel_y = -24
 	},
-/area/station/service/chapel)
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/station/service/clown)
 "aYB" = (
 /obj/structure/closet/coffin,
 /obj/structure/window/reinforced{
@@ -17827,17 +17693,27 @@
 	},
 /area/station/service/chapel)
 "aYC" = (
-/obj/structure/chair/stool{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
-"aYE" = (
-/obj/structure/chair/stool{
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "vault"
+	},
 /area/station/maintenance/fsmaint)
+"aYE" = (
+/obj/structure/table,
+/obj/item/stack/tape_roll,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/public/dorms)
 "aYF" = (
 /obj/structure/closet/coffin,
 /turf/simulated/floor/plasteel{
@@ -17854,26 +17730,12 @@
 	},
 /area/station/service/chapel)
 "aYJ" = (
-/obj/machinery/alarm{
+/obj/machinery/light_switch{
 	name = "north bump";
 	pixel_y = 24
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/carpet,
-/area/station/public/mrchangs)
-"aYK" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/turf/simulated/floor/wood,
+/area/station/public/pet_store)
 "aYL" = (
 /obj/machinery/light{
 	dir = 1
@@ -17886,15 +17748,13 @@
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/arrival/station)
 "aYO" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/railing{
+	dir = 1
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "rampbottom"
 	},
-/turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "aYP" = (
 /turf/simulated/wall,
@@ -17947,34 +17807,18 @@
 /turf/simulated/floor/plating/airless,
 /area/shuttle/arrival/station)
 "aYX" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/obj/structure/chair/sofa,
+/turf/simulated/floor/wood,
+/area/station/public/dorms)
 "aYY" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/structure/railing/cap/normal{
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
 /area/station/maintenance/fsmaint)
 "aYZ" = (
 /obj/structure/chair/comfy/shuttle{
@@ -18019,16 +17863,15 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/garden)
 "aZd" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/item/radio/intercom{
+	name = "west bump";
+	pixel_x = -28
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/turf/simulated/floor/plasteel{
+	icon_state = "black";
+	dir = 1
+	},
+/area/station/hallway/primary/starboard/east)
 "aZe" = (
 /obj/structure/table,
 /obj/machinery/light{
@@ -18185,26 +18028,21 @@
 /turf/simulated/floor/wood,
 /area/station/public/dorms)
 "aZu" = (
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/carpet,
-/area/station/public/dorms)
-"aZv" = (
-/turf/simulated/floor/carpet,
-/area/station/public/dorms)
-"aZw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/structure/closet/athletic_mixed,
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "arrival"
+	icon_state = "cafeteria"
 	},
+/area/station/service/kitchen)
+"aZv" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
 /area/station/public/dorms)
 "aZx" = (
 /obj/machinery/door/airlock/public/glass{
@@ -18225,39 +18063,54 @@
 	},
 /area/station/public/dorms)
 "aZz" = (
-/obj/structure/chair{
-	dir = 4
+/obj/structure/chair/sofa,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "arrival"
-	},
+/obj/effect/landmark/start/assistant,
+/turf/simulated/floor/wood,
 /area/station/public/dorms)
 "aZC" = (
-/obj/effect/decal/warning_stripes/white/hollow,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Library"
 	},
-/area/station/public/dorms)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet/red,
+/area/station/service/library)
 "aZD" = (
-/obj/effect/decal/warning_stripes/white,
-/obj/effect/landmark/start/assistant,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/mob/living/simple_animal/crab/Coffee,
+/turf/simulated/floor/beach/water{
+	icon_state = "seadeep"
 	},
 /area/station/public/dorms)
 "aZE" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "rampbottom"
+	icon_state = "stairs-r";
+	dir = 4
 	},
 /area/station/public/dorms)
 "aZF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/warning_stripes/southeastcorner,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/decal/warning_stripes/southeastcorner,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkbluecorners"
 	},
@@ -18276,11 +18129,22 @@
 	},
 /area/station/public/dorms)
 "aZJ" = (
-/obj/machinery/light,
-/obj/machinery/economy/vending/artvend,
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
+/obj/machinery/computer/mob_battle_terminal/red{
+	pixel_x = -32;
+	pixel_y = 28
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
 /area/station/public/dorms)
 "aZL" = (
 /turf/simulated/floor/plasteel{
@@ -18306,7 +18170,6 @@
 	name = "east bump";
 	pixel_x = 24
 	},
-/obj/item/kirbyplants,
 /obj/structure/sign/bobross{
 	pixel_y = 32
 	},
@@ -18321,12 +18184,10 @@
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "aZQ" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/turf_decal/woodsiding{
+	dir = 1
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/wood,
 /area/station/maintenance/fsmaint)
 "aZR" = (
 /turf/simulated/floor/plasteel{
@@ -18366,14 +18227,17 @@
 	},
 /area/station/security/checkpoint/secondary)
 "aZX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/turf/simulated/floor/plasteel{
+	icon_state = "rampbottom"
+	},
+/area/station/public/dorms)
 "aZY" = (
 /obj/machinery/camera{
 	c_tag = "Security Checkpoint";
@@ -18516,24 +18380,15 @@
 	},
 /area/station/service/expedition)
 "bao" = (
-/obj/machinery/status_display{
-	layer = 4;
-	pixel_y = 32
+/obj/structure/sink/kitchen{
+	pixel_y = 25
 	},
-/obj/structure/table/wood,
-/obj/item/paper_bin{
-	pixel_x = 1;
-	pixel_y = 9
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = 32
 	},
-/obj/item/stack/packageWrap,
+/obj/effect/spawner/random_spawners/cobweb_right_rare,
 /turf/simulated/floor/wood,
-/area/station/service/library)
-"bap" = (
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/area/station/maintenance/abandonedbar)
 "baq" = (
 /obj/effect/decal/warning_stripes/northwestcorner,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -18569,16 +18424,8 @@
 /turf/simulated/wall,
 /area/station/service/library)
 "bav" = (
-/obj/item/radio/intercom{
-	name = "north bump";
-	pixel_y = 28
-	},
-/obj/structure/table/wood,
-/obj/item/dice/d20,
-/obj/item/dice,
-/obj/item/storage/box/characters,
 /turf/simulated/floor/wood,
-/area/station/service/library)
+/area/station/maintenance/fsmaint)
 "baw" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -18591,11 +18438,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
-"bax" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk,
-/turf/simulated/floor/wood,
-/area/station/service/library)
 "bay" = (
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -18606,13 +18448,20 @@
 /turf/simulated/wall,
 /area/station/service/chapel/office)
 "baA" = (
-/obj/structure/rack,
-/obj/item/storage/fancy/candle_box/full,
-/turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "vault"
+/obj/machinery/door/airlock/public/glass,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/area/station/service/chapel)
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/hallway/primary/starboard/east)
 "baC" = (
 /obj/structure/closet/coffin,
 /obj/structure/window/reinforced,
@@ -18649,25 +18498,25 @@
 	icon_state = "bluecorner"
 	},
 /area/station/hallway/primary/fore)
+"baG" = (
+/obj/structure/chair/comfy/black,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/black,
+/area/station/maintenance/fore)
 "baI" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock{
-	name = "Crematorium";
-	req_access_txt = "27"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/carpet/black,
 /area/station/service/chapel/office)
 "baJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
 /turf/simulated/floor/wood,
@@ -18679,46 +18528,30 @@
 /turf/simulated/floor/wood,
 /area/station/service/bar)
 "baL" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
 /obj/machinery/door/airlock/maintenance{
 	name = "Bar Office Maintenance";
 	req_access_txt = "25"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "baM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/station/service/bar)
-"baS" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/turf/simulated/floor/plasteel,
+/area/station/public/dorms)
 "baZ" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -18734,42 +18567,15 @@
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/arrival/station)
 "bbb" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
+/obj/machinery/atmospherics/binary/valve,
 /turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/area/station/maintenance/fore)
 "bbd" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/turf/simulated/floor/plasteel{
+	icon_state = "cult"
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 4;
-	icon_state = "pipe-j2"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/area/station/service/chapel/office)
 "bbf" = (
 /obj/machinery/door/airlock/vault{
 	locked = 1;
@@ -18789,11 +18595,8 @@
 /area/station/command/vault)
 "bbi" = (
 /obj/machinery/economy/vending/cola,
-/obj/machinery/camera{
-	c_tag = "Dormitories West"
-	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	dir = 4;
 	icon_state = "neutralcorner"
 	},
 /area/station/public/dorms)
@@ -18802,15 +18605,6 @@
 /obj/item/storage/toolbox/electrical,
 /turf/simulated/floor/plasteel,
 /area/station/public/storage/tools)
-"bbk" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/turf/simulated/floor/beach/water{
-	icon_state = "seadeep"
-	},
-/area/station/public/dorms)
 "bbl" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -18826,18 +18620,23 @@
 /turf/simulated/floor/plasteel,
 /area/station/public/storage/tools)
 "bbn" = (
-/obj/structure/window/reinforced,
-/turf/simulated/floor/beach/water{
-	icon_state = "seadeep"
+/obj/structure/chair/stool{
+	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/carpet,
 /area/station/public/dorms)
 "bbo" = (
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "ramptop"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/area/station/public/dorms)
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet/red,
+/area/station/service/library)
 "bbp" = (
 /obj/structure/table,
 /obj/item/weldingtool,
@@ -18860,31 +18659,28 @@
 /area/station/hallway/primary/central/north)
 "bbs" = (
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 4
-	},
-/obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
-"bbu" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "rampbottom"
+	icon_state = "grimy"
 	},
-/area/station/public/dorms)
+/area/station/service/chapel/office)
+"bbu" = (
+/obj/machinery/status_display{
+	layer = 4;
+	pixel_y = 32
+	},
+/obj/structure/table/wood,
+/obj/item/storage/fancy/candle_box/full,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/service/chapel)
 "bbv" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -18892,10 +18688,12 @@
 	},
 /area/station/public/dorms)
 "bbw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 9;
+	icon_state = "caution"
 	},
 /area/station/public/dorms)
 "bby" = (
@@ -18909,47 +18707,22 @@
 	icon_state = "dark"
 	},
 /area/station/medical/morgue)
-"bbC" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"bbD" = (
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "caution"
+	},
+/area/station/public/dorms)
+"bbF" = (
+/obj/structure/table/wood,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
-"bbD" = (
-/obj/machinery/door/airlock/tranquillite{
-	name = "Mime's Office";
-	req_access_txt = "44"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	icon_regular_floor = "yellowsiding";
-	icon_state = "tranquillite"
-	},
-/area/station/service/mime)
-"bbF" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/poddoor{
-	id_tag = "maint2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/turf/simulated/floor/wood,
+/area/station/service/library)
 "bbG" = (
 /obj/effect/decal/remains/human,
 /turf/simulated/floor/plating,
@@ -18960,22 +18733,17 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
 "bbI" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "43"
 	},
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/area/station/maintenance/fore)
 "bbJ" = (
 /obj/item/reagent_containers/food/snacks/grown/banana,
 /obj/item/storage/backpack/duffel/clown,
@@ -19049,48 +18817,15 @@
 /obj/item/clothing/mask/gas,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
-"bbU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
 "bbX" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
-"bbY" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/turf/simulated/floor/plasteel,
+/area/station/public/dorms)
 "bbZ" = (
 /obj/machinery/light{
 	dir = 1
@@ -19101,100 +18836,103 @@
 	},
 /area/station/public/dorms)
 "bcg" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "vault"
+	},
 /area/station/maintenance/fsmaint)
 "bch" = (
-/obj/structure/chair/office/dark,
-/obj/machinery/camera{
-	c_tag = "Library North"
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/wood,
-/area/station/service/library)
-"bci" = (
-/obj/structure/chair/office/dark,
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/wood,
-/area/station/service/library)
+/area/station/public/pet_store)
 "bcj" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/wood,
-/area/station/service/library)
-"bck" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/spawner/window/reinforced,
+/obj/item/stack/tile/wood,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
+/area/station/maintenance/abandonedbar)
+"bck" = (
+/obj/structure/railing/cap/reversed{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "black";
+	dir = 4
+	},
 /area/station/maintenance/fsmaint)
 "bcm" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "bcn" = (
+/obj/structure/railing,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "rampbottom"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/space,
-/area/space/nearstation)
+/area/station/maintenance/fsmaint)
 "bco" = (
-/obj/structure/filingcabinet,
-/turf/simulated/floor/wood,
-/area/station/service/library)
+/turf/simulated/wall,
+/area/station/public/pet_store)
 "bcp" = (
 /turf/simulated/floor/wood,
 /area/station/service/library)
 "bcq" = (
-/obj/structure/closet/secure_closet/chaplain,
-/obj/machinery/firealarm{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/machinery/status_display{
-	layer = 4;
-	pixel_y = 32
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/station/service/chapel/office)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/carpet/red,
+/area/station/service/library)
 "bcr" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
@@ -19202,38 +18940,27 @@
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/arrival/station)
 "bcs" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
 /turf/simulated/floor/wood,
-/area/station/service/library)
+/area/station/service/bar)
 "bct" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/firealarm{
+	name = "north bump";
+	pixel_y = 24
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/turf/simulated/floor/plasteel,
+/area/station/public/dorms)
 "bcu" = (
-/obj/structure/table/wood,
-/obj/item/pen,
-/obj/item/reagent_containers/food/drinks/bottle/holywater,
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/newscaster/security_unit{
+	name = "north bump";
+	pixel_y = 28
 	},
-/turf/simulated/floor/carpet/black,
-/area/station/service/chapel/office)
+/turf/simulated/floor/carpet,
+/area/station/security/detective)
 "bcv" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -19247,101 +18974,68 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
 "bcw" = (
-/obj/machinery/alarm{
-	name = "north bump";
-	pixel_y = 24
+/obj/machinery/door/airlock/maintenance{
+	name = "Chapel Maintenance";
+	req_access_txt = "12"
 	},
-/obj/machinery/camera{
-	c_tag = "Chapel Chaplain's Office"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/table/wood,
-/obj/item/lighter/zippo/black,
-/turf/simulated/floor/carpet/black,
-/area/station/service/chapel/office)
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "bcx" = (
 /turf/simulated/floor/carpet/black,
 /area/station/service/chapel/office)
 "bcy" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/table/wood,
+/obj/machinery/status_display{
+	layer = 4;
+	pixel_x = -32
 	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "arrival"
-	},
-/area/station/public/dorms)
+/turf/simulated/floor/wood,
+/area/station/public/mrchangs)
 "bcz" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
 /area/station/service/chapel/office)
 "bcA" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 2;
+	pixel_y = 6
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
-"bcB" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin{
+/obj/item/reagent_containers/food/condiment/saltshaker{
 	pixel_x = -2;
-	pixel_y = 5
+	pixel_y = 4
 	},
-/obj/item/storage/fancy/crayons,
-/obj/machinery/light_switch{
-	name = "north bump";
-	pixel_y = 24
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/wood,
+/area/station/service/bar)
+"bcB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+	icon_state = "whitegreenfull"
 	},
-/area/station/service/chapel/office)
+/area/station/public/sleep)
 "bcC" = (
-/obj/structure/extinguisher_cabinet{
-	name = "north bump";
-	pixel_y = 30
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/station/service/chapel/office)
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/carpet,
+/area/station/public/mrchangs)
 "bcD" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/station/service/chapel)
-"bcE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel,
-/area/station/public/dorms)
 "bcF" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/ai_status_display{
-	pixel_x = -32;
-	step_size = 0
-	},
+/obj/structure/closet/secure_closet/chaplain,
 /turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "vault"
+	icon_state = "grimy"
 	},
-/area/station/service/chapel)
+/area/station/service/chapel/office)
 "bcG" = (
 /obj/machinery/camera{
 	c_tag = "Arrivals Lounge"
@@ -19366,11 +19060,9 @@
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/arrival/station)
 "bcO" = (
-/obj/item/radio/intercom{
-	name = "north bump";
-	pixel_y = 28
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/carpet/black,
 /area/station/service/chapel/office)
 "bcP" = (
@@ -19482,21 +19174,12 @@
 	},
 /area/station/hallway/primary/port)
 "bda" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Library"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "arrival"
-	},
-/area/station/public/dorms)
+/turf/simulated/floor/carpet/red,
+/area/station/service/library)
 "bdb" = (
 /obj/structure/table,
 /obj/item/wrench,
@@ -19512,15 +19195,13 @@
 /turf/simulated/floor/plasteel,
 /area/station/public/storage/tools)
 "bdf" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/poolcontroller{
+	pixel_y = -25;
+	srange = 7
 	},
-/obj/structure/chair/stool{
-	dir = 1
+/turf/simulated/floor/beach/water{
+	icon_state = "seadeep"
 	},
-/turf/simulated/floor/plasteel,
 /area/station/public/dorms)
 "bdg" = (
 /obj/structure/table,
@@ -19548,36 +19229,27 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/command/bridge)
-"bdj" = (
-/obj/structure/chair/stool{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/station/public/dorms)
 "bdk" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal,
 /turf/simulated/floor/plasteel,
 /area/station/public/storage/tools)
 "bdl" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
-/obj/structure/chair/stool{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/station/public/dorms)
-"bdm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/ai_status_display{
-	pixel_x = 32
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "grimy"
+	},
+/area/station/service/bar)
+"bdm" = (
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "caution"
 	},
 /area/station/public/dorms)
 "bdn" = (
@@ -19591,16 +19263,6 @@
 /area/station/hallway/secondary/entry)
 "bdo" = (
 /obj/item/flag/clown,
-/turf/simulated/floor/wood,
-/area/station/service/clown)
-"bdp" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp/bananalamp,
-/obj/item/reagent_containers/food/snacks/pie,
-/obj/machinery/alarm{
-	name = "north bump";
-	pixel_y = 24
-	},
 /turf/simulated/floor/wood,
 /area/station/service/clown)
 "bdq" = (
@@ -19793,6 +19455,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/station/public/dorms)
 "bdJ" = (
@@ -19804,6 +19467,9 @@
 	pixel_y = 28
 	},
 /obj/machinery/economy/vending/chefdrobe,
+/obj/effect/decal/snow/clean/edge{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
@@ -19837,6 +19503,9 @@
 /obj/machinery/chem_master/condimaster{
 	name = "CondiMaster Neo";
 	pixel_x = -5
+	},
+/obj/effect/decal/snow/clean/edge{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
@@ -20033,24 +19702,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood,
 /area/station/service/library)
-"bel" = (
-/obj/structure/rack,
-/obj/item/storage/bible,
-/obj/item/paper_bin{
-	pixel_x = -2;
-	pixel_y = 5
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
 "bem" = (
 /obj/structure/table/wood,
-/obj/item/folder/yellow,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
 /obj/item/pen,
-/turf/simulated/floor/wood,
-/area/station/service/library)
-"ben" = (
-/obj/structure/table/wood,
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood,
 /area/station/service/library)
 "beo" = (
@@ -20060,22 +19718,27 @@
 /turf/simulated/floor/wood,
 /area/station/service/library)
 "bep" = (
-/obj/machinery/newscaster{
-	dir = 8;
-	name = "east bump";
-	pixel_x = 28
+/obj/structure/table/wood,
+/obj/machinery/light/small{
+	dir = 1
 	},
 /turf/simulated/floor/wood,
 /area/station/service/library)
 "beq" = (
-/obj/machinery/ai_status_display{
-	pixel_x = -32;
-	step_size = 0
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/area/station/service/chapel/office)
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/electrical)
 "ber" = (
 /obj/structure/table/wood,
 /obj/item/stack/tile/carpet/black{
@@ -20090,13 +19753,6 @@
 	},
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/arrival/station)
-"bet" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/landmark/start/chaplain,
-/turf/simulated/floor/carpet/black,
-/area/station/service/chapel/office)
 "beu" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -20144,11 +19800,59 @@
 /turf/simulated/floor/plating/airless,
 /area/shuttle/arrival/station)
 "bez" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
+/obj/effect/decal/warning_stripes/white/hollow,
+/obj/structure/cable/white,
+/obj/structure/cable/white{
+	icon_state = "0-2";
+	d2 = 2
 	},
-/turf/simulated/floor/carpet,
-/area/station/public/mrchangs)
+/obj/structure/cable/white{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "0-8";
+	d2 = 8
+	},
+/obj/structure/cable/white{
+	icon_state = "1-2";
+	d2 = 4;
+	d1 = 1
+	},
+/obj/structure/cable/white{
+	icon_state = "1-4";
+	d2 = 4;
+	d1 = 1
+	},
+/obj/structure/cable/white{
+	icon_state = "1-8";
+	d2 = 8;
+	d1 = 1
+	},
+/obj/structure/cable/white{
+	icon_state = "2-4";
+	d2 = 4;
+	d1 = 2
+	},
+/obj/structure/cable/white{
+	icon_state = "2-8";
+	d2 = 8;
+	d1 = 2
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8";
+	d2 = 8;
+	d1 = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
+"beC" = (
+/obj/structure/rack,
+/obj/effect/landmark/costume/random,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/random_spawners/cobweb_left_rare,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "beF" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
@@ -20162,7 +19866,7 @@
 "beH" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+	dir = 10
 	},
 /turf/simulated/floor/wood,
 /area/station/service/bar)
@@ -20177,11 +19881,13 @@
 /turf/simulated/floor/wood,
 /area/station/service/bar)
 "beJ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/structure/closet/firecloset,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/station/maintenance/fsmaint)
 "beK" = (
 /obj/structure/cable{
@@ -20204,14 +19910,6 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/port)
-"beM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/effect/landmark/spawner/nukedisc_respawn,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
 "beN" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -20284,18 +19982,11 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 8
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralcorner"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plasteel,
 /area/station/public/dorms)
 "beU" = (
 /obj/structure/disposalpipe/segment,
@@ -20304,13 +19995,10 @@
 /area/station/public/storage/tools)
 "beW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 9
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
@@ -20326,42 +20014,10 @@
 	icon_state = "dark"
 	},
 /area/station/ai_monitored/storage/eva)
-"beY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	dir = 1;
-	name = "south bump";
-	pixel_y = -24
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
-	},
-/area/station/public/dorms)
 "bfb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/poolcontroller{
-	pixel_y = -25;
-	srange = 7
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
-	},
+/obj/structure/table/wood,
+/obj/item/paicard,
+/turf/simulated/floor/wood,
 /area/station/public/dorms)
 "bfc" = (
 /obj/structure/chair/stool{
@@ -20370,23 +20026,13 @@
 /turf/simulated/floor/plasteel,
 /area/station/public/locker)
 "bfd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/structure/chair/comfy/beige{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/machinery/power/apc{
-	name = "south bump";
-	pixel_y = -24
-	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
-	},
+/turf/simulated/floor/wood,
 /area/station/public/dorms)
 "bfe" = (
 /obj/machinery/camera{
@@ -20423,46 +20069,17 @@
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/storage/eva)
 "bfi" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/item/radio/intercom{
 	name = "south bump";
 	pixel_y = -28
 	},
-/obj/machinery/camera{
-	c_tag = "Dormitories Center";
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
-	},
+/turf/simulated/floor/wood,
 /area/station/public/dorms)
 "bfj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/chair/comfy/beige{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/light,
-/obj/machinery/newscaster{
-	dir = 1;
-	name = "south bump";
-	pixel_y = -28
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
-	},
+/turf/simulated/floor/wood,
 /area/station/public/dorms)
 "bfk" = (
 /obj/machinery/requests_console{
@@ -20494,70 +20111,40 @@
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plating,
 /area/station/turret_protected/aisat/interior)
-"bfn" = (
-/obj/structure/disposalpipe/segment,
+"bfo" = (
+/obj/machinery/light_switch{
+	dir = 8;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/wood,
+/area/station/public/dorms)
+"bfq" = (
+/obj/structure/table,
+/obj/item/paper{
+	desc = "";
+	info = "Brusies sustained in the holodeck can be healed simply by sleeping.";
+	name = "Holodeck Disclaimer"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/public/dorms)
+"bfr" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/item/radio/intercom{
+	name = "west bump";
+	pixel_x = -28
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
-"bfo" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/station/public/dorms)
-"bfq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/status_display{
-	layer = 4;
-	pixel_y = -32
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
-	},
-/area/station/public/dorms)
-"bfr" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
-	},
-/area/station/public/dorms)
+/turf/simulated/floor/carpet,
+/area/station/service/chapel)
 "bfs" = (
 /obj/machinery/light{
 	dir = 1
@@ -20569,31 +20156,19 @@
 /area/station/service/bar)
 "bft" = (
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
 /area/station/service/bar)
-"bfv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
-	},
-/area/station/public/dorms)
 "bfw" = (
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/machinery/door/airlock/maintenance{
 	name = "Kitchen Maintenance";
 	req_access_txt = "28"
@@ -20603,81 +20178,31 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
-"bfx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/alarm{
-	dir = 1;
-	name = "south bump";
-	pixel_y = -24
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
-	},
-/area/station/public/dorms)
-"bfy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/light,
-/obj/machinery/economy/atm{
-	pixel_y = -32
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
-	},
-/area/station/public/dorms)
-"bfz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	name = "south bump";
-	pixel_y = -24
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
-	},
-/area/station/public/dorms)
 "bfA" = (
-/obj/structure/chair/office/dark{
-	dir = 1
+/obj/machinery/light,
+/turf/simulated/floor/plasteel{
+	icon_state = "caution"
 	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
+/area/station/public/dorms)
+"bfB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 6
 	},
 /obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/obj/effect/landmark/start/clown,
-/turf/simulated/floor/wood,
-/area/station/service/clown)
-"bfB" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "vault"
+	},
 /area/station/maintenance/fsmaint)
 "bfC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/effect/landmark/spawner/xeno,
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
@@ -20699,6 +20224,9 @@
 /area/station/service/hydroponics)
 "bfE" = (
 /mob/living/simple_animal/hostile/retaliate/goat/chef,
+/obj/effect/decal/snow/clean/edge{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
@@ -20708,18 +20236,10 @@
 /turf/simulated/floor/grass,
 /area/station/service/hydroponics)
 "bfI" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "43"
+/turf/simulated/floor/plasteel{
+	icon_state = "whitegreencorner"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/area/station/public/sleep)
 "bfJ" = (
 /obj/item/radio/intercom{
 	name = "north bump";
@@ -20728,18 +20248,6 @@
 /obj/machinery/hydroponics/soil,
 /turf/simulated/floor/grass,
 /area/station/service/hydroponics)
-"bfK" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/poddoor{
-	id_tag = "maint1"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
 "bfL" = (
 /obj/structure/table,
 /obj/item/reagent_containers/spray/plantbgone{
@@ -20782,36 +20290,32 @@
 	},
 /area/station/service/hydroponics)
 "bfO" = (
-/obj/structure/disposalpipe/segment{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/turf/simulated/floor/plating,
+/area/station/maintenance/electrical)
+"bfP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
-"bfP" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "vault"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/area/station/service/chapel)
 "bfQ" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/door/airlock/bananium{
+	name = "Clown's Office";
+	req_access_txt = "43"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/wood,
+/area/station/service/clown)
 "bfS" = (
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel{
@@ -20820,61 +20324,70 @@
 	},
 /area/station/service/chapel)
 "bfT" = (
-/obj/machinery/light{
+/obj/machinery/camera{
+	c_tag = "Mr. Chang's";
+	dir = 10
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/wood,
-/area/station/service/library)
+/turf/simulated/floor/carpet,
+/area/station/public/mrchangs)
 "bfU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/wood,
 /area/station/service/library)
 "bfV" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/carpet/black,
-/area/station/service/chapel/office)
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/starboard/west)
 "bfW" = (
-/obj/structure/rack,
-/obj/item/storage/fancy/candle_box/full{
-	pixel_x = -3;
-	pixel_y = 3
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/obj/item/storage/fancy/candle_box/full,
-/obj/item/storage/fancy/candle_box/full{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
-"bfX" = (
 /obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/power/apc{
-	dir = 8;
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/station/security/detective)
+"bfX" = (
+/obj/machinery/alarm{
+	dir = 4;
 	name = "west bump";
 	pixel_x = -24
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/station/service/chapel/office)
+/turf/simulated/floor/carpet/red,
+/area/station/service/library)
 "bfY" = (
-/obj/structure/table/wood,
-/obj/item/book/manual/wiki/sop_service,
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
 /turf/simulated/floor/wood,
 /area/station/service/library)
 "bfZ" = (
-/obj/structure/table/wood,
-/obj/structure/disposalpipe/segment,
-/obj/item/book/manual/wiki/sop_general,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
-/area/station/service/library)
+/area/station/service/bar)
 "bga" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp{
@@ -21255,19 +20768,20 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/north)
 "bhe" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "whitegreenfull"
+	},
+/area/station/public/sleep)
+"bhf" = (
+/obj/structure/chair/sofa/right,
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
-	},
-/area/station/public/dorms)
-"bhf" = (
-/obj/machinery/economy/vending/cola,
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
-	},
+/obj/effect/landmark/start/assistant,
+/turf/simulated/floor/wood,
 /area/station/public/dorms)
 "bhg" = (
 /turf/simulated/floor/plasteel{
@@ -21289,46 +20803,31 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/service/clown)
-"bhj" = (
-/obj/structure/table/wood,
-/obj/machinery/firealarm{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/item/clothing/suit/soldiercoat,
-/obj/item/clothing/under/costume/soldieruniform,
-/obj/item/clothing/head/stalhelm,
-/obj/machinery/newscaster{
-	dir = 1;
-	name = "south bump";
-	pixel_y = -28
-	},
-/turf/simulated/floor/wood,
-/area/station/service/clown)
 "bhk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/machinery/light_switch{
+	name = "north bump";
+	pixel_y = 24
 	},
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_x = -2;
+	pixel_y = 5
+	},
+/obj/item/storage/fancy/crayons,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/service/chapel)
+"bhl" = (
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/wood,
-/area/station/service/clown)
-"bhl" = (
-/obj/machinery/camera{
-	c_tag = "Mime's Office";
-	dir = 4
-	},
-/obj/structure/statue/tranquillite/mime,
 /turf/simulated/floor/plasteel{
-	icon_regular_floor = "yellowsiding";
-	icon_state = "tranquillite"
+	icon_state = "dark"
 	},
-/area/station/service/mime)
+/area/station/security/brig)
 "bhm" = (
 /turf/simulated/floor/carpet,
 /area/station/hallway/secondary/entry)
@@ -21357,25 +20856,23 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
 /area/station/service/kitchen)
 "bhu" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance{
-	name = "Hydroponics Maintenance";
-	req_access_txt = "35"
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/machinery/door/airlock/maintenance{
+	name = "Hydroponics Maintenance";
+	req_access_txt = "35"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "bhv" = (
@@ -21386,22 +20883,6 @@
 	icon_state = "grimy"
 	},
 /area/station/hallway/secondary/entry)
-"bhw" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/station/service/library)
-"bhx" = (
-/obj/structure/chair/office/dark{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/wood,
-/area/station/service/library)
 "bhz" = (
 /obj/machinery/photocopier{
 	toner = 0
@@ -21415,16 +20896,36 @@
 /turf/simulated/floor/plasteel,
 /area/station/public/storage/office)
 "bhA" = (
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/carpet/black,
+/obj/machinery/door/airlock/glass{
+	name = "Chapel Office";
+	req_access_txt = "22"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
 /area/station/service/chapel/office)
 "bhB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/carpet/black,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
 /area/station/service/chapel/office)
 "bhC" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -21596,24 +21097,21 @@
 	},
 /area/station/hallway/primary/central/north)
 "bhW" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
+/obj/machinery/light_switch{
+	name = "north bump";
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "showroomfloor"
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
 	},
-/area/station/service/kitchen)
+/area/station/service/mime)
 "bhX" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
@@ -21640,13 +21138,21 @@
 	},
 /area/station/service/chapel)
 "bia" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green,
+/obj/machinery/alarm{
+	dir = 1;
+	name = "south bump";
+	pixel_y = -24
 	},
-/turf/simulated/floor/wood,
-/area/station/service/library)
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
+	},
+/area/station/service/mime)
 "bib" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -21682,121 +21188,65 @@
 	icon_state = "hydrofloor"
 	},
 /area/station/service/hydroponics)
-"bih" = (
-/obj/machinery/alarm{
-	dir = 4;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/table/wood,
-/turf/simulated/floor/wood,
-/area/station/service/library)
 "bii" = (
-/obj/machinery/economy/vending/cigarette,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
-"bij" = (
-/obj/structure/chair/office/dark{
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/wood,
-/area/station/service/library)
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/grille/broken,
+/obj/structure/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-j2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "bio" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	icon_state = "bar"
 	},
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/area/station/public/dorms)
 "bip" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/area/station/security/detective)
 "biq" = (
+/obj/structure/table/wood,
+/obj/machinery/reagentgrinder,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/station/maintenance/abandonedbar)
+"bir" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/station/service/chapel/office)
-"bir" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Chapel Office Maintenance";
-	req_access_txt = "27"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/turf/simulated/floor/plasteel,
+/area/station/public/dorms)
 "bis" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+	icon_state = "dark"
 	},
-/area/station/service/chapel/office)
+/area/station/service/chapel)
 "bit" = (
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plasteel{
@@ -21814,40 +21264,34 @@
 	},
 /area/station/hallway/secondary/entry)
 "biw" = (
-/obj/machinery/newscaster{
-	dir = 1;
-	name = "south bump";
-	pixel_y = -28
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/door/airlock/maintenance{
+	name = "Chapel Maintenance";
+	req_access_txt = "12"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+	icon_state = "dark"
 	},
-/area/station/service/chapel/office)
+/area/station/maintenance/fsmaint)
 "bix" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+	icon_state = "dark"
 	},
-/area/station/service/chapel/office)
+/area/station/service/chapel)
 "biy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+	icon_state = "dark"
 	},
-/area/station/service/chapel/office)
+/area/station/service/chapel)
 "biz" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -22017,25 +21461,18 @@
 	icon_state = "L13"
 	},
 /area/station/hallway/primary/central/north)
-"biP" = (
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/turf/simulated/floor/carpet,
-/area/station/public/mrchangs)
 "biQ" = (
-/obj/structure/statue/chickenstatue,
-/obj/machinery/camera{
-	c_tag = "Mr. Chang's"
+/obj/machinery/economy/vending/crittercare,
+/obj/machinery/status_display{
+	layer = 4;
+	pixel_y = 32
 	},
-/turf/simulated/floor/carpet,
-/area/station/public/mrchangs)
+/turf/simulated/floor/wood,
+/area/station/public/pet_store)
 "biR" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/turf/simulated/floor/carpet,
-/area/station/public/mrchangs)
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/wood,
+/area/station/public/pet_store)
 "biS" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
@@ -22056,12 +21493,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
@@ -22076,13 +21507,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/effect/landmark/spawner/xeno,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
@@ -22110,11 +21535,11 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
+	},
+/obj/effect/decal/snow/clean/edge{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
@@ -22170,27 +21595,19 @@
 	icon_state = "hydrofloor"
 	},
 /area/station/service/hydroponics)
-"bje" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/bananium{
-	name = "Clown's Office";
-	req_access_txt = "43"
-	},
-/turf/simulated/floor/wood,
-/area/station/service/clown)
 "bjf" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/simulated/floor/wood,
 /area/station/service/bar)
 "bjg" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Chapel Maintenance";
-	req_access_txt = "12"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock{
+	name = "Crematorium";
+	req_access_txt = "27"
+	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/area/station/service/chapel/office)
 "bji" = (
 /obj/item/radio/beacon,
 /turf/simulated/floor/plasteel,
@@ -22208,24 +21625,30 @@
 /turf/simulated/floor/wood,
 /area/station/service/bar)
 "bjk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
-"bjl" = (
-/obj/effect/decal/cleanable/fungus,
-/turf/simulated/wall,
-/area/station/public/dorms)
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet/red,
+/area/station/service/library)
 "bjm" = (
 /turf/simulated/floor/carpet,
 /area/station/service/bar)
 "bjn" = (
-/obj/structure/chair/comfy/beige{
-	dir = 1
+/obj/item/stack/cable_coil/yellow,
+/mob/living/simple_animal/mouse,
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "vault"
 	},
-/turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "bjp" = (
 /obj/machinery/door/morgue{
@@ -22246,9 +21669,11 @@
 	},
 /area/station/service/chapel/office)
 "bjs" = (
+/obj/structure/railing{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "rampbottom"
+	icon_state = "stairs-l"
 	},
 /area/station/service/chapel)
 "bjt" = (
@@ -22256,28 +21681,62 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "hydrofloor"
 	},
 /area/station/service/hydroponics)
 "bju" = (
-/obj/machinery/bookbinder,
+/obj/machinery/camera{
+	c_tag = "Library North"
+	},
+/obj/structure/table/wood,
+/obj/item/paper,
+/obj/item/pen,
+/obj/machinery/ai_status_display{
+	pixel_y = 32
+	},
 /turf/simulated/floor/wood,
 /area/station/service/library)
 "bjv" = (
 /turf/simulated/floor/grass,
 /area/station/service/hydroponics)
 "bjw" = (
-/obj/structure/disposalpipe/segment{
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/item/radio/intercom{
+	name = "south bump";
+	pixel_y = -28
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Secure Gate";
+	name = "Security Blast Door"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/obj/machinery/door/window/reinforced/normal{
+	id = "Cell 5";
+	name = "Cell 5";
+	req_access_txt = "2";
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/security/prison/cell_block/A)
 "bjx" = (
 /mob/living/simple_animal/cow/betsy,
 /turf/simulated/floor/grass,
@@ -22286,45 +21745,44 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/grass,
 /area/station/service/hydroponics)
-"bjz" = (
-/obj/effect/decal/cleanable/fungus,
-/turf/simulated/wall,
-/area/station/service/clown)
 "bjA" = (
-/obj/machinery/light{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/wood/wings{
+	dir = 4
 	},
-/obj/machinery/status_display{
-	layer = 4;
-	pixel_y = 32
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/service/chapel)
+/obj/effect/spawner/random_spawners/cobweb_left_rare,
+/turf/simulated/floor/plating,
+/area/station/maintenance/abandonedbar)
 "bjB" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/station/service/hydroponics)
 "bjD" = (
-/obj/item/kirbyplants,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/station/service/chapel)
 "bjE" = (
-/obj/structure/disposalpipe/segment,
+/obj/structure/bookcase{
+	name = "Forbidden Knowledge"
+	},
 /turf/simulated/floor/wood,
 /area/station/service/library)
 "bjF" = (
-/obj/machinery/photocopier,
-/turf/simulated/floor/wood,
-/area/station/service/library)
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/service/hydroponics)
 "bjI" = (
-/obj/item/kirbyplants,
-/obj/machinery/light_switch{
-	name = "north bump";
-	pixel_y = 24
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -22339,13 +21797,19 @@
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_x = 32
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
 /turf/simulated/floor/carpet,
 /area/station/service/bar)
 "bjN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -22429,18 +21893,6 @@
 	icon_state = "hydrofloor"
 	},
 /area/station/service/hydroponics)
-"bjX" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
 "bjY" = (
 /obj/structure/extinguisher_cabinet{
 	name = "south bump";
@@ -22583,14 +22035,11 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port)
 "bkn" = (
-/obj/structure/chair/office/dark{
-	dir = 1
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "rampbottom"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/station/service/library)
+/area/station/hallway/primary/starboard/east)
 "bko" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -22603,9 +22052,9 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port)
 "bkp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
+/obj/machinery/door/morgue{
+	name = "Private Study";
+	req_access_txt = "37"
 	},
 /turf/simulated/floor/wood,
 /area/station/service/library)
@@ -22658,11 +22107,14 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/nw)
 "bkt" = (
-/obj/structure/disposalpipe/segment{
+/obj/structure/railing/cap/reversed{
 	dir = 4
 	},
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
 /area/station/maintenance/fsmaint)
 "bku" = (
 /obj/structure/cable{
@@ -22756,15 +22208,14 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/east)
 "bkD" = (
-/obj/item/stack/rods{
-	amount = 10
+/obj/structure/cult/archives,
+/obj/machinery/newscaster{
+	dir = 8;
+	name = "east bump";
+	pixel_x = 28
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/spawner/random_spawners/grille_maybe,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/turf/simulated/floor/wood,
+/area/station/service/library)
 "bkE" = (
 /obj/structure/sign/electricshock{
 	pixel_y = -32
@@ -22801,40 +22252,37 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/ne)
 "bkI" = (
-/obj/structure/lattice,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "ramptop"
+	},
+/area/station/maintenance/fsmaint)
+"bkK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/space,
-/area/space/nearstation)
-"bkK" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/wood,
-/area/station/service/library)
-"bkL" = (
-/obj/structure/chair/office/dark{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/wood,
-/area/station/service/library)
+/turf/simulated/floor/carpet,
+/area/station/security/detective)
 "bkM" = (
 /obj/machinery/economy/slot_machine,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
 /area/station/service/bar)
-"bkN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
 "bkO" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel{
@@ -22853,11 +22301,19 @@
 	},
 /area/station/service/bar)
 "bkQ" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
+/obj/item/folder/red{
+	pixel_y = 3
 	},
-/turf/simulated/floor/wood,
-/area/station/service/library)
+/obj/item/hand_labeler,
+/obj/item/storage/box/evidence,
+/obj/structure/table/wood,
+/obj/item/radio/intercom/department/security{
+	pixel_y = -28
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/station/security/detective)
 "bkR" = (
 /obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/door/poddoor/preopen{
@@ -22961,9 +22417,11 @@
 "bla" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/railing{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "rampbottom"
+	icon_state = "stairs-r"
 	},
 /area/station/service/chapel)
 "blb" = (
@@ -22983,11 +22441,12 @@
 /obj/structure/chair/comfy/black{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -23038,22 +22497,49 @@
 	},
 /area/station/hallway/secondary/entry)
 "bli" = (
-/obj/structure/bookcase{
-	name = "bookcase (Religious)"
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	name = "west bump";
+	pixel_x = -28
 	},
 /turf/simulated/floor/wood,
 /area/station/service/library)
 "blj" = (
-/turf/simulated/floor/carpet,
+/obj/machinery/newscaster{
+	dir = 4;
+	name = "west bump";
+	pixel_x = -28
+	},
+/obj/machinery/light_switch{
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/effect/landmark/spawner/nukedisc_respawn,
+/turf/simulated/floor/plasteel{
+	icon_state = "cult"
+	},
 /area/station/service/library)
 "blk" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/carpet,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet/red,
 /area/station/service/library)
 "bll" = (
-/obj/structure/bookcase{
-	name = "bookcase (Reference)"
-	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/wood,
 /area/station/service/library)
 "blm" = (
@@ -23065,6 +22551,8 @@
 	name = "east bump";
 	pixel_x = 28
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -23082,10 +22570,16 @@
 	},
 /area/station/service/chapel)
 "blp" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
 	},
-/turf/simulated/floor/wood,
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/carpet/red,
 /area/station/service/library)
 "blr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -23130,16 +22624,17 @@
 /area/station/hallway/secondary/entry)
 "blt" = (
 /obj/machinery/economy/vending/cigarette,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/carpet,
 /area/station/service/bar)
 "blw" = (
-/obj/structure/chair/comfy/black{
-	dir = 4
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/item/radio/intercom{
-	name = "west bump";
-	pixel_x = -28
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -23595,58 +23090,41 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/nw)
-"bmD" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Library East";
-	dir = 8
-	},
-/turf/simulated/floor/wood,
-/area/station/service/library)
 "bmE" = (
-/obj/machinery/light/small,
-/turf/simulated/floor/plasteel{
-	icon_state = "cult"
-	},
+/turf/simulated/floor/carpet/red,
 /area/station/service/library)
 "bmF" = (
-/obj/structure/cult/archives,
-/obj/machinery/light_switch{
-	dir = 1;
+/obj/machinery/power/apc{
 	name = "south bump";
 	pixel_y = -24
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "cult"
-	},
-/area/station/service/library)
-"bmG" = (
-/obj/structure/chair/comfy/brown{
-	dir = 1
-	},
-/obj/effect/landmark/spawner/nukedisc_respawn,
-/turf/simulated/floor/plasteel{
-	icon_state = "cult"
-	},
-/area/station/service/library)
-"bmH" = (
-/obj/structure/grille,
+/obj/structure/cable,
 /turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/area/station/maintenance/fore)
+"bmH" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/starboard/east)
 "bmI" = (
-/obj/structure/chair/comfy/black{
-	dir = 4
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -23666,6 +23144,10 @@
 	dir = 8;
 	name = "east bump";
 	pixel_x = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -23689,11 +23171,24 @@
 	},
 /area/station/hallway/secondary/exit)
 "bmM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/wood,
-/area/station/service/bar)
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkredcorners"
+	},
+/area/station/security/brig)
 "bmN" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -23887,12 +23382,18 @@
 	name = "north bump";
 	pixel_y = 28
 	},
-/obj/item/kirbyplants,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/wood,
 /area/station/service/bar)
 "bnm" = (
 /obj/structure/noticeboard{
 	pixel_y = 32
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/station/service/bar)
@@ -24243,6 +23744,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
@@ -24270,12 +23774,10 @@
 	},
 /area/station/hallway/secondary/exit)
 "bom" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -24309,6 +23811,9 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/bartender,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -24377,19 +23882,9 @@
 	icon_state = "dark"
 	},
 /area/station/service/hydroponics)
-"bov" = (
-/obj/machinery/newscaster{
-	dir = 8;
-	name = "east bump";
-	pixel_x = 28
-	},
-/obj/machinery/hydroponics/constructable,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/service/hydroponics)
 "bow" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "green"
@@ -24428,6 +23923,18 @@
 "boB" = (
 /turf/simulated/floor/plasteel,
 /area/station/service/hydroponics)
+"boC" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "boD" = (
 /obj/structure/closet/crate/can,
 /obj/machinery/light,
@@ -24437,16 +23944,39 @@
 	},
 /area/station/hallway/secondary/exit)
 "boF" = (
-/obj/structure/bookcase{
-	name = "bookcase (Fiction)"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
-/turf/simulated/floor/wood,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet/red,
 /area/station/service/library)
 "boG" = (
-/obj/structure/bookcase{
-	name = "bookcase (Non-Fiction)"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
-/turf/simulated/floor/wood,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet/red,
 /area/station/service/library)
 "boI" = (
 /obj/machinery/door/airlock/external{
@@ -24469,16 +23999,17 @@
 /area/station/hallway/secondary/entry)
 "boM" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/carpet,
 /area/station/service/bar)
 "boN" = (
 /obj/machinery/gibber,
+/obj/effect/decal/snow/clean/edge,
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
@@ -24492,6 +24023,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/effect/decal/snow/clean/edge,
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
@@ -24514,7 +24046,6 @@
 	name = "east bump";
 	pixel_x = 24
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
@@ -24532,6 +24063,7 @@
 /area/station/hallway/secondary/entry)
 "boS" = (
 /obj/structure/closet/crate/freezer,
+/obj/effect/decal/snow/clean/edge,
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
@@ -24910,6 +24442,7 @@
 /area/station/service/hydroponics)
 "bpH" = (
 /obj/structure/disposalpipe/segment,
+/obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/grass,
 /area/station/service/hydroponics)
 "bpI" = (
@@ -24924,23 +24457,30 @@
 	},
 /area/station/service/hydroponics)
 "bpJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/chair/stool{
+	dir = 8
 	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "chapel"
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
-/area/station/service/chapel)
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/public/dorms)
 "bpK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "chapel"
+	icon_state = "dark"
 	},
-/area/station/service/chapel)
+/area/station/maintenance/fsmaint)
 "bpL" = (
 /obj/machinery/smartfridge/foodcart,
 /turf/simulated/floor/plasteel{
@@ -24948,46 +24488,67 @@
 	},
 /area/station/service/kitchen)
 "bpM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/effect/landmark/start/chaplain,
 /turf/simulated/floor/carpet,
 /area/station/service/chapel)
 "bpO" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/classic/reversed{
+	dir = 8;
+	name = "Hydroponics Desk";
+	req_access_txt = "35"
+	},
+/turf/simulated/floor/plating,
+/area/station/service/hydroponics)
+"bpP" = (
+/obj/structure/railing,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/carpet,
-/area/station/service/chapel)
-"bpP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "chapel"
+	dir = 8;
+	icon_state = "ramptop"
 	},
-/area/station/service/chapel)
+/area/station/maintenance/fsmaint)
 "bpQ" = (
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/fishtank/bowl,
+/obj/structure/table/wood,
+/obj/machinery/alarm{
+	dir = 4;
+	name = "west bump";
+	pixel_x = -24
 	},
-/obj/machinery/status_display{
-	layer = 4;
-	pixel_x = -32
-	},
-/obj/machinery/economy/vending/chinese,
-/turf/simulated/floor/carpet,
-/area/station/public/mrchangs)
+/turf/simulated/floor/wood,
+/area/station/public/pet_store)
 "bpR" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
-/turf/simulated/floor/carpet,
-/area/station/public/mrchangs)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood,
+/area/station/public/pet_store)
 "bpS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -25001,16 +24562,6 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/carpet,
 /area/station/public/mrchangs)
-"bpU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "chapel"
-	},
-/area/station/service/chapel)
 "bpV" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -25055,23 +24606,22 @@
 	},
 /area/station/science/hallway)
 "bqc" = (
-/obj/machinery/newscaster{
-	name = "north bump";
-	pixel_y = 28
-	},
-/turf/simulated/floor/wood,
-/area/station/service/library)
-"bqd" = (
-/obj/structure/table/wood,
-/obj/machinery/light/small{
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/light_switch{
-	dir = 8;
-	name = "east bump";
-	pixel_x = 24
+/obj/structure/window/reinforced,
+/obj/machinery/photocopier,
+/turf/simulated/floor/carpet/red,
+/area/station/service/library)
+"bqd" = (
+/obj/machinery/disposal,
+/obj/machinery/camera{
+	c_tag = "Library East";
+	dir = 8
 	},
-/obj/machinery/computer/library,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
 /turf/simulated/floor/wood,
 /area/station/service/library)
 "bqe" = (
@@ -25115,16 +24665,32 @@
 "bqi" = (
 /obj/structure/table/wood,
 /obj/item/kitchen/utensil/fork,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood,
 /area/station/service/bar)
 "bqj" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Library Maintenance";
-	req_access_txt = "12"
+/obj/structure/railing/cap/reversed{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
 /area/station/maintenance/fsmaint)
 "bqk" = (
 /obj/structure/chair/wood/wings{
@@ -25139,23 +24705,23 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port)
 "bqm" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Mr. Chang's"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Pet Shop"
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/wood,
-/area/station/public/mrchangs)
+/area/station/public/pet_store)
 "bqn" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
@@ -25208,9 +24774,10 @@
 /turf/simulated/floor/plasteel,
 /area/station/public/locker)
 "bqy" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/wood,
 /area/station/service/bar)
 "bqz" = (
@@ -25249,7 +24816,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
@@ -25329,9 +24895,8 @@
 	},
 /area/station/service/hydroponics)
 "bqM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/carpet/red,
 /area/station/service/library)
 "bqN" = (
 /turf/simulated/wall/r_wall,
@@ -25377,13 +24942,6 @@
 "bqS" = (
 /turf/simulated/floor/plasteel,
 /area/station/command/bridge)
-"bqT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "chapel"
-	},
-/area/station/service/chapel)
 "bqU" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -25397,11 +24955,10 @@
 	},
 /area/station/command/bridge)
 "bqW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon_state = "chapel"
-	},
-/area/station/service/chapel)
+/obj/machinery/power/port_gen/pacman,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/electrical)
 "bqX" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -25481,7 +25038,6 @@
 /turf/simulated/floor/wood,
 /area/station/service/bar)
 "brh" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/table/wood,
 /obj/item/taperecorder,
 /turf/simulated/floor/wood,
@@ -25585,22 +25141,10 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/service/hydroponics)
-"brt" = (
-/obj/machinery/hydroponics/constructable,
-/obj/item/radio/intercom{
-	name = "east bump";
-	pixel_x = 28
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/service/hydroponics)
 "bru" = (
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "green"
-	},
-/area/station/service/hydroponics)
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/plasteel,
+/area/station/public/dorms)
 "brv" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -25613,10 +25157,15 @@
 /turf/simulated/floor/plasteel,
 /area/station/public/locker)
 "brw" = (
-/obj/structure/bookcase{
-	name = "bookcase (Adult)"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/red,
 /area/station/service/library)
 "brx" = (
 /obj/structure/table/wood,
@@ -25624,7 +25173,9 @@
 /turf/simulated/floor/wood,
 /area/station/service/library)
 "bry" = (
-/obj/structure/chair/comfy/black,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/station/service/library)
 "brz" = (
@@ -25632,17 +25183,22 @@
 /turf/simulated/floor/plating,
 /area/station/public/storage/emergency/port)
 "brA" = (
-/obj/structure/chair/office/dark,
-/obj/effect/landmark/start/librarian,
-/turf/simulated/floor/wood,
-/area/station/service/library)
-"brB" = (
-/obj/item/radio/intercom{
-	name = "east bump";
-	pixel_x = 28
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/wood,
-/area/station/service/library)
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/station/security/detective)
+"brB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "brD" = (
 /obj/structure/chair{
 	dir = 8
@@ -25663,16 +25219,20 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
 "brG" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin{
-	pixel_x = 1;
-	pixel_y = 9
+/obj/machinery/door/airlock{
+	id_tag = "Cryogenics";
+	name = "Cryodorms"
 	},
-/turf/simulated/floor/wood,
-/area/station/service/library)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/station/public/sleep)
 "brH" = (
 /obj/structure/table/wood,
 /obj/item/clothing/head/cakehat,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood,
 /area/station/service/bar)
 "brI" = (
@@ -25680,6 +25240,10 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/ai_status_display{
+	pixel_x = -32;
+	step_size = 0
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -25718,30 +25282,22 @@
 /obj/structure/chair/stool{
 	dir = 8
 	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/station/service/bar)
 "brU" = (
 /turf/simulated/floor/wood,
 /area/station/public/vacant_office)
 "brV" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
 /turf/simulated/floor/wood,
 /area/station/service/bar)
 "brW" = (
 /obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/station/service/bar)
-"brX" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood,
 /area/station/service/bar)
 "brY" = (
@@ -25750,7 +25306,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
@@ -25766,7 +25321,7 @@
 /area/station/service/hydroponics)
 "bsa" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -25775,7 +25330,7 @@
 /area/station/service/chapel)
 "bsb" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -26213,16 +25768,22 @@
 /turf/simulated/floor/wood,
 /area/station/service/library)
 "btc" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/effect/landmark/start/clown,
+/obj/structure/chair/office/dark,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/station/security/detective)
+/turf/simulated/floor/wood,
+/area/station/service/clown)
 "bte" = (
 /turf/simulated/wall,
 /area/station/hallway/primary/starboard/east)
@@ -26243,23 +25804,24 @@
 	pixel_x = -2;
 	pixel_y = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood,
 /area/station/service/bar)
 "bth" = (
-/obj/structure/table/wood,
-/obj/item/paper,
-/turf/simulated/floor/wood,
-/area/station/service/library)
-"bti" = (
-/obj/structure/chair/comfy/black{
-	dir = 8
+/obj/machinery/light_switch{
+	dir = 1;
+	name = "south bump";
+	pixel_y = -24
 	},
 /turf/simulated/floor/wood,
 /area/station/service/library)
+"bti" = (
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/wood,
+/area/station/service/library)
 "btj" = (
-/obj/structure/table/wood,
-/obj/item/camera_film,
-/obj/item/camera_film,
+/obj/structure/chair/office/dark,
 /turf/simulated/floor/wood,
 /area/station/service/library)
 "btk" = (
@@ -26267,19 +25829,23 @@
 /turf/simulated/wall/r_wall,
 /area/station/hallway/secondary/exit)
 "btl" = (
-/obj/structure/table/wood,
-/turf/simulated/floor/wood,
-/area/station/service/library)
-"btm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/structure/chair/stool{
+	dir = 1
 	},
+/obj/machinery/firealarm{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/station/security/detective)
+"btm" = (
 /obj/structure/chair/wood/wings,
 /turf/simulated/floor/wood,
 /area/station/service/bar)
 "btn" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/table/wood,
 /obj/item/dice,
 /turf/simulated/floor/wood,
@@ -26315,24 +25881,6 @@
 	icon_state = "whitepurple"
 	},
 /area/station/science/rnd)
-"btw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/chair/wood/wings,
-/turf/simulated/floor/wood,
-/area/station/service/bar)
-"btx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/structure/chair/wood/wings{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/wood,
-/area/station/service/bar)
 "btA" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -26378,9 +25926,8 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
@@ -26492,59 +26039,39 @@
 /turf/simulated/floor/plasteel,
 /area/station/public/locker)
 "btU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "green"
 	},
 /area/station/service/hydroponics)
 "btV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/carpet,
-/area/station/service/library)
-"btW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/floor/carpet,
-/area/station/service/library)
-"btX" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/carpet,
-/area/station/service/library)
-"btY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
+/obj/structure/table/wood,
+/obj/item/folder/yellow,
 /turf/simulated/floor/wood,
 /area/station/service/library)
-"btZ" = (
+"btW" = (
+/obj/structure/table/wood,
+/obj/item/book/manual/wiki/sop_general,
+/turf/simulated/floor/wood,
+/area/station/service/library)
+"btY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/turf/simulated/floor/wood,
+/area/station/service/clown)
+"btZ" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green{
+	pixel_x = 1;
+	pixel_y = 5
 	},
+/obj/item/stack/packageWrap,
 /turf/simulated/floor/wood,
 /area/station/service/library)
 "bua" = (
@@ -26654,15 +26181,15 @@
 /turf/simulated/floor/plasteel,
 /area/station/command/bridge)
 "buq" = (
-/obj/structure/chair/wood/wings{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/wood,
-/area/station/service/bar)
+/turf/simulated/floor/plasteel,
+/area/station/public/dorms)
 "bur" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
@@ -26702,30 +26229,19 @@
 "buw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+	dir = 9
 	},
 /turf/simulated/floor/wood,
 /area/station/service/library)
 "buy" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp/green{
-	pixel_x = 1;
-	pixel_y = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/station/service/library)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "buz" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/machinery/ai_status_display{
-	pixel_x = -32;
-	step_size = 0
 	},
 /obj/machinery/camera{
 	c_tag = "Chapel West";
@@ -26793,32 +26309,34 @@
 /area/station/service/kitchen)
 "buL" = (
 /obj/machinery/hydroponics/constructable,
-/obj/machinery/firealarm{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/station/service/hydroponics)
 "buM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet,
-/area/station/public/mrchangs)
+/turf/simulated/floor/wood,
+/area/station/public/pet_store)
 "buN" = (
 /obj/structure/table/wood,
 /obj/item/candle,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
 /turf/simulated/floor/wood,
 /area/station/service/bar)
 "buP" = (
@@ -26831,10 +26349,7 @@
 	},
 /area/station/service/hydroponics)
 "buQ" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/chair/wood/wings{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood,
 /area/station/service/bar)
 "buR" = (
@@ -26865,24 +26380,13 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
 "buV" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/table/wood,
+/obj/item/dice,
+/obj/item/dice/d20,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/carpet,
-/area/station/service/library)
-"buW" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/wood,
 /area/station/service/library)
 "buX" = (
 /obj/structure/chair/office/dark{
@@ -26893,30 +26397,28 @@
 "buY" = (
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
 	},
 /turf/simulated/floor/carpet,
 /area/station/service/chapel)
 "buZ" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Chapel"
-	},
-/turf/simulated/floor/carpet,
-/area/station/service/chapel)
+/obj/structure/rack,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/air,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "bva" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Chapel"
+/obj/machinery/photocopier,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
 	},
-/turf/simulated/floor/carpet,
-/area/station/service/chapel)
+/area/station/security/detective)
 "bvb" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -26939,8 +26441,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/sign/poster/random{
-	pixel_y = 32
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard/east)
@@ -27102,14 +26607,6 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
-"bvI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/station/security/detective)
 "bvL" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -27118,32 +26615,33 @@
 /area/station/hallway/primary/central/ne)
 "bvM" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
 /area/station/service/kitchen)
 "bvN" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass{
-	name = "Chapel Office";
-	req_access_txt = "22"
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/station/service/chapel/office)
+/area/station/service/chapel)
 "bvO" = (
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
+/obj/item/radio/intercom{
+	name = "south bump";
+	pixel_y = -28
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/wood,
 /area/station/service/library)
 "bvP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -27348,6 +26846,7 @@
 	name = "Bar Office";
 	req_access_txt = "25"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/wood,
 /area/station/service/bar)
 "bwn" = (
@@ -27364,6 +26863,12 @@
 	pixel_x = 6;
 	pixel_y = -24;
 	req_access_txt = "28"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
@@ -27415,10 +26920,15 @@
 	},
 /area/station/service/kitchen)
 "bws" = (
-/obj/machinery/light{
-	dir = 4
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
 	},
-/obj/machinery/hydroponics/constructable,
+/obj/machinery/newscaster{
+	dir = 8;
+	name = "east bump";
+	pixel_x = 28
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -27660,18 +27170,16 @@
 /turf/simulated/floor/plasteel,
 /area/station/command/bridge)
 "bwX" = (
+/obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance{
 	name = "Bar Maintenance";
 	req_access_txt = "12"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "bwZ" = (
@@ -27930,7 +27438,10 @@
 /obj/machinery/economy/atm{
 	pixel_x = 32
 	},
-/obj/item/kirbyplants,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/wood,
 /area/station/service/bar)
 "bxF" = (
@@ -27978,15 +27489,16 @@
 	c_tag = "Hydroponics South";
 	dir = 8
 	},
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
-	},
-/obj/item/reagent_containers/glass/bucket,
 /obj/machinery/light_switch{
 	dir = 8;
 	name = "east bump";
 	pixel_x = 24
+	},
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24;
+	name = "south bump"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -28015,25 +27527,79 @@
 /turf/simulated/floor/wood,
 /area/station/service/library)
 "bxR" = (
-/obj/structure/chair/comfy/black{
-	dir = 4
+/obj/structure/table/wood,
+/obj/item/taperecorder,
+/obj/item/camera{
+	desc = "A one use - polaroid camera. 30 photos left.";
+	name = "Camera";
+	pictures_left = 30
 	},
+/obj/item/book/codex_gigas,
 /obj/machinery/light/small,
-/obj/effect/landmark/start/assistant,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/plasteel{
+	icon_state = "cult"
+	},
 /area/station/service/library)
 "bxS" = (
-/obj/structure/table/wood,
-/obj/item/pen,
-/turf/simulated/floor/wood,
-/area/station/service/library)
-"bxT" = (
-/obj/structure/chair/comfy/black{
-	dir = 8
+/obj/machinery/cryopod{
+	dir = 4
 	},
-/obj/effect/landmark/start/assistant,
-/turf/simulated/floor/wood,
-/area/station/service/library)
+/obj/item/radio/intercom{
+	name = "west bump";
+	pixel_x = -28
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whitegreen"
+	},
+/area/station/public/sleep)
+"bxT" = (
+/obj/effect/decal/warning_stripes/white/hollow,
+/obj/structure/cable/cyan,
+/obj/structure/cable/cyan{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/cable/cyan{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/cyan{
+	d2 = 2;
+	icon_state = "1-2";
+	d1 = 1
+	},
+/obj/structure/cable/cyan{
+	d2 = 4;
+	icon_state = "1-4";
+	d1 = 1
+	},
+/obj/structure/cable/cyan{
+	d2 = 4;
+	icon_state = "2-4";
+	d1 = 2
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "1-8";
+	d1 = 1
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "2-8";
+	d1 = 2
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "4-8";
+	d1 = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "bxU" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -28057,21 +27623,22 @@
 	},
 /area/station/command/bridge)
 "bxV" = (
-/obj/structure/chair/comfy/black{
-	dir = 4
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	name = "south bump";
+	pixel_y = -28
 	},
 /turf/simulated/floor/wood,
 /area/station/service/library)
 "bxW" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp/green{
-	pixel_x = 1;
-	pixel_y = 5
+/obj/structure/chair/office/dark{
+	dir = 1
 	},
-/obj/machinery/alarm{
-	dir = 1;
-	name = "south bump";
-	pixel_y = -24
+/obj/machinery/camera{
+	c_tag = "Library South";
+	dir = 1
 	},
 /turf/simulated/floor/wood,
 /area/station/service/library)
@@ -28401,8 +27968,9 @@
 /turf/simulated/floor/wood,
 /area/station/service/bar)
 "byE" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
@@ -28473,8 +28041,9 @@
 /turf/simulated/floor/wood,
 /area/station/command/meeting_room)
 "byM" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -28501,20 +28070,16 @@
 	},
 /area/station/turret_protected/ai_upload)
 "byR" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/carpet/red,
 /area/station/service/library)
 "byS" = (
 /obj/machinery/disposal,
@@ -28536,20 +28101,17 @@
 /turf/simulated/floor/wood,
 /area/station/command/office/captain)
 "byU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Library"
-	},
-/turf/simulated/floor/carpet,
-/area/station/service/library)
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/starboard/east)
 "byV" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -28678,6 +28240,12 @@
 /area/station/service/hydroponics)
 "bzl" = (
 /obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -28692,7 +28260,7 @@
 "bzn" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
-	dir = 1
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/station/service/bar)
@@ -28701,16 +28269,24 @@
 /obj/structure/chair/wood/wings{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/station/service/bar)
 "bzp" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/chair/office/dark{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/carpet,
+/obj/machinery/newscaster{
+	dir = 4;
+	name = "west bump";
+	pixel_x = -28
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/wood,
 /area/station/service/library)
 "bzr" = (
 /obj/item/radio/intercom{
@@ -29226,9 +28802,8 @@
 	},
 /area/station/command/bridge)
 "bAH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/wood,
 /area/station/service/bar)
 "bAK" = (
@@ -29267,46 +28842,48 @@
 /turf/simulated/floor/plating,
 /area/station/engineering/control)
 "bAU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/station/service/bar)
 "bAV" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/station/service/bar)
 "bAW" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/light{
 	dir = 8
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
 	},
 /obj/machinery/camera{
 	c_tag = "Starboard Primary Hallway 4";
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard/east)
 "bAX" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Library"
-	},
-/turf/simulated/floor/carpet,
-/area/station/service/library)
-"bAY" = (
-/obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/carpet,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
+"bAY" = (
+/obj/structure/chair/office/dark{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
 /area/station/service/library)
 "bBc" = (
 /obj/structure/chair/stool{
@@ -29815,6 +29392,9 @@
 /obj/structure/chair/wood/wings{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/station/service/bar)
 "bCC" = (
@@ -29861,6 +29441,9 @@
 	dir = 1
 	},
 /obj/machinery/gameboard,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/station/service/bar)
 "bCJ" = (
@@ -29899,30 +29482,9 @@
 /turf/simulated/floor/wood,
 /area/station/command/office/captain)
 "bCN" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/starboard/east)
-"bCO" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	name = "south bump";
-	pixel_y = -24
-	},
-/obj/machinery/camera{
-	c_tag = "Library South";
-	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/station/service/library)
+/obj/structure/table,
+/turf/simulated/floor/plating,
+/area/station/maintenance/electrical)
 "bCP" = (
 /turf/simulated/floor/carpet,
 /area/station/command/office/captain)
@@ -29931,14 +29493,16 @@
 /turf/simulated/floor/carpet,
 /area/station/command/office/captain)
 "bCR" = (
-/obj/item/kirbyplants,
+/obj/structure/cult/archives,
+/obj/machinery/newscaster{
+	dir = 4;
+	name = "west bump";
+	pixel_x = -28
+	},
 /turf/simulated/floor/wood,
 /area/station/service/library)
 "bCS" = (
-/obj/structure/chair/comfy/black{
-	dir = 8
-	},
-/obj/machinery/light/small,
+/obj/machinery/light,
 /turf/simulated/floor/wood,
 /area/station/service/library)
 "bCT" = (
@@ -30021,6 +29585,13 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/medical/chemistry)
+"bDd" = (
+/obj/item/toy/pet_rock,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/maintenance/fore)
 "bDf" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -30729,21 +30300,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard/west)
-"bFk" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/starboard/east)
 "bFl" = (
 /obj/machinery/light_switch{
 	dir = 4;
@@ -30764,7 +30320,6 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard/east)
 "bFo" = (
@@ -31535,12 +31090,13 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/sw)
 "bHr" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/starboard/east)
+/turf/simulated/floor/carpet/red,
+/area/station/service/library)
 "bHs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -31624,15 +31180,14 @@
 	},
 /area/station/engineering/gravitygenerator)
 "bHC" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel,
-/area/station/hallway/primary/starboard/east)
+/area/station/public/dorms)
 "bHD" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -31931,6 +31486,18 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/public/toilet/lockerroom)
+"bIu" = (
+/obj/structure/rack,
+/obj/item/storage/fancy/candle_box/full{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/storage/fancy/candle_box/full,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "bIv" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
@@ -32934,6 +32501,7 @@
 	dir = 4
 	},
 /mob/living/simple_animal/pig,
+/obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/grass,
 /area/station/service/hydroponics)
 "bLo" = (
@@ -33030,12 +32598,11 @@
 	},
 /area/station/medical/chemistry)
 "bLG" = (
-/obj/item/stack/rods{
-	amount = 10
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/blood/oil/streak,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/starboard/east)
 "bLI" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -33346,7 +32913,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
@@ -34004,6 +33570,26 @@
 	icon_state = "brown"
 	},
 /area/station/supply/office)
+"bOn" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "bOo" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -34483,19 +34069,9 @@
 	},
 /area/station/science/server)
 "bPx" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/starboard/east)
 "bPy" = (
 /obj/machinery/mecha_part_fabricator,
 /turf/simulated/floor/plasteel{
@@ -34579,6 +34155,12 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Kitchen";
 	req_access_txt = "28"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
@@ -42003,6 +41585,17 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/medbay2)
+"cjD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "cjF" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -45004,11 +44597,6 @@
 	name = "Brig Equipment Storage";
 	sort_type_txt = "8"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "BrigRight";
 	name = "Brig Foyer Right Entrance";
@@ -45017,6 +44605,11 @@
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Secure Gate";
 	name = "Security Blast Door"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -45725,7 +45318,7 @@
 	pixel_y = -24
 	},
 /obj/item/radio/intercom{
-	name = "east bump";
+	name = "west bump";
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
@@ -49082,6 +48675,15 @@
 	icon_state = "whitepurple"
 	},
 /area/station/science/misc_lab)
+"cGc" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/spawner/random_spawners/grille_maybe,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "cGd" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/syringes,
@@ -52960,6 +52562,21 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint2)
+"cRI" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fsmaint)
 "cRJ" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -53110,6 +52727,13 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/equipmentstorage)
+"cRW" = (
+/obj/structure/chair/stool{
+	dir = 8
+	},
+/mob/living/simple_animal/mouse,
+/turf/simulated/floor/carpet/black,
+/area/station/maintenance/fore)
 "cRX" = (
 /turf/simulated/floor/plasteel,
 /area/station/engineering/equipmentstorage)
@@ -53447,29 +53071,23 @@
 /turf/simulated/wall/r_wall,
 /area/station/engineering/control)
 "cSV" = (
-/obj/machinery/ai_status_display{
-	pixel_y = -32
-	},
-/turf/simulated/floor/carpet,
-/area/station/public/mrchangs)
-"cSW" = (
-/obj/structure/statue/chickenstatue,
-/obj/machinery/firealarm{
-	dir = 1;
+/obj/machinery/power/apc{
 	name = "south bump";
 	pixel_y = -24
 	},
-/turf/simulated/floor/carpet,
-/area/station/public/mrchangs)
+/obj/structure/cable,
+/turf/simulated/floor/wood,
+/area/station/public/pet_store)
+"cSW" = (
+/obj/machinery/economy/vending/crittercare,
+/turf/simulated/floor/wood,
+/area/station/public/pet_store)
 "cSX" = (
-/obj/structure/chair/wood,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
 	},
-/turf/simulated/floor/carpet,
-/area/station/public/mrchangs)
+/turf/simulated/floor/wood,
+/area/station/public/pet_store)
 "cSY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -53904,9 +53522,8 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint2)
 "cUi" = (
-/obj/structure/chair/wood,
-/turf/simulated/floor/carpet,
-/area/station/public/mrchangs)
+/turf/simulated/floor/wood,
+/area/station/public/pet_store)
 "cUj" = (
 /obj/machinery/requests_console{
 	department = "Engineering";
@@ -55237,6 +54854,25 @@
 /obj/machinery/atmospherics/pipe/manifold4w/visible,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
+"cYZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt{
+	pixel_x = 2
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/item/stack/rods,
+/obj/structure/grille/broken,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "cZa" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -55712,7 +55348,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/machinery/door/window/brigdoor{
+/obj/machinery/door/window/reinforced/normal{
 	dir = 1;
 	id = "Cell 1";
 	name = "Cell 1";
@@ -56652,6 +56288,25 @@
 /obj/structure/lattice/catwalk,
 /turf/space,
 /area/station/engineering/solar/starboard)
+"ddY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/structure/disposalpipe/sortjunction{
+	dir = 2;
+	icon_state = "pipe-j2s";
+	name = "Chapel";
+	sort_type_txt = "17"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/maintenance/fsmaint)
 "dea" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -57458,15 +57113,9 @@
 	name = "south bump";
 	pixel_y = -28
 	},
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/mug,
-/obj/machinery/power/apc{
-	name = "south bump";
-	pixel_y = -24
-	},
-/obj/structure/cable,
+/obj/machinery/fishtank/tank,
 /turf/simulated/floor/wood,
-/area/station/public/mrchangs)
+/area/station/public/pet_store)
 "dgI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
@@ -57612,29 +57261,21 @@
 /turf/simulated/wall/r_wall,
 /area/station/engineering/control)
 "dhp" = (
-/obj/machinery/light_switch{
+/obj/machinery/fishtank/tank,
+/turf/simulated/floor/wood,
+/area/station/public/pet_store)
+"dhq" = (
+/obj/machinery/fishtank/tank,
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = 32
+	},
+/obj/machinery/firealarm{
 	dir = 1;
 	name = "south bump";
 	pixel_y = -24
 	},
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = 2;
-	pixel_y = 6
-	},
 /turf/simulated/floor/wood,
-/area/station/public/mrchangs)
-"dhq" = (
-/obj/machinery/light,
-/obj/item/radio/intercom{
-	name = "south bump";
-	pixel_y = -28
-	},
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/turf/simulated/floor/wood,
-/area/station/public/mrchangs)
+/area/station/public/pet_store)
 "dhv" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
@@ -57778,6 +57419,9 @@
 "dhV" = (
 /obj/structure/sink/kitchen{
 	pixel_y = 25
+	},
+/obj/effect/decal/snow/clean/edge{
+	dir = 9
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
@@ -58103,7 +57747,6 @@
 /turf/space,
 /area/space/nearstation)
 "dje" = (
-/obj/item/kirbyplants,
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
@@ -58195,16 +57838,17 @@
 	},
 /area/station/service/bar)
 "djk" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/carpet,
-/area/station/service/bar)
+/turf/simulated/floor/plasteel{
+	icon_state = "black"
+	},
+/area/station/public/dorms)
 "djl" = (
 /obj/structure/table,
 /obj/item/cartridge/medical,
@@ -58212,6 +57856,9 @@
 /area/station/maintenance/aft)
 "djn" = (
 /obj/structure/closet/secure_closet/freezer/meat,
+/obj/effect/decal/snow/clean/edge{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
@@ -58345,10 +57992,9 @@
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "hydrofloor"
 	},
@@ -58771,8 +58417,6 @@
 /area/station/aisat/atmos)
 "dkN" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/carpet,
 /area/station/service/bar)
 "dkO" = (
@@ -58810,6 +58454,9 @@
 	dir = 8
 	},
 /obj/structure/kitchenspike,
+/obj/effect/decal/snow/clean/edge{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
@@ -59728,6 +59375,9 @@
 /area/station/turret_protected/ai)
 "dnu" = (
 /obj/structure/kitchenspike,
+/obj/effect/decal/snow/clean/edge{
+	dir = 10
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
@@ -59815,11 +59465,6 @@
 	icon_state = "bluecorner"
 	},
 /area/station/hallway/primary/central/ne)
-"dnD" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/machinery/hydroponics/soil,
-/turf/simulated/floor/grass,
-/area/station/service/hydroponics)
 "dnE" = (
 /obj/machinery/hydroponics/soil,
 /mob/living/simple_animal/chicken/clucky,
@@ -59859,26 +59504,20 @@
 /turf/simulated/floor/engine,
 /area/station/maintenance/turbine)
 "dnK" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
+/obj/machinery/floodlight,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/station/service/hydroponics)
 "dnM" = (
-/obj/structure/table/wood,
-/obj/item/taperecorder,
-/obj/item/camera{
-	desc = "A one use - polaroid camera. 30 photos left.";
-	name = "Camera";
-	pictures_left = 30
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/item/book/codex_gigas,
-/turf/simulated/floor/plasteel{
-	icon_state = "cult"
-	},
+/turf/simulated/floor/wood,
 /area/station/service/library)
 "dnN" = (
 /obj/machinery/light{
@@ -59902,7 +59541,10 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/floodlight,
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -60888,6 +60530,18 @@
 	},
 /turf/space,
 /area/station/turret_protected/ai)
+"dsp" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "dsx" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -61277,6 +60931,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
 "dwV" = (
+/obj/structure/railing/cap/normal{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/station/public/dorms)
@@ -61328,8 +60985,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -61353,17 +61010,30 @@
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
 "dzb" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/disposalpipe/sortjunction{
+	dir = 2;
+	icon_state = "pipe-j2s";
+	name = "Library";
+	sort_type_txt = "16"
+	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/plasteel{
-	icon_regular_floor = "yellowsiding";
-	icon_state = "tranquillite"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/area/station/service/mime)
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/starboard/east)
 "dzk" = (
 /obj/machinery/mineral/stacking_unit_console,
 /turf/simulated/wall,
@@ -61386,6 +61056,12 @@
 	icon_state = "white"
 	},
 /area/station/science/robotics)
+"dzF" = (
+/obj/structure/chair/stool{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/black,
+/area/station/maintenance/fore)
 "dzN" = (
 /obj/structure/mopbucket/full,
 /obj/item/mop,
@@ -61482,6 +61158,15 @@
 /obj/item/pizzabox/vegetable,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
+"dEL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/maintenance/fore)
 "dET" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -61521,6 +61206,16 @@
 	icon_state = "blue"
 	},
 /area/station/maintenance/aft)
+"dGB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/catwalk,
+/area/station/maintenance/fore)
 "dGR" = (
 /obj/structure/chair{
 	dir = 4
@@ -61599,6 +61294,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
+"dJc" = (
+/obj/effect/turf_decal/caution,
+/obj/effect/decal/warning_stripes/north,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "dJl" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -61895,6 +61595,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
+"dSo" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/catwalk,
+/area/station/maintenance/fore)
 "dSu" = (
 /obj/effect/spawner/random_spawners/fungus_maybe,
 /turf/simulated/wall,
@@ -61950,6 +61663,10 @@
 /obj/item/book/random,
 /turf/simulated/floor/carpet,
 /area/station/maintenance/asmaint)
+"dVa" = (
+/obj/effect/spawner/random_spawners/fungus_probably,
+/turf/simulated/wall,
+/area/station/maintenance/electrical)
 "dVG" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -62175,6 +61892,14 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
+"ebW" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood,
+/area/station/public/dorms)
 "ece" = (
 /obj/structure/table,
 /obj/item/candle,
@@ -62286,15 +62011,28 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/medical/cloning)
-"edM" = (
-/obj/machinery/light{
+"edK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "caution"
+	icon_state = "neutralcorner"
 	},
 /area/station/public/dorms)
+"edM" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/station/public/mrchangs)
 "edQ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -62417,12 +62155,21 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/aft)
+"egd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fore)
 "egi" = (
 /mob/living/simple_animal/mouse,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
 "egq" = (
-/obj/structure/closet/secure_closet/brig,
+/obj/structure/closet/secure_closet/brig{
+	name = "Old Cell 2 Locker"
+	},
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
@@ -62646,6 +62393,10 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/radio/intercom{
+	name = "west bump";
+	pixel_x = -28
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -62683,10 +62434,11 @@
 /turf/simulated/wall,
 /area/station/maintenance/aft)
 "emL" = (
-/obj/structure/closet/masks,
+/obj/structure/railing{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "caution"
+	icon_state = "rampbottom"
 	},
 /area/station/public/dorms)
 "enG" = (
@@ -62703,18 +62455,30 @@
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
 "enX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "whitegreenfull"
-	},
-/area/station/public/sleep)
-"eog" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/computer/monitor{
 	dir = 4;
-	icon_state = "pipe-c"
+	name = "Backup Power Monitoring Console"
 	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/electrical)
+"eog" = (
+/obj/structure/railing/cap/normal{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/station/public/dorms)
 "eoT" = (
@@ -62745,28 +62509,14 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port)
+"epQ" = (
+/obj/effect/spawner/random_spawners/fungus_maybe,
+/turf/simulated/wall,
+/area/station/service/kitchen)
 "epT" = (
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
 /area/station/engineering/smes)
-"epW" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/spray/waterflower,
-/obj/machinery/firealarm{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/machinery/newscaster{
-	dir = 1;
-	name = "south bump";
-	pixel_y = -28
-	},
-/turf/simulated/floor/plasteel{
-	icon_regular_floor = "yellowsiding";
-	icon_state = "tranquillite"
-	},
-/area/station/service/mime)
 "eqb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -62811,6 +62561,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
+"eqV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/maintenance/fsmaint)
 "erj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/portables_connector{
@@ -62897,6 +62661,10 @@
 /obj/effect/mapping_helpers/airlock/access/all/command/ntrep,
 /turf/simulated/floor/wood,
 /area/station/command/office/ntrep)
+"etQ" = (
+/obj/effect/spawner/random_spawners/grille_maybe,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "etR" = (
 /obj/machinery/door/airlock/external{
 	id_tag = "fpsolar_door_int";
@@ -63072,6 +62840,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint2)
+"eyK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/catwalk,
+/area/station/maintenance/fore)
 "ezf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
@@ -63082,6 +62856,11 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/maintenance/disposal)
+"ezh" = (
+/obj/item/clothing/suit/officercoat,
+/obj/item/clothing/head/armyofficer,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "ezn" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -63336,6 +63115,10 @@
 /obj/item/eftpos/register,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
+"eIY" = (
+/mob/living/simple_animal/mouse,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "eJo" = (
 /obj/machinery/door/airlock/public/glass{
 	autoclose = 0;
@@ -63451,6 +63234,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/morgue)
+"eMd" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/catwalk,
+/area/station/maintenance/fore)
 "eMs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 5
@@ -63528,9 +63320,15 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
 "eOh" = (
-/obj/machinery/economy/vending/cigarette,
-/obj/structure/window/reinforced,
-/turf/simulated/floor/wood,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/window/classic/reversed{
+	name = "Boxing Arena"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/station/public/dorms)
 "eOI" = (
 /obj/structure/closet/crate/trashcart,
@@ -63574,15 +63372,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/grass,
 /area/station/hallway/primary/aft)
-"ePV" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "caution"
-	},
-/area/station/public/dorms)
 "ePX" = (
 /obj/effect/spawner/random_spawners/oil_maybe,
 /obj/structure/disposalpipe/segment,
@@ -63622,7 +63411,7 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard/east)
 "eSm" = (
-/obj/machinery/door/window/brigdoor{
+/obj/machinery/door/window/reinforced/normal{
 	dir = 1;
 	id = "Cell 3";
 	name = "Cell 3";
@@ -63921,6 +63710,18 @@
 	icon_state = "dark"
 	},
 /area/station/service/chapel)
+"fbL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/catwalk,
+/area/station/maintenance/fore)
 "fbS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -63930,6 +63731,13 @@
 	icon_state = "white"
 	},
 /area/station/science/hallway)
+"fbU" = (
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = -32
+	},
+/obj/effect/spawner/random_spawners/grille_maybe,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "fcd" = (
 /obj/effect/turf_decal/stripes/white/line,
 /obj/effect/decal/cleanable/dirt,
@@ -64004,12 +63812,14 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
 "fes" = (
-/obj/structure/chair{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
-/obj/machinery/computer/mob_battle_terminal/red,
-/turf/simulated/floor/plasteel,
-/area/station/public/dorms)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/carpet,
+/area/station/public/mrchangs)
 "feR" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -64049,15 +63859,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
 "ffL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/machinery/economy/vending/snack,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "bluered"
+	dir = 4;
+	icon_state = "neutralcorner"
 	},
 /area/station/public/dorms)
 "ffY" = (
@@ -64110,6 +63915,12 @@
 	icon_state = "dark"
 	},
 /area/station/medical/morgue)
+"fgF" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fore)
 "fgN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -64137,12 +63948,20 @@
 	},
 /area/station/hallway/secondary/exit)
 "fho" = (
-/obj/machinery/light_switch{
-	dir = 4;
-	name = "west bump";
-	pixel_x = -24
+/obj/machinery/newscaster{
+	name = "north bump";
+	pixel_y = 28
 	},
-/turf/simulated/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
 /area/station/public/dorms)
 "fhA" = (
 /obj/machinery/door/airlock/maintenance{
@@ -64480,11 +64299,7 @@
 	c_tag = "Brig Cell Block A South";
 	dir = 8
 	},
-/obj/structure/disposalpipe/sortjunction{
-	dir = 2;
-	name = "Detective";
-	sort_type_txt = "24"
-	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "rampbottom"
@@ -64555,6 +64370,9 @@
 /obj/item/seeds/amanita,
 /turf/simulated/floor/grass,
 /area/station/security/permabrig)
+"ftv" = (
+/turf/simulated/floor/carpet/black,
+/area/station/maintenance/fore)
 "ftM" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -64664,6 +64482,11 @@
 /obj/item/storage/box/bodybags,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
+"fwK" = (
+/obj/structure/table,
+/obj/item/toy/figure/crew/hos,
+/turf/simulated/floor/carpet/black,
+/area/station/maintenance/fore)
 "fwZ" = (
 /obj/machinery/alarm{
 	name = "north bump";
@@ -64707,6 +64530,10 @@
 	icon_state = "red"
 	},
 /area/station/security/permabrig)
+"fxV" = (
+/obj/effect/decal/cleanable/fungus,
+/turf/simulated/wall,
+/area/station/service/library)
 "fyL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -64761,25 +64588,14 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "fzc" = (
-/obj/structure/disposalpipe/sortjunction{
-	dir = 4;
-	name = "Botany";
-	sort_type_txt = "21"
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "caution"
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/area/station/public/dorms)
 "fzd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/warning_stripes/north,
@@ -64818,6 +64634,12 @@
 	icon_state = "white"
 	},
 /area/station/science/robotics)
+"fzo" = (
+/obj/structure/rack,
+/obj/item/stack/packageWrap,
+/obj/item/kitchen/knife,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "fzC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/binary/valve/open{
@@ -64844,6 +64666,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
+"fAJ" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel,
+/area/station/public/dorms)
 "fAQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
@@ -64932,6 +64763,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft2)
+"fCw" = (
+/obj/structure/rack,
+/obj/item/vending_refill/dinnerware,
+/obj/item/vending_refill/chefdrobe,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "fCX" = (
 /obj/machinery/atmospherics/binary/valve/open{
 	name = "Maintenance Air Supply"
@@ -65092,15 +64932,6 @@
 	icon_state = "showroomfloor"
 	},
 /area/station/maintenance/fpmaint)
-"fHA" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "barmaint_door_ext";
-	locked = 1;
-	name = "External Access";
-	req_access_txt = "13"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
 "fHB" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan,
 /obj/structure/cable{
@@ -65139,13 +64970,16 @@
 /turf/simulated/floor/plasteel,
 /area/station/science/hallway)
 "fIB" = (
-/obj/structure/chair/stool{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "cafeteria"
+	icon_state = "dark"
 	},
-/area/station/public/dorms)
+/area/station/service/chapel)
 "fJa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/purple,
 /obj/structure/cable{
@@ -65260,6 +65094,13 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/public/dorms)
+"fNF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "fNM" = (
 /obj/effect/spawner/random_barrier/possibly_welded_airlock,
 /obj/structure/cable{
@@ -65280,6 +65121,10 @@
 	icon_state = "darkred"
 	},
 /area/station/security/brig)
+"fOR" = (
+/obj/effect/decal/cleanable/fungus,
+/turf/simulated/wall,
+/area/station/maintenance/fsmaint)
 "fPq" = (
 /obj/effect/spawner/lootdrop/maintenance{
 	lootcount = 3;
@@ -65313,6 +65158,15 @@
 /obj/item/storage/box/bodybags,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint2)
+"fQx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "fQI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -65381,12 +65235,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/assembly_line)
 "fRL" = (
-/obj/item/radio/intercom{
-	name = "west bump";
-	pixel_x = -28
+/obj/machinery/light/small{
+	dir = 8
 	},
-/turf/simulated/floor/plasteel,
-/area/station/public/dorms)
+/turf/simulated/floor/carpet/red,
+/area/station/service/library)
 "fSi" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4;
@@ -65423,6 +65276,18 @@
 	icon_state = "blue"
 	},
 /area/station/maintenance/aft)
+"fSP" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/public/dorms)
 "fTc" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -65477,19 +65342,19 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/office)
+"fUJ" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/spawner/random_spawners/grille_often,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "fUW" = (
 /obj/structure/sign/biohazard,
 /turf/simulated/wall/r_wall,
 /area/station/science/toxins/mixing)
-"fUX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
 "fVo" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -65626,6 +65491,20 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
+"fXw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "fXL" = (
 /obj/machinery/atmospherics/unary/tank/air{
 	dir = 4
@@ -65656,6 +65535,10 @@
 	icon_state = "white"
 	},
 /area/station/maintenance/asmaint)
+"gaM" = (
+/obj/machinery/atmospherics/binary/valve,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "gbs" = (
 /obj/machinery/economy/vending/cigarette,
 /turf/simulated/floor/plasteel{
@@ -65693,19 +65576,6 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/medbay)
-"gcJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light,
-/turf/simulated/floor/plasteel,
-/area/station/public/dorms)
 "gdp" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -65917,6 +65787,24 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/turbine)
+"gjk" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "vault"
+	},
+/area/station/maintenance/fsmaint)
 "gjN" = (
 /obj/structure/closet/l3closet/scientist,
 /obj/effect/decal/cleanable/dirt,
@@ -65965,6 +65853,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
+"glf" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/junction,
+/turf/simulated/floor/plasteel,
+/area/station/public/dorms)
 "glD" = (
 /obj/machinery/camera{
 	c_tag = "Departure Lounge North-West";
@@ -65997,6 +65894,11 @@
 	icon_state = "browncorner"
 	},
 /area/station/hallway/primary/central/west)
+"gml" = (
+/obj/structure/closet/emcloset,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "gmu" = (
 /obj/effect/spawner/random_spawners/grille_maybe,
 /turf/simulated/floor/plasteel,
@@ -66007,6 +65909,24 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/storage)
+"gmB" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "gmU" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -66167,6 +66087,16 @@
 /mob/living/simple_animal/mouse,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
+"gsC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel,
+/area/station/public/dorms)
 "gsQ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -66315,6 +66245,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
+"gvP" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "gvW" = (
 /obj/machinery/light{
 	dir = 1
@@ -66475,6 +66419,15 @@
 	icon_state = "wood-broken7"
 	},
 /area/station/maintenance/port)
+"gBH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 9
+	},
+/turf/simulated/floor/catwalk,
+/area/station/maintenance/fore)
 "gCE" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -66498,10 +66451,23 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint)
 "gCU" = (
-/obj/structure/punching_bag,
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel,
-/area/station/public/dorms)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/station/service/chapel)
+"gCX" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/catwalk,
+/area/station/maintenance/fore)
 "gDp" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/preopen{
@@ -66529,6 +66495,29 @@
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
+"gDO" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
+"gEb" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/station/public/dorms)
+"gEf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "gEj" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -66568,7 +66557,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 8
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -66578,20 +66567,34 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "stairs-m";
+	dir = 4
+	},
 /area/station/public/dorms)
 "gFG" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Holodeck Door"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/public/dorms)
+/obj/machinery/mech_bay_recharge_port,
+/turf/simulated/floor/plating,
+/area/station/maintenance/electrical)
 "gFV" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "purple"
 	},
 /area/station/science/hallway)
+"gGD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/public/dorms)
 "gGQ" = (
 /obj/effect/landmark/spawner/rev,
 /obj/machinery/light/small{
@@ -66732,6 +66735,12 @@
 	icon_state = "white"
 	},
 /area/station/maintenance/asmaint)
+"gKb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/turf/simulated/floor/catwalk,
+/area/station/maintenance/fore)
 "gKF" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -66779,6 +66788,15 @@
 "gLG" = (
 /turf/simulated/wall,
 /area/station/engineering/hardsuitstorage)
+"gLS" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/atmospherics/binary/pump{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "gMa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -66920,16 +66938,16 @@
 	},
 /area/station/maintenance/asmaint)
 "gOA" = (
+/obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralcorner"
 	},
-/turf/simulated/floor/plasteel,
 /area/station/public/dorms)
 "gOB" = (
 /obj/structure/disposalpipe/segment{
@@ -67011,6 +67029,26 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
+"gRm" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 9
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "gRp" = (
 /obj/machinery/atmospherics/unary/thermomachine/freezer/on{
 	dir = 1
@@ -67037,11 +67075,22 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
+"gRK" = (
+/obj/item/storage/secure/safe{
+	pixel_y = 25
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/maintenance/fore)
 "gRU" = (
 /obj/structure/table,
 /obj/item/stack/sheet/glass,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/asmaint)
+"gRY" = (
+/turf/simulated/floor/catwalk,
+/area/station/maintenance/fore)
 "gSd" = (
 /obj/structure/girder,
 /turf/simulated/floor/plating,
@@ -67277,6 +67326,15 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/science/toxins/launch)
+"gWw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/catwalk,
+/area/station/maintenance/fore)
 "gWZ" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Prison Wing";
@@ -67317,9 +67375,17 @@
 	icon_state = "red"
 	},
 /area/station/security/permabrig)
+"gXf" = (
+/obj/machinery/light/small,
+/obj/item/poster/random_contraband,
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "vault"
+	},
+/area/station/maintenance/fsmaint)
 "gXR" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/window/brigdoor{
+/obj/machinery/door/window/reinforced/normal{
 	dir = 2;
 	id = "Cell 4";
 	name = "Cell 4";
@@ -67349,6 +67415,12 @@
 	icon_state = "dark"
 	},
 /area/station/security/prison/cell_block/A)
+"gXS" = (
+/obj/effect/decal/cleanable/dirt{
+	pixel_x = 2
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "gXU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -67438,7 +67510,9 @@
 	},
 /area/station/maintenance/aft)
 "gZy" = (
-/obj/structure/closet/secure_closet/brig,
+/obj/structure/closet/secure_closet/brig{
+	name = "Old Cell 2 Locker"
+	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -67483,6 +67557,17 @@
 	icon_state = "black"
 	},
 /area/station/security/permabrig)
+"haR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/spawner/random_spawners/oil_often,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "haU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/light/small{
@@ -67520,18 +67605,30 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
+"hcl" = (
+/obj/structure/chair/wood/wings{
+	dir = 1
+	},
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = -32
+	},
+/turf/simulated/floor/wood,
+/area/station/maintenance/abandonedbar)
 "hcE" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
 /turf/simulated/floor/engine,
 /area/station/science/explab/chamber)
-"hdr" = (
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "whitegreen"
-	},
-/area/station/public/sleep)
+"hcL" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fore)
+"hdb" = (
+/obj/effect/spawner/random_spawners/fungus_maybe,
+/turf/simulated/wall,
+/area/station/service/mime)
 "hdW" = (
 /obj/item/lighter/random,
 /turf/simulated/floor/plasteel{
@@ -68006,6 +68103,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
+"hrw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/maintenance/fsmaint)
+"hsm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random_spawners/oil_maybe,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "hsO" = (
 /obj/structure/chair/stool{
 	dir = 8
@@ -68022,6 +68132,12 @@
 	icon_state = "whitepurplecorner"
 	},
 /area/station/science/toxins/mixing)
+"hte" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/deck/cards,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "htR" = (
 /obj/structure/chair/sofa/right{
 	dir = 4;
@@ -68064,12 +68180,25 @@
 /obj/effect/spawner/random_spawners/dirt_frequent,
 /turf/simulated/floor/wood,
 /area/station/maintenance/asmaint2)
+"huD" = (
+/obj/effect/spawner/random_spawners/fungus_maybe,
+/turf/simulated/wall,
+/area/station/service/hydroponics)
 "huR" = (
 /obj/item/crowbar/red,
 /turf/simulated/floor/plasteel{
 	icon_state = "cmo"
 	},
 /area/station/maintenance/aft)
+"hvz" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/catwalk,
+/area/station/maintenance/fore)
 "hvN" = (
 /obj/structure/table,
 /obj/item/paper/crumpled,
@@ -68099,6 +68228,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
+"hvW" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
+"hwu" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "hwC" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -68263,6 +68401,20 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/science/storage)
+"hzA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 5
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/catwalk,
+/area/station/maintenance/fore)
 "hzG" = (
 /obj/machinery/access_button{
 	autolink_id = "scimaint_btn_int";
@@ -68276,6 +68428,26 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
+"hAa" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
+"hAe" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "hAh" = (
 /obj/structure/flora/rock/pile/largejungle,
 /turf/simulated/floor/grass,
@@ -68327,6 +68499,16 @@
 /obj/item/robotanalyzer,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
+"hBD" = (
+/obj/effect/spawner/random_spawners/fungus_maybe,
+/turf/simulated/wall,
+/area/station/maintenance/fore)
+"hBQ" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "hCr" = (
 /obj/machinery/economy/vending/coffee,
 /turf/simulated/floor/plasteel,
@@ -68391,6 +68573,10 @@
 	icon_state = "red"
 	},
 /area/station/security/permabrig)
+"hDI" = (
+/obj/effect/spawner/random_spawners/fungus_maybe,
+/turf/simulated/wall,
+/area/station/maintenance/fsmaint)
 "hDJ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -68473,6 +68659,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
+"hFa" = (
+/obj/effect/decal/cleanable/fungus,
+/turf/simulated/wall,
+/area/station/maintenance/abandonedbar)
 "hFe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -68522,6 +68712,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint2)
+"hGP" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/obj/effect/spawner/random_spawners/cobweb_right_rare,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "hGW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 6
@@ -69172,6 +69368,10 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/port)
+"iaQ" = (
+/obj/effect/spawner/random_spawners/wall_rusted_maybe,
+/turf/simulated/wall,
+/area/station/maintenance/fsmaint)
 "ibl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -69216,17 +69416,15 @@
 /turf/simulated/floor/plasteel,
 /area/station/science/xenobiology)
 "idg" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutralcorner"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/area/station/public/dorms)
 "ido" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -69314,6 +69512,10 @@
 /obj/machinery/bottler,
 /turf/simulated/floor/wood,
 /area/station/maintenance/asmaint2)
+"ifU" = (
+/obj/machinery/space_heater,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "igq" = (
 /obj/structure/chair/sofa/left{
 	dir = 4
@@ -69338,6 +69540,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	icon_state = "barber"
 	},
@@ -69559,6 +69762,10 @@
 /obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
+"ink" = (
+/obj/machinery/gameboard,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "inv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -69651,6 +69858,11 @@
 /obj/structure/flora/ausbushes/leafybush,
 /turf/simulated/floor/grass,
 /area/station/hallway/secondary/exit)
+"isS" = (
+/obj/structure/table/wood,
+/obj/item/extinguisher,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "isZ" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -69659,6 +69871,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
+"itm" = (
+/obj/effect/spawner/random_spawners/fungus_maybe,
+/turf/simulated/wall,
+/area/station/service/chapel/office)
 "itF" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -69737,17 +69953,12 @@
 	},
 /area/station/medical/surgery/observation)
 "ivc" = (
-/obj/machinery/cryopod{
-	dir = 4
+/obj/structure/closet/secure_closet/brig{
+	name = "Old Cell 2 Locker"
 	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "whitegreen"
-	},
-/area/station/public/sleep)
+/obj/effect/spawner/lootdrop/maintenance/three,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "ivo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -69853,6 +70064,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/station/security/prisonlockers)
+"iyC" = (
+/obj/effect/spawner/random_spawners/wall_rusted_maybe,
+/turf/simulated/wall/r_wall,
+/area/station/security/evidence)
 "iyJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -69941,15 +70156,20 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/assembly_line)
+"izW" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "iAE" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/public/dorms)
+/obj/structure/statue/chickenstatue,
+/turf/simulated/floor/carpet,
+/area/station/public/mrchangs)
+"iBy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random_spawners/grille_maybe,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "iBI" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -70053,6 +70273,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/public/storage/emergency/port)
+"iFn" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "iFq" = (
 /obj/machinery/atmospherics/binary/pump{
 	name = "heat exchange to port"
@@ -70116,13 +70342,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
 "iGP" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/closet/boxinggloves,
+/obj/structure/weightmachine/weightlifter,
 /turf/simulated/floor/plasteel{
-	icon_state = "caution";
-	dir = 10
+	dir = 10;
+	icon_state = "caution"
 	},
 /area/station/public/dorms)
 "iHE" = (
@@ -70149,6 +70372,13 @@
 	icon_state = "green"
 	},
 /area/station/medical/virology)
+"iIf" = (
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/machinery/atmospherics/portable/canister/sleeping_agent,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/maintenance/fore)
 "iIA" = (
 /obj/structure/chair/sofa/corp/right,
 /turf/simulated/floor/plasteel{
@@ -70194,6 +70424,12 @@
 	icon_state = "whitepurple"
 	},
 /area/station/science/toxins/mixing)
+"iJx" = (
+/obj/effect/spawner/random_spawners/grille_maybe,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/maintenance/fore)
 "iKk" = (
 /obj/machinery/door/window/classic/reversed{
 	name = "Primate Pen";
@@ -70217,6 +70453,17 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/aft)
+"iKR" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 5
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	name = "west bump";
+	pixel_x = -24
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "iKY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/largecrate,
@@ -70226,10 +70473,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint2)
 "iMp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel,
 /area/station/public/dorms)
 "iMG" = (
@@ -70289,6 +70533,18 @@
 /obj/machinery/computer/library,
 /turf/simulated/floor/wood,
 /area/station/security/permabrig)
+"iPS" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "iPZ" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -70329,6 +70585,13 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/medical/cryo)
+"iSa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = 32
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fsmaint)
 "iSv" = (
 /obj/structure/chair{
 	dir = 4
@@ -70359,6 +70622,19 @@
 	icon_state = "caution"
 	},
 /area/station/engineering/controlroom)
+"iSH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/glass,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fsmaint)
 "iTq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -70404,6 +70680,12 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/aft)
+"iTW" = (
+/obj/structure/chair/stool{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/black,
+/area/station/maintenance/fore)
 "iUc" = (
 /turf/simulated/wall/r_wall,
 /area/station/telecomms/chamber)
@@ -70453,6 +70735,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/storage)
+"iVw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/turf/simulated/floor/carpet/black,
+/area/station/maintenance/fore)
 "iVE" = (
 /obj/structure/chair/stool,
 /turf/simulated/floor/plasteel{
@@ -70490,6 +70776,11 @@
 /obj/structure/table,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
+"iYz" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/mouse,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "iYO" = (
 /obj/machinery/light_switch{
 	dir = 1;
@@ -70584,17 +70875,24 @@
 	},
 /area/station/service/barber)
 "jaY" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 2;
 	icon_state = "pipe-j2s";
 	name = "Sci Robotics";
 	sort_type_txt = "14"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard/east)
 "jbt" = (
@@ -70622,6 +70920,20 @@
 /obj/machinery/light,
 /turf/simulated/floor/engine,
 /area/station/science/explab/chamber)
+"jcd" = (
+/obj/structure/closet/emcloset,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
+"jcl" = (
+/obj/machinery/atmospherics/portable/canister/air{
+	anchored = 1
+	},
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "jcY" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -70688,6 +71000,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
+"jep" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fsmaint)
 "jet" = (
 /obj/machinery/light{
 	dir = 1
@@ -70702,6 +71028,10 @@
 	},
 /turf/simulated/floor/engine/n20,
 /area/station/engineering/atmos)
+"jeJ" = (
+/obj/effect/spawner/random_spawners/fungus_probably,
+/turf/simulated/wall,
+/area/station/service/janitor)
 "jeQ" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -70770,6 +71100,15 @@
 /obj/effect/spawner/random_spawners/grille_often,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
+"jgE" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/carpet,
+/area/station/service/bar)
 "jid" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/engine,
@@ -70971,21 +71310,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint2)
-"jqS" = (
-/obj/machinery/light_switch{
-	dir = 1;
-	name = "south bump";
-	pixel_y = -24
-	},
-/obj/machinery/light,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_regular_floor = "yellowsiding";
-	icon_state = "tranquillite"
-	},
-/area/station/service/mime)
 "jrh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -71122,6 +71446,12 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/se)
+"jvc" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralcorner"
+	},
+/area/station/public/dorms)
 "jwb" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -71327,6 +71657,22 @@
 	icon_state = "purple"
 	},
 /area/station/science/hallway)
+"jCA" = (
+/obj/structure/rack{
+	dir = 1
+	},
+/obj/item/storage/fancy/donut_box,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
+"jCS" = (
+/obj/structure/chair/stool{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fore)
 "jDf" = (
 /obj/structure/table,
 /obj/item/hand_labeler,
@@ -71383,14 +71729,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
+"jDK" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/maintenance/fore)
 "jDV" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
-/area/station/public/dorms)
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/station/security/detective)
 "jEm" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -71407,15 +71759,9 @@
 /turf/simulated/floor/plating,
 /area/station/command/office/cmo)
 "jEq" = (
-/obj/machinery/access_button{
-	autolink_id = "barmaint_btn_ext";
-	pixel_x = -25;
-	pixel_y = -25;
-	req_access_txt = "13"
-	},
-/obj/structure/lattice/catwalk,
-/turf/space,
-/area/space/nearstation)
+/obj/structure/sign/pods,
+/turf/simulated/wall/r_wall,
+/area/station/maintenance/fore)
 "jEQ" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable,
@@ -71479,20 +71825,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/hardsuitstorage)
-"jHx" = (
-/obj/machinery/cryopod{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "whitegreencorner"
-	},
-/area/station/public/sleep)
 "jHG" = (
 /obj/machinery/kitchen_machine/grill,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
 /area/station/security/permabrig)
+"jHT" = (
+/obj/structure/rack,
+/obj/item/storage/toolbox/emergency,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "jIE" = (
 /obj/machinery/camera{
 	c_tag = "Xenobiology Module Hazard Pen";
@@ -71533,6 +71876,16 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
+"jJd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/wrench,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/maintenance/fore)
 "jJn" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -71550,6 +71903,10 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/public/arcade)
+"jKx" = (
+/obj/structure/closet/cardboard,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "jKZ" = (
 /obj/machinery/atmospherics/binary/pump/on,
 /turf/simulated/floor/plating,
@@ -71571,6 +71928,15 @@
 	icon_state = "bar"
 	},
 /area/station/security/permabrig)
+"jLi" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "jLy" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -71646,12 +72012,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
-"jPN" = (
-/obj/machinery/computer/mob_battle_terminal/blue{
-	pixel_x = -32
-	},
-/turf/simulated/floor/plasteel,
-/area/station/public/dorms)
 "jPY" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 8;
@@ -71711,19 +72071,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
 "jRo" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	autolink_id = "barmaint_vent"
-	},
-/obj/machinery/airlock_controller/air_cycler{
-	pixel_x = 25;
-	req_access_txt = "13";
-	vent_link_id = "barmaint_vent";
-	ext_door_link_id = "barmaint_door_ext";
-	int_door_link_id = "barmaint_door_int";
-	ext_button_link_id = "barmaint_btn_ext";
-	int_button_link_id = "barmaint_btn_int"
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel,
 /area/station/maintenance/fsmaint)
 "jRF" = (
 /obj/structure/chair/stool{
@@ -71815,6 +72163,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
+"jSX" = (
+/obj/machinery/door/airlock{
+	id_tag = "secmaintdorm2";
+	name = "Room 2"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/maintenance/fore)
 "jTb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/structure/falsewall,
@@ -71872,6 +72229,14 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint2)
+"jUP" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 6;
+	level = 1
+	},
+/obj/effect/landmark/spawner/nukedisc_respawn,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "jUZ" = (
 /obj/structure/window/plasmareinforced{
 	dir = 4
@@ -71932,20 +72297,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
-"jVw" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/sortjunction{
-	name = "Bar";
-	sort_type_txt = "19"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
 "jVA" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -72012,16 +72363,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
-"jXj" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "whitegreen"
-	},
-/area/station/public/sleep)
 "jYt" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -72345,9 +72686,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint2)
 "kiu" = (
-/obj/structure/weightmachine/weightlifter,
-/turf/simulated/floor/plasteel,
-/area/station/public/dorms)
+/obj/structure/chair/wood,
+/turf/simulated/floor/wood,
+/area/station/public/mrchangs)
 "kiF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -72493,16 +72834,52 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
+"knl" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "knB" = (
-/obj/structure/chair/wood{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/decal/remains/human{
-	desc = "This guy seemed to have died in terrible way! Half his remains are dust.";
-	name = "human remains"
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkredcorners"
 	},
-/obj/effect/decal/cleanable/blood/old,
-/turf/simulated/floor/plating,
+/area/station/security/brig)
+"knP" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/station/maintenance/fsmaint)
 "kok" = (
 /obj/effect/decal/cleanable/dirt,
@@ -72650,6 +73027,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
+"krY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/station/maintenance/abandonedbar)
 "ksj" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = 32
@@ -72709,6 +73092,10 @@
 	icon_state = "whitepurple"
 	},
 /area/station/science/explab)
+"ktK" = (
+/obj/effect/spawner/random_spawners/fungus_probably,
+/turf/simulated/wall,
+/area/station/public/dorms)
 "ktW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -72872,6 +73259,11 @@
 	icon_state = "dark"
 	},
 /area/station/medical/cryo)
+"kAq" = (
+/obj/structure/rack,
+/obj/item/storage/toolbox/mechanical,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "kBe" = (
 /obj/machinery/door/airlock{
 	name = "Prison Toilets"
@@ -72897,6 +73289,15 @@
 	icon_state = "white"
 	},
 /area/station/medical/medbay3)
+"kBp" = (
+/obj/structure/window/reinforced,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "vault"
+	},
+/area/station/maintenance/fsmaint)
 "kBr" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -73039,6 +73440,21 @@
 	icon_state = "whitebluefull"
 	},
 /area/station/medical/medbay2)
+"kGl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/rack,
+/obj/item/storage/fancy/crayons,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "vault"
+	},
+/area/station/maintenance/fsmaint)
 "kGB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood,
@@ -73081,6 +73497,13 @@
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint2)
+"kII" = (
+/obj/effect/decal/warning_stripes/white/hollow,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/maintenance/fore)
 "kIR" = (
 /obj/machinery/computer/general_air_control/large_tank_control{
 	dir = 8;
@@ -73288,8 +73711,14 @@
 /turf/simulated/floor/plating/airless,
 /area/station/science/toxins/test)
 "kOt" = (
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/plasteel,
+/obj/machinery/status_display{
+	pixel_y = -32
+	},
+/obj/structure/railing,
+/turf/simulated/floor/plasteel{
+	icon_state = "stairs-l";
+	dir = 8
+	},
 /area/station/public/dorms)
 "kOu" = (
 /obj/structure/cable{
@@ -73840,6 +74269,14 @@
 	icon_state = "redfull"
 	},
 /area/station/security/permabrig)
+"lfy" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
+	},
+/obj/structure/closet/secure_closet/engineering_welding,
+/obj/effect/spawner/lootdrop/maintenance/eight,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "lgb" = (
 /obj/machinery/access_button{
 	autolink_id = "fssolar_btn_ext";
@@ -73856,7 +74293,9 @@
 /turf/space,
 /area/station/engineering/solar/auxstarboard)
 "lgS" = (
-/obj/structure/closet/secure_closet/brig,
+/obj/structure/closet/secure_closet/brig{
+	name = "Old Cell 2 Locker"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "red"
@@ -73904,6 +74343,16 @@
 	icon_state = "whitepurple"
 	},
 /area/station/science/xenobiology)
+"lim" = (
+/obj/structure/closet/crate,
+/obj/item/vending_refill/hydroseeds,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/item/reagent_containers/spray/plantbgone{
+	pixel_x = 13;
+	pixel_y = 5
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "liO" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -73961,8 +74410,8 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "lkd" = (
@@ -73993,11 +74442,18 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/asmaint)
 "lkw" = (
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/hologram/holopad,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/plasteel,
-/area/station/public/dorms)
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
+	},
+/area/station/service/mime)
 "llf" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "barber"
@@ -74073,24 +74529,17 @@
 	icon_state = "hydrofloor"
 	},
 /area/station/maintenance/asmaint)
-"lop" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/landmark/start/assistant,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel,
-/area/station/public/dorms)
 "loL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/turf/simulated/floor/plasteel,
-/area/station/public/dorms)
+/obj/machinery/camera{
+	c_tag = "Brig Detective's Office"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/station/security/detective)
 "lpu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -74104,6 +74553,12 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/asmaint)
+"lpx" = (
+/obj/structure/rack,
+/obj/item/coin/mime,
+/obj/item/clothing/mask/gas/sexymime,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "lpJ" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -74336,6 +74791,26 @@
 	icon_state = "darkblue"
 	},
 /area/station/command/office/cmo)
+"lzV" = (
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 4
+	},
+/obj/machinery/atmospherics/portable/canister/air{
+	filled = 0.1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/maintenance/fore)
+"lzZ" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 2;
+	name = "2maintenance loot spawner"
+	},
+/obj/item/storage/fancy/cigarettes/dromedaryco,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "lAb" = (
 /obj/effect/landmark/damageturf,
 /obj/machinery/light_construct/small{
@@ -74383,6 +74858,10 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/science/explab/chamber)
+"lCa" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fsmaint)
 "lCG" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -74682,15 +75161,37 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/medbay3)
-"lLq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+"lLf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	d1 = 2;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "4-8"
+	},
+/obj/effect/spawner/random_spawners/oil_maybe,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/fore)
+/area/station/maintenance/fsmaint)
+"lLq" = (
+/obj/structure/closet/athletic_mixed,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/public/dorms)
 "lLC" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -74725,6 +75226,22 @@
 	icon_state = "dark"
 	},
 /area/station/medical/morgue)
+"lMp" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fsmaint)
 "lMP" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = 32
@@ -74735,6 +75252,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint)
+"lNC" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/station/service/chapel/office)
 "lNE" = (
 /obj/structure/rack{
 	dir = 8;
@@ -74790,15 +75315,13 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
 "lOY" = (
-/obj/machinery/camera{
-	c_tag = "Dormitories East";
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
-/obj/structure/table/wood,
-/obj/item/deck/cards,
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria"
-	},
+/turf/simulated/floor/plasteel,
 /area/station/public/dorms)
 "lPC" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -74901,6 +75424,17 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/grass,
 /area/station/hallway/secondary/exit)
+"lSL" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/catwalk,
+/area/station/maintenance/fore)
 "lTa" = (
 /obj/machinery/door/window/classic/normal{
 	dir = 2;
@@ -74947,6 +75481,10 @@
 	icon_state = "redfull"
 	},
 /area/station/security/permabrig)
+"lTC" = (
+/obj/effect/spawner/random_spawners/wall_rusted_maybe,
+/turf/simulated/wall,
+/area/station/service/chapel/office)
 "lUa" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -74967,6 +75505,11 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/permabrig)
+"lUu" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "lUC" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -75021,6 +75564,11 @@
 /obj/machinery/atmospherics/unary/passive_vent,
 /turf/simulated/floor/engine,
 /area/station/science/toxins/mixing)
+"lVI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/wood/wings,
+/turf/simulated/floor/plating,
+/area/station/maintenance/abandonedbar)
 "lVU" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -75124,6 +75672,11 @@
 /obj/effect/decal/cleanable/blood/drip,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
+"lYn" = (
+/mob/living/simple_animal/mouse,
+/obj/effect/spawner/random_spawners/blood_often,
+/turf/simulated/floor/wood,
+/area/station/maintenance/abandonedbar)
 "lYv" = (
 /obj/effect/spawner/random_barrier/floor_probably,
 /turf/simulated/floor/plating,
@@ -75234,11 +75787,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint2)
 "mdg" = (
-/obj/item/kirbyplants,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -24;
-	name = "south bump"
+	name = "south bump";
+	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "barber"
@@ -75272,6 +75824,12 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/controlroom)
+"mdF" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/catwalk,
+/area/station/maintenance/fore)
 "mdX" = (
 /obj/item/reagent_containers/food/snacks/grown/cannabis,
 /obj/effect/decal/cleanable/dirt,
@@ -75391,6 +75949,15 @@
 	icon_state = "wood-broken6"
 	},
 /area/station/maintenance/asmaint)
+"mhr" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/catwalk,
+/area/station/maintenance/fore)
 "mhQ" = (
 /obj/machinery/door/airlock/engineering/glass{
 	locked = 1;
@@ -75450,6 +76017,15 @@
 	icon_state = "whitepurple"
 	},
 /area/station/science/xenobiology)
+"miY" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/wood,
+/area/station/public/dorms)
 "mje" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -75470,6 +76046,23 @@
 	icon_state = "cautioncorner"
 	},
 /area/station/maintenance/asmaint2)
+"mjv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "mjE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/watertank,
@@ -75522,6 +76115,22 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/station/supply/qm)
+"mlk" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/maintenance/fsmaint)
 "mlv" = (
 /obj/machinery/light/small,
 /obj/structure/closet,
@@ -75629,6 +76238,10 @@
 	icon_state = "cafeteria"
 	},
 /area/station/medical/reception)
+"mpL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/turf/simulated/floor/catwalk,
+/area/station/maintenance/fore)
 "mqV" = (
 /obj/structure/railing,
 /obj/structure/chair{
@@ -75815,14 +76428,18 @@
 	},
 /area/station/command/office/rd)
 "mxZ" = (
-/obj/structure/table/wood,
-/obj/item/paper/crumpled/bloody{
-	info = "Mr. Ducky, I shall miss you!";
-	desc = "A scrap of paper with dried blood on it."
+/obj/machinery/camera{
+	c_tag = "Dormitories East";
+	dir = 1
 	},
-/obj/item/bikehorn/rubberducky,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/obj/item/radio/intercom{
+	name = "south bump";
+	pixel_y = -28
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralcorner"
+	},
+/area/station/public/dorms)
 "myq" = (
 /obj/structure/chair/sofa/corp/right{
 	dir = 1
@@ -75877,8 +76494,8 @@
 	},
 /area/station/medical/reception)
 "mzv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/structure/chair{
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
@@ -75999,11 +76616,21 @@
 	},
 /area/station/science/explab)
 "mDF" = (
-/obj/machinery/cryopod,
-/turf/simulated/floor/plasteel{
-	icon_state = "whitegreenfull"
+/obj/machinery/power/apc{
+	name = "south bump";
+	pixel_y = -24
 	},
-/area/station/public/sleep)
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/station/service/chapel/office)
 "mDZ" = (
 /obj/machinery/cryopod{
 	dir = 4
@@ -76102,6 +76729,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
+"mIy" = (
+/obj/structure/closet/cardboard,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "mIA" = (
 /obj/structure/table,
 /obj/item/stamp/granted,
@@ -76263,6 +76895,21 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
+"mKT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 6
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "mLu" = (
 /obj/machinery/atmospherics/portable/canister/air,
 /obj/machinery/atmospherics/unary/portables_connector{
@@ -76367,6 +77014,11 @@
 	icon_state = "cafeteria"
 	},
 /area/station/medical/reception)
+"mOg" = (
+/obj/structure/closet/firecloset,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "mOr" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -76423,19 +77075,21 @@
 /obj/item/stack/rods,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/port)
-"mQt" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/regular,
-/obj/machinery/requests_console{
-	department = "Crew Quarters";
-	name = "Crew Quarters Requests Console";
-	pixel_y = 30
+"mQn" = (
+/obj/structure/rack,
+/obj/item/storage/box/bodybags{
+	pixel_x = -4;
+	pixel_y = 7
 	},
+/obj/item/storage/box/bodybags,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
+"mQy" = (
+/mob/living/simple_animal/mouse,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "bluered"
+	icon_state = "grimy"
 	},
-/area/station/public/dorms)
+/area/station/maintenance/abandonedbar)
 "mQX" = (
 /obj/structure/barricade/wooden,
 /obj/effect/spawner/window/reinforced,
@@ -76594,6 +77248,14 @@
 	},
 /turf/simulated/floor/engine/n2,
 /area/station/engineering/atmos)
+"mVX" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "mWa" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1;
@@ -76604,6 +77266,16 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/control)
+"mWC" = (
+/obj/structure/rack,
+/obj/item/reagent_containers/food/drinks/flask/barflask,
+/obj/item/clothing/head/that{
+	pixel_x = 4;
+	pixel_y = 6
+	},
+/obj/effect/spawner/random_spawners/cobweb_right_rare,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "mWQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -76657,6 +77329,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/aft)
+"mXW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fsmaint)
 "mXZ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
@@ -76710,11 +77389,12 @@
 	},
 /area/station/medical/medbay2)
 "naU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/barricade/wooden,
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/area/station/maintenance/electrical)
 "nbx" = (
 /obj/machinery/hydroponics/soil,
 /turf/simulated/floor/grass,
@@ -76856,6 +77536,15 @@
 	icon_state = "whitepurple"
 	},
 /area/station/science/toxins/mixing)
+"nhE" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "vault"
+	},
+/area/station/maintenance/fsmaint)
 "nic" = (
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
@@ -76910,6 +77599,11 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/exit)
+"nkW" = (
+/obj/effect/spawner/window/reinforced/tinted,
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "nln" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -76976,6 +77670,11 @@
 	},
 /turf/simulated/floor/indestructible,
 /area/station/science/toxins/test)
+"nnK" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "noq" = (
 /obj/machinery/conveyor/west{
 	id = "QMLoad";
@@ -76986,6 +77685,15 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/storage)
+"nox" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/catwalk,
+/area/station/maintenance/fore)
 "noP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -77042,24 +77750,25 @@
 /turf/simulated/wall,
 /area/station/maintenance/port)
 "nqG" = (
-/obj/machinery/economy/vending/cola,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "caution"
-	},
-/area/station/public/dorms)
+/turf/simulated/floor/plating,
+/area/station/maintenance/auxsolarstarboard)
 "nqN" = (
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/turbine)
 "nqX" = (
-/obj/structure/table,
-/obj/item/paper{
-	desc = "";
-	info = "Brusies sustained in the holodeck can be healed simply by sleeping.";
-	name = "Holodeck Disclaimer"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plasteel,
-/area/station/public/dorms)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/security/interrogation)
 "nrD" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -77169,6 +77878,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/portsolar)
+"ntG" = (
+/obj/structure/rack,
+/obj/item/storage/backpack/mime,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "nuq" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel,
@@ -77288,6 +78002,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
+"nyv" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/mouse,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/electrical)
 "nyC" = (
 /obj/structure/rack,
 /turf/simulated/floor/plating,
@@ -77300,16 +78019,12 @@
 /turf/simulated/floor/plasteel,
 /area/station/supply/storage)
 "nAn" = (
-/obj/machinery/door/window/classic/reversed{
-	dir = 8;
-	name = "Library Desk Door";
-	req_access_txt = "37"
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/machinery/status_display{
-	layer = 4;
-	pixel_y = 32
-	},
-/turf/simulated/floor/wood,
+/obj/structure/window/reinforced,
+/obj/machinery/bookbinder,
+/turf/simulated/floor/carpet/red,
 /area/station/service/library)
 "nAq" = (
 /obj/item/paper_bin{
@@ -77471,6 +78186,14 @@
 	icon_state = "dark"
 	},
 /area/station/maintenance/asmaint)
+"nDU" = (
+/obj/structure/chair/sofa/bench/left{
+	dir = 1;
+	cover_color = "#85130b"
+	},
+/obj/effect/spawner/random_spawners/cobweb_left_rare,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "nDZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -77772,17 +78495,12 @@
 	},
 /area/station/supply/miningdock)
 "nNB" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp/green,
-/obj/machinery/alarm{
-	name = "north bump";
-	pixel_y = 24
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
 	},
-/turf/simulated/floor/plasteel{
-	icon_regular_floor = "yellowsiding";
-	icon_state = "tranquillite"
-	},
-/area/station/service/mime)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/station/public/dorms)
 "nOo" = (
 /turf/simulated/floor/plasteel,
 /area/station/science/hallway)
@@ -77791,6 +78509,15 @@
 /obj/structure/barricade/wooden,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint2)
+"nOy" = (
+/obj/machinery/atmospherics/binary/valve/open{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "nOz" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -77870,6 +78597,28 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/public/toilet)
+"nQn" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/maintenance/fsmaint)
+"nQD" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "nQG" = (
 /obj/effect/decal/warning_stripes/southeast,
 /obj/machinery/atmospherics/pipe/manifold/visible,
@@ -77893,6 +78642,12 @@
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
+"nSl" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/service/chapel)
 "nSm" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -77966,6 +78721,30 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/control)
+"nUV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/catwalk,
+/area/station/maintenance/fore)
+"nVf" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/mouse,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fsmaint)
 "nVM" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -77991,24 +78770,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
 "nXm" = (
-/obj/machinery/alarm{
-	dir = 8;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "whitegreen"
-	},
-/area/station/public/sleep)
-"nXr" = (
-/obj/machinery/status_display{
-	layer = 4;
-	pixel_x = -32
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel,
-/area/station/public/dorms)
+/area/station/hallway/primary/starboard/west)
 "nXu" = (
 /obj/structure/window/reinforced,
 /obj/structure/table/reinforced,
@@ -78160,6 +78925,10 @@
 	},
 /turf/simulated/floor/carpet,
 /area/station/medical/psych)
+"ocp" = (
+/obj/structure/reagent_dispensers/oil,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "ocw" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
@@ -78195,6 +78964,23 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/science/robotics)
+"odq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/item/poster/random_contraband,
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "vault"
+	},
+/area/station/maintenance/fsmaint)
 "odD" = (
 /obj/structure/bookcase,
 /turf/simulated/floor/wood,
@@ -78357,6 +79143,13 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/security/permabrig)
+"oil" = (
+/obj/structure/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-j2"
+	},
+/turf/simulated/floor/carpet,
+/area/station/public/dorms)
 "ois" = (
 /obj/machinery/newscaster/security_unit{
 	name = "north bump";
@@ -78377,25 +79170,15 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/surgery/secondary)
-"oiD" = (
-/obj/machinery/cryopod{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "whitegreenfull"
-	},
-/area/station/public/sleep)
 "oiL" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/disposalpipe/junction{
-	dir = 4;
-	icon_state = "pipe-j2"
-	},
-/obj/machinery/alarm{
+/obj/machinery/newscaster{
 	dir = 1;
 	name = "south bump";
-	pixel_y = -24
+	pixel_y = -28
+	},
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
@@ -78488,6 +79271,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
+"ojX" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/cyan,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "okf" = (
 /obj/machinery/access_button{
 	autolink_id = "secmaint_btn_ext";
@@ -78498,18 +79285,34 @@
 /obj/structure/lattice/catwalk,
 /turf/space,
 /area/space/nearstation)
-"okj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+"okh" = (
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = 32
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
+"okj" = (
+/obj/machinery/requests_console{
+	department = "Crew Quarters";
+	name = "Crew Quarters Requests Console";
+	pixel_y = 30
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "bluered"
+	dir = 4;
+	icon_state = "neutralcorner"
 	},
 /area/station/public/dorms)
+"okx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/catwalk,
+/area/station/maintenance/fore)
 "olG" = (
 /obj/machinery/atmospherics/unary/vent_pump/siphon/on{
 	dir = 8;
@@ -78551,11 +79354,14 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
 "omD" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/alarm{
+	name = "north bump";
+	pixel_y = 24
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
 /area/station/public/dorms)
 "onc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -78610,6 +79416,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
+"opC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "opZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 10
@@ -78665,13 +79485,15 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/server/coldroom)
 "oqL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5
+	},
 /obj/machinery/door/airlock/external{
 	id_tag = "secmaint_door_int";
 	locked = 1;
 	name = "External Access";
 	req_access_txt = "13"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
 "orE" = (
@@ -78680,6 +79502,12 @@
 /obj/effect/spawner/random_spawners/blood_maybe,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
+"orG" = (
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "orU" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -78812,6 +79640,12 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/medbay2)
+"ove" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random_spawners/cobweb_left_rare,
+/obj/effect/spawner/random_spawners/oil_maybe,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "ovm" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -78894,12 +79728,13 @@
 	},
 /area/station/medical/medbay)
 "oyv" = (
-/obj/structure/chair/comfy/beige{
-	dir = 8
-	},
-/obj/effect/landmark/start/assistant,
 /obj/structure/window/reinforced,
-/turf/simulated/floor/wood,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/station/public/dorms)
 "oyH" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
@@ -79032,6 +79867,11 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/science/xenobiology)
+"oDO" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance/three,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "oDT" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -79161,6 +80001,46 @@
 	icon_state = "whitepurple"
 	},
 /area/station/science/toxins/mixing)
+"oGB" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
+"oGT" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "oGU" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 8
@@ -79195,13 +80075,15 @@
 	},
 /area/station/medical/virology)
 "oHO" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/door/airlock{
+	id_tag = "Cryogenics";
+	name = "Cryodorms"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/station/public/sleep)
 "oHU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/structure/cable{
@@ -79265,6 +80147,15 @@
 "oJr" = (
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/asmaint)
+"oJD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/catwalk,
+/area/station/maintenance/fore)
 "oJO" = (
 /obj/machinery/light/small,
 /obj/structure/closet/firecloset/full,
@@ -79324,6 +80215,18 @@
 	icon_state = "white"
 	},
 /area/station/supply/miningdock)
+"oLK" = (
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "oLS" = (
 /obj/structure/window/reinforced,
 /obj/structure/table,
@@ -79390,11 +80293,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
 "oPE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -79405,7 +80308,9 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralcorner"
+	},
 /area/station/public/dorms)
 "oPO" = (
 /obj/item/radio/intercom{
@@ -79462,6 +80367,35 @@
 	icon_state = "dark"
 	},
 /area/station/telecomms/chamber)
+"oQk" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/grille/broken,
+/obj/item/stack/rods,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fsmaint)
+"oQL" = (
+/obj/effect/decal/warning_stripes/blue/hollow,
+/obj/machinery/atmospherics/portable/canister/oxygen,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/maintenance/fore)
+"oQY" = (
+/obj/structure/reagent_dispensers/watertank/high,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fsmaint)
 "oRn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -79477,6 +80411,13 @@
 	icon_state = "bluefull"
 	},
 /area/station/medical/storage)
+"oRp" = (
+/obj/structure/chair/stool{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "oRB" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -79552,6 +80493,10 @@
 /obj/structure/sign/biohazard,
 /turf/simulated/wall/r_wall,
 /area/station/medical/virology)
+"oTU" = (
+/obj/effect/decal/cleanable/fungus,
+/turf/simulated/wall,
+/area/station/security/interrogation)
 "oUV" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "redcorner"
@@ -79734,6 +80679,16 @@
 	icon_state = "dark"
 	},
 /area/station/maintenance/aft)
+"oZL" = (
+/obj/effect/spawner/random_spawners/fungus_maybe,
+/turf/simulated/wall/r_wall,
+/area/station/maintenance/fore)
+"oZZ" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "pak" = (
 /obj/structure/rack,
 /obj/item/circuitboard/chem_heater{
@@ -79745,6 +80700,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
+"pav" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/spawner/random_spawners/oil_maybe,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "paK" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -79911,6 +80881,37 @@
 "peU" = (
 /turf/simulated/floor/plasteel,
 /area/station/service/janitor)
+"pfp" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/item/stock_parts/cell,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
+"pft" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/maintenance/fsmaint)
 "pfF" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -79927,6 +80928,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/asmaint)
+"pgi" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "pgq" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research{
@@ -80401,7 +81410,9 @@
 	},
 /area/station/supply/storage)
 "psa" = (
-/obj/structure/closet/secure_closet/brig,
+/obj/structure/closet/secure_closet/brig{
+	name = "Old Cell 2 Locker"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "red"
@@ -80482,6 +81493,10 @@
 	icon_state = "white"
 	},
 /area/station/maintenance/asmaint)
+"pvG" = (
+/obj/effect/spawner/random_spawners/grille_often,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "pvP" = (
 /obj/machinery/defibrillator_mount/loaded{
 	pixel_x = -30
@@ -80783,6 +81798,15 @@
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
+"pFf" = (
+/obj/effect/decal/cleanable/dirt{
+	pixel_x = 2
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "pFm" = (
 /obj/structure/closet/crate/can,
 /obj/effect/decal/warning_stripes/southwest,
@@ -80792,20 +81816,13 @@
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
 "pFI" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/spawner/nukedisc_respawn,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 5
 	},
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "whitegreencorner"
-	},
-/area/station/public/sleep)
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/electrical)
 "pGh" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -80824,6 +81841,15 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint2)
+"pGA" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "pGL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/purple{
 	dir = 4
@@ -80883,12 +81909,20 @@
 	icon_state = "purple"
 	},
 /area/station/maintenance/asmaint2)
+"pLo" = (
+/obj/effect/spawner/random_spawners/grille_maybe,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "pMj" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 6
 	},
 /turf/simulated/floor/engine,
 /area/station/science/toxins/mixing)
+"pMv" = (
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
+/area/station/public/dorms)
 "pMy" = (
 /obj/effect/decal/warning_stripes/southwest,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -80896,6 +81930,12 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
+"pMH" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/public/dorms)
 "pMM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -81039,6 +82079,10 @@
 	icon_state = "darkbluecorners"
 	},
 /area/station/medical/morgue)
+"pQk" = (
+/obj/effect/spawner/random_spawners/wall_rusted_maybe,
+/turf/simulated/wall,
+/area/station/maintenance/abandonedbar)
 "pRg" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "whiteblue"
@@ -81069,6 +82113,10 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/science/xenobiology)
+"pRH" = (
+/obj/effect/spawner/random_spawners/fungus_probably,
+/turf/simulated/wall,
+/area/station/service/kitchen)
 "pRR" = (
 /obj/structure/girder,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
@@ -81204,13 +82252,18 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint2)
 "pVi" = (
-/obj/effect/landmark/start/assistant,
-/obj/structure/chair/comfy/beige{
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/public/dorms)
+"pVw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
-/obj/structure/window/reinforced,
-/turf/simulated/floor/wood,
-/area/station/public/dorms)
+/turf/simulated/floor/plating,
+/area/station/maintenance/abandonedbar)
 "pWW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/spawner/nukedisc_respawn,
@@ -81300,10 +82353,33 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/station/supply/miningdock)
+"qay" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "qaI" = (
 /obj/item/clothing/suit/chef/classic,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
+"qbc" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
+"qbT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "qcl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -81333,6 +82409,17 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/asmaint)
+"qcs" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "qcy" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -81413,6 +82500,15 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint)
+"qds" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/station/service/bar)
 "qdO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -81478,6 +82574,18 @@
 /obj/item/assembly/mousetrap/armed,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
+"qfK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/public/dorms)
 "qgj" = (
 /obj/effect/spawner/random_spawners/fungus_maybe,
 /turf/simulated/wall,
@@ -81512,28 +82620,24 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
 "qhL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/machinery/power/terminal{
+	dir = 8
 	},
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/starboard/east)
-"qhT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/area/station/maintenance/electrical)
+"qhT" = (
+/obj/structure/chair/wood/wings{
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/station/service/bar)
 "qhY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/purple,
 /obj/machinery/door/airlock/maintenance{
@@ -81541,6 +82645,10 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/asmaint)
+"qif" = (
+/obj/effect/spawner/random_spawners/grille_maybe,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fore)
 "qiB" = (
 /obj/structure/sign/poster/contraband/punch_shit{
 	pixel_y = -32
@@ -81568,6 +82676,12 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
+"qji" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/electrical)
 "qjs" = (
 /obj/structure/weightmachine/stacklifter,
 /obj/effect/decal/cleanable/dirt,
@@ -81942,6 +83056,12 @@
 	icon_state = "dark"
 	},
 /area/station/science/robotics/chargebay)
+"qsp" = (
+/obj/structure/rack,
+/obj/item/clothing/shoes/clown_shoes,
+/obj/item/clothing/mask/gas/clown_hat,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "qsB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
@@ -81953,17 +83073,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
 "qta" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "whitegreen"
-	},
-/area/station/public/sleep)
+/turf/simulated/floor/wood,
+/area/station/service/clown)
 "qth" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -81971,17 +83084,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
 "qtm" = (
-/obj/machinery/access_button{
-	autolink_id = "secmaint_btn_int";
-	name = "interior access button";
-	pixel_x = 9;
-	pixel_y = -25;
-	req_access_txt = "13"
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5
-	},
-/turf/simulated/floor/plating,
 /area/station/maintenance/fore)
 "qtC" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -82137,11 +83243,16 @@
 	},
 /area/station/science/xenobiology)
 "qyq" = (
-/obj/item/kirbyplants,
 /obj/machinery/newscaster{
 	dir = 1;
 	name = "south bump";
 	pixel_y = -28
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -82451,11 +83562,14 @@
 /turf/simulated/floor/engine,
 /area/station/science/xenobiology)
 "qFg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/door/airlock/public/glass{
+	name = "Chapel"
 	},
-/turf/simulated/floor/plasteel,
-/area/station/public/dorms)
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/service/chapel)
 "qFj" = (
 /obj/structure/sign/vacuum/external{
 	pixel_y = 32
@@ -82584,17 +83698,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/station/engineering/control)
-"qHd" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/public/sleep)
 "qHw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -82660,6 +83763,11 @@
 	icon_state = "whitehall"
 	},
 /area/station/medical/reception)
+"qJC" = (
+/obj/structure/table,
+/obj/item/toy/figure/owl,
+/turf/simulated/floor/carpet/black,
+/area/station/maintenance/fore)
 "qJN" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
@@ -82864,6 +83972,33 @@
 /obj/structure/grille/broken,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
+"qNF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door_control{
+	id = "secmaintdorm2";
+	name = "Door Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = 25;
+	specialfunctions = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
+"qOb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
+"qOo" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fsmaint)
 "qOs" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -82977,6 +84112,22 @@
 	},
 /turf/simulated/floor/engine/n2,
 /area/station/engineering/atmos)
+"qSb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/catwalk,
+/area/station/maintenance/fore)
 "qSF" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -83113,14 +84264,39 @@
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/asmaint2)
 "qZO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/statue/tranquillite/mime,
+/obj/machinery/camera{
+	c_tag = "Mime's Office";
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
+/turf/simulated/floor/plasteel{
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
+	},
+/area/station/service/mime)
+"qZV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/maintenance/fsmaint)
 "rac" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
@@ -83135,24 +84311,23 @@
 	},
 /area/station/maintenance/aft)
 "raC" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/sortjunction{
-	dir = 4;
-	name = "Kitchen";
-	sort_type_txt = "20"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 9
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/starboard/east)
 "raH" = (
 /obj/item/kirbyplants,
 /turf/simulated/floor/plasteel,
@@ -83402,20 +84577,14 @@
 /turf/simulated/wall/r_wall,
 /area/station/engineering/hardsuitstorage)
 "rhh" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/structure/railing{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_regular_floor = "yellowsiding";
-	icon_state = "tranquillite"
+	icon_state = "stairs-r";
+	dir = 8
 	},
-/area/station/service/mime)
+/area/station/public/dorms)
 "rhk" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -83449,6 +84618,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
+"riz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "rjh" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/barricade/wooden,
@@ -83596,6 +84772,17 @@
 /obj/effect/spawner/random_spawners/grille_often,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
+"rnk" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 6
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/catwalk,
+/area/station/maintenance/fore)
 "rnx" = (
 /obj/machinery/camera{
 	c_tag = "Departure Lounge South-East";
@@ -83609,6 +84796,12 @@
 	icon_state = "bluecorner"
 	},
 /area/station/hallway/secondary/exit)
+"rnT" = (
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/public/dorms)
 "rog" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
@@ -83645,6 +84838,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
+"rsY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/sortjunction{
+	name = "Bar";
+	sort_type_txt = "19"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fsmaint)
 "rtu" = (
 /obj/structure/rack{
 	dir = 1
@@ -83682,16 +84890,34 @@
 	},
 /area/station/ai_monitored/storage/eva)
 "rtY" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/light/small{
+/obj/structure/railing{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/turf/simulated/floor/plasteel{
+	icon_state = "rampbottom"
+	},
+/area/station/public/dorms)
+"run" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 9
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/sortjunction{
+	dir = 2;
+	name = "Janitor";
+	sort_type_txt = "22"
+	},
+/turf/simulated/floor/catwalk,
+/area/station/maintenance/fore)
 "ruu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/portable/canister,
@@ -83700,6 +84926,13 @@
 	icon_state = "cautioncorner"
 	},
 /area/station/maintenance/asmaint2)
+"ruw" = (
+/obj/structure/chair/sofa/bench/right{
+	dir = 1;
+	cover_color = "#85130b"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "ruR" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -83841,11 +85074,26 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/storage)
+"rBj" = (
+/obj/machinery/atmospherics/pipe/manifold/visible,
+/obj/machinery/atmospherics/meter,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "rBN" = (
 /obj/effect/spawner/random_spawners/blood_often,
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
+"rBO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "rCf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -83882,27 +85130,6 @@
 	icon_state = "dark"
 	},
 /area/station/medical/morgue)
-"rCM" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/sortjunction{
-	dir = 2;
-	icon_state = "pipe-j2s";
-	name = "Library";
-	sort_type_txt = "16"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/starboard/east)
 "rCQ" = (
 /obj/structure/chair/stool{
 	dir = 4
@@ -83984,19 +85211,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
-"rET" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "caution"
-	},
-/area/station/public/dorms)
 "rEZ" = (
 /obj/effect/spawner/random_spawners/wall_rusted_maybe,
 /turf/simulated/wall,
@@ -84050,6 +85264,10 @@
 /obj/structure/barricade/wooden,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
+"rGi" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "rGr" = (
 /obj/effect/spawner/window/reinforced/plasma,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
@@ -84067,7 +85285,12 @@
 	},
 /area/station/science/hallway)
 "rHR" = (
-/obj/machinery/hologram/holopad,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	icon_regular_floor = "yellowsiding";
 	icon_state = "tranquillite"
@@ -84171,6 +85394,18 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/south)
+"rML" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/public/dorms)
 "rMP" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	autolink_id = "fpsolar_vent"
@@ -84205,6 +85440,18 @@
 	icon_state = "yellowcorner"
 	},
 /area/station/maintenance/asmaint2)
+"rNa" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fore)
 "rNh" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command/glass{
@@ -84251,6 +85498,29 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/medbay2)
+"rPn" = (
+/obj/structure/rack,
+/obj/item/toner{
+	pixel_y = 3
+	},
+/obj/item/toner{
+	pixel_y = -4
+	},
+/obj/item/camera_film{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/camera_film{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/item/taperecorder,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "rPs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
@@ -84283,6 +85553,13 @@
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
+"rQm" = (
+/obj/effect/decal/warning_stripes/red/hollow,
+/obj/machinery/atmospherics/portable/canister/carbon_dioxide,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/maintenance/fore)
 "rQp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -84423,24 +85700,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
-"rTp" = (
-/obj/machinery/cryopod{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	name = "west bump";
-	pixel_x = -28
-	},
-/obj/machinery/light_switch{
-	dir = 1;
-	name = "south bump";
-	pixel_y = -24
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "whitegreencorner"
-	},
-/area/station/public/sleep)
 "rTy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -84451,6 +85710,26 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/station/telecomms/chamber)
+"rTY" = (
+/obj/item/storage/secure/safe{
+	pixel_y = 25
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
+"rUg" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "rVo" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -84548,6 +85827,17 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
+"rXM" = (
+/obj/structure/table/wood,
+/obj/item/deck/cards,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/wood{
+	broken = 1;
+	icon_state = "wood-broken"
+	},
+/area/station/maintenance/abandonedbar)
 "rYm" = (
 /obj/structure/girder,
 /turf/simulated/floor/plasteel,
@@ -84563,6 +85853,11 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint2)
+"rYD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/catwalk,
+/area/station/maintenance/fore)
 "rZE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -84572,6 +85867,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
+"saP" = (
+/obj/effect/spawner/random_spawners/fungus_maybe,
+/turf/simulated/wall,
+/area/station/maintenance/abandonedbar)
 "saV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/effect/decal/cleanable/dirt,
@@ -84600,6 +85899,12 @@
 	icon_state = "brown"
 	},
 /area/station/supply/miningdock)
+"scK" = (
+/obj/structure/rack,
+/obj/effect/landmark/costume/random,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "scM" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -84690,6 +85995,11 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port)
+"sfb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/firecloset,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fsmaint)
 "sft" = (
 /obj/machinery/door/airlock/external{
 	id_tag = "supply_home";
@@ -84777,17 +86087,16 @@
 	icon_state = "whitebluefull"
 	},
 /area/station/maintenance/aft)
-"six" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+"siv" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/girder,
 /turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
+"six" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/station/maintenance/fsmaint)
 "siM" = (
 /obj/effect/decal/cleanable/dirt,
@@ -84799,6 +86108,15 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/security/permabrig)
+"sjh" = (
+/obj/item/paper/crumpled/bloody{
+	info = "Mr. Ducky, I shall miss you!";
+	desc = "A scrap of paper with dried blood on it."
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/station/maintenance/abandonedbar)
 "sji" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random_spawners/cobweb_right_rare,
@@ -84857,6 +86175,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
+"smv" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/carpet,
+/area/station/public/dorms)
 "smx" = (
 /obj/effect/spawner/random_spawners/blood_maybe,
 /obj/effect/landmark/damageturf,
@@ -85104,6 +86429,21 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/control)
+"sta" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/obj/effect/spawner/random_spawners/grille_maybe,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "stu" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -85186,6 +86526,26 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
+"syE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/catwalk,
+/area/station/maintenance/fore)
+"syK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "szk" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -85198,16 +86558,11 @@
 /area/station/maintenance/assembly_line)
 "szt" = (
 /obj/machinery/door/airlock/maintenance{
+	name = "Library Maintenance";
 	req_access_txt = "12"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/fore)
+/area/station/maintenance/fsmaint)
 "szF" = (
 /obj/machinery/economy/vending/cola,
 /turf/simulated/floor/plasteel{
@@ -85389,24 +86744,24 @@
 /turf/simulated/floor/plating,
 /area/station/legal/lawoffice)
 "sDz" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /obj/machinery/access_button{
 	autolink_id = "fssolar_btn_int";
 	pixel_x = 25;
 	pixel_y = 25;
 	req_access_txt = "13"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarstarboard)
@@ -85535,6 +86890,16 @@
 /obj/item/plant_analyzer,
 /turf/simulated/floor/grass,
 /area/station/security/permabrig)
+"sGb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/public/dorms)
 "sGl" = (
 /obj/structure/lattice,
 /turf/simulated/floor/plating/airless,
@@ -85570,6 +86935,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
+"sJi" = (
+/obj/structure/chair/stool{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "sJo" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -85582,7 +86954,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/machinery/door/window/brigdoor{
+/obj/machinery/door/window/reinforced/normal{
 	dir = 2;
 	id = "Cell 2";
 	name = "Cell 2";
@@ -85617,6 +86989,13 @@
 /obj/effect/spawner/random_spawners/oil_maybe,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint2)
+"sJR" = (
+/obj/structure/table,
+/obj/item/dice/d20,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "sJX" = (
 /obj/machinery/atmospherics/binary/pump/on{
 	dir = 1
@@ -85717,6 +87096,16 @@
 	icon_state = "darkblue"
 	},
 /area/station/medical/surgery/observation)
+"sMX" = (
+/obj/structure/bed,
+/obj/item/toy/plushie/deer,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/maintenance/fore)
 "sMZ" = (
 /obj/machinery/door/poddoor/shutters{
 	dir = 2;
@@ -85802,13 +87191,9 @@
 /turf/simulated/floor/engine,
 /area/station/science/xenobiology)
 "sPb" = (
-/obj/machinery/alarm{
-	name = "north bump";
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/plasteel,
-/area/station/public/dorms)
+/obj/machinery/computer/mech_bay_power_console,
+/turf/simulated/floor/bluegrid,
+/area/station/maintenance/electrical)
 "sPu" = (
 /obj/item/clothing/suit/mantle/old,
 /turf/simulated/floor/carpet,
@@ -85832,19 +87217,13 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
 "sPN" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
+/area/station/service/chapel)
 "sQe" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -85880,26 +87259,32 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint)
 "sRg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/machinery/door/airlock/security/glass{
+	name = "Detective";
+	req_access_txt = "4"
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "Detective"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 2;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/sortjunction{
-	dir = 2;
-	name = "Janitor";
-	sort_type_txt = "22"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/security/detective)
 "sRk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -85960,6 +87345,30 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
+"sSt" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/public/dorms)
+"sSu" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Security Maintenance";
+	req_access_txt = "63";
+	security_level = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "sSE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -86041,6 +87450,19 @@
 /obj/effect/spawner/random_spawners/fungus_maybe,
 /turf/simulated/wall,
 /area/station/medical/coldroom)
+"sUr" = (
+/obj/structure/rack{
+	dir = 1
+	},
+/obj/item/radio{
+	pixel_x = 5
+	},
+/obj/item/reagent_containers/food/drinks/mug/sec,
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = 32
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "sUy" = (
 /obj/structure/disposalpipe/junction{
 	dir = 8;
@@ -86053,6 +87475,19 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard/east)
+"sVr" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "sWc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -86065,6 +87500,13 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/aft)
+"sWj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 6
+	},
+/turf/simulated/floor/catwalk,
+/area/station/maintenance/fore)
 "sWO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
@@ -86073,12 +87515,24 @@
 /obj/effect/spawner/random_spawners/grille_maybe,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint2)
+"sWR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fsmaint)
 "sXh" = (
 /obj/machinery/economy/vending/autodrobe,
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
 /area/station/public/dorms)
+"sXm" = (
+/obj/structure/closet/firecloset,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "sXJ" = (
 /obj/structure/rack{
 	dir = 1
@@ -86153,25 +87607,11 @@
 	},
 /area/station/maintenance/asmaint2)
 "sZa" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/chair/comfy/brown,
+/turf/simulated/floor/plasteel{
+	icon_state = "cult"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
+/area/station/service/library)
 "sZe" = (
 /obj/structure/rack{
 	dir = 1
@@ -86246,6 +87686,17 @@
 /mob/living/simple_animal/slime,
 /turf/simulated/floor/engine,
 /area/station/science/xenobiology)
+"taO" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fsmaint)
 "tbr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/binary/pump,
@@ -86267,11 +87718,22 @@
 /turf/simulated/floor/plating,
 /area/station/command/office/rd)
 "tbC" = (
-/obj/structure/chair{
-	dir = 4
+/obj/structure/table/wood,
+/obj/item/reagent_containers/spray/waterflower,
+/obj/machinery/firealarm{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
 	},
-/turf/simulated/floor/plasteel,
-/area/station/public/dorms)
+/obj/machinery/newscaster{
+	name = "north bump";
+	pixel_y = 28
+	},
+/turf/simulated/floor/plasteel{
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
+	},
+/area/station/service/mime)
 "tbU" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -86286,18 +87748,19 @@
 	},
 /area/station/engineering/smes)
 "tbZ" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 2;
 	icon_state = "pipe-j2s";
 	name = "Sci RD Office 1";
 	sort_type_txt = "13"
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard/east)
 "tcm" = (
@@ -86318,6 +87781,12 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/public/arcade)
+"tcr" = (
+/obj/machinery/atmospherics/binary/valve/open{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "tcM" = (
 /obj/effect/spawner/random_spawners/cobweb_right_frequent,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -86495,6 +87964,14 @@
 	icon_state = "white"
 	},
 /area/station/science/xenobiology)
+"tjc" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "tjl" = (
 /obj/structure/dresser,
 /turf/simulated/floor/plasteel{
@@ -86505,10 +87982,6 @@
 "tjS" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
-	},
-/obj/structure/sign/chinese{
-	pixel_x = -32;
-	pixel_y = -32
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -86649,6 +88122,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
+"tmL" = (
+/obj/effect/spawner/random_spawners/grille_often,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fore)
 "tmS" = (
 /obj/effect/spawner/random_spawners/grille_maybe,
 /turf/simulated/floor/plating,
@@ -86713,6 +88190,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint2)
+"trS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/turf/simulated/floor/catwalk,
+/area/station/maintenance/fore)
 "tsl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -86770,10 +88256,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/science/explab)
+"tuK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "tuZ" = (
-/obj/structure/weightmachine/stacklifter,
-/turf/simulated/floor/plasteel,
-/area/station/public/dorms)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/carpet,
+/area/station/public/mrchangs)
 "tvr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -86845,6 +88338,15 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/qm)
+"twq" = (
+/obj/structure/rack,
+/obj/item/vending_refill/boozeomat,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "twu" = (
 /obj/machinery/hydroponics/soil,
 /turf/simulated/floor/grass,
@@ -87012,7 +88514,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
 "tCY" = (
-/obj/structure/closet/secure_closet/brig,
+/obj/structure/closet/secure_closet/brig{
+	name = "Old Cell 2 Locker"
+	},
 /obj/machinery/firealarm{
 	dir = 4;
 	name = "east bump";
@@ -87110,6 +88614,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
+"tEI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = -32
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
+"tES" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random_spawners/cobweb_left_frequent,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fsmaint)
 "tEU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
@@ -87117,6 +88633,18 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint2)
+"tFq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/catwalk,
+/area/station/maintenance/fore)
 "tFt" = (
 /obj/machinery/computer/scan_consolenew{
 	dir = 8
@@ -87180,6 +88708,11 @@
 /obj/structure/girder,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
+"tHc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "tHh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
@@ -87339,6 +88872,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard/east)
+"tLP" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/public/dorms)
 "tMg" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/metal{
@@ -87405,6 +88948,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboardsolar)
+"tMW" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "vault"
+	},
+/area/station/maintenance/fsmaint)
 "tNc" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/drinks/drinkingglass,
@@ -87421,6 +88973,11 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/medical/psych)
+"tNJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/emcloset,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "tOo" = (
 /obj/structure/closet/l3closet/virology,
 /obj/item/clothing/mask/gas,
@@ -87588,6 +89145,16 @@
 	icon_state = "vault"
 	},
 /area/station/maintenance/apmaint)
+"tSq" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Fore-Starboard Atmospherics Maintenance";
+	req_access_txt = "12;24"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "tSu" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/emergency,
@@ -87669,6 +89236,10 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/science/explab/chamber)
+"tTW" = (
+/obj/effect/spawner/random_spawners/fungus_maybe,
+/turf/simulated/wall,
+/area/station/public/arcade)
 "tUd" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/accessory/stethoscope,
@@ -87875,6 +89446,17 @@
 	icon_state = "whitepurple"
 	},
 /area/station/science/rnd)
+"tZg" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken5"
+	},
+/area/station/maintenance/abandonedbar)
 "tZo" = (
 /obj/item/radio/intercom{
 	name = "west bump";
@@ -87908,6 +89490,12 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard/west)
+"tZP" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "uac" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -87974,6 +89562,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
+"uch" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/catwalk,
+/area/station/maintenance/fore)
 "ucE" = (
 /obj/structure/closet/emcloset,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -88095,6 +89695,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
+"uhj" = (
+/obj/effect/spawner/random_spawners/wall_rusted_maybe,
+/turf/simulated/wall,
+/area/station/service/chapel)
 "uhl" = (
 /obj/structure/sign/engineering{
 	pixel_x = -27
@@ -88129,6 +89733,23 @@
 "uij" = (
 /turf/simulated/floor/engine,
 /area/station/science/explab/chamber)
+"uiN" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Fore Atmospherics Maintenance";
+	req_access_txt = "12;24"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
+"ujq" = (
+/obj/effect/spawner/window/reinforced/tinted,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "uku" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -88226,6 +89847,13 @@
 	icon_state = "darkbluefull"
 	},
 /area/station/medical/surgery/observation)
+"umi" = (
+/obj/structure/table,
+/obj/item/storage/box/characters,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/turf/simulated/floor/carpet/black,
+/area/station/maintenance/fore)
 "umH" = (
 /obj/machinery/computer/camera_advanced/xenobio{
 	dir = 4
@@ -88521,6 +90149,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
+"uuQ" = (
+/obj/effect/spawner/random_spawners/fungus_maybe,
+/turf/simulated/wall,
+/area/station/service/library)
 "uuR" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Atmospherics Maintenance";
@@ -88617,6 +90249,10 @@
 	icon_state = "whitepurple"
 	},
 /area/station/science/robotics)
+"uyJ" = (
+/obj/structure/closet/coffin,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "uzh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
@@ -88642,6 +90278,18 @@
 	},
 /turf/simulated/floor/carpet/royalblack,
 /area/station/command/office/ntrep)
+"uAi" = (
+/obj/structure/rack,
+/obj/item/clothing/gloves/color/latex,
+/obj/item/storage/box/bodybags{
+	pixel_x = -4;
+	pixel_y = 7
+	},
+/obj/item/storage/box/evidence,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "uAo" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -88799,6 +90447,13 @@
 	icon_state = "green"
 	},
 /area/station/engineering/atmos/distribution)
+"uFT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/wood/wings{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/abandonedbar)
 "uGf" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/snacks/grilledcheese{
@@ -88835,6 +90490,11 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/security/permabrig)
+"uHt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/tile/wood,
+/turf/simulated/floor/plating,
+/area/station/maintenance/abandonedbar)
 "uHD" = (
 /obj/machinery/door/airlock/external{
 	id_tag = "eng_door_ext";
@@ -88958,6 +90618,18 @@
 	icon_state = "whitebluefull"
 	},
 /area/station/medical/medbay2)
+"uKO" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/rack,
+/obj/item/bikehorn,
+/obj/item/instrument/bikehorn,
+/obj/item/bikehorn/rubberducky,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "uLo" = (
 /obj/structure/chair/sofa/corp/right,
 /turf/simulated/floor/plasteel,
@@ -88975,13 +90647,6 @@
 	icon_state = "bluecorner"
 	},
 /area/station/hallway/secondary/exit)
-"uLZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/plasteel{
-	icon_state = "whitegreenfull"
-	},
-/area/station/public/sleep)
 "uMa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -89122,6 +90787,13 @@
 	icon_state = "darkpurple"
 	},
 /area/station/science/genetics)
+"uPY" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 9
+	},
+/obj/effect/landmark/spawner/nukedisc_respawn,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "uRo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -89143,15 +90815,27 @@
 /obj/item/scalpel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
+"uSF" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "uTo" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 1
+	},
 /obj/machinery/door/airlock/external{
 	id_tag = "secmaint_door_int";
 	locked = 1;
 	name = "External Access";
 	req_access_txt = "13"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 6
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
@@ -89266,6 +90950,16 @@
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
+"uWG" = (
+/obj/structure/rack,
+/obj/item/storage/bible,
+/obj/item/paper_bin{
+	pixel_x = -2;
+	pixel_y = 5
+	},
+/obj/item/pen,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "uWO" = (
 /obj/machinery/door/poddoor/shutters{
 	dir = 2;
@@ -89292,8 +90986,18 @@
 	name = "south bump";
 	pixel_y = -28
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/station/public/dorms)
+"uYF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/maintenance/fore)
 "uYU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -89345,10 +91049,12 @@
 	},
 /area/station/engineering/smes)
 "uZL" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard/west)
 "uZW" = (
@@ -89476,6 +91182,17 @@
 /obj/effect/landmark/start/cargo_technician,
 /turf/simulated/floor/plasteel,
 /area/station/supply/storage)
+"vcW" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 10
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/catwalk,
+/area/station/maintenance/fore)
 "vdo" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 1
@@ -89567,25 +91284,16 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
 "vgi" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/sortjunction{
-	dir = 4;
-	icon_state = "pipe-j2s";
-	name = "Chapel";
-	sort_type_txt = "17"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/area/station/service/chapel/office)
 "vgx" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -89653,6 +91361,11 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/office)
+"vhM" = (
+/obj/item/reagent_containers/glass/bucket,
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "vic" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -89675,6 +91388,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
+"viK" = (
+/obj/effect/spawner/random_spawners/fungus_maybe,
+/turf/simulated/wall,
+/area/station/public/sleep)
 "viP" = (
 /obj/structure/table/glass,
 /obj/item/hand_labeler,
@@ -89735,6 +91452,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint2)
+"vkB" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Electrical Maintenance";
+	req_access_txt = "11"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/electrical)
 "vkC" = (
 /obj/machinery/light{
 	dir = 4
@@ -89825,6 +91555,17 @@
 	icon_state = "dark"
 	},
 /area/station/medical/morgue)
+"vnW" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fore)
 "vnY" = (
 /obj/structure/chair{
 	dir = 8
@@ -90021,17 +91762,6 @@
 	icon_state = "purple"
 	},
 /area/station/science/hallway)
-"vuP" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/junction,
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
-	},
-/area/station/public/dorms)
 "vvd" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -90056,19 +91786,30 @@
 	icon_state = "whitebluefull"
 	},
 /area/station/medical/medbay)
-"vvy" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "44"
+"vvx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
 	},
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/turf/simulated/floor/plasteel,
+/area/station/public/dorms)
+"vvO" = (
+/obj/structure/closet/secure_closet/brig{
+	name = "Old Cell 1 Locker"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/maintenance/three,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/maintenance/fore)
 "vwg" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -90286,6 +92027,12 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/medbay2)
+"vAQ" = (
+/obj/effect/spawner/random_spawners/cobweb_left_rare,
+/turf/simulated/floor/plasteel{
+	icon_state = "cult"
+	},
+/area/station/service/chapel/office)
 "vAZ" = (
 /obj/machinery/light{
 	dir = 4
@@ -90295,6 +92042,11 @@
 	icon_state = "brown"
 	},
 /area/station/supply/storage)
+"vBf" = (
+/obj/structure/grille/broken,
+/obj/item/stack/rods,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "vBs" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -90305,6 +92057,17 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/smes)
+"vBt" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/spawner/random_spawners/grille_maybe,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "vBv" = (
 /obj/machinery/atmospherics/pipe/simple/insulated,
 /obj/machinery/atmospherics/meter{
@@ -90333,6 +92096,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
+"vCk" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "vCo" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -90353,6 +92129,27 @@
 	icon_state = "dark"
 	},
 /area/station/security/execution)
+"vDq" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics Maintenance";
+	req_access_txt = "12;24"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/maintenance/fore)
+"vDN" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "vDR" = (
 /obj/structure/table,
 /obj/item/reagent_containers/spray/cleaner,
@@ -90367,7 +92164,9 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/asmaint)
 "vDY" = (
-/obj/structure/closet/secure_closet/brig,
+/obj/structure/closet/secure_closet/brig{
+	name = "Old Cell 2 Locker"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "red"
@@ -90465,30 +92264,17 @@
 	},
 /area/station/maintenance/asmaint)
 "vFZ" = (
-/obj/machinery/camera{
-	c_tag = "Holodeck East";
-	dir = 1
-	},
-/obj/item/radio/intercom{
-	name = "south bump";
-	pixel_y = -28
-	},
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/station/public/dorms)
+/obj/structure/chair/stool,
+/turf/simulated/floor/plating,
+/area/station/maintenance/electrical)
 "vGf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/simulated/floor/plasteel,
-/area/station/public/dorms)
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/maintenance/fsmaint)
 "vGj" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -90550,6 +92336,16 @@
 	icon_state = "darkbluefull"
 	},
 /area/station/science/server/coldroom)
+"vJj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/spawner/random_spawners/grille_often,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "vJm" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -90611,6 +92407,20 @@
 	icon_state = "bluecorner"
 	},
 /area/station/hallway/secondary/exit)
+"vKX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/catwalk,
+/area/station/maintenance/fore)
 "vLT" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -90708,6 +92518,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
+"vOC" = (
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = 1;
+	pixel_y = 9
+	},
+/obj/item/pen,
+/turf/simulated/floor/carpet/black,
+/area/station/maintenance/fore)
 "vOD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -90794,6 +92613,25 @@
 	icon_state = "redfull"
 	},
 /area/station/security/lobby)
+"vPH" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
+"vQn" = (
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "vQt" = (
 /obj/machinery/airlock_controller/air_cycler{
 	pixel_y = 6;
@@ -90817,6 +92655,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
+"vRg" = (
+/obj/structure/table/wood,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "vRG" = (
 /obj/structure/sign/poster/contraband/revolver{
 	pixel_y = 30
@@ -90908,6 +92750,31 @@
 	icon_state = "dark"
 	},
 /area/station/service/chapel)
+"vUx" = (
+/obj/machinery/alarm{
+	dir = 1;
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "redcorner"
+	},
+/area/station/security/processing)
+"vUA" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/public/dorms)
 "vUK" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/emergency{
@@ -90923,6 +92790,18 @@
 	icon_state = "purple"
 	},
 /area/station/maintenance/asmaint2)
+"vUY" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "vUZ" = (
 /obj/structure/table/glass,
 /obj/item/storage/belt/medical,
@@ -91049,6 +92928,31 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint2)
+"vYJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/mouse,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fore)
+"vZv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/catwalk,
+/area/station/maintenance/fore)
 "vZD" = (
 /obj/machinery/computer/scan_consolenew{
 	dir = 4
@@ -91057,6 +92961,22 @@
 	icon_state = "dark"
 	},
 /area/station/science/genetics)
+"vZR" = (
+/obj/structure/window/reinforced,
+/obj/item/stack/cable_coil/cyan,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 9
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "vault"
+	},
+/area/station/maintenance/fsmaint)
 "vZV" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/table,
@@ -91064,11 +92984,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
 "wam" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
+/obj/structure/table/wood,
+/turf/simulated/floor/carpet,
 /area/station/public/dorms)
 "was" = (
 /obj/structure/cable{
@@ -91132,6 +93049,22 @@
 	icon_state = "dark"
 	},
 /area/station/security/execution)
+"wcE" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/machinery/camera{
+	c_tag = "Brig Prisoner Processing East";
+	dir = 8;
+	pixel_y = -22
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "redcorner"
+	},
+/area/station/security/processing)
 "wcG" = (
 /obj/effect/spawner/random_spawners/fungus_maybe,
 /turf/simulated/wall/r_wall,
@@ -91187,13 +93120,6 @@
 /obj/item/storage/toolbox/mechanical,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
-"weF" = (
-/obj/structure/table/wood,
-/obj/item/storage/pill_bottle/dice,
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
-	},
-/area/station/public/dorms)
 "weM" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -91226,11 +93152,14 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint2)
 "wfQ" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/plasteel{
-	icon_state = "caution"
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green{
+	on = 0;
+	pixel_x = -3;
+	pixel_y = 8
 	},
-/area/station/public/dorms)
+/turf/simulated/floor/carpet,
+/area/station/security/detective)
 "wgt" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -91243,12 +93172,6 @@
 /obj/effect/spawner/random_barrier/obstruction,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/asmaint)
-"whv" = (
-/obj/machinery/computer/HolodeckControl{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/station/public/dorms)
 "why" = (
 /obj/effect/decal/warning_stripes/southeastcorner,
 /obj/effect/decal/cleanable/dirt,
@@ -91301,6 +93224,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
+"wjv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "wjC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -91404,6 +93334,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/science/xenobiology)
+"wnk" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "wnB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
@@ -91456,6 +93398,9 @@
 /obj/effect/decal/cleanable/vomit,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
+"wql" = (
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fore)
 "wqu" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -91508,6 +93453,10 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
+"wry" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel,
+/area/station/public/dorms)
 "wrK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -91537,19 +93486,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint2)
-"wss" = (
-/obj/machinery/computer/cryopod{
-	pixel_x = 30;
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitegreencorner"
-	},
-/area/station/public/sleep)
 "wsT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -91666,6 +93602,12 @@
 	icon_state = "white"
 	},
 /area/station/science/toxins/mixing)
+"wvA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "wvD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -91696,6 +93638,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/science/robotics)
+"wxg" = (
+/obj/effect/decal/cleanable/dirt{
+	pixel_x = 2
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fsmaint)
 "wxp" = (
 /obj/machinery/alarm{
 	name = "north bump";
@@ -91743,6 +93691,18 @@
 	icon_state = "darkred"
 	},
 /area/station/security/brig)
+"wyY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 9
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "wzD" = (
 /obj/machinery/door/window/classic/normal{
 	name = "EVA Equipment";
@@ -91822,6 +93782,21 @@
 	icon_state = "white"
 	},
 /area/station/science/toxins/mixing)
+"wCI" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fsmaint)
 "wCQ" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -91832,6 +93807,17 @@
 	icon_state = "dark"
 	},
 /area/station/science/robotics/chargebay)
+"wDq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 6
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "wEP" = (
 /obj/machinery/newscaster{
 	dir = 8;
@@ -91926,6 +93912,12 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/maintenance/asmaint)
+"wHI" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "wHW" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -91944,6 +93936,17 @@
 	icon_state = "darkred"
 	},
 /area/station/security/brig)
+"wIc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/catwalk,
+/area/station/maintenance/fore)
+"wIp" = (
+/obj/machinery/fishtank/tank,
+/obj/effect/spawner/random_spawners/cobweb_left_frequent,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "wIB" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -92008,6 +94011,13 @@
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plating,
 /area/station/security/permabrig)
+"wLM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/electrical)
 "wLT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/wall,
@@ -92105,6 +94115,10 @@
 /obj/machinery/light,
 /turf/simulated/floor/plating,
 /area/station/engineering/control)
+"wQF" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/wood,
+/area/station/public/dorms)
 "wQI" = (
 /obj/structure/closet/crate/internals,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -92123,6 +94137,26 @@
 /obj/structure/sign/lifestar,
 /turf/simulated/floor/plating,
 /area/station/medical/cryo)
+"wQP" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
+"wRm" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/turf/simulated/floor/wood{
+	broken = 1;
+	icon_state = "wood-broken"
+	},
+/area/station/maintenance/abandonedbar)
 "wRz" = (
 /obj/machinery/atmospherics/unary/tank/air{
 	dir = 4
@@ -92131,22 +94165,9 @@
 /area/station/maintenance/port)
 "wRI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock{
-	id_tag = "Cryogenics";
-	name = "Cryodorms"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitegreen"
-	},
-/area/station/public/sleep)
+/turf/simulated/floor/plasteel,
+/area/station/public/dorms)
 "wSi" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -92282,47 +94303,27 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/maintenance/apmaint2)
-"wXT" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+"wXC" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
+"wXT" = (
+/obj/machinery/alarm{
+	name = "north bump";
+	pixel_y = 24
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/window/brigdoor{
-	id = "Cell 5";
-	name = "Cell 5";
-	req_access_txt = "2";
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/item/radio/intercom{
-	name = "south bump";
-	pixel_y = -28
-	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Secure Gate";
-	name = "Security Blast Door"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/security/prison/cell_block/A)
+/turf/simulated/floor/carpet,
+/area/station/public/mrchangs)
 "wYg" = (
 /obj/machinery/airlock_controller/access_controller{
 	name = "Virology Lab Access Console";
@@ -92361,7 +94362,7 @@
 "wYE" = (
 /obj/structure/closet/l3closet/janitor,
 /obj/item/radio/intercom{
-	name = "east bump";
+	name = "west bump";
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel,
@@ -92439,6 +94440,21 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
+"xaJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "vault"
+	},
+/area/station/maintenance/fsmaint)
 "xaS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -92506,13 +94522,15 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard/east)
-"xcB" = (
-/obj/structure/chair{
-	dir = 8
+"xda" = (
+/obj/machinery/door/airlock{
+	id_tag = "secmaintdorm1";
+	name = "Room 1"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel,
-/area/station/public/dorms)
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/maintenance/fore)
 "xde" = (
 /obj/machinery/mech_bay_recharge_port{
 	dir = 1
@@ -92582,6 +94600,27 @@
 	icon_state = "darkred"
 	},
 /area/station/hallway/secondary/exit)
+"xfd" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/obj/effect/spawner/random_spawners/grille_maybe,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "xfk" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
 	dir = 4
@@ -92610,14 +94649,10 @@
 /turf/simulated/wall/r_wall,
 /area/station/engineering/smes)
 "xfQ" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/weightmachine/stacklifter,
+/turf/simulated/floor/plasteel{
+	icon_state = "caution"
 	},
-/obj/machinery/firealarm{
-	name = "north bump";
-	pixel_y = 24
-	},
-/turf/simulated/floor/plasteel,
 /area/station/public/dorms)
 "xgp" = (
 /obj/structure/closet/secure_closet/engineering_personal,
@@ -92690,17 +94725,21 @@
 	},
 /area/station/command/office/rd)
 "xkh" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/chair/stool{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "cafeteria"
 	},
 /area/station/public/dorms)
+"xku" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 10
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "cult"
+	},
+/area/station/service/chapel/office)
 "xkF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -92718,6 +94757,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
+"xlO" = (
+/obj/effect/spawner/random_spawners/fungus_probably,
+/turf/simulated/wall,
+/area/station/maintenance/fsmaint)
 "xlV" = (
 /obj/machinery/atmospherics/binary/pump/on,
 /obj/machinery/access_button{
@@ -93054,11 +95097,41 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
+"xxy" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/catwalk,
+/area/station/maintenance/fore)
 "xxQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
+"xyl" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fsmaint)
 "xyr" = (
 /obj/machinery/light{
 	dir = 8
@@ -93105,6 +95178,21 @@
 	},
 /turf/space,
 /area/space/nearstation)
+"xzU" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "vault"
+	},
+/area/station/maintenance/fsmaint)
 "xzY" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Mining Maintenance";
@@ -93139,6 +95227,13 @@
 	icon_state = "whitepurple"
 	},
 /area/station/science/toxins/mixing)
+"xAz" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics Maintenance";
+	req_access_txt = "12;24"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "xAK" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -93188,6 +95283,10 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/garden)
+"xCq" = (
+/obj/effect/spawner/random_spawners/wall_rusted_maybe,
+/turf/simulated/wall/r_wall,
+/area/station/maintenance/auxsolarstarboard)
 "xDc" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plasteel{
@@ -93230,24 +95329,18 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutralcorner"
 	},
-/area/station/public/dorms)
-"xEW" = (
-/obj/structure/table/wood,
-/obj/item/paicard,
-/obj/structure/window/reinforced,
-/turf/simulated/floor/wood,
 /area/station/public/dorms)
 "xFt" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -93341,6 +95434,10 @@
 /obj/item/poster/random_contraband,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
+"xIV" = (
+/obj/effect/spawner/random_spawners/grille_often,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "xJa" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 6
@@ -93402,6 +95499,11 @@
 /obj/item/stack/rods,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
+"xKn" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/maintenance/fore)
 "xKv" = (
 /obj/machinery/hydroponics/constructable{
 	desc = "These are connected with an irrigation tube. You see a little pipe connecting the trays.";
@@ -93459,6 +95561,23 @@
 /obj/machinery/light,
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
+"xOh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fsmaint)
 "xOn" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/effect/decal/warning_stripes/northeastcorner,
@@ -93525,27 +95644,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint2)
-"xRy" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door_control{
-	id = "maint2";
-	name = "Blast Control Door B";
-	pixel_x = -28;
-	pixel_y = 4
-	},
-/obj/machinery/door_control{
-	id = "maint1";
-	name = "Blast Control Door A";
-	pixel_x = -28;
-	pixel_y = -6
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
 "xRB" = (
 /obj/structure/chair{
 	dir = 1
@@ -93615,6 +95713,13 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint2)
+"xSv" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance/eight,
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/effect/spawner/random_spawners/cobweb_right_frequent,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "xSH" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
@@ -93623,6 +95728,12 @@
 /obj/machinery/prize_counter,
 /turf/simulated/floor/carpet/arcade,
 /area/station/public/arcade)
+"xTs" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "xTJ" = (
 /obj/machinery/alarm{
 	name = "north bump";
@@ -93661,6 +95772,13 @@
 	icon_state = "whitepurple"
 	},
 /area/station/science/xenobiology)
+"xUr" = (
+/obj/item/flag/sec,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "xUK" = (
 /obj/structure/table/glass,
 /obj/item/radio/intercom{
@@ -93692,6 +95810,20 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/public/toilet)
+"xVh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door_control{
+	id = "secmaintdorm1";
+	name = "Door Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = 25;
+	specialfunctions = 4
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/maintenance/fore)
 "xVy" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -93720,7 +95852,9 @@
 	},
 /area/station/security/execution)
 "xVM" = (
-/obj/structure/closet/secure_closet/brig,
+/obj/structure/closet/secure_closet/brig{
+	name = "Old Cell 2 Locker"
+	},
 /obj/machinery/status_display{
 	layer = 4;
 	pixel_y = 32
@@ -93795,6 +95929,13 @@
 	dir = 2;
 	icon_state = "pipe-j2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard/east)
 "xWz" = (
@@ -93969,6 +96110,10 @@
 	icon_state = "bot"
 	},
 /area/station/maintenance/fsmaint)
+"ybH" = (
+/obj/effect/decal/cleanable/fungus,
+/turf/simulated/wall/r_wall,
+/area/station/maintenance/fore)
 "ybL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random_spawners/grille_maybe,
@@ -94004,6 +96149,12 @@
 	icon_state = "whitepurple"
 	},
 /area/station/science/toxins/mixing)
+"ycE" = (
+/obj/structure/closet/crate,
+/obj/item/vending_refill/coffee,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "ydz" = (
 /turf/simulated/floor/plasteel,
 /area/station/security/prisonlockers)
@@ -94038,6 +96189,18 @@
 	icon_state = "dark"
 	},
 /area/station/medical/morgue)
+"yeZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "yfn" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -94152,6 +96315,10 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
+"yhE" = (
+/obj/effect/spawner/random_spawners/fungus_probably,
+/turf/simulated/wall,
+/area/station/maintenance/fore)
 "yhP" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plasteel,
@@ -94207,6 +96374,18 @@
 	icon_state = "bar"
 	},
 /area/station/security/permabrig)
+"yjg" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "yjv" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /obj/machinery/alarm/server{
@@ -94345,6 +96524,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
+"ykx" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "ykF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/girder,
@@ -94402,17 +96586,15 @@
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
 "ylV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 6
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/station/public/dorms)
+/area/station/service/mime)
 "ylW" = (
 /obj/structure/chair/stool{
 	dir = 8
@@ -123305,7 +125487,7 @@ aEh
 aFx
 aAU
 aIr
-aKg
+aAU
 aAU
 aAU
 aAU
@@ -123562,7 +125744,7 @@ aFF
 aGx
 aHT
 aIO
-aKz
+aHT
 aHT
 aNc
 aHT
@@ -123812,14 +125994,14 @@ aoq
 aAP
 aAx
 aAx
-aEi
-aFw
-aFw
-aFw
+aCx
+aFF
+aFF
+aFF
 aJh
 aKy
-aEj
-aPb
+awl
+aHp
 awl
 awl
 awl
@@ -123827,13 +126009,13 @@ awl
 awl
 awl
 awl
-aPm
+aFa
 bdI
-aDN
-aDN
-aDN
-aDN
-aDN
+bco
+bco
+bco
+bco
+bco
 bdw
 bgW
 bni
@@ -124069,28 +126251,28 @@ azN
 ayS
 aCq
 aAx
-aEm
-aFA
-aFA
-aFw
-aJj
-aKA
+aCx
+aCx
 awl
-aKH
-avq
-avq
-avq
-avq
-avq
-avq
+awl
+awl
+awl
+hBD
+gRY
+gRY
+gRY
+mdF
+gRY
+gRY
+gRY
 aHp
 aRx
 bdN
-aDN
+bco
 biQ
 bpQ
 cSW
-aDN
+bco
 dje
 biO
 bnk
@@ -124325,16 +126507,16 @@ sJo
 azK
 ayR
 aCp
-aHE
-axe
+aAx
+azY
 aFz
-aFz
-aLh
-aFz
-axe
-awl
-aKH
-chc
+aAx
+hcL
+wvA
+wql
+qay
+gRY
+jeJ
 chc
 chc
 chc
@@ -124343,12 +126525,12 @@ chc
 chc
 bbZ
 bdN
-bgT
-biP
-boU
+aVN
+cUi
+bch
 cSV
-aDN
-aDN
+bco
+bco
 bdD
 bna
 bkz
@@ -124582,15 +126764,15 @@ aAx
 aoq
 arq
 asZ
-aHE
+aAx
 aEo
 aFC
-aGz
-aHW
-aJk
-axe
-aCz
-aKH
+aAx
+aSP
+oRp
+dzF
+aSP
+gRY
 chc
 lDM
 kzK
@@ -124600,12 +126782,12 @@ kXA
 chc
 aRx
 bdN
-bgT
-biT
-bpT
+aVN
+cUi
+aSm
 cUi
 dhp
-aDN
+bco
 dkl
 bkG
 bno
@@ -124839,15 +127021,15 @@ gXR
 dof
 azx
 aCr
-aHE
+aAx
 aEn
-aFB
-aGy
-ayV
-ayA
-axe
-aMj
-sZa
+aJl
+aAx
+ftv
+akc
+fwK
+ftv
+uch
 taA
 mSN
 lEy
@@ -124857,12 +127039,12 @@ xBd
 lhi
 xGn
 kHT
-bgT
+aVN
 biR
 bpR
 cSX
 dgH
-aDN
+bco
 bhq
 bnn
 bkE
@@ -125096,15 +127278,15 @@ auQ
 azO
 aro
 aCs
-aHE
+aAx
 aEp
 aFD
-aGB
-aEk
-aJm
-axe
-avq
-sPN
+aAx
+baG
+sJR
+umi
+iVw
+hzA
 chc
 shh
 mJJ
@@ -125114,12 +127296,12 @@ sLv
 chc
 aRx
 bdN
-aDN
+bco
 aYJ
 buM
-bez
+cUi
 dhq
-aDN
+bco
 dkn
 bnn
 bkF
@@ -125353,15 +127535,15 @@ aAx
 aoq
 arq
 asZ
-aHE
+aAx
 axe
-axe
-aGA
-aHX
-aJl
-axe
-aFH
-sPN
+bjw
+aAx
+aEI
+vOC
+qJC
+aEI
+syE
 chc
 qLU
 dXj
@@ -125371,12 +127553,12 @@ peU
 jwH
 aRx
 bdN
-aDN
-bgT
+bco
+aVN
 bqm
-bgT
-aDN
-aDN
+aVN
+bco
+bco
 dkm
 bnn
 bkF
@@ -125609,16 +127791,16 @@ axM
 ayX
 azQ
 aAX
-aCt
+aBe
 aDo
 aEr
 aFG
-aGD
-aEA
-aJn
-axe
-axe
-sPN
+awK
+aSP
+iTW
+cRW
+wql
+syE
 qjM
 pDG
 voU
@@ -125632,7 +127814,7 @@ ejO
 biW
 xEG
 dyw
-iAE
+aZs
 djg
 bhg
 bns
@@ -125870,12 +128052,12 @@ art
 fqq
 aEq
 aFE
-aGC
-btc
-bvI
-aKB
-axe
-sPN
+awK
+syK
+fgF
+aSP
+aEI
+syE
 chc
 ryV
 tyQ
@@ -126121,18 +128303,18 @@ awV
 awf
 axP
 aza
-aoq
-wXT
-asZ
-aAx
+aza
+aza
+aza
+aza
 aEt
-axe
-aGF
-aIb
-awG
-aKD
-axe
-sPN
+awK
+awK
+awl
+hBD
+aBt
+qif
+syE
 chc
 chc
 chc
@@ -126140,7 +128322,7 @@ chc
 chc
 chc
 bbi
-aPm
+rhh
 gEU
 kOt
 aDP
@@ -126377,29 +128559,29 @@ ati
 auT
 awe
 axR
-ayY
+aHe
 ayr
 aAZ
 aAA
-aAx
-aEs
-axe
-aGE
-aHZ
-aJo
-aKC
-axe
-sPN
+aBs
+eMd
+aEI
+aBt
+rGi
+atr
+aEI
+aSP
+syE
 aOI
 aQk
 aSk
 aTD
 aWB
-aZs
-aZs
+aAa
+tLP
 eog
 oPE
-uYm
+aOC
 aDP
 tJS
 jaF
@@ -126626,7 +128808,7 @@ apJ
 anx
 ago
 aiR
-atE
+bmM
 auE
 awh
 avB
@@ -126634,28 +128816,28 @@ avB
 aAF
 awj
 axR
-ayY
+aHe
 azW
 aBb
 aCw
-aAx
-aEs
-axe
-axe
-aIg
-axe
-axe
-axe
-sPN
-aOI
-aQn
-aSx
-aTF
-aTF
-aTF
-aTF
-vuP
-beT
+aBs
+dSo
+rYD
+apZ
+dGB
+dGB
+dGB
+dGB
+run
+vUY
+rML
+fAJ
+fAJ
+fAJ
+fAJ
+glf
+fSP
+edK
 aDP
 aDP
 pHs
@@ -126883,7 +129065,7 @@ afx
 anA
 ago
 aso
-atE
+bmM
 auE
 avA
 avA
@@ -126891,28 +129073,28 @@ arv
 ayp
 awi
 axQ
-aAx
-aAx
-aAx
-aAx
-aAx
-aEu
-aGK
-aGG
-aId
-aJp
-aJp
-aJp
-sRg
-aPP
+aQT
+nqX
+aKJ
+aJq
+aBs
+tFq
+avq
+cGc
+aEI
+avq
+fNF
+aSP
+gRY
+aOI
 aQm
-aSm
+aPm
 aTE
-aWC
-aZt
+aWU
+aWU
 eOh
-bbv
-gcJ
+pMH
+beT
 aDP
 hUO
 hnj
@@ -127147,28 +129329,28 @@ arz
 atl
 ayq
 awA
-apb
-azd
-azY
-aBo
-aAB
+aOE
 aBs
-aBt
-avq
-aGH
-avq
-avq
-avq
-avq
-avq
-aOI
+aBs
+aBs
+aBs
+oTU
+trS
+aEI
+att
+yhE
+aIc
+aIc
+aIc
+aIc
+aIc
 aQp
-aSB
-aTI
-aWE
-aZv
+aPm
+aUT
+aZG
+aZG
 pVi
-bbv
+pMH
 gOA
 aDP
 lRq
@@ -127397,7 +129579,7 @@ aoR
 aqA
 ago
 aso
-atE
+bmM
 auE
 ayp
 ary
@@ -127405,33 +129587,33 @@ atk
 atv
 awn
 axS
-azc
-azX
-aBi
-aFn
-aBs
-aBt
-aFH
-aIq
-aIi
-aJq
-aKE
 awl
-aFH
-aOI
-aQo
-aSB
-aTG
-aWD
-aZu
-xEW
-bbv
-ylV
+lfy
+wHI
+nkW
+sWj
+gBH
+ajB
+uKO
+qsp
+aIc
+bhi
+aIP
+bdo
+aIe
+aXf
+aPm
+aUT
+aZG
+aZG
+pVi
+pMH
+beT
 aDP
 qMk
 hnj
 otb
-aJu
+llf
 kFj
 bhq
 bnM
@@ -127662,28 +129844,28 @@ atn
 apb
 awC
 axU
-azc
-azZ
-aBp
-aAC
-aBs
-aBt
-aFI
-aFI
-aFI
-aFI
-aFI
-aFI
-aFI
-aFI
+awl
+gLS
+aAK
+xAz
+gKb
+pLo
+avq
+jLi
+avq
+aIc
+aBX
+btY
+qta
+bfQ
 aQr
-aSB
+aPm
 aTR
-aWF
-aZt
+aWW
+aWW
 oyv
-bbv
-gOA
+pMH
+beT
 aDP
 lRq
 llf
@@ -127909,7 +130091,7 @@ anS
 aoM
 aoJ
 anx
-ago
+agN
 aiT
 akx
 auE
@@ -127917,29 +130099,29 @@ apc
 arE
 atm
 auW
-awV
-awV
-aBs
-aBs
-aBs
-aBs
-aBs
-aBt
-aFI
-aGO
-aIp
-aJv
-aKI
-xSM
-aMC
-aPf
-aZs
-aSD
+wcE
+vUx
+awl
+jcl
+gEf
+nkW
+vZv
+oJD
+fbL
+vKX
+oJD
+aKP
+aKm
+aBo
+bdr
+aIe
+bio
+wRI
+aTJ
+bpJ
 aTJ
 aTJ
-aTJ
-aTJ
-aPm
+sSt
 beW
 aDP
 hUO
@@ -128175,28 +130357,28 @@ aFL
 axC
 aFL
 aFL
-axV
-azm
 awl
-ayd
-avq
-aDp
-aBt
-aIY
-aGN
-aGN
-mOR
-sMv
-rCQ
-bZV
-aPf
-aQu
-aSG
-aUG
+awl
+awl
+awl
+hBD
+sSu
+awl
+hBD
+gml
+mOg
+aIc
+azm
+btc
+aYA
+aIc
+aZH
+aPm
+aPm
 aWH
-aZw
-aUG
-bcE
+aPm
+aPm
+rnT
 oiL
 aUS
 aUS
@@ -128423,7 +130605,7 @@ ahf
 aoN
 aoJ
 apT
-ago
+agP
 aiU
 aFL
 alS
@@ -128432,29 +130614,29 @@ arK
 ato
 auY
 aFL
-atw
-azl
-aBv
-aBq
+anc
+bDd
+awl
 aSP
-aSP
-aEv
+wDq
+wyY
+ykx
 aFI
-lFV
-xUR
-aJw
-aKK
-fmN
-tcm
-aPg
+aFI
+aFI
+aIc
+aIc
+aIc
+aIc
+aIc
 aQt
-aSE
-aUd
-aWG
-aWG
-bbk
-bcy
-beY
+aPm
+aPm
+lOY
+aPm
+aPm
+uYm
+aOI
 aUS
 biZ
 bJV
@@ -128462,14 +130644,14 @@ cWo
 aUS
 djh
 dkE
-aZR
+boc
 bkM
 bmr
 brT
 btf
 btf
 bmq
-byD
+aXj
 bmq
 bmq
 aUS
@@ -128680,7 +130862,7 @@ apO
 apO
 apO
 anx
-aqX
+aMe
 aiW
 akC
 avF
@@ -128689,28 +130871,28 @@ arP
 arA
 ayt
 aFL
-azM
-aAK
-aBR
-avq
-avq
-aCh
-avq
+gRK
+xKn
+xda
+wql
+azT
+wql
+izW
 aFI
-hRq
-aGN
-aJz
-aKK
-dwg
-iQP
-ckc
-aZs
-aSJ
-aUI
-aWK
-aZy
-bbn
-bda
+aGO
+aIp
+aJv
+aKI
+xSM
+aMC
+aPf
+aWC
+aPm
+bru
+awF
+aPk
+aZt
+gEb
 bfd
 aUS
 bjf
@@ -128719,15 +130901,15 @@ beI
 aUS
 bfs
 aYe
-boc
+bnQ
 bkP
 bmr
 brV
-btg
-bqi
-bmq
+bcA
+aQu
+buQ
 buN
-bmq
+aQR
 aVG
 aUS
 cMK
@@ -128946,28 +131128,28 @@ arO
 qMh
 ama
 aFL
-azL
-aAJ
-aBv
-aBr
+ivc
+xVh
+awl
+aEI
+vnW
 avq
-avq
-avq
-aFI
-kpf
-aIt
-qou
-jJX
-fbg
-rSO
+wql
+aIv
+aGN
+aGN
+mOR
+sMv
+rCQ
+bZV
 aPf
-aZs
-aSJ
-aUI
-aWJ
-aWK
+tLP
+wry
+wry
+gsC
+wQF
 bbn
-bcy
+oil
 bfb
 aUS
 bjc
@@ -128976,15 +131158,15 @@ beH
 bwl
 bft
 aYd
-bnQ
+bdl
 bkO
 bmr
-bmM
+bmq
 brg
 brg
 bmq
 bqk
-bmq
+bAU
 bJQ
 aUS
 bAk
@@ -129205,30 +131387,30 @@ auI
 aFL
 awl
 awl
-aIq
-aBu
-avq
-avq
-avq
+awl
+xUr
+yeZ
+riz
+jCS
 aFI
-aHa
-aIu
-aJA
-edU
-aMJ
-vof
-aPf
-aQA
-aSJ
-aUK
-aWM
-aWM
-bbo
-bcy
+lFV
+xUR
+aJw
+aKK
+fmN
+tcm
+aPg
+qfK
+aWY
+aWY
+aDt
+bhf
+aWE
+aZv
 bfj
 aUS
 bjj
-baM
+qds
 cWG
 aUS
 bfk
@@ -129236,16 +131418,16 @@ aZR
 bop
 bkO
 bmr
-bmM
 bmq
 bmq
 bmq
 bmq
 bmq
+bAU
 bmq
 bAv
-bAk
-bHy
+nuq
+aUG
 bDa
 bOU
 aTY
@@ -129460,28 +131642,28 @@ aFL
 apG
 auI
 aFL
-axW
+vvO
+jDK
+hBD
 avq
+vYJ
 avq
-aBt
-aCh
-avq
-avq
-aLP
-aLP
-aLP
-aLP
-aLP
-aLP
-aLP
-aLP
-mQt
-aSD
-aUJ
+hte
+aFI
+hRq
+aGN
+aJz
+aKK
+dwg
+iQP
+ckc
+aRx
+aPm
+aPm
 aWL
 aZz
-aUJ
-aSD
+aWD
+aZv
 bfi
 aUS
 aUS
@@ -129493,16 +131675,16 @@ biS
 bom
 bkO
 bmr
-bmM
+bmq
 btm
 brh
 btn
-buQ
-aZV
+buR
+bAU
 bzn
 bsN
-nuq
-uZL
+bAk
+axW
 hUx
 bEq
 aTW
@@ -129713,53 +131895,53 @@ asA
 aFL
 aFL
 aFL
+iyC
+iyC
 aFL
 aFL
-aFL
-aFL
-axY
-avq
-avq
-aBu
-arR
-awl
-awl
-aLP
-jHx
-mDZ
-mDZ
-wYS
-ivc
-rTp
-aLP
-agu
-vGf
+rTY
+qtm
+jSX
+aEI
+qOb
+aSP
+sJi
+aFI
+kpf
+aIt
+qou
+jJX
+fbg
+rSO
+aPf
+aRx
+aPm
 iMp
-aWY
-aWY
+aYE
+aYX
 wam
-loL
-jDV
-bhf
-aOI
-baS
-beJ
+smv
+miY
+wnk
+rBO
+rsY
+pgi
 aUS
 djj
 dkL
 pkG
 bpC
 bmr
-bmM
-btw
+bmq
+btm
 bri
 bto
 buR
-bmq
-bmq
-bAv
-bAk
-bHy
+aTj
+aJN
+aCL
+aDq
+bfV
 bDA
 bEp
 aUP
@@ -129965,42 +132147,42 @@ ahm
 aiY
 apU
 aqG
-aqX
-asA
+knB
+aQU
 atg
-awl
-aab
-aaa
-aaa
-aab
-awl
-axX
-avq
-avq
-aBu
-arR
-avq
-ayb
-aLP
-jet
-aPL
-aQZ
-fwg
-uLZ
-aYp
-aSl
-ffL
 aSD
-aNV
-aWP
+aab
+aaa
+aaa
+aab
+aSD
+sMX
+qNF
+awl
+aSP
+vnW
+aSP
+ifU
+aFI
+aHa
+aIu
+aJA
+edU
+aMJ
+vof
+aPf
+ffL
+aPm
+aPm
+vvx
 aWP
 aSe
-aSD
+ebW
 bfo
-bhe
 aOI
-aSg
-bkN
+iSa
+cjD
+sWR
 aUS
 aRL
 beF
@@ -130008,11 +132190,11 @@ bot
 bjm
 bmq
 brW
-btq
 bmq
 bmq
 bmq
 bmq
+bAU
 bzo
 bze
 bAk
@@ -130226,49 +132408,49 @@ ari
 aiZ
 akD
 awl
-awl
-awl
-awl
-awl
-awl
-aIq
-avq
-aAc
-aBt
-aHp
-aCh
-aEw
-aLP
-mDF
-mDF
-mDF
-mDF
-mDF
-enX
-aSl
-ffL
-aSB
-aVo
-aWU
-aWU
-bbv
 aSD
-beW
+aSD
+awl
+aSD
+awl
+awl
+awl
+awl
+hBD
+sSu
+awl
+awl
+tTW
+aFI
+aFI
+aFI
+aFI
+aFI
+aFI
+aFI
+aFO
+aPm
+aPm
+gGD
+aUd
+aWG
+aWF
 aOI
-bjl
-aWA
-bfn
+aOI
+etQ
+mjv
+taO
 bwX
-djk
+jgE
 dkN
 boM
 dkN
 bqy
-brX
-btx
-buq
-buq
-buq
+bmq
+byD
+byD
+byD
+byD
 bAU
 bCI
 aUS
@@ -130479,49 +132661,49 @@ aeV
 aoS
 apW
 aih
-aqX
-aqW
+aMe
+aCQ
 atg
 ame
+aSP
+egd
 avq
 avq
-aBw
+aBr
+yhE
+rGi
+atr
 avq
+okx
+qay
+pLo
 avq
+aEI
 avq
-att
-aAa
-aBt
-awl
-avq
-ayc
-aLP
-oiD
-oiD
-oiD
-oiD
-oiD
-eDZ
-wRI
-okj
-aSB
-aUT
-aWT
-aZC
-bbu
-bdf
-bfq
+pLo
+nnK
+nnK
+ykx
 aOI
-bjk
-bbb
-beM
+okj
+aPm
+aPm
+lLq
+aUI
+aWK
+bdf
+aOI
+wIp
+aGY
+lMp
+twq
 aUS
 aRN
 bfl
 bjK
 blt
-bmq
-bmq
+bfZ
+bcs
 bqi
 brH
 btg
@@ -130736,55 +132918,55 @@ aih
 aih
 aih
 aih
-aqX
-aqW
-aqW
+ayb
+aJM
+bhl
 fWd
 avq
-aCh
+pLo
+xIV
+aSP
 avq
-avq
-avq
-avq
-avq
-avq
-aBu
-awl
-awl
-awl
-aLP
-pFI
-hdr
-jXj
-nXm
-qta
-wss
-aSl
-aZs
-aSB
-aVp
+aBt
+tjc
+pGA
+aKz
+nUV
+hvz
+hvz
+hvz
+lSL
+sVr
+aKz
+boC
+pGA
+aKz
+wQP
+fMW
+vUA
+vUA
 aWT
 aZD
-bbu
-bdl
-bfv
+aWK
+aWK
 aOI
-bjw
-bbI
-bdT
+fzo
+lCa
+jep
+epQ
 bdT
 bdT
 bdT
 bdT
 bdT
 bnm
-bmq
+aQs
 bqk
 bqk
 bqk
-bqk
+qhT
 bAV
-bmq
+btq
 aUS
 bAo
 bHy
@@ -130992,42 +133174,42 @@ aaa
 aaa
 aab
 aab
-aqI
-aqI
-aqI
-aqI
-atG
+abz
+aAC
+sRg
+aAC
+aHE
 awl
-arR
-awl
-aHp
-aqc
-aya
+hBD
 awl
 avq
-aBz
 aSP
 aSP
-aBr
-aLP
-qHd
-aLP
-aLP
-aLP
-aLP
-aLP
-aLP
+rnk
+mpL
+mpL
+nox
+sUr
+jCA
+aBt
+wIc
+jLi
+hdb
+aLA
+aLA
+aLA
+aLA
 aQE
-aSB
-aUT
-aWT
-aZC
-bbu
-bdj
-bfr
-bPx
-jVw
-bbd
+aPm
+aPm
+aWL
+aUI
+aZy
+aWK
+aOI
+fCw
+aGY
+rUg
 bdT
 dhV
 djn
@@ -131035,12 +133217,12 @@ dkR
 dnu
 bdT
 bnl
-bmq
-bmq
-bmq
-bmq
-bmq
-bmq
+aZV
+aZV
+aZV
+aZV
+aZV
+aTF
 bxE
 aUS
 bAn
@@ -131247,47 +133429,47 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aab
-aab
-atG
-apZ
-avq
-atr
-ava
-awD
-awD
+aHE
+abz
+aHE
+ayV
+bkK
+bkQ
+aHE
+iIf
+kII
 awl
-aqc
-avq
-avq
-avq
-aBz
-aSP
-lLq
+ava
+eIY
+xIV
+qSb
+bmF
+awl
+uiN
+awl
+awl
+awl
+wIc
+fUJ
+aLA
 qZO
-qZO
-qZO
-qZO
-qZO
-szt
+edu
+bds
+aIh
 xkh
-rET
-aVs
-aWW
-aZG
-bbv
 aPm
-bfy
+aPm
+lOY
+aUI
+aWK
+aWK
 aOI
-aGY
-bbs
+sfb
+lCa
+oGT
 bfw
 bht
-bhW
+bht
 biV
 boO
 bdT
@@ -131504,44 +133686,44 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aab
-atG
-apY
+aHE
+auK
+aDY
+ayV
+bkK
+ayA
+aHE
+jJd
 arS
-aqc
-auZ
-att
-ava
+vDq
+dJc
 avq
+avq
+okx
+aEI
 awl
+tZP
+bbb
+iKR
+hBD
+xxy
+jLi
+aLA
+bhW
+ylV
 aFJ
-aFJ
-aFJ
-aFJ
-aFJ
-aFJ
-aFJ
-aFJ
-aFJ
-aFJ
-aFJ
-aOI
+aLh
 aQG
-qFg
-aVq
+aWY
+aWY
 aVq
 aZE
-aPm
-aPm
-bfx
+aWM
 aOI
-aQI
-bbI
+aOI
+mWC
+lCa
+sta
 bdT
 bdJ
 bfC
@@ -131554,7 +133736,7 @@ bpL
 bof
 bof
 bof
-bof
+aZu
 bxF
 bdT
 gvW
@@ -131761,48 +133943,48 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-atG
-aqc
-aqc
-aqc
-ava
-awF
-awF
-avq
-aHp
-aPm
-aPm
+aHE
+aDs
+aFB
+auZ
+bkK
+aBU
+aHE
+oQL
+rQm
+awl
+awl
+yhE
+aEI
+okx
+mOg
+awl
+nOy
+jUP
+rBj
+awl
+eyK
+gCX
+bbI
+rHR
 lkw
-aPm
-nXr
-aKQ
-fRL
-aPm
-jPN
-lkw
-fho
+bdt
+aIh
+aZL
 aPm
 aPm
-aSR
-aVu
-aWY
-bbw
+lOY
+aUb
 bbw
 bdm
-bfz
 aOI
-aMo
-bbI
+aKg
+aGY
+jep
 bdT
 bdM
 bhX
-biU
+aEz
 boS
 bdT
 bmt
@@ -131811,7 +133993,7 @@ bof
 bof
 bof
 bof
-bof
+aTk
 bxG
 bdT
 bAq
@@ -132018,44 +134200,44 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-atG
-aqb
-aCh
-ats
-ava
-awE
-ayf
-azn
-arR
-fes
+aHE
+bcu
+wfQ
+aEk
+bfW
+aCz
+aHE
+awl
+awl
+awl
+ezh
+awl
+oZZ
+okx
+gml
+awl
+brB
+aqc
+aqc
+awl
+lpx
+ntG
+aLA
 tbC
-tbC
-aPm
-tbC
-tbC
-aPm
-tbC
-tbC
-tbC
-aPm
-aPm
-aPm
+aDr
+bia
+aLA
+sXh
 aPm
 aVt
-aXf
-aZH
-aIc
-aIc
-aIc
-aIc
-bjz
-bbI
+lOY
+aUb
+fzc
+aHc
+iGP
+aOI
+buy
+rUg
 qGh
 bdL
 bfE
@@ -132275,45 +134457,45 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-atG
-apY
-arT
-aqc
-aEI
-awH
-ayg
-aOY
+aHE
+aJm
+brA
+brA
+aAg
+aUi
+aHE
+mIy
+lzV
+hBD
 awl
-aFK
-aFK
-aFK
-gFG
-aFK
-aFK
-gFG
-aFK
-aFK
-aFK
-aFK
-aPk
-ePV
-iGP
-aVt
-aXf
-weF
-aIe
-bdo
-aIP
-bhi
-aIc
-bbI
-bdT
+awl
+pLo
+okx
+aBt
+yhE
+ats
+aMq
+aMq
+aMq
+aMq
+aMq
+aMq
+aMq
+aDN
+aDN
+aDN
+aDN
+aDN
+aRx
+lOY
+aUb
+fzc
+aPm
+avc
+aOI
+etQ
+oQk
+pRH
 bdT
 bdT
 bdT
@@ -132532,45 +134714,45 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-atG
-aqc
-aqc
-arR
-avb
-aAQ
-aNH
-ava
-awl
-sHt
-sHt
-sHt
-sHt
-sHt
-sHt
-sHt
-sHt
-sHt
-sHt
-aFK
+aHE
+aKT
+awG
+bip
+jDV
+aKB
+aHE
+qtm
+ajb
+qtm
+iBy
+avq
+avq
+vcW
+gWw
+gWw
+mhr
+aMq
+aGz
+aId
+enX
+aEV
+aGB
+aMq
+aMo
+aVQ
 kiu
+bcy
+aDN
+bbZ
+bHC
+aBq
+bbv
 aPm
-aSM
-aVt
-aXf
-aXf
-bje
-aKn
-aKm
-aVU
-aIc
-raC
-bfB
+aHK
+aOI
+hBQ
+rUg
+aGY
 yat
 djt
 bjd
@@ -132789,45 +134971,45 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-awl
-aqn
-asc
-att
-avc
+abz
+aGF
+btl
+aGH
+aDW
+aAQ
+aHE
+uAi
+aEv
+xKn
+iJx
+aEI
 avq
+nQD
+tmL
 avq
-avq
-awl
-sHt
-sHt
-sHt
-sHt
-sHt
-sHt
-sHt
-sHt
-sHt
-sHt
-aFK
-kiu
+vnW
+dVa
+qhL
+aDZ
+aTl
+aOL
+qhL
+aMq
+aTm
+boU
+boU
+aKD
+bgT
+aRx
+lOY
+aUb
+bbv
 aPm
-aNQ
-aVz
-aXf
-aXf
-aIe
-bdr
 aUA
-bhk
-bfI
-bbC
-aGY
+aOI
+lCa
+wCI
+buy
 beb
 djw
 bFJ
@@ -133046,50 +135228,50 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-awl
-awl
-awl
-awl
-awl
-awl
-avq
-avq
+aHE
+aHE
+aHE
+loL
+aKn
+aNm
+aHE
+rPn
+dEL
+aEI
 atG
 atG
 avs
+jEq
 atG
-atG
-sHt
-sHt
-sHt
-pwU
-sHt
-sHt
-pwU
-sHt
-sHt
-sHt
+apY
+rNa
+vkB
+beq
+bfO
+pFI
+naU
+aOk
+aMq
+wXT
 aFK
+aFM
+aVA
+bgT
+aRx
+aWH
+aUb
+bbv
 aPm
-aPm
-aSM
-aVt
-aXf
-aZJ
-aIc
-bdp
 bfA
-bhj
-aIc
-bbI
-aGY
+aOI
+aEX
+pav
+fbU
 beb
 dju
 bLn
 bjv
-dnD
+bfH
 bmy
 boo
 btM
@@ -133099,8 +135281,8 @@ bof
 bof
 oYf
 bzf
-bAk
-bHy
+nuq
+azM
 bAk
 chh
 chh
@@ -133305,43 +135487,43 @@ aaa
 aaa
 aaa
 aaa
-awl
-amK
-avq
-asf
-atw
-atT
-auK
-qtm
-atG
+aHE
+aKM
+awG
+bva
+aHE
+tHc
+aEv
+uYF
+oZL
 aup
 avq
 avq
-atG
-sHt
-sHt
-sHt
-sHt
-sHt
-sHt
-sHt
-sHt
-sHt
-sHt
-aOI
-gCU
-aPm
-aSM
+ybH
+asf
+awl
+aMq
+aCU
+aDZ
+wLM
+aOL
+bqW
+aMq
+iAE
+boU
+boU
+aGD
+aDN
 aIF
-aZL
-sXh
-aLA
-aLA
-aLA
-aLA
-aLA
-bbI
-aGY
+aWH
+aUb
+fzc
+aPm
+xfQ
+aOI
+oDO
+jep
+ocp
 beb
 djx
 bLU
@@ -133356,7 +135538,7 @@ bof
 bof
 lSw
 bzf
-nuq
+bAk
 uZL
 npM
 chh
@@ -133562,43 +135744,43 @@ aaa
 aaa
 aaa
 aaa
-awl
-aCh
-aqq
-awl
+aHE
+aBz
+awG
+atT
 atu
+azZ
+ajb
+aWV
 atG
-uTo
-oqL
-axh
 lQS
 avt
 lQS
 atG
-sHt
-sHt
-sHt
-sHt
-sHt
-sHt
-sHt
-sHt
-sHt
-sHt
-aOI
-aPm
-aPm
+amK
+aqq
+aMq
+aMq
+aCO
+arR
+aOY
+aMq
+aMq
+aFH
+boU
+bpT
+fes
 aSM
-aVt
-aZL
-aZL
-aIh
-bds
-edu
-bhl
-aLA
-bbI
-aGY
+aQA
+aVq
+aUb
+fzc
+aTZ
+atw
+aOI
+scK
+lLf
+oQY
 beb
 bfH
 bLU
@@ -133819,43 +136001,43 @@ aaa
 aaa
 aaa
 aaa
-awl
+abz
 amL
 aqr
+aHE
+aHE
 awl
-awl
-atG
-iwn
-iDk
+uTo
+oqL
 axh
 auq
 avp
 auq
 atG
-aFK
-aFK
-aOI
+aCh
+ink
+aMq
 gFG
-aFK
-aFK
-gFG
-aOI
-aOI
-aOI
-aOI
-tuZ
-aPm
-wfQ
+aOL
+aUJ
+aDZ
+bCN
+aMq
+iAE
+boU
+boU
+bfT
+aDN
 omD
-aZL
-aZL
+lOY
+aUb
 bbD
 aXi
-rHR
-jqS
-aLA
-bbI
-aGY
+aOI
+aKg
+scK
+gvP
+vhM
 beb
 bfJ
 bLU
@@ -133869,7 +136051,7 @@ bsX
 buK
 bwr
 bdT
-aQs
+bzf
 bAk
 bHy
 phl
@@ -134076,43 +136258,43 @@ aaa
 aaa
 aaa
 aaa
-awl
-awl
-awl
-awl
+aHE
+abz
+abz
+aHE
 aaa
 awl
-oQd
-oQd
+iwn
+iDk
 axh
 auq
 avu
 auq
-aaa
-aaa
-aaa
-aOI
-xfQ
-whv
-nqX
+awl
+aNR
+aGd
+aMq
+aNo
+nyv
+aOL
 vFZ
-aOI
-aUW
+aEU
+aMq
 aLc
-aOI
+bcC
 tuZ
-aPm
-aSM
-aVt
-aZL
-aZL
-aIh
-bdt
-dzb
-rhh
-vvy
-bbU
-beJ
+aTs
+bgT
+aRx
+bbX
+aBp
+aOI
+aOI
+aKg
+beC
+aGY
+wCI
+tNJ
 beb
 bhY
 xZH
@@ -134338,38 +136520,38 @@ aaa
 aaa
 aaa
 aaa
-awl
-doE
-okf
-doE
+aSD
+oQd
+oQd
+axh
 auq
 avw
 auq
-aaa
-aaa
-aaa
-aOI
+aSD
+awl
+aSD
+aMq
 sPb
-lop
-xcB
-mzv
-ljR
-fUX
-aGY
-aOI
-nqG
+qji
+aOL
+aDZ
+awD
+aMq
+biT
+boU
+boU
 edM
-emL
-aVt
-lOY
-fIB
-aLA
+bgT
+tLP
+gsC
+wry
+jvc
 nNB
-afN
-epW
-aLA
-bbY
-bfO
+knl
+aes
+qOo
+bii
+aEX
 beb
 bib
 bjN
@@ -134595,38 +136777,38 @@ aaa
 aaa
 aab
 aaa
+doE
+doE
+okf
+doE
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aOI
-aFK
-aFK
-aFK
-aOI
-aOI
-aSg
+azS
+azS
+aMq
+aDZ
+aOL
+aQC
+aMq
 aHb
-aOI
-aOI
-aOI
-aOI
+aHb
+kiu
+aUW
+aDN
 idg
+aOG
+aPm
+aCS
 aOI
-aOI
-aLA
-aLA
-aLA
-aLA
-aLA
-bbX
-fzc
+aGY
+lCa
+jRo
+oGB
+hAe
 bhu
 djF
 bjt
@@ -134864,26 +137046,26 @@ aaa
 aaa
 aaa
 aaa
-aab
-aab
-aab
-aGX
-aSi
+aMq
+aMq
+aBi
+aMq
+aMq
 oHO
-aRX
-aRX
-aRX
-naU
-qhT
-aGY
+aLP
+aLP
+aLP
+aLP
+aLP
+fho
 mxZ
-knB
-aMz
-aLc
-aNh
-aQL
-bcg
-bfQ
+aGX
+aGX
+aQo
+xlO
+etQ
+jep
+jRo
 beb
 bif
 bjW
@@ -135121,26 +137303,26 @@ aab
 aab
 aab
 aab
-aDS
+xCq
+aBw
+nqG
+aJE
 aGT
-aGT
-aGT
-aGT
-aMz
-aMz
-aMn
-aGX
+bfI
+mDZ
+wYS
+bxS
 aHP
-aQC
+aLP
+aOG
+aUb
+aTg
+aZQ
+bav
+aGX
 aGY
-aGY
-aGY
-aGY
-aGY
-aXW
-bjX
-vgi
-rtY
+wCI
+lim
 beb
 bfD
 bjV
@@ -135380,24 +137562,24 @@ aDS
 aDS
 aDS
 aGU
-aHK
+aHI
 aIB
 aGT
-aKT
-aMi
-aGY
-aOF
-aHP
-aVA
-aXW
+jet
+aPL
+aQZ
+fwg
+bcB
+aSl
+aOG
+aHd
+aRX
 aZQ
-aZQ
-aZQ
-aZQ
-bfP
-bkD
-bcm
-beb
+bav
+aGX
+jRo
+rUg
+huD
 beb
 bif
 bke
@@ -135410,10 +137592,10 @@ boA
 boA
 boA
 boB
-bxM
-bzk
-bAr
-bHy
+aKA
+aHf
+aFA
+nXm
 bJe
 bEu
 bEI
@@ -135639,36 +137821,36 @@ tSW
 sDz
 aHI
 aIA
-aJD
+aGT
 aKS
+aKS
+aKS
+aKS
+eDZ
+brG
+ayd
+aHd
+aRX
 aZQ
-aZQ
-aOE
+axY
 aGX
-aQL
-aOG
-aGY
-aMz
-aGX
-aMz
-aMz
 bkt
-bck
+aSJ
 beb
 bdV
 bie
 bka
 bjB
-ble
+bmA
 bxM
 boB
 btS
 brs
 boB
+bjF
 boB
-boB
-bxM
-bjB
+aSx
+beb
 bAr
 bHy
 bJg
@@ -135896,20 +138078,20 @@ aDS
 aGW
 aHJ
 aIC
-aJH
-aMK
-aGY
-aGY
+aGT
+mDZ
+mDZ
+mDZ
+mDZ
+bhe
+aSl
 aOG
+aHd
+aRX
+aZQ
+bav
 aGX
-aQJ
-aOG
-aGY
-aGX
-aTZ
-aGY
-aGX
-bkI
+aYO
 bcn
 beb
 bdW
@@ -135923,9 +138105,9 @@ btU
 bow
 bow
 byM
-bru
-bxL
-mFG
+bow
+aXX
+beb
 bAr
 bHy
 bJh
@@ -136149,24 +138331,24 @@ aab
 aab
 aab
 aaa
+xCq
+aGT
+aqb
 aGT
 aGT
-aGT
-aGT
-aGT
-aGX
-aHb
+azn
+aPL
 aNh
+aMi
+aUg
+aSl
 aOG
-aGX
-aHb
-aOG
-aGY
+aUb
 aTg
-aGY
-aGY
-aHP
-bkt
+aZQ
+bav
+asc
+aMK
 bck
 beb
 bei
@@ -136175,14 +138357,14 @@ bhR
 bjB
 dnK
 dnU
-bov
+ble
+aJo
 bqa
-brt
 bsY
 buL
 bws
 bxN
-bjB
+beb
 bAt
 bHy
 tZJ
@@ -136406,24 +138588,24 @@ aaa
 aaa
 aab
 aab
-aGX
+aHN
 aTX
-aUR
-aVN
-aKP
+mVX
+aGY
+aMn
 aML
-aVJ
+aKS
 aPs
 aRD
-aMz
-aGX
-aOG
-aGY
-aMz
-aGX
+aEW
+aLP
+aUj
+aUb
 aGX
 aGX
-bkN
+aGX
+aGX
+aGX
 bcm
 beb
 beb
@@ -136432,9 +138614,9 @@ beb
 beb
 beb
 beb
-beb
-beb
-beb
+bjB
+bpO
+bjB
 beb
 beb
 beb
@@ -136663,42 +138845,42 @@ aaa
 aaa
 aaa
 aaa
-aGX
-aUa
-aUa
-bLG
-aGY
-aGX
-aGX
-aGX
-aTs
-aMz
-aOF
+aHN
+jcd
+fQx
+vBf
+viK
+aLP
+aLP
+aLP
+aLP
+aLP
+aLP
 aOG
-aGX
 aUb
-aGY
-aGX
+aUb
+aFn
+emL
 aWb
-aYK
-bct
-aZd
-aZd
-aZd
+aOI
+mlk
 six
+six
+vGf
+six
+bte
 aZd
-aZd
-aZd
-aZd
-aZd
-aZd
+bkn
+bwv
+bwv
+bwv
 bPx
-rCM
+bwv
 bAW
-qhL
-bCN
-bFk
-bHC
+bwv
+bwv
+bwv
+bHI
 bJk
 bEu
 bEu
@@ -136916,42 +139098,42 @@ apn
 ann
 aqZ
 aab
-aaa
 aab
 aab
 aab
-aGX
-aMz
-aMz
-aMz
-aGY
-aGX
-aOi
-aGX
+aab
+iaQ
+aEX
+vPH
+aBf
+aBf
+aBf
+hAa
+bir
 aRI
-aMz
-aHb
-aOG
-aIE
-aGY
-aGY
-aMz
-aSg
-aYO
-aGY
-aGY
-aGY
-aGY
-aTg
-aGY
-aGY
+aRZ
+agu
+aZJ
+sGb
+baM
+sGb
+aZX
+djk
+aJk
+knP
+ddY
+eqV
+nQn
+bpK
+baA
+aAB
 aQL
 bmH
-aTg
-aGY
-bte
-bvg
-bwv
+bmH
+bmH
+byU
+dzb
+awH
 aSV
 xWq
 jaY
@@ -137178,38 +139360,38 @@ aaa
 aaa
 aaa
 aGX
-aHc
-aIv
-aGX
-aMn
-aGX
-aGX
-aGX
+kAq
+mVX
+buy
+buy
+lUu
+aOI
+aID
 aRG
-aGX
-aGX
-aOG
-aMz
-aMz
-aMz
-aMz
+azl
+aRG
+aRG
+aUb
+aIb
+aIi
+rtY
 aSg
-aYO
-aGY
-aQL
-bmH
-aGY
-aGY
-aGY
-aGY
-aGY
-aGY
-aGY
-aGY
+aOI
+qZV
+aWJ
+six
+hrw
+six
 bte
+aOK
+bkn
+bLG
+bwv
+bwv
+bPx
 bve
 bwv
-bwv
+aUK
 aSI
 eRI
 bHF
@@ -137430,29 +139612,32 @@ aab
 aab
 aqZ
 aaa
-aab
-doE
-aHN
-aHN
-aHN
-aGY
-aOC
-aGX
-aGY
-aQI
-aGX
-aMo
-aRJ
+aaa
+aaa
+aaa
+aaa
+iaQ
+jHT
+mVX
+etQ
+hDI
+aOI
+aOI
+pMv
+pMv
 aTe
-xRy
-aXX
-aZX
-bbF
-aZX
-bfK
-aWg
-aYX
-bmH
+pMv
+pMv
+aTe
+pMv
+pMv
+pMv
+aOI
+aGX
+pft
+bau
+aOM
+beJ
 bau
 bau
 bau
@@ -137461,10 +139646,7 @@ bau
 bau
 bau
 bau
-bau
-bau
-bau
-bvg
+bve
 bwv
 bwv
 aSI
@@ -137688,40 +139870,40 @@ aab
 aqZ
 aaa
 aaa
-jEq
-fHA
-jRo
-rvA
-cZV
-aGY
-aMn
-aGY
-aGY
-aMn
+aaa
+aaa
+aaa
+aGX
+sXm
+fQx
 aGY
 aGY
-aPK
-aGY
-aGY
-aQI
-aUc
-aAY
-aVQ
-aSg
-aYO
+aOI
+sHt
+sHt
+sHt
+sHt
+sHt
+sHt
+sHt
+sHt
+sHt
+sHt
+aOI
+aHO
+aVs
+uuQ
 bau
 bau
-btl
-bih
-bia
+bau
 bju
 bli
 blp
-boF
-blp
-brw
-bau
-bvg
+fRL
+aPS
+bfX
+bda
+bve
 bwv
 bwv
 aSI
@@ -137945,45 +140127,45 @@ aab
 aqZ
 aaa
 aaa
-doE
-aHN
-aHN
-aHN
-aNg
-aGY
+aaa
+aaa
+aaa
 aGX
-aQI
-aGY
-aGX
-aNi
-aGY
-aGX
-aGX
-aGY
-aMz
-aGX
-aGX
-aGX
-aSg
-aYO
+buy
+mVX
+vRg
+iYz
+aOI
+sHt
+sHt
+sHt
+sHt
+sHt
+sHt
+sHt
+sHt
+sHt
+sHt
+aOI
+bkI
+bpP
 bau
-bco
-bhw
+bjE
+bCR
+bau
+aGC
 bcp
-bcp
-bcp
-bli
-bcp
+bHr
 boF
-bcp
 brw
-bau
-bvg
+brw
+aZC
+raC
 bwv
 kKJ
 kmN
 bFn
-bHr
+dck
 bzc
 qEE
 eYY
@@ -138205,38 +140387,38 @@ aaa
 aaa
 aaa
 aaa
-aHN
-aJI
+iaQ
 aGY
-aGX
-aGX
-aMn
-aGX
-aGX
-aGY
-aMz
-aQM
-aGY
-aGX
-aUe
-aGY
-aGX
-aWA
+uSF
+aMc
+orG
+aOI
+sHt
+sHt
+sHt
+pwU
+sHt
+sHt
+pwU
+sHt
+sHt
+sHt
+aOI
 aYY
 bqj
-bfU
-bhx
-bij
+bau
+bep
+bcp
 bkp
-bfU
-bfU
+bcp
+afN
 bqM
-bfU
+arT
 btW
 brx
 bau
-byU
-bAX
+bau
+bau
 bau
 bau
 eiq
@@ -138460,41 +140642,41 @@ aqZ
 aaa
 aaa
 aGX
-aGX
-aGX
-aGX
-aGX
-aGX
-aGX
-aID
-aGY
-aGY
-aGY
-aGY
-aMz
-aGY
-aGY
-aIE
-aGY
-aGY
-aGX
-bbI
+iaQ
+iaQ
+hDI
+pvG
+cjD
+isS
+tEI
+aOI
+sHt
+sHt
+sHt
+sHt
+sHt
+sHt
+sHt
+sHt
+sHt
+sHt
+aOI
+hBQ
+xyl
 bau
-bau
-bch
 bem
 bfY
-bkn
+bau
+bjE
 bcp
-blj
-blj
-blj
-btV
-blj
+bmE
+blk
+aFw
+bcp
 bvO
-byR
+bau
 blj
-bxQ
+bkX
 bau
 bFo
 bHI
@@ -138716,41 +140898,41 @@ aab
 aqZ
 aaa
 aaa
-aGX
-aDq
-aEx
-aFM
-aHd
-aGY
-aJE
+aHN
+ove
 aGY
 aGY
-aYE
-aGY
-aGY
+buy
+cjD
 aGX
 aGX
-aMn
-aGX
-aMz
-aMz
-aGX
-bbI
+aOI
+sHt
+sHt
+sHt
+sHt
+sHt
+sHt
+sHt
+sHt
+sHt
+sHt
+aOI
+buy
+bOn
 bau
-bav
-bci
-ben
-bfZ
-bkL
+bau
+bau
+bau
 bjE
+bcp
+bmE
 blk
-blk
-blk
-btX
-blk
-blk
-buW
-blj
+btb
+bcp
+bcp
+boy
+sZa
 bxR
 bau
 bvg
@@ -138974,41 +141156,41 @@ aqZ
 aaa
 aaa
 aHN
-aWV
-aEy
-aFO
-aHf
 aGY
-aGY
-aGY
-aKV
-aMo
-aMo
-aGY
-aMz
-aQO
-aGY
-aKX
-aIE
-aUW
-aGY
-bbI
+hsm
+aBc
+aQI
+gDO
+vDN
+bcg
+aOI
+aOI
+aOI
+aOI
+aTe
+pMv
+pMv
+aTe
+aOI
+aOI
+aOI
+aKg
+jRo
+xfd
 bau
-bao
-bcs
-beo
-beo
-bkK
+bem
+bfY
+bau
+bjE
 bcp
-bcp
-blj
-bcp
+bmE
+blk
 btV
 bry
 bth
-buV
-blj
-bxS
+bau
+aBv
+bkZ
 bau
 bFr
 bHI
@@ -139230,42 +141412,42 @@ aab
 aqZ
 aaa
 aaa
-aHN
-aDr
-aQI
-aFN
-aHe
-aGY
-aGY
-aGY
+aGX
+hvW
+qbc
+aVp
+lUu
+aGX
+fOR
+odq
 aKU
 aMl
 aNj
-aGY
-aMz
+aOI
+aIY
 aQN
-aGY
+bfq
 aUU
-aIE
-aUW
+aOI
+tES
 aGY
-bbI
+aGY
+wxg
+bOn
 bau
-bax
-bcj
 bep
-bfT
-bkQ
-bjF
+bcp
+bkp
+bcp
 bll
-bcp
-boG
+bcq
+bjk
 btZ
-bcp
+aEA
 bti
-buV
-blj
-bxT
+bau
+bau
+bau
 bau
 pua
 bHI
@@ -139487,42 +141669,42 @@ ann
 aqZ
 aaa
 aaa
-aGX
-aHO
-aGY
-aGY
+iaQ
 aGX
 aGX
-aHP
+ujq
+aGX
+aGX
+nhE
 aJK
 aYC
-aGY
-aGY
-aGY
-aGX
-aGY
-aGY
-aGY
-aGY
-aGY
-aGY
-bbI
-aGX
-aGX
-aGX
-aGX
-aGX
-aGX
-aGX
-bll
-bmD
+aPO
+aYC
+aOI
+bct
+aJH
+mzv
+buq
+ljR
+mKT
+qbT
+iSH
+qbT
+gRm
+bau
+bjE
+bkD
+bau
+aCW
+bcp
+bmE
 boG
-btY
+bfU
 buw
 bek
 bzp
 bAY
-bCO
+bcp
 bau
 bFs
 bHI
@@ -139741,44 +141923,44 @@ apq
 apq
 apq
 aab
-aaa
-aaa
 aab
-aAf
-aAf
-aAf
-aMn
-aAf
-aHb
-aMz
-aMz
+aab
+aab
+aGX
+aNH
+aNH
+aVp
+xlO
+kBp
+bez
+gjk
 aIE
-aGX
-aMn
-aMz
-aGX
-aXW
-aZQ
-aZQ
-aZQ
-aZQ
-aZQ
-aXa
-aZd
-bcA
-aZd
-aZd
-bip
-bjn
-aGX
+aOF
+aAY
+aOI
+aOI
+aOI
+aOI
+aOI
+ktK
+xOh
+lCa
+aEX
+aGY
+sWR
+uuQ
 bau
 bau
 bau
+azL
+bfY
+bmE
+bbo
 nAn
-buy
+bcp
 btj
 buV
-blj
+aAJ
 bxV
 bau
 bvg
@@ -140000,42 +142182,42 @@ aab
 aaa
 aaa
 aaa
-aAf
-aCN
-aDt
-aEz
-aFP
-aCP
-aGY
-aGY
-aGY
-aGY
-aGY
-aMc
-aNn
-aNR
-aOk
-aRX
-aRK
-aXb
-aRX
-aRX
-bap
 aGX
-aHO
-bel
-bfW
-bio
-bii
+fOR
+vQn
+uPY
+tcr
 aGX
-bkX
-bmE
+aMj
+tMW
+xaJ
+xzU
+bjn
+aYC
+gXf
+aGX
+pvG
+aGY
+lCa
+lCa
+aHZ
+etQ
+aGX
+lCa
+tuK
+aEX
+uWG
+bIu
+fxV
 bau
+bjE
+bmE
+bbo
 bqc
-bkQ
-btb
-buV
-blj
+bcp
+btj
+bbF
+aGK
 bxW
 bau
 bFv
@@ -140257,42 +142439,42 @@ alv
 alv
 alv
 alv
-aAf
-aCO
-aDs
-aES
-aDs
-aAf
-aGY
-aMq
-aMq
-aMq
-aPO
-aMb
-aPO
-aMq
-aMq
-aUY
+iaQ
+xSv
+iFn
+gaM
+ojX
 aGX
-aSg
-aQI
+aBd
+bfB
+vZR
+bxT
+aOF
+aMb
+kGl
+aGX
+okh
+opC
+bAX
+haR
+cRI
+buy
+buy
+nVf
+siv
 aGY
-aSg
-baz
-baz
-baz
-baz
-bir
-baz
-aYP
+lCa
+aGY
+hwu
+bau
 dnM
-bmG
-boy
+bmE
+bbo
 bcp
-brA
-btl
-buV
-blj
+bcp
+bcp
+aQO
+beo
 bCS
 bau
 bFu
@@ -140513,44 +142695,44 @@ aaa
 aaa
 aaa
 aaa
-aAf
-aAf
-aCP
-aDW
-aCP
-aCP
-aCP
+aGX
+aGX
+hDI
+aGX
+aGX
+tSq
+aGX
+hDI
+wXC
+aGX
+xlO
+aGX
+aGX
+aGX
+hDI
+hBQ
+cYZ
+aEX
+hvW
+qbc
+ycE
+jRo
+mXW
+sWR
+pvG
 aGY
-aMq
-aCL
-aDZ
-aMq
-aMg
-aMq
-aTj
-aUg
-aUY
-aHO
-aSg
-aQL
-aGY
-aSg
-baz
-bcq
-beq
-bfX
-biq
-bjr
-aYP
-bkZ
-bmF
-bau
+lCa
+buy
+szt
+bcp
+bmE
+byR
 bqd
-brB
-brG
-buV
-blj
-bCR
+bxQ
+bjE
+bjE
+bjE
+bjE
 bau
 bFz
 bHI
@@ -140769,44 +142951,44 @@ aaa
 aaa
 aaa
 aaa
-aAf
-aAf
-aBU
-aCM
-aDV
-aEU
-aAf
+iaQ
+xlO
+pfp
 aGY
-aGY
-aMq
-aCU
-aOL
-aKJ
-aMe
-aNr
-aQR
-aQR
-aMq
-aHb
-aSg
+etQ
+oLK
+qcs
+vJj
+yjg
+gmB
+bAX
+dsp
+bAX
+vCk
+vBt
+iPS
+bAX
+fXw
+itm
 baz
 baz
-aXd
+baz
+baz
 baz
 bcw
-bet
-bcx
-biw
 baz
+baz
+biw
+aYP
+aYP
+aYP
+qFg
+aQM
 aYP
 aYP
 aYP
 aYP
 aYP
-aYP
-aYP
-buZ
-bva
 aYP
 aYP
 bFw
@@ -141026,36 +143208,36 @@ aaa
 aaa
 aaa
 aaa
-aAf
-aBd
-aBg
-aCR
-aDY
-aEW
-aCP
-aAY
+aHN
+nDU
+buy
 aGY
-aMq
-aNm
-aEY
-aKM
-aQU
-aNs
-aTl
-aUi
-aMq
 aGY
-aSg
+buy
+aGY
+buy
+aVp
+xTs
+buy
+pvG
+aGY
+buy
+buy
+aVp
+buy
+pvG
 baz
-aXj
-aXc
-baz
-bcu
-ber
+bcF
+aFb
 bga
+aXc
+bcz
+aGG
+bhB
+bgg
 bis
 bvN
-bcD
+aGc
 bld
 blw
 bmI
@@ -141063,7 +143245,7 @@ bmT
 buz
 brI
 buY
-boJ
+bfr
 bjD
 aYP
 bvg
@@ -141283,38 +143465,38 @@ aaa
 aaa
 aaa
 aaa
-aAg
-aBc
-aBV
-aCQ
-aDX
-aEV
-aCP
-aHb
+aHN
+ruw
 aGY
-aMq
-aMq
-aMq
-aPS
-aQT
-aOL
-aTk
-aUh
-aMq
+buy
+xTs
+jcd
+sXm
+buy
+aVp
+saP
+aAf
+aAf
+aAf
+saP
+aEX
+aVp
 aGY
-aSg
+lzZ
 baz
-aUL
+aNi
+aKC
+ber
 aXg
-baz
+aSG
 bcO
-bfV
-bhB
-biy
+lNC
 bgg
+biy
 bcD
-bpK
-bqT
+aya
+bln
+bmJ
 bsa
 bmp
 buB
@@ -141540,37 +143722,37 @@ aaa
 aaa
 aaa
 aaa
-aAg
-aBe
-aBg
-aCS
-aBg
-aEX
-aGd
-aMz
+iaQ
+hBQ
 aGY
-aMq
+uyJ
+aAf
+saP
+aAf
+aAf
+tZg
+aAf
 aNp
 aGV
 aOJ
-aOM
-aOL
-aTm
-aUi
-aMq
+aAf
+hGP
+wjv
 aGY
-aSg
+jKx
 baz
+aKQ
+aUR
 aXk
-aXe
+bcx
 baI
 bcx
-bcx
+bbs
 bhA
 bix
-bgg
 bcD
-bpJ
+bjI
+blo
 bmO
 blo
 bqg
@@ -141796,38 +143978,38 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aAg
-aBg
-aBV
-aBg
-aBg
-aBg
-aGc
+aab
+iaQ
+buZ
 aGY
-aGY
-aMq
-aNo
-aHL
-aDZ
-aQY
-aEY
-aQR
-aQR
-aMq
-aQI
-aSg
+aAf
+aAf
+lVI
+rXM
+hcl
+pVw
+aAf
+aPK
+sjh
+biq
+aAf
+aAf
+aVp
+pFf
+mQn
 baz
-aYx
+aKV
+bcx
+aBW
 aXo
+aXd
+bcx
+mDF
 baz
-bcC
-bcz
-bcz
-bcz
 baz
-bjD
-bpO
+sPN
+bjI
+boJ
 blz
 boJ
 boJ
@@ -142053,37 +144235,37 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aAg
-aBh
-aBX
-aBg
-aBg
-aEZ
+aab
+aGX
+hDI
+aMn
 aAf
-aGY
-aGY
-aMq
-aNq
-aNk
-aOK
-aQW
-aRZ
-aTn
-aUj
-aMq
-aGY
-aSg
-aYP
-aYP
-aYP
-baz
-bcB
-bcz
-bcz
-bcz
-baz
 bjA
+aBg
+aBg
+lYn
+krY
+aCM
+aHL
+aNk
+mQy
+aQW
+aAf
+aTn
+baz
+baz
+baz
+aYp
+bcz
+bcz
+bcz
+vgi
+bcz
+aGG
+bjr
+baz
+bbu
+bjI
 bpM
 blx
 boJ
@@ -142308,40 +144490,40 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aAg
-aBf
-aBg
-azS
+doE
+aHN
+aHN
+aHN
+gXS
+aGY
+aAf
 aAb
 aAL
+aKX
+uHt
+wRm
 aAf
-aGY
-aHO
-aMq
-aMq
-aMq
-aMq
-aMq
-aMq
-aMq
-aMq
+pQk
+hFa
+aAf
+pQk
+aAf
+xku
+bbd
 aUf
-aGY
-aSg
-aYP
-aYA
-baA
 baz
+aOi
 baz
-bvN
+bgg
+bgg
+aqn
 bgg
 bgg
 baz
+baz
+bhk
 bjI
-bpO
+boJ
 blz
 boJ
 boJ
@@ -142349,10 +144531,10 @@ boJ
 boJ
 boJ
 boJ
-boJ
-bEl
-bvg
-bHI
+aUY
+aJj
+ayc
+azX
 bwv
 lRy
 nOo
@@ -142565,40 +144747,40 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aAg
-aBj
+aWg
+aEs
+aBh
+rvA
+cZV
+aGY
+saP
+uFT
 aBg
 aCV
 aEa
-aFb
+aSR
 aAf
-aIE
-aGX
-aGX
 aab
 aMr
 aab
-aGX
-aJN
-aKZ
+baz
+vAQ
 aMz
-aQI
-aGY
-aSg
+aMz
+aMz
+aDX
+aBj
 aYP
 aYz
-bay
 aZl
-bcF
+bfP
+bay
 bcD
 bhC
 bcD
 bjs
-bcD
-bpP
+bjI
+bln
 bmJ
 bln
 bmp
@@ -142606,7 +144788,7 @@ buB
 bmp
 boJ
 boJ
-boJ
+gCU
 aYQ
 bvg
 bHI
@@ -142822,41 +145004,41 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+doE
+aHN
+aHN
+aHN
+aNg
+gXS
 aAf
-aBe
+aBg
+aBV
+bcj
 aBg
 aBg
-aBg
-aFa
-aAf
-aGY
-aGY
-aGX
+hFa
 aab
 aMr
 aab
-aGX
+lTC
 aJL
 aKY
+aJL
 aMz
-aOF
-aGY
+aMz
 aSi
 bjg
-aUX
-aUX
+nSl
+aDV
 aZF
 bcP
 bgb
 bhD
 aUX
 bla
-aUX
-bpU
-bqW
+aUa
+blo
+bmO
 bsb
 bqg
 buA
@@ -143078,30 +145260,30 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
 aab
-aab
-aab
-aab
-aAf
-aAf
-aBW
-aCW
-aEc
-aAf
-aAf
-aGY
-aLc
 aGX
+aGX
+aJI
+aAf
+aAf
+bao
+aJu
+aHW
+aEi
+pQk
 aab
 aMr
 aaa
-aGX
-aGX
-aGX
-aGX
-aJM
-aGY
-aGY
+baz
+lTC
+baz
+lTC
+aYx
+aMz
+azc
 aYP
 aYB
 pJI
@@ -143111,15 +145293,15 @@ bfS
 bgi
 bgi
 aYP
-bcD
+fIB
 blm
-bcD
+aUX
 bmK
-bcD
-bcD
-bcD
-boJ
-boJ
+aUX
+aUX
+aUX
+aQJ
+aQJ
 qyq
 aYP
 xmi
@@ -143340,25 +145522,25 @@ aaa
 aaa
 aab
 aab
-aAf
-aAf
-aAf
-aAf
-aFd
-aAf
+iaQ
+iaQ
 aGX
-aGX
-aGX
+aAf
+aAf
+pQk
+pQk
+pQk
+aAf
 aaa
 aMr
 aaa
 aaa
 aaa
 aaa
-aGX
-aGX
-aGX
-aGX
+lTC
+baz
+lTC
+baz
 aYP
 aYG
 baC
@@ -143616,7 +145798,7 @@ aaa
 aab
 aab
 aab
-aYP
+uhj
 aYF
 baC
 aXh
@@ -143629,7 +145811,7 @@ vTz
 hFx
 fbA
 aYP
-aYP
+uhj
 aYP
 aYP
 aaa
@@ -143874,8 +146056,8 @@ afO
 aaa
 aaa
 aYP
-aYP
-aYP
+uhj
+uhj
 aYP
 aXl
 aYP
@@ -143883,7 +146065,7 @@ aYQ
 aYQ
 aYP
 aYP
-aYP
+uhj
 aYP
 aYP
 aab

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -11998,6 +11998,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarstarboard)
 "aIB" = (
@@ -62943,10 +62944,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
-"eCG" = (
-/mob/living/simple_animal/mouse,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
 "eDs" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -67048,6 +67045,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/coldroom)
+"gRq" = (
+/mob/living/simple_animal/mouse,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "gRE" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -67757,6 +67758,17 @@
 	icon_state = "bar"
 	},
 /area/station/security/permabrig)
+"hiq" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "hiO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -68180,12 +68192,6 @@
 	icon_state = "cmo"
 	},
 /area/station/maintenance/aft)
-"hvu" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
 "hvz" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -74570,7 +74576,7 @@
 "lpx" = (
 /obj/structure/rack,
 /obj/item/coin/mime,
-/obj/item/clothing/mask/gas/sexymime,
+/obj/item/clothing/mask/gas/mime,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
 "lpJ" = (
@@ -76553,17 +76559,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/science/xenobiology)
-"mAb" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
 "mAq" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -82559,6 +82554,12 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/service/bar)
+"qdA" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "qdO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -139255,7 +139256,7 @@ iaQ
 aEX
 vPH
 aBf
-mAb
+hiq
 aBf
 hAa
 bir
@@ -140026,7 +140027,7 @@ aGX
 sXm
 fQx
 aGY
-eCG
+gRq
 aOI
 sHt
 sHt
@@ -141050,7 +141051,7 @@ aaa
 aHN
 ove
 aGY
-hvu
+qdA
 buy
 cjD
 aGX

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -757,6 +757,11 @@
 "aes" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "aeu" = (
@@ -9438,19 +9443,6 @@
 /area/station/security/prison/cell_block/A)
 "aAY" = (
 /obj/effect/decal/warning_stripes/white/hollow,
-/obj/structure/cable/yellow,
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
@@ -9566,6 +9558,11 @@
 	name = "Electrical Maintenance";
 	req_access_txt = "11"
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/electrical)
 "aBj" = (
@@ -9601,9 +9598,7 @@
 	name = "south bump";
 	pixel_y = -24
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
+/obj/structure/cable,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
 	},
@@ -11467,6 +11462,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/carpet,
 /area/station/public/mrchangs)
 "aGF" = (
@@ -12057,19 +12057,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/structure/cable/blue{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable/blue{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/cable/blue,
-/obj/structure/cable/blue{
-	d2 = 2;
-	icon_state = "0-2"
 	},
 /obj/effect/decal/warning_stripes/white/hollow,
 /turf/simulated/floor/plating,
@@ -12751,6 +12738,11 @@
 /obj/structure/chair/wood{
 	dir = 8
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/wood,
 /area/station/public/mrchangs)
 "aKI" = (
@@ -12830,19 +12822,6 @@
 /area/station/security/detective)
 "aKU" = (
 /obj/effect/decal/warning_stripes/white/hollow,
-/obj/structure/cable/pink,
-/obj/structure/cable/pink{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/cable/pink{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/cable/pink{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/structure/cable/pink{
 	d2 = 4;
 	icon_state = "1-4";
@@ -13330,19 +13309,6 @@
 /area/station/legal/courtroom)
 "aMb" = (
 /obj/effect/decal/warning_stripes/white/hollow,
-/obj/structure/cable/green,
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "1-2";
@@ -13579,6 +13545,7 @@
 	name = "east bump";
 	pixel_x = 24
 	},
+/obj/structure/cable,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitegreencorner"
@@ -13754,19 +13721,6 @@
 /area/station/service/chapel/office)
 "aNj" = (
 /obj/effect/decal/warning_stripes/white/hollow,
-/obj/structure/cable/orange,
-/obj/structure/cable/orange{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/cable/orange{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/cable/orange{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/structure/cable/orange{
 	d2 = 2;
 	icon_state = "1-2";
@@ -14370,6 +14324,10 @@
 	pixel_y = -24
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/electrical)
 "aOZ" = (
@@ -14835,6 +14793,11 @@
 "aQA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -15613,6 +15576,11 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/wood,
 /area/station/public/mrchangs)
 "aSN" = (
@@ -16615,6 +16583,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/wood,
 /area/station/public/mrchangs)
 "aVE" = (
@@ -16724,6 +16697,10 @@
 	dir = 8;
 	name = "west bump";
 	pixel_x = -24
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/wood,
 /area/station/public/mrchangs)
@@ -18821,8 +18798,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/station/public/dorms)
@@ -19801,19 +19786,6 @@
 /area/shuttle/arrival/station)
 "bez" = (
 /obj/effect/decal/warning_stripes/white/hollow,
-/obj/structure/cable/white,
-/obj/structure/cable/white{
-	icon_state = "0-2";
-	d2 = 2
-	},
-/obj/structure/cable/white{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/obj/structure/cable/white{
-	icon_state = "0-8";
-	d2 = 8
-	},
 /obj/structure/cable/white{
 	icon_state = "1-2";
 	d2 = 4;
@@ -21201,6 +21173,11 @@
 /obj/structure/disposalpipe/junction{
 	dir = 4;
 	icon_state = "pipe-j2"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
@@ -27555,19 +27532,6 @@
 /area/station/public/sleep)
 "bxT" = (
 /obj/effect/decal/warning_stripes/white/hollow,
-/obj/structure/cable/cyan,
-/obj/structure/cable/cyan{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/cable/cyan{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/cable/cyan{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/structure/cable/cyan{
 	d2 = 2;
 	icon_state = "1-2";
@@ -61667,6 +61631,16 @@
 /obj/effect/spawner/random_spawners/fungus_probably,
 /turf/simulated/wall,
 /area/station/maintenance/electrical)
+"dVo" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/public/dorms)
 "dVG" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -62211,6 +62185,13 @@
 	icon_state = "cmo"
 	},
 /area/station/maintenance/apmaint)
+"egN" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/public/dorms)
 "egO" = (
 /obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -63817,6 +63798,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/carpet,
 /area/station/public/mrchangs)
@@ -70374,7 +70360,9 @@
 /area/station/medical/virology)
 "iIf" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/machinery/atmospherics/portable/canister/sleeping_agent,
+/obj/machinery/atmospherics/portable/canister/sleeping_agent{
+	filled = 0.1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -71448,6 +71436,11 @@
 /area/station/hallway/primary/central/se)
 "jvc" = (
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner"
 	},
@@ -73485,6 +73478,14 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/simulated/floor/plasteel,
 /area/station/science/storage)
+"kHS" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/carpet,
+/area/station/public/mrchangs)
 "kHT" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -74961,6 +74962,19 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
+"lFu" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "lFG" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -77750,6 +77764,11 @@
 /turf/simulated/wall,
 /area/station/maintenance/port)
 "nqG" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarstarboard)
 "nqN" = (
@@ -78499,6 +78518,11 @@
 	req_access_txt = "12"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/station/public/dorms)
 "nOo" = (
@@ -80386,7 +80410,9 @@
 /area/station/maintenance/fsmaint)
 "oQL" = (
 /obj/effect/decal/warning_stripes/blue/hollow,
-/obj/machinery/atmospherics/portable/canister/oxygen,
+/obj/machinery/atmospherics/portable/canister/oxygen{
+	filled = 0.1
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -83997,6 +84023,11 @@
 /area/station/maintenance/fore)
 "qOo" = (
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fsmaint)
 "qOs" = (
@@ -84825,6 +84856,14 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/public/toilet)
+"rqZ" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/electrical)
 "rrg" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -85555,7 +85594,9 @@
 /area/station/engineering/control)
 "rQm" = (
 /obj/effect/decal/warning_stripes/red/hollow,
-/obj/machinery/atmospherics/portable/canister/carbon_dioxide,
+/obj/machinery/atmospherics/portable/canister/carbon_dioxide{
+	filled = 0.1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -85838,6 +85879,14 @@
 	icon_state = "wood-broken"
 	},
 /area/station/maintenance/abandonedbar)
+"rYc" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet,
+/area/station/public/mrchangs)
 "rYm" = (
 /obj/structure/girder,
 /turf/simulated/floor/plasteel,
@@ -86076,6 +86125,21 @@
 	icon_state = "white"
 	},
 /area/station/medical/virology)
+"sib" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/public/dorms)
 "sir" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair{
@@ -87819,6 +87883,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint2)
+"tdh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/electrical)
 "tdj" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -88199,6 +88272,19 @@
 	},
 /turf/simulated/floor/catwalk,
 /area/station/maintenance/fore)
+"tsc" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/auxsolarstarboard)
 "tsl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -90249,6 +90335,15 @@
 	icon_state = "whitepurple"
 	},
 /area/station/science/robotics)
+"uyi" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "uyJ" = (
 /obj/structure/closet/coffin,
 /turf/simulated/floor/plating,
@@ -92265,6 +92360,11 @@
 /area/station/maintenance/asmaint)
 "vFZ" = (
 /obj/structure/chair/stool,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/electrical)
 "vGf" = (
@@ -93025,6 +93125,15 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/telecomms/chamber)
+"wbw" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/public/dorms)
 "wbT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -94044,6 +94153,22 @@
 /obj/effect/spawner/random_spawners/cobweb_right_rare,
 /turf/simulated/floor/carpet/royalblack,
 /area/station/maintenance/apmaint)
+"wOq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/sortjunction{
+	dir = 4;
+	name = "Kitchen";
+	sort_type_txt = "20"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "wOM" = (
 /obj/machinery/camera{
 	c_tag = "Prison Solitary 1";
@@ -134751,8 +134876,8 @@ aPm
 aHK
 aOI
 hBQ
-rUg
-aGY
+wOq
+knl
 yat
 djt
 bjd
@@ -134996,8 +135121,8 @@ aOL
 qhL
 aMq
 aTm
-boU
-boU
+kHS
+rYc
 aKD
 bgT
 aRx
@@ -135772,7 +135897,7 @@ bpT
 fes
 aSM
 aQA
-aVq
+dVo
 aUb
 fzc
 aTZ
@@ -136020,7 +136145,7 @@ aMq
 gFG
 aOL
 aUJ
-aDZ
+tdh
 bCN
 aMq
 iAE
@@ -136029,7 +136154,7 @@ boU
 bfT
 aDN
 omD
-lOY
+gGD
 aUb
 bbD
 aXi
@@ -136285,7 +136410,7 @@ bcC
 tuZ
 aTs
 bgT
-aRx
+egN
 bbX
 aBp
 aOI
@@ -136534,7 +136659,7 @@ aMq
 sPb
 qji
 aOL
-aDZ
+tdh
 awD
 aMq
 biT
@@ -136543,11 +136668,11 @@ boU
 edM
 bgT
 tLP
-gsC
-wry
+sib
+wbw
 jvc
 nNB
-knl
+uyi
 aes
 qOo
 bii
@@ -136791,7 +136916,7 @@ azS
 azS
 aMq
 aDZ
-aOL
+rqZ
 aQC
 aMq
 aHb
@@ -137562,7 +137687,7 @@ aDS
 aDS
 aDS
 aGU
-aHI
+tsc
 aIB
 aGT
 jet
@@ -138590,9 +138715,9 @@ aab
 aab
 aHN
 aTX
-mVX
-aGY
-aMn
+lFu
+aBf
+hAa
 aML
 aKS
 aPs

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -92250,9 +92250,9 @@
 	},
 /area/station/security/execution)
 "vDq" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics Maintenance";
-	req_access_txt = "12;24"
+/obj/machinery/door/airlock/security{
+	name = "Used Carnisters Storage";
+	req_access_txt = "63"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -5144,7 +5144,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -70377,7 +70376,7 @@
 "iIf" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/portable/canister/sleeping_agent{
-	filled = 0.01
+	filled = 0.015
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -80430,7 +80429,7 @@
 "oQL" = (
 /obj/effect/decal/warning_stripes/blue/hollow,
 /obj/machinery/atmospherics/portable/canister/oxygen{
-	filled = 0.1
+	filled = 0.3
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -85620,7 +85619,7 @@
 "rQm" = (
 /obj/effect/decal/warning_stripes/red/hollow,
 /obj/machinery/atmospherics/portable/canister/carbon_dioxide{
-	filled = 0.01
+	filled = 0.015
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Changes old Dominatories, Service and Fore/Fore-Starboard Maintenances look to new one.

## Why It's Good For The Game
Expands boring dominatories and give more content for surrounding it maintenances.

## Images of changes
(This image will be updated every time there will be change)
![2023-09-10 00 52 44](https://github.com/ParadiseSS13/Paradise/assets/89580971/ac5dc047-20c8-4fe9-a4dd-fd30d91e3f1c)
(Download Image for full resolution)

## Testing
Run Code, didn't see to crash, (still need do disposal testing and stuff)

## Changelog
:cl:
tweak: Changed Cyberiad Service and Dominatory shape and accessibility.
tweak: Chanded Cyberiad Fore and Fore-Starboard Maintenances shape and content.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
