### PR TITLE
Stops sleepers from runtiming when attempting to dialysis

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -123,7 +123,7 @@
 				for(var/datum/reagent/R in occupant.reagents.reagent_list)
 					occupant.transfer_blood_to(beaker, 1)
 					if(R.id in GLOB.blocked_chems)
-						occupant.reagents.remove_reagent(G.id, 3)
+						occupant.reagents.remove_reagent(R.id, 3)
 						beaker.reagents.add_reagent("saturated_charcoal", 3)
 						continue
 					occupant.reagents.trans_to(beaker, 3)

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -122,8 +122,7 @@
 				occupant.transfer_blood_to(beaker, 1)
 				for(var/datum/reagent/R in occupant.reagents.reagent_list)
 					occupant.transfer_blood_to(beaker, 1)
-					var/datum/reagent/G
-					if(G.id in GLOB.blocked_chems)
+					if(R.id in GLOB.blocked_chems)
 						occupant.reagents.remove_reagent(G.id, 3)
 						beaker.reagents.add_reagent("saturated_charcoal", 3)
 						continue

--- a/code/modules/reagents/reagent_containers/iv_bag.dm
+++ b/code/modules/reagents/reagent_containers/iv_bag.dm
@@ -75,8 +75,7 @@
 		if(reagents.total_volume < reagents.maximum_volume)
 			injection_target.transfer_blood_to(src, amount_per_transfer_from_this)
 			for(var/datum/reagent/x in injection_target.reagents.reagent_list) // Pull small amounts of reagents from the person while drawing blood
-				var/datum/reagent/R
-				if(R.id in GLOB.blocked_chems)
+				if(x.id in GLOB.blocked_chems)
 					continue
 				injection_target.reagents.trans_to(src, amount_per_transfer_from_this/10)
 			update_icon(UPDATE_OVERLAYS)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes sleepers runtiming when doing dialysis
Does the same thing for IV bags
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
This is something I should've noticed and I think something went wrong when I worked on this PR from my remote branch not carrying things over or some dumb stuff.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Dialysis did not runtime on me and actually worked as intended
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Fixed dialysis not working on IV bags and sleepers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
