### PR TITLE
Adds lewcc as commit access in documentation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -747,6 +747,7 @@ Each role inherits the lower role's responsibilities (IE: Headcoders also have c
 
 * [AffectedArc07](https://github.com/AffectedArc07)
 * [Charliminator](https://github.com/hal9000PR)
+* [lewcc](https://github.com/lewcc)
 * [S34N](https://github.com/S34NW)
 
 ---


### PR DESCRIPTION
## What Does This PR Do
Adds @lewcc as a commit access member in documentation

## Why It's Good For The Repo
Should be properly noted
