### PR TITLE
Revert "fireflash_sm is now more dangerous"

### DIFF
--- a/code/modules/atmospherics/environmental/LINDA_fire.dm
+++ b/code/modules/atmospherics/environmental/LINDA_fire.dm
@@ -337,7 +337,6 @@
 			if(capped)
 				chance = min(chance, 30)
 			if(prob(chance) || bypass_rng)
-				explosion(T, 0, 0, 3, 7, smoke = TRUE, adminlog = FALSE) // when its used in chem nade, 150 explosions admin logs is not good
 				T.visible_message("<span class='warning'>[T] melts!</span>")
 				T.burn_down()
 	return affected


### PR DESCRIPTION
Reverts ParadiseSS13/Paradise#21951

This has caused a number of problems due to a poor testing depth, including:

- Explosions being way out of scope for what is expected
- Smoke causing mass damage to surroundings

What was meant to be a way to make wall-melting dangerous has turned into an easy way to cause big explosions, making the problem worse if anything.

See: https://discord.com/channels/145533722026967040/984761070159818753/1151823517885673472