### PR TITLE
You can no longer stack Rad Collectors on the same turf

### DIFF
--- a/code/modules/power/engines/singularity/collector.dm
+++ b/code/modules/power/engines/singularity/collector.dm
@@ -82,7 +82,7 @@ GLOBAL_LIST_EMPTY(rad_collectors)
 			return TRUE
 		var/turf/T = get_turf(src)
 		for(var/obj/machinery/power/rad_collector/can_wrench in T.contents)
-			if(istype(can_wrench, /obj/machinery/power/rad_collector) && can_wrench.anchored && !anchored)
+			if(can_wrench.anchored && !anchored)
 				to_chat(user, "<span class='notice'>You can't wrench down [src] here!</span>")
 				return
 		playsound(loc, I.usesound, 75, TRUE)

--- a/code/modules/power/engines/singularity/collector.dm
+++ b/code/modules/power/engines/singularity/collector.dm
@@ -77,13 +77,13 @@ GLOBAL_LIST_EMPTY(rad_collectors)
 			eject()
 			return TRUE
 	else if(iswrench(I))
-		var/turf/T = get_turf(src)
 		if(loaded_tank)
 			to_chat(user, "<span class='notice'>Remove the plasma tank first.</span>")
 			return TRUE
+		var/turf/T = get_turf(src)
 		for(var/obj/machinery/power/rad_collector/can_wrench in T.contents)
 			if(istype(can_wrench, /obj/machinery/power/rad_collector) && can_wrench.anchored && !anchored)
-				to_chat(user, "<span class='notice'>You can't wrench down [src] here!</span?")
+				to_chat(user, "<span class='notice'>You can't wrench down [src] here!</span>")
 				return
 		playsound(loc, I.usesound, 75, TRUE)
 		anchored = !anchored

--- a/code/modules/power/engines/singularity/collector.dm
+++ b/code/modules/power/engines/singularity/collector.dm
@@ -77,9 +77,14 @@ GLOBAL_LIST_EMPTY(rad_collectors)
 			eject()
 			return TRUE
 	else if(iswrench(I))
+		var/turf/T = get_turf(src)
 		if(loaded_tank)
 			to_chat(user, "<span class='notice'>Remove the plasma tank first.</span>")
 			return TRUE
+		for(var/obj/machinery/power/rad_collector/can_wrench in T.contents)
+			if(istype(can_wrench, /obj/machinery/power/rad_collector) && can_wrench.anchored && !anchored)
+				to_chat(user, "<span class='notice'>You can't wrench down [src] here!</span?")
+				return
 		playsound(loc, I.usesound, 75, TRUE)
 		anchored = !anchored
 		user.visible_message("[user.name] [anchored ? "secures" : "unsecures"] the [name].", "You [anchored ? "secure" : "undo"] the external bolts.", "You hear a ratchet")


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds a check to prevent multiple rad collectors from being anchored on the same turf.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Stacking collectors provided a cheesy way to maximize power gain without the limitations of space and dealing with the drop off of rad strength that a similar unstacked number of collectors would suffer from as they are added further and further from the source.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://github.com/ParadiseSS13/Paradise/assets/107899953/86c792d8-e1b9-452f-a3f2-9b42ad37f3e9)
![image](https://github.com/ParadiseSS13/Paradise/assets/107899953/5619a5ac-3cb8-4c64-a2e4-ab5538261ca2)


<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Spawned in 2 collectors on top of each other, spawned in one alone nearby
Unanchored and anchored the rad collector with no others on the turf: worked as intended
Anchored one rad collector of the two stacked, attempted to anchor the second: could not anchor the second
Unanchored the first rad collector, anchored the second rad collector: worked as intended
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Multiple radiation collectors can no longer be stacked and anchored on the same tile.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
