### PR TITLE
Combo now restarts if step failed

### DIFF
--- a/code/modules/martial_arts/martial.dm
+++ b/code/modules/martial_arts/martial.dm
@@ -110,6 +110,8 @@
 					return TRUE
 	if(!LAZYLEN(current_combos))
 		reset_combos()
+		if(HAS_COMBOS)
+			act(step, user, target)
 
 /datum/martial_art/proc/basic_hit(mob/living/carbon/human/A, mob/living/carbon/human/D)
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
This PR changes martial art combo logic. Before, if you fail a step, all you combos are failed and you need to start from beginning.
Now, if you fail a step, this step will be counted as a start of the new combo, so you dont need to do the same step again to do something.
This allows you to faster switch between targets, faster switch between combos on single target.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Combos and martial art system currently is not easy to understand
Lets say, you have combo grab-harm on CQC. Does that mean that if you do grab-harm on the target fast enough, that combo will be performed and the target will be knockdown? In current system, no. If you started doing this combo with active combo meter(usually means if you used any of intents some time ago), you will need to do first step of the new combo twice.
This PR changes this.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
https://youtu.be/OHDozwPrX74
This video compares current system with PR changes

## Testing
<!-- How did you test the PR, if at all? -->
Compiled, did something funny with CQC

## Changelog
:cl:
tweak: Failed combo step now becomes start of the new combo instead of wiping your combo meter
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
