### PR TITLE
Fixes oversight about loadout prescription glasses

### DIFF
--- a/code/controllers/subsystem/SSjobs.dm
+++ b/code/controllers/subsystem/SSjobs.dm
@@ -511,8 +511,7 @@ SUBSYSTEM_DEF(jobs)
 			if(equipped != 1)
 				var/obj/item/clothing/glasses/G = H.glasses
 				if(istype(G) && !G.prescription)
-					G.prescription = TRUE
-					G.name = "prescription [G.name]"
+					G.upgrade_prescription()
 					H.update_nearsighted_effects()
 
 	H.create_log(MISC_LOG, "Spawned as \an [H.dna?.species ? H.dna.species : "Undefined species"] named [H]. [joined_late ? "Joined during the round" : "Roundstart joined"] as job: [rank].")

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -206,6 +206,7 @@
 	desc = "Yarr."
 	icon_state = "eyepatch"
 	item_state = "eyepatch"
+	prescription_upgradable = TRUE
 
 	sprite_sheets = list(
 		"Vox" = 'icons/mob/clothing/species/vox/eyes.dmi',
@@ -265,7 +266,7 @@
 	desc = "Made by Nerd. Co."
 	icon_state = "glasses"
 	item_state = "glasses"
-	prescription = 1
+	prescription = TRUE
 
 	sprite_sheets = list(
 		"Vox" = 'icons/mob/clothing/species/vox/eyes.dmi',
@@ -332,6 +333,8 @@
 	see_in_dark = 0
 	flash_protect = FLASH_PROTECTION_NONE
 	tint = FLASH_PROTECTION_NONE
+	prescription_upgradable = TRUE
+
 	sprite_sheets = list(
 		"Vox" = 'icons/mob/clothing/species/vox/eyes.dmi',
 		"Drask" = 'icons/mob/clothing/species/drask/eyes.dmi',
@@ -518,6 +521,7 @@
 	actions_types = list(/datum/action/item_action/toggle)
 	up = FALSE
 	tint = FLASH_PROTECTION_NONE
+	prescription_upgradable = TRUE
 
 	sprite_sheets = list(
 		"Vox" = 'icons/mob/clothing/species/vox/eyes.dmi',


### PR DESCRIPTION
## What Does This PR Do

Makes all loadout glasses options prescription upgradable (cheap sunglasses, monocle, eyepatch, Tajaran veils). Current behaviour is that they just get set to `prescription = TRUE`, with this fix, they will call `upgrade_prescription()` properly, introduced in #22227. A side-effect is that these items can be now upgraded during the round as well.

Fixes #22351 

## Why It's Good For The Game

Consistency, fixes an oversight regarding my refactor

## Images of changes

![image](https://github.com/ParadiseSS13/Paradise/assets/33333517/a5023f78-9dba-4433-8834-68ea9f6aa7cc)

## Testing

1. Set character's disability to Nearsighted
2. Select a glasses option in loadout
3. Spawn in
4. Use screwdriver on the glasses
5. Try to put the prescription lenses back into the glasses

## Changelog
:cl:
fix: You can now properly remove prescription glasses from roundstart prescription glasses.
tweak: Eyepatches, cheap sunglasses, monocles, and Tajaran veils can be now upgraded with prescription glasses.
/:cl:
