### PR TITLE
[s] Fixes a monkey issue with changelings

### DIFF
--- a/code/modules/antagonists/changeling/powers/humanform.dm
+++ b/code/modules/antagonists/changeling/powers/humanform.dm
@@ -10,6 +10,10 @@
 	var/datum/dna/chosen_dna = cling.select_dna("Select the target DNA: ", "Target DNA")
 	if(!chosen_dna || !user)
 		return FALSE
+
+	var/brute_damage = user.getBruteLoss()
+	var/burn_damage = user.getFireLoss()
+
 	to_chat(user, "<span class='notice'>We transform our appearance.</span>")
 	user.dna.SetSEState(GLOB.monkeyblock,0,1)
 	singlemutcheck(user,GLOB.monkeyblock, MUTCHK_FORCED)
@@ -23,6 +27,9 @@
 	user.dna.UpdateUI()
 	user.sync_organ_dna(1)
 	user.UpdateAppearance()
+
+	user.adjustBruteLoss(brute_damage)
+	user.adjustFireLoss(burn_damage)
 
 	cling.acquired_powers -= src
 	Remove(user)

--- a/code/modules/antagonists/changeling/powers/lesserform.dm
+++ b/code/modules/antagonists/changeling/powers/lesserform.dm
@@ -19,9 +19,15 @@
 		to_chat(H, "<span class='warning'>We cannot perform this ability in this form!</span>")
 		return FALSE
 
+	var/brute_damage = H.getBruteLoss() * 0.66 // To offset the 1.5 brute/burn mod that monkeys have
+	var/burn_damage = H.getFireLoss() * 0.66
+
 	H.visible_message("<span class='warning'>[H] transforms!</span>")
 	to_chat(H, "<span class='warning'>Our genes cry out!</span>")
 	H.monkeyize()
+
+	H.adjustBruteLoss(brute_damage)
+	H.adjustFireLoss(burn_damage)
 
 	cling.give_power(new /datum/action/changeling/humanform)
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes an oversight with transformation code that allowed some annoying things to happen
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
We really shouldn't have this in the game.
Also my god transformation code has so many oversights it's unreal
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Hit myself a few times with an armblade, did some black magic and checked  the damage values before and afterwards
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Fixed an issue pertaining to monkeys and changelings
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
