### PR TITLE
Makes Safety Override Module Require Illegals 4

### DIFF
--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -1093,7 +1093,7 @@
 	name = "Cyborg Upgrade (Safety Override)"
 	id = "borg_syndicate_module"
 	build_type = MECHFAB
-	req_tech = list("combat" = 7, "programming" = 7)
+	req_tech = list("combat" = 7, "programming" = 7, "syndicate" = 4)
 	build_path = /obj/item/borg/upgrade/syndicate
 	materials = list(MAT_METAL=10000,MAT_GLASS=15000,MAT_DIAMOND = 10000)
 	construction_time = 120


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Requires Illegals 4 for the Safety Override Cyborg Module.

## Why It's Good For The Game
Im very very very tired of seeing (the same) cyborgs get an emitter cannon every Shift and use it on antags.

This makes it doable still, but requires some investment or EXTREME Maints Loot luck.

Youre circumventing NT Safety standards, this should not be something you can do willy-nilly every Shift.

## Changelog
:cl:
tweak: Safety Override now requires Illegals 4.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
