### PR TITLE
box: remove redundant varedited plaque

### DIFF
--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -16193,6 +16193,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
+"aYD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plasteel/goonplaque,
+/area/station/hallway/secondary/entry)
 "aYE" = (
 /obj/structure/chair/stool{
 	dir = 4
@@ -21113,28 +21131,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry)
-"bls" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plasteel{
-	desc = "\"This is a plaque in honour of our comrades on the G4407 Stations. Hopefully TG4407 model can live up to your fame and fortune.\" Scratched in beneath that is a crude image of a meteor and a spaceman. The spaceman is laughing. The meteor is exploding.";
-	icon_state = "plaque";
-	name = "Comemmorative Plaque"
-	},
 /area/station/hallway/secondary/entry)
 "blt" = (
 /obj/machinery/economy/vending/cigarette,
@@ -109786,7 +109782,7 @@ aTu
 bgD
 aSf
 aSf
-bls
+aYD
 blV
 boW
 bnu


### PR DESCRIPTION
**What Does This PR Do**: Removes a varedited "plaque" tile and replaces it with the proper subtype. Note this is an exact replacement:  

https://github.com/ParadiseSS13/Paradise/blob/859a38cde20d9d2fbd0637b138627715d59d405c/code/game/turfs/simulated/floor/plasteel_floor.dm#L27-L30

**Why It's Good For The Game**: Varedits bad, duplicate object state bad.

**Testing**: Built and ran.

**Changelog**: NPFC
