### PR TITLE
Disables Mob Dodging for Megafauna

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
@@ -28,6 +28,7 @@
 	layer = LARGE_MOB_LAYER //Looks weird with them slipping under mineral walls and cameras and shit otherwise
 	flags_2 = IMMUNE_TO_SHUTTLECRUSH_2
 	mouse_opacity = MOUSE_OPACITY_OPAQUE // Easier to click on in melee, they're giant targets anyway
+	dodging = FALSE // This needs to be false until someone fixes megafauna pathing so they dont lag-switch teleport at you (09-15-2023)
 	var/list/crusher_loot
 	var/medal_type
 	var/score_type = BOSS_SCORE


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Placeholder fix to #22220 regarding megafauna

Disables random dodging for all megafauna.

## Why It's Good For The Game
Currently megafauna have a small issue where they _teleport wildly toward you when moving._

This disables that until someone can look into it and miners dont die to bullshit.

Regular mobs arent affected as we didnt notice this behavior in them for some reason.

## Images of changes
https://github.com/ParadiseSS13/Paradise/assets/57759731/e7bb4c7d-3b52-4ae7-9fbd-441fadcfeadc

## Testing
Ran about smacking megafauna on live.

## Changelog
:cl:
tweak: disables hostile mob dodging for megafauna.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
