### PR TITLE
Reroll destroy AI objective when the AI goes to cryo

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -616,6 +616,18 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 		return FALSE
 	return TRUE
 
+/datum/objective/destroy/post_target_cryo(list/owners)
+	var/datum/objective/new_objective
+	for(var/datum/mind/M in owners)
+		new_objective = new /datum/objective/assassinate
+		new_objective.owner = M
+		new_objective.find_target()
+		if(!new_objective.target)
+			new_objective.Destroy()
+		else
+			M.objectives += new_objective
+		M.remove_objective(src)
+	Destroy()
 /datum/objective/steal_five_of_type
 	name = "Steal Five Items"
 	explanation_text = "Steal at least five items!"

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -617,17 +617,7 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 	return TRUE
 
 /datum/objective/destroy/post_target_cryo(list/owners)
-	var/datum/objective/new_objective
-	for(var/datum/mind/M in owners)
-		new_objective = new /datum/objective/assassinate
-		new_objective.owner = M
-		new_objective.find_target()
-		if(!new_objective.target)
-			qdel(new_objective)
-			continue
-		else
-			M.objectives += new_objective
-		M.remove_objective(src)
+	holder.replace_objective(src, /datum/objective/assassinate)
 	
 /datum/objective/steal_five_of_type
 	name = "Steal Five Items"

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -628,7 +628,7 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 		else
 			M.objectives += new_objective
 		M.remove_objective(src)
-	Destroy()
+	
 /datum/objective/steal_five_of_type
 	name = "Steal Five Items"
 	explanation_text = "Steal at least five items!"

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -623,7 +623,8 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 		new_objective.owner = M
 		new_objective.find_target()
 		if(!new_objective.target)
-			new_objective.Destroy()
+			qdel(new_objective)
+			continue
 		else
 			M.objectives += new_objective
 		M.remove_objective(src)

--- a/code/modules/mob/living/silicon/ai/latejoin.dm
+++ b/code/modules/mob/living/silicon/ai/latejoin.dm
@@ -29,6 +29,11 @@ GLOBAL_LIST_EMPTY(empty_playable_ai_cores)
 			var/datum/game_mode/traitor/autotraitor/current_mode = SSticker.mode
 			current_mode.possible_traitors.Remove(src)
 
+	for(var/datum/objective/O in GLOB.all_objectives)
+		if(O.target != mind)
+			continue
+		O.on_target_cryo()
+
 	// Ghost the current player and disallow them to return to the body
 	if(TOO_EARLY_TO_GHOST)
 		ghostize(FALSE)

--- a/code/modules/mob/living/silicon/ai/latejoin.dm
+++ b/code/modules/mob/living/silicon/ai/latejoin.dm
@@ -29,7 +29,7 @@ GLOBAL_LIST_EMPTY(empty_playable_ai_cores)
 			var/datum/game_mode/traitor/autotraitor/current_mode = SSticker.mode
 			current_mode.possible_traitors.Remove(src)
 
-	for(var/datum/objective/O in GLOB.all_objectives)
+	for(var/datum/objective/destroy/O in GLOB.all_objectives)
 		if(O.target != mind)
 			continue
 		O.on_target_cryo()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes it so that the destroy AI objective is automatically rerolled into an assassination objective when the AI wipes their core.
Fixes: #21948
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
There's no longer a chance traitors end up with a moot objective when the AI cryos.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Two traitor skrells with the destroy AI objective and an AI are on station.
AI cryos.
The traitor skrells have their destroy AI objective replaced with an assassination objective for the other skrell.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: The destroy AI objective is automatically rerolled into an assassination objective if the AI wipes their core.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
