### PR TITLE
Xenos can no longer get viruses

### DIFF
--- a/code/datums/diseases/_MobProcs.dm
+++ b/code/datums/diseases/_MobProcs.dm
@@ -23,6 +23,9 @@
 	if(!(type in D.viable_mobtypes))
 		return -1 //for stupid fucking monkies
 
+	if(HAS_TRAIT(src, TRAIT_VIRUSIMMUNE))
+		return FALSE
+
 	return TRUE
 
 

--- a/code/datums/diseases/_MobProcs.dm
+++ b/code/datums/diseases/_MobProcs.dm
@@ -23,9 +23,6 @@
 	if(!(type in D.viable_mobtypes))
 		return -1 //for stupid fucking monkies
 
-	if(HAS_TRAIT(src, TRAIT_VIRUSIMMUNE))
-		return FALSE
-
 	return TRUE
 
 

--- a/code/modules/mob/living/carbon/alien/alien_base.dm
+++ b/code/modules/mob/living/carbon/alien/alien_base.dm
@@ -209,6 +209,9 @@
 /mob/living/carbon/alien/proc/deathrattle_message()
 	return "<i><span class='alien'>The hivemind echoes: [name] has been slain!</span></i>"
 
+/mob/living/carbon/alien/CanContractDisease(datum/disease/D)
+	return FALSE
+
 /*----------------------------------------
 Proc: AddInfectionImages()
 Des: Gives the client of the alien an image on each infected mob.

--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
@@ -26,7 +26,6 @@
 	add_language("Xenomorph")
 	add_language("Hivemind")
 	AddSpell(new /obj/effect/proc_holder/spell/alien_spell/regurgitate)
-	ADD_TRAIT(src, TRAIT_VIRUSIMMUNE, "alien")
 	. = ..()
 	AddComponent(/datum/component/footstep, FOOTSTEP_MOB_CLAW, 0.5, -11)
 
@@ -37,9 +36,7 @@
 	return 0
 
 /mob/living/carbon/alien/humanoid/CanContractDisease(datum/disease/D)
-	. = ..()
-	if(HAS_TRAIT(src, TRAIT_VIRUSIMMUNE))
-		return FALSE
+	return FALSE
 
 /mob/living/carbon/alien/humanoid/emp_act(severity)
 	if(r_store) r_store.emp_act(severity)

--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
@@ -26,6 +26,7 @@
 	add_language("Xenomorph")
 	add_language("Hivemind")
 	AddSpell(new /obj/effect/proc_holder/spell/alien_spell/regurgitate)
+	ADD_TRAIT(src, TRAIT_VIRUSIMMUNE, "alien")
 	. = ..()
 	AddComponent(/datum/component/footstep, FOOTSTEP_MOB_CLAW, 0.5, -11)
 

--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
@@ -36,7 +36,10 @@
 
 	return 0
 
-///mob/living/carbon/alien/humanoid/bullet_act(obj/item/projectile/Proj) taken care of in living
+/mob/living/carbon/alien/humanoid/CanContractDisease(datum/disease/D)
+	. = ..()
+	if(HAS_TRAIT(src, TRAIT_VIRUSIMMUNE))
+		return FALSE
 
 /mob/living/carbon/alien/humanoid/emp_act(severity)
 	if(r_store) r_store.emp_act(severity)

--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
@@ -35,9 +35,6 @@
 
 	return 0
 
-/mob/living/carbon/alien/humanoid/CanContractDisease(datum/disease/D)
-	return FALSE
-
 /mob/living/carbon/alien/humanoid/emp_act(severity)
 	if(r_store) r_store.emp_act(severity)
 	if(l_store) l_store.emp_act(severity)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes Xenomorphs virus immune. 
Resolves #11668 
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
This was discussed by the teams and was decided to be fixed, as an issue report for it was made.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Put some aliens around a skrell who I blessed with the flu, none got sick
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Xenomorphs now can't get sick anymore 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
