### PR TITLE
Certain headsets now no longer need telecomms to work (Nukeops, Deathsquad, ERT Commander)

### DIFF
--- a/code/game/machinery/tcomms/tcomms_base.dm
+++ b/code/game/machinery/tcomms/tcomms_base.dm
@@ -296,9 +296,6 @@ GLOBAL_LIST_EMPTY(tcomms_machines)
 
 		for(var/obj/item/radio/R in new_connection.devices["[RADIO_CHAT]"])
 
-			if(istype(R, /obj/item/radio/headset))
-				continue
-
 			if(R.receive_range(display_freq, tcm.zlevels) > -1)
 				radios += R
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes it so that certain headsets no longer need telecomms to be on to communicate with each other (Eg. Nukeops, deathsquad, CentComm, ERT Commander), this was an intended feature (See variable "requires_tcomms" on headsets), but was not working.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Certain roles should have access to telecomms even when telecomms are down for various reasons.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Attempted to speak over common comms while comms were up, functions normally.
Attempted to speak over syndicate comms while comms were up, functions normally.
Attempted to speak over common comms with a normal headset while comms were down, no messsage sent.
Attempted to speak over syndicate comms with a syndicate headset while comms were down, messsage is sent.

Note that I have yet to test this with a second player, will do so later.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Certain headsets now no longer need telecomms to work (Nukeops, Deathsquad, ERT Commander)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
