### PR TITLE
You can no longer turn on portable scrubbers/pumps if they're connected to a connector.

### DIFF
--- a/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
+++ b/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
@@ -148,6 +148,8 @@
 			if(connect(possible_port))
 				to_chat(user, "<span class='notice'>You connect [src] to the port.</span>")
 				update_icon()
+			if(on)
+				on = !on
 				return
 			else
 				to_chat(user, "<span class='notice'>[src] failed to connect to the port.</span>")

--- a/code/modules/atmospherics/machinery/portable/portable_pump.dm
+++ b/code/modules/atmospherics/machinery/portable/portable_pump.dm
@@ -141,12 +141,15 @@
 
 	return data
 
-/obj/machinery/atmospherics/portable/pump/ui_act(action, list/params)
+/obj/machinery/atmospherics/portable/pump/ui_act(action, list/params, datum/tgui/ui)
 	if(..())
 		return
 
 	switch(action)
 		if("power")
+			if(connected_port)
+				to_chat(ui.user, "<span class='warning'>[src] fails to turn on, the port is covered!</span>")
+				return
 			on = !on
 			if(on && direction == DIRECTION_OUT)
 				investigate_log("[key_name(usr)] started a transfer into [holding_tank].<br>", "atmos")

--- a/code/modules/atmospherics/machinery/portable/scrubber.dm
+++ b/code/modules/atmospherics/machinery/portable/scrubber.dm
@@ -136,12 +136,15 @@
 
 	return data
 
-/obj/machinery/atmospherics/portable/scrubber/ui_act(action, list/params)
+/obj/machinery/atmospherics/portable/scrubber/ui_act(action, list/params, datum/tgui/ui)
 	if(..())
 		return
 
 	switch(action)
 		if("power")
+			if(connected_port)
+				to_chat(ui.user, "<span class='warning'>[src] fails to turn on, the port is covered!</span>")
+				return
 			on = !on
 			update_icon()
 			return TRUE


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
You're unable to turn on portable pumps, and scrubbers, if they're connected to a connector, and they turn off if you connect them while on.
This does NOT affect canisters.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
The fact you're able to turn the pump/scrubber on while they're wrenched, is silly. as you're covering the intake/outlet to remove/add the gasses, so how are you also pumping/scrubbing in/out gas from room?

## Testing
<!-- How did you test the PR, if at all? -->
Wrenched portable scrubbers, canisters, and pumps down and tried to turn them on.
Turned all three types on, then wrenched them down.
All worked as expected.
## Changelog
:cl:
tweak: You can no longer turn portable pumps/scrubbers on if they're wrenched to a connector.
tweak: Wrenching a portable pump/scrubber to a connector now turns them off.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
