### PR TITLE
Prevents Quartermaster job slots from being raised.

### DIFF
--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -49,8 +49,9 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 		/datum/job/blueshield,
 		/datum/job/nanotrasenrep,
 		/datum/job/chaplain,
-		/datum/job/officer
-	)
+		/datum/job/officer,
+		/datum/job/qm)
+
 	//The scaling factor of max total positions in relation to the total amount of people on board the station in %
 	var/max_relative_positions = 30 //30%: Seems reasonable, limit of 6 @ 20 players
 

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -50,7 +50,8 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 		/datum/job/nanotrasenrep,
 		/datum/job/chaplain,
 		/datum/job/officer,
-		/datum/job/qm)
+		/datum/job/qm
+)
 
 	//The scaling factor of max total positions in relation to the total amount of people on board the station in %
 	var/max_relative_positions = 30 //30%: Seems reasonable, limit of 6 @ 20 players


### PR DESCRIPTION
## What Does This PR Do
Prevents ID consoles from raising Quartermaster slots.

## Why It's Good For The Game
QM PR oversight.

## Testing
Tried to raise QM slots as HOP, couldn't.

![qmmeme](https://github.com/ParadiseSS13/Paradise/assets/85680653/4d330cb1-07c4-4aa1-9c7e-eca565724af5)

## Changelog
:cl:
fix: QM slots can no longer be raised.
/:cl: