### PR TITLE
Fixes missing name for fireproofing injector

### DIFF
--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -265,6 +265,7 @@
 	flawless = TRUE
 
 /obj/item/fireproofing_injector
+	name = "fireproofing injector"
 	desc = "It contains an alien nanoswarm created by the technomancers of boron. Through near sorcerous feats via use of nanomachines, it enables its user to become fully fireproof."
 	icon = 'icons/obj/hypo.dmi'
 	icon_state = "combat_hypo"


### PR DESCRIPTION
## What Does This PR Do
This fixes a missing name for the fireproofing injector, a species specific traitor item. 
## Why It's Good For The Game
It allows the item to be identifiable.
## Images of changes
### **Before**
![ApplicationFrameHost_VVw4Gkfs6K](https://github.com/ParadiseSS13/Paradise/assets/116982774/24e0e354-1828-4192-8e0f-085cf13db47e)
### **After**
![ApplicationFrameHost_PSuU3fB2fk](https://github.com/ParadiseSS13/Paradise/assets/116982774/5a0e0700-ee54-48a2-8801-2ed637365344)
## Testing
Purchased a fireproofing injector from an uplink and checked the name.
## Changelog
:cl:
fix: Fixed missing name from fireproofing injector 
/:cl: