### PR TITLE
Removes appearance options not available to species from mirror

### DIFF
--- a/code/modules/mob/living/carbon/human/species/moth.dm
+++ b/code/modules/mob/living/carbon/human/species/moth.dm
@@ -13,7 +13,7 @@
 	species_traits = list(NO_HAIR)
 	inherent_biotypes = MOB_ORGANIC | MOB_HUMANOID | MOB_BUG
 	clothing_flags = HAS_UNDERWEAR | HAS_UNDERSHIRT
-	bodyflags = HAS_HEAD_ACCESSORY | HAS_HEAD_MARKINGS | HAS_BODY_MARKINGS | HAS_WING | BALD
+	bodyflags = HAS_HEAD_ACCESSORY | HAS_HEAD_MARKINGS | HAS_BODY_MARKINGS | HAS_WING | BALD | SHAVED
 	reagent_tag = PROCESS_ORG
 	dietflags = DIET_HERB
 	tox_mod = 1.5

--- a/code/modules/tgui/modules/appearance_changer.dm
+++ b/code/modules/tgui/modules/appearance_changer.dm
@@ -231,30 +231,33 @@
 		data["head_accessory_styles"] = head_accessory_styles
 		data["head_accessory_style"] = head_organ ? head_organ.ha_style : "None"
 
-	data["change_hair"] = can_change(APPEARANCE_HAIR)
-	if(data["change_hair"])
-		var/list/hair_styles = list()
-		for(var/hair_style in valid_hairstyles)
-			hair_styles += list(list("hairstyle" = hair_style))
-		data["hair_styles"] = hair_styles
-		data["hair_style"] = head_organ ? head_organ.h_style : "Skinhead"
+	if(!isgrey(user) && !ismoth(user) && !isdrask(user))
+		data["change_hair"] = can_change(APPEARANCE_HAIR)
+		if(data["change_hair"])
+			var/list/hair_styles = list()
+			for(var/hair_style in valid_hairstyles)
+				hair_styles += list(list("hairstyle" = hair_style))
+			data["hair_styles"] = hair_styles
+			data["hair_style"] = head_organ ? head_organ.h_style : "Skinhead"
 
-	data["change_facial_hair"] = can_change(APPEARANCE_FACIAL_HAIR)
-	if(data["change_facial_hair"])
-		var/list/facial_hair_styles = list()
-		for(var/facial_hair_style in valid_facial_hairstyles)
-			facial_hair_styles += list(list("facialhairstyle" = facial_hair_style))
-		data["facial_hair_styles"] = facial_hair_styles
-		data["facial_hair_style"] = head_organ ? head_organ.f_style : "Shaved"
+	if(!ismachineperson(user) && !isgrey(user) && !ismoth(user) && !isdrask(user) && !iskidan(user) && !isskrell(user))
+		data["change_facial_hair"] = can_change(APPEARANCE_FACIAL_HAIR)
+		if(data["change_facial_hair"])
+			var/list/facial_hair_styles = list()
+			for(var/facial_hair_style in valid_facial_hairstyles)
+				facial_hair_styles += list(list("facialhairstyle" = facial_hair_style))
+			data["facial_hair_styles"] = facial_hair_styles
+			data["facial_hair_style"] = head_organ ? head_organ.f_style : "Shaved"
 
-	data["change_head_markings"] = can_change_markings("head")
-	if(data["change_head_markings"])
-		var/m_style = owner.m_styles["head"]
-		var/list/head_marking_styles = list()
-		for(var/head_marking_style in valid_head_marking_styles)
-			head_marking_styles += list(list("headmarkingstyle" = head_marking_style))
-		data["head_marking_styles"] = head_marking_styles
-		data["head_marking_style"] = m_style
+	if(!ismachineperson(user))
+		data["change_head_markings"] = can_change_markings("head")
+		if(data["change_head_markings"])
+			var/m_style = owner.m_styles["head"]
+			var/list/head_marking_styles = list()
+			for(var/head_marking_style in valid_head_marking_styles)
+				head_marking_styles += list(list("headmarkingstyle" = head_marking_style))
+			data["head_marking_styles"] = head_marking_styles
+			data["head_marking_style"] = m_style
 
 	data["change_body_markings"] = can_change_markings("body")
 	if(data["change_body_markings"])

--- a/code/modules/tgui/modules/appearance_changer.dm
+++ b/code/modules/tgui/modules/appearance_changer.dm
@@ -231,7 +231,7 @@
 		data["head_accessory_styles"] = head_accessory_styles
 		data["head_accessory_style"] = head_organ ? head_organ.ha_style : "None"
 
-	if(!isgrey(user) && !ismoth(user) && !isdrask(user))
+	if(!(user.dna.species.bodyflags & BALD))
 		data["change_hair"] = can_change(APPEARANCE_HAIR)
 		if(data["change_hair"])
 			var/list/hair_styles = list()
@@ -239,8 +239,10 @@
 				hair_styles += list(list("hairstyle" = hair_style))
 			data["hair_styles"] = hair_styles
 			data["hair_style"] = head_organ ? head_organ.h_style : "Skinhead"
+		data["change_hair_color"] = can_change(APPEARANCE_HAIR_COLOR)
+		data["change_secondary_hair_color"] = can_change(APPEARANCE_SECONDARY_HAIR_COLOR)
 
-	if(!ismachineperson(user) && !isgrey(user) && !ismoth(user) && !isdrask(user) && !iskidan(user) && !isskrell(user))
+	if(!(user.dna.species.bodyflags & SHAVED))
 		data["change_facial_hair"] = can_change(APPEARANCE_FACIAL_HAIR)
 		if(data["change_facial_hair"])
 			var/list/facial_hair_styles = list()
@@ -248,6 +250,9 @@
 				facial_hair_styles += list(list("facialhairstyle" = facial_hair_style))
 			data["facial_hair_styles"] = facial_hair_styles
 			data["facial_hair_style"] = head_organ ? head_organ.f_style : "Shaved"
+		data["change_facial_hair_color"] = can_change(APPEARANCE_FACIAL_HAIR_COLOR)
+		data["change_secondary_facial_hair_color"] = can_change(APPEARANCE_SECONDARY_FACIAL_HAIR_COLOR)
+		data["change_hair_gradient"] = can_change(APPEARANCE_HAIR) && length(valid_hairstyles)
 
 	if(!ismachineperson(user))
 		data["change_head_markings"] = can_change_markings("head")
@@ -258,6 +263,7 @@
 				head_marking_styles += list(list("headmarkingstyle" = head_marking_style))
 			data["head_marking_styles"] = head_marking_styles
 			data["head_marking_style"] = m_style
+		data["change_head_marking_color"] = can_change_markings("head")
 
 	data["change_body_markings"] = can_change_markings("body")
 	if(data["change_body_markings"])
@@ -294,14 +300,8 @@
 		data["alt_head_style"] = head_organ.alt_head
 
 	data["change_head_accessory_color"] = can_change_head_accessory()
-	data["change_hair_color"] = can_change(APPEARANCE_HAIR_COLOR)
-	data["change_secondary_hair_color"] = can_change(APPEARANCE_SECONDARY_HAIR_COLOR)
-	data["change_facial_hair_color"] = can_change(APPEARANCE_FACIAL_HAIR_COLOR)
-	data["change_secondary_facial_hair_color"] = can_change(APPEARANCE_SECONDARY_FACIAL_HAIR_COLOR)
-	data["change_head_marking_color"] = can_change_markings("head")
 	data["change_body_marking_color"] = can_change_markings("body")
 	data["change_tail_marking_color"] = can_change_markings("tail")
-	data["change_hair_gradient"] = can_change(APPEARANCE_HAIR) && length(valid_hairstyles)
 
 	return data
 


### PR DESCRIPTION
## What Does This PR Do
This removes the appearance fields for certain species from the mirror that they cannot change. An example of this would be removing the Hair option when a Grey uses the mirror.
## Why It's Good For The Game
This cleans up the UI and reflects the appearance options that a specie has correctly.
## Images of changes
### **Nian Before:**
![mhQbAdOlY5](https://github.com/ParadiseSS13/Paradise/assets/116982774/e190a889-2f59-48b5-8020-1ebbcaf1f604)
### **Nian After:**
![7k3Sd9Mx1e](https://github.com/ParadiseSS13/Paradise/assets/116982774/f4e3608c-4974-4ac1-adee-d86e3daeb064)
## Testing
Spawned in as each species and checked what appearance options were available to them in the mirror.
## Changelog
:cl:
tweak: Tweaked the visible appearance options on the mirror based on species
/:cl: