### PR TITLE
Fixes runtime, cluwned clowns waddle after being cluwned

### DIFF
--- a/code/datums/elements/waddling.dm
+++ b/code/datums/elements/waddling.dm
@@ -5,9 +5,9 @@
 	if(!ismovable(target))
 		return ELEMENT_INCOMPATIBLE
 	if(isliving(target))
-		RegisterSignal(target, COMSIG_MOVABLE_MOVED, PROC_REF(LivingWaddle))
+		RegisterSignal(target, COMSIG_MOVABLE_MOVED, PROC_REF(LivingWaddle), override = TRUE)
 	else
-		RegisterSignal(target, COMSIG_MOVABLE_MOVED, PROC_REF(Waddle))
+		RegisterSignal(target, COMSIG_MOVABLE_MOVED, PROC_REF(Waddle), override = TRUE)
 
 /datum/element/waddling/Detach(datum/source, force)
 	. = ..()

--- a/code/datums/elements/waddling.dm
+++ b/code/datums/elements/waddling.dm
@@ -5,9 +5,9 @@
 	if(!ismovable(target))
 		return ELEMENT_INCOMPATIBLE
 	if(isliving(target))
-		RegisterSignal(target, COMSIG_MOVABLE_MOVED, PROC_REF(LivingWaddle), override = TRUE)
+		RegisterSignal(target, COMSIG_MOVABLE_MOVED, PROC_REF(LivingWaddle))
 	else
-		RegisterSignal(target, COMSIG_MOVABLE_MOVED, PROC_REF(Waddle), override = TRUE)
+		RegisterSignal(target, COMSIG_MOVABLE_MOVED, PROC_REF(Waddle))
 
 /datum/element/waddling/Detach(datum/source, force)
 	. = ..()

--- a/code/datums/spells/cluwne.dm
+++ b/code/datums/spells/cluwne.dm
@@ -24,8 +24,7 @@
 	if(mind)
 		mind.assigned_role = "Cluwne"
 
-	var/obj/item/organ/internal/honktumor/cursed/tumor = new
-	tumor.insert(src)
+
 	dna.SetSEState(GLOB.nervousblock, 1, 1)
 	singlemutcheck(src, GLOB.nervousblock, MUTCHK_FORCED)
 	rename_character(real_name, "cluwne")
@@ -33,6 +32,8 @@
 	unEquip(w_uniform, 1)
 	unEquip(shoes, 1)
 	unEquip(gloves, 1)
+	var/obj/item/organ/internal/honktumor/cursed/tumor = new
+	tumor.insert(src)
 	if(!istype(wear_mask, /obj/item/clothing/mask/cursedclown)) //Infinite loops otherwise
 		unEquip(wear_mask, 1)
 	equip_to_slot_if_possible(new /obj/item/clothing/under/cursedclown, slot_w_uniform, TRUE, TRUE)


### PR DESCRIPTION
## What Does This PR Do
Fixes a runtime when a clown is cluwned. Clowns waddle after cluwned as god intended. 
Fixes #18946

## Why It's Good For The Game
Runtime bad, cluwned clowns should waddle
## Testing
Spawned as clown, cluwned self via proc call and by equipping cursed mask. Maintained waddle

## Changelog
:cl:
fix: Cluwned clowns now no longer runtime, cluwned clowns waddle like god intended.
/:cl:
