### PR TITLE
Buffs Nuclear Operative Cyborgs

### DIFF
--- a/code/game/gamemodes/nuclear/pinpointer.dm
+++ b/code/game/gamemodes/nuclear/pinpointer.dm
@@ -371,34 +371,18 @@
 		else
 			. += "No operatives detected within scanning range."
 
-/obj/item/pinpointer/operative_nad
+/obj/item/pinpointer/operative/nad
 	name = "operative pinpointer"
 	desc = "A pinpointer that leads to the first Syndicate operative detected. Also has a mode to point towards the NAD."
 	modes = list(MODE_OPERATIVE, MODE_DISK)
-	var/mob/living/carbon/nearest_op = null
 
-/obj/item/pinpointer/operative_nad/process()
+/obj/item/pinpointer/operative/nad/process()
 	switch(mode)
 		if(MODE_DISK)
 			workdisk()
 		if(MODE_OPERATIVE)
 			scan_for_ops()
 			point_at_target(nearest_op, FALSE)
-
-/obj/item/pinpointer/operative_nad/proc/scan_for_ops()
-	if(mode != MODE_OPERATIVE)
-		return
-	nearest_op = null //Resets nearest_op every time it scans
-
-	var/closest_distance = 1000
-	for(var/datum/mind/Mind in SSticker.mode.syndicates)
-		var/mob/M = Mind.current
-		if(!ishuman(M))
-			continue
-		var/current_dist = get_dist(M, get_turf(src))
-		if(current_dist < closest_distance)
-			nearest_op = M
-			closest_distance = current_dist
 
 /obj/item/pinpointer/crew
 	name = "crew pinpointer"

--- a/code/game/gamemodes/nuclear/pinpointer.dm
+++ b/code/game/gamemodes/nuclear/pinpointer.dm
@@ -371,6 +371,45 @@
 		else
 			. += "No operatives detected within scanning range."
 
+/obj/item/pinpointer/operative_nad
+	name = "operative pinpointer"
+	desc = "A pinpointer that leads to the first Syndicate operative detected. Also has a mode to point towards the NAD."
+	modes = list(MODE_OPERATIVE, MODE_DISK)
+	var/mob/living/carbon/nearest_op = null
+
+/obj/item/pinpointer/operative_nad/process()
+	switch(mode)
+		if(MODE_DISK)
+			workdisk()
+		if(MODE_OPERATIVE)
+			scan_for_ops()
+			point_at_target(nearest_op, FALSE)
+
+/obj/item/pinpointer/operative_nad/proc/scan_for_ops()
+	if(mode != MODE_OPERATIVE)
+		return
+	nearest_op = null //Resets nearest_op every time it scans
+
+	var/closest_distance = 1000
+	for(var/datum/mind/Mind in SSticker.mode.syndicates)
+		var/mob/M = Mind.current
+		if(!ishuman(M))
+			continue
+		var/current_dist = get_dist(M, get_turf(src))
+		if(current_dist < closest_distance)
+			nearest_op = M
+			closest_distance = current_dist
+
+/obj/item/pinpointer/operative_nad/workbomb()
+	if(GLOB.bomb_set)	//If the bomb is set, lead to the shuttle
+		mode = MODE_SHIP	//Ensures worklocation() continues to work
+		modes = list(MODE_SHIP)
+		playsound(loc, 'sound/machines/twobeep.ogg', 50, 1)	//Plays a beep
+		visible_message("Shuttle Locator mode actived.")			//Lets the mob holding it know that the mode has changed
+		return		//Get outta here
+	scanbomb()
+	point_at_target(the_s_bomb)
+
 /obj/item/pinpointer/crew
 	name = "crew pinpointer"
 	desc = "A handheld tracking device that points to crew suit sensors."

--- a/code/game/gamemodes/nuclear/pinpointer.dm
+++ b/code/game/gamemodes/nuclear/pinpointer.dm
@@ -372,7 +372,6 @@
 			. += "No operatives detected within scanning range."
 
 /obj/item/pinpointer/operative/nad
-	name = "operative pinpointer"
 	desc = "A pinpointer that leads to the first Syndicate operative detected. Also has a mode to point towards the NAD."
 	modes = list(MODE_OPERATIVE, MODE_DISK)
 

--- a/code/game/gamemodes/nuclear/pinpointer.dm
+++ b/code/game/gamemodes/nuclear/pinpointer.dm
@@ -400,16 +400,6 @@
 			nearest_op = M
 			closest_distance = current_dist
 
-/obj/item/pinpointer/operative_nad/workbomb()
-	if(GLOB.bomb_set)	//If the bomb is set, lead to the shuttle
-		mode = MODE_SHIP	//Ensures worklocation() continues to work
-		modes = list(MODE_SHIP)
-		playsound(loc, 'sound/machines/twobeep.ogg', 50, 1)	//Plays a beep
-		visible_message("Shuttle Locator mode actived.")			//Lets the mob holding it know that the mode has changed
-		return		//Get outta here
-	scanbomb()
-	point_at_target(the_s_bomb)
-
 /obj/item/pinpointer/crew
 	name = "crew pinpointer"
 	desc = "A handheld tracking device that points to crew suit sensors."

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -620,7 +620,7 @@
 		/obj/item/gun/projectile/revolver/grenadelauncher/multi/cyborg,
 		/obj/item/card/emag,
 		/obj/item/crowbar/cyborg,
-		/obj/item/pinpointer/operative,
+		/obj/item/pinpointer/operative_nad,
 		/obj/item/stack/nanopaste/cyborg/syndicate
 	)
 
@@ -647,7 +647,7 @@
 		/obj/item/FixOVein,
 		/obj/item/card/emag,
 		/obj/item/crowbar/cyborg,
-		/obj/item/pinpointer/operative,
+		/obj/item/pinpointer/operative_nad,
 		/obj/item/stack/medical/bruise_pack/advanced/cyborg/syndicate,
 		/obj/item/stack/medical/ointment/advanced/cyborg/syndicate,
 		/obj/item/stack/medical/splint/cyborg/syndicate,
@@ -679,7 +679,7 @@
 		/obj/item/melee/energy/sword/cyborg,
 		/obj/item/card/emag,
 		/obj/item/borg_chameleon,
-		/obj/item/pinpointer/operative,
+		/obj/item/pinpointer/operative_nad,
 		/obj/item/stack/sheet/metal/cyborg,
 		/obj/item/stack/rods/cyborg,
 		/obj/item/stack/tile/plasteel/cyborg,

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -620,7 +620,7 @@
 		/obj/item/gun/projectile/revolver/grenadelauncher/multi/cyborg,
 		/obj/item/card/emag,
 		/obj/item/crowbar/cyborg,
-		/obj/item/pinpointer/operative_nad,
+		/obj/item/pinpointer/operative/nad,
 		/obj/item/stack/nanopaste/cyborg/syndicate
 	)
 
@@ -647,7 +647,7 @@
 		/obj/item/FixOVein,
 		/obj/item/card/emag,
 		/obj/item/crowbar/cyborg,
-		/obj/item/pinpointer/operative_nad,
+		/obj/item/pinpointer/operative/nad,
 		/obj/item/stack/medical/bruise_pack/advanced/cyborg/syndicate,
 		/obj/item/stack/medical/ointment/advanced/cyborg/syndicate,
 		/obj/item/stack/medical/splint/cyborg/syndicate,
@@ -679,7 +679,7 @@
 		/obj/item/melee/energy/sword/cyborg,
 		/obj/item/card/emag,
 		/obj/item/borg_chameleon,
-		/obj/item/pinpointer/operative_nad,
+		/obj/item/pinpointer/operative/nad,
 		/obj/item/stack/sheet/metal/cyborg,
 		/obj/item/stack/rods/cyborg,
 		/obj/item/stack/tile/plasteel/cyborg,

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -620,7 +620,8 @@
 		/obj/item/gun/projectile/revolver/grenadelauncher/multi/cyborg,
 		/obj/item/card/emag,
 		/obj/item/crowbar/cyborg,
-		/obj/item/pinpointer/operative_nad
+		/obj/item/pinpointer/operative,
+		/obj/item/stack/nanopaste/cyborg/syndicate
 	)
 
 // Sydicate medical cyborg module.
@@ -684,7 +685,8 @@
 		/obj/item/stack/tile/plasteel/cyborg,
 		/obj/item/stack/cable_coil/cyborg,
 		/obj/item/stack/sheet/glass/cyborg,
-		/obj/item/stack/sheet/rglass/cyborg
+		/obj/item/stack/sheet/rglass/cyborg,
+		/obj/item/stack/nanopaste/cyborg/syndicate
 	)
 	special_rechargables = list(/obj/item/extinguisher, /obj/item/weldingtool/largetank/cyborg)
 

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -620,7 +620,7 @@
 		/obj/item/gun/projectile/revolver/grenadelauncher/multi/cyborg,
 		/obj/item/card/emag,
 		/obj/item/crowbar/cyborg,
-		/obj/item/pinpointer/operative
+		/obj/item/pinpointer/operative_nad
 	)
 
 // Sydicate medical cyborg module.

--- a/code/modules/mob/living/silicon/robot/syndicate_robot.dm
+++ b/code/modules/mob/living/silicon/robot/syndicate_robot.dm
@@ -23,7 +23,7 @@
 
 /mob/living/silicon/robot/syndicate/New(loc)
 	..()
-	cell = new /obj/item/stock_parts/cell/hyper(src)
+	cell = new /obj/item/stock_parts/cell/bluespace(src)
 
 /mob/living/silicon/robot/syndicate/init(alien = FALSE, mob/living/silicon/ai/ai_to_sync_to = null)
 	laws = new /datum/ai_laws/syndicate_override

--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -147,9 +147,9 @@
 	ammo_type = /obj/item/ammo_casing/a40mm
 	max_ammo = 6
 
-/obj/item/ammo_box/magazine/internal/cylinder/grenadelauncher/multi/ten
+/obj/item/ammo_box/magazine/internal/cylinder/grenadelauncher/multi/fifteen
 	ammo_type = /obj/item/ammo_casing/a40mm
-	max_ammo = 10
+	max_ammo = 15
 
 /obj/item/ammo_box/magazine/internal/speargun
 	name = "speargun internal magazine"

--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -147,6 +147,10 @@
 	ammo_type = /obj/item/ammo_casing/a40mm
 	max_ammo = 6
 
+/obj/item/ammo_box/magazine/internal/cylinder/grenadelauncher/multi/ten
+	ammo_type = /obj/item/ammo_casing/a40mm
+	max_ammo = 10
+
 /obj/item/ammo_box/magazine/internal/speargun
 	name = "speargun internal magazine"
 	ammo_type = /obj/item/ammo_casing/caseless/magspear

--- a/code/modules/projectiles/guns/projectile/launchers.dm
+++ b/code/modules/projectiles/guns/projectile/launchers.dm
@@ -27,7 +27,7 @@
 	desc = "A 10-shot grenade launcher."
 	icon = 'icons/mecha/mecha_equipment.dmi'
 	icon_state = "mecha_grenadelnchr"
-	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/grenadelauncher/multi/ten
+	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/grenadelauncher/multi/fifteen
 
 /obj/item/gun/projectile/revolver/grenadelauncher/multi/cyborg/attack_self()
 	return

--- a/code/modules/projectiles/guns/projectile/launchers.dm
+++ b/code/modules/projectiles/guns/projectile/launchers.dm
@@ -24,7 +24,7 @@
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/grenadelauncher/multi
 
 /obj/item/gun/projectile/revolver/grenadelauncher/multi/cyborg
-	desc = "A 10-shot grenade launcher."
+	desc = "A 15-shot grenade launcher."
 	icon = 'icons/mecha/mecha_equipment.dmi'
 	icon_state = "mecha_grenadelnchr"
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/grenadelauncher/multi/fifteen

--- a/code/modules/projectiles/guns/projectile/launchers.dm
+++ b/code/modules/projectiles/guns/projectile/launchers.dm
@@ -24,9 +24,10 @@
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/grenadelauncher/multi
 
 /obj/item/gun/projectile/revolver/grenadelauncher/multi/cyborg
-	desc = "A 6-shot grenade launcher."
+	desc = "A 10-shot grenade launcher."
 	icon = 'icons/mecha/mecha_equipment.dmi'
 	icon_state = "mecha_grenadelnchr"
+	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/grenadelauncher/multi/ten
 
 /obj/item/gun/projectile/revolver/grenadelauncher/multi/cyborg/attack_self()
 	return


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Buffs:
All nuclear cyborgs to:
- Have a bluespace cell (30k charge to 40k charge)
- A pinpointer that can both point towards nuclear operatives and the NAD
Assault cyborg:
- Increases the magazine of their grenade launcher from 6 to 15 shots.
- Gives them nanopaste
Sabotage cyborg:
- Gives them nanopaste
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Let's be honest. Out of the three cyborgs, only the medical cyborg is only useful. The assault cyborg can barely hold it's own ground, and the saboteur cyborg is almost always called out roundstart because of the AI telling which cyborgs are connected to it.
The pinpointer change should give every cyborg the ability to help navigate the station + if they somehow have to work alone and need to find the NAD. 
The extra charge is a QOL upgrade, mostly for mediborgs and assault borgs.
The assault borg gets extra shots in their grenade launcher, in case they miss some, and it has to be recharged at a cyborg recharger.

What I am considering if the balance team wants stronger/weaker buffs  - This is what I'd prefer, but I'm open for more changes:
- Make the assault borg grenade launcher recharge over time - Would be at the cost of the increased magazine
- Reduce the costs of the assault borg, maybe increase the saboteur or medical slightly.
- Reduce max charge on their cells, give them a slow recharge
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Spawned in some borgos, fucked around and stole the NAD
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: All Nuclear cyborgs now have a bluespace cell
tweak: All Nuclear cyborgs now get a pinpointer for both operatives and the NAD
tweak: Assault cyborgs get extra grenade launcher capacity from 6 to 15, and get nanopaste
tweak: Sabotage cyborgs now get nanopaste
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
