### PR TITLE
machine people are no longer affected by headslugs

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/headslug.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headslug.dm
@@ -44,7 +44,7 @@
 	egg_layed = TRUE
 
 /mob/living/simple_animal/hostile/headslug/AltClickOn(mob/living/carbon/carbon_target)
-	if(egg_layed || !istype(carbon_target) || !Adjacent(carbon_target))
+	if(egg_layed || !istype(carbon_target) || !Adjacent(carbon_target) || ismachineperson(carbon_target))
 		return ..()
 	if(carbon_target.stat != DEAD && !do_mob(src, carbon_target, 5 SECONDS))
 		return


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
machine people are no longer affected by headslugs
The fact nobody noticed this until now is really funny

## Why It's Good For The Game
inconsistency

## Testing
qwerty made me walk like a drunk
## Changelog
:cl:
fix: machine people are no longer affected by headslugs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
