### PR TITLE
Tweaks to Orion and Battle arcades ticket amounts

### DIFF
--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -190,7 +190,7 @@
 				emagged = FALSE
 			else
 				SSblackbox.record_feedback("tally", "arcade_status", 1, "win_normal")
-				var/score = player_hp + player_mp + 15
+				var/score = rand(20, 30)
 				prizevend(score)
 
 	else if(emagged && (turtle >= 4))
@@ -199,8 +199,8 @@
 		playsound(loc, 'sound/arcade/boom.ogg', 50, TRUE)
 		player_hp -= boomamt
 
-	else if((enemy_mp <= 5) && prob(70))
-		var/stealamt = rand(5, 6)
+	else if((enemy_mp <= 5) && (prob(70)))
+		var/stealamt = rand(2,3)
 		temp = "[enemy_name] steals [stealamt] of your power!"
 		playsound(loc, 'sound/arcade/steal.ogg', 50, TRUE)
 		player_mp -= stealamt

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -190,7 +190,7 @@
 				emagged = FALSE
 			else
 				SSblackbox.record_feedback("tally", "arcade_status", 1, "win_normal")
-				prizevend(30)
+				prizevend(35)
 
 	else if(emagged && (turtle >= 4))
 		var/boomamt = rand(5,10)
@@ -955,7 +955,7 @@
 		message_admins("[key_name_admin(usr)] made it to Orion on an emagged machine and got an explosive toy ship.")
 		log_game("[key_name(usr)] made it to Orion on an emagged machine and got an explosive toy ship.")
 	else
-		var/score = 15 * (alive - lings_aboard) + 5 * (engine + hull + electronics)
+		var/score = 10 * (alive - lings_aboard) + 5 * (engine + hull + electronics)
 		prizevend(score)
 	emagged = FALSE
 	name = "The Orion Trail"

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -190,7 +190,7 @@
 				emagged = FALSE
 			else
 				SSblackbox.record_feedback("tally", "arcade_status", 1, "win_normal")
-				var/score = player_hp + player_mp + 5
+				var/score = player_hp + player_mp + 15
 				prizevend(score)
 
 	else if(emagged && (turtle >= 4))
@@ -199,8 +199,8 @@
 		playsound(loc, 'sound/arcade/boom.ogg', 50, TRUE)
 		player_hp -= boomamt
 
-	else if((enemy_mp <= 5) && (prob(70)))
-		var/stealamt = rand(2,3)
+	else if((enemy_mp <= 5) && prob(70))
+		var/stealamt = rand(5, 6)
 		temp = "[enemy_name] steals [stealamt] of your power!"
 		playsound(loc, 'sound/arcade/steal.ogg', 50, TRUE)
 		player_mp -= stealamt
@@ -956,7 +956,7 @@
 		message_admins("[key_name_admin(usr)] made it to Orion on an emagged machine and got an explosive toy ship.")
 		log_game("[key_name(usr)] made it to Orion on an emagged machine and got an explosive toy ship.")
 	else
-		var/score = alive + round(food/2) + round(fuel/5) + engine + hull + electronics - lings_aboard
+		var/score = 15 * (alive - lings_aboard) + 5 * (engine + hull + electronics)
 		prizevend(score)
 	emagged = FALSE
 	name = "The Orion Trail"

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -190,8 +190,7 @@
 				emagged = FALSE
 			else
 				SSblackbox.record_feedback("tally", "arcade_status", 1, "win_normal")
-				var/score = rand(20, 30)
-				prizevend(score)
+				prizevend(30)
 
 	else if(emagged && (turtle >= 4))
 		var/boomamt = rand(5,10)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Changed the way score is calculated for Orion and battle arcade:
* Battle arcade: HP + MP + 5 -> 35 tickets
* Orion arcade: crew + food/2 + fuel/5 + engine + hull + electronics - clings ->
10 * (crew - clings) + 5 * (engine+hull+electronics)

Feel free to suggest different numbers
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Battle arcade: With the way this game is built i find it unlikely to find a way which will prevent the spam that players can do to accumulate scores. Turning into a random amount would be better, making the players play the game multiple times for tickets instead of just spamming "recharge power" until their stats are high enough.

Orion arcade: This will result in better amounts of tickets for this arcade and will incentivise players to keep their crew alive for more tickets (which is what makes sense for the theme of this game).

## Testing
<!-- How did you test the PR, if at all? -->
- Played both games and won a few times
## Changelog
:cl:
tweak: Battle arcade: The amount of tickets is now a fixed number
tweak: Orion arcade: The amount of tickets now relies more on your crew and eng/hull/elects
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
