### PR TITLE
Fixes blocked alien hand HUD

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -453,8 +453,9 @@
 				. += handcuff_overlay
 
 			var/obj/item/organ/external/hand = C.get_organ("[slot_id == slot_l_hand ? "l" : "r"]_hand")
-			if(!hand || !hand.is_usable())
-				. += blocked_overlay
+			if(!isalien(C))
+				if(!hand || !hand.is_usable())
+					. += blocked_overlay
 
 		if(slot_id == slot_l_hand && hud.mymob.hand)
 			. += active_overlay

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -453,9 +453,8 @@
 				. += handcuff_overlay
 
 			var/obj/item/organ/external/hand = C.get_organ("[slot_id == slot_l_hand ? "l" : "r"]_hand")
-			if(!isalien(C))
-				if(!hand || !hand.is_usable())
-					. += blocked_overlay
+			if(!isalien(C) && !hand || !hand.is_usable())
+				. += blocked_overlay
 
 		if(slot_id == slot_l_hand && hud.mymob.hand)
 			. += active_overlay

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -453,7 +453,7 @@
 				. += handcuff_overlay
 
 			var/obj/item/organ/external/hand = C.get_organ("[slot_id == slot_l_hand ? "l" : "r"]_hand")
-			if(!isalien(C) && !hand || !hand.is_usable())
+			if(!isalien(C) && (!hand || !hand.is_usable()))
 				. += blocked_overlay
 
 		if(slot_id == slot_l_hand && hud.mymob.hand)


### PR DESCRIPTION
## What Does This PR Do
This fixes https://github.com/ParadiseSS13/Paradise/issues/22163, where alien mobs hands are blocked in the HUD as they have no hands, technically.
## Why It's Good For The Game
Hand HUD will now function properly for alien mobs.
## Images
![dreamseeker_IxgwBlGuex](https://github.com/ParadiseSS13/Paradise/assets/116982774/4471b256-b225-42a9-918b-eaffd6136909)
## Testing
Spawned in as multiple different aliens and checked the HUD.
## Changelog
:cl:
fix: Fixed block on alien hand HUD
/:cl:
