### PR TITLE
Remove invalid icon dirs from station floors.

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -3854,7 +3854,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "blue"
 	},
 /area/station/command/customs)
@@ -3929,7 +3928,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "red"
 	},
 /area/station/security/checkpoint/secondary)
@@ -10804,7 +10802,6 @@
 /obj/structure/table,
 /obj/structure/bedsheetbin,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "barber"
 	},
 /area/station/security/permabrig)
@@ -12899,7 +12896,6 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "red"
 	},
 /area/station/security/permabrig)
@@ -13520,7 +13516,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "red"
 	},
 /area/station/security/permabrig)
@@ -13554,7 +13549,6 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "red"
 	},
 /area/station/security/permabrig)
@@ -13840,7 +13834,6 @@
 /obj/machinery/hologram/holopad,
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "red"
 	},
 /area/station/security/permabrig)
@@ -14874,7 +14867,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "neutral"
 	},
 /area/station/security/permabrig)
@@ -14905,7 +14897,6 @@
 	dir = 6
 	},
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "neutral"
 	},
 /area/station/security/permabrig)
@@ -14941,7 +14932,6 @@
 	dir = 6
 	},
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "neutral"
 	},
 /area/station/security/permabrig)
@@ -15691,7 +15681,6 @@
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "red"
 	},
 /area/station/security/permabrig)
@@ -38424,7 +38413,6 @@
 	dir = 6
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/station/medical/storage)
@@ -39961,7 +39949,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/station/medical/storage)
@@ -52772,13 +52759,11 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/station/medical/storage)
 "cMC" = (
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/station/medical/storage)
@@ -53312,7 +53297,6 @@
 	},
 /obj/effect/landmark/start/doctor,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/station/medical/storage)
@@ -53321,7 +53305,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/station/medical/storage)
@@ -58032,7 +58015,6 @@
 	dir = 9
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/station/command/office/cmo)
@@ -59859,7 +59841,6 @@
 /obj/structure/closet/l3closet/virology,
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "whitegreencorner"
 	},
 /area/station/medical/virology)
@@ -60260,7 +60241,6 @@
 	},
 /obj/structure/closet/wardrobe/pjs,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/station/medical/medbay)
@@ -60273,20 +60253,17 @@
 	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/station/medical/medbay)
 "dhd" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/station/medical/medbay)
 "dhe" = (
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/station/medical/medbay)
@@ -60298,7 +60275,6 @@
 	},
 /obj/structure/closet/wardrobe/pjs,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/station/medical/medbay)
@@ -60823,7 +60799,6 @@
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/station/medical/medbay)
@@ -62527,7 +62502,6 @@
 /obj/item/cartridge/medical,
 /obj/item/cartridge/chemistry,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/station/command/office/cmo)
@@ -62537,7 +62511,6 @@
 /obj/item/flashlight/pen,
 /obj/item/clothing/accessory/stethoscope,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/station/command/office/cmo)
@@ -62545,7 +62518,6 @@
 /obj/structure/table/glass,
 /obj/item/storage/firstaid/regular,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/station/command/office/cmo)
@@ -62736,7 +62708,6 @@
 /obj/item/analyzer,
 /obj/item/rpd,
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "yellowcorner"
 	},
 /area/station/public/construction)
@@ -63152,7 +63123,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/station/command/office/cmo)
@@ -63169,7 +63139,6 @@
 	dir = 10
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/station/command/office/cmo)
@@ -63180,7 +63149,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/station/command/office/cmo)
@@ -63317,7 +63285,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "yellowcorner"
 	},
 /area/station/public/construction)
@@ -63604,7 +63571,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/station/command/office/cmo)
@@ -63684,7 +63650,6 @@
 /obj/structure/table,
 /obj/item/flashlight/lamp,
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "yellowcorner"
 	},
 /area/station/public/construction)
@@ -63693,7 +63658,6 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "yellowcorner"
 	},
 /area/station/public/construction)
@@ -64023,7 +63987,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/station/command/office/cmo)
@@ -64032,7 +63995,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/station/command/office/cmo)
@@ -64044,7 +64006,6 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/station/command/office/cmo)
@@ -64455,7 +64416,6 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/station/command/office/cmo)
@@ -64477,7 +64437,6 @@
 /obj/item/stamp/cmo,
 /obj/item/pen/multi,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/station/command/office/cmo)
@@ -64499,7 +64458,6 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/station/command/office/cmo)
@@ -64905,7 +64863,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/station/command/office/cmo)
@@ -64945,7 +64902,6 @@
 	pixel_y = 6
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/station/command/office/cmo)
@@ -64958,7 +64914,6 @@
 	},
 /obj/effect/landmark/start/chief_medical_officer,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/station/command/office/cmo)
@@ -65372,7 +65327,6 @@
 /area/station/medical/morgue)
 "dvG" = (
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/station/command/office/cmo)
@@ -65385,7 +65339,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/station/command/office/cmo)
@@ -65408,7 +65361,6 @@
 	req_access_txt = "40"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/station/command/office/cmo)
@@ -65464,7 +65416,6 @@
 "dvR" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/station/medical/medbay)
@@ -65687,7 +65638,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/station/medical/medbay)
@@ -65711,7 +65661,6 @@
 	},
 /obj/effect/landmark/start/doctor,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/station/medical/medbay)
@@ -65846,7 +65795,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/start/doctor,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/station/medical/medbay)
@@ -66049,7 +65997,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/station/command/office/cmo)
@@ -66104,7 +66051,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/station/medical/medbay)
@@ -66292,7 +66238,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/station/command/office/cmo)
@@ -66301,7 +66246,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/station/command/office/cmo)
@@ -66590,7 +66534,6 @@
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/station/command/office/cmo)
@@ -66608,7 +66551,6 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/station/command/office/cmo)
@@ -67960,7 +67902,6 @@
 "dFe" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "whitegreencorner"
 	},
 /area/station/medical/medbay)
@@ -68982,7 +68923,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "whitegreencorner"
 	},
 /area/station/medical/virology)
@@ -69208,7 +69148,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "whitegreencorner"
 	},
 /area/station/medical/virology)
@@ -69216,7 +69155,6 @@
 /obj/structure/table,
 /obj/machinery/kitchen_machine/microwave,
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "whitegreencorner"
 	},
 /area/station/medical/virology)
@@ -69855,7 +69793,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "whitegreencorner"
 	},
 /area/station/medical/virology)
@@ -70582,7 +70519,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "whitegreencorner"
 	},
 /area/station/medical/virology)
@@ -70850,7 +70786,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "whitegreencorner"
 	},
 /area/station/medical/virology)
@@ -70872,7 +70807,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "whitegreencorner"
 	},
 /area/station/medical/virology)
@@ -71025,7 +70959,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "whitegreencorner"
 	},
 /area/station/medical/virology)
@@ -73322,7 +73255,6 @@
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "whitegreencorner"
 	},
 /area/station/medical/virology)
@@ -73335,7 +73267,6 @@
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "whitegreencorner"
 	},
 /area/station/medical/virology)
@@ -73439,7 +73370,6 @@
 /area/station/medical/virology)
 "dXi" = (
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "whitegreencorner"
 	},
 /area/station/medical/virology)
@@ -73585,7 +73515,6 @@
 	network = list("Medical","SS13")
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/station/command/office/cmo)
@@ -73916,7 +73845,6 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /mob/living/carbon/human/monkey,
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "whitegreencorner"
 	},
 /area/station/medical/virology)
@@ -74434,7 +74362,6 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/station/medical/medbay)
@@ -75100,7 +75027,6 @@
 /area/station/maintenance/fsmaint)
 "eNI" = (
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "barber"
 	},
 /area/station/security/permabrig)
@@ -76157,7 +76083,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "barber"
 	},
 /area/station/security/permabrig)
@@ -77048,7 +76973,6 @@
 	},
 /obj/item/crutches,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/station/medical/medbay)
@@ -77602,7 +77526,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/station/medical/medbay)
@@ -77821,7 +77744,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random_spawners/blood_maybe,
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "neutral"
 	},
 /area/station/maintenance/apmaint)
@@ -78665,7 +78587,6 @@
 "hIE" = (
 /obj/item/bodybag,
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/station/maintenance/apmaint)
@@ -79915,7 +79836,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/station/maintenance/apmaint)
@@ -82641,7 +82561,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 6;
 	icon_state = "bluecorner"
 	},
 /area/station/hallway/secondary/entry)
@@ -83117,12 +83036,6 @@
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/supply/qm)
-"lMo" = (
-/turf/simulated/floor/plasteel{
-	dir = 0;
-	icon_state = "red"
-	},
-/area/station/security/permabrig)
 "lMs" = (
 /obj/machinery/light{
 	dir = 4
@@ -84517,7 +84430,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "neutral"
 	},
 /area/station/maintenance/apmaint)
@@ -85063,7 +84975,6 @@
 	network = list("SS13","Security","Prison")
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "barber"
 	},
 /area/station/security/permabrig)
@@ -85943,7 +85854,6 @@
 "nQM" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/station/maintenance/apmaint)
@@ -86018,12 +85928,6 @@
 	icon_state = "whitepurplecorner"
 	},
 /area/station/command/office/rd)
-"nVk" = (
-/turf/simulated/floor/plasteel{
-	dir = 0;
-	icon_state = "neutral"
-	},
-/area/station/maintenance/apmaint)
 "nVq" = (
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
@@ -87184,7 +87088,6 @@
 /area/station/public/fitness)
 "oLR" = (
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/station/maintenance/apmaint)
@@ -87557,7 +87460,6 @@
 	},
 /obj/item/crutches,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/station/medical/medbay)
@@ -89331,7 +89233,6 @@
 "qDL" = (
 /obj/effect/spawner/random_spawners/blood_maybe,
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/station/maintenance/apmaint)
@@ -90821,7 +90722,6 @@
 "rQu" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "neutral"
 	},
 /area/station/maintenance/apmaint)
@@ -91596,7 +91496,6 @@
 /obj/effect/spawner/random_spawners/blood_maybe,
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/station/maintenance/apmaint)
@@ -92158,7 +92057,6 @@
 /obj/item/hand_labeler,
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/station/maintenance/apmaint)
@@ -96588,7 +96486,6 @@
 "wKt" = (
 /obj/effect/turf_decal/bot_white,
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/station/maintenance/apmaint)
@@ -97006,7 +96903,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "red"
 	},
 /area/station/security/permabrig)
@@ -97893,7 +97789,6 @@
 "xKN" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/station/medical/storage)
@@ -131039,7 +130934,7 @@ djA
 dOP
 dOO
 dOO
-nVk
+dID
 dOO
 iQO
 iQO
@@ -131278,7 +131173,7 @@ iNi
 iRf
 iRf
 dFm
-nVk
+dID
 dbp
 lMM
 sKG
@@ -152270,7 +152165,7 @@ aPe
 aNG
 aOY
 aQB
-lMo
+aPv
 aJx
 aVm
 aWP
@@ -152784,7 +152679,7 @@ aPe
 aNM
 aQD
 aQD
-lMo
+aPv
 aJx
 aVq
 aWO
@@ -153555,7 +153450,7 @@ aPe
 aNM
 aPe
 aPe
-lMo
+aPv
 aTK
 aVs
 baS

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -847,7 +847,6 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 7;
 	icon_state = "yellow"
 	},
 /area/station/engineering/break_room)
@@ -1691,7 +1690,6 @@
 /obj/structure/window/reinforced,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/station/security/permabrig)
@@ -7715,7 +7713,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "green"
 	},
 /area/station/security/permabrig)
@@ -12878,7 +12875,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/station/security/permabrig)
@@ -18690,7 +18686,6 @@
 /area/station/hallway/primary/starboard)
 "bnl" = (
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "blue"
 	},
 /area/station/hallway/primary/central)
@@ -29785,7 +29780,6 @@
 	},
 /obj/machinery/atmospherics/portable/pump,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "barber"
 	},
 /area/station/engineering/atmos)
@@ -34031,7 +34025,6 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "darkbluefull"
 	},
 /area/station/medical/surgery/primary)
@@ -38579,7 +38572,6 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "darkbluefull"
 	},
 /area/station/medical/surgery/secondary)
@@ -48555,7 +48547,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "neutral"
 	},
 /area/station/hallway/secondary/bridge)
@@ -48966,7 +48957,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/crowbar/large,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/station/security/permabrig)
@@ -49005,7 +48995,6 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "green"
 	},
 /area/station/security/permabrig)
@@ -51149,7 +51138,6 @@
 /area/station/engineering/atmos)
 "etG" = (
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "blue"
 	},
 /area/station/security/brig)
@@ -52114,7 +52102,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "whiteyellowfull"
 	},
 /area/station/medical/chemistry)
@@ -53909,7 +53896,6 @@
 	},
 /obj/effect/mapping_helpers/airlock/windoor/access/all/medical/chemistry,
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "whiteyellowfull"
 	},
 /area/station/medical/chemistry)
@@ -54160,7 +54146,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/station/security/permabrig)
@@ -54322,7 +54307,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 7;
 	icon_state = "yellow"
 	},
 /area/station/engineering/break_room)
@@ -55781,7 +55765,6 @@
 	},
 /obj/effect/mapping_helpers/airlock/windoor/access/all/medical/chemistry,
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "whiteyellowfull"
 	},
 /area/station/medical/chemistry)
@@ -58776,7 +58759,6 @@
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "blue"
 	},
 /area/station/engineering/atmos)
@@ -65809,7 +65791,6 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel{
-	dir = 7;
 	icon_state = "yellow"
 	},
 /area/station/engineering/break_room)
@@ -66112,7 +66093,6 @@
 	name = "Anti-Theft Shield"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "whiteyellowfull"
 	},
 /area/station/medical/chemistry)
@@ -68897,7 +68877,6 @@
 	pixel_y = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "yellowfull"
 	},
 /area/station/hallway/primary/aft)
@@ -70210,7 +70189,6 @@
 	},
 /obj/effect/turf_decal/stripes/corner,
 /turf/simulated/floor/plasteel{
-	dir = 7;
 	icon_state = "yellow"
 	},
 /area/station/engineering/break_room)
@@ -70386,7 +70364,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 7;
 	icon_state = "yellow"
 	},
 /area/station/engineering/break_room)
@@ -76475,7 +76452,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "whiteyellowfull"
 	},
 /area/station/medical/chemistry)
@@ -82830,7 +82806,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/station/security/permabrig)
@@ -83494,7 +83469,6 @@
 /obj/machinery/washing_machine,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/station/security/permabrig)
@@ -84817,7 +84791,6 @@
 	pixel_x = 6
 	},
 /turf/simulated/floor/plasteel{
-	dir = 7;
 	icon_state = "yellow"
 	},
 /area/station/engineering/break_room)
@@ -86666,7 +86639,6 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel{
-	dir = 7;
 	icon_state = "yellow"
 	},
 /area/station/engineering/break_room)
@@ -87979,7 +87951,6 @@
 /area/station/engineering/atmos/control)
 "vug" = (
 /turf/simulated/floor/plasteel{
-	dir = 7;
 	icon_state = "yellow"
 	},
 /area/station/engineering/break_room)
@@ -90592,7 +90563,6 @@
 "wRy" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "blue"
 	},
 /area/station/security/brig)
@@ -90660,7 +90630,6 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/medical/chemistry,
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "whiteyellowfull"
 	},
 /area/station/medical/chemistry)
@@ -91155,7 +91124,6 @@
 /area/station/security/armory/secure)
 "xdy" = (
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "yellowfull"
 	},
 /area/station/hallway/primary/aft)
@@ -91822,7 +91790,6 @@
 	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "green"
 	},
 /area/station/hallway/primary/central)

--- a/_maps/map_files/cerestation/cerestation.dmm
+++ b/_maps/map_files/cerestation/cerestation.dmm
@@ -1,7 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aab" = (
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/turret_protected/aisat/interior/secondary)
@@ -48,7 +47,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/east)
@@ -205,7 +203,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/east)
@@ -417,7 +414,6 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/turret_protected/ai)
@@ -433,7 +429,6 @@
 	name = "south bump"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/turret_protected/ai)
@@ -551,7 +546,6 @@
 	},
 /obj/structure/cable/orange,
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_regular_floor = "yellowsiding";
 	icon_state = "tranquillite"
 	},
@@ -742,7 +736,6 @@
 	},
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "barber"
 	},
 /area/station/security/permabrig)
@@ -752,7 +745,6 @@
 	pixel_y = 25
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "barber"
 	},
 /area/station/security/permabrig)
@@ -761,7 +753,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkgreenfull"
 	},
 /area/station/service/hydroponics)
@@ -825,7 +816,6 @@
 "aeM" = (
 /obj/item/kirbyplants,
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/turret_protected/ai)
@@ -865,7 +855,6 @@
 	network = list("Prison","SS13")
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "barber"
 	},
 /area/station/security/permabrig)
@@ -884,7 +873,6 @@
 /area/station/maintenance/electrical_shop)
 "afz" = (
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "barber"
 	},
 /area/station/security/permabrig)
@@ -919,7 +907,6 @@
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/turret_protected/ai)
@@ -1036,7 +1023,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/turret_protected/ai)
@@ -1059,7 +1045,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/turret_protected/ai)
@@ -1139,7 +1124,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/turret_protected/ai)
@@ -1177,7 +1161,6 @@
 	pixel_x = 5
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/turret_protected/ai)
@@ -1195,7 +1178,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/turret_protected/ai)
@@ -1572,7 +1554,6 @@
 	name = "Cyborg Statue"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/turret_protected/ai)
@@ -1592,7 +1573,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/turret_protected/ai)
@@ -1614,7 +1594,6 @@
 	pixel_y = 21
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/turret_protected/ai)
@@ -1629,7 +1608,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/turret_protected/ai)
@@ -1648,7 +1626,6 @@
 	name = "Cyborg Statue"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/turret_protected/ai)
@@ -1747,7 +1724,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/turret_protected/ai)
@@ -1863,7 +1839,6 @@
 "alw" = (
 /obj/effect/turf_decal/box,
 /turf/simulated/floor/plasteel{
-	dir = 1;
 	icon_state = "purplefull"
 	},
 /area/station/hallway/primary/aft/west)
@@ -1884,7 +1859,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/turret_protected/ai)
@@ -1938,7 +1912,6 @@
 /obj/item/clothing/suit/beekeeper_suit,
 /obj/item/clothing/head/beekeeper_head,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkgreenfull"
 	},
 /area/station/service/hydroponics)
@@ -2008,7 +1981,6 @@
 	},
 /obj/machinery/blackbox_recorder,
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/telecomms/chamber)
@@ -2021,7 +1993,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/turret_protected/aisat/interior/secondary)
@@ -2571,7 +2542,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/turret_protected/aisat/interior/secondary)
@@ -2589,7 +2559,6 @@
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/turret_protected/aisat/interior/secondary)
@@ -2849,7 +2818,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/turret_protected/aisat/interior/secondary)
@@ -2858,7 +2826,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/turret_protected/aisat/interior/secondary)
@@ -2871,7 +2838,6 @@
 	dir = 9
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/turret_protected/aisat/interior/secondary)
@@ -3058,7 +3024,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/landmark/lightsout,
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/turret_protected/aisat/interior/secondary)
@@ -3611,7 +3576,6 @@
 	name = "custom placement"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/telecomms/chamber)
@@ -3696,7 +3660,6 @@
 	pixel_y = 2
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/telecomms/chamber)
@@ -3753,7 +3716,6 @@
 	},
 /obj/effect/turf_decal/caution/red,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/spacebridge/servsci)
@@ -3934,7 +3896,6 @@
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/station/turret_protected/aisat/interior)
@@ -4165,7 +4126,6 @@
 	name = "west bump"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/telecomms/chamber)
@@ -4177,7 +4137,6 @@
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/telecomms/chamber)
@@ -4244,7 +4203,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/telecomms/chamber)
@@ -4582,7 +4540,6 @@
 	dir = 10
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/station/turret_protected/aisat/interior)
@@ -5835,7 +5792,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/turret_protected/aisat/interior/secondary)
@@ -5925,7 +5881,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/north)
@@ -6345,7 +6300,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/station/turret_protected/aisat/interior)
@@ -6780,7 +6734,6 @@
 	},
 /obj/effect/spawner/random_spawners/dirt_often,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/entry/north)
@@ -7132,7 +7085,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkgreenfull"
 	},
 /area/station/service/hydroponics)
@@ -7368,7 +7320,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore)
@@ -7493,7 +7444,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore/west)
@@ -7539,7 +7489,6 @@
 /obj/machinery/message_server,
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/telecomms/chamber)
@@ -8132,7 +8081,6 @@
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/turret_protected/aisat/interior/secondary)
@@ -8676,7 +8624,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/turret_protected/aisat/interior)
@@ -8901,7 +8848,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central)
@@ -9135,7 +9081,6 @@
 "beJ" = (
 /obj/machinery/economy/vending/autodrobe,
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_regular_floor = "yellowsiding";
 	icon_state = "tranquillite"
 	},
@@ -9187,7 +9132,6 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central)
@@ -9204,7 +9148,6 @@
 	name = "navigation beacon (Engineering-Middle)"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central)
@@ -9215,7 +9158,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central)
@@ -9231,7 +9173,6 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central)
@@ -9247,7 +9188,6 @@
 	name = "navigation beacon (Engineering-East)"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central)
@@ -9464,7 +9404,6 @@
 /area/station/hallway/primary/central)
 "bgf" = (
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central)
@@ -9502,7 +9441,6 @@
 	name = "navigation beacon (Engineering-East 3)"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central)
@@ -9751,7 +9689,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/starboard/north)
@@ -10253,7 +10190,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/turret_protected/aisat/interior)
@@ -10393,7 +10329,6 @@
 "bld" = (
 /obj/machinery/hydroponics/constructable,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkgreenfull"
 	},
 /area/station/service/hydroponics)
@@ -10442,7 +10377,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central)
@@ -10504,7 +10438,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central)
@@ -10766,7 +10699,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/south)
@@ -11239,7 +11171,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central)
@@ -11284,7 +11215,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central)
@@ -11455,7 +11385,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central)
@@ -11907,7 +11836,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central)
@@ -11986,7 +11914,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central)
@@ -12260,7 +12187,6 @@
 	uses = 10
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/turret_protected/aisat/interior/secondary)
@@ -12437,7 +12363,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/turret_protected/aisat/interior/secondary)
@@ -12531,7 +12456,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "yellow"
 	},
 /area/station/hallway/primary/central)
@@ -12686,7 +12610,6 @@
 	name = "navigation beacon (Engineering-East 2)"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "yellow"
 	},
 /area/station/hallway/primary/central)
@@ -12770,7 +12693,6 @@
 /area/station/maintenance/maintcentral)
 "bvt" = (
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/starboard/south)
@@ -12877,7 +12799,6 @@
 "bvW" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/turret_protected/aisat/interior)
@@ -12982,7 +12903,6 @@
 "bwA" = (
 /obj/structure/disposalpipe/segment/corner,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/starboard/south)
@@ -13808,7 +13728,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/north)
@@ -14748,7 +14667,6 @@
 /area/station/medical/medbay)
 "bED" = (
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/turret_protected/aisat/interior)
@@ -15734,7 +15652,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/public/locker)
@@ -16520,7 +16437,6 @@
 	},
 /obj/effect/spawner/random_spawners/dirt_often,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore/west)
@@ -17984,7 +17900,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/turret_protected/aisat/interior)
@@ -18367,7 +18282,6 @@
 	name = "quantum pad"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkpurplefull"
 	},
 /area/station/public/quantum/security)
@@ -19098,7 +19012,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore/west)
@@ -19643,7 +19556,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/effect/spawner/random_spawners/dirt_often,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/aft/west)
@@ -19906,7 +19818,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "red"
 	},
 /area/station/hallway/secondary/exit)
@@ -20216,7 +20127,6 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/telecomms/chamber)
@@ -20275,7 +20185,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore/west)
@@ -20309,7 +20218,6 @@
 	icon_state = "plant-22"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/telecomms/chamber)
@@ -20320,7 +20228,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_regular_floor = "yellowsiding";
 	icon_state = "tranquillite"
 	},
@@ -20334,7 +20241,6 @@
 /area/station/hallway/primary/starboard/south)
 "cfd" = (
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/turret_protected/ai_upload)
@@ -20371,7 +20277,6 @@
 	name = "quantum pad"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkpurplefull"
 	},
 /area/station/public/quantum/docking)
@@ -20816,7 +20721,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/north)
@@ -20834,7 +20738,6 @@
 /area/station/public/locker)
 "chV" = (
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore/west)
@@ -20948,7 +20851,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/aft/west)
@@ -20963,7 +20865,6 @@
 /area/station/maintenance/fsmaint)
 "ciG" = (
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/aft/east)
@@ -21036,15 +20937,6 @@
 	icon_state = "dark"
 	},
 /area/station/security/armory/secure)
-"cjs" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/secondary/entry/south)
 "cjw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -21302,7 +21194,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/entry)
@@ -21397,7 +21288,6 @@
 	color = "#954535"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/aft/west)
@@ -21646,7 +21536,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkbrownfull"
 	},
 /area/station/supply/office)
@@ -21919,7 +21808,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/turret_protected/aisat/interior)
@@ -22451,7 +22339,6 @@
 "csA" = (
 /obj/structure/closet/l3closet/scientist,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "whitepurplefull"
 	},
 /area/station/science/hallway)
@@ -22664,7 +22551,6 @@
 	},
 /obj/machinery/hydroponics/constructable,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkgreenfull"
 	},
 /area/station/service/hydroponics)
@@ -23058,7 +22944,6 @@
 	},
 /obj/effect/spawner/random_spawners/dirt_often,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore)
@@ -23519,7 +23404,6 @@
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "whitepurplefull"
 	},
 /area/station/science/xenobiology)
@@ -23902,7 +23786,6 @@
 "cCD" = (
 /obj/item/flag/mime,
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_regular_floor = "yellowsiding";
 	icon_state = "tranquillite"
 	},
@@ -23933,7 +23816,6 @@
 	pixel_y = 30
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/public/locker)
@@ -23943,14 +23825,12 @@
 	name = "north bump"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/public/locker)
 "cCL" = (
 /obj/structure/closet/wardrobe/black,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/public/locker)
@@ -24650,14 +24530,12 @@
 /area/station/engineering/control)
 "cGD" = (
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/public/locker)
 "cGE" = (
 /obj/structure/closet/wardrobe/grey,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/public/locker)
@@ -25026,7 +24904,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central)
@@ -25144,7 +25021,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central)
@@ -25693,14 +25569,12 @@
 "cLM" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central)
 "cLN" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/public/locker)
@@ -25710,7 +25584,6 @@
 	},
 /obj/structure/closet/wardrobe/xenos,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/public/locker)
@@ -25811,7 +25684,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/turret_protected/aisat/interior/secondary)
@@ -25956,7 +25828,6 @@
 	name = "quantum pad"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkgreenfull"
 	},
 /area/station/public/quantum/cargo)
@@ -25987,14 +25858,12 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_regular_floor = "yellowsiding";
 	icon_state = "tranquillite"
 	},
 /area/station/service/theatre)
 "cNh" = (
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_regular_floor = "yellowsiding";
 	icon_state = "tranquillite"
 	},
@@ -26004,7 +25873,6 @@
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkbrownfull"
 	},
 /area/station/supply/office)
@@ -26562,7 +26430,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/public/locker)
@@ -26639,7 +26506,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/public/locker)
@@ -26677,7 +26543,6 @@
 	},
 /obj/structure/closet/wardrobe/white,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/public/locker)
@@ -26735,7 +26600,6 @@
 	name = "west bump"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_regular_floor = "yellowsiding";
 	icon_state = "tranquillite"
 	},
@@ -27564,7 +27428,6 @@
 	},
 /obj/machinery/washing_machine,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/public/locker)
@@ -27576,7 +27439,6 @@
 /obj/structure/table,
 /obj/structure/bedsheetbin,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/public/locker)
@@ -27681,7 +27543,6 @@
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_regular_floor = "yellowsiding";
 	icon_state = "tranquillite"
 	},
@@ -29874,7 +29735,6 @@
 /area/station/maintenance/fore)
 "djw" = (
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/entry)
@@ -30473,7 +30333,6 @@
 "dnc" = (
 /obj/effect/spawner/random_spawners/dirt_often,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/entry/north)
@@ -30541,7 +30400,6 @@
 	color = "#954535"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/aft/west)
@@ -30929,7 +30787,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore/west)
@@ -31636,7 +31493,6 @@
 	color = "#954535"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central)
@@ -31967,13 +31823,11 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkyellowfull"
 	},
 /area/station/engineering/break_room)
 "dvV" = (
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/turret_protected/ai)
@@ -32388,7 +32242,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/aft/west)
@@ -32509,7 +32362,6 @@
 	name = "custom placement"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/turret_protected/aisat/interior/secondary)
@@ -32599,7 +32451,6 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central)
@@ -33238,7 +33089,6 @@
 "dCF" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore/west)
@@ -33403,7 +33253,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/aft/west)
@@ -33628,7 +33477,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore/west)
@@ -33655,7 +33503,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/south)
@@ -33704,7 +33551,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/east)
@@ -33783,7 +33629,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore/west)
@@ -33797,7 +33642,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore/west)
@@ -33905,7 +33749,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore/west)
@@ -33921,7 +33764,6 @@
 	name = "navigation beacon (Security)"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore/west)
@@ -33963,7 +33805,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore/west)
@@ -33990,7 +33831,6 @@
 	name = "Central Access"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore/west)
@@ -34017,7 +33857,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore/west)
@@ -34038,7 +33877,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore/west)
@@ -34132,7 +33970,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore/west)
@@ -34143,7 +33980,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore/west)
@@ -34158,7 +33994,6 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/spawner/random_spawners/dirt_often,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/entry/north)
@@ -34183,7 +34018,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore)
@@ -34210,7 +34044,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore)
@@ -34223,7 +34056,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore)
@@ -34347,14 +34179,12 @@
 	},
 /obj/effect/spawner/random_spawners/dirt_often,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/entry/south)
 "dSs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore)
@@ -34363,7 +34193,6 @@
 	name = "Central Access"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore)
@@ -34401,7 +34230,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/turret_protected/ai)
@@ -34435,7 +34263,6 @@
 	},
 /obj/effect/turf_decal/stripes/red/full,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/maintenance/fsmaint)
@@ -34466,7 +34293,6 @@
 "dTd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore)
@@ -34481,7 +34307,6 @@
 	name = "navigation beacon (Command-Middle 2)"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore)
@@ -34492,7 +34317,6 @@
 	name = "navigation beacon (Command-Middle)"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore)
@@ -34503,7 +34327,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore)
@@ -34733,7 +34556,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore)
@@ -34746,7 +34568,6 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore)
@@ -34768,7 +34589,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/aft/west)
@@ -34804,7 +34624,6 @@
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/windoor/access/any/service/hydroponics,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/service/hydroponics)
@@ -34849,7 +34668,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkyellowfull"
 	},
 /area/station/engineering/atmos)
@@ -34982,7 +34800,6 @@
 "ebN" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/aft/west)
@@ -34993,7 +34810,6 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/entry/south)
@@ -35013,7 +34829,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore/east)
@@ -35033,7 +34848,6 @@
 "ecG" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/south)
@@ -35113,7 +34927,6 @@
 "edT" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore/east)
@@ -35126,7 +34939,6 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore/east)
@@ -35158,7 +34970,6 @@
 	name = "navigation beacon (Cargo)"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore/east)
@@ -35564,7 +35375,6 @@
 	},
 /obj/effect/mapping_helpers/airlock/windoor/access/any/service/hydroponics,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/service/hydroponics)
@@ -35642,7 +35452,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central)
@@ -35712,7 +35521,6 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/supply/qm,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkbrownfull"
 	},
 /area/station/supply/qm)
@@ -35881,7 +35689,6 @@
 "etV" = (
 /obj/structure/closet/secure_closet/hydroponics,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkgreenfull"
 	},
 /area/station/service/hydroponics)
@@ -36043,7 +35850,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore/west)
@@ -36176,7 +35982,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central)
@@ -36924,7 +36729,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
 	icon_state = "purplefull"
 	},
 /area/station/hallway/primary/aft/west)
@@ -37446,7 +37250,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/south)
@@ -37713,7 +37516,6 @@
 	color = "#954535"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/north)
@@ -37754,7 +37556,6 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/starboard/south)
@@ -37825,7 +37626,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/spacebridge/sercom)
@@ -37865,7 +37665,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkgreenfull"
 	},
 /area/station/service/hydroponics)
@@ -38049,7 +37848,6 @@
 /area/station/medical/cloning)
 "fmI" = (
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore/east)
@@ -38359,7 +38157,6 @@
 "fsW" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/north)
@@ -38430,7 +38227,6 @@
 /area/station/security/lobby)
 "fuU" = (
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_regular_floor = "yellowsiding";
 	icon_state = "tranquillite"
 	},
@@ -38550,7 +38346,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "whitepurplefull"
 	},
 /area/station/science/toxins/mixing)
@@ -38641,7 +38436,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore/east)
@@ -38930,7 +38724,6 @@
 /obj/effect/turf_decal/bot_white,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 1;
 	icon_state = "purplefull"
 	},
 /area/station/hallway/primary/aft/west)
@@ -39321,7 +39114,6 @@
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_regular_floor = "yellowsiding";
 	icon_state = "tranquillite"
 	},
@@ -39756,7 +39548,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkgreenfull"
 	},
 /area/station/service/hydroponics)
@@ -39983,7 +39774,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkyellowfull"
 	},
 /area/station/engineering/smes)
@@ -40187,7 +39977,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 1;
 	icon_state = "purplefull"
 	},
 /area/station/hallway/primary/aft/west)
@@ -40265,7 +40054,6 @@
 	color = "#954535"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central)
@@ -40333,7 +40121,6 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkyellowfull"
 	},
 /area/station/engineering/control)
@@ -40474,7 +40261,6 @@
 /area/station/hallway/primary/central)
 "gfe" = (
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "red"
 	},
 /area/station/hallway/secondary/exit)
@@ -40907,7 +40693,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore)
@@ -41254,7 +41039,6 @@
 /obj/structure/table,
 /obj/item/aiModule/nanotrasen,
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/turret_protected/ai_upload)
@@ -41313,7 +41097,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/south)
@@ -41416,7 +41199,6 @@
 	dir = 5
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_regular_floor = "yellowsiding";
 	icon_state = "tranquillite"
 	},
@@ -41601,7 +41383,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/north)
@@ -41619,7 +41400,6 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore/west)
@@ -41994,7 +41774,6 @@
 /obj/structure/table,
 /obj/structure/bedsheetbin,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "barber"
 	},
 /area/station/security/permabrig)
@@ -42029,7 +41808,6 @@
 "gIv" = (
 /obj/machinery/chem_master/condimaster,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkgreenfull"
 	},
 /area/station/service/hydroponics)
@@ -42450,7 +42228,6 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/service/hydroponics)
@@ -42615,7 +42392,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkgreenfull"
 	},
 /area/station/service/hydroponics)
@@ -42756,7 +42532,6 @@
 "gTe" = (
 /obj/item/kirbyplants,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "whitepurplefull"
 	},
 /area/station/science/hallway)
@@ -42808,7 +42583,6 @@
 	uses = 10
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/turret_protected/ai)
@@ -43143,7 +42917,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkgreenfull"
 	},
 /area/station/service/hydroponics)
@@ -43157,7 +42930,6 @@
 	color = "#954535"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/starboard/north)
@@ -43184,7 +42956,6 @@
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore/west)
@@ -43404,7 +43175,6 @@
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/entry)
@@ -43921,7 +43691,6 @@
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkpurplefull"
 	},
 /area/station/science/robotics)
@@ -43954,7 +43723,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/turret_protected/aisat/interior/secondary)
@@ -43966,7 +43734,6 @@
 	dir = 10
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkgreenfull"
 	},
 /area/station/service/hydroponics)
@@ -43990,7 +43757,6 @@
 "hqe" = (
 /obj/machinery/economy/vending/hydroseeds,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkgreenfull"
 	},
 /area/station/service/hydroponics)
@@ -44096,7 +43862,6 @@
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkgreenfull"
 	},
 /area/station/service/hydroponics)
@@ -44133,7 +43898,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore/east)
@@ -44223,7 +43987,6 @@
 "htz" = (
 /obj/effect/spawner/random_spawners/dirt_often,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkgreenfull"
 	},
 /area/station/service/hydroponics)
@@ -44348,7 +44111,6 @@
 "huO" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/entry/north)
@@ -44467,7 +44229,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/turret_protected/aisat/interior/secondary)
@@ -45341,7 +45102,6 @@
 	start_active = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/turret_protected/ai)
@@ -45634,7 +45394,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/east)
@@ -45798,7 +45557,6 @@
 "hSA" = (
 /obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/public/locker)
@@ -45826,7 +45584,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkgreenfull"
 	},
 /area/station/service/hydroponics)
@@ -45941,7 +45698,6 @@
 	color = "#954535"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/starboard/north)
@@ -46038,7 +45794,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore/west)
@@ -46196,7 +45951,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central)
@@ -46356,7 +46110,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/north)
@@ -46424,7 +46177,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/aft/west)
@@ -46525,7 +46277,6 @@
 	color = "#954535"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central)
@@ -46748,7 +46499,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkgreenfull"
 	},
 /area/station/service/hydroponics)
@@ -46951,7 +46701,6 @@
 "ima" = (
 /obj/effect/spawner/random_spawners/dirt_often,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore/east)
@@ -47387,7 +47136,6 @@
 /obj/item/shovel/spade,
 /obj/structure/closet/crate/hydroponics,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkgreenfull"
 	},
 /area/station/service/hydroponics)
@@ -47454,7 +47202,6 @@
 "irU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/aft/east)
@@ -47964,7 +47711,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkgreenfull"
 	},
 /area/station/service/hydroponics)
@@ -48031,7 +47777,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/south)
@@ -48108,7 +47853,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/turret_protected/ai_upload)
@@ -48243,7 +47987,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/north)
@@ -48489,7 +48232,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/north)
@@ -48563,7 +48305,6 @@
 /obj/effect/turf_decal/stripes/full,
 /obj/effect/turf_decal/stripes/red/full,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central)
@@ -48676,7 +48417,6 @@
 /obj/structure/table,
 /obj/item/aiModule/reset,
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/turret_protected/ai_upload)
@@ -48704,7 +48444,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/south)
@@ -48745,7 +48484,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central)
@@ -48877,7 +48615,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/entry/south)
@@ -49146,7 +48883,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/east)
@@ -49329,7 +49065,6 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central)
@@ -49438,7 +49173,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_regular_floor = "yellowsiding";
 	icon_state = "tranquillite"
 	},
@@ -49544,7 +49278,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/entry/north)
@@ -50041,7 +49774,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/turret_protected/ai_upload)
@@ -50368,7 +50100,6 @@
 	pixel_y = 3
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/turret_protected/ai_upload)
@@ -50442,7 +50173,6 @@
 	color = "#954535"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore/west)
@@ -50480,7 +50210,6 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkgreenfull"
 	},
 /area/station/service/hydroponics)
@@ -50829,7 +50558,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkyellowfull"
 	},
 /area/station/engineering/break_room)
@@ -51162,7 +50890,6 @@
 	color = "#954535"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/starboard/north)
@@ -51932,7 +51659,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central)
@@ -52323,7 +52049,6 @@
 "jTe" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/aft/west)
@@ -52363,7 +52088,6 @@
 	name = "Central Access"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/north)
@@ -52423,7 +52147,6 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central)
@@ -53187,7 +52910,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore/east)
@@ -53208,7 +52930,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/aft/west)
@@ -53494,7 +53215,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/entry/south)
@@ -53617,7 +53337,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/spawner/random_spawners/dirt_often,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore/east)
@@ -53688,7 +53407,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/command/vault)
@@ -53770,7 +53488,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/command/vault)
@@ -54134,7 +53851,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/starboard/south)
@@ -54204,7 +53920,6 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/entry)
@@ -54231,7 +53946,6 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore/east)
@@ -54450,7 +54164,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central)
@@ -54688,7 +54401,6 @@
 	},
 /obj/effect/spawner/random_spawners/dirt_often,
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_regular_floor = "yellowsiding";
 	icon_state = "tranquillite"
 	},
@@ -54770,7 +54482,6 @@
 	name = "custom placement"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/command/vault)
@@ -54814,7 +54525,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/public/locker)
@@ -54846,7 +54556,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/command/vault)
@@ -54944,7 +54653,6 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/north)
@@ -55871,7 +55579,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/north)
@@ -56161,7 +55868,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore)
@@ -56265,7 +55971,6 @@
 	},
 /obj/effect/spawner/random_spawners/dirt_often,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkgreenfull"
 	},
 /area/station/service/hydroponics)
@@ -56458,7 +56163,6 @@
 	name = "Silver Crate"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/command/vault)
@@ -56505,7 +56209,6 @@
 "ljp" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/starboard/south)
@@ -56660,7 +56363,6 @@
 	dir = 9
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/command/vault)
@@ -56798,7 +56500,6 @@
 	pixel_y = 5
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/command/vault)
@@ -57014,7 +56715,6 @@
 "lqQ" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/entry)
@@ -57107,7 +56807,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/aft/west)
@@ -57257,7 +56956,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/turret_protected/aisat/interior/secondary)
@@ -57468,7 +57166,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/south)
@@ -57791,7 +57488,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/spacebridge/cargocom)
@@ -58068,7 +57764,6 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/command/vault)
@@ -58172,7 +57867,6 @@
 	color = "#954535"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central)
@@ -58505,7 +58199,6 @@
 	},
 /obj/effect/spawner/random_spawners/dirt_often,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/starboard/north)
@@ -58846,7 +58539,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/east)
@@ -59396,7 +59088,6 @@
 "mcu" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkgreenfull"
 	},
 /area/station/service/hydroponics)
@@ -59446,7 +59137,6 @@
 	color = "#954535"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/maintenance/fsmaint)
@@ -59459,7 +59149,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore/east)
@@ -60018,7 +59707,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/spacebridge/scidock)
@@ -60199,7 +59887,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/spacebridge/servsci)
@@ -60379,7 +60066,6 @@
 	},
 /obj/effect/spawner/random_spawners/dirt_often,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/starboard/south)
@@ -60393,7 +60079,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/south)
@@ -60461,7 +60146,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "whitepurplefull"
 	},
 /area/station/science/xenobiology)
@@ -60479,7 +60163,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/spacebridge/engmed)
@@ -60583,7 +60266,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/entry/south)
@@ -60808,7 +60490,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/aft/east)
@@ -60868,7 +60549,6 @@
 /area/station/security/execution)
 "mCM" = (
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/south)
@@ -61027,7 +60707,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/south)
@@ -61209,7 +60888,6 @@
 	name = "custom placement"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_regular_floor = "yellowsiding";
 	icon_state = "tranquillite"
 	},
@@ -61240,7 +60918,6 @@
 	anchored = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkbrownfull"
 	},
 /area/station/supply/office)
@@ -61281,7 +60958,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore)
@@ -61303,7 +60979,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/south)
@@ -61413,7 +61088,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/turret_protected/ai_upload)
@@ -61569,7 +61243,6 @@
 "mOX" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/aft/west)
@@ -61836,7 +61509,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/north)
@@ -61915,7 +61587,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/east)
@@ -62494,7 +62165,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central)
@@ -62671,7 +62341,6 @@
 	color = "#954535"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/spacebridge/comeng)
@@ -62981,7 +62650,6 @@
 /obj/structure/closet/secure_closet/personal,
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/public/locker)
@@ -63221,7 +62889,6 @@
 /obj/item/book/manual/hydroponics_pod_people,
 /obj/item/book/manual/hydroponics_pod_people,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkgreenfull"
 	},
 /area/station/service/hydroponics)
@@ -63293,7 +62960,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/spacebridge/serveng)
@@ -63397,7 +63063,6 @@
 	color = "#954535"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/spacebridge/comeng)
@@ -63603,7 +63268,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/starboard/south)
@@ -64032,7 +63696,6 @@
 	color = "#954535"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/starboard/south)
@@ -64246,7 +63909,6 @@
 /area/station/engineering/break_room)
 "nGE" = (
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/starboard/north)
@@ -64541,7 +64203,6 @@
 "nMt" = (
 /obj/structure/closet/firecloset/full,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "whitepurplefull"
 	},
 /area/station/science/hallway)
@@ -64645,7 +64306,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkgreenfull"
 	},
 /area/station/service/hydroponics)
@@ -65018,7 +64678,6 @@
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkgreenfull"
 	},
 /area/station/service/hydroponics)
@@ -65081,7 +64740,6 @@
 	},
 /obj/effect/spawner/random_spawners/dirt_often,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkgreenfull"
 	},
 /area/station/service/hydroponics)
@@ -65445,7 +65103,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/entry/north)
@@ -65764,14 +65421,12 @@
 	name = "north bump"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkgreenfull"
 	},
 /area/station/service/hydroponics)
 "ojm" = (
 /obj/machinery/economy/vending/hydrodrobe,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkgreenfull"
 	},
 /area/station/service/hydroponics)
@@ -65807,7 +65462,6 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/turret_protected/ai)
@@ -65923,7 +65577,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkgreenfull"
 	},
 /area/station/service/hydroponics)
@@ -66059,7 +65712,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/spacebridge/cargocom)
@@ -66126,7 +65778,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/north)
@@ -66646,7 +66297,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/starboard/north)
@@ -66842,7 +66492,6 @@
 /obj/effect/turf_decal/stripes/full,
 /obj/effect/turf_decal/stripes/red/full,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/aft/west)
@@ -67244,7 +66893,6 @@
 	},
 /obj/effect/spawner/random_spawners/dirt_often,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/south)
@@ -67304,7 +66952,6 @@
 	name = "Central Access"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central)
@@ -67453,7 +67100,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkgreenfull"
 	},
 /area/station/service/hydroponics)
@@ -67502,7 +67148,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore)
@@ -67531,7 +67176,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/south)
@@ -67634,7 +67278,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore)
@@ -68091,7 +67734,6 @@
 /obj/machinery/suit_storage_unit/cmo/secure/sec_storage,
 /obj/effect/turf_decal/bot,
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "darkbluefull"
 	},
 /area/station/medical/storage/secondary)
@@ -68109,7 +67751,6 @@
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore/west)
@@ -68365,7 +68006,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/starboard/north)
@@ -68472,7 +68112,6 @@
 	name = "west bump"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/telecomms/chamber)
@@ -69209,7 +68848,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/east)
@@ -69499,7 +69137,6 @@
 	pixel_y = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkgreenfull"
 	},
 /area/station/service/hydroponics)
@@ -69547,7 +69184,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore)
@@ -69675,7 +69311,6 @@
 /area/station/telecomms/chamber)
 "prN" = (
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkgreenfull"
 	},
 /area/station/service/hydroponics)
@@ -69889,7 +69524,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkgreenfull"
 	},
 /area/station/service/hydroponics)
@@ -70011,7 +69645,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/turret_protected/aisat/interior)
@@ -70049,7 +69682,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/south)
@@ -70168,7 +69800,6 @@
 "pAb" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_regular_floor = "yellowsiding";
 	icon_state = "tranquillite"
 	},
@@ -70671,7 +70302,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/entry/north)
@@ -70815,7 +70445,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/entry)
@@ -70865,7 +70494,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/turret_protected/ai_upload)
@@ -70995,14 +70623,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/spawner/random_spawners/dirt_often,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore/west)
 "pNE" = (
 /obj/effect/spawner/random_spawners/dirt_frequent,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkgreenfull"
 	},
 /area/station/service/hydroponics)
@@ -71135,7 +70761,6 @@
 	},
 /obj/effect/mapping_helpers/airlock/windoor/access/any/science/research,
 /turf/simulated/floor/plasteel{
-	dir = 1;
 	icon_state = "purplefull"
 	},
 /area/station/science/rnd)
@@ -71174,7 +70799,6 @@
 /area/station/security/brig)
 "pQa" = (
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/entry/north)
@@ -72059,7 +71683,6 @@
 "qcS" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/starboard/south)
@@ -72270,7 +71893,6 @@
 	pixel_y = 5
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkgreenfull"
 	},
 /area/station/service/hydroponics)
@@ -72376,7 +71998,6 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/starboard/north)
@@ -72452,7 +72073,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/starboard/north)
@@ -72530,7 +72150,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/starboard/north)
@@ -72615,7 +72234,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/starboard/north)
@@ -72637,7 +72255,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/starboard/north)
@@ -72771,7 +72388,6 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/starboard/north)
@@ -72795,7 +72411,6 @@
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/starboard/north)
@@ -72845,7 +72460,6 @@
 	color = "#954535"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore)
@@ -72947,7 +72561,6 @@
 	name = "Slime Processor"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "whitepurplefull"
 	},
 /area/station/science/xenobiology)
@@ -73136,7 +72749,6 @@
 	name = "south bump"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_regular_floor = "yellowsiding";
 	icon_state = "tranquillite"
 	},
@@ -73157,7 +72769,6 @@
 /obj/item/clothing/mask/facehugger/toy,
 /obj/item/clothing/mask/fakemoustache,
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_regular_floor = "yellowsiding";
 	icon_state = "tranquillite"
 	},
@@ -73398,7 +73009,6 @@
 /obj/structure/closet/secure_closet/hydroponics,
 /obj/effect/spawner/random_spawners/dirt_often,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkgreenfull"
 	},
 /area/station/service/hydroponics)
@@ -73552,7 +73162,6 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkgreenfull"
 	},
 /area/station/service/hydroponics)
@@ -73851,7 +73460,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/east)
@@ -73884,7 +73492,6 @@
 	},
 /obj/effect/spawner/random_spawners/dirt_often,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/entry)
@@ -73894,7 +73501,6 @@
 	color = "#954535"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore)
@@ -73986,7 +73592,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore/west)
@@ -74295,7 +73900,6 @@
 	color = "#954535"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore)
@@ -74439,7 +74043,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/entry/south)
@@ -74854,7 +74457,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/spacebridge/engmed)
@@ -75015,7 +74617,6 @@
 	},
 /obj/effect/spawner/random_spawners/dirt_often,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/north)
@@ -75091,7 +74692,6 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkbrownfull"
 	},
 /area/station/supply/storage)
@@ -75147,7 +74747,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/turret_protected/ai_upload)
@@ -75361,7 +74960,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/south)
@@ -75535,7 +75133,6 @@
 "rkb" = (
 /obj/machinery/biogenerator,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkgreenfull"
 	},
 /area/station/service/hydroponics)
@@ -75655,7 +75252,6 @@
 	dir = 6
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkgreenfull"
 	},
 /area/station/service/hydroponics)
@@ -76006,7 +75602,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/aft/west)
@@ -76190,7 +75785,6 @@
 	color = "#954535"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/starboard/south)
@@ -76241,7 +75835,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central)
@@ -76302,7 +75895,6 @@
 	},
 /obj/effect/turf_decal/caution/red,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/spacebridge/medcargo)
@@ -77168,7 +76760,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/spacebridge/scidock)
@@ -77616,7 +77207,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/spawner/random_spawners/dirt_often,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/south)
@@ -77754,7 +77344,6 @@
 	color = "#954535"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/starboard/south)
@@ -77989,7 +77578,6 @@
 "sdF" = (
 /obj/effect/spawner/random_spawners/dirt_often,
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_regular_floor = "yellowsiding";
 	icon_state = "tranquillite"
 	},
@@ -78019,7 +77607,6 @@
 	name = "quantum pad"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkyellowfull"
 	},
 /area/station/public/quantum/security)
@@ -78539,7 +78126,6 @@
 	},
 /obj/effect/turf_decal/bot_white,
 /turf/simulated/floor/plasteel{
-	dir = 1;
 	icon_state = "purplefull"
 	},
 /area/station/hallway/primary/aft/west)
@@ -79045,7 +78631,6 @@
 	},
 /obj/effect/turf_decal/caution/red,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/spacebridge/sercom)
@@ -79088,7 +78673,6 @@
 /obj/item/reagent_containers/glass/bucket,
 /obj/effect/spawner/random_spawners/dirt_frequent,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkgreenfull"
 	},
 /area/station/service/hydroponics)
@@ -79130,7 +78714,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/east)
@@ -79171,7 +78754,6 @@
 	},
 /obj/effect/spawner/random_spawners/dirt_often,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/entry/south)
@@ -79377,7 +78959,6 @@
 "syo" = (
 /obj/effect/spawner/random_spawners/dirt_often,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore)
@@ -79641,7 +79222,6 @@
 	},
 /obj/machinery/hydroponics/constructable,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkgreenfull"
 	},
 /area/station/service/hydroponics)
@@ -80048,7 +79628,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkgreenfull"
 	},
 /area/station/service/hydroponics)
@@ -80238,7 +79817,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/east)
@@ -80619,7 +80197,6 @@
 "sWc" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/aft/east)
@@ -80648,7 +80225,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/north)
@@ -81066,7 +80642,6 @@
 "tet" = (
 /obj/effect/spawner/random_spawners/dirt_often,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central)
@@ -81082,7 +80657,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/aft/east)
@@ -81401,7 +80975,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_regular_floor = "yellowsiding";
 	icon_state = "tranquillite"
 	},
@@ -81794,7 +81367,6 @@
 	name = "navigation beacon (Service)"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/north)
@@ -81987,12 +81559,6 @@
 	dir = 1
 	},
 /area/station/engineering/smes)
-"tuh" = (
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/secondary/entry/south)
 "tuj" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable/orange{
@@ -82358,7 +81924,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkgreenfull"
 	},
 /area/station/service/hydroponics)
@@ -82374,7 +81939,6 @@
 	color = "#954535"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/north)
@@ -82403,7 +81967,6 @@
 	sort_type_txt = "19"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/east)
@@ -82460,7 +82023,6 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/starboard/south)
@@ -82501,7 +82063,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/east)
@@ -82647,7 +82208,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/starboard/south)
@@ -83244,7 +82804,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore/west)
@@ -83285,7 +82844,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/starboard/south)
@@ -83401,7 +82959,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "whitepurplefull"
 	},
 /area/station/science/hallway)
@@ -83415,17 +82972,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/port/east)
-"tWq" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/secondary/entry/south)
 "tWy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -83585,7 +83131,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkgreenfull"
 	},
 /area/station/service/hydroponics)
@@ -83880,7 +83425,6 @@
 	color = "#954535"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/starboard/south)
@@ -84033,7 +83577,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore)
@@ -84475,14 +84018,12 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/east)
 "unj" = (
 /obj/machinery/seed_extractor,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkgreenfull"
 	},
 /area/station/service/hydroponics)
@@ -84631,7 +84172,6 @@
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/caution/red,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/spacebridge/dockmed)
@@ -84641,7 +84181,6 @@
 	},
 /obj/effect/spawner/random_spawners/dirt_often,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/aft/east)
@@ -84745,7 +84284,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/east)
@@ -84898,7 +84436,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/aft/east)
@@ -84930,7 +84467,6 @@
 	},
 /obj/machinery/disposal,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkgreenfull"
 	},
 /area/station/service/hydroponics)
@@ -84967,7 +84503,6 @@
 	},
 /obj/effect/spawner/random_spawners/dirt_often,
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_regular_floor = "yellowsiding";
 	icon_state = "tranquillite"
 	},
@@ -85120,7 +84655,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/spawner/random_spawners/dirt_often,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central)
@@ -85339,7 +84873,6 @@
 /area/station/maintenance/starboard)
 "uBC" = (
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "whitepurplefull"
 	},
 /area/station/science/xenobiology)
@@ -85374,7 +84907,6 @@
 	color = "#954535"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central)
@@ -85445,7 +84977,6 @@
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkgreenfull"
 	},
 /area/station/service/hydroponics)
@@ -85659,7 +85190,6 @@
 	anchored = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
 	icon_state = "purplefull"
 	},
 /area/station/science/robotics)
@@ -85809,7 +85339,6 @@
 	},
 /obj/effect/landmark/burnturf,
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/maintenance/electrical_shop)
@@ -86008,7 +85537,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/entry/south)
@@ -86113,7 +85641,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/spacebridge/dockmed)
@@ -86214,7 +85741,6 @@
 "uQB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkgreenfull"
 	},
 /area/station/service/hydroponics)
@@ -87095,7 +86621,6 @@
 	name = "navigation beacon (Research)"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/aft/west)
@@ -87140,7 +86665,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_regular_floor = "yellowsiding";
 	icon_state = "tranquillite"
 	},
@@ -87265,7 +86789,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkyellowfull"
 	},
 /area/station/engineering/control)
@@ -87558,7 +87081,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/entry/south)
@@ -87664,7 +87186,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_regular_floor = "yellowsiding";
 	icon_state = "tranquillite"
 	},
@@ -87886,7 +87407,6 @@
 	name = "quantum pad"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkyellowfull"
 	},
 /area/station/public/quantum/docking)
@@ -88142,7 +87662,6 @@
 /area/station/medical/cloning)
 "vuY" = (
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore)
@@ -88428,7 +87947,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkgreenfull"
 	},
 /area/station/service/hydroponics)
@@ -88467,7 +87985,6 @@
 	name = "Cyborg Statue"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/turret_protected/ai)
@@ -88569,7 +88086,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/aft/west)
@@ -88675,7 +88191,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/turret_protected/ai_upload)
@@ -88868,7 +88383,6 @@
 /obj/item/reagent_containers/food/snacks/grown/chili,
 /obj/item/seeds/grape,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkgreenfull"
 	},
 /area/station/service/hydroponics)
@@ -88962,7 +88476,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkbrownfull"
 	},
 /area/station/supply/office)
@@ -89075,7 +88588,6 @@
 	},
 /obj/effect/spawner/random_spawners/dirt_often,
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_regular_floor = "yellowsiding";
 	icon_state = "tranquillite"
 	},
@@ -89179,7 +88691,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/aft/east)
@@ -89509,7 +89020,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
 /obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "whitepurplefull"
 	},
 /area/station/science/xenobiology)
@@ -89843,7 +89353,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/turret_protected/ai_upload)
@@ -89914,7 +89423,6 @@
 /obj/machinery/recharge_station,
 /obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/aft/west)
@@ -90205,7 +89713,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/starboard/south)
@@ -90356,7 +89863,6 @@
 	color = "#954535"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore)
@@ -90795,7 +90301,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/north)
@@ -91084,7 +90589,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/south)
@@ -91390,7 +90894,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/starboard/south)
@@ -91683,7 +91186,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/south)
@@ -91735,7 +91237,6 @@
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/entry/north)
@@ -91934,7 +91435,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/turret_protected/aisat/interior/secondary)
@@ -92730,7 +92230,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/turret_protected/aisat/interior/secondary)
@@ -92782,7 +92281,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/starboard/south)
@@ -92961,7 +92459,6 @@
 /obj/item/storage/box/monkeycubes,
 /obj/item/storage/box/beakers,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "whitepurplefull"
 	},
 /area/station/science/xenobiology)
@@ -93003,7 +92500,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkyellowfull"
 	},
 /area/station/engineering/atmos/distribution)
@@ -93438,7 +92934,6 @@
 	name = "hallway turret"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/turret_protected/aisat/interior/secondary)
@@ -93459,7 +92954,6 @@
 	},
 /obj/effect/spawner/random_spawners/dirt_often,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/north)
@@ -93499,7 +92993,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_regular_floor = "yellowsiding";
 	icon_state = "tranquillite"
 	},
@@ -93593,7 +93086,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/spacebridge/medcargo)
@@ -93648,7 +93140,6 @@
 	},
 /obj/effect/turf_decal/caution/red,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/spacebridge/servsci)
@@ -93714,7 +93205,6 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/starboard/south)
@@ -93824,7 +93314,6 @@
 	color = "#954535"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore/west)
@@ -94485,7 +93974,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/south)
@@ -94743,7 +94231,6 @@
 /area/station/maintenance/gambling_den)
 "xsS" = (
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/north)
@@ -94970,7 +94457,6 @@
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	dir = 10;
 	icon_state = "bcircuit"
 	},
 /area/station/turret_protected/ai)
@@ -94984,7 +94470,6 @@
 	},
 /obj/effect/spawner/random_spawners/dirt_frequent,
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_regular_floor = "yellowsiding";
 	icon_state = "tranquillite"
 	},
@@ -95379,7 +94864,6 @@
 "xCH" = (
 /obj/effect/turf_decal/bot_white,
 /turf/simulated/floor/plasteel{
-	dir = 1;
 	icon_state = "purplefull"
 	},
 /area/station/hallway/primary/aft/west)
@@ -95476,7 +94960,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/public/locker)
@@ -95489,7 +94972,6 @@
 /area/station/science/storage)
 "xEd" = (
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/aft/west)
@@ -95638,7 +95120,6 @@
 	},
 /obj/effect/spawner/random_spawners/dirt_often,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/north)
@@ -95739,7 +95220,6 @@
 	},
 /obj/effect/spawner/random_spawners/dirt_often,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/entry/north)
@@ -95768,7 +95248,6 @@
 	name = "quantum pad"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkgreenfull"
 	},
 /area/station/public/quantum/science)
@@ -95904,7 +95383,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/supply/mail_sorting,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "darkbrownfull"
 	},
 /area/station/supply/office)
@@ -96116,7 +95594,6 @@
 	sort_type_txt = "20"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/east)
@@ -96883,7 +96360,6 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/south)
@@ -135519,7 +134995,7 @@ bhO
 bhO
 nFW
 abZ
-tuh
+dbg
 mqR
 sHm
 rNK
@@ -135776,7 +135252,7 @@ nFW
 nFW
 eiE
 tbP
-tuh
+dbg
 mqR
 sHm
 rNK
@@ -136033,7 +135509,7 @@ rrt
 hNb
 pLr
 gUa
-tuh
+dbg
 mqR
 sHm
 rNK
@@ -136547,7 +136023,7 @@ tJP
 kQz
 pLr
 akn
-tWq
+iFb
 mqR
 syJ
 jYp
@@ -136804,7 +136280,7 @@ qWI
 qWI
 nFW
 kpC
-tWq
+iFb
 sFj
 dbg
 eWu
@@ -137061,7 +136537,7 @@ imG
 vRX
 hOD
 hje
-tWq
+iFb
 sFj
 dbg
 eWu
@@ -138092,7 +137568,7 @@ kFu
 iFb
 sFj
 dbg
-cjs
+eWu
 hiN
 sHm
 rNK
@@ -138349,7 +137825,7 @@ lTa
 ppe
 njf
 ucc
-cjs
+eWu
 clB
 sHm
 rNK
@@ -138863,7 +138339,7 @@ cic
 bhm
 oWG
 aJW
-cjs
+eWu
 vjb
 rcj
 rNK
@@ -139120,7 +138596,7 @@ tnW
 quK
 tWC
 gIR
-cjs
+eWu
 vjb
 rcj
 rNK
@@ -139377,7 +138853,7 @@ diO
 tHB
 tWC
 aJW
-cjs
+eWu
 vjb
 rcj
 rNK
@@ -139634,7 +139110,7 @@ woU
 ezV
 qvh
 dQF
-cjs
+eWu
 vjb
 rcj
 rNK
@@ -139891,7 +139367,7 @@ xEJ
 bmg
 tWC
 aJW
-cjs
+eWu
 vjb
 rcj
 rNK
@@ -140148,7 +139624,7 @@ tWC
 tWC
 tWC
 acV
-cjs
+eWu
 vjb
 rcj
 rNK
@@ -140405,7 +139881,7 @@ ohr
 gQP
 xSo
 rpZ
-cjs
+eWu
 vjb
 sHm
 rNK
@@ -140662,7 +140138,7 @@ ioE
 drE
 xSo
 vwi
-cjs
+eWu
 vjb
 sHm
 rNK
@@ -140919,7 +140395,7 @@ uYW
 nEO
 fVo
 feH
-cjs
+eWu
 vjb
 sHm
 rNK
@@ -141433,7 +140909,7 @@ ioE
 ciN
 qLz
 cRN
-cjs
+eWu
 opo
 qyx
 wCC

--- a/_maps/map_files/cerestation/cerestation.dmm
+++ b/_maps/map_files/cerestation/cerestation.dmm
@@ -5283,14 +5283,6 @@
 	icon_state = "dark"
 	},
 /area/station/security/evidence)
-"aJE" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8
-	},
-/area/station/supply/miningdock)
 "aJG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/landmark/start/shaft_miner,
@@ -6349,9 +6341,7 @@
 /area/station/security/lobby)
 "aQc" = (
 /obj/structure/disposalpipe/junction,
-/turf/simulated/floor/plasteel{
-	dir = 8
-	},
+/turf/simulated/floor/plasteel,
 /area/station/security/lobby)
 "aQg" = (
 /obj/structure/cable/orange{
@@ -6972,9 +6962,7 @@
 /area/station/public/arcade)
 "aTX" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/plasteel{
-	dir = 1
-	},
+/turf/simulated/floor/plasteel,
 /area/station/security/prison/cell_block/A)
 "aUb" = (
 /obj/machinery/door/airlock{
@@ -7045,9 +7033,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/plasteel{
-	dir = 1
-	},
+/turf/simulated/floor/plasteel,
 /area/station/security/prison/cell_block/A)
 "aUv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -7056,17 +7042,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	dir = 1
-	},
+/turf/simulated/floor/plasteel,
 /area/station/security/prison/cell_block/A)
 "aUw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/turf/simulated/floor/plasteel{
-	dir = 1
-	},
+/turf/simulated/floor/plasteel,
 /area/station/security/prison/cell_block/A)
 "aUx" = (
 /obj/structure/disposalpipe/segment,
@@ -8404,18 +8386,14 @@
 /area/station/hallway/secondary/garden)
 "bbo" = (
 /obj/structure/table,
-/turf/simulated/floor/plasteel{
-	dir = 1
-	},
+/turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central)
 "bbp" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/structure/table,
-/turf/simulated/floor/plasteel{
-	dir = 4
-	},
+/turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central)
 "bbu" = (
 /obj/structure/cable{
@@ -8475,9 +8453,7 @@
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 4
-	},
+/turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central)
 "bbP" = (
 /obj/machinery/door/poddoor/preopen{
@@ -8631,9 +8607,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel{
-	dir = 10
-	},
+/turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central)
 "bcA" = (
 /obj/structure/cable/orange{
@@ -8653,9 +8627,7 @@
 	pixel_x = 24;
 	name = "east bump"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 4
-	},
+/turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central)
 "bcC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -8826,11 +8798,6 @@
 	dir = 10
 	},
 /turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central)
-"bds" = (
-/turf/simulated/floor/plasteel{
-	dir = 4
-	},
 /area/station/hallway/primary/central)
 "bdu" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -9006,9 +8973,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	dir = 4
-	},
+/turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central)
 "bep" = (
 /obj/structure/cable{
@@ -9328,9 +9293,7 @@
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 8
-	},
+/turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central)
 "bfW" = (
 /obj/machinery/firealarm{
@@ -9338,14 +9301,7 @@
 	pixel_y = -24;
 	name = "south bump"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 8
-	},
-/area/station/hallway/primary/central)
-"bfX" = (
-/turf/simulated/floor/plasteel{
-	dir = 8
-	},
+/turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central)
 "bfZ" = (
 /obj/machinery/camera{
@@ -11160,9 +11116,7 @@
 	pixel_x = -32;
 	pixel_y = 24
 	},
-/turf/simulated/floor/plasteel{
-	dir = 1
-	},
+/turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central)
 "boZ" = (
 /obj/structure/cable{
@@ -14107,9 +14061,7 @@
 /area/station/engineering/control)
 "bBV" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel{
-	dir = 1
-	},
+/turf/simulated/floor/plasteel,
 /area/station/command/office/hop)
 "bBW" = (
 /obj/machinery/status_display{
@@ -20334,9 +20286,7 @@
 	pixel_y = -24;
 	name = "south bump"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 1
-	},
+/turf/simulated/floor/plasteel,
 /area/station/supply/miningdock)
 "cfD" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -24188,14 +24138,6 @@
 /obj/effect/landmark/start/assistant,
 /turf/simulated/floor/grass/jungle,
 /area/station/hallway/secondary/garden)
-"cFi" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 5
-	},
-/area/station/hallway/primary/central)
 "cFj" = (
 /obj/structure/sign/securearea{
 	pixel_x = 32;
@@ -24480,9 +24422,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 1
-	},
+/turf/simulated/floor/plasteel,
 /area/station/security/prison/cell_block/A)
 "cGq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -24512,14 +24452,6 @@
 	name = "custom placement"
 	},
 /turf/simulated/floor/plasteel,
-/area/station/public/locker)
-"cGB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4
-	},
 /area/station/public/locker)
 "cGC" = (
 /obj/effect/landmark/start/engineer,
@@ -24671,9 +24603,7 @@
 	dir = 4;
 	color = "#954535"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 8
-	},
+/turf/simulated/floor/plasteel,
 /area/station/hallway/primary/fore/west)
 "cHx" = (
 /obj/structure/cable/orange{
@@ -24806,11 +24736,6 @@
 	},
 /turf/simulated/floor/grass/jungle,
 /area/station/hallway/secondary/garden)
-"cIe" = (
-/turf/simulated/floor/plasteel{
-	dir = 5
-	},
-/area/station/hallway/primary/central)
 "cIf" = (
 /obj/structure/cable/orange{
 	d2 = 2;
@@ -24843,9 +24768,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel{
-	dir = 1
-	},
+/turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central)
 "cIr" = (
 /obj/structure/chair/office/dark,
@@ -24883,9 +24806,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/turf/simulated/floor/plasteel{
-	dir = 10
-	},
+/turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central)
 "cIA" = (
 /obj/machinery/status_display{
@@ -24985,9 +24906,7 @@
 	dir = 8
 	},
 /obj/structure/table,
-/turf/simulated/floor/plasteel{
-	dir = 8
-	},
+/turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central)
 "cJa" = (
 /obj/structure/disposalpipe/segment,
@@ -25843,9 +25762,7 @@
 	layer = 4;
 	pixel_x = -32
 	},
-/turf/simulated/floor/plasteel{
-	dir = 1
-	},
+/turf/simulated/floor/plasteel,
 /area/station/command/office/hop)
 "cNg" = (
 /obj/structure/table,
@@ -26032,9 +25949,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	dir = 1
-	},
+/turf/simulated/floor/plasteel,
 /area/station/security/prison/cell_block/A)
 "cNW" = (
 /obj/structure/cable/orange{
@@ -26080,9 +25995,7 @@
 	},
 /area/station/service/theatre)
 "cOh" = (
-/turf/simulated/floor/plasteel{
-	dir = 1
-	},
+/turf/simulated/floor/plasteel,
 /area/station/security/prison/cell_block/A)
 "cOl" = (
 /obj/structure/cable/orange{
@@ -26090,9 +26003,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 1
-	},
+/turf/simulated/floor/plasteel,
 /area/station/security/prison/cell_block/A)
 "cOo" = (
 /obj/machinery/door/airlock/external{
@@ -26446,14 +26357,6 @@
 	icon_state = "whitegreen"
 	},
 /area/station/medical/virology)
-"cPM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4
-	},
-/area/station/public/locker)
 "cPN" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -27364,9 +27267,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	dir = 1
-	},
+/turf/simulated/floor/plasteel,
 /area/station/security/prison/cell_block/A)
 "cTr" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -27375,9 +27276,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	dir = 1
-	},
+/turf/simulated/floor/plasteel,
 /area/station/security/prison/cell_block/A)
 "cTu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -27417,9 +27316,7 @@
 /area/station/public/locker)
 "cTH" = (
 /obj/machinery/washing_machine,
-/turf/simulated/floor/plasteel{
-	dir = 4
-	},
+/turf/simulated/floor/plasteel,
 /area/station/public/locker)
 "cTJ" = (
 /obj/item/radio/intercom{
@@ -29597,9 +29494,7 @@
 	dir = 4
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel{
-	dir = 9
-	},
+/turf/simulated/floor/plasteel,
 /area/station/command/office/hop)
 "djb" = (
 /obj/machinery/light/small{
@@ -29611,9 +29506,7 @@
 	name = "east bump";
 	pixel_x = 28
 	},
-/turf/simulated/floor/plasteel{
-	dir = 5
-	},
+/turf/simulated/floor/plasteel,
 /area/station/command/office/hop)
 "djc" = (
 /obj/structure/disposalpipe/segment,
@@ -31621,9 +31514,7 @@
 	pixel_x = 28;
 	name = "custom placement"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 4
-	},
+/turf/simulated/floor/plasteel,
 /area/station/command/office/hop)
 "dvc" = (
 /obj/structure/disposaloutlet{
@@ -36106,9 +35997,7 @@
 /obj/structure/chair{
 	dir = 1
 	},
-/turf/simulated/floor/plasteel{
-	dir = 8
-	},
+/turf/simulated/floor/plasteel,
 /area/station/security/lobby)
 "eDx" = (
 /obj/machinery/status_display{
@@ -39680,28 +39569,6 @@
 	icon_state = "white"
 	},
 /area/station/medical/cloning)
-"fUS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/command/glass{
-	id_tag = "cmoofficedoor";
-	name = "CMO's Office"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/cmo,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "cmo"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1
-	},
-/area/station/command/office/cmo)
 "fUT" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
@@ -47973,6 +47840,26 @@
 "iFs" = (
 /turf/simulated/wall,
 /area/mine/unexplored/cere/research)
+"iFu" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/command/glass{
+	id_tag = "cmoofficedoor";
+	name = "CMO's Office"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/cmo,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "cmo"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/command/office/cmo)
 "iFB" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -50111,9 +49998,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	dir = 1
-	},
+/turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central)
 "jpk" = (
 /obj/machinery/status_display{
@@ -51668,9 +51553,7 @@
 	id = "hopflash";
 	pixel_y = 24
 	},
-/turf/simulated/floor/plasteel{
-	dir = 1
-	},
+/turf/simulated/floor/plasteel,
 /area/station/command/office/hop)
 "jNk" = (
 /obj/structure/sign/chinese{
@@ -56179,9 +56062,7 @@
 	dir = 4;
 	color = "#954535"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 8
-	},
+/turf/simulated/floor/plasteel,
 /area/station/hallway/primary/fore/west)
 "liR" = (
 /obj/structure/table/reinforced,
@@ -61839,9 +61720,7 @@
 	pixel_x = -32;
 	pixel_y = 40
 	},
-/turf/simulated/floor/plasteel{
-	dir = 1
-	},
+/turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central)
 "mXt" = (
 /obj/machinery/light{
@@ -62390,14 +62269,6 @@
 /obj/structure/chair/stool,
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
-"ngx" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Rehabilitation Dome"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 5
-	},
-/area/station/hallway/secondary/garden)
 "ngA" = (
 /obj/structure/chair/office/light,
 /turf/simulated/floor/plasteel{
@@ -77297,9 +77168,7 @@
 "rZe" = (
 /obj/machinery/recharge_station,
 /obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel{
-	dir = 1
-	},
+/turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central)
 "rZi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -80989,9 +80858,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	dir = 1
-	},
+/turf/simulated/floor/plasteel,
 /area/station/security/prison/cell_block/A)
 "tkg" = (
 /obj/machinery/door/poddoor/shutters{
@@ -84392,9 +84259,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	dir = 1
-	},
+/turf/simulated/floor/plasteel,
 /area/station/security/prison/cell_block/A)
 "utF" = (
 /obj/structure/cable/orange{
@@ -85572,9 +85437,7 @@
 /area/station/supply/qm)
 "uPi" = (
 /obj/machinery/hologram/holopad,
-/turf/simulated/floor/plasteel{
-	dir = 1
-	},
+/turf/simulated/floor/plasteel,
 /area/station/security/prison/cell_block/A)
 "uPp" = (
 /obj/machinery/door/airlock/security/glass{
@@ -95287,9 +95150,7 @@
 	name = "custom placement"
 	},
 /obj/structure/closet/wardrobe/pjs,
-/turf/simulated/floor/plasteel{
-	dir = 4
-	},
+/turf/simulated/floor/plasteel,
 /area/station/public/locker)
 "xJO" = (
 /obj/structure/sign/directions/security{
@@ -125116,9 +124977,9 @@ abW
 abW
 abW
 xJA
-cGB
+oFu
 cGD
-cPM
+cPI
 cTH
 diS
 aqC
@@ -126948,7 +126809,7 @@ aXP
 aXP
 ctw
 fph
-ngx
+bbM
 uMC
 fph
 lip
@@ -127206,7 +127067,7 @@ kZW
 beR
 fph
 rxi
-cFi
+cIs
 lip
 joZ
 bfW
@@ -127464,9 +127325,9 @@ hqg
 bbM
 lip
 cIs
-cIe
+lip
 cIs
-bfX
+lip
 aZK
 aZK
 aZK
@@ -128234,7 +128095,7 @@ lWT
 bbo
 lip
 cIq
-bds
+lip
 rLW
 bgf
 cFj
@@ -128491,7 +128352,7 @@ lWT
 bbp
 bbO
 bcB
-bds
+lip
 rLW
 bgf
 bfZ
@@ -144693,7 +144554,7 @@ bjJ
 bgq
 bhl
 bia
-fUS
+iFu
 izY
 vEA
 bst
@@ -151320,7 +151181,7 @@ aGC
 wxm
 bGA
 ijr
-aJE
+ijr
 iyv
 cfC
 uKL

--- a/_maps/map_files/cerestation/cerestation.dmm
+++ b/_maps/map_files/cerestation/cerestation.dmm
@@ -50,6 +50,15 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/east)
+"aar" = (
+/obj/machinery/r_n_d/server/core,
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 6
+	},
+/turf/simulated/floor/plasteel/dark/telecomms{
+	icon_state = "bcircuit"
+	},
+/area/station/science/server/coldroom)
 "aas" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -813,10 +822,39 @@
 	icon_state = "dark"
 	},
 /area/station/security/execution)
+"aeL" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/maintenance/external{
+	name = "External Airlock Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/turf/simulated/floor/plating,
+/area/station/hallway/primary/central)
 "aeM" = (
 /obj/item/kirbyplants,
 /turf/simulated/floor/plasteel{
 	icon_state = "bcircuit"
+	},
+/area/station/turret_protected/ai)
+"aeN" = (
+/obj/machinery/door/window/classic/reversed{
+	dir = 8;
+	name = "AI Core Door"
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/command/ai_upload{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id_tag = "aisat"
+	},
+/obj/effect/turf_decal/caution/stand_clear,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
 /area/station/turret_protected/ai)
 "aeO" = (
@@ -837,6 +875,28 @@
 "afd" = (
 /turf/simulated/wall/r_wall,
 /area/station/security/permabrig)
+"afn" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/window/classic/reversed{
+	dir = 4;
+	name = "AI Core Door"
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/command/ai_upload{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id_tag = "aisat"
+	},
+/obj/effect/turf_decal/caution/stand_clear,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/turret_protected/ai)
 "afq" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -1761,6 +1821,22 @@
 /obj/item/clothing/under/color/orange/prison,
 /turf/simulated/floor/plasteel,
 /area/station/security/prisonershuttle)
+"alg" = (
+/obj/machinery/door/window/reinforced/normal{
+	dir = 1;
+	name = "Glass Door"
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/security/doors{
+	dir = 1
+	},
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel,
+/area/station/security/prisonershuttle)
 "alh" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -2071,6 +2147,23 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal/north)
+"ang" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/classic/normal{
+	name = "Hydroponics";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/service/hydroponics{
+	dir = 4
+	},
+/obj/item/desk_bell{
+	pixel_x = 7;
+	pixel_y = 7;
+	anchored = 1
+	},
+/turf/simulated/floor/plating,
+/area/station/service/hydroponics)
 "anm" = (
 /obj/structure/disposalpipe/junction{
 	dir = 8
@@ -2212,21 +2305,6 @@
 "aog" = (
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal/northeast)
-"aoh" = (
-/obj/machinery/door/airlock{
-	name = "Crematorium"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/service/crematorium,
-/obj/structure/cable/orange{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/maintenance/port)
 "aok" = (
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -2413,6 +2491,20 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/prisonlockers)
+"apf" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Prisoner Lockers"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/security/prisonlockers)
 "apg" = (
 /obj/structure/chair/office/dark,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -2529,6 +2621,19 @@
 /obj/structure/railing,
 /turf/simulated/floor/plating/airless,
 /area/space/nearstation)
+"aqb" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Disposals Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/turret_protected/aisat/interior/secondary)
 "aqc" = (
 /obj/machinery/porta_turret{
 	dir = 4;
@@ -2544,6 +2649,21 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "bcircuit"
 	},
+/area/station/turret_protected/aisat/interior/secondary)
+"aqd" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Disposals Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
 /area/station/turret_protected/aisat/interior/secondary)
 "aqk" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -2649,6 +2769,19 @@
 /obj/effect/spawner/random_spawners/wall_rusted_always,
 /turf/simulated/wall,
 /area/station/maintenance/disposal/northeast)
+"aqY" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Prisoner Lockers"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/machinery/door/firedoor,
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/security/prisonlockers)
 "ara" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -2702,6 +2835,13 @@
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore2)
+"arm" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Fore Asteroid Maintenance Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/disposal/northeast)
 "arp" = (
 /obj/structure/cable/orange{
 	d2 = 2;
@@ -2722,6 +2862,19 @@
 	slowdown = -0.3
 	},
 /area/station/hallway/spacebridge/engmed)
+"aru" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Fore Asteroid Maintenance Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/station/maintenance/disposal/northeast)
 "arw" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -2787,6 +2940,19 @@
 /obj/item/clothing/under/color/orange/prison,
 /turf/simulated/floor/plasteel,
 /area/station/security/prisonlockers)
+"asc" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Prison Wing";
+	security_level = 1
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/security/permabrig)
 "asd" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
@@ -2841,6 +3007,22 @@
 	icon_state = "bcircuit"
 	},
 /area/station/turret_protected/aisat/interior/secondary)
+"asH" = (
+/obj/machinery/disposal/deliveryChute{
+	dir = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/door/window/classic/reversed{
+	name = "Mail Chute";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/general{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/disposal)
 "asJ" = (
 /obj/machinery/disposal/deliveryChute{
 	desc = "A chute for big and small criminals alike!";
@@ -3333,6 +3515,23 @@
 /obj/machinery/ai_status_display,
 /turf/simulated/wall/r_wall,
 /area/station/telecomms/computer)
+"avr" = (
+/obj/machinery/door/airlock/hatch{
+	name = "AI Satellite Secondary Antechamber"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/turret_protected/aisat/interior/secondary)
 "avu" = (
 /obj/effect/decal/warning_stripes/southeastcorner,
 /turf/simulated/floor/plasteel{
@@ -3884,6 +4083,16 @@
 	icon_state = "dark"
 	},
 /area/station/turret_protected/aisat/interior)
+"ayK" = (
+/obj/machinery/door/airlock/hatch{
+	name = "AI Asteroid Teleporter Room"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/command/teleporter,
+/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/turret_protected/aisat/interior)
 "ayL" = (
 /obj/effect/decal/warning_stripes/east,
 /obj/machinery/door_control{
@@ -4218,6 +4427,31 @@
 	},
 /turf/simulated/floor/carpet/black,
 /area/station/command/office/captain)
+"aBl" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/highsecurity{
+	name = "Telecommunications"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/telecomms/chamber)
 "aBn" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -4353,6 +4587,27 @@
 	icon_state = "dark"
 	},
 /area/station/telecomms/computer)
+"aCw" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/airlock/highsecurity{
+	name = "Telecommunications"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/telecomms/computer)
 "aCy" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -4423,22 +4678,6 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/main)
-"aCZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "researchlockdown";
-	layer = 2.6;
-	name = "Research Emergency Lockdown"
-	},
-/obj/machinery/door/airlock/research{
-	name = "Research Division Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/medical/genetics,
-/obj/effect/mapping_helpers/airlock/access/any/science/research,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel/white,
-/area/station/science/hallway)
 "aDa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -4770,6 +5009,23 @@
 /obj/effect/spawner/random_spawners/dirt_often,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/fore)
+"aFu" = (
+/obj/machinery/door/airlock/security{
+	name = "Evidence Storage"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/machinery/door/firedoor,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/security/evidence)
 "aFw" = (
 /obj/structure/cable/orange{
 	d2 = 2;
@@ -4877,6 +5133,15 @@
 "aGv" = (
 /turf/simulated/floor/plating,
 /area/station/supply/office)
+"aGw" = (
+/obj/machinery/door/airlock/external{
+	id_tag = "supply_home";
+	locked = 1;
+	name = "Cargo Docking Hatch"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/supply/general,
+/turf/simulated/floor/plating,
+/area/station/supply/office)
 "aGx" = (
 /obj/structure/disposalpipe/segment/corner,
 /turf/simulated/floor/plating/asteroid/ancient/airless,
@@ -4932,6 +5197,17 @@
 	icon_state = "red"
 	},
 /area/station/security/processing)
+"aGL" = (
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "Brig";
+	name = "Prisoner Processing"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/security/processing)
 "aGP" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
@@ -4971,14 +5247,6 @@
 /obj/item/gun/energy/kinetic_accelerator,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
-"aHj" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Aft Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plating,
-/area/station/science/xenobiology)
 "aHk" = (
 /obj/machinery/door_control{
 	id = "bridge";
@@ -5086,6 +5354,18 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/station/public/locker)
+"aIv" = (
+/obj/machinery/door/window/classic/reversed{
+	dir = 1;
+	name = "Bridge Desk"
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/command/general{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "rampbottom"
+	},
+/area/station/command/bridge)
 "aIx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
@@ -5106,24 +5386,6 @@
 /obj/effect/landmark/start/shaft_miner,
 /turf/simulated/floor/plasteel,
 /area/station/supply/miningdock)
-"aII" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 8;
-	id_tag = "kitchen1"
-	},
-/obj/machinery/door/window/classic/reversed{
-	dir = 4;
-	name = "Kitchen"
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/service/kitchen{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/station/service/kitchen)
 "aIP" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -5414,14 +5676,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/fore2)
-"aKo" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Hydroponics"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plating,
-/area/station/maintenance/gambling_den)
 "aKp" = (
 /turf/simulated/wall,
 /area/station/hallway/primary/fore)
@@ -5495,6 +5749,18 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore2)
+"aKO" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Dorm SMES Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore2)
 "aKP" = (
@@ -5623,6 +5889,20 @@
 	icon_state = "solarpanel"
 	},
 /area/station/engineering/solar/auxport)
+"aLQ" = (
+/obj/machinery/door/airlock/command{
+	name = "Captain's Quarters"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/captain,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/station/command/office/captain)
 "aLU" = (
 /obj/structure/chair/comfy/brown{
 	dir = 1
@@ -5885,6 +6165,22 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/lobby)
+"aNK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/window/classic/reversed{
+	name = "Captain's Desk";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/command/captain{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/station/command/office/captain)
 "aNM" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -6697,27 +6993,14 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/legal/magistrate)
-"aSt" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"aSs" = (
+/obj/machinery/door/airlock{
+	name = "Magistrate's Office"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/airlock/command/glass{
-	name = "E.V.A."
-	},
-/obj/effect/mapping_helpers/airlock/access/any/command/eva,
+/obj/effect/mapping_helpers/airlock/access/all/command/magistrate,
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/ai_monitored/storage/eva)
+/turf/simulated/floor/wood,
+/area/station/legal/lawoffice)
 "aSw" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -6731,6 +7014,23 @@
 /obj/machinery/ai_status_display,
 /turf/simulated/wall,
 /area/station/legal/lawoffice)
+"aSC" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Secure Gate";
+	name = "Security Blast Door";
+	opacity = 0
+	},
+/obj/machinery/door/airlock/security/glass{
+	name = "General Population Cell"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/security/prison/cell_block/A)
 "aSE" = (
 /obj/machinery/camera{
 	c_tag = "Bridge East"
@@ -7024,6 +7324,19 @@
 "aUo" = (
 /turf/simulated/floor/carpet,
 /area/station/legal/lawoffice)
+"aUq" = (
+/obj/machinery/door/airlock/glass{
+	name = "Internal Affairs Office"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/iaa,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "IAA"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "cult"
+	},
+/area/station/legal/lawoffice)
 "aUr" = (
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel/airless,
@@ -7060,6 +7373,21 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore2)
+"aUA" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Starboard Asteroid Maintenance Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/disposal/east)
 "aUB" = (
 /obj/effect/landmark/start/botanist,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -7332,31 +7660,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/office)
-"aWi" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Transfer Processing"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/machinery/door/firedoor,
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/orange{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/orange{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/security/prisonershuttle)
 "aWl" = (
 /obj/structure/cable/orange{
 	d1 = 4;
@@ -7410,6 +7713,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
+"aWw" = (
+/obj/machinery/door/airlock{
+	name = "Custodial Closet"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/janitor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel,
+/area/station/service/janitor)
 "aWx" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
@@ -7582,6 +7896,35 @@
 /obj/structure/lattice/catwalk,
 /turf/space,
 /area/station/engineering/solar/auxport)
+"aXd" = (
+/obj/machinery/door/airlock/hatch{
+	name = "AI Satellite Antechamber"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/command/teleporter,
+/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/turret_protected/aisat/interior)
+"aXe" = (
+/obj/machinery/door/airlock/hatch{
+	name = "AI Satellite Antechamber"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/command/teleporter,
+/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/turret_protected/aisat/interior)
 "aXi" = (
 /obj/machinery/power/tracker,
 /obj/structure/lattice/catwalk,
@@ -7687,27 +8030,6 @@
 	icon_state = "dark"
 	},
 /area/station/turret_protected/aisat/interior)
-"aXH" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/door/window/classic/reversed{
-	dir = 1;
-	name = "Interior Pipe Access"
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/engineering/atmos{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/engineering/atmos)
 "aXI" = (
 /obj/structure/disposalpipe/segment/corner{
 	color = "#954535"
@@ -7718,19 +8040,6 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/lobby)
-"aXL" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Science SMES Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/cable/orange{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plating,
-/area/station/maintenance/apmaint)
 "aXN" = (
 /obj/machinery/economy/vending/hydronutrients,
 /turf/simulated/floor/grass/jungle,
@@ -7929,6 +8238,16 @@
 	icon_state = "neutral"
 	},
 /area/station/public/storage/tools)
+"aZa" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Port Asteroid Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/port2)
 "aZb" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -7973,6 +8292,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/central)
+"aZn" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Medbay Reception"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Biohazard_medi";
+	name = "Quarantine Lockdown";
+	opacity = 0
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/medbay)
 "aZo" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -8272,6 +8606,22 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/cloning)
+"baE" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Firing Range"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel,
+/area/station/security/range)
 "baF" = (
 /turf/simulated/wall,
 /area/station/service/kitchen)
@@ -8455,31 +8805,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central)
-"bbP" = (
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "XenoPod1";
-	layer = 2.6;
-	name = "containment door 1"
-	},
-/obj/structure/cable/orange{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/orange{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/door/window/classic/normal{
-	dir = 1;
-	name = "Containment Pen"
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/science/xenobio{
-	dir = 1
-	},
-/turf/simulated/floor/engine,
-/area/station/science/xenobiology)
 "bbS" = (
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -8507,6 +8832,21 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/turf/simulated/floor/plating,
+/area/station/hallway/primary/central)
+"bbV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/maintenance/external{
+	name = "External Airlock Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/central)
 "bca" = (
@@ -8799,6 +9139,18 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central)
+"bdt" = (
+/obj/machinery/door/window/reinforced/normal{
+	dir = 4;
+	name = "Evidence Storage"
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/security/doors{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/security/evidence)
 "bdu" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -8817,6 +9169,19 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
+/area/station/hallway/primary/central)
+"bdx" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/maintenance/external{
+	name = "External Airlock Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
 /area/station/hallway/primary/central)
 "bdy" = (
 /obj/structure/cable/orange{
@@ -8938,15 +9303,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/main)
-"bea" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Port Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/disposalpipe/segment,
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plasteel,
-/area/station/service/library)
 "beb" = (
 /obj/structure/table/wood,
 /turf/simulated/floor/grass/jungle,
@@ -8997,6 +9353,23 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/carpet/blue,
 /area/station/command/office/hop)
+"bev" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/command/glass{
+	name = "E.V.A."
+	},
+/obj/effect/mapping_helpers/airlock/access/any/command/eva,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/ai_monitored/storage/eva)
 "bew" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -9050,15 +9423,6 @@
 	icon_state = "tranquillite"
 	},
 /area/station/service/theatre)
-"beO" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Disposals"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/access/any/supply/general,
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
 "beR" = (
 /obj/structure/flora/grass/jungle,
 /turf/simulated/floor/grass/jungle,
@@ -9070,6 +9434,19 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/security/range)
+"beT" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance{
+	name = "Fore Asteroid Maintenance Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/disposal/north)
 "beU" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
@@ -9201,6 +9578,19 @@
 	icon_state = "dark"
 	},
 /area/station/ai_monitored/storage/eva)
+"bfm" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Psych Office"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/psychology,
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "psych"
+	},
+/turf/simulated/floor/wood,
+/area/station/medical/psych)
 "bfn" = (
 /obj/machinery/door/firedoor,
 /obj/effect/spawner/window/reinforced/polarized{
@@ -9208,6 +9598,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/psych)
+"bfo" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Starboard Asteroid Maintenance Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/starboard)
 "bfp" = (
 /obj/structure/grille/broken,
 /turf/simulated/floor/plating/asteroid/ancient,
@@ -9240,19 +9637,6 @@
 /obj/item/assembly/mousetrap/armed,
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
-"bfF" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Dorm SMES Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/cable/orange{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore2)
 "bfQ" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -9417,6 +9801,27 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central)
+"bgl" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/airlock/command/glass{
+	name = "E.V.A."
+	},
+/obj/effect/mapping_helpers/airlock/access/any/command/eva,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/ai_monitored/storage/eva)
 "bgm" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -9944,22 +10349,6 @@
 	},
 /turf/simulated/floor/carpet/black,
 /area/station/command/office/captain)
-"biY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/maintenance/external{
-	name = "External Airlock Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plating,
-/area/station/hallway/primary/port/south)
 "biZ" = (
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -9974,18 +10363,6 @@
 	},
 /turf/simulated/floor/carpet/black,
 /area/station/command/office/captain)
-"bjf" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Security SMES Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/hallway/primary/fore/west)
 "bjh" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
@@ -10112,6 +10489,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/turret_protected/aisat/interior)
+"bki" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance/external{
+	name = "External Airlock Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/turret_protected/aisat/interior)
 "bkj" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -10229,6 +10624,24 @@
 	icon_state = "white"
 	},
 /area/station/medical/surgery/primary)
+"bkJ" = (
+/obj/machinery/door/airlock/maintenance/external{
+	name = "AI Satellite Atmospherics"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/turret_protected/aisat/interior)
 "bkM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -10306,6 +10719,21 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/turf/simulated/floor/plating,
+/area/station/hallway/primary/central)
+"bli" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance/external{
+	name = "External Airlock Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/central)
 "blj" = (
@@ -10415,6 +10843,24 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central)
+"blw" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance/external{
+	name = "External Airlock Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/hallway/primary/central)
 "bly" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -10429,22 +10875,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/central)
-"blz" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Laser Room"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/engineering/control)
 "blC" = (
 /obj/machinery/economy/vending/cola,
 /turf/simulated/floor/plasteel,
@@ -10503,6 +10933,20 @@
 	icon_state = "dark"
 	},
 /area/station/supply/storage)
+"blL" = (
+/obj/machinery/door/airlock/medical{
+	name = "Operating Theatre Storage"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "showroomfloor"
+	},
+/area/station/medical/surgery/secondary)
 "blM" = (
 /obj/structure/cable/orange{
 	d1 = 4;
@@ -10868,6 +11312,26 @@
 	icon_state = "dark"
 	},
 /area/station/security/evidence)
+"bnx" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Interrogation"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/machinery/door/firedoor,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "Interrogation"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/security/interrogation)
 "bnz" = (
 /obj/effect/spawner/window/reinforced/polarized{
 	id = "Interrogation"
@@ -10919,24 +11383,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/science/hallway)
-"bnP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/maintenance/external{
-	name = "External Airlock Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/cable/orange{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/hallway/primary/starboard/south)
 "bnQ" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
@@ -10995,6 +11441,16 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/station/medical/virology)
+"bon" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Warden's Office"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/armory,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/security/armory/secure)
 "bop" = (
 /obj/machinery/atmospherics/binary/valve{
 	dir = 4
@@ -11128,6 +11584,22 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central)
+"bpc" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Laser Room"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/engineering/control)
 "bpe" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -12003,6 +12475,22 @@
 /obj/machinery/ai_status_display,
 /turf/simulated/wall,
 /area/station/security/storage)
+"bsN" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Equipment Storage"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/door/firedoor,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "red"
+	},
+/area/station/security/storage)
 "bsO" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/ears/earmuffs,
@@ -12170,6 +12658,20 @@
 	},
 /turf/simulated/floor/transparent/glass/reinforced/plasma,
 /area/station/engineering/engine/supermatter)
+"btv" = (
+/obj/machinery/door/airlock/command{
+	name = "Head of Personnel's Private Quarters"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/hop,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/blue,
+/area/station/command/office/hop)
 "btw" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -12645,6 +13147,22 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/maintcentral)
+"bvr" = (
+/obj/machinery/door/airlock/command{
+	name = "Captain's Office"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/captain,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet/black,
+/area/station/command/office/captain)
 "bvt" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -13215,6 +13733,18 @@
 	icon_state = "white"
 	},
 /area/station/medical/reception)
+"bxQ" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/classic/normal{
+	name = "Hydroponics";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/service/hydroponics{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/service/hydroponics)
 "bxR" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/glass/bottle/epinephrine,
@@ -13605,19 +14135,6 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/control)
-"bzH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/atmos{
-	name = "Docking Atmospherics Checkpoint"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/machinery/atmospherics/pipe/simple/hidden/universal{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry/north)
 "bzK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -13666,6 +14183,43 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/reception)
+"bzO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "medmain";
+	name = "Medbay Entrance"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/medical/general,
+/obj/effect/mapping_helpers/airlock/access/any/medical/genetics,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Biohazard_medi";
+	name = "Quarantine Lockdown";
+	opacity = 0
+	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whiteblue"
+	},
+/area/station/medical/medbay)
 "bzT" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 4
@@ -13685,6 +14239,42 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/north)
+"bzY" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/virology{
+	autoclose = 0;
+	id_tag = "viro_door_int";
+	locked = 1;
+	name = "Virology Lab Internal Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/access_button{
+	autolink_id = "viro_btn_int";
+	name = "Virology Lab Access Button";
+	req_access_txt = "39";
+	pixel_y = -24
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "whitegreenfull"
+	},
+/area/station/medical/virology)
 "bzZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -13881,6 +14471,20 @@
 "bAO" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /turf/simulated/wall/r_wall,
+/area/station/engineering/engine/supermatter)
+"bAP" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/engineering/glass{
+	heat_proof = 1;
+	name = "Supermatter Chamber"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/turf/simulated/floor/engine,
 /area/station/engineering/engine/supermatter)
 "bAQ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
@@ -14478,6 +15082,36 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/station/engineering/control)
+"bEe" = (
+/obj/machinery/door/airlock/engineering/glass{
+	autoclose = 0;
+	id_tag = "engsm_door_int";
+	locked = 1;
+	name = "Supermatter Interior Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/engine,
+/area/station/engineering/control)
+"bEg" = (
+/obj/machinery/door/airlock/engineering/glass{
+	autoclose = 0;
+	id_tag = "engsm_door_int";
+	locked = 1;
+	name = "Supermatter Interior Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/engine,
+/area/station/engineering/control)
 "bEh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/spawner/window/reinforced/plasma,
@@ -14565,6 +15199,24 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/engine,
+/area/station/medical/chemistry)
+"bEu" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/smartfridge/secure/medbay,
+/obj/effect/mapping_helpers/airlock/windoor/access/any/medical/chemistry{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/medical/general{
+	dir = 4
+	},
+/obj/machinery/door/window/antitheft/normal{
+	dir = 4;
+	name = "Medbay Fridge"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
 /area/station/medical/chemistry)
 "bEv" = (
 /obj/machinery/alarm{
@@ -15128,6 +15780,25 @@
 	icon_state = "whiteyellow"
 	},
 /area/station/medical/chemistry)
+"bFI" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/medical/glass{
+	name = "Chemistry Lab"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/chemistry,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/station/medical/chemistry)
 "bFJ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -15213,17 +15884,24 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/medbay)
-"bGd" = (
-/obj/machinery/door/airlock/glass{
-	name = "Courtroom"
+"bFY" = (
+/obj/machinery/door/airlock{
+	name = "Chaplain's Office"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "Courtroom"
+/obj/effect/mapping_helpers/airlock/access/all/service/chapel_office,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/wood,
-/area/station/legal/courtroom)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/service/chapel)
 "bGk" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -15269,6 +15947,19 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
+/turf/simulated/floor/plasteel,
+/area/station/supply/miningdock)
+"bGF" = (
+/obj/machinery/door/airlock/external{
+	id_tag = "mining_home";
+	locked = 1;
+	name = "Mining Dock Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/supply/mining,
+/obj/machinery/door/firedoor,
+/obj/structure/fans/tiny,
+/obj/effect/decal/warning_stripes/south,
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/station/supply/miningdock)
 "bGH" = (
@@ -15498,6 +16189,16 @@
 	icon_state = "whitepurple"
 	},
 /area/station/science/genetics)
+"bHB" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/external/glass{
+	id_tag = "mining_home";
+	name = "Mining Dock Airlock";
+	locked = 1
+	},
+/obj/effect/mapping_helpers/airlock/access/all/supply/mining,
+/turf/simulated/floor/plating,
+/area/station/supply/miningdock)
 "bHD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -15596,6 +16297,16 @@
 	},
 /area/station/engineering/atmos)
 "bIi" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/engineering/atmos)
+"bIj" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Atmospherics Storage"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -15734,6 +16445,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
+/area/station/medical/medbay)
+"bIP" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "MedbayFoyer";
+	name = "Medical Supplies"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel/white,
 /area/station/medical/medbay)
 "bIQ" = (
 /obj/effect/spawner/window/reinforced,
@@ -16093,6 +16814,46 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/gravitygenerator)
+"bKV" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/reinforced/normal{
+	name = "Secure Armory";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/security/armory{
+	dir = 4
+	},
+/obj/machinery/door/window/reinforced/normal{
+	dir = 8;
+	name = "Secure Armory"
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/security/general{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/security/armory/secure)
+"bKZ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/airlock/medical/glass{
+	name = "Staff Room"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/station/medical/break_room)
 "bLa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -16280,6 +17041,18 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/service/library)
+"bLO" = (
+/obj/machinery/door/window/classic/reversed{
+	dir = 1;
+	name = "Interior Pipe Access"
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/engineering/atmos{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/engineering/atmos)
 "bLQ" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1;
@@ -16436,6 +17209,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/starboard/south)
+"bMx" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance/external{
+	name = "External Airlock Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/starboard)
 "bMy" = (
 /obj/structure/table/wood,
 /obj/structure/railing{
@@ -16550,15 +17336,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
-"bMZ" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Aft Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plating,
-/area/station/maintenance/apmaint)
 "bNf" = (
 /obj/structure/chair/office/dark,
 /obj/effect/landmark/start/librarian,
@@ -16583,6 +17360,18 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet/black,
+/area/station/command/bridge)
+"bNj" = (
+/obj/machinery/door/window/classic/normal{
+	dir = 1;
+	name = "Bridge Desk"
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/command/general{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "rampbottom"
+	},
 /area/station/command/bridge)
 "bNl" = (
 /turf/simulated/floor/engine{
@@ -17303,6 +18092,16 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/processing)
+"bQe" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/research{
+	name = "Research Division Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/research,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel/white,
+/area/station/science/rnd)
 "bQg" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
@@ -18662,6 +19461,27 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
+"bVw" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/window/classic/reversed{
+	dir = 1;
+	name = "Interior Pipe Access"
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/engineering/atmos{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/engineering/atmos)
 "bVx" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/trinary/filter{
@@ -19230,13 +20050,6 @@
 	icon_state = "dark"
 	},
 /area/station/command/bridge)
-"bXN" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Port Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating/asteroid/ancient,
-/area/station/maintenance/gambling_den)
 "bYc" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/engine/co2,
@@ -19611,6 +20424,23 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
+/area/station/supply/miningdock)
+"cbN" = (
+/obj/machinery/door/airlock/mining{
+	name = "Mining Dock"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/supply/mining,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
 /area/station/supply/miningdock)
 "cbP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -20334,27 +21164,6 @@
 /obj/machinery/ai_status_display,
 /turf/simulated/wall/r_wall,
 /area/station/security/processing)
-"cgd" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance/external{
-	name = "External Airlock Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
-	icon_state = "space";
-	layer = 4;
-	name = "EXTERNAL AIRLOCK";
-	pixel_x = -32
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/port2)
 "cge" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -20372,6 +21181,29 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/fore2)
+"cgh" = (
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "BrigRight";
+	name = "Brig Foyer Right Entrance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Secure Gate";
+	name = "Security Blast Door";
+	opacity = 0
+	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/security/brig)
 "cgi" = (
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -20796,6 +21628,18 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/aft/west)
+"ciy" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Command Asteroid Solars"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/auxsolarport)
 "ciB" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -20968,6 +21812,22 @@
 "cjR" = (
 /turf/simulated/wall,
 /area/station/public/quantum/security)
+"cjV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "researchlockdown";
+	layer = 2.6;
+	name = "Research Emergency Lockdown"
+	},
+/obj/machinery/door/airlock/research{
+	name = "Research Division Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/medical/genetics,
+/obj/effect/mapping_helpers/airlock/access/any/science/research,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel/white,
+/area/station/science/hallway)
 "cki" = (
 /obj/structure/chair/stool{
 	dir = 1
@@ -21111,21 +21971,6 @@
 	icon_state = "darkblue"
 	},
 /area/station/command/bridge)
-"ckM" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/airlock/maintenance/external{
-	name = "External Airlock Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry/north)
 "ckQ" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=ArrivalsMiddle";
@@ -21302,6 +22147,15 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/station/science/toxins/mixing)
+"clS" = (
+/obj/machinery/door/airlock/research{
+	name = "Toxins Storage"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/tox,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/corner,
+/turf/simulated/floor/plasteel,
+/area/station/science/storage)
 "clV" = (
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -21472,23 +22326,6 @@
 	},
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/station/maintenance/apmaint)
-"cnf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/mining/glass{
-	name = "Cargo Bay"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/supply/mail_sorting,
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "darkbrownfull"
-	},
-/area/station/supply/office)
 "cni" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 10
@@ -21761,6 +22598,21 @@
 	icon_state = "neutralfull"
 	},
 /area/station/turret_protected/aisat/interior)
+"coU" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Central Asteroid Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/turf/simulated/floor/plating,
+/area/station/maintenance/maintcentral)
 "coV" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -21791,6 +22643,22 @@
 "cpi" = (
 /obj/machinery/ai_status_display,
 /turf/simulated/wall,
+/area/station/command/bridge)
+"cpk" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "bridge";
+	layer = 2.6;
+	name = "Emergency Blast Door"
+	},
+/obj/machinery/door/airlock/command/glass{
+	name = "Bridge"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/station/command/bridge)
 "cpm" = (
 /obj/structure/railing{
@@ -21925,6 +22793,14 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/south)
+"cpO" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Port Asteroid Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/theatre,
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/turf/simulated/floor/plating,
+/area/station/maintenance/port)
 "cpQ" = (
 /obj/structure/closet/firecloset/full,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -22143,6 +23019,27 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/fsmaint)
+"crd" = (
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "BrigEast";
+	name = "Brig East Entrance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/machinery/door/firedoor,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/security/prison/cell_block/A)
 "crh" = (
 /obj/structure/table,
 /obj/machinery/alarm{
@@ -22459,6 +23356,13 @@
 	icon_state = "white"
 	},
 /area/station/science/misc_lab)
+"ctU" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Port Asteroid Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating/asteroid/ancient,
+/area/station/maintenance/fpmaint)
 "ctV" = (
 /obj/structure/sign/xenobio{
 	pixel_x = 32
@@ -22486,14 +23390,6 @@
 	},
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/station/maintenance/fpmaint)
-"cuh" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Port Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/service/theatre,
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plating,
-/area/station/maintenance/port)
 "cuk" = (
 /obj/item/radio/intercom{
 	pixel_y = 28;
@@ -22956,6 +23852,23 @@
 /obj/effect/spawner/lootdrop/maintenance/eight,
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/station/maintenance/apmaint)
+"cxl" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Aft Asteroid Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating{
+	icon_state = "asteroidplating"
+	},
+/area/station/maintenance/apmaint)
 "cxq" = (
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/stripes/line{
@@ -22980,6 +23893,21 @@
 /obj/structure/flora/ausbushes/reedbush,
 /turf/simulated/floor/grass,
 /area/station/service/hydroponics)
+"cxD" = (
+/obj/machinery/door/airlock{
+	name = "Crematorium"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/crematorium,
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/maintenance/port)
 "cxI" = (
 /obj/machinery/camera{
 	c_tag = "Service Atmospherics Checkpoint"
@@ -23047,6 +23975,35 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
+	},
+/turf/simulated/floor/engine,
+/area/station/science/explab/chamber)
+"cyl" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/door/window/classic/normal{
+	name = "Containment Pen";
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/science/tox{
+	dir = 8
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "telescienceblast";
+	name = "test chamber blast doors";
+	opacity = 0
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/engine,
 /area/station/science/explab/chamber)
@@ -23255,6 +24212,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
+"czM" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Aft Asteroid Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/apmaint)
 "czN" = (
 /obj/machinery/alarm{
 	pixel_y = 24;
@@ -23413,6 +24377,27 @@
 	icon_state = "darkbrown"
 	},
 /area/station/supply/office)
+"cAq" = (
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "BrigEast";
+	name = "Brig East Entrance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Secure Gate";
+	name = "Security Blast Door";
+	opacity = 0
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/security/prison/cell_block/A)
 "cAr" = (
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -23499,19 +24484,6 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/carpet/arcade,
 /area/station/public/arcade)
-"cAX" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance{
-	name = "Aft Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/disposal/south)
 "cAY" = (
 /obj/machinery/light_switch{
 	dir = 4;
@@ -23714,17 +24686,6 @@
 "cCw" = (
 /turf/simulated/floor/engine,
 /area/station/science/test_chamber)
-"cCx" = (
-/obj/machinery/door/window/classic/normal{
-	name = "Monkey Pen";
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/medical/genetics{
-	dir = 8
-	},
-/mob/living/carbon/human/monkey,
-/turf/simulated/floor/grass,
-/area/station/science/genetics)
 "cCB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment{
@@ -24316,18 +25277,6 @@
 	},
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/pod_2)
-"cFO" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Dorm SMES Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore2)
 "cFP" = (
 /obj/machinery/atmospherics/portable/canister/toxins,
 /turf/simulated/floor/plasteel{
@@ -24409,6 +25358,23 @@
 "cGd" = (
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/apmaint)
+"cGh" = (
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Secure Gate";
+	name = "Security Blast Door";
+	opacity = 0
+	},
+/obj/machinery/door/airlock/security/glass{
+	name = "General Population Cell"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/security/prison/cell_block/A)
 "cGn" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
@@ -24445,6 +25411,17 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/station/medical/medbay)
+"cGv" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Bar"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/turf/simulated/floor/plating,
+/area/station/maintenance/gambling_den)
 "cGw" = (
 /obj/structure/disposalpipe/segment,
 /obj/item/radio/intercom{
@@ -24507,6 +25484,15 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/command/office/hop)
+"cGN" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance Drone Dispensary"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/station/maintenance/storage)
 "cGP" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
@@ -24730,6 +25716,17 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/public/locker)
+"cHZ" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/command{
+	name = "Head of Personnel"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/hop,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/wood,
+/area/station/command/office/hop)
 "cIc" = (
 /obj/structure/chair/stool{
 	dir = 8
@@ -25340,6 +26337,14 @@
 /obj/structure/filingcabinet,
 /turf/simulated/floor/wood,
 /area/station/legal/magistrate)
+"cKZ" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating{
+	icon_state = "asteroidplating"
+	},
+/area/station/maintenance/fore2)
 "cLa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -25356,20 +26361,6 @@
 /obj/structure/closet/secure_closet/iaa,
 /turf/simulated/floor/carpet,
 /area/station/legal/lawoffice)
-"cLc" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock{
-	name = "Bar Office"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/service/bar,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/station/service/bar)
 "cLe" = (
 /obj/structure/cable/orange{
 	d1 = 2;
@@ -25439,6 +26430,16 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/fore2)
+"cLx" = (
+/obj/machinery/door/airlock/external{
+	id_tag = "supply_home";
+	locked = 1;
+	name = "Cargo Docking Hatch"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/supply/general,
+/obj/structure/fans/tiny,
+/turf/simulated/floor/plating,
+/area/station/supply/office)
 "cLz" = (
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -25532,6 +26533,27 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/command/office/hop)
+"cMa" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "bridge";
+	layer = 2.6;
+	name = "Emergency Blast Door"
+	},
+/obj/machinery/door/airlock/command/glass{
+	name = "Bridge Foyer"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/command/general,
+/obj/effect/mapping_helpers/airlock/access/any/supply/qm,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "bridge"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "darkblue"
+	},
+/area/station/command/bridge)
 "cMb" = (
 /obj/effect/spawner/window/reinforced/polarized{
 	id = "Magistrate"
@@ -25547,6 +26569,27 @@
 	icon_state = "dark"
 	},
 /area/station/supply/office)
+"cMm" = (
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "bridge";
+	layer = 2.6;
+	name = "Emergency Blast Door"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/command/glass{
+	name = "Bridge Foyer"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/command/general,
+/obj/effect/mapping_helpers/airlock/access/any/supply/qm,
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "bridge"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkblue"
+	},
+/area/station/command/bridge)
 "cMn" = (
 /obj/structure/chair{
 	dir = 8
@@ -25764,6 +26807,34 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/command/office/hop)
+"cNd" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Port Asteroid Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating{
+	icon_state = "asteroidplating"
+	},
+/area/station/maintenance/port)
+"cNe" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Port Asteroid Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating{
+	icon_state = "asteroidplating"
+	},
+/area/station/maintenance/port)
 "cNg" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/baguette,
@@ -26053,21 +27124,6 @@
 	icon_state = "whitebluecorner"
 	},
 /area/station/medical/surgery/primary)
-"cOx" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Medbay Reception"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Biohazard_medi";
-	name = "Quarantine Lockdown";
-	opacity = 0
-	},
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/medbay)
 "cOz" = (
 /obj/structure/shuttle/engine/propulsion/burst{
 	dir = 4
@@ -26412,6 +27468,18 @@
 	icon_state = "neutralfull"
 	},
 /area/station/public/locker)
+"cPX" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Science SMES Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/apmaint)
 "cQa" = (
 /obj/effect/landmark/start/engineer,
 /turf/simulated/floor/plasteel{
@@ -26452,6 +27520,32 @@
 "cQl" = (
 /turf/simulated/wall,
 /area/station/engineering/atmos/control)
+"cQn" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/door/airlock/command/glass{
+	id_tag = "ceofficedoor";
+	name = "Chief Engineer"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/ce,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 2;
+	id_tag = "ceoffice"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel,
+/area/station/command/office/ce)
 "cQp" = (
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
@@ -26719,21 +27813,6 @@
 "cRz" = (
 /turf/simulated/floor/plating,
 /area/station/service/clown/secret)
-"cRF" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/airlock/maintenance/external{
-	name = "External Airlock Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/hallway/primary/central)
 "cRH" = (
 /obj/structure/table,
 /turf/simulated/floor/plating,
@@ -26802,6 +27881,14 @@
 	},
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/station/maintenance/fore)
+"cRV" = (
+/obj/structure/barricade/wooden,
+/obj/machinery/door/airlock/maintenance{
+	name = "Aft Asteroid Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/hallway/primary/aft/west)
 "cRZ" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -27339,10 +28426,36 @@
 	icon_state = "neutralfull"
 	},
 /area/station/public/locker)
+"cTN" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Port Asteroid Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/disposal/westalt)
 "cTO" = (
 /obj/machinery/ai_status_display,
 /turf/simulated/wall/r_wall,
 /area/station/command/office/hop)
+"cTZ" = (
+/obj/machinery/door/airlock/medical{
+	name = "Operating Theatre Storage"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "showroomfloor"
+	},
+/area/station/medical/surgery/primary)
 "cUa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -27375,6 +28488,14 @@
 	icon_state = "darkblue"
 	},
 /area/station/command/bridge)
+"cUg" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Central Asteroid Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/turf/simulated/floor/plating,
+/area/station/maintenance/storage)
 "cUj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
 /turf/simulated/floor/plating,
@@ -27483,6 +28604,24 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore2)
+"cUB" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Central Asteroid Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/storage)
 "cUE" = (
 /obj/machinery/atmospherics/portable/canister/oxygen,
 /obj/machinery/atmospherics/unary/portables_connector{
@@ -27683,6 +28822,27 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/turbine)
+"cVe" = (
+/obj/machinery/door/airlock/public/glass{
+	autoclose = 0;
+	heat_proof = 1;
+	id_tag = "turbine_door_int";
+	locked = 1;
+	name = "Turbine Interior Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/construction,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/access_button{
+	autolink_id = "turbine_btn_int";
+	name = "Gas Turbine Airlock Control";
+	pixel_x = 24
+	},
+/turf/simulated/floor/engine,
+/area/station/maintenance/turbine)
 "cVf" = (
 /obj/machinery/atmospherics/pipe/simple/visible/purple,
 /turf/simulated/wall/r_wall,
@@ -27725,6 +28885,28 @@
 /obj/machinery/atmospherics/pipe/simple/visible/purple,
 /turf/space,
 /area/space/nearstation)
+"cVl" = (
+/obj/machinery/door/airlock/public/glass{
+	autoclose = 0;
+	heat_proof = 1;
+	id_tag = "turbine_door_ext";
+	locked = 1;
+	name = "Turbine Exterior Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/construction,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/access_button{
+	layer = 3.1;
+	autolink_id = "turbine_btn_ext";
+	name = "Gas Turbine Airlock Control";
+	pixel_x = -24
+	},
+/turf/simulated/floor/engine,
+/area/station/maintenance/turbine)
 "cVm" = (
 /obj/machinery/door/poddoor{
 	id_tag = "auxincineratorvent";
@@ -27781,6 +28963,12 @@
 /obj/structure/cable/yellow,
 /turf/simulated/floor/engine/vacuum,
 /area/station/maintenance/turbine)
+"cVt" = (
+/obj/machinery/atmospherics/unary/outlet_injector/on{
+	dir = 1
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/maintenance/turbine)
 "cVu" = (
 /obj/structure/sign/fire,
 /turf/simulated/wall/r_wall,
@@ -27830,16 +29018,6 @@
 	icon_state = "floorgrime"
 	},
 /area/station/security/permabrig)
-"cVW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/engineering/glass{
-	heat_proof = 1;
-	name = "Supermatter Chamber"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
-/turf/simulated/floor/engine,
-/area/station/engineering/engine/supermatter)
 "cVX" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -27848,6 +29026,30 @@
 	},
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/station/maintenance/fore)
+"cWb" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/door/airlock/command/glass{
+	id_tag = "ceofficedoor";
+	name = "Chief Engineer"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/ce,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 2;
+	id_tag = "ceoffice"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/universal,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel,
+/area/station/command/office/ce)
 "cWg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -28365,19 +29567,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/hallway/spacebridge/scidock)
-"cZZ" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Security Office"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	icon_state = "darkredfull"
-	},
-/area/station/security/checkpoint/secondary)
 "daf" = (
 /obj/item/reagent_containers/glass/beaker/large{
 	pixel_x = 9;
@@ -28595,6 +29784,19 @@
 	icon_state = "cult"
 	},
 /area/station/legal/lawoffice)
+"ddh" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Service SMES Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/turf/simulated/floor/plating,
+/area/station/maintenance/port)
 "ddk" = (
 /obj/structure/cable/orange{
 	d1 = 4;
@@ -28828,6 +30030,28 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/atmos)
+"ddO" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green,
+/obj/machinery/atmospherics/binary/pump{
+	dir = 4;
+	name = "N2 to Pure"
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/door/window/classic/reversed{
+	name = "Interior Pipe Access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/engineering/atmos{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/engineering/atmos)
 "ddP" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/machinery/firealarm{
@@ -28926,6 +30150,28 @@
 	dir = 8
 	},
 /area/station/engineering/atmos)
+"deh" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green,
+/obj/machinery/atmospherics/binary/pump{
+	dir = 4;
+	name = "O2 to Pure"
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/door/window/classic/reversed{
+	name = "Interior Pipe Access";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/engineering/atmos{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/engineering/atmos)
 "dej" = (
 /obj/machinery/atmospherics/unary/thermomachine/freezer,
 /obj/machinery/light{
@@ -29013,6 +30259,31 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/atmos/distribution)
+"dex" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/window/classic/reversed{
+	dir = 1;
+	name = "Interior Pipe Access"
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/engineering/atmos{
+	dir = 1
+	},
+/obj/machinery/atmospherics/binary/pump{
+	dir = 1;
+	name = "Air to South Canister"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/engineering/atmos)
 "dey" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
@@ -29197,6 +30468,17 @@
 "dgg" = (
 /turf/simulated/floor/wood,
 /area/station/service/clown)
+"dgl" = (
+/obj/machinery/door/airlock/mining/glass{
+	name = "Cargo Office"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/supply/mail_sorting,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel{
+	icon_state = "darkbrownfull"
+	},
+/area/station/supply/office)
 "dgr" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -29281,6 +30563,23 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/service/clown/secret)
+"dgX" = (
+/obj/machinery/door/airlock/engineering{
+	name = "SMES Room"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	icon_state = "darkyellowfull"
+	},
+/area/station/engineering/smes)
 "dgZ" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "redcorner"
@@ -30148,6 +31447,18 @@
 	icon_state = "white"
 	},
 /area/station/science/toxins/mixing)
+"dmC" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Command SMES Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "dmK" = (
 /obj/machinery/hydroponics/constructable{
 	desc = "These are connected with an irrigation tube. You see a little pipe connecting the trays.";
@@ -30217,6 +31528,20 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/fore/east)
+"dmY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/maintenance/external{
+	name = "External Airlock Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/station/hallway/primary/fore)
 "dnb" = (
 /obj/machinery/status_display{
 	layer = 4
@@ -30248,14 +31573,6 @@
 	icon_state = "dark"
 	},
 /area/station/security/brig)
-"dnp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/maintenance/external{
-	name = "External Airlock Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/fore)
 "dnw" = (
 /obj/structure/chair{
 	dir = 1
@@ -30406,6 +31723,21 @@
 	icon_state = "dark"
 	},
 /area/station/security/execution)
+"doO" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Security SMES Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fpmaint)
 "doR" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -30443,6 +31775,19 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/prisonershuttle)
+"dph" = (
+/obj/machinery/door/airlock/security{
+	aiControlDisabled = 1;
+	name = "Deluxe Prisoner 'Transfer' Lounge";
+	security_level = 1
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/structure/fans/tiny,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/security/execution)
 "dpl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
@@ -30866,6 +32211,29 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/station/security/prisonershuttle)
+"drz" = (
+/obj/machinery/door/airlock/security{
+	aiControlDisabled = 1;
+	name = "Prisoner 'Transfer' Lounge";
+	security_level = 1
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/door/firedoor,
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/security/execution)
 "drA" = (
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -30964,20 +32332,6 @@
 	icon_state = "redcorner"
 	},
 /area/station/hallway/primary/fore/west)
-"drP" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Fore Asteroid Maintenance Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
 "dsc" = (
 /obj/structure/bookcase/random,
 /turf/simulated/floor/wood,
@@ -31605,6 +32959,14 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/carpet/green,
 /area/station/service/library)
+"dvt" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Security Office"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel,
+/area/station/security/main)
 "dvD" = (
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -31695,28 +33057,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/station/maintenance/asmaint)
-"dvU" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "engineeringlockdown";
-	layer = 2.6;
-	name = "Emergency Lockdown Blastdoor"
-	},
-/obj/machinery/door/airlock/engineering{
-	name = "Engineering Foyer"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel{
-	icon_state = "darkyellowfull"
-	},
-/area/station/engineering/break_room)
 "dvV" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "bcircuit"
@@ -31903,27 +33243,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
-"dxh" = (
-/obj/machinery/navbeacon{
-	codes_txt = "delivery";
-	location = "Janitor"
-	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/machinery/door/window/classic/reversed{
-	dir = 1;
-	name = "Janitor Delivery"
-	},
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/mule_bot{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/service/janitor{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/station/service/janitor)
 "dxj" = (
 /obj/structure/cable/orange{
 	d1 = 4;
@@ -32333,6 +33652,17 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/reception)
+"dzc" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Laser Room"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/engineering/control)
 "dzd" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -32459,6 +33789,31 @@
 	},
 /turf/simulated/wall,
 /area/station/maintenance/starboard)
+"dzN" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/airlock/medical/glass{
+	name = "Isolation B"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/station/medical/virology)
 "dzP" = (
 /obj/structure/table,
 /obj/machinery/kitchen_machine/microwave,
@@ -32552,6 +33907,37 @@
 	icon_state = "white"
 	},
 /area/station/medical/medbay)
+"dAf" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/virology{
+	autoclose = 0;
+	id_tag = "viro_door_ext";
+	locked = 1;
+	name = "Virology Lab External Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/access_button{
+	layer = 3.6;
+	autolink_id = "viro_btn_ext";
+	name = "Virology Lab Access Button";
+	req_access_txt = "39";
+	pixel_y = -24
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "whitegreenfull"
+	},
+/area/station/medical/virology)
 "dAg" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -33054,16 +34440,6 @@
 /obj/item/multitool,
 /turf/simulated/floor/plating,
 /area/station/engineering/tech_storage)
-"dDa" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/universal{
-	dir = 4
-	},
-/obj/machinery/door/airlock/atmos{
-	name = "Service Atmospherics Checkpoint"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/turf/simulated/floor/plating,
-/area/station/maintenance/port2)
 "dDB" = (
 /obj/effect/spawner/random_spawners/wall_rusted_always,
 /turf/simulated/wall,
@@ -33192,6 +34568,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
+"dFf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/plating/airless{
+	icon_state = "asteroidplating"
+	},
+/area/station/hallway/spacebridge/servsci)
 "dFU" = (
 /obj/structure/table,
 /obj/machinery/recharger,
@@ -33206,15 +34591,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/processing)
-"dFZ" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Aft Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plating,
-/area/station/maintenance/asmaint)
 "dGr" = (
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 2;
@@ -33293,22 +34669,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/service/bar)
-"dHj" = (
-/obj/machinery/disposal/deliveryChute{
-	dir = 4
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/door/window/classic/reversed{
-	name = "Mail Chute";
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/general{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/disposal)
 "dHk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -33432,6 +34792,19 @@
 /obj/structure/dispenser/oxygen,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry/north)
+"dJG" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Aft Asteroid Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/turf/simulated/floor/plating,
+/area/station/maintenance/asmaint)
 "dKi" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -33597,6 +34970,21 @@
 	icon_state = "darkblue"
 	},
 /area/station/command/bridge)
+"dMd" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/bananium{
+	name = "Clown's Office"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/theatre,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood,
+/area/station/service/clown)
 "dMk" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -33839,20 +35227,6 @@
 /obj/effect/spawner/random_spawners/dirt_often,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry/north)
-"dPl" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Port Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating{
-	icon_state = "asteroidplating"
-	},
-/area/station/maintenance/port)
 "dPq" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -33996,6 +35370,19 @@
 	icon_state = "bluered"
 	},
 /area/station/hallway/secondary/entry/south)
+"dQR" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Aft Asteroid Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/turf/simulated/floor/plating,
+/area/station/maintenance/asmaint)
 "dQT" = (
 /obj/machinery/camera{
 	c_tag = "Research Toxins Test Chamber North";
@@ -34107,23 +35494,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/service/hydroponics)
-"dSC" = (
-/obj/machinery/door/airlock/hatch{
-	name = "AI Satellite Secondary Antechamber"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel{
-	icon_state = "bcircuit"
-	},
-/area/station/turret_protected/ai)
 "dSD" = (
 /obj/machinery/flasher{
 	id = "Cell 4";
@@ -34312,23 +35682,28 @@
 	slowdown = -0.3
 	},
 /area/station/hallway/spacebridge/scidock)
-"dVw" = (
-/obj/machinery/door/airlock/engineering/glass{
-	autoclose = 0;
-	id_tag = "engsm_door_ext";
-	locked = 1;
-	name = "Supermatter Exterior Access"
+"dVv" = (
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "BrigRight";
+	name = "Brig Foyer Right Entrance"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Secure Gate";
+	name = "Security Blast Door";
+	opacity = 0
+	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/station/engineering/control)
+/area/station/security/brig)
 "dVA" = (
 /obj/effect/spawner/airlock/s_to_n,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -34349,67 +35724,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/apmaint)
-"dVV" = (
-/obj/structure/cable/orange{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "BrigEast";
-	name = "Brig East Entrance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 4
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Secure Gate";
-	name = "Security Blast Door";
-	opacity = 0
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkredcorners"
-	},
-/area/station/security/prison/cell_block/A)
-"dWd" = (
-/obj/structure/cable/orange{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Medbay Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Biohazard_medi";
-	name = "Quarantine Lockdown";
-	opacity = 0
-	},
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plating,
-/area/station/maintenance/starboard)
 "dWf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -34425,19 +35739,6 @@
 	icon_state = "dark"
 	},
 /area/station/security/prison/cell_block/A)
-"dWu" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Aft Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plating,
-/area/station/maintenance/asmaint)
 "dWE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -34540,28 +35841,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal/external/southeast)
-"dYx" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id_tag = "atmodesk"
-	},
-/obj/machinery/door/window/classic/reversed{
-	name = "Atmospherics Desk";
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/engineering/atmos{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "darkyellowfull"
-	},
-/area/station/engineering/atmos)
 "dYD" = (
 /obj/effect/spawner/random_spawners/fungus_maybe,
 /turf/simulated/wall,
@@ -34586,26 +35865,6 @@
 	icon_state = "white"
 	},
 /area/station/science/misc_lab)
-"eac" = (
-/obj/structure/cable/orange{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Aft Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating{
-	icon_state = "asteroidplating"
-	},
-/area/station/maintenance/apmaint)
 "eag" = (
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 1;
@@ -34677,17 +35936,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/security/prison/cell_block/A)
-"ebK" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Aft Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plating,
-/area/station/hallway/secondary/exit)
 "ebN" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
@@ -34716,6 +35964,19 @@
 	icon_state = "dark"
 	},
 /area/station/maintenance/disposal)
+"ecd" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/atmos{
+	name = "Docking Atmospherics Checkpoint"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry/north)
 "ecv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -34748,42 +36009,6 @@
 	icon_state = "darkbrowncorners"
 	},
 /area/station/supply/office)
-"edd" = (
-/obj/structure/cable/orange{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/orange{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command/glass{
-	id_tag = "hosofficedoor";
-	name = "Head of Security"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/hos,
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "hos"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/station/command/office/hos)
 "edn" = (
 /obj/machinery/door_control{
 	id = "paramedic";
@@ -34901,6 +36126,22 @@
 	},
 /turf/simulated/floor/carpet/black,
 /area/station/service/chapel)
+"efR" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 9
+	},
+/obj/machinery/power/apc{
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/cable/orange{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plasteel/dark/telecomms{
+	icon_state = "bcircuit"
+	},
+/area/station/science/server/coldroom)
 "efU" = (
 /obj/structure/railing,
 /turf/simulated/floor/plasteel{
@@ -34928,6 +36169,17 @@
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
+"egB" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance{
+	name = "Morgue"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/morgue,
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/maintenance/starboard)
 "ehd" = (
 /obj/effect/spawner/random_spawners/wall_rusted_always,
 /turf/simulated/wall,
@@ -35126,6 +36378,30 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/science/explab/chamber)
+"ekV" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/door/airlock/medical/glass{
+	name = "Monkey Pen"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/station/medical/virology)
 "elJ" = (
 /obj/structure/cable/orange{
 	d1 = 4;
@@ -35168,31 +36444,6 @@
 	},
 /turf/simulated/floor/plasteel/dark/telecomms,
 /area/station/science/server)
-"emE" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Permabrig Cell 2";
-	security_level = 1
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/obj/machinery/door/firedoor,
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Prison Gate";
-	name = "Prison Lockdown Blast Doors";
-	opacity = 0
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/security/permabrig)
 "emI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -35232,20 +36483,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore2)
-"enq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/maintenance/external{
-	name = "External Airlock Access"
+"emS" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Fore Asteroid Maintenance Access"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/spawner/random_spawners/dirt_frequent,
 /turf/simulated/floor/plating,
-/area/station/hallway/primary/fore)
+/area/station/maintenance/fore2)
 "enw" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/classic/normal{
@@ -35464,6 +36712,28 @@
 	icon_state = "showroomfloor"
 	},
 /area/station/medical/surgery)
+"erl" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance/external{
+	name = "External Airlock Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/turf/simulated/floor/plating,
+/area/station/hallway/primary/starboard/south)
 "erm" = (
 /obj/structure/table,
 /obj/item/stack/sheet/mineral/plasma,
@@ -35488,18 +36758,6 @@
 "erB" = (
 /turf/simulated/mineral/ancient/outer,
 /area/station/maintenance/disposal)
-"erU" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Port Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/cable/orange{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/disposal/westalt)
 "esB" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
@@ -35511,6 +36769,22 @@
 /obj/item/storage/bible,
 /turf/simulated/floor/carpet/red,
 /area/station/service/chapel)
+"esX" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Port Asteroid Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/station/maintenance/disposal/west)
 "etb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -35591,15 +36865,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/service/clown)
-"eut" = (
-/obj/machinery/door/airlock/command{
-	name = "Expedition Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/command/expedition,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/ai_monitored/storage/eva)
 "eux" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plating/asteroid/ancient,
@@ -35744,14 +37009,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore/west)
-"exF" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance{
-	name = "Port Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/port)
 "exK" = (
 /turf/simulated/wall,
 /area/station/security/processing)
@@ -35808,6 +37065,18 @@
 	slowdown = -0.3
 	},
 /area/station/hallway/spacebridge/comeng)
+"ezi" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/maintenance/external{
+	name = "External Airlock Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/hallway/primary/port/north)
 "ezq" = (
 /obj/effect/spawner/window/reinforced/polarized{
 	id = "bar"
@@ -35817,6 +37086,32 @@
 "ezu" = (
 /turf/simulated/wall,
 /area/station/service/mime)
+"ezE" = (
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "cell2";
+	name = "Permabrig Cell 2";
+	security_level = 1
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/machinery/door/firedoor,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Prison Gate";
+	name = "Prison Lockdown Blast Doors";
+	opacity = 0
+	},
+/obj/effect/mapping_helpers/airlock/unres,
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/turf/simulated/floor/plasteel,
+/area/station/security/permabrig)
 "ezU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/wall,
@@ -36097,17 +37392,6 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/medbay)
-"eFa" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Equipment Storage"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "red"
-	},
-/area/station/security/storage)
 "eFm" = (
 /obj/machinery/status_display{
 	layer = 4
@@ -36131,16 +37415,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
-"eFR" = (
-/obj/machinery/door/window/classic/reversed{
-	dir = 4;
-	pixel_x = 1;
-	name = "Boxing Arena"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/public/fitness)
 "eGe" = (
 /obj/structure/table,
 /obj/item/soap,
@@ -36153,6 +37427,16 @@
 "eGr" = (
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
+"eGv" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Aft Asteroid Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/tox,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/turf/simulated/floor/plating,
+/area/station/maintenance/apmaint)
 "eGS" = (
 /obj/machinery/power/apc{
 	name = "south bump";
@@ -36367,18 +37651,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/fore)
-"eJW" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Bridge APC Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/cable/orange{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore2)
 "eKf" = (
 /obj/structure/cable/orange{
 	d1 = 4;
@@ -36388,22 +37660,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
-"eKk" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 8;
-	id_tag = "kitchen1"
-	},
-/obj/machinery/door/window/classic/normal{
-	dir = 4;
-	name = "Kitchen"
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/service/kitchen{
-	dir = 4
-	},
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/service/kitchen)
 "eKx" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -36534,6 +37790,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarport)
+"eMW" = (
+/obj/machinery/door/window/classic/reversed{
+	dir = 4;
+	pixel_x = 1;
+	name = "Boxing Arena"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/public/fitness)
 "eMX" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5
@@ -36694,19 +37960,6 @@
 /obj/effect/spawner/airlock/w_to_e/long,
 /turf/simulated/wall,
 /area/station/maintenance/apmaint)
-"eRc" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 1;
-	id_tag = "kitchen2"
-	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Kitchen"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/station/service/kitchen)
 "eRT" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -36795,16 +38048,6 @@
 	},
 /turf/simulated/floor/carpet/green,
 /area/station/service/library)
-"eTt" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Starboard Asteroid Maintenance Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/starboard)
 "eTA" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -36847,19 +38090,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
-"eUi" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/maintenance/external{
-	name = "External Airlock Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/starboard)
 "eUo" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -37148,23 +38378,22 @@
 /obj/item/lighter/zippo/black,
 /turf/simulated/floor/carpet/black,
 /area/station/service/chapel)
-"fax" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/command/glass{
-	name = "E.V.A."
+"fav" = (
+/obj/machinery/door/airlock{
+	name = "Theatre Backstage"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/command/eva,
+/obj/effect/mapping_helpers/airlock/access/all/service/theatre,
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "bar"
 	},
-/area/station/ai_monitored/storage/eva)
+/area/station/service/theatre)
 "faF" = (
 /obj/structure/rack,
 /obj/item/aicard,
@@ -37283,6 +38512,19 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/gambling_den)
+"fdh" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Service SMES Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/turf/simulated/floor/plating,
+/area/station/maintenance/port)
 "fdk" = (
 /obj/structure/noticeboard{
 	dir = 8;
@@ -37408,28 +38650,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/north)
-"ffp" = (
-/obj/machinery/navbeacon{
-	codes_txt = "delivery";
-	dir = 4;
-	location = "Bar"
-	},
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/machinery/door/window/classic/reversed{
-	dir = 8;
-	name = "Bar Delivery"
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/mule_bot{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/service/bar{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/station/service/bar)
 "ffy" = (
 /obj/machinery/atmospherics/portable/canister/carbon_dioxide,
 /turf/simulated/floor/plasteel{
@@ -37455,13 +38675,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/xenobiology)
-"fgw" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Port Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating/asteroid/ancient,
-/area/station/maintenance/fpmaint)
 "fgS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -37518,19 +38731,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/spacebridge/sercom)
-"fit" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Security Office"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "red"
-	},
-/area/station/security/main)
 "fiK" = (
 /turf/simulated/mineral/ancient/outer,
 /area/station/maintenance/disposal/west)
@@ -37625,18 +38825,14 @@
 "fkt" = (
 /turf/simulated/mineral/ancient,
 /area/station/service/bar)
-"fku" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+"fkw" = (
 /obj/machinery/door/airlock/maintenance{
-	name = "Command SMES Access"
+	name = "Starboard Asteroid Maintenance Access"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/spawner/random_spawners/dirt_frequent,
 /turf/simulated/floor/plating,
-/area/station/maintenance/fore)
+/area/station/maintenance/starboard)
 "fkL" = (
 /obj/structure/disposalpipe/segment{
 	color = "#954535"
@@ -37665,19 +38861,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/science/toxins/launch)
-"flt" = (
-/obj/machinery/door/airlock/glass{
-	name = "Magistrate's Office";
-	id_tag = "magistrateofficedoor"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/command/magistrate,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "Magistrate"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/wood,
-/area/station/legal/magistrate)
 "flF" = (
 /obj/effect/spawner/random_spawners/wall_rusted_always,
 /turf/simulated/wall/r_wall,
@@ -37721,20 +38904,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/prison/cell_block/A)
-"fmC" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Genetics Cloning"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/medical/general,
-/obj/effect/mapping_helpers/airlock/access/any/medical/genetics,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull"
-	},
-/area/station/medical/cloning)
 "fmI" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -37790,6 +38959,14 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/starboard/north)
+"fnN" = (
+/obj/machinery/door/airlock/freezer{
+	name = "Freezer"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel/freezer,
+/area/station/service/kitchen)
 "fob" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
@@ -37857,20 +39034,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/port/south)
-"fpJ" = (
-/obj/machinery/door/airlock/maintenance/external{
-	name = "External Airlock Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/hallway/primary/port/east)
 "fpM" = (
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -37955,6 +39118,23 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/apmaint)
+"frS" = (
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Secure Gate";
+	name = "Security Blast Door";
+	opacity = 0
+	},
+/obj/machinery/door/airlock/glass{
+	name = "Courtroom"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "Courtroom"
+	},
+/turf/simulated/floor/carpet,
+/area/station/security/processing)
 "frV" = (
 /obj/structure/closet/crate,
 /obj/item/coin/silver,
@@ -38134,6 +39314,27 @@
 	icon_state = "white"
 	},
 /area/station/science/misc_lab)
+"fvb" = (
+/obj/structure/table/reinforced,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/window/reinforced/reversed{
+	name = "Arrival Security Checkpoint";
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/security/doors{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel,
+/area/station/security/checkpoint/secondary)
+"fvg" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Aft Asteroid Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/exit)
 "fvk" = (
 /obj/structure/cable/orange{
 	d1 = 4;
@@ -38214,49 +39415,26 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal/east)
-"fwO" = (
-/obj/structure/cable/orange{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"fwJ" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock{
+	name = "Bar Office"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/bar,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/research{
-	name = "Toxins Mixing Room"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/science/tox,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "whitepurplefull"
-	},
-/area/station/science/toxins/mixing)
+/turf/simulated/floor/wood,
+/area/station/service/bar)
 "fxg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
 /turf/simulated/wall,
 /area/station/hallway/primary/aft/west)
-"fxl" = (
-/obj/structure/table/reinforced,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/window/reinforced/reversed{
-	name = "Arrival Security Checkpoint";
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/security/doors{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/security/checkpoint/secondary)
 "fxo" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -38344,16 +39522,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/port/north)
-"fyM" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Service Atmospherics Checkpoint"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/machinery/atmospherics/pipe/simple/hidden/universal{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/port2)
 "fyR" = (
 /obj/structure/closet/secure_closet/roboticist,
 /obj/item/radio/intercom{
@@ -38477,18 +39645,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/service/library)
-"fCJ" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Fore Asteroid Solars"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/cable/orange{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/auxsolarstarboard)
 "fDg" = (
 /obj/structure/girder,
 /obj/structure/grille,
@@ -38526,14 +39682,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
-"fDF" = (
-/obj/machinery/door/airlock/freezer{
-	name = "Freezer"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/freezer,
-/area/station/service/hydroponics)
 "fDQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -38558,19 +39706,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/port/north)
-"fEf" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance{
-	name = "Fore Asteroid Maintenance Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/disposal/north)
 "fEm" = (
 /obj/structure/girder,
 /obj/structure/grille,
@@ -38681,17 +39816,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/command/office/rd)
-"fFG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock{
-	name = "Vacant Office"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/station/public/vacant_office)
 "fFH" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -38837,6 +39961,16 @@
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/command/office/ntrep)
+"fIe" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/mining{
+	name = "Cargo Warehouse"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/supply/general,
+/turf/simulated/floor/plasteel{
+	icon_state = "darkbrownfull"
+	},
+/area/station/supply/storage)
 "fIg" = (
 /turf/simulated/wall/r_wall,
 /area/station/hallway/primary/fore/west)
@@ -38846,14 +39980,6 @@
 	},
 /turf/simulated/floor/plasteel/dark/telecomms,
 /area/station/science/server/coldroom)
-"fIz" = (
-/obj/machinery/door/airlock{
-	name = "Magistrate's Office"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/command/magistrate,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/wood,
-/area/station/legal/lawoffice)
 "fID" = (
 /turf/simulated/wall,
 /area/station/maintenance/storage)
@@ -38932,24 +40058,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/hallway/secondary/exit)
-"fJT" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Central Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/storage)
 "fKo" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -28;
@@ -38965,19 +40073,6 @@
 	icon_state = "whitepurple"
 	},
 /area/station/science/genetics)
-"fKD" = (
-/obj/machinery/door/airlock/security{
-	aiControlDisabled = 1;
-	name = "Deluxe Prisoner 'Transfer' Lounge";
-	security_level = 1
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/structure/fans/tiny,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/security/execution)
 "fLp" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 2;
@@ -39037,6 +40132,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/prison/cell_block/A)
+"fMH" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Security SMES Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/primary/fore/west)
 "fMK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
@@ -39199,21 +40306,6 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/station/public/quantum/science)
-"fPt" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Aft Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/science/tox,
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plating,
-/area/station/science/misc_lab)
 "fPv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -39292,36 +40384,6 @@
 /obj/effect/spawner/random_spawners/dirt_often,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/aft/west)
-"fRg" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Permabrig Cell 3";
-	security_level = 1
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Prison Gate";
-	name = "Prison Lockdown Blast Doors";
-	opacity = 0
-	},
-/obj/structure/cable/orange{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/security/permabrig)
 "fRy" = (
 /obj/machinery/status_display{
 	layer = 4
@@ -39358,6 +40420,22 @@
 /obj/structure/lattice/catwalk,
 /turf/space,
 /area/station/engineering/solar/auxstarboard)
+"fRS" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Prison Wing";
+	security_level = 1
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/machinery/door/firedoor,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/security/permabrig)
 "fRZ" = (
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -39424,44 +40502,18 @@
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/security/prisonershuttle)
-"fSR" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass{
-	name = "Hydroponics"
+"fSQ" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Fore Asteroid Maintenance Access"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "darkgreenfull"
-	},
-/area/station/service/hydroponics)
-"fST" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "BrigRight";
-	name = "Brig Foyer Right Entrance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Secure Gate";
-	name = "Security Blast Door";
-	opacity = 0
-	},
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/security/brig)
+/turf/simulated/floor/plating,
+/area/station/hallway/primary/fore/west)
 "fTe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -39470,6 +40522,13 @@
 	icon_state = "cafeteria"
 	},
 /area/station/science/hallway)
+"fTn" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Fore Asteroid Maintenance Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/hallway/primary/fore/west)
 "fTu" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -39582,6 +40641,21 @@
 /obj/structure/sign/security,
 /turf/simulated/wall,
 /area/station/hallway/primary/fore/west)
+"fVe" = (
+/obj/machinery/door/airlock/vault{
+	locked = 1
+	},
+/obj/effect/mapping_helpers/airlock/access/all/supply/vault,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/fore/west)
 "fVo" = (
 /obj/structure/disposalpipe/segment{
 	color = "#954535"
@@ -39627,23 +40701,6 @@
 /obj/item/extinguisher,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry/north)
-"fWt" = (
-/obj/machinery/door/airlock/engineering{
-	name = "SMES Room"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	icon_state = "darkyellowfull"
-	},
-/area/station/engineering/smes)
 "fWA" = (
 /obj/structure/weightmachine/weightlifter,
 /obj/effect/landmark/start/assistant,
@@ -39653,6 +40710,14 @@
 	},
 /turf/simulated/floor/carpet/cyan,
 /area/station/public/fitness)
+"fWE" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Command Atmospherics Checkpoint"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/turf/simulated/floor/plating,
+/area/station/hallway/primary/fore)
 "fWQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -39680,6 +40745,19 @@
 	icon_state = "dark"
 	},
 /area/station/turret_protected/aisat/interior)
+"fXt" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/maintenance/external{
+	name = "External Airlock Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/hallway/primary/fore)
 "fXv" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -39708,6 +40786,32 @@
 	icon_state = "darkpurplecorners"
 	},
 /area/station/science/robotics)
+"fXS" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/command{
+	id_tag = "blueshieldofficedoor";
+	name = "Blueshield's Office"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/blueshield,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/wood,
+/area/station/command/office/blueshield)
 "fYb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -39895,6 +40999,14 @@
 	icon_state = "white"
 	},
 /area/station/medical/chemistry)
+"gaX" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Fore Asteroid Maintenance Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "gaZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -39910,20 +41022,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
-"gbp" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Criminal Delivery Chute"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/effect/turf_decal/stripes/full,
-/obj/effect/turf_decal/stripes/red/full,
-/obj/structure/disposalpipe/segment{
-	color = "#954535"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/primary/central)
 "gbF" = (
 /obj/structure/cable/orange{
 	d1 = 4;
@@ -39967,55 +41065,19 @@
 "gch" = (
 /turf/simulated/wall,
 /area/station/command/office/ntrep)
-"gcq" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Engine Room"
+"gck" = (
+/obj/machinery/door/airlock/glass{
+	name = "Courtroom"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "Courtroom"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	icon_state = "darkyellowfull"
-	},
-/area/station/engineering/control)
-"gcy" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/door/window/classic/reversed{
-	dir = 1;
-	name = "Interior Pipe Access"
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/engineering/atmos{
-	dir = 1
-	},
-/obj/machinery/atmospherics/binary/pump{
-	dir = 1;
-	name = "Air to South Canister"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/engineering/atmos)
+/turf/simulated/floor/wood,
+/area/station/legal/courtroom)
 "gcN" = (
 /obj/machinery/hydroponics/constructable{
 	desc = "These are connected with an irrigation tube. You see a little pipe connecting the trays.";
@@ -40039,6 +41101,32 @@
 	icon_state = "dark"
 	},
 /area/station/turret_protected/aisat/interior)
+"gcW" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/command{
+	id_tag = "ntrepofficedoor";
+	name = "NT Representative's Office"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/ntrep,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/wood,
+/area/station/command/office/ntrep)
 "gdn" = (
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
@@ -40099,18 +41187,6 @@
 	icon_state = "dark"
 	},
 /area/station/medical/morgue)
-"geC" = (
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Medbay SMES Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/turf/simulated/floor/plating,
-/area/station/hallway/primary/starboard/north)
 "geD" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -40126,6 +41202,14 @@
 /obj/effect/spawner/random_spawners/dirt_often,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/central)
+"gfd" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/maintenance/external{
+	name = "External Airlock Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/fore)
 "gfe" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
@@ -40227,13 +41311,6 @@
 /obj/effect/spawner/random_spawners/dirt_often,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/central)
-"ghn" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Fore Asteroid Maintenance Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fpmaint)
 "ghr" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -40253,6 +41330,14 @@
 "ghw" = (
 /obj/machinery/ai_status_display,
 /turf/simulated/wall,
+/area/station/maintenance/fsmaint)
+"ghF" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/obj/machinery/door/airlock/atmos{
+	name = "Cargo Atmospherics Checkpoint"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "ghP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -40343,29 +41428,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/starboard)
-"gjd" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/airlock/external/glass{
-	id_tag = "mining_home";
-	name = "Mining Dock Airlock";
-	locked = 1
-	},
-/obj/effect/mapping_helpers/airlock/access/all/supply/mining,
-/turf/simulated/floor/plating,
-/area/station/supply/miningdock)
-"gju" = (
-/obj/machinery/door/airlock{
-	name = "Bar Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/service/bar,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/station/service/bar)
 "gjD" = (
 /obj/machinery/camera{
 	c_tag = "Cloning South";
@@ -40389,6 +41451,22 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/atmos)
+"glm" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance{
+	name = "Port Asteroid Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/visible,
+/turf/simulated/floor/plating{
+	icon_state = "asteroidplating"
+	},
+/area/station/maintenance/gambling_den)
 "glw" = (
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -40476,21 +41554,6 @@
 /obj/structure/sign/security,
 /turf/simulated/wall/r_wall,
 /area/station/security/prison/cell_block/A)
-"gon" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/orange{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Starboard Asteroid Maintenance Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/disposal/east)
 "got" = (
 /obj/machinery/door/window/reinforced/normal{
 	name = "Server Exterior Door";
@@ -40529,6 +41592,22 @@
 /obj/item/storage/fancy/crayons,
 /turf/simulated/floor/plating,
 /area/station/service/clown/secret)
+"goP" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Port Asteroid Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/disposal/west)
 "goU" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
@@ -40689,16 +41768,16 @@
 	icon_state = "dark"
 	},
 /area/station/maintenance/fsmaint)
-"gtd" = (
-/obj/structure/barricade/wooden,
-/obj/machinery/door/airlock/maintenance{
-	name = "Port Asteroid Maintenance"
+"gsS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating{
-	icon_state = "asteroidplating"
+/obj/machinery/door/airlock/atmos{
+	name = "Service Atmospherics Checkpoint"
 	},
-/area/station/maintenance/port)
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/turf/simulated/floor/plating,
+/area/station/maintenance/port2)
 "gtk" = (
 /obj/structure/sink/puddle,
 /turf/simulated/floor/grass,
@@ -40800,6 +41879,24 @@
 	icon_state = "dark"
 	},
 /area/station/telecomms/computer)
+"guD" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Fore Asteroid Maintenance Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fpmaint)
 "guO" = (
 /obj/structure/table/glass,
 /obj/item/storage/firstaid/toxin{
@@ -40921,21 +42018,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/aft/west)
-"gwF" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/atmos{
-	name = "Research Atmospherics Checkpoint"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/machinery/atmospherics/pipe/simple/hidden/universal{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/hallway/primary/aft/west)
 "gwO" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 1
@@ -40972,31 +42054,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/service/clown/secret)
-"gxt" = (
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "XenoPod2";
-	layer = 2.6;
-	name = "containment door 2"
-	},
-/obj/structure/cable/orange{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/orange{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/door/window/classic/normal{
-	dir = 1;
-	name = "Containment Pen"
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/science/xenobio{
-	dir = 1
-	},
-/turf/simulated/floor/engine,
-/area/station/science/xenobiology)
 "gxv" = (
 /obj/structure/mirror{
 	icon_state = "mirror_broke";
@@ -41221,18 +42278,6 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/cloning)
-"gBk" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Fore Asteroid Maintenance Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/hallway/primary/fore/west)
 "gBp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -41532,21 +42577,6 @@
 	icon_state = "darkredcorners"
 	},
 /area/station/security/brig)
-"gFs" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/airlock/maintenance/external{
-	name = "External Airlock Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
 "gFu" = (
 /obj/structure/cable/orange{
 	d2 = 8;
@@ -41685,22 +42715,6 @@
 "gIG" = (
 /turf/simulated/floor/plasteel,
 /area/station/service/janitor)
-"gIH" = (
-/obj/machinery/door/airlock{
-	name = "Theatre Backstage"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/service/theatre,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "bar"
-	},
-/area/station/service/theatre)
 "gIJ" = (
 /obj/effect/spawner/random_spawners/dirt_often,
 /turf/simulated/floor/plasteel{
@@ -41751,24 +42765,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/service/janitor)
-"gJq" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/smartfridge/secure/medbay,
-/obj/effect/mapping_helpers/airlock/windoor/access/any/medical/chemistry{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/medical/general{
-	dir = 4
-	},
-/obj/machinery/door/window/antitheft/normal{
-	dir = 4;
-	name = "Medbay Fridge"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/station/medical/chemistry)
 "gJw" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -41842,22 +42838,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/service/theatre)
-"gKq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/airlock/medical/glass{
-	name = "Paramedic"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/paramedic,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull"
-	},
-/area/station/medical/paramedic)
 "gKA" = (
 /obj/machinery/holosign_switch{
 	dir = 4;
@@ -41952,19 +42932,6 @@
 	},
 /turf/space,
 /area/space/nearstation)
-"gLq" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/maintenance/external{
-	name = "External Airlock Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/hallway/primary/central)
 "gLu" = (
 /obj/machinery/light_switch{
 	pixel_y = 24;
@@ -41997,6 +42964,22 @@
 	icon_state = "dark"
 	},
 /area/station/security/armory/secure)
+"gLY" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id_tag = "kitchen1"
+	},
+/obj/machinery/door/window/classic/normal{
+	dir = 4;
+	name = "Kitchen"
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/service/kitchen{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/station/service/kitchen)
 "gMb" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/sign/securearea{
@@ -42060,6 +43043,23 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/service/janitor)
+"gNb" = (
+/obj/machinery/door/airlock/highsecurity{
+	locked = 1;
+	name = "AI Upload Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/ai_upload,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/turret_protected/ai_upload)
 "gNc" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -42111,6 +43111,19 @@
 	icon_state = "vault"
 	},
 /area/station/command/vault)
+"gOh" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Criminal Delivery Chute"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/effect/turf_decal/stripes/full,
+/obj/effect/turf_decal/stripes/red/full,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	color = "#954535"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/starboard/south)
 "gOp" = (
 /obj/structure/table,
 /obj/item/phone,
@@ -42119,29 +43132,6 @@
 	icon_state = "vault"
 	},
 /area/station/command/vault)
-"gOA" = (
-/obj/machinery/door/airlock/security{
-	aiControlDisabled = 1;
-	name = "Prisoner 'Transfer' Lounge";
-	security_level = 1
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/machinery/door/firedoor,
-/obj/structure/cable/orange{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/security/execution)
 "gOC" = (
 /obj/structure/chair/comfy/red{
 	dir = 4
@@ -42158,16 +43148,6 @@
 	icon_state = "dark"
 	},
 /area/station/maintenance/asmaint)
-"gPr" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Atmospherics Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/visible/yellow,
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plating,
-/area/station/engineering/atmos)
 "gPA" = (
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -42530,22 +43510,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/station/maintenance/maintcentral)
-"gWt" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Port Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/orange{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plating,
-/area/station/maintenance/port)
 "gXb" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line{
@@ -42584,6 +43548,31 @@
 /obj/structure/closet/firecloset/full,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/fore)
+"gYc" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Transfer Processing"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/door/firedoor,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/security/prisonershuttle)
 "gYw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -42884,6 +43873,17 @@
 /obj/item/kirbyplants,
 /turf/simulated/floor/wood,
 /area/station/command/office/blueshield)
+"hcb" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Equipment Storage"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "red"
+	},
+/area/station/security/storage)
 "hcp" = (
 /obj/structure/chair/comfy{
 	dir = 8
@@ -42893,37 +43893,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/exit)
-"hcw" = (
-/obj/structure/cable/orange{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/virology{
-	autoclose = 0;
-	id_tag = "viro_door_ext";
-	locked = 1;
-	name = "Virology Lab External Airlock"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/access_button{
-	layer = 3.6;
-	autolink_id = "viro_btn_ext";
-	name = "Virology Lab Access Button";
-	req_access_txt = "39";
-	pixel_y = -24
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "whitegreenfull"
-	},
-/area/station/medical/virology)
 "hcB" = (
 /obj/structure/chair/sofa/corp/right{
 	dir = 8
@@ -43358,24 +44327,6 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/medbay)
-"hlh" = (
-/obj/structure/cable/orange{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/airlock/research{
-	name = "Toxins Launch Room"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/science/tox,
-/turf/simulated/floor/plasteel,
-/area/station/science/toxins/mixing)
 "hli" = (
 /obj/structure/cable/orange{
 	d2 = 4;
@@ -43386,6 +44337,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/command/office/blueshield)
+"hlA" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Port Asteroid Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating{
+	icon_state = "asteroidplating"
+	},
+/area/station/maintenance/fpmaint)
 "hlH" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -43548,19 +44513,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
-"hpo" = (
-/obj/machinery/door/airlock/research{
-	name = "Robotics Lab"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/science/robotics,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	icon_state = "darkpurplefull"
-	},
-/area/station/science/robotics)
 "hpD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -43669,6 +44621,19 @@
 	icon_state = "darkyellow"
 	},
 /area/station/engineering/smes)
+"hrp" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance/external{
+	name = "AI Satellite Atmospherics"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/turret_protected/aisat/interior)
 "hrx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -43706,24 +44671,6 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
-"hsb" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Fore Asteroid Maintenance Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fpmaint)
 "hsc" = (
 /obj/structure/sink{
 	pixel_y = 24
@@ -43782,16 +44729,6 @@
 	icon_state = "browncorner"
 	},
 /area/station/hallway/primary/fore/east)
-"htb" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "supply_home";
-	locked = 1;
-	name = "Cargo Docking Hatch"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/supply/general,
-/obj/structure/fans/tiny,
-/turf/simulated/floor/plating,
-/area/station/supply/office)
 "htc" = (
 /obj/structure/grille,
 /obj/effect/spawner/random_spawners/wall_rusted_always,
@@ -43912,26 +44849,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/station/service/bar)
-"hur" = (
-/obj/structure/cable/orange{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Medbay Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Biohazard_medi";
-	name = "Quarantine Lockdown";
-	opacity = 0
-	},
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plating,
-/area/station/maintenance/starboard)
 "huu" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 1
@@ -43981,17 +44898,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/entry/north)
-"hvb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel,
-/area/station/engineering/atmos/control)
 "hve" = (
 /obj/effect/spawner/grouped_spawner{
 	group_id = "tunnelbats";
@@ -44114,18 +45020,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
-"hyX" = (
+"hyY" = (
 /obj/machinery/door/airlock/maintenance{
-	name = "Science SMES Access"
+	name = "Fore Asteroid Maintenance Access"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/simulated/floor/plating,
-/area/station/maintenance/apmaint)
+/area/station/maintenance/fpmaint)
 "hyZ" = (
 /obj/machinery/camera/autoname{
 	dir = 9
@@ -44384,22 +45285,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/asmaint)
-"hEj" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Port Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plating,
-/area/station/maintenance/port)
 "hEk" = (
 /obj/structure/cable/orange{
 	d1 = 4;
@@ -44494,6 +45379,16 @@
 /obj/structure/lattice/catwalk,
 /turf/space,
 /area/station/engineering/solar/auxstarboard)
+"hFn" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Starboard Asteroid Maintenance Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/starboard)
 "hFo" = (
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/auxsolarstarboard)
@@ -44525,31 +45420,6 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/reception)
-"hFJ" = (
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "XenoPod3";
-	layer = 2.6;
-	name = "containment door 3"
-	},
-/obj/structure/cable/orange{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/orange{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/door/window/classic/normal{
-	dir = 1;
-	name = "Containment Pen"
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/science/xenobio{
-	dir = 1
-	},
-/turf/simulated/floor/engine,
-/area/station/science/xenobiology)
 "hFR" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -44691,6 +45561,21 @@
 	},
 /turf/simulated/floor/transparent/glass/reinforced/plasma,
 /area/station/engineering/control)
+"hHX" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Hydroponics Garden"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/service/hydroponics,
+/obj/effect/mapping_helpers/airlock/access/any/service/kitchen,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/turf/simulated/floor/plating,
+/area/station/maintenance/gambling_den)
 "hIa" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -44761,6 +45646,20 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/service/bar)
+"hIA" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Turbine Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/construction,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/turf/simulated/floor/plating,
+/area/station/maintenance/turbine)
 "hIC" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -44871,23 +45770,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/hallway)
-"hKt" = (
-/obj/structure/cable/orange{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Aft Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating{
-	icon_state = "asteroidplating"
-	},
-/area/station/maintenance/apmaint)
 "hKz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -44972,29 +45854,6 @@
 	icon_state = "bcircuit"
 	},
 /area/station/turret_protected/ai)
-"hMT" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Fore Asteroid Maintenance Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/disposal/northeast)
-"hMW" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 9
-	},
-/obj/machinery/power/apc{
-	name = "south bump";
-	pixel_y = -24
-	},
-/obj/structure/cable/orange{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plasteel/dark/telecomms{
-	icon_state = "bcircuit"
-	},
-/area/station/science/server/coldroom)
 "hMY" = (
 /obj/structure/closet/secure_closet/RD,
 /obj/item/cartridge/signal/toxins,
@@ -45071,14 +45930,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/service/theatre)
-"hOD" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Aft Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plating,
-/area/station/maintenance/asmaint)
 "hPf" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -45130,25 +45981,6 @@
 /obj/item/roller,
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
-"hPW" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/airlock/medical/glass{
-	name = "Staff Room"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/station/medical/break_room)
 "hPX" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -45320,6 +46152,27 @@
 	icon_state = "redcorner"
 	},
 /area/station/hallway/primary/fore/west)
+"hRF" = (
+/obj/machinery/door/airlock/atmos/glass{
+	autoclose = 0;
+	id_tag = "atmossm_door_ext";
+	locked = 1;
+	name = "Atmospherics Access Chamber"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/machinery/access_button{
+	autolink_id = "atmossm_btn_ext";
+	name = "Atmospherics Access Button";
+	pixel_y = -24;
+	req_access_txt = "24"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/engineering/control)
 "hRI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -45379,27 +46232,6 @@
 	icon_state = "dark"
 	},
 /area/station/security/evidence)
-"hSe" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "BrigEast";
-	name = "Brig East Entrance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Secure Gate";
-	name = "Security Blast Door";
-	opacity = 0
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/security/prison/cell_block/A)
 "hSk" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -45460,16 +46292,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/fore)
-"hSV" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Port Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/port2)
 "hSY" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -45530,14 +46352,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/command/office/blueshield)
-"hUo" = (
-/obj/machinery/door/airlock/maintenance/external{
-	name = "External Airlock Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/station/maintenance/starboard)
 "hUs" = (
 /turf/space,
 /area/station/security/armory/secure)
@@ -45550,6 +46364,16 @@
 	icon_state = "darkblue"
 	},
 /area/station/medical/storage/secondary)
+"hUN" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Starboard Asteroid Maintenance Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/disposal/east)
 "hUO" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -45645,6 +46469,19 @@
 /obj/effect/spawner/window/reinforced/polarized,
 /turf/simulated/floor/plating,
 /area/station/science/robotics)
+"hVY" = (
+/obj/machinery/door/window/classic/reversed{
+	dir = 8;
+	name = "Medical Secure Storage"
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/medical/general{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkblue"
+	},
+/area/station/medical/storage/secondary)
 "hWm" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -45742,14 +46579,6 @@
 	icon_state = "dark"
 	},
 /area/station/security/armory/secure)
-"hZb" = (
-/obj/structure/barricade/wooden,
-/obj/machinery/door/airlock/maintenance{
-	name = "Starboard Asteroid Maintenance Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating/asteroid/ancient,
-/area/station/maintenance/starboard)
 "hZh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -45848,6 +46677,21 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/maintcentral)
+"iab" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Starboard Asteroid Maintenance Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating/asteroid/ancient,
+/area/station/maintenance/starboard)
 "iag" = (
 /obj/machinery/computer/med_data{
 	dir = 1
@@ -45874,26 +46718,6 @@
 /obj/structure/flora/ausbushes/genericbush,
 /turf/simulated/floor/grass,
 /area/station/hallway/secondary/exit)
-"iaQ" = (
-/obj/machinery/door/airlock/command{
-	name = "Expedition Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/command/expedition,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/ai_monitored/storage/eva)
 "iaV" = (
 /obj/structure/rack{
 	dir = 8;
@@ -45984,6 +46808,26 @@
 /obj/effect/spawner/airlock,
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/disposal/external/north)
+"icI" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/command/glass{
+	id_tag = "cmoofficedoor";
+	name = "CMO's Office"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/cmo,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "cmo"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/command/office/cmo)
 "icM" = (
 /obj/structure/chair/wood/wings,
 /turf/simulated/floor/wood,
@@ -46076,16 +46920,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/fore)
-"iec" = (
-/obj/machinery/door/airlock/vault{
-	locked = 1
-	},
-/obj/effect/mapping_helpers/airlock/access/all/supply/vault,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel,
-/area/station/command/vault)
 "ieh" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -46216,17 +47050,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/science/xenobiology)
-"ifP" = (
-/obj/machinery/door/airlock{
-	name = "Custodial Closet"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/service/janitor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/service/janitor)
 "ifS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating{
@@ -46287,6 +47110,10 @@
 	icon_state = "white"
 	},
 /area/station/science/misc_lab)
+"igy" = (
+/obj/structure/shuttle/engine/propulsion,
+/turf/simulated/floor/plating/airless,
+/area/shuttle/arrival/station)
 "igZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/wood,
@@ -46379,22 +47206,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/detective)
-"iiO" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Equipment Storage"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/machinery/door/firedoor,
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "red"
-	},
-/area/station/security/main)
 "iiV" = (
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -46501,20 +47312,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/port)
-"ikJ" = (
-/obj/machinery/door/airlock/medical{
-	name = "Operating Theatre Storage"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
-/obj/structure/cable/orange{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "showroomfloor"
-	},
-/area/station/medical/surgery/primary)
 "ikM" = (
 /obj/structure/table/wood,
 /obj/item/gavelblock,
@@ -46681,26 +47478,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/starboard)
-"ink" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Permabrig Cell 1";
-	security_level = 1
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Prison Gate";
-	name = "Prison Lockdown Blast Doors";
-	opacity = 0
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/security/permabrig)
 "inP" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -46708,21 +47485,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/port)
-"inV" = (
-/obj/machinery/door/airlock/engineering/glass{
-	autoclose = 0;
-	id_tag = "engsm_door_int";
-	locked = 1;
-	name = "Supermatter Interior Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/engine,
-/area/station/engineering/control)
 "inW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -47072,12 +47834,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/aft/east)
-"irV" = (
-/obj/machinery/atmospherics/unary/outlet_injector/on{
-	dir = 1
-	},
-/turf/simulated/floor/plating/airless,
-/area/station/maintenance/turbine)
 "isf" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -47117,17 +47873,6 @@
 	},
 /turf/simulated/wall,
 /area/station/hallway/primary/central)
-"isx" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/command{
-	name = "Head of Personnel"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/command/hop,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/wood,
-/area/station/command/office/hop)
 "isE" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -47212,6 +47957,14 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/hallway/primary/fore/west)
+"iuC" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Central Asteroid Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/turf/simulated/floor/plating,
+/area/station/maintenance/maintcentral)
 "iuE" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -47489,6 +48242,22 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
+"iyF" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/maintenance/external{
+	name = "External Airlock Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/turf/simulated/floor/plating,
+/area/station/hallway/primary/port/south)
 "iyK" = (
 /obj/machinery/economy/slot_machine,
 /turf/simulated/floor/carpet,
@@ -47508,13 +48277,6 @@
 	icon_state = "whitepurple"
 	},
 /area/station/science/hallway)
-"iyX" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Aft Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/apmaint)
 "izl" = (
 /mob/living/simple_animal/pet/sloth/paperwork,
 /turf/simulated/floor/carpet,
@@ -47552,15 +48314,6 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/medbay)
-"iAy" = (
-/obj/machinery/r_n_d/server/core,
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 6
-	},
-/turf/simulated/floor/plasteel/dark/telecomms{
-	icon_state = "bcircuit"
-	},
-/area/station/science/server/coldroom)
 "iAF" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
@@ -47840,26 +48593,17 @@
 "iFs" = (
 /turf/simulated/wall,
 /area/mine/unexplored/cere/research)
-"iFu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+"iFv" = (
+/obj/machinery/door/window/classic/normal{
+	name = "Monkey Pen";
+	dir = 8
 	},
-/obj/machinery/door/airlock/command/glass{
-	id_tag = "cmoofficedoor";
-	name = "CMO's Office"
+/obj/effect/mapping_helpers/airlock/windoor/access/any/medical/genetics{
+	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/cmo,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "cmo"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/command/office/cmo)
+/mob/living/carbon/human/monkey,
+/turf/simulated/floor/grass,
+/area/station/science/genetics)
 "iFB" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -47976,6 +48720,18 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/service/clown/secret)
+"iHL" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Bridge APC Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore2)
 "iHT" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -48060,6 +48816,14 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/fore)
+"iIW" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Aft Asteroid Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/turf/simulated/floor/plating,
+/area/station/science/xenobiology)
 "iJa" = (
 /obj/effect/spawner/grouped_spawner{
 	group_id = "tunnelbats";
@@ -48314,6 +49078,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry/north)
+"iNu" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Fore Asteroid Solars"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/auxsolarstarboard)
 "iNC" = (
 /obj/structure/closet/secure_closet/medical2,
 /obj/machinery/light{
@@ -48323,6 +49099,23 @@
 	icon_state = "white"
 	},
 /area/station/medical/surgery/secondary)
+"iNK" = (
+/obj/machinery/door/airlock/research{
+	name = "Test Lab"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/tox,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/station/science/misc_lab)
 "iOk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -48390,6 +49183,21 @@
 	icon_state = "dark"
 	},
 /area/station/service/library)
+"iPj" = (
+/obj/effect/turf_decal/stripes/full,
+/obj/machinery/door/airlock/security/glass{
+	name = "Criminal Delivery Chute"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/effect/turf_decal/stripes/red/full,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	color = "#954535"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/maintenance/fsmaint)
 "iPq" = (
 /obj/machinery/requests_console{
 	announcementConsole = 1;
@@ -48505,21 +49313,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/entry/south)
-"iSj" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance{
-	name = "Fore Asteroid Maintenance Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore2)
 "iSn" = (
 /obj/effect/spawner/random_spawners/wall_rusted_always,
 /turf/simulated/wall,
@@ -48696,19 +49489,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
-"iUZ" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/external{
-	name = "External airlock"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/exit)
 "iVd" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 1
@@ -48813,6 +49593,13 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/port/north)
+"iWx" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Escape Shuttle Cell"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/exit)
 "iWF" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 1
@@ -48982,23 +49769,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central)
-"iYb" = (
-/obj/machinery/door/airlock/research{
-	name = "Research Break Room"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/medical/genetics,
-/obj/effect/mapping_helpers/airlock/access/any/science/research,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel/freezer,
-/area/station/science/hallway)
 "iYg" = (
 /turf/simulated/floor/plating,
 /area/mine/unexplored/cere/orbiting)
@@ -49046,24 +49816,6 @@
 	},
 /turf/simulated/wall,
 /area/station/hallway/primary/starboard/north)
-"iYs" = (
-/obj/machinery/door/airlock/tranquillite{
-	name = "Mime's Office"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/service/theatre,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel{
-	icon_regular_floor = "yellowsiding";
-	icon_state = "tranquillite"
-	},
-/area/station/service/mime)
 "iYK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -49177,27 +49929,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
-"jai" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "bridge";
-	layer = 2.6;
-	name = "Emergency Blast Door"
-	},
-/obj/machinery/door/airlock/command/glass{
-	name = "Bridge Foyer"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/command/general,
-/obj/effect/mapping_helpers/airlock/access/any/supply/qm,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "bridge"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "darkblue"
-	},
-/area/station/command/bridge)
 "jao" = (
 /obj/machinery/light{
 	dir = 4
@@ -49264,6 +49995,18 @@
 	icon_state = "redyellowfull"
 	},
 /area/station/service/bar)
+"jba" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Medbay SMES Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/turf/simulated/floor/plating,
+/area/station/hallway/primary/starboard/north)
 "jbg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
@@ -49647,6 +50390,27 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
+"jjn" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "engineeringlockdown";
+	layer = 2.6;
+	name = "Emergency Lockdown Blastdoor"
+	},
+/obj/machinery/door/airlock/engineering{
+	name = "Engineering Foyer"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel{
+	icon_state = "darkyellowfull"
+	},
+/area/station/engineering/break_room)
 "jjp" = (
 /obj/structure/cable/orange{
 	d1 = 2;
@@ -49664,6 +50428,13 @@
 	icon_state = "bcircuit"
 	},
 /area/station/turret_protected/ai_upload)
+"jjN" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Central Asteroid Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating/asteroid/ancient,
+/area/station/maintenance/maintcentral)
 "jjO" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/disposalpipe/segment,
@@ -49776,20 +50547,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/station/security/storage)
-"jlK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/simulated/floor/plating/airless{
-	icon_state = "asteroidplating"
-	},
-/area/station/hallway/spacebridge/servsci)
 "jlN" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -49877,46 +50634,25 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/armory/secure)
-"jnv" = (
-/obj/machinery/atmospherics/unary/outlet_injector/on{
-	dir = 4
-	},
-/turf/simulated/floor/plating/airless,
-/area/station/science/test_chamber)
-"jnJ" = (
-/obj/machinery/door/window/classic/reversed{
-	dir = 8;
-	name = "AI Core Door"
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/command/ai_upload{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id_tag = "aisat"
-	},
-/obj/effect/turf_decal/caution/stand_clear,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/turret_protected/ai)
-"jnP" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Command Asteroid Solars"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/auxsolarport)
 "jnV" = (
 /obj/machinery/status_display{
 	layer = 4
 	},
 /turf/simulated/wall,
 /area/station/hallway/secondary/entry/north)
+"jnZ" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Security Office"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "red"
+	},
+/area/station/security/main)
 "joj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -49956,26 +50692,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/service/janitor)
-"joH" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/door/airlock/medical/glass{
-	name = "Isolation A"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/virology)
 "joJ" = (
 /obj/machinery/flasher{
 	id = "AI";
@@ -50006,6 +50722,28 @@
 	},
 /turf/simulated/wall,
 /area/station/hallway/secondary/exit)
+"jps" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id_tag = "atmodesk"
+	},
+/obj/machinery/door/window/classic/reversed{
+	name = "Atmospherics Desk";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/engineering/atmos{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "darkyellowfull"
+	},
+/area/station/engineering/atmos)
 "jpz" = (
 /obj/machinery/light,
 /obj/structure/chair/comfy/corp{
@@ -50082,22 +50820,6 @@
 	icon_state = "whitepurple"
 	},
 /area/station/science/xenobiology)
-"jqI" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Garden"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	icon_state = "darkgreenfull"
-	},
-/area/station/service/hydroponics)
 "jqP" = (
 /obj/structure/table,
 /obj/item/storage/box/lights/mixed,
@@ -50166,6 +50888,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/portsolar)
+"jrM" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Port Asteroid Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/station/maintenance/gambling_den)
 "jrT" = (
 /obj/effect/spawner/random_spawners/fungus_maybe,
 /turf/simulated/wall,
@@ -50240,6 +50975,19 @@
 "jsE" = (
 /turf/simulated/floor/wood,
 /area/station/maintenance/starboard)
+"jsN" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Port Asteroid Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/port)
 "jsU" = (
 /obj/structure/rack,
 /turf/simulated/floor/plating/asteroid/ancient,
@@ -50425,27 +51173,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/exit)
-"jvt" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "engineeringlockdown";
-	layer = 2.6;
-	name = "Emergency Lockdown Blastdoor"
-	},
-/obj/machinery/door/airlock/engineering{
-	name = "Engineering Foyer"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	icon_state = "darkyellowfull"
-	},
-/area/station/engineering/break_room)
 "jvx" = (
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -50572,6 +51299,31 @@
 /obj/effect/spawner/random_spawners/dirt_frequent,
 /turf/simulated/floor/plating,
 /area/station/supply/miningdock)
+"jxw" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24;
+	name = "east bump"
+	},
+/obj/machinery/door/airlock/research{
+	name = "Kill Chamber"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
+/obj/effect/turf_decal/delivery,
+/turf/simulated/floor/plasteel{
+	icon_state = "whitepurplefull"
+	},
+/area/station/science/xenobiology)
+"jxJ" = (
+/obj/machinery/door/airlock/vault{
+	locked = 1
+	},
+/obj/effect/mapping_helpers/airlock/access/all/supply/vault,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel,
+/area/station/command/vault)
 "jxK" = (
 /obj/item/radio/intercom{
 	pixel_y = 28;
@@ -50695,6 +51447,17 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/port)
+"jAr" = (
+/obj/machinery/door/airlock/glass{
+	name = "Courtroom"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "Courtroom"
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/wood,
+/area/station/legal/courtroom)
 "jAy" = (
 /obj/machinery/door_control{
 	id = "researchlockdown";
@@ -51281,24 +52044,22 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/storage)
-"jII" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/engineering{
-	name = "Tech Storage"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/tech_storage,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/engineering/tech_storage)
 "jJc" = (
 /turf/simulated/mineral/ancient,
 /area/station/science/robotics)
+"jJf" = (
+/obj/machinery/door/airlock{
+	name = "Bar Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/bar,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/station/service/bar)
 "jJi" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -51386,14 +52147,6 @@
 /obj/structure/chair/office/dark,
 /turf/simulated/floor/carpet/royalblack,
 /area/station/command/office/ntrep)
-"jJQ" = (
-/obj/machinery/door/airlock/maintenance/external{
-	name = "External Airlock Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/station/hallway/primary/central)
 "jJY" = (
 /obj/machinery/keycard_auth{
 	pixel_y = 24
@@ -51439,14 +52192,6 @@
 	icon_state = "redcorner"
 	},
 /area/station/hallway/primary/fore/west)
-"jKX" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Port Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plasteel,
-/area/station/service/library)
 "jLm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -51588,6 +52333,18 @@
 "jNX" = (
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/mine/unexplored/cere/civilian)
+"jNZ" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Cargo SMES Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/primary/fore/east)
 "jOi" = (
 /obj/machinery/atmospherics/portable/scrubber,
 /obj/machinery/atmospherics/unary/portables_connector{
@@ -51714,22 +52471,6 @@
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
-"jQd" = (
-/obj/machinery/door/window/reinforced/normal{
-	dir = 1;
-	name = "Glass Door"
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/security/doors{
-	dir = 1
-	},
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/plasteel,
-/area/station/security/prisonershuttle)
 "jQe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -51777,15 +52518,6 @@
 /obj/structure/disposaloutlet,
 /turf/simulated/floor/plating/airless,
 /area/station/maintenance/disposal/west)
-"jQJ" = (
-/obj/machinery/door/airlock/security{
-	name = "Firing Range";
-	security_level = 1
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plating,
-/area/station/security/range)
 "jRd" = (
 /obj/structure/sign/poster/random{
 	name = "random official poster";
@@ -51905,30 +52637,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/port/north)
-"jSW" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/door/airlock/command/glass{
-	id_tag = "ceofficedoor";
-	name = "Chief Engineer"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/ce,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 2;
-	id_tag = "ceoffice"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/universal,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/command/office/ce)
 "jTe" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
@@ -52039,6 +52747,27 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/atmos)
+"jUP" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Detective"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/forensics,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "Detective"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/station/security/detective)
 "jUW" = (
 /obj/machinery/light{
 	dir = 1
@@ -52046,6 +52775,19 @@
 /obj/machinery/hydroponics/soil,
 /turf/simulated/floor/grass,
 /area/station/service/hydroponics)
+"jUZ" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Aft Asteroid Solars"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/barricade/wooden,
+/turf/simulated/floor/plating,
+/area/station/maintenance/starboardsolar/aft)
 "jVa" = (
 /obj/machinery/conveyor/auto{
 	dir = 4
@@ -52229,16 +52971,6 @@
 /obj/structure/closet/secure_closet/brig,
 /turf/simulated/floor/plasteel,
 /area/station/security/prisonlockers)
-"jYl" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Warden's Office"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/armory,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/security/warden)
 "jYp" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -52277,6 +53009,24 @@
 /obj/machinery/atmospherics/binary/valve/open,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/fore)
+"jZN" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/airlock/research{
+	name = "Toxins Launch Room"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/tox,
+/turf/simulated/floor/plasteel,
+/area/station/science/toxins/mixing)
 "jZQ" = (
 /obj/machinery/camera{
 	c_tag = "Teleporter";
@@ -52289,18 +53039,6 @@
 	icon_state = "dark"
 	},
 /area/station/command/teleporter)
-"kak" = (
-/obj/machinery/door/airlock/engineering/glass{
-	autoclose = 0;
-	id_tag = "engsm_door_ext";
-	locked = 1;
-	name = "Supermatter Exterior Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/engineering/control)
 "kal" = (
 /obj/structure/cable/orange{
 	d1 = 4;
@@ -52652,6 +53390,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal/north)
+"kfe" = (
+/obj/machinery/door/window{
+	dir = 1;
+	name = "Desk Door"
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/command/ntrep{
+	dir = 1
+	},
+/obj/machinery/keycard_auth{
+	pixel_x = 24
+	},
+/turf/simulated/floor/wood,
+/area/station/command/office/ntrep)
 "kfo" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -52706,20 +53457,6 @@
 /obj/machinery/ai_status_display,
 /turf/simulated/mineral/ancient,
 /area/station/hallway/primary/starboard/north)
-"khL" = (
-/obj/structure/cable/orange{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Science Asteroid Solars"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/turf/simulated/floor/plating{
-	icon_state = "asteroidplating"
-	},
-/area/station/maintenance/portsolar)
 "khM" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -52786,6 +53523,16 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/xenobiology)
+"kjq" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance{
+	name = "Port Asteroid Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating{
+	icon_state = "asteroidplating"
+	},
+/area/station/maintenance/port)
 "kju" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -52858,15 +53605,28 @@
 /obj/structure/disposalpipe/junction,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal/southwest)
-"kki" = (
-/obj/machinery/r_n_d/server/robotics,
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 5
+"kkk" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/classic/reversed{
+	name = "Cargo Desk";
+	dir = 1
 	},
-/turf/simulated/floor/plasteel/dark/telecomms{
-	icon_state = "bcircuit"
+/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/mail_sorting{
+	dir = 1
 	},
-/area/station/science/server/coldroom)
+/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/mining{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/obj/item/desk_bell{
+	pixel_x = 7;
+	pixel_y = 7;
+	anchored = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "darkbrownfull"
+	},
+/area/station/supply/office)
 "kkt" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -52995,6 +53755,18 @@
 /obj/effect/spawner/random_spawners/dirt_frequent,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/xenobiology)
+"kmi" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Cargo SMES Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/primary/fore/east)
 "kmk" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Chapel"
@@ -53040,23 +53812,6 @@
 	},
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/station/maintenance/fsmaint)
-"knv" = (
-/obj/machinery/door/airlock/highsecurity{
-	locked = 1;
-	name = "AI Upload Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/command/ai_upload,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/turret_protected/ai_upload)
 "knB" = (
 /obj/item/kirbyplants/dead,
 /turf/simulated/floor/plasteel{
@@ -53270,20 +54025,6 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/cloning)
-"kri" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Prisoner Lockers"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/station/security/prisonlockers)
 "krw" = (
 /obj/structure/closet/secure_closet/freezer/money,
 /obj/machinery/light{
@@ -53293,16 +54034,42 @@
 	icon_state = "bcircuit"
 	},
 /area/station/command/vault)
-"krK" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance{
-	name = "Port Asteroid Maintenance"
+"krP" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating{
-	icon_state = "asteroidplating"
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/area/station/maintenance/port)
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/command/glass{
+	id_tag = "hosofficedoor";
+	name = "Head of Security"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/hos,
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "hos"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/station/command/office/hos)
 "krX" = (
 /obj/machinery/economy/vending/cola,
 /turf/simulated/floor/plasteel{
@@ -53806,6 +54573,27 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/entry)
+"kyW" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/window{
+	dir = 8;
+	icon_state = "right";
+	name = "Research Delivery Chute"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/mule_bot{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/science/research{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/science/misc_lab)
 "kzd" = (
 /obj/effect/landmark/spawner/nukedisc_respawn,
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
@@ -53836,32 +54624,6 @@
 /obj/effect/spawner/random_spawners/fungus_maybe,
 /turf/simulated/wall,
 /area/station/maintenance/disposal/east)
-"kzM" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
-	id_tag = "blueshieldofficedoor";
-	name = "Blueshield's Office"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/command/blueshield,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/wood,
-/area/station/command/office/blueshield)
 "kzS" = (
 /obj/machinery/camera{
 	c_tag = "Docking Quantum Pad";
@@ -53959,6 +54721,13 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/aft/west)
+"kBa" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Central Asteroid Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/maintcentral)
 "kBj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -54009,6 +54778,15 @@
 	icon_state = "cafeteria"
 	},
 /area/station/science/hallway)
+"kCa" = (
+/obj/machinery/door/airlock/command{
+	name = "Expedition Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/expedition,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/ai_monitored/storage/eva)
 "kCe" = (
 /obj/machinery/atmospherics/binary/volume_pump/on{
 	dir = 1;
@@ -54244,23 +55022,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/fore/west)
-"kGO" = (
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Secure Gate";
-	name = "Security Blast Door";
-	opacity = 0
-	},
-/obj/machinery/door/airlock/security/glass{
-	name = "General Population Cell"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/security/prison/cell_block/A)
 "kGR" = (
 /turf/simulated/mineral/ancient/outer,
 /area/station/maintenance/starboardsolar)
@@ -54359,6 +55120,31 @@
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal/west)
+"kII" = (
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "XenoPod3";
+	layer = 2.6;
+	name = "containment door 3"
+	},
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/door/window/classic/normal{
+	dir = 1;
+	name = "Containment Pen"
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/science/xenobio{
+	dir = 1
+	},
+/turf/simulated/floor/engine,
+/area/station/science/xenobiology)
 "kIM" = (
 /obj/item/radio/intercom{
 	pixel_x = -28;
@@ -54639,6 +55425,48 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/spacebridge/sercom)
+"kMC" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/research{
+	name = "Toxins Mixing Room"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/tox,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "whitepurplefull"
+	},
+/area/station/science/toxins/mixing)
+"kMH" = (
+/obj/machinery/door/airlock/tranquillite{
+	name = "Mime's Office"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/theatre,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	icon_regular_floor = "yellowsiding";
+	icon_state = "tranquillite"
+	},
+/area/station/service/mime)
 "kMZ" = (
 /obj/structure/cable/orange{
 	d1 = 2;
@@ -54702,6 +55530,19 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
 /turf/simulated/floor/wood,
 /area/station/command/office/ntrep)
+"kOb" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Science SMES Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/turf/simulated/floor/plating,
+/area/station/maintenance/apmaint)
 "kOk" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -54761,6 +55602,14 @@
 	icon_state = "dark"
 	},
 /area/station/service/hydroponics)
+"kPs" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Fore Asteroid Maintenance Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "kPx" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
@@ -54849,17 +55698,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/public/fitness)
-"kRr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/airlock/maintenance/external{
-	name = "External Airlock Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plating,
-/area/station/hallway/primary/aft/west)
 "kRw" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -54876,6 +55714,20 @@
 	},
 /turf/simulated/floor/carpet,
 /area/station/legal/courtroom)
+"kRH" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Aft Asteroid Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/tox,
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/turf/simulated/floor/plating,
+/area/station/science/toxins/mixing)
 "kRI" = (
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -55025,24 +55877,6 @@
 	icon_state = "whiteyellow"
 	},
 /area/station/science/robotics/chargebay)
-"kTQ" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/airlock/maintenance/external{
-	name = "External Airlock Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/turret_protected/aisat/interior)
 "kUd" = (
 /obj/structure/disposalpipe/segment/corner,
 /obj/structure/sign/poster/random{
@@ -55286,17 +56120,6 @@
 /obj/effect/spawner/airlock/w_to_e,
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/auxsolarstarboard)
-"kXs" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Fore Asteroid Maintenance Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore2)
 "kXu" = (
 /turf/simulated/mineral/ancient,
 /area/station/public/vacant_office)
@@ -55318,6 +56141,15 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/hallway)
+"kXZ" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Port Asteroid Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/disposalpipe/segment,
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/turf/simulated/floor/plasteel,
+/area/station/service/library)
 "kYc" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -55418,13 +56250,6 @@
 	},
 /turf/simulated/wall,
 /area/station/service/clown)
-"laP" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Fore Asteroid Maintenance Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
 "lbb" = (
 /obj/machinery/economy/vending/cola,
 /obj/item/radio/intercom{
@@ -55488,19 +56313,6 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/lobby)
-"lbA" = (
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Port Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/station/maintenance/gambling_den)
 "lbJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -55571,19 +56383,6 @@
 /obj/item/pen,
 /turf/simulated/floor/plating,
 /area/mine/unexplored/cere/orbiting)
-"lcy" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Prison Wing";
-	security_level = 1
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/security/permabrig)
 "lcB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -55679,6 +56478,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
+"led" = (
+/obj/machinery/disposal/deliveryChute{
+	dir = 1
+	},
+/obj/structure/disposalpipe/trunk,
+/turf/simulated/floor/plating/airless,
+/area/station/maintenance/disposal/westalt)
 "leh" = (
 /obj/structure/grille/broken,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -55789,31 +56595,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/security/permabrig)
-"lgt" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/door/airlock/command/glass{
-	id_tag = "rdofficedoor";
-	name = "Research Director's Office"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/science/rd,
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "rd"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel,
-/area/station/command/office/rd)
 "lgu" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable/orange{
@@ -56098,16 +56879,26 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood,
 /area/station/public/vacant_office)
-"ljD" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "MedbayFoyer";
-	name = "Medical Supplies"
+"ljN" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Medbay Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/medbay)
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Biohazard_medi";
+	name = "Quarantine Lockdown";
+	opacity = 0
+	},
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/turf/simulated/floor/plating,
+/area/station/maintenance/starboard)
 "ljV" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -56141,58 +56932,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/port)
-"lkk" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/virology{
-	autoclose = 0;
-	id_tag = "viro_door_int";
-	locked = 1;
-	name = "Virology Lab Internal Airlock"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/orange{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/access_button{
-	autolink_id = "viro_btn_int";
-	name = "Virology Lab Access Button";
-	req_access_txt = "39";
-	pixel_y = -24
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "whitegreenfull"
-	},
-/area/station/medical/virology)
-"lko" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "bridge";
-	layer = 2.6;
-	name = "Emergency Blast Door"
-	},
-/obj/machinery/door/airlock/command/glass{
-	name = "Bridge"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/command/general,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/command/bridge)
 "lkx" = (
 /obj/item/radio/intercom{
 	pixel_y = 28;
@@ -56278,6 +57017,26 @@
 /obj/structure/disposalpipe/segment/corner,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal/west)
+"llK" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Permabrig Cell 1";
+	security_level = 1
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Prison Gate";
+	name = "Prison Lockdown Blast Doors";
+	opacity = 0
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/security/permabrig)
 "llN" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -56321,29 +57080,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/security/permabrig)
-"lms" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "BrigRight";
-	name = "Brig Foyer Right Entrance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Secure Gate";
-	name = "Security Blast Door";
-	opacity = 0
-	},
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/security/brig)
 "lmt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/spawner/random_spawners/dirt_often,
@@ -56368,6 +57104,21 @@
 /obj/item/flashlight,
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/station/maintenance/apmaint)
+"lmF" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance/external{
+	name = "External Airlock Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry/north)
 "lmO" = (
 /obj/structure/closet/crate{
 	name = "Silver Crate"
@@ -56394,6 +57145,35 @@
 	icon_state = "whitepurple"
 	},
 /area/station/science/hallway)
+"lmS" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/external{
+	name = "External airlock"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/exit)
+"lmX" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Garden"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel{
+	icon_state = "darkgreenfull"
+	},
+/area/station/service/hydroponics)
 "lmZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -56461,6 +57241,20 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/fore/east)
+"lnN" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Medbay Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Biohazard_medi";
+	name = "Quarantine Lockdown";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/starboard)
 "lnY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -56619,19 +57413,6 @@
 	icon_state = "dark"
 	},
 /area/station/ai_monitored/storage/eva)
-"lrf" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Fore Asteroid Maintenance Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
-/area/station/maintenance/disposal/northeast)
 "lrx" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -56735,6 +57516,19 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/port)
+"ltr" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Port Asteroid Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/station/maintenance/disposal/northwest)
 "lts" = (
 /obj/structure/chair,
 /obj/item/radio/intercom{
@@ -56746,6 +57540,31 @@
 	icon_state = "red"
 	},
 /area/station/hallway/secondary/exit)
+"ltP" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/door/airlock/command/glass{
+	id_tag = "rdofficedoor";
+	name = "Research Director's Office"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/rd,
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "rd"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel,
+/area/station/command/office/rd)
 "ltY" = (
 /obj/machinery/door_control{
 	id = "cargoeva";
@@ -56771,23 +57590,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal/external/southeast)
-"lue" = (
-/obj/machinery/door/airlock/mining{
-	name = "Mining Dock"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/supply/mining,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/station/supply/miningdock)
 "luv" = (
 /obj/effect/spawner/window/reinforced/polarized/grilled{
 	id = "process"
@@ -56868,6 +57670,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/service/clown/secret)
+"lvT" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance/external{
+	name = "External Airlock Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "lwc" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/grass/jungle,
@@ -56963,6 +57780,18 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/public/vacant_office)
+"lwQ" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Aft Asteroid Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/apmaint)
 "lxh" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/secure_data/laptop,
@@ -57309,19 +58138,6 @@
 "lBh" = (
 /turf/simulated/mineral/ancient/outer,
 /area/station/maintenance/auxsolarport)
-"lBi" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical/glass{
-	name = "Psych Office"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/psychology,
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "psych"
-	},
-/turf/simulated/floor/wood,
-/area/station/medical/psych)
 "lBr" = (
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -57624,6 +58440,21 @@
 /obj/structure/table/wood,
 /turf/simulated/floor/wood,
 /area/station/public/vacant_office)
+"lGh" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance{
+	name = "Fore Asteroid Maintenance Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore2)
 "lGj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -57675,13 +58506,6 @@
 	icon_state = "dark"
 	},
 /area/station/service/library)
-"lHS" = (
-/obj/machinery/disposal/deliveryChute,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/simulated/floor/plating/airless,
-/area/station/maintenance/disposal/external/east)
 "lHZ" = (
 /obj/effect/spawner/window/reinforced/polarized{
 	id = "library"
@@ -57703,27 +58527,6 @@
 	icon_state = "dark"
 	},
 /area/station/service/chapel/office)
-"lIM" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/door/window{
-	dir = 8;
-	icon_state = "right";
-	name = "Research Delivery Chute"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/mule_bot{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/science/research{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/station/science/misc_lab)
 "lIN" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -57887,6 +58690,29 @@
 /obj/effect/spawner/lootdrop/maintenance/eight,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
+"lMj" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Service Atmospherics Checkpoint"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/port2)
+"lMr" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance{
+	name = "Aft Asteroid Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/disposal/south)
 "lMu" = (
 /obj/machinery/atmospherics/trinary/mixer{
 	dir = 1;
@@ -57906,22 +58732,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
-"lMD" = (
-/obj/machinery/door/airlock/public/glass{
-	autoclose = 0;
-	heat_proof = 1;
-	id_tag = "incinerator_door_int";
-	locked = 1;
-	name = "Mixing Room Interior Airlock"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/access_button{
-	autolink_id = "incinerator_btn_int";
-	name = "Incinerator Airlock Control";
-	pixel_y = -22
-	},
-/turf/simulated/floor/engine,
-/area/station/science/toxins/mixing)
 "lME" = (
 /obj/machinery/economy/atm{
 	pixel_y = -32
@@ -58434,22 +59244,6 @@
 	slowdown = -0.3
 	},
 /area/station/hallway/spacebridge/servsci)
-"lUG" = (
-/obj/machinery/door/airlock/hatch{
-	name = "AI Satellite Antechamber"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/command/teleporter,
-/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/turret_protected/aisat/interior)
 "lUU" = (
 /obj/effect/spawner/random_spawners/dirt_often,
 /turf/simulated/floor/plasteel{
@@ -58473,18 +59267,6 @@
 	icon_state = "dark"
 	},
 /area/station/command/bridge)
-"lVn" = (
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Aft Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/apmaint)
 "lVq" = (
 /obj/structure/cable,
 /obj/structure/cable{
@@ -58522,23 +59304,26 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore2)
-"lVN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/atmos{
-	name = "Medbay Atmospherics Checkpoint"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/machinery/atmospherics/pipe/simple/hidden/universal{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/hallway/primary/starboard/south)
 "lVP" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/station/service/theatre)
+"lVX" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Equipment Storage"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/door/firedoor,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "red"
+	},
+/area/station/security/main)
 "lWh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -58589,18 +59374,6 @@
 	icon_state = "arrival"
 	},
 /area/station/hallway/secondary/entry)
-"lXu" = (
-/obj/machinery/door/airlock/highsecurity{
-	name = "Secure Tech Storage"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/tech_storage,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/engineering/tech_storage)
 "lXM" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -58618,32 +59391,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/public/fitness)
-"lYc" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/door/airlock/command/glass{
-	id_tag = "ceofficedoor";
-	name = "Chief Engineer"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/ce,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 2;
-	id_tag = "ceoffice"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel,
-/area/station/command/office/ce)
 "lYi" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/structure/disposalpipe/segment/corner{
@@ -58772,21 +59519,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/storage)
-"maj" = (
-/obj/machinery/door/airlock/engineering/glass{
-	autoclose = 0;
-	id_tag = "engsm_door_int";
-	locked = 1;
-	name = "Supermatter Interior Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/engine,
-/area/station/engineering/control)
 "maq" = (
 /obj/structure/table/wood,
 /obj/item/camera_film,
@@ -58828,19 +59560,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/fore/east)
-"maJ" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Aft Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/cable/orange{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plating,
-/area/station/maintenance/asmaint)
 "maW" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/disposalpipe/segment,
@@ -58934,17 +59653,6 @@
 	icon_state = "white"
 	},
 /area/station/science/toxins/mixing)
-"mbO" = (
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "MedbayFoyer";
-	name = "Medical Supplies"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	icon_state = "whiteblue"
-	},
-/area/station/medical/storage/secondary)
 "mbP" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -58959,6 +59667,28 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/starboard/south)
+"mbZ" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "engineeringlockdown";
+	layer = 2.6;
+	name = "Emergency Lockdown Blastdoor"
+	},
+/obj/machinery/door/airlock/engineering{
+	name = "Engineering Foyer"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel{
+	icon_state = "darkyellowfull"
+	},
+/area/station/engineering/break_room)
 "mco" = (
 /obj/machinery/conveyor/auto{
 	dir = 8
@@ -59006,21 +59736,6 @@
 	icon_state = "whitepurple"
 	},
 /area/station/science/xenobiology)
-"mdk" = (
-/obj/effect/turf_decal/stripes/full,
-/obj/machinery/door/airlock/security/glass{
-	name = "Criminal Delivery Chute"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/effect/turf_decal/stripes/red/full,
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	color = "#954535"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
-	},
-/area/station/maintenance/fsmaint)
 "mdl" = (
 /obj/effect/spawner/random_spawners/dirt_frequent,
 /turf/simulated/floor/plasteel,
@@ -59042,19 +59757,6 @@
 	icon_state = "neutral"
 	},
 /area/station/public/storage/tools)
-"mdI" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Docking Asteroid SMES Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/station/maintenance/asmaint)
 "mdQ" = (
 /obj/machinery/light{
 	dir = 8
@@ -59243,16 +59945,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/fore/east)
-"mho" = (
-/obj/machinery/door/window/classic/reversed{
-	dir = 8;
-	pixel_x = 1;
-	name = "Boxing Arena"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/public/fitness)
 "mhv" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -59805,22 +60497,6 @@
 /obj/effect/spawner/random_spawners/dirt_often,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry/north)
-"mrq" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Security Maintenance";
-	security_level = 1
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Secure Gate";
-	name = "Security Blast Door";
-	opacity = 0
-	},
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore2)
 "mrt" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
@@ -59832,84 +60508,18 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/service/library)
-"mrT" = (
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/window/classic/normal{
-	dir = 1;
-	name = "Containment Pen"
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/science/xenobio{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "whitepurple"
-	},
-/area/station/science/xenobiology)
 "mrW" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal/westalt)
-"msx" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Port Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/orange{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/station/maintenance/disposal/west)
 "msD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal/westalt)
-"msH" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "medmain";
-	name = "Medbay Entrance"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/medical/general,
-/obj/effect/mapping_helpers/airlock/access/any/medical/genetics,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Biohazard_medi";
-	name = "Quarantine Lockdown";
-	opacity = 0
-	},
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel/white,
-/area/station/medical/medbay)
-"msK" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Aft Asteroid Solars"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/barricade/wooden,
-/turf/simulated/floor/plating,
-/area/station/maintenance/starboardsolar/aft)
 "mte" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -60121,6 +60731,19 @@
 	icon_state = "darkyellow"
 	},
 /area/station/engineering/break_room)
+"mxd" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Docking Asteroid SMES Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/station/maintenance/asmaint)
 "mxn" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -60248,15 +60871,6 @@
 	icon_state = "darkred"
 	},
 /area/station/security/permabrig)
-"mzW" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "supply_home";
-	locked = 1;
-	name = "Cargo Docking Hatch"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/supply/general,
-/turf/simulated/floor/plating,
-/area/station/supply/office)
 "mAb" = (
 /obj/structure/toilet{
 	dir = 8
@@ -60409,6 +61023,32 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/science/explab/chamber)
+"mCe" = (
+/obj/machinery/door/airlock/medical{
+	name = "Morgue"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/morgue,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Biohazard_medi";
+	name = "Quarantine Lockdown";
+	opacity = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/medical/morgue)
 "mCg" = (
 /obj/effect/spawner/random_spawners/fungus_maybe,
 /turf/simulated/wall/r_wall,
@@ -60527,25 +61167,9 @@
 /obj/effect/spawner/random_spawners/dirt_frequent,
 /turf/simulated/floor/plasteel,
 /area/station/security/range)
-"mFN" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Security Office"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/security/main)
 "mFT" = (
 /turf/simulated/floor/plasteel,
 /area/station/security/prisonershuttle)
-"mGb" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Fore Asteroid Maintenance Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
 "mGs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -60623,28 +61247,20 @@
 /obj/item/stack/sheet/metal,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
-"mHq" = (
-/obj/machinery/door/airlock/public/glass{
-	autoclose = 0;
-	heat_proof = 1;
-	id_tag = "turbine_door_ext";
-	locked = 1;
-	name = "Turbine Exterior Airlock"
+"mHA" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/construction,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/door/airlock/maintenance{
+	name = "Science Asteroid Solars"
 	},
-/obj/machinery/access_button{
-	layer = 3.1;
-	autolink_id = "turbine_btn_ext";
-	name = "Gas Turbine Airlock Control";
-	pixel_x = -24
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/turf/simulated/floor/plating{
+	icon_state = "asteroidplating"
 	},
-/turf/simulated/floor/engine,
-/area/station/maintenance/turbine)
+/area/station/maintenance/portsolar)
 "mHE" = (
 /obj/machinery/door/airlock{
 	name = "Bathroom"
@@ -60710,6 +61326,15 @@
 /obj/structure/disposalpipe/segment/corner,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/hallway)
+"mIS" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Aft Asteroid Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/turf/simulated/floor/plating,
+/area/station/maintenance/asmaint)
 "mJk" = (
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -60780,28 +61405,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/starboard/south)
-"mKd" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/classic/reversed{
-	name = "Cargo Desk";
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/mail_sorting{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/mining{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
-/obj/item/desk_bell{
-	pixel_x = 7;
-	pixel_y = 7;
-	anchored = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "darkbrownfull"
-	},
-/area/station/supply/office)
 "mKh" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -60937,29 +61540,6 @@
 	},
 /turf/simulated/mineral/ancient,
 /area/station/public/quantum/docking)
-"mMD" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 8;
-	id_tag = "kitchen1"
-	},
-/obj/item/desk_bell{
-	pixel_x = 7;
-	pixel_y = 7;
-	anchored = 1
-	},
-/obj/machinery/door/window/classic/normal{
-	dir = 4;
-	name = "Kitchen"
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/service/kitchen{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/station/service/kitchen)
 "mMG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/engine,
@@ -60991,6 +61571,19 @@
 /obj/structure/lattice/catwalk,
 /turf/space,
 /area/station/engineering/solar/starboard)
+"mNc" = (
+/obj/machinery/door/airlock/research{
+	name = "Robotics Lab"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/robotics,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	icon_state = "darkpurplefull"
+	},
+/area/station/science/robotics)
 "mNd" = (
 /obj/machinery/constructable_frame/machine_frame,
 /turf/simulated/floor/plating,
@@ -61137,63 +61730,10 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/fpmaint)
-"mPk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "medmain";
-	name = "Medbay Entrance"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/medical/general,
-/obj/effect/mapping_helpers/airlock/access/any/medical/genetics,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Biohazard_medi";
-	name = "Quarantine Lockdown";
-	opacity = 0
-	},
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 4
-	},
-/obj/structure/cable/orange{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whiteblue"
-	},
-/area/station/medical/medbay)
 "mPp" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/electrical_shop)
-"mPt" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Equipment Storage"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/machinery/door/firedoor,
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "red"
-	},
-/area/station/security/storage)
 "mPu" = (
 /obj/structure/table/wood/poker,
 /turf/simulated/floor/wood{
@@ -61212,15 +61752,6 @@
 "mPI" = (
 /turf/simulated/wall/r_wall,
 /area/mine/unexplored/cere/cargo)
-"mPL" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Central Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/station/maintenance/maintcentral)
 "mPT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
@@ -61615,18 +62146,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/fore2)
-"mVP" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Cargo SMES Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/hallway/primary/fore/east)
 "mVY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -61682,6 +62201,25 @@
 /obj/machinery/atmospherics/supermatter_crystal/engine,
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/supermatter)
+"mWM" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Port Asteroid Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/turf/simulated/floor/plating,
+/area/station/maintenance/port)
 "mWU" = (
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -61772,23 +62310,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/carpet/black,
 /area/station/service/chapel)
-"mYE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/simulated/floor/plating/airless{
-	icon_state = "asteroidplating"
-	},
-/area/station/hallway/spacebridge/servsci)
-"mYF" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Central Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plating,
-/area/station/maintenance/maintcentral)
 "mYI" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -61889,6 +62410,15 @@
 	icon_state = "dark"
 	},
 /area/station/maintenance/asmaint)
+"mZH" = (
+/obj/machinery/door/airlock/external{
+	id_tag = "laborcamp_home";
+	locked = 1;
+	name = "Labor Camp Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/turf/simulated/floor/plating,
+/area/station/security/prisonershuttle)
 "mZP" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -61988,6 +62518,19 @@
 	icon_state = "dark"
 	},
 /area/station/maintenance/port2)
+"nbT" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Medical Asteroid Solars"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/station/maintenance/starboardsolar)
 "nca" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -62199,6 +62742,15 @@
 /obj/effect/spawner/random_spawners/dirt_frequent,
 /turf/simulated/floor/plating,
 /area/station/supply/miningdock)
+"nfq" = (
+/obj/machinery/r_n_d/server/robotics,
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 5
+	},
+/turf/simulated/floor/plasteel/dark/telecomms{
+	icon_state = "bcircuit"
+	},
+/area/station/science/server/coldroom)
 "nfF" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 8
@@ -62223,21 +62775,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/spacebridge/comeng)
-"nfQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/orange{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Starboard Asteroid Maintenance Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating/asteroid/ancient,
-/area/station/maintenance/starboard)
 "nfU" = (
 /obj/effect/spawner/window/reinforced/plasma/grilled,
 /obj/structure/cable{
@@ -62302,23 +62839,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/starboard/south)
-"ngX" = (
-/obj/machinery/door/airlock/hatch{
-	name = "AI Satellite Secondary Antechamber"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/turret_protected/aisat/interior/secondary)
 "nhe" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -62346,14 +62866,6 @@
 "nhx" = (
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
-"nhD" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Fore Asteroid Maintenance Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
 "nhE" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -62361,21 +62873,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal/southwest)
-"nhN" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/maintenance/external{
-	name = "External Airlock Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plating,
-/area/station/hallway/primary/fore/west)
 "nhP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -62591,6 +63088,13 @@
 	icon_state = "white"
 	},
 /area/station/medical/cloning)
+"nll" = (
+/obj/machinery/disposal/deliveryChute,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/maintenance/disposal/external/east)
 "nln" = (
 /obj/structure/cable/orange{
 	d1 = 2;
@@ -62621,16 +63125,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central)
-"nlx" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance{
-	name = "Fore Asteroid Maintenance Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/station/maintenance/disposal/north)
 "nlE" = (
 /obj/machinery/door/poddoor/shutters{
 	id_tag = "MiningWarehouse"
@@ -62650,6 +63144,20 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/port)
+"nlS" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Criminal Delivery Chute"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/effect/turf_decal/stripes/full,
+/obj/effect/turf_decal/stripes/red/full,
+/obj/structure/disposalpipe/segment{
+	color = "#954535"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/primary/central)
 "nmk" = (
 /obj/structure/cable/orange{
 	d2 = 8;
@@ -62793,24 +63301,6 @@
 "npb" = (
 /turf/simulated/wall,
 /area/station/science/robotics)
-"npe" = (
-/obj/machinery/door/airlock/maintenance/external{
-	name = "AI Satellite Atmospherics"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/turret_protected/aisat/interior)
 "npl" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -62969,6 +63459,19 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/spacebridge/medcargo)
+"nsb" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "Secure Tech Storage"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/tech_storage,
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/tech_storage)
 "nsy" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -63005,6 +63508,18 @@
 	icon_state = "darkblue"
 	},
 /area/station/command/bridge)
+"nsZ" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "Secure Tech Storage"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/tech_storage,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/tech_storage)
 "nta" = (
 /obj/structure/cable/orange{
 	d1 = 4;
@@ -63027,19 +63542,6 @@
 	icon_state = "dark"
 	},
 /area/station/turret_protected/ai_upload)
-"ntj" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Medical Asteroid Solars"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/station/maintenance/starboardsolar)
 "nto" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable/orange,
@@ -63067,34 +63569,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore2)
-"nui" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Operating Theatre"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
-/obj/machinery/holosign/surgery{
-	id = "surgery2"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "surg2"
-	},
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/station/medical/surgery/secondary)
 "num" = (
 /obj/structure/disposalpipe/segment{
 	color = "#954535"
@@ -63224,22 +63698,23 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/control)
+"nvF" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Genetics Research"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/genetics,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/turf/simulated/floor/plating,
+/area/station/maintenance/starboard)
 "nvU" = (
 /turf/simulated/floor/carpet/black,
 /area/station/service/chapel)
-"nwk" = (
-/obj/machinery/door/window/classic/reversed{
-	dir = 8;
-	name = "Medical Secure Storage"
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/medical/general{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkblue"
-	},
-/area/station/medical/storage/secondary)
 "nwl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -63257,6 +63732,18 @@
 /obj/machinery/economy/vending/cola,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/aft/east)
+"nwD" = (
+/obj/machinery/door/airlock/research{
+	name = "Research Division Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/medical/genetics,
+/obj/effect/mapping_helpers/airlock/access/any/science/research,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel/white,
+/area/station/science/hallway)
 "nwI" = (
 /obj/item/radio/intercom{
 	pixel_x = -28;
@@ -63334,27 +63821,6 @@
 	icon_state = "purplecorner"
 	},
 /area/station/hallway/primary/aft/east)
-"nya" = (
-/obj/machinery/door/airlock/atmos/glass{
-	autoclose = 0;
-	id_tag = "atmossm_door_int";
-	locked = 1;
-	name = "Atmospherics Access Chamber"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/machinery/access_button{
-	autolink_id = "atmossm_btn_int";
-	name = "Atmospherics Access Button";
-	pixel_y = -24;
-	req_access_txt = "24"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/engineering/control)
 "nyc" = (
 /obj/structure/sign/vacuum{
 	pixel_y = 32
@@ -63364,6 +63830,22 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/science/toxins/mixing)
+"nyv" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Starboard Asteroid Maintenance Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/turf/simulated/floor/plating,
+/area/station/maintenance/starboard)
 "nyA" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -63637,6 +64119,23 @@
 	},
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/station/maintenance/port2)
+"nDG" = (
+/obj/machinery/door/airlock/research{
+	name = "Research Break Room"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/medical/genetics,
+/obj/effect/mapping_helpers/airlock/access/any/science/research,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/freezer,
+/area/station/science/hallway)
 "nDQ" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -63772,6 +64271,27 @@
 "nFW" = (
 /turf/simulated/wall,
 /area/station/public/quantum/docking)
+"nGd" = (
+/obj/machinery/door/airlock/research/glass{
+	name = "Test Chamber"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/tox,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "RnDChem";
+	name = "Biohazard Shutter";
+	opacity = 0
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/engine,
+/area/station/science/test_chamber)
 "nGm" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /turf/simulated/floor/plasteel{
@@ -63790,6 +64310,16 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/south)
+"nGZ" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Atmospherics Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/turf/simulated/floor/plating,
+/area/station/engineering/atmos)
 "nHa" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
@@ -63875,6 +64405,13 @@
 	},
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/station/maintenance/apmaint)
+"nIZ" = (
+/obj/machinery/door/airlock/research{
+	name = "Toxins Launch Room"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/tox,
+/turf/simulated/floor/plasteel,
+/area/station/science/toxins/mixing)
 "nJA" = (
 /obj/structure/punching_bag,
 /turf/simulated/floor/carpet/cyan,
@@ -63954,6 +64491,14 @@
 /obj/effect/spawner/airlock/s_to_n,
 /turf/simulated/wall/r_wall,
 /area/station/security/permabrig)
+"nKB" = (
+/obj/machinery/door/airlock/maintenance/external{
+	name = "External Airlock Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/station/maintenance/starboard)
 "nKC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -64057,20 +64602,6 @@
 	icon_state = "redyellowfull"
 	},
 /area/station/service/bar)
-"nMj" = (
-/obj/machinery/door/airlock/command{
-	name = "Head of Personnel's Private Quarters"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/command/hop,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/blue,
-/area/station/command/office/hop)
 "nMt" = (
 /obj/structure/closet/firecloset/full,
 /turf/simulated/floor/plasteel{
@@ -64135,6 +64666,18 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/fore/east)
+"nNF" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Service SMES Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/port)
 "nNN" = (
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -64193,10 +64736,39 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/control)
+"nON" = (
+/obj/machinery/door/airlock/maintenance/external{
+	name = "External Airlock Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/station/hallway/primary/central)
 "nOP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/wall,
 /area/station/hallway/primary/aft/west)
+"nOU" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance/external{
+	name = "External Airlock Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
+	icon_state = "space";
+	layer = 4;
+	name = "EXTERNAL AIRLOCK";
+	pixel_x = -32
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/port2)
 "nPo" = (
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -64282,19 +64854,6 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/gravitygenerator)
-"nQv" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Port Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/port)
 "nQA" = (
 /obj/machinery/ai_status_display,
 /turf/simulated/mineral/ancient,
@@ -64405,21 +64964,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/command/office/cmo)
-"nSS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/maintenance/external{
-	name = "External Airlock Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/hallway/primary/central)
 "nTJ" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 8
@@ -64455,18 +64999,6 @@
 	icon_state = "darkpurple"
 	},
 /area/station/science/robotics)
-"nTZ" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Medbay Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/starboard)
 "nUg" = (
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -64525,26 +65057,6 @@
 	icon_state = "dark"
 	},
 /area/station/public/fitness)
-"nVs" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Interrogation"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/machinery/door/firedoor,
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "Interrogation"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/security/interrogation)
 "nVE" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/light,
@@ -64586,19 +65098,6 @@
 	},
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/station/science/rnd)
-"nWI" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/maintenance/external{
-	name = "External Airlock Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plating,
-/area/station/hallway/primary/central)
 "nWK" = (
 /obj/item/soap,
 /turf/simulated/floor/plasteel{
@@ -64776,16 +65275,6 @@
 	icon_state = "darkblue"
 	},
 /area/station/command/office/cmo)
-"oaj" = (
-/obj/machinery/door/airlock/hatch{
-	name = "AI Asteroid Teleporter Room"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/command/teleporter,
-/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/turret_protected/aisat/interior)
 "oam" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -64814,31 +65303,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/starboard/north)
-"oaR" = (
-/obj/machinery/navbeacon{
-	codes_txt = "delivery";
-	dir = 8;
-	location = "Security"
-	},
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Secure Gate";
-	name = "Security Blast Door"
-	},
-/obj/machinery/door/window/classic/reversed{
-	dir = 4;
-	name = "Security Delivery"
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/mule_bot{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/security/brig{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/security/range)
 "oba" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -64912,6 +65376,14 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/service/clown)
+"odn" = (
+/obj/machinery/door/airlock/freezer{
+	name = "Freezer"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel/freezer,
+/area/station/service/hydroponics)
 "odt" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
 	dir = 8;
@@ -64964,6 +65436,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/virology)
+"oep" = (
+/obj/machinery/door/airlock/maintenance/external{
+	name = "External Airlock Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/primary/port/east)
 "oes" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -65097,18 +65583,6 @@
 	icon_state = "dark"
 	},
 /area/station/security/brig)
-"ogh" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/maintenance/external{
-	name = "External Airlock Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/hallway/primary/port/north)
 "ogk" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
@@ -65154,10 +65628,11 @@
 	icon_state = "darkred"
 	},
 /area/station/security/checkpoint/secondary)
-"ohD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+"ohs" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Engine Room"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -65166,16 +65641,25 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock/maintenance/external{
-	name = "External Airlock Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel{
+	icon_state = "darkyellowfull"
+	},
+/area/station/engineering/control)
+"ohu" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Port Asteroid Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /obj/effect/spawner/random_spawners/dirt_frequent,
 /turf/simulated/floor/plating,
-/area/station/hallway/primary/starboard/south)
+/area/station/maintenance/port)
 "ohH" = (
 /obj/machinery/economy/vending/boozeomat,
 /turf/simulated/floor/wood,
@@ -65236,22 +65720,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/aft/west)
-"oio" = (
-/obj/machinery/door/airlock/command{
-	name = "Captain's Office"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/command/captain,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/carpet/black,
-/area/station/command/office/captain)
 "oix" = (
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -65425,19 +65893,18 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/control)
-"old" = (
-/obj/machinery/door/airlock/highsecurity{
-	name = "Secure Tech Storage"
+"olg" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Docking Asteroid SMES Access"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/tech_storage,
-/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/station/engineering/tech_storage)
+/area/station/maintenance/asmaint)
 "olh" = (
 /obj/structure/table,
 /obj/item/storage/bag/plants/portaseeder,
@@ -65481,13 +65948,6 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/xenobiology)
-"olD" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Starboard Asteroid Maintenance Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/starboard)
 "olT" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -65697,20 +66157,6 @@
 	icon_state = "darkred"
 	},
 /area/station/public/quantum/security)
-"oof" = (
-/obj/machinery/door/airlock/medical{
-	name = "Operating Theatre Storage"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
-/obj/structure/cable/orange{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "showroomfloor"
-	},
-/area/station/medical/surgery/secondary)
 "ooj" = (
 /obj/machinery/camera{
 	c_tag = "Research Eastern Wing";
@@ -65786,6 +66232,16 @@
 	icon_state = "white"
 	},
 /area/station/medical/virology)
+"ooI" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance{
+	name = "Fore Asteroid Maintenance Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/station/maintenance/disposal/north)
 "ooM" = (
 /obj/machinery/light{
 	dir = 8
@@ -66023,19 +66479,6 @@
 /obj/structure/closet/secure_closet/engineering_personal,
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
-"oto" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Disposals Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/turret_protected/aisat/interior/secondary)
 "otq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -66262,6 +66705,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/station/command/bridge)
+"oxO" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Aft Asteroid Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/turf/simulated/floor/plating,
+/area/station/maintenance/asmaint)
 "oxQ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -66437,32 +66888,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/range)
-"oBe" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/window/classic/reversed{
-	dir = 4;
-	name = "AI Core Door"
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/command/ai_upload{
-	dir = 4
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 8;
-	id_tag = "aisat"
-	},
-/obj/effect/turf_decal/caution/stand_clear,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/turret_protected/ai)
-"oBg" = (
-/obj/structure/shuttle/engine/propulsion,
-/turf/simulated/floor/plating/airless,
-/area/shuttle/arrival/station)
 "oBh" = (
 /obj/effect/spawner/random_spawners/dirt_often,
 /turf/simulated/floor/carpet/arcade,
@@ -66514,27 +66939,6 @@
 "oBP" = (
 /turf/simulated/mineral/ancient/outer,
 /area/station/maintenance/apmaint)
-"oBR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Starboard Asteroid Maintenance Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/disposal/east)
-"oBS" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Warden's Office"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/armory,
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/security/warden)
 "oCn" = (
 /obj/structure/table,
 /obj/item/stack/sheet/metal/fifty,
@@ -66585,17 +66989,6 @@
 	},
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/station/hallway/primary/starboard/north)
-"oDJ" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Bar"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plating,
-/area/station/maintenance/gambling_den)
 "oDM" = (
 /obj/structure/table,
 /obj/item/stack/packageWrap,
@@ -66725,16 +67118,6 @@
 	icon_state = "whitebluecorner"
 	},
 /area/station/medical/medbay)
-"oGj" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Port Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/disposal/southwest)
 "oGk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -66777,17 +67160,6 @@
 /obj/effect/spawner/random_spawners/dirt_often,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal/northeast)
-"oGO" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Laser Room"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/engineering/control)
 "oGS" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/sign/explosives/alt,
@@ -66839,25 +67211,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboardsolar)
-"oIo" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "cell1";
-	name = "Permabrig Cell 1";
-	security_level = 1
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Prison Gate";
-	name = "Prison Lockdown Blast Doors";
-	opacity = 0
-	},
-/obj/effect/mapping_helpers/airlock/unres,
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plasteel,
-/area/station/security/permabrig)
 "oIu" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -66974,21 +67327,6 @@
 	icon_state = "darkgreenfull"
 	},
 /area/station/service/hydroponics)
-"oKh" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Security SMES Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/cable/orange{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fpmaint)
 "oKi" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 1
@@ -67003,6 +67341,26 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
+"oKk" = (
+/obj/machinery/door/airlock/command{
+	name = "Expedition Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/expedition,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/ai_monitored/storage/eva)
 "oKm" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -67189,25 +67547,6 @@
 	dir = 1
 	},
 /area/station/engineering/smes)
-"oNe" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Port Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/cable/orange{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plating,
-/area/station/maintenance/port)
 "oNg" = (
 /obj/machinery/light{
 	dir = 8
@@ -67355,20 +67694,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/public/fitness)
-"oPt" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Genetics Research"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/genetics,
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plating,
-/area/station/maintenance/starboard)
 "oPw" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -67584,6 +67909,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry/north)
+"oSb" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/atmos{
+	name = "Research Atmospherics Checkpoint"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/primary/aft/west)
 "oSt" = (
 /obj/machinery/chem_master/condimaster,
 /turf/simulated/floor/plasteel/freezer,
@@ -67729,6 +68069,12 @@
 	icon_state = "white"
 	},
 /area/station/science/misc_lab)
+"oUM" = (
+/obj/machinery/atmospherics/unary/outlet_injector/on{
+	dir = 4
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/science/test_chamber)
 "oVa" = (
 /obj/structure/cable/orange{
 	d1 = 4;
@@ -67752,6 +68098,17 @@
 	icon_state = "darkredcorners"
 	},
 /area/station/security/prison/cell_block/A)
+"oVj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock{
+	name = "Vacant Office"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/station/public/vacant_office)
 "oVA" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
@@ -67908,21 +68265,6 @@
 	icon_state = "white"
 	},
 /area/station/science/misc_lab)
-"oXu" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Port Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/orange{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/port2)
 "oXv" = (
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -67939,27 +68281,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/apmaint)
-"oXy" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/airlock/highsecurity{
-	name = "Telecommunications"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/telecomms/computer)
 "oXz" = (
 /obj/effect/decal/cleanable/vomit,
 /turf/simulated/floor/plating{
@@ -68060,20 +68381,16 @@
 /obj/effect/turf_decal/bot_white,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/electrical_shop)
-"oZy" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+"oZD" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Warden's Office"
 	},
-/obj/machinery/door/airlock/engineering/glass{
-	heat_proof = 1;
-	name = "Supermatter Chamber"
+/obj/effect/mapping_helpers/airlock/access/all/security/armory,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
-/turf/simulated/floor/engine,
-/area/station/engineering/engine/supermatter)
+/area/station/security/warden)
 "oZE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -68194,55 +68511,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal/north)
-"pcy" = (
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "bridge";
-	layer = 2.6;
-	name = "Emergency Blast Door"
+"pcI" = (
+/obj/machinery/door/airlock/mining/glass{
+	name = "Cargo Bay"
 	},
-/obj/machinery/door/airlock/command/glass{
-	name = "Bridge"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/command/general,
+/obj/effect/mapping_helpers/airlock/access/all/supply/mail_sorting,
 /obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "darkbrownfull"
 	},
-/area/station/command/bridge)
-"pcB" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Aft Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/science/tox,
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plating,
-/area/station/science/toxins/mixing)
-"pcC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Kitchen"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 8;
-	id_tag = "kitchen1"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/station/service/kitchen)
+/area/station/supply/office)
 "pdg" = (
 /obj/structure/cable/orange,
 /obj/structure/cable/orange{
@@ -68261,27 +68539,6 @@
 	icon_state = "dark"
 	},
 /area/station/security/evidence)
-"pdh" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Gravity Generator"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/engineering/gravitygenerator)
 "pdj" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -68379,29 +68636,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/prison/cell_block/A)
-"peC" = (
-/obj/structure/cable/orange{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/window/classic/normal{
-	name = "Containment Pen";
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/science/tox{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/station/science/misc_lab)
 "peG" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -68486,18 +68720,6 @@
 /obj/effect/spawner/random_spawners/dirt_often,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal/northeast)
-"pgj" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Starboard Asteroid Maintenance Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/cable/orange{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/starboard)
 "pgO" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 5
@@ -68634,23 +68856,6 @@
 	},
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/station/maintenance/asmaint)
-"pjc" = (
-/obj/machinery/door/airlock/public/glass{
-	autoclose = 0;
-	heat_proof = 1;
-	id_tag = "incinerator_door_ext";
-	locked = 1;
-	name = "Mixing Room Exterior Airlock"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/access_button{
-	layer = 3.1;
-	autolink_id = "incinerator_btn_ext";
-	name = "Incinerator Airlock Control";
-	pixel_y = -23
-	},
-/turf/simulated/floor/engine,
-/area/station/science/toxins/mixing)
 "pjx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -68722,10 +68927,42 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/east)
+"pkp" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Warden's Office"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/armory,
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/security/warden)
 "pkt" = (
 /obj/effect/spawner/window/shuttle,
 /turf/simulated/floor/plating,
 /area/shuttle/arrival/station)
+"pkO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/computer/borgupload{
+	dir = 1
+	},
+/obj/machinery/door/window/classic/reversed{
+	dir = 1;
+	name = "Console Access"
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/command/ai_upload{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/turret_protected/ai_upload)
 "pkP" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -68739,14 +68976,29 @@
 	},
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/station/hallway/primary/starboard/north)
-"pkW" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance{
-	name = "Aft Asteroid Maintenance"
+"pkQ" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Medbay Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Biohazard_medi";
+	name = "Quarantine Lockdown";
+	opacity = 0
+	},
+/obj/effect/spawner/random_spawners/dirt_frequent,
 /turf/simulated/floor/plating,
-/area/station/maintenance/disposal/south)
+/area/station/maintenance/starboard)
 "pli" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -68763,24 +69015,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/carpet/black,
 /area/station/command/bridge)
-"plF" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/orange{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Aft Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/apmaint)
 "plG" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowcorner"
@@ -68884,19 +69118,26 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/secondary/entry/north)
-"pnQ" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical/glass{
-	name = "Private Patient Room"
+"pnr" = (
+/obj/structure/plasticflaps{
+	opacity = 1
 	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "private"
+/obj/machinery/navbeacon{
+	codes_txt = "delivery";
+	location = "Hydroponics"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
+/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/mule_bot{
+	dir = 4
 	},
-/area/station/medical/patients_rooms)
+/obj/effect/mapping_helpers/airlock/windoor/access/any/service/hydroponics{
+	dir = 4
+	},
+/obj/machinery/door/window/classic/reversed{
+	dir = 4;
+	name = "Botany Delivery"
+	},
+/turf/simulated/floor/plating,
+/area/station/service/hydroponics)
 "pnV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -69155,31 +69396,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/service/theatre)
-"prK" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/highsecurity{
-	name = "Telecommunications"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/telecomms/chamber)
 "prN" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "darkgreenfull"
@@ -69192,30 +69408,6 @@
 	},
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/station/maintenance/asmaint)
-"pst" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/door/airlock/medical/glass{
-	name = "Monkey Pen"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/station/medical/virology)
 "psw" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
@@ -69562,6 +69754,19 @@
 	icon_state = "cafeteria"
 	},
 /area/station/service/kitchen)
+"pxr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/maintenance/external{
+	name = "External Airlock Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/hallway/primary/starboard/north)
 "pxP" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -69574,19 +69779,6 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plasteel/airless,
 /area/station/science/toxins/test)
-"pyd" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Criminal Delivery Chute"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/effect/turf_decal/stripes/full,
-/obj/effect/turf_decal/stripes/red/full,
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	color = "#954535"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/starboard/south)
 "pyp" = (
 /obj/structure/grille,
 /turf/simulated/floor/plating/asteroid/ancient,
@@ -69632,18 +69824,6 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/main)
-"pzp" = (
-/obj/machinery/door/window/classic/normal{
-	dir = 1;
-	name = "Bridge Desk"
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/command/general{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "rampbottom"
-	},
-/area/station/command/bridge)
 "pzs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -69675,13 +69855,6 @@
 	icon_state = "tranquillite"
 	},
 /area/station/service/theatre)
-"pAh" = (
-/obj/machinery/door/airlock/research{
-	name = "Toxins Launch Room"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/science/tox,
-/turf/simulated/floor/plasteel,
-/area/station/science/toxins/mixing)
 "pAi" = (
 /turf/simulated/floor/engine,
 /area/station/science/xenobiology)
@@ -69719,22 +69892,6 @@
 /obj/item/candle,
 /turf/simulated/floor/wood,
 /area/station/service/theatre)
-"pBe" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Prison Wing";
-	security_level = 1
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/obj/machinery/door/firedoor,
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/security/permabrig)
 "pBh" = (
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 4;
@@ -70252,6 +70409,17 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/qm)
+"pJG" = (
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "BrigEast";
+	name = "Brig East Entrance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/security/prison/cell_block/A)
 "pJK" = (
 /obj/structure/table/wood,
 /obj/machinery/firealarm{
@@ -70319,21 +70487,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/entry)
-"pKA" = (
-/obj/structure/disposalpipe/segment{
-	color = "#954535"
-	},
-/obj/machinery/door/airlock/security/glass{
-	name = "Criminal Delivery Chute"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/effect/turf_decal/stripes/full,
-/obj/effect/turf_decal/stripes/red/full,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/aft/west)
 "pKQ" = (
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -70451,6 +70604,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal/north)
+"pMm" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Aft Asteroid Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/exit)
 "pMq" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/disposalpipe/segment,
@@ -70473,6 +70637,24 @@
 /obj/effect/spawner/random_spawners/wall_rusted_always,
 /turf/simulated/wall,
 /area/station/maintenance/turbine)
+"pMT" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/window{
+	dir = 8;
+	icon_state = "right";
+	name = "Engineering Delivery Chute"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/mapping_helpers/airlock/windoor/access/any/engineering/general{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/mule_bot{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/smes)
 "pNi" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/grille,
@@ -70543,6 +70725,22 @@
 	icon_state = "barber"
 	},
 /area/station/service/barber)
+"pOl" = (
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "bridge";
+	layer = 2.6;
+	name = "Emergency Blast Door"
+	},
+/obj/machinery/door/airlock/command/glass{
+	name = "Bridge"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/command/bridge)
 "pOG" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/orange{
@@ -70552,31 +70750,6 @@
 	},
 /turf/space,
 /area/space/nearstation)
-"pOL" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel/dark/telecomms{
-	icon_state = "bcircuit"
-	},
-/area/station/science/server/coldroom)
-"pOP" = (
-/obj/machinery/door/airlock/security{
-	name = "Evidence Storage"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/machinery/door/firedoor,
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/security/evidence)
 "pOU" = (
 /obj/item/kirbyplants,
 /turf/simulated/floor/plasteel{
@@ -70824,41 +70997,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/command/teleporter)
-"pSL" = (
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "delivery";
-	location = "Hydroponics"
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/mule_bot{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/service/hydroponics{
-	dir = 4
-	},
-/obj/machinery/door/window/classic/reversed{
-	dir = 4;
-	name = "Botany Delivery"
-	},
-/turf/simulated/floor/plating,
-/area/station/service/hydroponics)
-"pSM" = (
-/obj/machinery/door/airlock/command{
-	name = "Server Room"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/science/rd,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel/dark/telecomms,
-/area/station/science/server)
 "pSN" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -70939,24 +71077,6 @@
 	icon_state = "floorgrime"
 	},
 /area/station/security/permabrig)
-"pTU" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/door/window{
-	dir = 8;
-	icon_state = "right";
-	name = "Engineering Delivery Chute"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/mapping_helpers/airlock/windoor/access/any/engineering/general{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/mule_bot{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/station/engineering/smes)
 "pUe" = (
 /obj/machinery/conveyor/auto{
 	dir = 5
@@ -71118,18 +71238,6 @@
 /obj/effect/spawner/lootdrop/maintenance/three,
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/station/maintenance/starboard)
-"pWO" = (
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Starboard Asteroid Maintenance Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/starboard)
 "pWW" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -71206,6 +71314,44 @@
 /obj/structure/girder,
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/station/maintenance/asmaint)
+"pXX" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "BrigEast";
+	name = "Brig East Entrance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Secure Gate";
+	name = "Security Blast Door";
+	opacity = 0
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkredcorners"
+	},
+/area/station/security/prison/cell_block/A)
 "pXZ" = (
 /obj/structure/girder,
 /obj/structure/grille,
@@ -71644,6 +71790,27 @@
 	},
 /turf/simulated/wall,
 /area/station/hallway/primary/starboard/south)
+"qeR" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Gravity Generator"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/engineering/gravitygenerator)
 "qeX" = (
 /obj/item/reagent_containers/food/drinks/bottle/patron,
 /obj/structure/table/wood,
@@ -71812,14 +71979,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
-"qiz" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Fore Asteroid Maintenance Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore2)
 "qiI" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line{
@@ -71913,23 +72072,6 @@
 /obj/structure/lattice/catwalk,
 /turf/space,
 /area/station/engineering/solar/starboard/aft)
-"qkd" = (
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Secure Gate";
-	name = "Security Blast Door";
-	opacity = 0
-	},
-/obj/machinery/door/airlock/glass{
-	name = "Courtroom"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "Courtroom"
-	},
-/turf/simulated/floor/carpet,
-/area/station/security/processing)
 "qke" = (
 /obj/effect/landmark/spawner/xeno,
 /turf/simulated/floor/plating,
@@ -72045,15 +72187,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/maintenance/gambling_den)
-"qlk" = (
-/obj/machinery/door/airlock/research{
-	name = "Toxins Storage"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/science/tox,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/corner,
-/turf/simulated/floor/plasteel,
-/area/station/science/storage)
 "qll" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -72252,6 +72385,24 @@
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/service/janitor)
+"qnS" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Aft Asteroid Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/apmaint)
 "qoo" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -72407,19 +72558,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/maintcentral)
-"qpR" = (
-/obj/machinery/door/airlock/glass{
-	name = "Courtroom"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "Courtroom"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/wood,
-/area/station/legal/courtroom)
 "qpU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -72527,51 +72665,6 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/prison/cell_block/A)
-"qsb" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "cell3";
-	name = "Permabrig Cell 3";
-	security_level = 1
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Prison Gate";
-	name = "Prison Lockdown Blast Doors";
-	opacity = 0
-	},
-/obj/structure/cable/orange{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 8
-	},
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plasteel,
-/area/station/security/permabrig)
-"qsd" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/maintenance/external{
-	name = "External Airlock Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/hallway/primary/fore)
 "qsf" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -72735,18 +72828,6 @@
 	icon_state = "darkredcorners"
 	},
 /area/station/security/prison/cell_block/A)
-"qvh" = (
-/obj/machinery/door/airlock/command{
-	name = "Teleport Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/command/teleporter,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/command/teleporter)
 "qvk" = (
 /obj/structure/closet/bombcloset,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -72795,6 +72876,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/detective)
+"qwe" = (
+/obj/machinery/door/window/classic/normal{
+	dir = 8;
+	name = "Medical Secure Storage"
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/medical/general{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkblue"
+	},
+/area/station/medical/storage/secondary)
 "qwq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -72848,19 +72942,6 @@
 	icon_state = "whitepurple"
 	},
 /area/station/science/rnd)
-"qxv" = (
-/obj/machinery/door/window/classic/normal{
-	dir = 8;
-	name = "Medical Secure Storage"
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/medical/general{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkblue"
-	},
-/area/station/medical/storage/secondary)
 "qxB" = (
 /obj/machinery/conveyor/auto,
 /obj/machinery/light/small{
@@ -72883,6 +72964,15 @@
 	icon_state = "darkgreenfull"
 	},
 /area/station/service/hydroponics)
+"qyc" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Aft Asteroid Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/turf/simulated/floor/plating,
+/area/station/maintenance/apmaint)
 "qyk" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -72951,6 +73041,18 @@
 	slowdown = -0.3
 	},
 /area/station/hallway/spacebridge/scidock)
+"qyV" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Medbay SMES Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/turf/simulated/floor/plating,
+/area/station/hallway/primary/starboard/north)
 "qyY" = (
 /obj/machinery/conveyor/auto{
 	dir = 4
@@ -73014,28 +73116,10 @@
 	icon_state = "darkyellow"
 	},
 /area/station/engineering/control)
-"qAr" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Command Atmospherics Checkpoint"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/machinery/atmospherics/pipe/simple/hidden/universal,
-/turf/simulated/floor/plating,
-/area/station/hallway/primary/fore)
 "qAv" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/station/service/clown)
-"qAB" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass{
-	name = "Hydroponics"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
-/turf/simulated/floor/plasteel{
-	icon_state = "darkgreenfull"
-	},
-/area/station/service/hydroponics)
 "qAH" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -73435,6 +73519,17 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/lobby)
+"qHa" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Equipment Storage"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "red"
+	},
+/area/station/security/storage)
 "qHd" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 8
@@ -73470,14 +73565,6 @@
 /obj/item/pickaxe,
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/station/maintenance/port)
-"qHz" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Central Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
-/turf/simulated/floor/plating,
-/area/station/maintenance/storage)
 "qHC" = (
 /obj/effect/spawner/random_spawners/wall_rusted_always,
 /turf/simulated/wall,
@@ -73496,6 +73583,31 @@
 	icon_state = "grimy"
 	},
 /area/station/security/detective)
+"qHL" = (
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "XenoPod1";
+	layer = 2.6;
+	name = "containment door 1"
+	},
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/door/window/classic/normal{
+	dir = 1;
+	name = "Containment Pen"
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/science/xenobio{
+	dir = 1
+	},
+/turf/simulated/floor/engine,
+/area/station/science/xenobiology)
 "qHZ" = (
 /obj/structure/cable/orange{
 	d1 = 4;
@@ -73574,19 +73686,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/starboard)
-"qIZ" = (
-/obj/machinery/door/airlock/glass{
-	name = "Disposals"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/supply/general,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/maintenance/disposal)
 "qJm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -73628,22 +73727,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
-"qJE" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Port Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/disposal/west)
 "qJG" = (
 /obj/structure/lattice/catwalk,
 /turf/space,
@@ -73757,6 +73840,24 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/station/command/bridge)
+"qLv" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/highsecurity{
+	locked = 1;
+	name = "AI Upload Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/ai_upload,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/turret_protected/ai_upload)
 "qLz" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
@@ -73774,14 +73875,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore)
-"qLM" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Cargo SMES Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
 "qLN" = (
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -73819,30 +73912,6 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/control)
-"qMt" = (
-/obj/structure/cable/orange{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/airlock/research{
-	name = "Xenobiology Research"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/station/science/xenobiology)
 "qMy" = (
 /turf/simulated/floor/transparent/glass/reinforced/plasma,
 /area/station/engineering/control)
@@ -74064,6 +74133,13 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/port2)
+"qQx" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Port Asteroid Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating/asteroid/ancient,
+/area/station/maintenance/gambling_den)
 "qQJ" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
@@ -74096,19 +74172,6 @@
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/maintenance/turbine)
-"qRf" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Port Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/station/maintenance/disposal/northwest)
 "qRl" = (
 /obj/machinery/chem_heater,
 /turf/simulated/floor/plating{
@@ -74210,22 +74273,6 @@
 /obj/effect/spawner/random_spawners/dirt_often,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry/north)
-"qTZ" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Firing Range"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/security/range)
 "qUd" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/orange{
@@ -74445,18 +74492,6 @@
 /obj/structure/fans/tiny,
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/pod_1)
-"qYa" = (
-/obj/machinery/door/window/classic/reversed{
-	dir = 1;
-	name = "Interior Pipe Access"
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/engineering/atmos{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/engineering/atmos)
 "qYg" = (
 /obj/structure/cable/orange{
 	d1 = 4;
@@ -74556,16 +74591,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/asmaint)
-"rap" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/mining{
-	name = "Cargo Warehouse"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/supply/general,
-/turf/simulated/floor/plasteel{
-	icon_state = "darkbrownfull"
-	},
-/area/station/supply/storage)
 "raH" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /turf/simulated/floor/plasteel{
@@ -74834,14 +74859,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/south)
-"rhj" = (
-/obj/machinery/door/airlock/freezer{
-	name = "Freezer"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel/freezer,
-/area/station/service/kitchen)
 "rho" = (
 /obj/effect/spawner/random_spawners/wall_rusted_always,
 /turf/simulated/wall,
@@ -75025,18 +75042,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
-"rky" = (
-/obj/machinery/door/airlock/research{
-	name = "Research Division Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/medical/genetics,
-/obj/effect/mapping_helpers/airlock/access/any/science/research,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel/white,
-/area/station/science/hallway)
 "rkP" = (
 /obj/machinery/kitchen_machine/candy_maker,
 /turf/simulated/floor/plasteel/freezer,
@@ -75186,14 +75191,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/public/fitness)
-"rnn" = (
-/obj/machinery/door/airlock/mining{
-	name = "Mining Dock"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/supply/mining,
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plating,
-/area/station/supply/miningdock)
 "rns" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
@@ -75219,6 +75216,23 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/gambling_den)
+"rnN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/mining/glass{
+	name = "Cargo Bay"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/supply/mail_sorting,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "darkbrownfull"
+	},
+/area/station/supply/office)
 "rnQ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -75238,6 +75252,28 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard/south)
+"rnX" = (
+/obj/machinery/navbeacon{
+	codes_txt = "delivery";
+	dir = 4;
+	location = "Bar"
+	},
+/obj/structure/plasticflaps{
+	opacity = 1
+	},
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/machinery/door/window/classic/reversed{
+	dir = 8;
+	name = "Bar Delivery"
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/mule_bot{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/service/bar{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/service/bar)
 "rob" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -75301,18 +75337,6 @@
 /obj/effect/spawner/random_spawners/dirt_often,
 /turf/simulated/floor/plasteel,
 /area/station/public/locker)
-"roC" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/classic/normal{
-	name = "Hydroponics";
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/service/hydroponics{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/service/hydroponics)
 "roF" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -75365,14 +75389,6 @@
 /obj/machinery/economy/vending/cigarette,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry/south)
-"rpS" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Aft Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plating,
-/area/station/hallway/secondary/exit)
 "rpT" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -75464,6 +75480,14 @@
 	icon_state = "darkgreen"
 	},
 /area/station/public/quantum/docking)
+"rrC" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Fore Asteroid Maintenance Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/turf/simulated/floor/plating,
+/area/station/public/arcade)
 "rrN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -75506,6 +75530,19 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/break_room)
+"rsH" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Dorm SMES Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore2)
 "rsZ" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
@@ -75531,6 +75568,19 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/legal/courtroom)
+"rtB" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Garden"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "darkgreenfull"
+	},
+/area/station/service/hydroponics)
 "rtU" = (
 /obj/structure/closet/crate,
 /obj/effect/turf_decal/stripes/line{
@@ -75769,6 +75819,36 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/spacebridge/medcargo)
+"rAx" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Permabrig Cell 3";
+	security_level = 1
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Prison Gate";
+	name = "Prison Lockdown Blast Doors";
+	opacity = 0
+	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/security/permabrig)
 "rAB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -75866,9 +75946,45 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/maintenance/disposal/east)
+"rBB" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Port Asteroid Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/disposal/southwest)
 "rBH" = (
 /turf/simulated/wall/r_wall,
 /area/mine/unexplored/cere/command)
+"rBJ" = (
+/obj/machinery/navbeacon{
+	codes_txt = "delivery";
+	location = "Janitor"
+	},
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/machinery/door/window/classic/reversed{
+	dir = 1;
+	name = "Janitor Delivery"
+	},
+/obj/structure/plasticflaps{
+	opacity = 1
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/mule_bot{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/service/janitor{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/station/service/janitor)
 "rBO" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -75984,14 +76100,6 @@
 /obj/effect/spawner/random_spawners/dirt_often,
 /turf/simulated/floor/plasteel,
 /area/station/security/range)
-"rDV" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Starboard Asteroid Maintenance Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plating,
-/area/station/maintenance/starboard)
 "rDY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -76062,32 +76170,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/aft/west)
-"rFr" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Service SMES Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plating,
-/area/station/maintenance/port)
-"rFE" = (
-/obj/machinery/door/window{
-	dir = 1;
-	name = "Desk Door"
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/command/ntrep{
-	dir = 1
-	},
-/obj/machinery/keycard_auth{
-	pixel_x = 24
-	},
-/turf/simulated/floor/wood,
-/area/station/command/office/ntrep)
 "rFJ" = (
 /obj/structure/chair/comfy/corp{
 	dir = 1
@@ -76271,13 +76353,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal/north)
-"rIL" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Central Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating/asteroid/ancient,
-/area/station/maintenance/maintcentral)
 "rIO" = (
 /obj/item/radio/intercom{
 	pixel_x = -28;
@@ -76377,6 +76452,29 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/lobby)
+"rKE" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id_tag = "kitchen1"
+	},
+/obj/item/desk_bell{
+	pixel_x = 7;
+	pixel_y = 7;
+	anchored = 1
+	},
+/obj/machinery/door/window/classic/normal{
+	dir = 4;
+	name = "Kitchen"
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/service/kitchen{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/station/service/kitchen)
 "rLb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/alarm{
@@ -76396,24 +76494,20 @@
 /obj/item/storage/firstaid/regular,
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/arrival/station)
-"rLr" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/maintenance/external{
-	name = "External Airlock Access"
+"rLu" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Fore Asteroid Maintenance Access"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/spawner/random_spawners/dirt_frequent,
 /turf/simulated/floor/plating,
-/area/station/hallway/primary/starboard/south)
+/area/station/maintenance/fore)
 "rLA" = (
 /obj/structure/cable/orange{
 	d1 = 4;
@@ -76502,6 +76596,20 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal/southwest)
+"rMT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/simulated/floor/plating/airless{
+	icon_state = "asteroidplating"
+	},
+/area/station/hallway/spacebridge/servsci)
 "rMW" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -76681,19 +76789,6 @@
 "rPi" = (
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/fsmaint)
-"rPF" = (
-/obj/machinery/door/airlock/glass{
-	name = "Internal Affairs Office"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/iaa,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "IAA"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "cult"
-	},
-/area/station/legal/lawoffice)
 "rQk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -76723,31 +76818,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/command/office/captain)
-"rQG" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Cargo SMES Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/cable/orange{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/hallway/primary/fore/east)
-"rQI" = (
-/obj/structure/cable/orange{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Command SMES Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
 "rQK" = (
 /obj/effect/spawner/airlock/e_to_w,
 /turf/simulated/wall,
@@ -76809,6 +76879,18 @@
 	icon_state = "white"
 	},
 /area/station/medical/virology)
+"rRe" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Medbay Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/starboard)
 "rRj" = (
 /obj/structure/disposalpipe/segment{
 	color = "#954535"
@@ -76912,6 +76994,25 @@
 	icon_state = "redyellowfull"
 	},
 /area/station/service/bar)
+"rTA" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Starboard Asteroid Maintenance Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/starboard)
+"rTH" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Starboard Asteroid Maintenance Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating/asteroid/ancient,
+/area/station/maintenance/starboard)
 "rTQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -76943,18 +77044,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
-"rUz" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Docking Asteroid SMES Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/asmaint)
 "rUL" = (
 /obj/structure/table/wood,
 /obj/item/storage/pill_bottle/dice,
@@ -77023,6 +77112,15 @@
 /obj/item/storage/backpack/duffel/medical,
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
+"rVG" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Disposals"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/supply/general,
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "rVH" = (
 /obj/machinery/light/small,
 /obj/structure/cable/orange{
@@ -77052,17 +77150,6 @@
 "rWb" = (
 /turf/simulated/mineral/ancient,
 /area/station/maintenance/fsmaint)
-"rWg" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "BrigEast";
-	name = "Brig East Entrance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/security/prison/cell_block/A)
 "rWs" = (
 /obj/machinery/light,
 /obj/structure/disposalpipe/junction{
@@ -77112,14 +77199,6 @@
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal/south)
-"rXt" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating{
-	icon_state = "asteroidplating"
-	},
-/area/station/maintenance/fore2)
 "rXV" = (
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 1;
@@ -77142,6 +77221,31 @@
 	icon_state = "redcorner"
 	},
 /area/station/hallway/secondary/entry/north)
+"rYs" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Permabrig Cell 2";
+	security_level = 1
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/machinery/door/firedoor,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Prison Gate";
+	name = "Prison Lockdown Blast Doors";
+	opacity = 0
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/security/permabrig)
 "rYV" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -77170,6 +77274,21 @@
 /obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central)
+"rZg" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/maintenance/external{
+	name = "External Airlock Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/turf/simulated/floor/plating,
+/area/station/hallway/primary/fore/west)
 "rZi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -77260,27 +77379,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/storage)
-"saq" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/reinforced/normal{
-	name = "Secure Armory";
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/security/armory{
-	dir = 4
-	},
-/obj/machinery/door/window/reinforced/normal{
-	dir = 8;
-	name = "Secure Armory"
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/security/general{
-	dir = 8
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/security/armory/secure)
 "saJ" = (
 /obj/structure/cable/orange{
 	d1 = 4;
@@ -77411,6 +77509,24 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
+"sdo" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance/external{
+	name = "External Airlock Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/hallway/primary/starboard/south)
 "sdv" = (
 /obj/machinery/atmospherics/portable/canister/air,
 /obj/machinery/atmospherics/unary/portables_connector{
@@ -77458,16 +77574,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/command/office/ntrep)
-"sea" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Aft Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/science/tox,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plating,
-/area/station/maintenance/apmaint)
 "sed" = (
 /obj/effect/turf_decal/stripes/end{
 	dir = 4
@@ -77501,22 +77607,6 @@
 	icon_state = "purplecorner"
 	},
 /area/station/hallway/primary/aft/east)
-"set" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Security SMES Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/cable/orange{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fpmaint)
 "seK" = (
 /obj/machinery/light{
 	dir = 1
@@ -77660,6 +77750,16 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/smes)
+"sgV" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Escape Shuttle Cell"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/exit)
 "shh" = (
 /obj/effect/decal/warning_stripes/south,
 /obj/item/radio/intercom{
@@ -77715,13 +77815,6 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
-"shF" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Central Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/maintcentral)
 "shH" = (
 /obj/structure/cable/orange{
 	d1 = 4;
@@ -77815,6 +77908,18 @@
 	icon_state = "white"
 	},
 /area/station/medical/virology)
+"siF" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Starboard Asteroid Maintenance Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/starboard)
 "siJ" = (
 /obj/effect/landmark/spawner/xeno,
 /turf/simulated/floor/plasteel{
@@ -77838,23 +77943,6 @@
 	icon_state = "whitepurplecorner"
 	},
 /area/station/science/hallway)
-"sjO" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/classic/normal{
-	name = "Hydroponics";
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/service/hydroponics{
-	dir = 4
-	},
-/obj/item/desk_bell{
-	pixel_x = 7;
-	pixel_y = 7;
-	anchored = 1
-	},
-/turf/simulated/floor/plating,
-/area/station/service/hydroponics)
 "skb" = (
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "XenoPod6";
@@ -78017,27 +78105,6 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/gravitygenerator)
-"smd" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "BrigEast";
-	name = "Brig East Entrance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/machinery/door/firedoor,
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/security/prison/cell_block/A)
 "smf" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -78073,6 +78140,16 @@
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plating/asteroid/ancient,
+/area/station/maintenance/port)
+"smJ" = (
+/obj/structure/barricade/wooden,
+/obj/machinery/door/airlock/maintenance{
+	name = "Port Asteroid Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating{
+	icon_state = "asteroidplating"
+	},
 /area/station/maintenance/port)
 "smT" = (
 /obj/effect/spawner/airlock/w_to_e,
@@ -78206,18 +78283,6 @@
 /obj/structure/cable,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry/north)
-"sqD" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Medbay SMES Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/turf/simulated/floor/plating,
-/area/station/hallway/primary/starboard/north)
 "sri" = (
 /obj/structure/chair/stool{
 	dir = 8
@@ -78256,6 +78321,15 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/control)
+"srt" = (
+/obj/machinery/door/airlock/security{
+	name = "Firing Range";
+	security_level = 1
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/turf/simulated/floor/plating,
+/area/station/security/range)
 "srw" = (
 /obj/structure/closet/firecloset/full,
 /turf/simulated/floor/plating,
@@ -78699,20 +78773,6 @@
 	icon_state = "darkblue"
 	},
 /area/station/command/office/cmo)
-"swR" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Equipment Storage"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "red"
-	},
-/area/station/security/storage)
 "swV" = (
 /obj/structure/table/glass,
 /obj/item/hemostat,
@@ -78745,22 +78805,6 @@
 /obj/structure/closet/firecloset/full,
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/station/maintenance/storage)
-"sxQ" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel,
-/area/station/engineering/atmos/control)
 "sxR" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -78894,6 +78938,26 @@
 	icon_state = "white"
 	},
 /area/station/medical/virology)
+"szM" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/airlock/medical/glass{
+	name = "Isolation A"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/virology)
 "sAd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -78908,6 +78972,25 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/engine,
 /area/station/science/test_chamber)
+"sAH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Kitchen"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id_tag = "kitchen1"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/station/service/kitchen)
 "sAI" = (
 /obj/structure/sign/security{
 	pixel_x = 32
@@ -79000,6 +79083,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
+"sCr" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics Distro"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel{
+	icon_state = "darkyellowfull"
+	},
+/area/station/engineering/atmos/distribution)
 "sCs" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -79125,6 +79222,50 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/service/theatre)
+"sES" = (
+/obj/machinery/door/airlock/public/glass{
+	autoclose = 0;
+	heat_proof = 1;
+	id_tag = "incinerator_door_int";
+	locked = 1;
+	name = "Mixing Room Interior Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/access_button{
+	autolink_id = "incinerator_btn_int";
+	name = "Incinerator Airlock Control";
+	pixel_y = -22
+	},
+/turf/simulated/floor/engine,
+/area/station/science/toxins/mixing)
+"sEV" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Operating Theatre"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
+/obj/machinery/holosign/surgery{
+	id = "surgery2"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "surg2"
+	},
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/station/medical/surgery/secondary)
 "sFd" = (
 /obj/effect/spawner/random_spawners/dirt_often,
 /turf/simulated/floor/plasteel{
@@ -79148,36 +79289,12 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/control)
-"sFD" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/bananium{
-	name = "Clown's Office"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/service/theatre,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/wood,
-/area/station/service/clown)
 "sFF" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Broom Closet"
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/port/south)
-"sFI" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "laborcamp_home";
-	locked = 1;
-	name = "Labor Camp Airlock"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/turf/simulated/floor/plating,
-/area/station/security/prisonershuttle)
 "sFU" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plating{
@@ -79272,22 +79389,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/carpet,
 /area/station/hallway/primary/port/east)
-"sIU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/window/classic/reversed{
-	name = "Captain's Desk";
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/command/captain{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/station/command/office/captain)
 "sJe" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -79384,6 +79485,31 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/apmaint)
+"sLb" = (
+/obj/machinery/navbeacon{
+	codes_txt = "delivery";
+	dir = 8;
+	location = "Security"
+	},
+/obj/structure/plasticflaps{
+	opacity = 1
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Secure Gate";
+	name = "Security Blast Door"
+	},
+/obj/machinery/door/window/classic/reversed{
+	dir = 4;
+	name = "Security Delivery"
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/mule_bot{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/security/brig{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/security/range)
 "sLg" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -79487,19 +79613,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/station/service/bar)
-"sNc" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Garden"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "darkgreenfull"
-	},
-/area/station/service/hydroponics)
 "sNg" = (
 /obj/structure/chair/wood/wings,
 /obj/effect/landmark/start/chaplain,
@@ -79548,6 +79661,19 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/port)
+"sNy" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	id_tag = "kitchen2"
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Kitchen"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/station/service/kitchen)
 "sNz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -79864,6 +79990,72 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/port/north)
+"sSq" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Command SMES Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
+"sSv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/engineering/glass{
+	heat_proof = 1;
+	name = "Supermatter Chamber"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/turf/simulated/floor/engine,
+/area/station/engineering/engine/supermatter)
+"sSB" = (
+/obj/machinery/holosign/surgery{
+	id = "surgery1"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Operating Theatre"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "surg1"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/station/medical/surgery/primary)
+"sSG" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Aft Asteroid Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating{
+	icon_state = "asteroidplating"
+	},
+/area/station/maintenance/apmaint)
 "sSU" = (
 /obj/structure/weightmachine/weightlifter,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -80014,35 +80206,6 @@
 	icon_state = "cafeteria"
 	},
 /area/station/service/kitchen)
-"sVP" = (
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/door/window/classic/normal{
-	name = "Containment Pen";
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/science/tox{
-	dir = 8
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "telescienceblast";
-	name = "test chamber blast doors";
-	opacity = 0
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/engine,
-/area/station/science/explab/chamber)
 "sVX" = (
 /obj/structure/cable/orange{
 	d1 = 4;
@@ -80139,11 +80302,6 @@
 	icon_state = "whitegreen"
 	},
 /area/station/medical/virology)
-"sXv" = (
-/obj/structure/girder,
-/obj/structure/grille,
-/turf/simulated/floor/plating/airless,
-/area/space/nearstation)
 "sXw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -80529,6 +80687,17 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/aft/east)
+"teW" = (
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "MedbayFoyer";
+	name = "Medical Supplies"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel{
+	icon_state = "whiteblue"
+	},
+/area/station/medical/storage/secondary)
 "teX" = (
 /obj/structure/cable/orange{
 	d1 = 4;
@@ -80550,13 +80719,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/port/east)
-"tfG" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Fore Asteroid Maintenance Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/hallway/primary/fore/west)
 "tfU" = (
 /obj/machinery/camera{
 	c_tag = "Service Asteroid Hallway 7"
@@ -80664,20 +80826,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/port)
-"thB" = (
-/obj/structure/cable/orange{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Port Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating{
-	icon_state = "asteroidplating"
-	},
-/area/station/maintenance/fpmaint)
 "thC" = (
 /obj/structure/chair{
 	dir = 4
@@ -80789,6 +80937,42 @@
 	icon_state = "dark"
 	},
 /area/station/service/chapel/office)
+"tjp" = (
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "XenoPod2";
+	layer = 2.6;
+	name = "containment door 2"
+	},
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/door/window/classic/normal{
+	dir = 1;
+	name = "Containment Pen"
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/science/xenobio{
+	dir = 1
+	},
+/turf/simulated/floor/engine,
+/area/station/science/xenobiology)
+"tjL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance/external{
+	name = "External Airlock Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/turf/simulated/floor/plating,
+/area/station/hallway/primary/aft/west)
 "tjO" = (
 /obj/machinery/light{
 	dir = 4
@@ -80974,21 +81158,6 @@
 /obj/effect/spawner/random_spawners/dirt_often,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/fore)
-"tml" = (
-/obj/machinery/door/airlock/vault{
-	locked = 1
-	},
-/obj/effect/mapping_helpers/airlock/access/all/supply/vault,
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/fore/west)
 "tmG" = (
 /obj/structure/cable/orange{
 	d1 = 4;
@@ -81134,17 +81303,6 @@
 "tpl" = (
 /turf/simulated/floor/plating/airless,
 /area/station/science/toxins/test)
-"tpn" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Kitchen"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plating,
-/area/station/maintenance/gambling_den)
 "tpo" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -81181,6 +81339,29 @@
 	icon_state = "dark"
 	},
 /area/station/command/bridge)
+"tpC" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance{
+	name = "Port Asteroid Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/port)
+"tpK" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance{
+	name = "Port Asteroid Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating{
+	icon_state = "asteroidplating"
+	},
+/area/station/maintenance/port)
 "tqb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair{
@@ -81290,27 +81471,6 @@
 /obj/effect/spawner/random_spawners/dirt_often,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/fore)
-"trY" = (
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "bridge";
-	layer = 2.6;
-	name = "Emergency Blast Door"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command/glass{
-	name = "Bridge Foyer"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/command/general,
-/obj/effect/mapping_helpers/airlock/access/any/supply/qm,
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "bridge"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkblue"
-	},
-/area/station/command/bridge)
 "tsc" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -81354,27 +81514,20 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/medical/chemistry)
-"ttb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+"ttA" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Equipment Storage"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/computer/borgupload{
-	dir = 1
-	},
-/obj/machinery/door/window/classic/reversed{
-	dir = 1;
-	name = "Console Access"
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/command/ai_upload{
-	dir = 1
-	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 8;
+	icon_state = "red"
 	},
-/area/station/turret_protected/ai_upload)
+/area/station/security/storage)
 "ttB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/light{
@@ -81410,6 +81563,22 @@
 	icon_state = "dark"
 	},
 /area/station/security/execution)
+"ttV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/airlock/medical/glass{
+	name = "Paramedic"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/paramedic,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel{
+	icon_state = "whitebluefull"
+	},
+/area/station/medical/paramedic)
 "tug" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -81563,21 +81732,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/station/maintenance/fpmaint)
-"twQ" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Port Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/orange{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/disposal/southwest)
 "twS" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
@@ -81794,21 +81948,6 @@
 	icon_state = "darkgreenfull"
 	},
 /area/station/service/hydroponics)
-"tzD" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Criminal Delivery Chute"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/effect/turf_decal/stripes/full,
-/obj/effect/turf_decal/stripes/red/full,
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	color = "#954535"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/primary/port/north)
 "tzN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -81837,35 +81976,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/east)
-"tAq" = (
-/obj/machinery/door/airlock/public/glass{
-	autoclose = 0;
-	heat_proof = 1;
-	id_tag = "turbine_door_int";
-	locked = 1;
-	name = "Turbine Interior Airlock"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/construction,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/access_button{
-	autolink_id = "turbine_btn_int";
-	name = "Gas Turbine Airlock Control";
-	pixel_x = 24
-	},
-/turf/simulated/floor/engine,
-/area/station/maintenance/turbine)
-"tAO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/universal,
-/obj/machinery/door/airlock/atmos{
-	name = "Cargo Atmospherics Checkpoint"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
 "tBd" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -82313,6 +82423,21 @@
 	icon_state = "dark"
 	},
 /area/station/supply/office)
+"tKi" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Criminal Delivery Chute"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/effect/turf_decal/stripes/full,
+/obj/effect/turf_decal/stripes/red/full,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	color = "#954535"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/primary/port/north)
 "tKm" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -82465,19 +82590,6 @@
 	icon_state = "purplecorner"
 	},
 /area/station/hallway/primary/aft/east)
-"tNJ" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Fore Asteroid Maintenance Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/cable/orange{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
 "tNQ" = (
 /obj/structure/cable/orange{
 	d1 = 2;
@@ -82525,36 +82637,32 @@
 /obj/item/reagent_containers/glass/bucket,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/port/south)
-"tOz" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "cell2";
-	name = "Permabrig Cell 2";
-	security_level = 1
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/obj/machinery/door/firedoor,
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Prison Gate";
-	name = "Prison Lockdown Blast Doors";
-	opacity = 0
-	},
-/obj/effect/mapping_helpers/airlock/unres,
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plasteel,
-/area/station/security/permabrig)
 "tOU" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
+"tOY" = (
+/obj/machinery/door/airlock/engineering/glass{
+	autoclose = 0;
+	id_tag = "engsm_door_ext";
+	locked = 1;
+	name = "Supermatter Exterior Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/engineering/control)
+"tPw" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass{
+	name = "Hydroponics"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
+/turf/simulated/floor/plasteel{
+	icon_state = "darkgreenfull"
+	},
+/area/station/service/hydroponics)
 "tPV" = (
 /obj/machinery/door/airlock{
 	name = "Bathroom"
@@ -82750,6 +82858,25 @@
 /obj/structure/lattice/catwalk,
 /turf/space,
 /area/station/engineering/solar/starboard/aft)
+"tVb" = (
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "cell1";
+	name = "Permabrig Cell 1";
+	security_level = 1
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Prison Gate";
+	name = "Prison Lockdown Blast Doors";
+	opacity = 0
+	},
+/obj/effect/mapping_helpers/airlock/unres,
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/turf/simulated/floor/plasteel,
+/area/station/security/permabrig)
 "tVf" = (
 /obj/structure/grille/broken,
 /turf/simulated/floor/plating/asteroid/ancient,
@@ -83036,6 +83163,14 @@
 	},
 /turf/space,
 /area/station/engineering/solar/port)
+"tYu" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Port Asteroid Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/turf/simulated/floor/plating,
+/area/station/public/fitness)
 "tYz" = (
 /turf/simulated/wall/r_wall,
 /area/station/security/processing)
@@ -83285,6 +83420,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal/west)
+"ucH" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Fore Asteroid Maintenance Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "ucV" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/disposalpipe/segment/corner{
@@ -83326,17 +83474,24 @@
 "udk" = (
 /turf/simulated/wall,
 /area/station/medical/patients_rooms)
-"udR" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance{
-	name = "Morgue"
+"udq" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id_tag = "kitchen1"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/morgue,
-/obj/effect/spawner/random_spawners/dirt_frequent,
+/obj/machinery/door/window/classic/reversed{
+	dir = 4;
+	name = "Kitchen"
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/service/kitchen{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "cafeteria"
 	},
-/area/station/maintenance/starboard)
+/area/station/service/kitchen)
 "uep" = (
 /obj/machinery/economy/vending/snack,
 /turf/simulated/floor/plating,
@@ -83527,19 +83682,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
-"uhX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/maintenance/external{
-	name = "External Airlock Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/hallway/primary/starboard/north)
 "uii" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
@@ -83823,23 +83965,6 @@
 	},
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/station/maintenance/maintcentral)
-"ulw" = (
-/obj/machinery/door/airlock/research{
-	name = "Test Lab"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/science/tox,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/station/science/misc_lab)
 "ulG" = (
 /obj/machinery/light_switch{
 	dir = 1;
@@ -83875,6 +84000,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
+"umV" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Fore Asteroid Maintenance Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "umX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -84128,6 +84260,41 @@
 	slowdown = -0.3
 	},
 /area/station/hallway/spacebridge/engmed)
+"uqV" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Central Asteroid Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/station/maintenance/maintcentral)
+"uro" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Engine Room"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "darkyellowfull"
+	},
+/area/station/engineering/control)
 "urz" = (
 /turf/simulated/wall/r_wall,
 /area/station/hallway/spacebridge/dockmed)
@@ -84538,23 +84705,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/asmaint)
-"uxT" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/drinks/britcup,
-/obj/machinery/door/window/classic/normal{
-	dir = 8;
-	name = "Medical Reception"
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/medical/general{
-	dir = 8
-	},
-/obj/item/storage/box/masks{
-	pixel_y = 5
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/station/medical/reception)
 "uyf" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -84725,6 +84875,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal/westalt)
+"uBy" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Port Asteroid Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/disposal/southwest)
 "uBA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -84816,14 +84976,6 @@
 	icon_state = "dark"
 	},
 /area/station/maintenance/asmaint)
-"uCJ" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Port Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plating,
-/area/station/public/fitness)
 "uCK" = (
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/station/maintenance/port)
@@ -84869,25 +85021,41 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/permabrig)
-"uDk" = (
+"uDw" = (
+/obj/structure/closet/crate,
+/obj/item/pickaxe,
+/turf/simulated/floor/plating/asteroid/ancient,
+/area/station/maintenance/maintcentral)
+"uDy" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Port Asteroid Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/turf/simulated/floor/plating,
+/area/station/maintenance/port)
+"uDD" = (
 /obj/structure/cable/orange{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/maintenance{
-	name = "Port Asteroid Maintenance"
+	name = "Fore Asteroid Maintenance Access"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating{
-	icon_state = "asteroidplating"
-	},
-/area/station/maintenance/port)
-"uDw" = (
-/obj/structure/closet/crate,
-/obj/item/pickaxe,
-/turf/simulated/floor/plating/asteroid/ancient,
-/area/station/maintenance/maintcentral)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "uDK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -84902,33 +85070,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
-"uEb" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance Drone Dispensary"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
-/area/station/maintenance/storage)
-"uEe" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/highsecurity{
-	locked = 1;
-	name = "AI Upload Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/command/ai_upload,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/turret_protected/ai_upload)
 "uEm" = (
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 4;
@@ -84947,29 +85088,6 @@
 /obj/effect/spawner/random_spawners/wall_rusted_always,
 /turf/simulated/wall,
 /area/station/maintenance/disposal/north)
-"uEY" = (
-/obj/machinery/holosign/surgery{
-	id = "surgery1"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical/glass{
-	name = "Operating Theatre"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "surg1"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/station/medical/surgery/primary)
 "uFq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -85034,30 +85152,17 @@
 	icon_state = "dark"
 	},
 /area/station/supply/storage)
-"uGQ" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/classic/normal{
-	dir = 1;
-	name = "Robotics Desk"
+"uGM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics"
 	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/science/robotics{
-	dir = 1
-	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 2;
-	id_tag = "RoboticsShutters"
-	},
-/obj/item/paper_bin,
-/obj/item/desk_bell{
-	pixel_x = 7;
-	pixel_y = 7;
-	anchored = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "purplefull"
-	},
-/area/station/science/robotics)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel,
+/area/station/engineering/atmos/control)
 "uGY" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 1
@@ -85069,6 +85174,29 @@
 "uHx" = (
 /turf/simulated/mineral/ancient,
 /area/station/supply/miningdock)
+"uHA" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/window/classic/normal{
+	name = "Containment Pen";
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/science/tox{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/station/science/misc_lab)
 "uHJ" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -85288,6 +85416,14 @@
 /obj/effect/spawner/airlock/s_to_n,
 /turf/simulated/mineral/ancient,
 /area/station/hallway/primary/port/north)
+"uLT" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark/telecomms{
+	icon_state = "bcircuit"
+	},
+/area/station/science/server/coldroom)
 "uMe" = (
 /obj/effect/spawner/random_spawners/blood_maybe,
 /obj/item/toy/plushie/robo_corgi,
@@ -85383,17 +85519,21 @@
 	icon_state = "chapel"
 	},
 /area/station/service/chapel)
-"uOn" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Equipment Storage"
+"uNN" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/engineering{
+	name = "Tech Storage"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/tech_storage,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "red"
-	},
-/area/station/security/storage)
+/turf/simulated/floor/plating,
+/area/station/engineering/tech_storage)
 "uOu" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -85439,27 +85579,6 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/security/prison/cell_block/A)
-"uPp" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Detective"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/forensics,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "Detective"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/station/security/detective)
 "uPs" = (
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -85680,6 +85799,34 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
+"uRH" = (
+/obj/machinery/door/airlock/engineering/glass{
+	autoclose = 0;
+	id_tag = "engsm_door_ext";
+	locked = 1;
+	name = "Supermatter Exterior Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/engineering/control)
+"uRP" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Kitchen"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/turf/simulated/floor/plating,
+/area/station/maintenance/gambling_den)
 "uRS" = (
 /obj/structure/cable/orange{
 	d1 = 4;
@@ -85765,18 +85912,6 @@
 	icon_state = "cafeteria"
 	},
 /area/station/command/office/rd)
-"uSK" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Service SMES Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/cable/orange{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/port)
 "uSM" = (
 /obj/machinery/light{
 	dir = 8
@@ -85865,6 +86000,18 @@
 	icon_state = "whiteyellow"
 	},
 /area/station/science/robotics/chargebay)
+"uTR" = (
+/obj/machinery/door/airlock/command{
+	name = "Teleport Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/teleporter,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/command/teleporter)
 "uTX" = (
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -85895,14 +86042,6 @@
 /obj/item/seeds/coffee/robusta,
 /turf/simulated/floor/plating/asteroid/ancient/airless,
 /area/station/hallway/spacebridge/scidock)
-"uUm" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Fore Asteroid Maintenance Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plating,
-/area/station/public/arcade)
 "uUo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -85912,23 +86051,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/starboard/south)
-"uUw" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Secure Gate";
-	name = "Security Blast Door";
-	opacity = 0
-	},
-/obj/machinery/door/airlock/security/glass{
-	name = "General Population Cell"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/security/prison/cell_block/A)
 "uUF" = (
 /obj/machinery/light,
 /obj/structure/disposalpipe/junction{
@@ -85947,6 +86069,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/starboard/south)
+"uUM" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Port Asteroid Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/port2)
 "uUT" = (
 /obj/structure/chair/sofa/pew/left{
 	dir = 8
@@ -86033,25 +86170,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/starboard/south)
-"uVA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/medical/glass{
-	name = "Chemistry Lab"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/chemistry,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/station/medical/chemistry)
 "uVC" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/item/storage/box/monkeycubes,
@@ -86126,6 +86244,21 @@
 	icon_state = "dark"
 	},
 /area/station/maintenance/disposal)
+"uWx" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Aft Asteroid Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/tox,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/turf/simulated/floor/plating,
+/area/station/science/misc_lab)
 "uWX" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
@@ -86287,6 +86420,19 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry/north)
+"vav" = (
+/obj/machinery/door/airlock{
+	name = "Crematorium"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/crematorium,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/black,
+/area/station/service/chapel/office)
 "vaI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -86339,6 +86485,14 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/medbay)
+"vbc" = (
+/obj/structure/barricade/wooden,
+/obj/machinery/door/airlock/maintenance{
+	name = "Starboard Asteroid Maintenance Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating/asteroid/ancient,
+/area/station/maintenance/starboard)
 "vbl" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/girder,
@@ -86370,6 +86524,30 @@
 /obj/effect/landmark/start/assistant,
 /turf/simulated/floor/carpet/red,
 /area/station/service/chapel)
+"vbY" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/airlock/research{
+	name = "Xenobiology Research"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/station/science/xenobiology)
 "vbZ" = (
 /turf/simulated/wall/r_wall,
 /area/station/hallway/primary/aft/west)
@@ -86385,6 +86563,19 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/cloning)
+"vcq" = (
+/obj/machinery/door/airlock/glass{
+	name = "Disposals"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/supply/general,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/maintenance/disposal)
 "vcx" = (
 /obj/machinery/light_switch{
 	pixel_y = 24;
@@ -86532,31 +86723,6 @@
 	icon_state = "tranquillite"
 	},
 /area/station/service/mime)
-"veP" = (
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "delivery";
-	dir = 4;
-	location = "Medbay"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Biohazard_medi";
-	name = "Quarantine Lockdown"
-	},
-/obj/machinery/door/window/classic/reversed{
-	dir = 8;
-	name = "Medical Delivery"
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/mule_bot{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/medical/general{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/station/medical/medbay)
 "veQ" = (
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -86573,6 +86739,22 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
+"vfc" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Security Maintenance";
+	security_level = 1
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Secure Gate";
+	name = "Security Blast Door";
+	opacity = 0
+	},
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore2)
 "vfi" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp,
@@ -86629,32 +86811,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/aft/west)
-"vgN" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Engine Room"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "darkyellowfull"
-	},
-/area/station/engineering/control)
 "vgP" = (
 /obj/machinery/light{
 	dir = 4
@@ -86687,27 +86843,6 @@
 	icon_state = "darkpurple"
 	},
 /area/station/science/robotics)
-"vhj" = (
-/obj/machinery/door/airlock/atmos/glass{
-	autoclose = 0;
-	id_tag = "atmossm_door_ext";
-	locked = 1;
-	name = "Atmospherics Access Chamber"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/machinery/access_button{
-	autolink_id = "atmossm_btn_ext";
-	name = "Atmospherics Access Button";
-	pixel_y = -24;
-	req_access_txt = "24"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/engineering/control)
 "vid" = (
 /obj/structure/window/plasmareinforced,
 /obj/structure/window/plasmareinforced{
@@ -87028,6 +87163,14 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/hallway/primary/port/east)
+"vnM" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Cargo SMES Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "vnT" = (
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
@@ -87125,21 +87268,6 @@
 /obj/effect/spawner/random_spawners/wall_rusted_always,
 /turf/simulated/wall,
 /area/station/maintenance/fsmaint)
-"vpf" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Central Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plating,
-/area/station/maintenance/maintcentral)
 "vpg" = (
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/station/maintenance/fore)
@@ -87273,6 +87401,19 @@
 	icon_state = "darkyellowfull"
 	},
 /area/station/public/quantum/docking)
+"vqN" = (
+/obj/machinery/door/airlock/glass{
+	name = "Magistrate's Office";
+	id_tag = "magistrateofficedoor"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/magistrate,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "Magistrate"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/wood,
+/area/station/legal/magistrate)
 "vrf" = (
 /obj/structure/cable/orange{
 	d1 = 4;
@@ -87360,6 +87501,23 @@
 /obj/structure/filingcabinet,
 /turf/simulated/floor/wood,
 /area/station/command/office/hop)
+"vsD" = (
+/obj/machinery/door/airlock/hatch{
+	name = "AI Satellite Secondary Antechamber"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel{
+	icon_state = "bcircuit"
+	},
+/area/station/turret_protected/ai)
 "vsE" = (
 /obj/effect/spawner/window/reinforced/plasma,
 /turf/simulated/floor/plating,
@@ -87371,6 +87529,19 @@
 /obj/machinery/atmospherics/portable/canister/air,
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarstarboard)
+"vsP" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/atmos{
+	name = "Medbay Atmospherics Checkpoint"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/primary/starboard/south)
 "vsT" = (
 /obj/structure/cable/orange{
 	d2 = 2;
@@ -87597,15 +87768,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/command/office/hos)
-"vvQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/maintenance/external{
-	name = "External Airlock Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plating,
-/area/station/hallway/primary/central)
 "vvU" = (
 /obj/machinery/mech_bay_recharge_port{
 	dir = 1
@@ -87715,39 +87877,10 @@
 /obj/effect/spawner/random_spawners/oil_maybe,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/electrical_shop)
-"vwF" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Prisoner Lockers"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/machinery/door/firedoor,
-/obj/structure/cable/orange{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/security/prisonlockers)
 "vxp" = (
 /obj/effect/spawner/random_spawners/oil_maybe,
 /turf/simulated/floor/plating,
 /area/station/maintenance/electrical_shop)
-"vxx" = (
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance{
-	name = "Port Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/visible,
-/turf/simulated/floor/plating{
-	icon_state = "asteroidplating"
-	},
-/area/station/maintenance/gambling_den)
 "vxE" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -87970,21 +88103,6 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/atmos)
-"vBG" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Disposals Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/turret_protected/aisat/interior/secondary)
 "vBP" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 1
@@ -87993,34 +88111,6 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/starboard/south)
-"vBR" = (
-/obj/machinery/door/airlock/glass{
-	name = "Genetics Research"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/medical/genetics,
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Biohazard_medi";
-	name = "Quarantine Lockdown";
-	opacity = 0
-	},
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel/white,
-/area/station/science/genetics)
 "vBV" = (
 /obj/structure/cable/orange{
 	d1 = 2;
@@ -88128,6 +88218,23 @@
 	icon_state = "whitebluefull"
 	},
 /area/station/medical/medbay)
+"vDS" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/drinks/britcup,
+/obj/machinery/door/window/classic/normal{
+	dir = 8;
+	name = "Medical Reception"
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/medical/general{
+	dir = 8
+	},
+/obj/item/storage/box/masks{
+	pixel_y = 5
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/station/medical/reception)
 "vDV" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -88138,6 +88245,16 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/processing)
+"vEm" = (
+/obj/machinery/door/airlock/research{
+	name = "Toxins Storage"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/tox_storage,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel,
+/area/station/science/storage)
 "vEr" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -88328,20 +88445,22 @@
 	icon_state = "whitepurple"
 	},
 /area/station/science/genetics)
+"vFz" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Aft Asteroid Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/turf/simulated/floor/plating,
+/area/station/maintenance/asmaint)
 "vFB" = (
 /turf/simulated/wall,
 /area/station/legal/magistrate)
-"vFC" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "Cargo Office"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/supply/mail_sorting,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	icon_state = "darkbrownfull"
-	},
-/area/station/supply/office)
 "vFG" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "cult"
@@ -88404,27 +88523,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/aft/west)
-"vGS" = (
-/obj/machinery/door/airlock/research/glass{
-	name = "Test Chamber"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/science/tox,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "RnDChem";
-	name = "Biohazard Shutter";
-	opacity = 0
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/engine,
-/area/station/science/test_chamber)
 "vGW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -88692,6 +88790,14 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/science/toxins/launch)
+"vLi" = (
+/obj/machinery/door/airlock/mining{
+	name = "Mining Dock"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/supply/mining,
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/turf/simulated/floor/plating,
+/area/station/supply/miningdock)
 "vLm" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -88818,32 +88924,6 @@
 	icon_state = "yellowcorner"
 	},
 /area/station/hallway/primary/central)
-"vNi" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
-	id_tag = "ntrepofficedoor";
-	name = "NT Representative's Office"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/command/ntrep,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/wood,
-/area/station/command/office/ntrep)
 "vNu" = (
 /obj/structure/cable/orange{
 	d1 = 2;
@@ -88871,21 +88951,6 @@
 	icon_state = "dark"
 	},
 /area/station/telecomms/chamber)
-"vNz" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24;
-	name = "east bump"
-	},
-/obj/machinery/door/airlock/research{
-	name = "Kill Chamber"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel{
-	icon_state = "whitepurplefull"
-	},
-/area/station/science/xenobiology)
 "vNJ" = (
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/virology)
@@ -88987,28 +89052,6 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/gravitygenerator)
-"vPz" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green,
-/obj/machinery/atmospherics/binary/pump{
-	dir = 4;
-	name = "N2 to Pure"
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/door/window/classic/reversed{
-	name = "Interior Pipe Access";
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/engineering/atmos{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/engineering/atmos)
 "vPD" = (
 /obj/machinery/floodlight{
 	light_power = 1
@@ -89112,6 +89155,27 @@
 /obj/item/analyzer,
 /turf/simulated/floor/plating,
 /area/station/engineering/tech_storage)
+"vRC" = (
+/obj/machinery/navbeacon{
+	codes_txt = "delivery";
+	location = "Kitchen"
+	},
+/obj/structure/plasticflaps{
+	opacity = 1
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/mule_bot{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/service/kitchen{
+	dir = 4
+	},
+/obj/machinery/door/window/classic/reversed{
+	dir = 4;
+	pixel_x = 1;
+	name = "Kitchen Delivery"
+	},
+/turf/simulated/floor/plating,
+/area/station/service/kitchen)
 "vRQ" = (
 /obj/effect/turf_decal/delivery/red,
 /obj/vehicle/secway,
@@ -89150,6 +89214,21 @@
 	slowdown = -0.3
 	},
 /area/station/hallway/spacebridge/medcargo)
+"vSg" = (
+/obj/machinery/door/airlock/command{
+	name = "Server Room"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/rd,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel/dark/telecomms,
+/area/station/science/server)
 "vSk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 6
@@ -89289,16 +89368,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/aft/west)
-"vVf" = (
-/obj/machinery/door/airlock/research{
-	name = "Toxins Storage"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/science/tox_storage,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/science/storage)
 "vVG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -89384,6 +89453,31 @@
 	dir = 4;
 	icon_state = "whiteblue"
 	},
+/area/station/medical/medbay)
+"vWu" = (
+/obj/structure/plasticflaps{
+	opacity = 1
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "delivery";
+	dir = 4;
+	location = "Medbay"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "Biohazard_medi";
+	name = "Quarantine Lockdown"
+	},
+/obj/machinery/door/window/classic/reversed{
+	dir = 8;
+	name = "Medical Delivery"
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/mule_bot{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/medical/general{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
 /area/station/medical/medbay)
 "vWF" = (
 /turf/simulated/mineral/ancient,
@@ -89560,6 +89654,19 @@
 /obj/machinery/light,
 /turf/simulated/floor/plasteel,
 /area/station/public/fitness)
+"waf" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Security Office"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel{
+	icon_state = "darkredfull"
+	},
+/area/station/security/checkpoint/secondary)
 "wag" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 9
@@ -89579,6 +89686,14 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/starboard/south)
+"waN" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Hydroponics"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/turf/simulated/floor/plating,
+/area/station/maintenance/gambling_den)
 "waT" = (
 /obj/item/clothing/head/cone,
 /turf/simulated/floor/plating,
@@ -89681,21 +89796,14 @@
 /obj/structure/lattice,
 /turf/space,
 /area/space/nearstation)
-"wdu" = (
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
+"wdl" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Port Asteroid Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating{
-	icon_state = "asteroidplating"
-	},
-/area/station/maintenance/port)
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/turf/simulated/floor/plasteel,
+/area/station/service/library)
 "wdJ" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/wood,
@@ -89797,24 +89905,6 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/plating,
 /area/station/maintenance/gambling_den)
-"wfq" = (
-/obj/machinery/door/airlock{
-	name = "Chaplain's Office"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/service/chapel_office,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/service/chapel)
 "wfJ" = (
 /obj/machinery/computer/secure_data{
 	dir = 8
@@ -90012,6 +90102,23 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/science/storage)
+"wig" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/window/classic/normal{
+	dir = 1;
+	name = "Containment Pen"
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/science/xenobio{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "whitepurple"
+	},
+/area/station/science/xenobiology)
 "wim" = (
 /obj/machinery/light,
 /obj/structure/sign/electricshock{
@@ -90167,6 +90274,23 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/north)
+"wkx" = (
+/obj/machinery/door/airlock/public/glass{
+	autoclose = 0;
+	heat_proof = 1;
+	id_tag = "incinerator_door_ext";
+	locked = 1;
+	name = "Mixing Room Exterior Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/access_button{
+	layer = 3.1;
+	autolink_id = "incinerator_btn_ext";
+	name = "Incinerator Airlock Control";
+	pixel_y = -23
+	},
+/turf/simulated/floor/engine,
+/area/station/science/toxins/mixing)
 "wkC" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Walkway"
@@ -90241,19 +90365,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/port2)
-"wkT" = (
-/obj/machinery/door/airlock{
-	name = "Crematorium"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/service/crematorium,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/black,
-/area/station/service/chapel/office)
 "wla" = (
 /obj/structure/cable/orange{
 	d1 = 4;
@@ -90399,31 +90510,6 @@
 /obj/structure/dispenser/oxygen,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/fore/west)
-"wnh" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/door/airlock/medical/glass{
-	name = "Isolation B"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/station/medical/virology)
 "wnB" = (
 /obj/structure/cable/orange,
 /obj/machinery/door/poddoor{
@@ -90622,6 +90708,14 @@
 /obj/effect/spawner/random_spawners/wall_rusted_always,
 /turf/simulated/wall,
 /area/mine/unexplored/cere/research)
+"wqE" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance{
+	name = "Aft Asteroid Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/disposal/south)
 "wqG" = (
 /obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
@@ -90760,17 +90854,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/starboard/south)
-"wsd" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "Brig";
-	name = "Prisoner Processing"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/doors,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/security/processing)
 "wst" = (
 /obj/machinery/iv_drip,
 /obj/structure/closet/crate/freezer/iv_storage,
@@ -90814,6 +90897,22 @@
 "wsR" = (
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/station/maintenance/apmaint)
+"wsU" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Security SMES Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fpmaint)
 "wsV" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -90935,6 +91034,31 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/office)
+"wum" = (
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "XenoPod4";
+	layer = 2.6;
+	name = "containment door 4"
+	},
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/door/window/classic/normal{
+	dir = 1;
+	name = "Containment Pen"
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/science/xenobio{
+	dir = 1
+	},
+/turf/simulated/floor/engine,
+/area/station/science/xenobiology)
 "wuC" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -91033,6 +91157,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/tech_storage)
+"wvJ" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Genetics Cloning"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/medical/general,
+/obj/effect/mapping_helpers/airlock/access/any/medical/genetics,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "whitebluefull"
+	},
+/area/station/medical/cloning)
 "wvN" = (
 /obj/machinery/shower{
 	dir = 8
@@ -91052,20 +91190,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/south)
-"wwi" = (
-/obj/machinery/door/airlock/command{
-	name = "Captain's Quarters"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/command/captain,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/station/command/office/captain)
 "wwl" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -91077,6 +91201,38 @@
 	icon_state = "dark"
 	},
 /area/station/medical/morgue)
+"wwm" = (
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "cell3";
+	name = "Permabrig Cell 3";
+	security_level = 1
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Prison Gate";
+	name = "Prison Lockdown Blast Doors";
+	opacity = 0
+	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/turf/simulated/floor/plasteel,
+/area/station/security/permabrig)
 "wwy" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -91135,18 +91291,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/maintcentral)
-"wxf" = (
-/obj/machinery/door/window/reinforced/normal{
-	dir = 4;
-	name = "Evidence Storage"
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/security/doors{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/security/evidence)
 "wxm" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/machinery/alarm{
@@ -91490,28 +91634,6 @@
 	icon_state = "neutral"
 	},
 /area/station/public/storage/tools)
-"wAU" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green,
-/obj/machinery/atmospherics/binary/pump{
-	dir = 4;
-	name = "O2 to Pure"
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/door/window/classic/reversed{
-	name = "Interior Pipe Access";
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/engineering/atmos{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/engineering/atmos)
 "wBp" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -91822,6 +91944,22 @@
 	icon_state = "purple"
 	},
 /area/station/hallway/primary/aft/west)
+"wFq" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Port Asteroid Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/turf/simulated/floor/plating,
+/area/station/maintenance/port)
 "wFr" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/closet/crate/freezer,
@@ -91952,13 +92090,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal/southwest)
-"wHx" = (
-/obj/machinery/disposal/deliveryChute{
-	dir = 1
-	},
-/obj/structure/disposalpipe/trunk,
-/turf/simulated/floor/plating/airless,
-/area/station/maintenance/disposal/westalt)
 "wHA" = (
 /obj/effect/spawner/grouped_spawner{
 	group_id = "tunnelbats";
@@ -92111,6 +92242,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
+"wKd" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/maintenance/external{
+	name = "External Airlock Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/turf/simulated/floor/plating,
+/area/station/hallway/primary/central)
 "wKi" = (
 /obj/effect/spawner/airlock,
 /turf/simulated/wall,
@@ -92193,6 +92333,26 @@
 	icon_state = "purplecorner"
 	},
 /area/station/hallway/primary/aft/east)
+"wLn" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "medmain";
+	name = "Medbay Entrance"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/medical/general,
+/obj/effect/mapping_helpers/airlock/access/any/medical/genetics,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Biohazard_medi";
+	name = "Quarantine Lockdown";
+	opacity = 0
+	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/medbay)
 "wLr" = (
 /obj/effect/spawner/random_spawners/wall_rusted_always,
 /turf/simulated/wall,
@@ -92252,24 +92412,6 @@
 	icon_state = "white"
 	},
 /area/station/medical/medbay)
-"wMI" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/maintenance/external{
-	name = "External Airlock Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/hallway/primary/central)
 "wMJ" = (
 /obj/machinery/light{
 	dir = 1
@@ -92338,6 +92480,16 @@
 	icon_state = "purplecorner"
 	},
 /area/station/hallway/primary/aft/west)
+"wOe" = (
+/obj/machinery/door/window/classic/reversed{
+	dir = 8;
+	pixel_x = 1;
+	name = "Boxing Arena"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/public/fitness)
 "wOn" = (
 /obj/item/radio/intercom{
 	pixel_y = -28;
@@ -92352,20 +92504,30 @@
 "wOD" = (
 /turf/simulated/floor/plasteel,
 /area/station/security/range)
-"wOJ" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4
+"wOH" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/classic/normal{
+	dir = 1;
+	name = "Robotics Desk"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics Distro"
+/obj/effect/mapping_helpers/airlock/windoor/access/any/science/robotics{
+	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	icon_state = "darkyellowfull"
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 2;
+	id_tag = "RoboticsShutters"
 	},
-/area/station/engineering/atmos/distribution)
+/obj/item/paper_bin,
+/obj/item/desk_bell{
+	pixel_x = 7;
+	pixel_y = 7;
+	anchored = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "purplefull"
+	},
+/area/station/science/robotics)
 "wOV" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/firealarm{
@@ -92551,6 +92713,22 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/public/vacant_office)
+"wSh" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass{
+	name = "Hydroponics"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "darkgreenfull"
+	},
+/area/station/service/hydroponics)
 "wSk" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/carpet,
@@ -92584,29 +92762,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
-"wSz" = (
-/obj/structure/cable/orange{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Service SMES Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plating,
-/area/station/maintenance/port)
-"wSG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/research{
-	name = "Research Division Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/science/research,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel/white,
-/area/station/science/rnd)
 "wSP" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -93194,6 +93349,11 @@
 "xbO" = (
 /turf/simulated/mineral/ancient/outer,
 /area/mine/unexplored/cere/engineering)
+"xcc" = (
+/obj/structure/girder,
+/obj/structure/grille,
+/turf/simulated/floor/plating/airless,
+/area/space/nearstation)
 "xcn" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plating,
@@ -93214,20 +93374,6 @@
 	icon_state = "white"
 	},
 /area/station/science/toxins/mixing)
-"xcw" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Turbine Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/construction,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plating,
-/area/station/maintenance/turbine)
 "xcD" = (
 /obj/structure/cable/orange{
 	d1 = 4;
@@ -93400,16 +93546,6 @@
 /obj/effect/spawner/random_spawners/dirt_often,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/central)
-"xfl" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Warden's Office"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/armory,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/security/armory/secure)
 "xfm" = (
 /obj/structure/cable/orange{
 	d1 = 4;
@@ -93690,6 +93826,24 @@
 "xkf" = (
 /turf/simulated/floor/plasteel,
 /area/station/security/main)
+"xkj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance/external{
+	name = "External Airlock Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/primary/starboard/south)
 "xkk" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -93725,21 +93879,6 @@
 "xla" = (
 /turf/simulated/wall/r_wall,
 /area/station/security/prison/cell_block/A)
-"xlx" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Hydroponics Garden"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/service/hydroponics,
-/obj/effect/mapping_helpers/airlock/access/any/service/kitchen,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plating,
-/area/station/maintenance/gambling_den)
 "xlM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light{
@@ -93922,13 +94061,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/spacebridge/dockmed)
-"xpd" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Escape Shuttle Cell"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/turf/simulated/floor/plating,
-/area/station/hallway/secondary/exit)
 "xpe" = (
 /obj/structure/grille/broken,
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
@@ -93958,6 +94090,21 @@
 /obj/machinery/chem_heater,
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
+"xpt" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Central Asteroid Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/turf/simulated/floor/plating,
+/area/station/maintenance/maintcentral)
 "xqt" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -94044,14 +94191,6 @@
 /obj/machinery/status_display/supply_display,
 /turf/simulated/wall,
 /area/station/supply/storage)
-"xrF" = (
-/obj/structure/barricade/wooden,
-/obj/machinery/door/airlock/maintenance{
-	name = "Aft Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/hallway/primary/aft/west)
 "xrN" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -94149,18 +94288,6 @@
 /obj/item/coin/clown,
 /turf/simulated/floor/plating,
 /area/station/service/clown/secret)
-"xug" = (
-/obj/machinery/door/window/classic/reversed{
-	dir = 1;
-	name = "Bridge Desk"
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/command/general{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "rampbottom"
-	},
-/area/station/command/bridge)
 "xut" = (
 /turf/simulated/floor/carpet/blue,
 /area/station/hallway/secondary/garden)
@@ -94251,16 +94378,6 @@
 	slowdown = -0.3
 	},
 /area/station/hallway/spacebridge/dockmed)
-"xwL" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Escape Shuttle Cell"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/exit)
 "xwQ" = (
 /obj/structure/table,
 /obj/item/wrench,
@@ -94439,6 +94556,19 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/service/clown)
+"xyT" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Private Patient Room"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "private"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/station/medical/patients_rooms)
 "xzd" = (
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -94462,6 +94592,14 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan,
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
+"xzp" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Fore Asteroid Maintenance Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/spawner/random_spawners/dirt_frequent,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore2)
 "xzA" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -94502,16 +94640,6 @@
 	icon_state = "dark"
 	},
 /area/station/security/warden)
-"xAe" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Atmospherics Storage"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/engineering/atmos)
 "xAk" = (
 /obj/machinery/light{
 	dir = 1
@@ -94644,32 +94772,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/spacebridge/scidock)
-"xBP" = (
-/obj/machinery/door/airlock/medical{
-	name = "Morgue"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/morgue,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Biohazard_medi";
-	name = "Quarantine Lockdown";
-	opacity = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/medical/morgue)
 "xCc" = (
 /obj/effect/spawner/airlock/s_to_n,
 /obj/effect/spawner/window/reinforced/grilled,
@@ -94756,31 +94858,6 @@
 	icon_state = "purplecorner"
 	},
 /area/station/hallway/spacebridge/scidock)
-"xCV" = (
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "XenoPod4";
-	layer = 2.6;
-	name = "containment door 4"
-	},
-/obj/structure/cable/orange{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/orange{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/door/window/classic/normal{
-	dir = 1;
-	name = "Containment Pen"
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/science/xenobio{
-	dir = 1
-	},
-/turf/simulated/floor/engine,
-/area/station/science/xenobiology)
 "xDf" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
@@ -94895,19 +94972,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/gambling_den)
-"xFI" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Aft Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plating,
-/area/station/maintenance/asmaint)
 "xFJ" = (
 /obj/structure/cable/orange{
 	d1 = 2;
@@ -95002,6 +95066,27 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/carpet,
 /area/station/medical/psych)
+"xGA" = (
+/obj/machinery/door/airlock/atmos/glass{
+	autoclose = 0;
+	id_tag = "atmossm_door_int";
+	locked = 1;
+	name = "Atmospherics Access Chamber"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/machinery/access_button{
+	autolink_id = "atmossm_btn_int";
+	name = "Atmospherics Access Button";
+	pixel_y = -24;
+	req_access_txt = "24"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/engineering/control)
 "xGE" = (
 /obj/structure/girder,
 /obj/structure/grille,
@@ -95165,19 +95250,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/fore/west)
-"xJR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/airlock/maintenance/external{
-	name = "AI Satellite Atmospherics"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating,
-/area/station/turret_protected/aisat/interior)
 "xJW" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/disposalpipe/segment{
@@ -95237,16 +95309,6 @@
 /obj/effect/spawner/random_spawners/dirt_often,
 /turf/simulated/floor/plasteel,
 /area/station/public/locker)
-"xLe" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "Cargo Bay"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/supply/mail_sorting,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	icon_state = "darkbrownfull"
-	},
-/area/station/supply/office)
 "xLj" = (
 /turf/simulated/wall,
 /area/station/service/chapel/office)
@@ -95306,6 +95368,21 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/secondary/entry/north)
+"xMA" = (
+/obj/structure/disposalpipe/segment{
+	color = "#954535"
+	},
+/obj/machinery/door/airlock/security/glass{
+	name = "Criminal Delivery Chute"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/obj/effect/turf_decal/stripes/full,
+/obj/effect/turf_decal/stripes/red/full,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/aft/west)
 "xME" = (
 /obj/machinery/light{
 	dir = 1
@@ -95793,6 +95870,22 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/spacebridge/dockmed)
+"xVj" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel,
+/area/station/engineering/atmos/control)
 "xVr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -95913,33 +96006,6 @@
 /obj/structure/sign/security,
 /turf/simulated/wall,
 /area/station/maintenance/fsmaint)
-"xWL" = (
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Fore Asteroid Maintenance Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
-"xXf" = (
-/obj/machinery/door/airlock/hatch{
-	name = "AI Satellite Antechamber"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/command/teleporter,
-/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/turret_protected/aisat/interior)
 "xXl" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -96010,13 +96076,6 @@
 	icon_state = "cafeteria"
 	},
 /area/station/service/kitchen)
-"xYs" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Starboard Asteroid Maintenance Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/plating/asteroid/ancient,
-/area/station/maintenance/starboard)
 "xYM" = (
 /turf/simulated/wall/mineral/titanium,
 /area/shuttle/pod_1)
@@ -96161,27 +96220,6 @@
 	icon_state = "whitepurple"
 	},
 /area/station/science/genetics)
-"yay" = (
-/obj/machinery/navbeacon{
-	codes_txt = "delivery";
-	location = "Kitchen"
-	},
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/mule_bot{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/service/kitchen{
-	dir = 4
-	},
-/obj/machinery/door/window/classic/reversed{
-	dir = 4;
-	pixel_x = 1;
-	name = "Kitchen Delivery"
-	},
-/turf/simulated/floor/plating,
-/area/station/service/kitchen)
 "yaN" = (
 /turf/simulated/floor/plasteel,
 /area/station/security/lobby)
@@ -96248,22 +96286,6 @@
 "ybP" = (
 /turf/simulated/floor/carpet/green,
 /area/station/service/library)
-"ybR" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Starboard Asteroid Maintenance Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/cable/orange{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plating,
-/area/station/maintenance/starboard)
 "ybZ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/camera{
@@ -96446,21 +96468,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
-"yeS" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Central Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plating,
-/area/station/maintenance/maintcentral)
 "yfx" = (
 /obj/structure/cable/orange{
 	d1 = 4;
@@ -96484,19 +96491,6 @@
 "yfZ" = (
 /turf/simulated/wall,
 /area/station/medical/storage/secondary)
-"yga" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "mining_home";
-	locked = 1;
-	name = "Mining Dock Airlock"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/supply/mining,
-/obj/machinery/door/firedoor,
-/obj/structure/fans/tiny,
-/obj/effect/decal/warning_stripes/south,
-/obj/effect/decal/warning_stripes/north,
-/turf/simulated/floor/plasteel,
-/area/station/supply/miningdock)
 "ygi" = (
 /obj/machinery/chem_heater,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -96638,14 +96632,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/central)
-"yhE" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Port Asteroid Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plating,
-/area/station/maintenance/port)
 "yhO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -96695,6 +96681,34 @@
 	icon_state = "dark"
 	},
 /area/station/security/brig)
+"yie" = (
+/obj/machinery/door/airlock/glass{
+	name = "Genetics Research"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/medical/genetics,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Biohazard_medi";
+	name = "Quarantine Lockdown";
+	opacity = 0
+	},
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel/white,
+/area/station/science/genetics)
 "yii" = (
 /turf/simulated/mineral/ancient/outer,
 /area/station/hallway/primary/central)
@@ -96796,20 +96810,6 @@
 	},
 /turf/simulated/wall,
 /area/station/hallway/secondary/entry/south)
-"ykf" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Medbay Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Biohazard_medi";
-	name = "Quarantine Lockdown";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/starboard)
 "ykj" = (
 /turf/simulated/floor/plasteel,
 /area/station/security/prisonlockers)
@@ -105531,8 +105531,8 @@ aXn
 bTp
 gRZ
 gRZ
-oGj
-twQ
+uBy
+rBB
 bTp
 bTp
 bTp
@@ -106456,7 +106456,7 @@ psw
 cdK
 vDK
 ciw
-jnP
+ciy
 qEb
 xta
 bnj
@@ -106818,7 +106818,7 @@ xaR
 xaR
 lhM
 fFl
-gtd
+smJ
 rNw
 whg
 uCK
@@ -106974,7 +106974,7 @@ duF
 cDt
 dvD
 bnp
-qRf
+ltr
 ubY
 bIf
 xJa
@@ -107500,8 +107500,8 @@ xJa
 xJa
 xJa
 xJa
-thB
-fgw
+hlA
+ctU
 yhW
 xJa
 cRv
@@ -108081,7 +108081,7 @@ tIM
 xUT
 tIM
 xUT
-krK
+kjq
 xaR
 xaR
 pDY
@@ -108098,7 +108098,7 @@ vvt
 uvg
 xLj
 xLj
-aoh
+cxD
 bXj
 bXj
 vtY
@@ -108308,7 +108308,7 @@ pXy
 oyM
 oKF
 paW
-uDk
+cNd
 sNu
 ktW
 cNW
@@ -108338,7 +108338,7 @@ jwF
 xyf
 jvx
 pFm
-nQv
+jsN
 pFm
 pFm
 pFm
@@ -108546,7 +108546,7 @@ vuL
 jQH
 wdb
 wdb
-wHx
+led
 vUp
 lPs
 lYX
@@ -108565,7 +108565,7 @@ uCK
 xFT
 oLZ
 lcq
-dPl
+cNe
 pUg
 lcq
 cNX
@@ -108824,7 +108824,7 @@ pDl
 cMT
 cMT
 cMT
-cuh
+cpO
 cMT
 cMT
 cUx
@@ -108907,8 +108907,8 @@ gQc
 gQc
 uCu
 uCu
-pAh
-hlh
+nIZ
+jZN
 uCu
 uCu
 ccW
@@ -109036,7 +109036,7 @@ xhk
 xhk
 xhk
 cch
-bGd
+jAr
 uTo
 yaN
 yaN
@@ -109067,7 +109067,7 @@ iCE
 iCE
 iCE
 iCE
-erU
+cTN
 sNq
 aXn
 aXn
@@ -109125,7 +109125,7 @@ cDo
 dzm
 uME
 bXj
-wkT
+vav
 bXj
 bXj
 bXj
@@ -109293,7 +109293,7 @@ dxE
 dxE
 dxE
 oPb
-qpR
+gck
 lyS
 jMr
 dyS
@@ -109566,8 +109566,8 @@ vZt
 nxA
 dCV
 dCV
-msx
-qJE
+esX
+goP
 dDB
 dDB
 cRv
@@ -109852,7 +109852,7 @@ pZo
 cMT
 cMT
 cMT
-gIH
+fav
 cMT
 cMT
 hfi
@@ -109931,7 +109931,7 @@ cJu
 dcG
 uCu
 sxb
-pjc
+wkx
 sxb
 uCu
 eUs
@@ -110199,7 +110199,7 @@ fNC
 tbu
 viJ
 jJs
-pcB
+kRH
 cuy
 cvs
 vyU
@@ -110318,7 +110318,7 @@ wUX
 wUX
 tYz
 dFX
-qkd
+frS
 dFX
 tYz
 tYz
@@ -110326,7 +110326,7 @@ qGR
 rKD
 yaN
 tsf
-flt
+vqN
 sOm
 ude
 cKY
@@ -110375,7 +110375,7 @@ ewd
 xaR
 tIM
 xaR
-exF
+tpC
 xUT
 xaR
 xaR
@@ -110409,7 +110409,7 @@ sym
 sym
 sym
 bUN
-wfq
+bFY
 bUN
 bUN
 rNT
@@ -110445,7 +110445,7 @@ cJu
 dcG
 uCu
 clR
-lMD
+sES
 clR
 cmF
 saR
@@ -110554,11 +110554,11 @@ rNK
 pVD
 pVD
 fSO
-sFI
+mZH
 fSO
 cdL
 fSO
-sFI
+mZH
 fSO
 pVD
 pVD
@@ -110585,13 +110585,13 @@ joR
 mnL
 dkp
 dkp
-fIz
+aSs
 dkp
 dkp
 cSV
 dkq
 dkq
-set
+wsU
 uuj
 uuj
 uuj
@@ -110617,8 +110617,8 @@ usD
 bav
 bav
 bav
-wSz
-rFr
+fdh
+ddh
 bav
 cMX
 pqy
@@ -110632,7 +110632,7 @@ veQ
 jwF
 pTp
 xyf
-wdu
+tpK
 vFn
 uko
 xyf
@@ -110644,7 +110644,7 @@ rZO
 wxr
 bsv
 xaR
-bea
+kXZ
 hVC
 hVC
 sUt
@@ -110825,9 +110825,9 @@ cDJ
 dtj
 wUX
 aJz
-wxf
+bdt
 puM
-wxf
+bdt
 bnv
 wUX
 aGH
@@ -110901,7 +110901,7 @@ wLy
 lhM
 jAn
 xGu
-jKX
+wdl
 jlo
 jlo
 voH
@@ -110931,7 +110931,7 @@ oeN
 rNT
 wjk
 aXq
-iYs
+kMH
 vnV
 adb
 ceV
@@ -110974,7 +110974,7 @@ wXW
 wXW
 jiS
 lMW
-iyX
+czM
 lMW
 wqx
 ccW
@@ -111070,13 +111070,13 @@ doB
 ajA
 dpg
 akC
-jQd
+alg
 vKV
 akC
 aok
 apa
 vKV
-aWi
+gYc
 dtp
 aui
 dtr
@@ -111225,9 +111225,9 @@ dnQ
 iBC
 lwr
 wXW
-iAy
+aar
 hTx
-kki
+nfq
 wXW
 lZz
 lMW
@@ -111337,13 +111337,13 @@ vpS
 emI
 hEk
 dtl
-pOP
+aFu
 hSd
 duM
 pdg
 eLU
 hSd
-pOP
+aFu
 dww
 bIS
 bQd
@@ -111365,7 +111365,7 @@ tPX
 dpd
 xXQ
 cub
-bjf
+fMH
 duz
 duh
 uuj
@@ -111474,7 +111474,7 @@ cxg
 cxg
 cxg
 cxg
-qlk
+clS
 cxg
 cxg
 cxg
@@ -111484,7 +111484,7 @@ iid
 wXW
 dmO
 oqU
-pOL
+uLT
 wXW
 sBh
 wsR
@@ -111585,11 +111585,11 @@ mCL
 mCL
 mCL
 mCL
-gOA
+drz
 mCL
 xQS
 xQS
-vwF
+aqY
 xQS
 xQS
 aum
@@ -111611,7 +111611,7 @@ bsk
 rKD
 yaN
 idf
-rPF
+aUq
 vFG
 vFG
 cLq
@@ -111620,11 +111620,11 @@ dkp
 cXr
 dkq
 dkq
-oKh
+doO
 dkq
 fIg
-hsb
-ghn
+guD
+hyY
 ioJ
 abW
 cRv
@@ -111643,7 +111643,7 @@ aXn
 aXn
 mJl
 bcp
-uSK
+nNF
 bcp
 oie
 bco
@@ -111702,7 +111702,7 @@ mfk
 qdP
 ped
 oxo
-sFD
+dMd
 oRH
 odg
 wqN
@@ -111719,7 +111719,7 @@ ccW
 ccW
 ccW
 ccW
-xrF
+cRV
 ccW
 ccW
 ccW
@@ -111739,9 +111739,9 @@ cpx
 kal
 bsR
 wXW
-pOL
+uLT
 fIu
-hMW
+efR
 wXW
 dCt
 irG
@@ -111756,7 +111756,7 @@ irG
 irG
 uVg
 czI
-pkW
+wqE
 oyp
 mrh
 ira
@@ -111856,7 +111856,7 @@ xrZ
 aAy
 pnf
 bdy
-nVs
+bnx
 aFw
 pjD
 loa
@@ -111868,7 +111868,7 @@ tmS
 ujO
 dyS
 idf
-rPF
+aUq
 cDi
 vFG
 wSk
@@ -111889,10 +111889,10 @@ cRv
 abE
 abE
 rNK
-sXv
-sXv
-sXv
-sXv
+xcc
+xcc
+xcc
+xcc
 rNK
 hUU
 aXn
@@ -112013,7 +112013,7 @@ qUd
 mvK
 uZl
 mvK
-cAX
+lMr
 orU
 ron
 pBh
@@ -112250,7 +112250,7 @@ cpz
 wbT
 cxg
 oGS
-fwO
+kMC
 dCc
 xnA
 llN
@@ -112393,7 +112393,7 @@ qCk
 ctA
 pNB
 gVN
-nhN
+rZg
 hAY
 cWq
 iZd
@@ -112509,7 +112509,7 @@ coy
 pOU
 ssD
 buE
-pSM
+vSg
 emA
 jvJ
 tlj
@@ -112610,7 +112610,7 @@ sxa
 vva
 mCL
 mCL
-fKD
+dph
 mCL
 aeK
 ttS
@@ -112629,10 +112629,10 @@ vRQ
 dvH
 exK
 exK
-wsd
+aGL
 dUb
 uSW
-wsd
+aGL
 exK
 tYz
 nZi
@@ -112733,15 +112733,15 @@ pLE
 hsf
 iQh
 dUv
-mYE
-mYE
-mYE
-mYE
-mYE
-mYE
-mYE
-mYE
-mYE
+dFf
+dFf
+dFf
+dFf
+dFf
+dFf
+dFf
+dFf
+dFf
 pin
 jKa
 hEC
@@ -112762,7 +112762,7 @@ dzr
 puz
 vQk
 uuU
-vVf
+vEm
 lpv
 cqx
 fzj
@@ -112901,7 +112901,7 @@ dkp
 aSz
 dkp
 dkp
-rPF
+aUq
 dkp
 dkp
 dpV
@@ -112933,14 +112933,14 @@ bbb
 uSv
 uSv
 uSv
-ogh
+ezi
 cMT
 lVP
 kLh
 lVP
 cMT
-hEj
-oNe
+wFq
+mWM
 eiB
 bkU
 eMc
@@ -112948,15 +112948,15 @@ pRF
 bkU
 vUJ
 bkU
-tzD
+tKi
 bkU
 vUJ
 bkU
 dcW
 bkU
 nQA
-gWt
-yhE
+uDy
+ohu
 aEe
 aEe
 aEe
@@ -113006,7 +113006,7 @@ vkl
 vkl
 vkl
 vkl
-kRr
+tjL
 vkl
 vkl
 gGI
@@ -113148,7 +113148,7 @@ bIT
 nJL
 cHB
 kGm
-fST
+dVv
 lbr
 hzh
 joR
@@ -113644,7 +113644,7 @@ afd
 afd
 afd
 xQS
-kri
+apf
 xQS
 xQS
 xQS
@@ -113801,8 +113801,8 @@ cxf
 mas
 mas
 mas
-hKt
-iyX
+cxl
+czM
 pDu
 ccW
 ccW
@@ -113953,8 +113953,8 @@ hrT
 lAN
 lAN
 leM
-hSV
-oXu
+aZa
+uUM
 bEM
 bEM
 pwt
@@ -113982,7 +113982,7 @@ oOg
 kOk
 oOg
 aZZ
-ffp
+rnX
 aZZ
 xKV
 aZZ
@@ -114004,15 +114004,15 @@ ohY
 fAD
 btd
 lJR
-qAB
-fSR
+tPw
+wSh
 lJR
-roC
-sjO
+bxQ
+ang
 lJR
 uQa
 hVt
-biY
+iyF
 lZN
 lZN
 lZN
@@ -114034,7 +114034,7 @@ gtU
 vkl
 vkl
 vkl
-gwF
+oSb
 vkl
 vkl
 vkl
@@ -114151,11 +114151,11 @@ gHh
 afs
 ahr
 adc
-oIo
+tVb
 iCK
 pTT
 aln
-ink
+llK
 avy
 aou
 apg
@@ -114176,7 +114176,7 @@ mng
 bzZ
 awr
 qro
-lms
+cgh
 lyS
 cnz
 lyS
@@ -114250,11 +114250,11 @@ jXC
 baF
 baF
 dBV
-pcC
-eKk
-aII
-mMD
-aII
+sAH
+gLY
+udq
+rKE
+udq
 baF
 nYB
 tOx
@@ -114276,15 +114276,15 @@ lUo
 mZu
 mMA
 wPV
-jlK
-jlK
-jlK
-jlK
-jlK
-jlK
-jlK
-jlK
-jlK
+rMT
+rMT
+rMT
+rMT
+rMT
+rMT
+rMT
+rMT
+rMT
 bJg
 fWh
 cge
@@ -114438,9 +114438,9 @@ gmC
 cnJ
 xla
 xla
-hSe
+cAq
 aWX
-dVV
+pXX
 xla
 jzO
 jXP
@@ -114565,7 +114565,7 @@ lsp
 lxD
 dqA
 sOo
-lgt
+ltP
 bVI
 lZS
 gZS
@@ -114665,16 +114665,16 @@ kUO
 afI
 ahJ
 xZx
-tOz
+ezE
 fxI
 qZG
 vNx
-emE
+rYs
 qpk
 duG
 hdv
 bkA
-lcy
+asc
 pqs
 auG
 uii
@@ -114693,7 +114693,7 @@ tZS
 yfX
 yfX
 yfX
-rWg
+pJG
 eWZ
 dWr
 dWr
@@ -114814,7 +114814,7 @@ rrN
 tVm
 tHG
 tHG
-iYb
+nDG
 tHG
 tHG
 eBU
@@ -114931,7 +114931,7 @@ aPx
 vLd
 gBX
 drA
-pBe
+fRS
 dsy
 shH
 cHH
@@ -115065,7 +115065,7 @@ ccW
 ccW
 vkl
 ozM
-pKA
+xMA
 cSI
 clw
 rWs
@@ -115184,7 +115184,7 @@ afd
 afd
 afd
 afd
-fRg
+rAx
 gAO
 afd
 afd
@@ -115207,7 +115207,7 @@ cHu
 cgi
 bEz
 cnL
-smd
+crd
 cxc
 cAr
 cAC
@@ -115268,7 +115268,7 @@ oOg
 oOg
 aZZ
 aZZ
-cLc
+fwJ
 aZZ
 aZZ
 ezq
@@ -115326,11 +115326,11 @@ iLY
 ldf
 dyb
 sEg
-aCZ
+cjV
 ckC
 mII
 sOA
-rky
+nwD
 frn
 ved
 rOj
@@ -115452,16 +115452,16 @@ dtr
 uqz
 uqz
 rCG
-mFN
+dvt
 rCG
 uqz
 tNT
 tNT
 tNT
-eFa
-uOn
+hcb
+qHa
 rJj
-jYl
+oZD
 lgu
 nto
 rJj
@@ -115612,7 +115612,7 @@ ccW
 rWw
 cdb
 cdb
-jnv
+oUM
 rNK
 rNK
 euP
@@ -116212,7 +116212,7 @@ vNP
 dqz
 alu
 afd
-qsb
+wwm
 afd
 afd
 rNK
@@ -116274,7 +116274,7 @@ vOI
 iry
 cFF
 nVj
-mho
+wOe
 bPa
 gGR
 cFF
@@ -116291,7 +116291,7 @@ lQY
 aZZ
 bjn
 aZZ
-gju
+jJf
 aZZ
 gWc
 dte
@@ -116568,7 +116568,7 @@ juY
 mrt
 uzY
 uzY
-rhj
+fnN
 baF
 baF
 btd
@@ -116734,13 +116734,13 @@ wvl
 yfX
 dnd
 cMx
-fit
+jnZ
 duu
 aAI
 eFw
 bdI
 eTD
-swR
+ttA
 uwt
 jlI
 vkq
@@ -116819,7 +116819,7 @@ idC
 uIG
 bjr
 bjr
-eRc
+sNy
 mrt
 juY
 hpJ
@@ -116834,8 +116834,8 @@ mgV
 mgV
 mgV
 mgV
-sNc
-jqI
+rtB
+lmX
 mgV
 mgV
 mgV
@@ -116991,13 +116991,13 @@ mjR
 dsy
 ogg
 awu
-iiO
+lVX
 mLm
 ipR
 vlz
 bdQ
 bog
-mPt
+bsN
 aGU
 bKr
 tMP
@@ -117019,7 +117019,7 @@ peB
 oms
 qHk
 wDC
-uPp
+jUP
 kTq
 rzy
 sIe
@@ -117046,7 +117046,7 @@ sSU
 cFF
 vkc
 bQh
-eFR
+eMW
 bRg
 cFF
 pSW
@@ -117098,8 +117098,8 @@ lUc
 wFD
 mNA
 btd
-aKo
-pSL
+waN
+pnr
 btd
 gBI
 slc
@@ -117143,7 +117143,7 @@ cuQ
 quI
 mCc
 pbR
-sVP
+cyl
 quI
 hLg
 quI
@@ -117392,7 +117392,7 @@ pzi
 oRh
 kvo
 lyQ
-ulw
+iNK
 eHo
 vKW
 uxD
@@ -117400,17 +117400,17 @@ fSl
 igu
 ufg
 cxq
-peC
+uHA
 dyK
 nnf
 pqg
 pon
-eac
+sSG
 cGd
 cGd
 uyl
 wZW
-vGS
+nGd
 nXw
 oqO
 uyl
@@ -117599,7 +117599,7 @@ agw
 srW
 ogl
 ogl
-fDF
+odn
 lYO
 riS
 mcu
@@ -117634,7 +117634,7 @@ uQE
 jWb
 fAm
 sYa
-hpo
+mNc
 fZs
 ovQ
 jTe
@@ -117645,7 +117645,7 @@ qlv
 xOw
 fCc
 cnU
-wSG
+bQe
 cpB
 vvb
 dka
@@ -117773,12 +117773,12 @@ bAl
 fEL
 iZY
 dti
-oBS
+pkp
 pIR
 fjm
 xzK
 aOI
-jYl
+oZD
 eWZ
 ddk
 aEn
@@ -117815,7 +117815,7 @@ kWu
 kWu
 kWu
 kWu
-uCJ
+tYu
 kWu
 xho
 nJA
@@ -118148,7 +118148,7 @@ oUw
 nNO
 qWS
 heU
-uGQ
+wOH
 alw
 vBs
 xEd
@@ -118161,7 +118161,7 @@ uMr
 uMr
 uMr
 xIa
-qMt
+vbY
 pzF
 uwd
 cul
@@ -118175,10 +118175,10 @@ asL
 czb
 dZA
 oUJ
-fPt
+uWx
 eJf
 wpX
-sea
+eGv
 aFn
 dZA
 oqN
@@ -118270,28 +118270,28 @@ aTz
 aTz
 afd
 afd
-rXt
+cKZ
 mYJ
 fqh
 eBm
-edd
+krP
 evh
 azW
 azu
 uJY
-qTZ
+baE
 hmc
 azu
 azu
 qQO
-saq
+bKV
 mgO
 jnu
 qQO
 pQm
 lhf
 wKz
-xfl
+bon
 qQO
 cAA
 dlv
@@ -118358,13 +118358,13 @@ fkt
 fkt
 fkt
 fkt
-oDJ
+cGv
 fkt
 fkt
 uzY
 uzY
-tpn
-yay
+uRP
+vRC
 uzY
 uzY
 uzY
@@ -118374,7 +118374,7 @@ ueB
 ueB
 ueB
 ueB
-xlx
+hHX
 ueB
 ueB
 ueB
@@ -118552,7 +118552,7 @@ laC
 qQO
 cBa
 vsi
-uUw
+aSC
 men
 uPi
 cTr
@@ -118597,7 +118597,7 @@ qxQ
 ghP
 vyk
 wIm
-cgd
+nOU
 gyr
 xPf
 eIs
@@ -118809,7 +118809,7 @@ gLL
 qQO
 cBb
 gdV
-kGO
+cGh
 mhv
 aTX
 aUt
@@ -118847,21 +118847,21 @@ aZF
 cEM
 cEM
 cEM
-fyM
+lMj
 aZF
 aZF
 aZF
-dDa
+gsS
 bBI
 ssq
 wxX
 tiI
 iVI
 gvW
-fpJ
+oep
 uQd
 vnL
-vxx
+glm
 vXX
 wpF
 wDL
@@ -118882,7 +118882,7 @@ vFf
 wCB
 wpF
 wpl
-lbA
+jrM
 dcC
 caw
 qJI
@@ -118942,12 +118942,12 @@ pon
 pon
 pon
 pon
-lIM
+kyW
 pon
 pon
 pon
 pon
-plF
+qnS
 cGd
 cGd
 cdb
@@ -119139,7 +119139,7 @@ fcR
 caw
 gtv
 caw
-bXN
+qQx
 caw
 sbn
 sbn
@@ -119438,7 +119438,7 @@ hVS
 lnY
 mBQ
 suu
-hyX
+cPX
 pFr
 hQo
 gmN
@@ -119450,7 +119450,7 @@ cpI
 qZD
 tia
 kvs
-vNz
+jxw
 wQY
 nej
 vey
@@ -119589,7 +119589,7 @@ toX
 dsv
 dNU
 oIX
-gBk
+fSQ
 aWF
 hGb
 iuy
@@ -119697,7 +119697,7 @@ ciG
 gPL
 dXV
 cGd
-aXL
+kOb
 cGd
 cGd
 cGd
@@ -119846,7 +119846,7 @@ xla
 dsw
 dOb
 mcK
-tfG
+fTn
 aWG
 jRG
 ice
@@ -120216,12 +120216,12 @@ cGd
 isf
 vUX
 pAi
-bbP
+qHL
 cny
 vld
 lJg
 vld
-mrT
+wig
 iTH
 pAi
 pAi
@@ -120486,7 +120486,7 @@ dHN
 ftr
 wIq
 nta
-iyX
+czM
 rza
 dha
 ccW
@@ -120593,8 +120593,8 @@ fqh
 swq
 swq
 swq
-jQJ
-oaR
+srt
+sLb
 swq
 uXj
 uXj
@@ -120607,7 +120607,7 @@ uXj
 uXj
 uXj
 xla
-mrq
+vfc
 xla
 xla
 fso
@@ -120870,7 +120870,7 @@ qny
 wiJ
 aUx
 wiJ
-iSj
+lGh
 jKR
 bMn
 mcK
@@ -121127,11 +121127,11 @@ cLH
 vrQ
 vXM
 vrQ
-qiz
+xzp
 scK
 chV
 shl
-dxh
+rBJ
 gIG
 jpP
 jpP
@@ -121237,19 +121237,19 @@ izC
 nxX
 irU
 sOk
-bMZ
+qyc
 dhH
 uPP
 cGd
 isf
 cvW
 pAi
-gxt
+tjp
 cny
 vld
 olo
 vld
-mrT
+wig
 skb
 pAi
 pAi
@@ -121370,8 +121370,8 @@ vPt
 vly
 vrQ
 rAT
-bfF
-cFO
+rsH
+aKO
 vPt
 vPt
 vPt
@@ -122138,8 +122138,8 @@ avS
 avS
 avS
 aqC
-kXs
-qiz
+emS
+xzp
 aqC
 aqC
 aqC
@@ -122272,12 +122272,12 @@ cGd
 isf
 pAi
 pAi
-hFJ
+kII
 cny
 vld
 uUY
 vld
-mrT
+wig
 clL
 pAi
 cvW
@@ -122769,13 +122769,13 @@ ful
 ful
 joJ
 dNT
-ttb
+pkO
 ajq
 vCk
 nHm
-knv
+gNb
 mfu
-uEe
+qLv
 njR
 ciG
 gPL
@@ -122896,7 +122896,7 @@ gtq
 kfd
 ayf
 llq
-fEf
+beT
 aKY
 aKY
 aKY
@@ -123153,7 +123153,7 @@ cZD
 aUS
 iIj
 hXe
-nlx
+ooI
 snc
 snc
 snc
@@ -123187,7 +123187,7 @@ aqC
 xas
 tSt
 vpK
-ifP
+aWw
 gML
 hOn
 iAF
@@ -123300,12 +123300,12 @@ cGd
 isf
 cvW
 pAi
-xCV
+wum
 cny
 nPR
 fcg
 nPR
-mrT
+wig
 jLP
 pAi
 pAi
@@ -123497,7 +123497,7 @@ yaP
 yaP
 yaP
 uio
-qHz
+cUg
 ddC
 uio
 uio
@@ -123816,7 +123816,7 @@ cGd
 ftr
 cGd
 dOm
-aHj
+iIW
 xPU
 ftr
 eFm
@@ -124801,7 +124801,7 @@ gwb
 xpe
 fEm
 uio
-qHz
+cUg
 uio
 cUn
 kzf
@@ -124848,7 +124848,7 @@ nta
 eBj
 wsR
 xFJ
-lVn
+lwQ
 vNV
 wsR
 wsR
@@ -124986,11 +124986,11 @@ aqC
 dtZ
 dPt
 lYm
-tml
+fVe
 gNT
 hQs
 iCo
-iec
+jxJ
 jXD
 rRO
 jXD
@@ -125038,7 +125038,7 @@ gwb
 bDR
 bDR
 bDR
-xAe
+bIj
 bDR
 xZl
 bDR
@@ -125105,7 +125105,7 @@ nta
 ftr
 mBm
 eMX
-iyX
+czM
 wsR
 czQ
 ftr
@@ -125298,7 +125298,7 @@ pJS
 dvd
 ddu
 ddH
-qYa
+bLO
 bNo
 bIi
 obN
@@ -125358,7 +125358,7 @@ iFs
 ccW
 ccW
 rfn
-khL
+mHA
 rfn
 rfn
 kOP
@@ -125549,7 +125549,7 @@ aXR
 ozA
 cUl
 uio
-gPr
+nGZ
 aZY
 fms
 jUL
@@ -125559,11 +125559,11 @@ ddI
 ddJ
 ddM
 bPr
-vPz
+ddO
 ddQ
 ddV
 dea
-wAU
+deh
 deq
 dev
 bVu
@@ -125572,7 +125572,7 @@ bDR
 cGJ
 jIp
 yiE
-uEb
+cGN
 yiE
 sak
 cRm
@@ -126080,7 +126080,7 @@ bSZ
 bQs
 bUZ
 bUV
-aXH
+bVw
 bVW
 bDR
 bDR
@@ -126123,7 +126123,7 @@ xCT
 uwf
 lzH
 lzH
-sXv
+xcc
 rNK
 rNK
 rNK
@@ -126380,7 +126380,7 @@ hKz
 nZe
 rNK
 rNK
-sXv
+xcc
 rNK
 rNK
 rNK
@@ -126503,7 +126503,7 @@ wES
 vPt
 tXQ
 uyM
-uUm
+rrC
 tXQ
 aEC
 uyM
@@ -126573,7 +126573,7 @@ fvQ
 baN
 jCl
 baN
-jJQ
+nON
 sgp
 sgp
 kzf
@@ -126825,7 +126825,7 @@ aYJ
 rLW
 tet
 xXl
-vvQ
+wKd
 buM
 jCl
 cJN
@@ -126871,7 +126871,7 @@ cVk
 cVk
 cVk
 cVk
-irV
+cVt
 rNK
 rNK
 lRR
@@ -127108,7 +127108,7 @@ bOk
 dek
 pRz
 tKQ
-gcy
+dex
 bVY
 bDR
 bDR
@@ -127117,7 +127117,7 @@ bDR
 bDR
 qkL
 kkS
-xcw
+hIA
 nhe
 roF
 cUR
@@ -127333,7 +127333,7 @@ aZK
 aZK
 aZK
 aYJ
-cRF
+bli
 aYJ
 aYJ
 rLW
@@ -127350,7 +127350,7 @@ kmt
 nxa
 bDR
 bFf
-dYx
+jps
 cQl
 cQl
 bKE
@@ -127547,7 +127547,7 @@ csz
 rmq
 nuE
 nuE
-nMj
+btv
 nuE
 nuE
 bAK
@@ -127636,9 +127636,9 @@ cUI
 cUN
 cUT
 cUZ
-tAq
+cVe
 cVi
-mHq
+cVl
 cVo
 cVr
 cVs
@@ -127665,7 +127665,7 @@ hKz
 nZe
 rNK
 rNK
-sXv
+xcc
 rNK
 rNK
 rNK
@@ -127855,7 +127855,7 @@ hZy
 brW
 eob
 buP
-dvU
+mbZ
 bxu
 bDX
 bDX
@@ -127865,11 +127865,11 @@ mYI
 mYI
 bFh
 nMX
-sxQ
+xVj
 uga
 eBf
 eBf
-hvb
+uGM
 rZi
 ddN
 fTT
@@ -127922,7 +127922,7 @@ hKz
 nZe
 lzH
 lzH
-sXv
+xcc
 rNK
 rNK
 rNK
@@ -128136,7 +128136,7 @@ lRU
 nqw
 bIi
 bUV
-aXH
+bVw
 bVZ
 bDR
 bDR
@@ -128179,7 +128179,7 @@ dVe
 uVb
 rNK
 rNK
-sXv
+xcc
 rNK
 rNK
 rNK
@@ -128375,7 +128375,7 @@ bwi
 bwi
 bwi
 bBW
-vhj
+hRF
 bwi
 lzu
 oeM
@@ -128572,7 +128572,7 @@ abW
 abW
 xYZ
 xYZ
-eJW
+iHL
 nuE
 bse
 btG
@@ -128635,7 +128635,7 @@ wPJ
 fGr
 bhd
 bvR
-vgN
+uro
 cQl
 cQl
 cQl
@@ -128831,7 +128831,7 @@ aVS
 xLP
 cyR
 fPE
-isx
+cHZ
 btJ
 cLU
 byn
@@ -128889,7 +128889,7 @@ eGr
 eGr
 bhd
 bhd
-nya
+xGA
 bhd
 oFg
 wob
@@ -128916,7 +128916,7 @@ bXz
 bDR
 gwb
 hke
-fJT
+cUB
 gwb
 aXR
 aXR
@@ -129071,7 +129071,7 @@ eTm
 awk
 eTm
 eTm
-wwi
+aLQ
 dxS
 dxS
 dxS
@@ -129159,7 +129159,7 @@ cQB
 bPA
 iTF
 bRv
-wOJ
+sCr
 bTc
 bTc
 bTD
@@ -129377,7 +129377,7 @@ xbO
 aZK
 aZK
 aYJ
-nWI
+aeL
 aZK
 aYJ
 aYJ
@@ -129849,7 +129849,7 @@ aEU
 aEU
 eTm
 bDy
-xug
+aIv
 bRp
 bYj
 tpA
@@ -129869,7 +129869,7 @@ aVS
 duJ
 lfg
 uOz
-qAr
+fWE
 gPS
 aFp
 iFR
@@ -129894,7 +129894,7 @@ wZl
 tsB
 aYJ
 iKN
-gbp
+nlS
 dQd
 bgf
 buQ
@@ -129906,7 +129906,7 @@ cKs
 sFl
 bmA
 bnR
-blz
+bpc
 bqt
 sUQ
 iGA
@@ -129924,11 +129924,11 @@ mUV
 oFH
 xCd
 bTB
-lYc
+cQn
 bNv
 cQE
 cQL
-jSW
+cWb
 bRy
 uob
 bTH
@@ -130099,7 +130099,7 @@ dxS
 dxS
 eTm
 jJY
-sIU
+aNK
 aVt
 aEU
 biU
@@ -130369,13 +130369,13 @@ imn
 xLP
 hor
 chM
-lko
+cpk
 chM
 cyO
 cBp
 cCR
 cGP
-jai
+cMa
 cQP
 cUa
 djc
@@ -130405,7 +130405,7 @@ aYJ
 aYJ
 aYJ
 aYJ
-nSS
+bbV
 aYJ
 aYJ
 aYJ
@@ -130618,7 +130618,7 @@ aCg
 aCg
 bjh
 cLr
-oio
+bvr
 lnf
 lGj
 plu
@@ -130689,10 +130689,10 @@ bzA
 bAO
 wmE
 thN
-inV
+bEe
 bFl
 voE
-dVw
+uRH
 gFE
 qAc
 iTF
@@ -130883,13 +130883,13 @@ fxL
 xLP
 rMM
 chM
-pcy
+pOl
 chM
 vvZ
 txk
 lVh
 cGP
-trY
+cMm
 cRh
 cUb
 bSg
@@ -130941,9 +130941,9 @@ btx
 bxz
 mWL
 bxz
-cVW
+sSv
 bzB
-oZy
+bAP
 bBQ
 uRu
 bhd
@@ -130953,12 +130953,12 @@ bhd
 bJQ
 emJ
 rZj
-fWt
+dgX
 bVT
 bPE
 aJc
 wJe
-vpf
+coU
 cUm
 mVp
 mVp
@@ -131203,10 +131203,10 @@ fFU
 bAQ
 xdu
 bCV
-maj
+bEg
 bFs
 gbH
-kak
+tOY
 nOF
 mlM
 cQf
@@ -131391,7 +131391,7 @@ uER
 hzs
 eTm
 aHm
-pzp
+bNj
 isr
 bYO
 tpA
@@ -131925,7 +131925,7 @@ aKp
 dxa
 dTd
 qhH
-qsd
+fXt
 fiV
 hSY
 wxb
@@ -131950,7 +131950,7 @@ aGF
 rpT
 pXq
 bbu
-gLq
+bdx
 bep
 bfb
 buQ
@@ -131962,7 +131962,7 @@ cKs
 jlN
 lYE
 lYE
-oGO
+dzc
 qcI
 xzk
 iGA
@@ -132805,7 +132805,7 @@ hKz
 nZe
 ayb
 ayb
-sXv
+xcc
 rNK
 rNK
 ayb
@@ -133062,7 +133062,7 @@ hKz
 nZe
 ayb
 rNK
-sXv
+xcc
 rNK
 rNK
 rNK
@@ -133177,7 +133177,7 @@ obB
 aog
 vYQ
 aog
-hMT
+arm
 dQr
 cDp
 cMH
@@ -133206,7 +133206,7 @@ cMz
 cRI
 aBI
 cVX
-fku
+dmC
 dxx
 dTM
 wyo
@@ -133235,7 +133235,7 @@ rji
 rji
 eOx
 gJw
-jII
+uNN
 gLf
 iXq
 buQ
@@ -133319,7 +133319,7 @@ hKz
 uVb
 rNK
 rNK
-sXv
+xcc
 rNK
 rNK
 rNK
@@ -133434,7 +133434,7 @@ anB
 wUc
 vIp
 tNQ
-lrf
+aru
 iOP
 atC
 uPs
@@ -133467,7 +133467,7 @@ dmA
 dyC
 dWE
 gDe
-kzM
+fXS
 hab
 hXC
 iKW
@@ -133576,7 +133576,7 @@ hKz
 nZe
 rNK
 rNK
-sXv
+xcc
 rNK
 rNK
 rNK
@@ -133775,7 +133775,7 @@ bBX
 tHo
 tBG
 vLR
-gcq
+ohs
 bID
 mJM
 mJM
@@ -133833,7 +133833,7 @@ hKz
 nZe
 rNK
 rNK
-sXv
+xcc
 rNK
 rNK
 rNK
@@ -133999,7 +133999,7 @@ aXD
 xbO
 baR
 ncV
-old
+nsb
 ncV
 baR
 cll
@@ -134023,7 +134023,7 @@ boZ
 bsg
 bdw
 bvf
-jvt
+jjn
 bxH
 lNw
 lNw
@@ -134090,7 +134090,7 @@ hKz
 nZe
 rNK
 rNK
-sXv
+xcc
 rNK
 rNK
 rNK
@@ -134297,15 +134297,15 @@ nVW
 nVW
 bND
 bND
-pTU
+pMT
 bND
 bND
 hxE
 mJM
 mJM
 hxE
-rIL
-shF
+jjN
+kBa
 mJM
 hxE
 bXD
@@ -134347,7 +134347,7 @@ xBI
 uwf
 rNK
 rNK
-sXv
+xcc
 rNK
 rNK
 rNK
@@ -134489,7 +134489,7 @@ gKc
 lxO
 flF
 flF
-rQI
+sSq
 cMz
 dmA
 dwg
@@ -134513,7 +134513,7 @@ rNK
 aXD
 mUQ
 mUQ
-lXu
+nsZ
 cll
 baR
 baS
@@ -134523,13 +134523,13 @@ qgu
 baS
 baS
 bfh
-aSt
+bgl
 bfh
 sUW
 aYJ
 aYJ
 aYJ
-wMI
+blw
 aYJ
 aYJ
 bpm
@@ -134604,7 +134604,7 @@ mqR
 sHm
 lzH
 lzH
-sXv
+xcc
 rNK
 rNK
 rNK
@@ -134748,7 +134748,7 @@ rBk
 bvD
 aKC
 rUq
-drP
+rLu
 xIm
 pqi
 oPw
@@ -134861,7 +134861,7 @@ mqR
 sHm
 rNK
 rNK
-sXv
+xcc
 rNK
 rNK
 rNK
@@ -135005,11 +135005,11 @@ aQq
 bjY
 nHR
 dQr
-nhD
+kPs
 vml
 cwJ
 gDe
-vNi
+gcW
 heG
 ick
 iRM
@@ -135049,7 +135049,7 @@ aYJ
 beV
 uxM
 rdN
-yeS
+xpt
 bvi
 fLT
 nVW
@@ -135292,7 +135292,7 @@ bZk
 bYS
 bdA
 lrd
-fax
+bev
 bfk
 bgo
 bYQ
@@ -135306,7 +135306,7 @@ aYJ
 uKX
 tet
 jJi
-mYF
+iuC
 bvj
 fLT
 uMu
@@ -135519,7 +135519,7 @@ abW
 abW
 npV
 djH
-enq
+dmY
 dzo
 dTM
 mDs
@@ -135528,7 +135528,7 @@ hkx
 idg
 iUh
 jKs
-rFE
+kfe
 kwS
 kQN
 gch
@@ -135870,7 +135870,7 @@ plQ
 ccB
 azM
 lhp
-msK
+jUZ
 cdj
 ctC
 vRX
@@ -136061,12 +136061,12 @@ xbO
 sUW
 sUW
 sUW
-iaQ
+oKk
 sUW
 sUW
 sUW
 baS
-eut
+kCa
 sUW
 aYJ
 aZK
@@ -136294,7 +136294,7 @@ dnb
 dAc
 dSs
 uOz
-dnp
+gfd
 hmJ
 lnJ
 aKp
@@ -136396,7 +136396,7 @@ kwQ
 hjb
 imG
 vRX
-hOD
+oxO
 hje
 iFb
 sFj
@@ -136653,7 +136653,7 @@ abc
 gak
 uCM
 wKu
-dFZ
+mIS
 onR
 svU
 eSb
@@ -136855,7 +136855,7 @@ aXR
 mJM
 lpT
 hmM
-mPL
+uqV
 vKO
 vKO
 vKO
@@ -138065,7 +138065,7 @@ wIp
 rRM
 rRM
 sZi
-prK
+aBl
 vNy
 rRM
 rRM
@@ -138219,7 +138219,7 @@ lQB
 xbJ
 uOy
 eGf
-oBg
+igy
 rNK
 rNK
 rNK
@@ -138446,7 +138446,7 @@ wLr
 vSy
 lhA
 ojy
-mdI
+mxd
 eyB
 uwa
 vWF
@@ -138476,7 +138476,7 @@ xbJ
 xbJ
 uOy
 uSP
-oBg
+igy
 rNK
 rNK
 rNK
@@ -138703,7 +138703,7 @@ wLr
 mpB
 ftG
 ldH
-rUz
+olg
 jrw
 lhz
 wcl
@@ -138733,7 +138733,7 @@ oEE
 xbJ
 nAT
 uSP
-oBg
+igy
 rNK
 rNK
 rNK
@@ -138969,7 +138969,7 @@ jZQ
 ruW
 woU
 ezV
-qvh
+uTR
 dQF
 eWu
 vjb
@@ -139247,7 +139247,7 @@ kjb
 xbJ
 kic
 uSP
-oBg
+igy
 rNK
 rNK
 rNK
@@ -139344,7 +139344,7 @@ okP
 okP
 okP
 okP
-oto
+aqb
 okP
 okP
 okP
@@ -139504,7 +139504,7 @@ xbJ
 xbJ
 xbJ
 uSP
-oBg
+igy
 rNK
 rNK
 rNK
@@ -139761,7 +139761,7 @@ fcO
 xbJ
 xbJ
 sws
-oBg
+igy
 rNK
 rNK
 rNK
@@ -139847,7 +139847,7 @@ dvV
 agS
 sYg
 agW
-jnJ
+aeN
 agW
 akr
 sYg
@@ -139864,11 +139864,11 @@ asE
 sgE
 atJ
 atJ
-oXy
+aCw
 atJ
 atJ
 atJ
-kTQ
+bki
 bke
 bke
 bke
@@ -140123,7 +140123,7 @@ okP
 kVY
 aCy
 gcR
-lUG
+aXd
 bcr
 bkj
 cXU
@@ -140366,7 +140366,7 @@ vTo
 akt
 akZ
 gUh
-dSC
+vsD
 amJ
 amJ
 aNf
@@ -140376,7 +140376,7 @@ aZL
 kTL
 btr
 atK
-ngX
+avr
 axP
 aDi
 aPA
@@ -140511,7 +140511,7 @@ xSo
 chG
 eYI
 cjy
-fxl
+fvb
 flM
 uOu
 clH
@@ -140637,7 +140637,7 @@ okP
 dgb
 aDl
 aPB
-xXf
+aXe
 bcG
 bkl
 cXB
@@ -140875,7 +140875,7 @@ dvV
 agS
 sYg
 agW
-oBe
+afn
 agW
 akv
 sYg
@@ -140896,11 +140896,11 @@ iKq
 aPD
 mmW
 mmW
-npe
+bkJ
 bke
 bke
 bke
-xJR
+hrp
 bke
 bke
 cXJ
@@ -141400,7 +141400,7 @@ okP
 okP
 okP
 okP
-vBG
+aqd
 okP
 okP
 okP
@@ -141468,7 +141468,7 @@ tnq
 tnq
 nVQ
 nVQ
-rLr
+sdo
 vXn
 oNy
 baq
@@ -141476,7 +141476,7 @@ bvt
 cWQ
 vXn
 vXn
-lVN
+vsP
 vXn
 vXn
 wpN
@@ -141485,11 +141485,11 @@ wZv
 rMf
 wZv
 wZv
-gKq
+ttV
 hfR
 eCB
 vXn
-bnP
+xkj
 vXn
 vXn
 vXn
@@ -141519,12 +141519,12 @@ wPr
 jnV
 wPr
 wPr
-bzH
+ecd
 gzv
 gzv
 gzv
 gzv
-pdh
+qeR
 gzv
 gzv
 gzv
@@ -141533,10 +141533,10 @@ wPr
 aXn
 aXn
 vpJ
-dWu
-maJ
+dQR
+dJG
 xSo
-cZZ
+waf
 xSo
 xSo
 xSo
@@ -141919,7 +141919,7 @@ fZZ
 okP
 okP
 mmW
-oaj
+ayK
 aDD
 aPL
 mmW
@@ -142489,7 +142489,7 @@ orw
 eEF
 oVZ
 pfU
-sqD
+qyV
 uoh
 qjG
 qBz
@@ -142500,7 +142500,7 @@ bmS
 bmS
 vXn
 oGF
-pyd
+gOh
 oGF
 vXn
 vXn
@@ -142518,7 +142518,7 @@ aYQ
 bCg
 bCg
 vXn
-ohD
+erl
 vXn
 vXn
 vXn
@@ -142548,7 +142548,7 @@ wPr
 wPr
 wPr
 wPr
-ckM
+lmF
 wPr
 aXn
 aXn
@@ -142561,8 +142561,8 @@ cGc
 vpJ
 vpJ
 vpJ
-hOD
-maJ
+oxO
+dJG
 vpJ
 vpJ
 vpJ
@@ -142746,7 +142746,7 @@ orw
 oDz
 oWo
 pit
-geC
+jba
 ala
 bhp
 qBN
@@ -143533,7 +143533,7 @@ jVQ
 jVQ
 jVQ
 bwF
-uxT
+vDS
 byM
 dza
 qql
@@ -143559,12 +143559,12 @@ rNK
 rNK
 rNK
 rNK
-sXv
-sXv
-sXv
-sXv
-sXv
-sXv
+xcc
+xcc
+xcc
+xcc
+xcc
+xcc
 rNK
 rNK
 hUU
@@ -143802,8 +143802,8 @@ lUY
 lUY
 nvb
 bCg
-hUo
-eUi
+nKB
+bMx
 bnZ
 nVQ
 nVQ
@@ -144109,7 +144109,7 @@ ljv
 dmP
 wRM
 vmb
-fFG
+oVj
 mjG
 lqQ
 jPk
@@ -144229,7 +144229,7 @@ rNK
 rIu
 jmv
 erB
-dHj
+asH
 waj
 waj
 ayS
@@ -144288,7 +144288,7 @@ orR
 xGv
 cYq
 bex
-lBi
+bfm
 phb
 bhp
 wSq
@@ -144304,10 +144304,10 @@ uha
 uwq
 cKk
 cKk
-cOx
+aZn
 cKk
-mPk
-msH
+bzO
+wLn
 cKk
 bCg
 xVB
@@ -144488,7 +144488,7 @@ aqt
 arC
 kte
 eyN
-beO
+rVG
 ayT
 alk
 cHS
@@ -144554,7 +144554,7 @@ bjJ
 bgq
 bhl
 bia
-iFu
+icI
 izY
 vEA
 bst
@@ -145032,7 +145032,7 @@ dod
 xME
 fmI
 mhd
-tAO
+ghF
 hsa
 rWb
 alc
@@ -145081,13 +145081,13 @@ dAX
 dBO
 mau
 bCg
-gJq
-uVA
+bEu
+bFI
 gIm
 bCg
 bCg
 bCg
-veP
+vWu
 cKk
 jXm
 utF
@@ -145272,7 +145272,7 @@ bFR
 bwZ
 nLP
 xrC
-rap
+fIe
 nLP
 any
 qIF
@@ -145285,7 +145285,7 @@ iIK
 cSz
 qWY
 qWY
-xWL
+uDD
 wue
 kqp
 vEV
@@ -145347,7 +145347,7 @@ gfF
 bMB
 cKk
 cKk
-hur
+ljN
 cKk
 jVQ
 jVQ
@@ -145542,7 +145542,7 @@ iIK
 djm
 ayS
 cpC
-mGb
+gaX
 ojx
 ima
 oRl
@@ -145573,7 +145573,7 @@ jIf
 qwq
 gZm
 gZm
-uhX
+pxr
 iqc
 qlO
 wSq
@@ -145598,7 +145598,7 @@ dBO
 dBz
 tqm
 rHA
-ljD
+bIP
 rHA
 sBd
 dBO
@@ -145839,7 +145839,7 @@ rqu
 cOG
 cOM
 cOZ
-uEY
+sSB
 lWh
 avK
 bwU
@@ -146031,7 +146031,7 @@ qPQ
 dfd
 ebW
 nZZ
-qIZ
+vcq
 kvC
 alS
 alS
@@ -146114,14 +146114,14 @@ uxF
 bHp
 uhF
 bME
-hPW
+bKZ
 bME
 bME
 kSI
 rHq
 yfZ
 rwg
-mbO
+teW
 yfZ
 vrs
 moY
@@ -146165,7 +146165,7 @@ sOl
 mJk
 ogw
 tXW
-xFI
+vFz
 lzP
 qFr
 wby
@@ -146319,13 +146319,13 @@ fmI
 bDQ
 rWb
 xWF
-mdk
+iPj
 xWF
 rWb
 rWb
 rPi
 aRx
-gFs
+lvT
 ghw
 aRx
 aRx
@@ -146550,9 +146550,9 @@ bZX
 bZX
 bZX
 vtS
-mzW
+aGw
 any
-mzW
+aGw
 cLD
 bZX
 dKI
@@ -146608,7 +146608,7 @@ wSq
 dzw
 dzw
 dzw
-ikJ
+cTZ
 dzw
 dzw
 evQ
@@ -146667,8 +146667,8 @@ cdT
 aXn
 jpk
 cdT
-rpS
-ebK
+fvg
+pMm
 cdT
 cdT
 cdT
@@ -146823,7 +146823,7 @@ cAb
 aRE
 aSj
 wnI
-vFC
+dgl
 cSC
 aov
 aov
@@ -147064,9 +147064,9 @@ rNK
 rNK
 bZX
 vtS
-htb
+cLx
 bZX
-htb
+cLx
 cLD
 bZX
 bZX
@@ -147332,7 +147332,7 @@ rNK
 any
 rJE
 vEB
-xLe
+pcI
 cAj
 hZJ
 hZJ
@@ -147349,8 +147349,8 @@ ayP
 any
 aRx
 rPi
-rQG
-mVP
+jNZ
+kmi
 kDg
 rPi
 rPi
@@ -147372,8 +147372,8 @@ dkU
 tnq
 tnq
 aZq
-rDV
-ybR
+fkw
+nyv
 bhr
 fqw
 bij
@@ -147393,7 +147393,7 @@ nqG
 dBO
 wOn
 udk
-pnQ
+xyT
 bEy
 xeq
 cdI
@@ -147454,7 +147454,7 @@ cem
 lcR
 ceQ
 tDr
-iUZ
+lmS
 uut
 wCU
 aXn
@@ -147589,7 +147589,7 @@ rNK
 bZX
 woa
 cqa
-cnf
+rnN
 aQz
 hZJ
 jAN
@@ -147636,7 +147636,7 @@ itf
 dzy
 dzy
 dzy
-oof
+blL
 dzy
 dzy
 nqG
@@ -147916,7 +147916,7 @@ uhF
 bME
 uhF
 aMC
-dWd
+pkQ
 uhF
 qua
 jDW
@@ -147948,7 +147948,7 @@ iXO
 rTV
 njn
 cem
-xwL
+sgV
 geD
 jvl
 vCc
@@ -148108,7 +148108,7 @@ aQA
 hZJ
 cEv
 cIr
-mKd
+kkk
 oMs
 vfQ
 aov
@@ -148130,10 +148130,10 @@ alc
 alc
 lCC
 lCC
-sXv
-sXv
-sXv
-sXv
+xcc
+xcc
+xcc
+xcc
 aZu
 aZu
 aZu
@@ -148177,8 +148177,8 @@ bAn
 yfZ
 oSI
 bMK
-nwk
-qxv
+hVY
+qwe
 hUF
 yfZ
 gFg
@@ -148379,7 +148379,7 @@ alc
 rPi
 rPi
 rPi
-qLM
+vnM
 rPi
 rPi
 alc
@@ -148409,7 +148409,7 @@ cHT
 bne
 sit
 ddr
-nui
+sEV
 tly
 dAe
 pTr
@@ -148418,7 +148418,7 @@ nZp
 nZp
 vMc
 nZp
-fmC
+wvJ
 wPK
 xeq
 xeq
@@ -148628,8 +148628,8 @@ any
 any
 fue
 kaw
-tNJ
-mGb
+ucH
+gaX
 any
 qIF
 alc
@@ -148937,12 +148937,12 @@ fUk
 sVA
 qdn
 baD
-vBR
+yie
 oix
 xoO
 xmL
 jYO
-oPt
+nvF
 mOC
 byK
 stJ
@@ -148976,7 +148976,7 @@ hud
 ceQ
 lvj
 ceQ
-xpd
+iWx
 mNn
 jqX
 vCc
@@ -149432,12 +149432,12 @@ pyp
 iFS
 wyL
 vHH
-ykf
+lnN
 wyL
 vHH
 wyL
 vBm
-nTZ
+rRe
 glw
 lnI
 dla
@@ -149467,8 +149467,8 @@ jvZ
 kKp
 isj
 itf
-pgj
-eTt
+siF
+hFn
 aZN
 aZM
 aZM
@@ -149701,7 +149701,7 @@ oiL
 nZp
 biN
 biN
-xBP
+mCe
 biN
 biN
 biN
@@ -149953,7 +149953,7 @@ bil
 bil
 bil
 byY
-hcw
+dAf
 bil
 bil
 bvJ
@@ -150177,7 +150177,7 @@ cpC
 cpC
 cpC
 cpC
-laP
+umV
 cpC
 kXF
 vpe
@@ -150224,7 +150224,7 @@ bkH
 qhP
 bDA
 iXy
-cCx
+iFv
 lFm
 bLj
 cFA
@@ -150687,7 +150687,7 @@ klx
 vpe
 hFo
 hFo
-fCJ
+iNu
 hFo
 hFo
 rWb
@@ -150925,7 +150925,7 @@ uKL
 hWG
 nlE
 lEr
-lue
+cbN
 uKL
 uKL
 any
@@ -150969,7 +150969,7 @@ lzH
 qMm
 dsZ
 oYa
-ntj
+nbT
 xTb
 pUy
 qqu
@@ -150981,7 +150981,7 @@ blP
 rCN
 bom
 bAb
-lkk
+bzY
 bil
 bil
 bil
@@ -151235,7 +151235,7 @@ itf
 bni
 bil
 blS
-joH
+szM
 blS
 blS
 cOQ
@@ -151250,7 +151250,7 @@ oOu
 bCu
 cFv
 nJX
-udR
+egB
 yda
 bJb
 lio
@@ -151441,7 +151441,7 @@ uoi
 aIB
 cbP
 mdl
-rnn
+vLi
 tKI
 cpC
 dgV
@@ -152001,7 +152001,7 @@ fqw
 fqw
 otq
 ivK
-olD
+bfo
 vHH
 cKe
 bil
@@ -152207,7 +152207,7 @@ alc
 uHx
 uHx
 uHx
-yga
+bGF
 uKL
 uKL
 uKL
@@ -152269,7 +152269,7 @@ dAi
 dAi
 upd
 uGx
-pst
+ekV
 fQF
 lON
 bil
@@ -152539,8 +152539,8 @@ biN
 fqw
 fqw
 fqw
-nfQ
-eTt
+iab
+hFn
 fqw
 gSQ
 gSQ
@@ -152560,7 +152560,7 @@ sGf
 lhU
 jtJ
 pmQ
-lHS
+nll
 wdb
 wdb
 wdb
@@ -152978,7 +152978,7 @@ lCC
 rNK
 uKL
 nYc
-gjd
+bHB
 nYc
 hWG
 rNK
@@ -153034,7 +153034,7 @@ fqw
 itf
 bil
 bil
-wnh
+dzN
 blS
 bIX
 bil
@@ -153312,7 +153312,7 @@ vHH
 itf
 qIV
 xAV
-hZb
+vbc
 gSQ
 gSQ
 gSQ
@@ -154574,7 +154574,7 @@ aZM
 aZM
 gSQ
 qsn
-pWO
+rTA
 vzL
 bno
 xTb
@@ -154831,7 +154831,7 @@ aZM
 aLH
 fqw
 rtW
-xYs
+rTH
 skM
 tvJ
 aLH
@@ -155367,8 +155367,8 @@ vZg
 kZs
 kZs
 kZs
-gon
-oBR
+aUA
+hUN
 kZs
 dQj
 xiQ

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -153,7 +153,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/exit)
@@ -4586,7 +4585,6 @@
 "aqF" = (
 /obj/machinery/monkey_recycler,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "whitepurplefull"
 	},
 /area/station/science/xenobiology)
@@ -6269,7 +6267,6 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 9;
 	icon_state = "darkbluefull"
 	},
 /area/station/command/office/cmo)
@@ -6422,7 +6419,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/exit)
@@ -12979,7 +12975,6 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "blue"
 	},
 /area/station/legal/courtroom)
@@ -12999,7 +12994,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "blue"
 	},
 /area/station/legal/courtroom)
@@ -13010,7 +13004,6 @@
 	},
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "blue"
 	},
 /area/station/legal/courtroom)
@@ -13032,7 +13025,6 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "blue"
 	},
 /area/station/legal/courtroom)
@@ -15016,12 +15008,6 @@
 	icon_state = "caution"
 	},
 /area/station/public/dorms)
-"aVr" = (
-/turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "dark"
-	},
-/area/station/service/expedition)
 "aVs" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -16831,7 +16817,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/landmark/start/explorer,
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/station/service/expedition)
@@ -16839,7 +16824,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/landmark/start/explorer,
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/station/service/expedition)
@@ -21152,7 +21136,6 @@
 	},
 /turf/simulated/floor/plasteel{
 	desc = "\"This is a plaque in honour of our comrades on the G4407 Stations. Hopefully TG4407 model can live up to your fame and fortune.\" Scratched in beneath that is a crude image of a meteor and a spaceman. The spaceman is laughing. The meteor is exploding.";
-	dir = 4;
 	icon_state = "plaque";
 	name = "Comemmorative Plaque"
 	},
@@ -22072,14 +22055,12 @@
 "bnW" = (
 /obj/machinery/computer/station_alert,
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "yellow"
 	},
 /area/station/command/bridge)
 "bnX" = (
 /obj/machinery/computer/communications,
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "blue"
 	},
 /area/station/command/bridge)
@@ -23226,7 +23207,6 @@
 	network = list("SS13","Research Outpost","Mining Outpost","Telecomms")
 	},
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "red"
 	},
 /area/station/command/bridge)
@@ -23571,7 +23551,6 @@
 "brS" = (
 /obj/machinery/computer/crew,
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "green"
 	},
 /area/station/command/bridge)
@@ -25030,7 +25009,6 @@
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "blue"
 	},
 /area/station/command/bridge)
@@ -25132,7 +25110,6 @@
 "bwc" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "blue"
 	},
 /area/station/command/bridge)
@@ -25160,13 +25137,11 @@
 "bwh" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "blue"
 	},
 /area/station/hallway/primary/central/ne)
 "bwi" = (
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "blue"
 	},
 /area/station/hallway/primary/central/ne)
@@ -25550,7 +25525,6 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "blue"
 	},
 /area/station/command/bridge)
@@ -25595,7 +25569,6 @@
 	pixel_y = -30
 	},
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "blue"
 	},
 /area/station/command/bridge)
@@ -25622,7 +25595,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "blue"
 	},
 /area/station/command/bridge)
@@ -25643,7 +25615,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "blue"
 	},
 /area/station/command/bridge)
@@ -25666,7 +25637,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "blue"
 	},
 /area/station/command/bridge)
@@ -25699,7 +25669,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "blue"
 	},
 /area/station/command/bridge)
@@ -25750,7 +25719,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "blue"
 	},
 /area/station/command/bridge)
@@ -25796,7 +25764,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "blue"
 	},
 /area/station/command/bridge)
@@ -25848,7 +25815,6 @@
 	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "blue"
 	},
 /area/station/command/bridge)
@@ -26007,7 +25973,6 @@
 "byp" = (
 /obj/effect/landmark/start/assistant,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "barber"
 	},
 /area/station/public/locker)
@@ -26443,7 +26408,6 @@
 "bzA" = (
 /obj/machinery/washing_machine,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "barber"
 	},
 /area/station/public/locker)
@@ -26801,7 +26765,6 @@
 "bAy" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "blue"
 	},
 /area/station/hallway/primary/central/nw)
@@ -26822,7 +26785,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "blue"
 	},
 /area/station/hallway/primary/central/nw)
@@ -26835,7 +26797,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "blue"
 	},
 /area/station/command/bridge)
@@ -26855,7 +26816,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "blue"
 	},
 /area/station/command/bridge)
@@ -26880,7 +26840,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/exit)
@@ -26948,7 +26907,6 @@
 	},
 /obj/effect/landmark/start/scientist,
 /turf/simulated/floor/plasteel{
-	dir = 9;
 	icon_state = "purplefull"
 	},
 /area/station/science/rnd)
@@ -27003,7 +26961,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/exit)
@@ -27264,7 +27221,6 @@
 	},
 /obj/structure/closet/wardrobe/pjs,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "barber"
 	},
 /area/station/public/locker)
@@ -27533,7 +27489,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "green"
 	},
 /area/station/hallway/secondary/exit)
@@ -27564,7 +27519,6 @@
 "bCX" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "green"
 	},
 /area/station/hallway/secondary/exit)
@@ -27597,7 +27551,6 @@
 /area/station/hallway/primary/starboard/west)
 "bDb" = (
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "blue"
 	},
 /area/station/hallway/primary/starboard/west)
@@ -27683,7 +27636,6 @@
 	},
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "green"
 	},
 /area/station/hallway/secondary/exit)
@@ -29330,7 +29282,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/exit)
@@ -30463,7 +30414,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 6;
 	icon_state = "whiteyellowfull"
 	},
 /area/station/medical/chemistry)
@@ -31105,7 +31055,6 @@
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/structure/closet/walllocker/emerglocker/west,
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "bluefull"
 	},
 /area/station/medical/reception)
@@ -31774,7 +31723,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 6;
 	icon_state = "whiteyellowfull"
 	},
 /area/station/medical/chemistry)
@@ -31796,7 +31744,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "bluefull"
 	},
 /area/station/medical/reception)
@@ -32837,7 +32784,6 @@
 	},
 /obj/effect/landmark/start/doctor,
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "bluefull"
 	},
 /area/station/medical/reception)
@@ -33401,7 +33347,6 @@
 "bTL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 6;
 	icon_state = "whiteyellowfull"
 	},
 /area/station/medical/chemistry)
@@ -35938,7 +35883,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	dir = 9;
 	icon_state = "darkbluefull"
 	},
 /area/station/command/office/cmo)
@@ -37069,7 +37013,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "darkgreenfull"
 	},
 /area/station/medical/medbay2)
@@ -37107,7 +37050,6 @@
 	dir = 10
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "darkgreenfull"
 	},
 /area/station/medical/medbay2)
@@ -38907,7 +38849,6 @@
 	},
 /obj/structure/rack,
 /turf/simulated/floor/plasteel{
-	dir = 9;
 	icon_state = "darkbluefull"
 	},
 /area/station/medical/storage/secondary)
@@ -39393,7 +39334,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 9;
 	icon_state = "darkredfull"
 	},
 /area/station/medical/storage/secondary)
@@ -39631,7 +39571,6 @@
 "cns" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "barber"
 	},
 /area/station/public/locker)
@@ -39735,7 +39674,6 @@
 "cnJ" = (
 /obj/machinery/suit_storage_unit/cmo/secure/sec_storage,
 /turf/simulated/floor/plasteel{
-	dir = 9;
 	icon_state = "darkredfull"
 	},
 /area/station/medical/storage/secondary)
@@ -40708,7 +40646,6 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "blue"
 	},
 /area/station/medical/storage)
@@ -40747,7 +40684,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "bluefull"
 	},
 /area/station/medical/storage)
@@ -41206,7 +41142,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 9;
 	icon_state = "darkbluefull"
 	},
 /area/station/medical/surgery/observation)
@@ -41226,7 +41161,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 9;
 	icon_state = "darkbluefull"
 	},
 /area/station/medical/surgery/observation)
@@ -41244,7 +41178,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 9;
 	icon_state = "darkbluefull"
 	},
 /area/station/medical/surgery/observation)
@@ -41270,7 +41203,6 @@
 	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 9;
 	icon_state = "darkbluefull"
 	},
 /area/station/medical/surgery/observation)
@@ -41296,7 +41228,6 @@
 	icon_state = "pipe-y"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 9;
 	icon_state = "darkbluefull"
 	},
 /area/station/medical/surgery/observation)
@@ -41313,7 +41244,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 9;
 	icon_state = "darkbluefull"
 	},
 /area/station/medical/surgery/observation)
@@ -41331,7 +41261,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 9;
 	icon_state = "darkbluefull"
 	},
 /area/station/medical/surgery/observation)
@@ -41348,7 +41277,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 9;
 	icon_state = "darkbluefull"
 	},
 /area/station/medical/surgery/observation)
@@ -41367,7 +41295,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 9;
 	icon_state = "darkbluefull"
 	},
 /area/station/medical/surgery/observation)
@@ -41695,7 +41622,6 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "bluefull"
 	},
 /area/station/medical/storage)
@@ -42149,7 +42075,6 @@
 	dir = 9
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "bluefull"
 	},
 /area/station/medical/storage)
@@ -42378,7 +42303,6 @@
 /obj/structure/table,
 /obj/machinery/recharger,
 /turf/simulated/floor/plasteel{
-	dir = 9;
 	icon_state = "darkbluefull"
 	},
 /area/station/medical/storage/secondary)
@@ -43396,7 +43320,6 @@
 "czO" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	dir = 9;
 	icon_state = "darkbluefull"
 	},
 /area/station/medical/surgery/observation)
@@ -43474,7 +43397,6 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "blue"
 	},
 /area/station/medical/storage)
@@ -43611,7 +43533,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "bluefull"
 	},
 /area/station/medical/storage)
@@ -44099,7 +44020,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 9;
 	icon_state = "purplefull"
 	},
 /area/station/maintenance/asmaint2)
@@ -44631,7 +44551,6 @@
 /area/station/science/misc_lab)
 "cDG" = (
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "whitepurplefull"
 	},
 /area/station/science/misc_lab)
@@ -45231,7 +45150,6 @@
 "cFU" = (
 /obj/machinery/atmospherics/unary/portables_connector,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "whitepurplefull"
 	},
 /area/station/science/misc_lab)
@@ -45334,7 +45252,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "yellow"
 	},
 /area/station/hallway/primary/aft)
@@ -45717,7 +45634,6 @@
 "cHp" = (
 /obj/machinery/atmospherics/binary/pump,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "whitepurplefull"
 	},
 /area/station/science/misc_lab)
@@ -46029,7 +45945,6 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "yellow"
 	},
 /area/station/command/office/ce)
@@ -49424,7 +49339,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "bluefull"
 	},
 /area/station/medical/storage)
@@ -49493,7 +49407,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "yellow"
 	},
 /area/station/command/office/ce)
@@ -49503,7 +49416,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "yellow"
 	},
 /area/station/command/office/ce)
@@ -51509,7 +51421,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/station/maintenance/aft)
@@ -52896,7 +52807,6 @@
 /area/station/maintenance/storage)
 "dfT" = (
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "blue"
 	},
 /area/station/maintenance/storage)
@@ -52909,7 +52819,6 @@
 "dgb" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "blue"
 	},
 /area/station/maintenance/storage)
@@ -56860,7 +56769,6 @@
 	},
 /obj/effect/landmark/start/scientist,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "whitepurplefull"
 	},
 /area/station/science/xenobiology)
@@ -57476,7 +57384,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	dir = 9;
 	icon_state = "darkbluefull"
 	},
 /area/station/command/office/cmo)
@@ -57491,7 +57398,6 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/station/maintenance/aft)
@@ -57534,7 +57440,6 @@
 	dir = 9
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "bluefull"
 	},
 /area/station/medical/storage)
@@ -57786,7 +57691,6 @@
 	autolink_sensors = list("o2_sensor"="Tank")
 	},
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "blue"
 	},
 /area/station/engineering/atmos)
@@ -59335,7 +59239,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "bluefull"
 	},
 /area/station/medical/storage)
@@ -60219,7 +60122,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/exit)
@@ -61413,7 +61315,6 @@
 	dir = 5
 	},
 /turf/simulated/floor/plasteel{
-	dir = 6;
 	icon_state = "whiteyellowfull"
 	},
 /area/station/medical/chemistry)
@@ -62057,7 +61958,6 @@
 "gmU" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/station/maintenance/asmaint)
@@ -62829,7 +62729,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/station/maintenance/aft)
@@ -63325,7 +63224,6 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/exit)
@@ -63422,7 +63320,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 9;
 	icon_state = "darkyellowcorners"
 	},
 /area/station/science/robotics/chargebay)
@@ -63953,7 +63850,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/station/security/permabrig)
@@ -64129,7 +64025,6 @@
 	location = "Stbd"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/exit)
@@ -64373,7 +64268,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/exit)
@@ -64805,7 +64699,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "darkpurplefull"
 	},
 /area/station/science/genetics)
@@ -65271,7 +65164,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/station/maintenance/aft)
@@ -65774,7 +65666,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/exit)
@@ -66160,7 +66051,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/exit)
@@ -66207,7 +66097,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/station/maintenance/aft)
@@ -66694,7 +66583,6 @@
 /area/station/security/detective)
 "iNP" = (
 /turf/simulated/floor/plasteel{
-	dir = 9;
 	icon_state = "darkyellowcorners"
 	},
 /area/station/science/robotics/chargebay)
@@ -67543,7 +67431,6 @@
 	id = "CMO"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 9;
 	icon_state = "darkbluefull"
 	},
 /area/station/command/office/cmo)
@@ -67695,7 +67582,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/station/maintenance/aft)
@@ -68355,7 +68241,6 @@
 "jNY" = (
 /obj/machinery/washing_machine,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/station/security/permabrig)
@@ -69945,7 +69830,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/station/security/permabrig)
@@ -70213,7 +70097,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 9;
 	icon_state = "darkbluefull"
 	},
 /area/station/command/office/cmo)
@@ -70632,7 +70515,6 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/station/maintenance/aft)
@@ -72857,7 +72739,6 @@
 /obj/effect/decal/cleanable/vomit,
 /obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/station/maintenance/aft)
@@ -73087,7 +72968,6 @@
 "mmt" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/exit)
@@ -73203,7 +73083,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "yellow"
 	},
 /area/station/hallway/primary/aft)
@@ -73250,7 +73129,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "whitepurplefull"
 	},
 /area/station/science/xenobiology)
@@ -73298,7 +73176,6 @@
 	pixel_y = 2
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "barber"
 	},
 /area/station/public/locker)
@@ -73512,7 +73389,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/station/security/permabrig)
@@ -74152,7 +74028,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "bluefull"
 	},
 /area/station/medical/storage)
@@ -74245,7 +74120,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 9;
 	icon_state = "darkbluefull"
 	},
 /area/station/medical/surgery/observation)
@@ -74648,7 +74522,6 @@
 	dir = 10
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/exit)
@@ -75473,7 +75346,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 6;
 	icon_state = "whiteyellowfull"
 	},
 /area/station/medical/chemistry)
@@ -75705,7 +75577,6 @@
 	},
 /mob/living/simple_animal/pet/cat/Runtime,
 /turf/simulated/floor/plasteel{
-	dir = 9;
 	icon_state = "darkbluefull"
 	},
 /area/station/command/office/cmo)
@@ -76547,7 +76418,6 @@
 	id = "Surgery 1"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 9;
 	icon_state = "darkbluefull"
 	},
 /area/station/medical/surgery/primary)
@@ -76585,7 +76455,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/exit)
@@ -76753,7 +76622,6 @@
 "orU" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/station/security/permabrig)
@@ -76871,7 +76739,6 @@
 	},
 /obj/effect/landmark/start/doctor,
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "bluefull"
 	},
 /area/station/medical/storage)
@@ -77271,7 +77138,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "blue"
 	},
 /area/station/medical/storage)
@@ -77554,7 +77420,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 9;
 	icon_state = "darkbluefull"
 	},
 /area/station/medical/surgery/secondary)
@@ -77706,7 +77571,6 @@
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "bluefull"
 	},
 /area/station/medical/storage)
@@ -77885,7 +77749,6 @@
 /area/station/engineering/atmos/control)
 "oWE" = (
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/exit)
@@ -77937,7 +77800,6 @@
 /obj/item/clothing/shoes/sandal/white,
 /obj/item/clothing/shoes/sandal/white,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/station/security/permabrig)
@@ -78000,7 +77862,6 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/station/maintenance/aft)
@@ -78174,7 +78035,6 @@
 "pek" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/exit)
@@ -78910,7 +78770,6 @@
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "green"
 	},
 /area/station/medical/virology)
@@ -79703,7 +79562,6 @@
 /obj/item/storage/box/bodybags,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/station/maintenance/asmaint)
@@ -81124,7 +80982,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "bluefull"
 	},
 /area/station/medical/storage)
@@ -81273,7 +81130,6 @@
 	anchored = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "whitepurplefull"
 	},
 /area/station/science/rnd)
@@ -81837,7 +81693,6 @@
 	pixel_x = -3
 	},
 /turf/simulated/floor/plasteel{
-	dir = 9;
 	icon_state = "darkbluefull"
 	},
 /area/station/command/office/cmo)
@@ -81968,7 +81823,6 @@
 	pixel_x = -27
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "bluefull"
 	},
 /area/station/medical/reception)
@@ -83599,7 +83453,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "whitepurplefull"
 	},
 /area/station/science/xenobiology)
@@ -83909,7 +83762,6 @@
 	dir = 10
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/exit)
@@ -84898,7 +84750,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/station/maintenance/aft)
@@ -85448,7 +85299,6 @@
 "tjl" = (
 /obj/structure/dresser,
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "barber"
 	},
 /area/station/public/locker)
@@ -86310,7 +86160,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "blue"
 	},
 /area/station/hallway/primary/starboard/west)
@@ -86693,7 +86542,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 0;
 	icon_state = "yellow"
 	},
 /area/station/hallway/primary/aft)
@@ -87392,7 +87240,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 9;
 	icon_state = "darkbluefull"
 	},
 /area/station/medical/surgery/observation)
@@ -87401,7 +87248,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "whitepurplefull"
 	},
 /area/station/science/xenobiology)
@@ -87544,7 +87390,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "whitepurplefull"
 	},
 /area/station/science/xenobiology)
@@ -87881,7 +87726,6 @@
 /obj/item/clothing/mask/breath/vox,
 /obj/item/clothing/mask/breath/vox,
 /turf/simulated/floor/plasteel{
-	dir = 9;
 	icon_state = "darkbluefull"
 	},
 /area/station/medical/storage/secondary)
@@ -88493,7 +88337,6 @@
 /area/station/security/permabrig)
 "uVr" = (
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "cmo"
 	},
 /area/station/security/permabrig)
@@ -89321,7 +89164,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/station/maintenance/asmaint)
@@ -90137,7 +89979,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/station/maintenance/asmaint)
@@ -90920,7 +90761,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "darkgreenfull"
 	},
 /area/station/medical/medbay2)
@@ -91968,7 +91808,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/exit)
@@ -92825,7 +92664,6 @@
 	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
 	icon_state = "bluefull"
 	},
 /area/station/maintenance/aft)
@@ -93311,7 +93149,6 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/command/eva,
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/station/service/expedition)
@@ -93764,7 +93601,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/station/maintenance/aft)
@@ -93982,7 +93818,6 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
 	icon_state = "dark"
 	},
 /area/station/maintenance/aft)
@@ -94213,7 +94048,6 @@
 	},
 /obj/effect/mapping_helpers/airlock/windoor/access/any/medical/chemistry,
 /turf/simulated/floor/plasteel{
-	dir = 6;
 	icon_state = "whiteyellowfull"
 	},
 /area/station/medical/chemistry)
@@ -94252,7 +94086,6 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/exit)
@@ -119240,8 +119073,8 @@ aQl
 aSA
 aTy
 aUH
-aVr
-aVr
+aUF
+aUF
 aUF
 cGZ
 rmK

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -8847,7 +8847,6 @@
 /obj/item/stack/rods,
 /obj/item/airlock_electronics,
 /turf/simulated/floor/plating{
-	dir = 9;
 	icon_regular_floor = "escape"
 	},
 /area/station/maintenance/abandonedbar)
@@ -8871,7 +8870,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating{
-	dir = 5;
 	icon_regular_floor = "escape"
 	},
 /area/station/maintenance/abandonedbar)
@@ -9271,7 +9269,6 @@
 	},
 /obj/item/stack/rods,
 /turf/simulated/floor/plating{
-	dir = 4;
 	icon_regular_floor = "escape"
 	},
 /area/station/maintenance/abandonedbar)
@@ -9602,7 +9599,6 @@
 	icon_state = "medium"
 	},
 /turf/simulated/floor/plating{
-	dir = 10;
 	icon_regular_floor = "escape"
 	},
 /area/station/maintenance/abandonedbar)
@@ -40265,9 +40261,7 @@
 "cpS" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
-/turf/simulated/floor/plasteel{
-	dir = 1
-	},
+/turf/simulated/floor/plasteel,
 /area/station/medical/storage)
 "cpU" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -41698,9 +41692,7 @@
 "cuA" = (
 /obj/structure/closet/secure_closet/medical1,
 /obj/effect/turf_decal/bot_white,
-/turf/simulated/floor/plasteel{
-	dir = 1
-	},
+/turf/simulated/floor/plasteel,
 /area/station/medical/storage)
 "cuB" = (
 /obj/machinery/door/firedoor,
@@ -44250,9 +44242,7 @@
 	},
 /obj/item/storage/firstaid/toxin,
 /obj/structure/table,
-/turf/simulated/floor/plasteel{
-	dir = 1
-	},
+/turf/simulated/floor/plasteel,
 /area/station/medical/storage)
 "cCT" = (
 /obj/structure/closet/l3closet/scientist,
@@ -48427,9 +48417,7 @@
 	pixel_y = 5
 	},
 /obj/item/storage/firstaid/toxin,
-/turf/simulated/floor/plasteel{
-	dir = 1
-	},
+/turf/simulated/floor/plasteel,
 /area/station/medical/storage)
 "cQS" = (
 /obj/structure/cable{
@@ -57081,9 +57069,7 @@
 	pixel_y = 32
 	},
 /obj/machinery/economy/vending/medidrobe,
-/turf/simulated/floor/plasteel{
-	dir = 1
-	},
+/turf/simulated/floor/plasteel,
 /area/station/medical/storage)
 "dOs" = (
 /turf/simulated/wall,
@@ -58266,9 +58252,7 @@
 /obj/structure/table,
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high,
-/turf/simulated/floor/plasteel{
-	dir = 1
-	},
+/turf/simulated/floor/plasteel,
 /area/station/medical/storage)
 "epu" = (
 /obj/item/radio/intercom{
@@ -61426,9 +61410,7 @@
 	dir = 1
 	},
 /obj/item/storage/box/monkeycubes,
-/turf/simulated/floor/plasteel{
-	dir = 1
-	},
+/turf/simulated/floor/plasteel,
 /area/station/science/genetics)
 "fXp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -63260,9 +63242,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
 	},
-/turf/simulated/floor/plasteel{
-	dir = 1
-	},
+/turf/simulated/floor/plasteel,
 /area/station/medical/storage)
 "gVs" = (
 /obj/structure/reagent_dispensers/fueltank,
@@ -64280,9 +64260,7 @@
 	dir = 4
 	},
 /mob/living/carbon/human/monkey,
-/turf/simulated/floor/plasteel{
-	dir = 1
-	},
+/turf/simulated/floor/plasteel,
 /area/station/medical/virology)
 "hxA" = (
 /obj/machinery/door/firedoor,
@@ -65801,9 +65779,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	dir = 1
-	},
+/turf/simulated/floor/plasteel,
 /area/station/medical/virology)
 "inP" = (
 /obj/effect/spawner/window/reinforced/grilled,
@@ -67088,9 +67064,7 @@
 	dir = 8
 	},
 /mob/living/carbon/human/monkey,
-/turf/simulated/floor/plasteel{
-	dir = 1
-	},
+/turf/simulated/floor/plasteel,
 /area/station/medical/virology)
 "jdz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -67927,9 +67901,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
 	},
-/turf/simulated/floor/plasteel{
-	dir = 1
-	},
+/turf/simulated/floor/plasteel,
 /area/station/medical/storage)
 "jCu" = (
 /obj/machinery/economy/vending/scidrobe,
@@ -70256,9 +70228,7 @@
 	},
 /obj/effect/turf_decal/bot_white,
 /obj/machinery/camera/autoname,
-/turf/simulated/floor/plasteel{
-	dir = 1
-	},
+/turf/simulated/floor/plasteel,
 /area/station/medical/storage)
 "kQb" = (
 /obj/structure/chair/sofa/bench/left{
@@ -74579,9 +74549,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	dir = 1
-	},
+/turf/simulated/floor/plasteel,
 /area/station/medical/virology)
 "nnF" = (
 /obj/machinery/door/airlock/external{
@@ -75153,9 +75121,7 @@
 /obj/item/storage/firstaid/fire,
 /obj/structure/table,
 /obj/machinery/light,
-/turf/simulated/floor/plasteel{
-	dir = 1
-	},
+/turf/simulated/floor/plasteel,
 /area/station/medical/storage)
 "nCa" = (
 /obj/machinery/conveyor/west{
@@ -76276,9 +76242,7 @@
 	dir = 10
 	},
 /mob/living/carbon/human/monkey,
-/turf/simulated/floor/plasteel{
-	dir = 1
-	},
+/turf/simulated/floor/plasteel,
 /area/station/medical/virology)
 "oja" = (
 /obj/structure/cable{
@@ -78731,9 +78695,7 @@
 	pixel_y = 28
 	},
 /obj/effect/turf_decal/bot_white,
-/turf/simulated/floor/plasteel{
-	dir = 1
-	},
+/turf/simulated/floor/plasteel,
 /area/station/medical/storage)
 "pxP" = (
 /obj/structure/cable{
@@ -80641,9 +80603,7 @@
 	},
 /obj/item/storage/firstaid/o2,
 /obj/structure/table,
-/turf/simulated/floor/plasteel{
-	dir = 1
-	},
+/turf/simulated/floor/plasteel,
 /area/station/medical/storage)
 "qxZ" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -87880,9 +87840,7 @@
 "uFn" = (
 /obj/structure/closet/secure_closet/medical3,
 /obj/effect/turf_decal/bot_white,
-/turf/simulated/floor/plasteel{
-	dir = 1
-	},
+/turf/simulated/floor/plasteel,
 /area/station/medical/storage)
 "uFr" = (
 /obj/machinery/computer/general_air_control/large_tank_control{


### PR DESCRIPTION
## What Does This PR Do
This PR removes directional varedits from floor tiles where either the direction is invalid (such as 0 or 7 (?!)) or the icon state does not have a direction which matches it. This PR applies only to station maps; a followup PR may contain other DMMs. Note that this also results in the removal of many redundant tile definitions.

## Why It's Good For The Game
This improves map correctness.

## Images of changes
If done correctly there should be no visual changes, since these tiles should have defaulted to the south icon state if they were missing in the first place. That also means there should be no visual diffs of the map in MDB.

## Testing

Tested compile, tested map override for each station map loaded cleanly on roundstart.

## Changelog

NPFC
