### PR TITLE
Adjusts the virus selection probability for Disease Outbreak event.

### DIFF
--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -16,7 +16,7 @@ GLOBAL_LIST_EMPTY(current_pending_diseases)
 	if(isemptylist(transmissable_symptoms))
 		populate_symptoms()
 	var/datum/disease/virus
-	if(prob(25))
+	if(prob(50))
 		switch(severity)
 			if(EVENT_LEVEL_MUNDANE)
 				virus = pick(diseases_minor)


### PR DESCRIPTION
## What Does This PR Do
This adjusts the overall probability for the Disease Outbreak event to pull from the predetermined list of viruses, adjusting it from 25% to 50%. 
## Why It's Good For The Game
This will make it an even chance to pull from a list of known diseases versus a disease that is randomly generated when the event is initiated, making some of the more interesting known viruses more common. 
## Testing
Used event manager to cause disease outbreak to occur and viewed the results.
## Changelog
:cl:
tweak: Tweaked the probability of known viruses to be selected during Disease Outbreak
/:cl: