### PR TITLE
Logs playtime history for ALL departments

### DIFF
--- a/SQL/paradise_schema.sql
+++ b/SQL/paradise_schema.sql
@@ -474,7 +474,17 @@ CREATE TABLE `playtime_history` (
   `ckey` varchar(32) NOT NULL,
   `date` DATE NOT NULL,
   `time_living` SMALLINT NOT NULL,
+  `time_crew` SMALLINT NOT NULL,
+  `time_special` SMALLINT NOT NULL,
   `time_ghost` SMALLINT NOT NULL,
+  `time_command` SMALLINT NOT NULL,
+  `time_engineering` SMALLINT NOT NULL,
+  `time_medical` SMALLINT NOT NULL,
+  `time_science` SMALLINT NOT NULL,
+  `time_supply` SMALLINT NOT NULL,
+  `time_security` SMALLINT NOT NULL,
+  `time_silicon` SMALLINT NOT NULL,
+  `time_service` SMALLINT NOT NULL,
   PRIMARY KEY (`ckey`, `date`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 

--- a/SQL/updates/51-52.sql
+++ b/SQL/updates/51-52.sql
@@ -1,0 +1,13 @@
+# Updating SQL from 51 to 52 -AffectedArc07
+# Adding all department columns to playtime_history
+ALTER TABLE `playtime_history`
+	ADD COLUMN `time_crew` SMALLINT NOT NULL AFTER `time_living`,
+	ADD COLUMN `time_special` SMALLINT NOT NULL AFTER `time_crew`,
+	ADD COLUMN `time_command` SMALLINT NOT NULL AFTER `time_ghost`,
+	ADD COLUMN `time_engineering` SMALLINT NOT NULL AFTER `time_command`,
+	ADD COLUMN `time_medical` SMALLINT NOT NULL AFTER `time_engineering`,
+	ADD COLUMN `time_science` SMALLINT NOT NULL AFTER `time_medical`,
+	ADD COLUMN `time_supply` SMALLINT NOT NULL AFTER `time_science`,
+	ADD COLUMN `time_security` SMALLINT NOT NULL AFTER `time_supply`,
+	ADD COLUMN `time_silicon` SMALLINT NOT NULL AFTER `time_security`,
+	ADD COLUMN `time_service` SMALLINT NOT NULL AFTER `time_silicon`;

--- a/code/__DEFINES/misc_defines.dm
+++ b/code/__DEFINES/misc_defines.dm
@@ -375,7 +375,7 @@
 #define INVESTIGATE_BOMB "bombs"
 
 // The SQL version required by this version of the code
-#define SQL_VERSION 51
+#define SQL_VERSION 52
 
 // Vending machine stuff
 #define CAT_NORMAL 1

--- a/code/controllers/subsystem/SSjobs.dm
+++ b/code/controllers/subsystem/SSjobs.dm
@@ -819,11 +819,24 @@ SUBSYSTEM_DEF(jobs)
 			else if(C.mob.mind.assigned_role)
 				myrole = C.mob.mind.assigned_role
 
-		var/added_living = 0
-		var/added_ghost = 0
+		// Track all the added ammounts for a mega update query
+		var/list/added_differential = list(
+			EXP_TYPE_LIVING = 0,
+			EXP_TYPE_CREW = 0,
+			EXP_TYPE_SPECIAL = 0,
+			EXP_TYPE_GHOST = 0,
+			EXP_TYPE_COMMAND = 0,
+			EXP_TYPE_ENGINEERING = 0,
+			EXP_TYPE_MEDICAL = 0,
+			EXP_TYPE_SCIENCE = 0,
+			EXP_TYPE_SUPPLY = 0,
+			EXP_TYPE_SECURITY = 0,
+			EXP_TYPE_SILICON = 0,
+			EXP_TYPE_SERVICE = 0
+		)
 		if(C.mob.stat == CONSCIOUS && myrole)
 			play_records[C.ckey][EXP_TYPE_LIVING] += minutes
-			added_living += minutes
+			added_differential[EXP_TYPE_LIVING] += minutes
 
 			if(announce)
 				to_chat(C.mob, "<span class='notice'>You got: [minutes] Living EXP!</span>")
@@ -832,6 +845,7 @@ SUBSYSTEM_DEF(jobs)
 				if(GLOB.exp_jobsmap[category]["titles"])
 					if(myrole in GLOB.exp_jobsmap[category]["titles"])
 						play_records[C.ckey][category] += minutes
+						added_differential[category] += minutes
 						if(announce)
 							to_chat(C.mob, "<span class='notice'>You got: [minutes] [category] EXP!</span>")
 
@@ -842,7 +856,7 @@ SUBSYSTEM_DEF(jobs)
 
 		else if(isobserver(C.mob))
 			play_records[C.ckey][EXP_TYPE_GHOST] += minutes
-			added_ghost += minutes
+			added_differential[EXP_TYPE_GHOST] += minutes
 			if(announce)
 				to_chat(C.mob, "<span class='notice'>You got: [minutes] Ghost EXP!</span>")
 		else
@@ -862,14 +876,25 @@ SUBSYSTEM_DEF(jobs)
 
 		player_update_queries += update_query
 
+		// This gets hellish
 		var/datum/db_query/update_query_history = SSdbcore.NewQuery({"
-			INSERT INTO playtime_history (ckey, date, time_living, time_ghost)
-			VALUES (:ckey, CURDATE(), :addedliving, :addedghost)
-			ON DUPLICATE KEY UPDATE time_living=time_living + VALUES(time_living), time_ghost=time_ghost + VALUES(time_ghost)"},
+			INSERT INTO playtime_history (ckey, date, time_living, time_crew, time_special, time_ghost, time_command, time_engineering, time_medical, time_science, time_supply, time_security, time_silicon, time_service)
+			VALUES (:ckey, CURDATE(), :addedliving, :addedcrew, :addedspecial, :addedghost, :addedcommand, :addedengineering, :addedmedical, :addedscience, :addedsupply, :addedsecurity, :addedsilicon, :addedservice)
+			ON DUPLICATE KEY UPDATE time_living=time_living + VALUES(time_living), time_crew=time_crew + VALUES(time_crew), time_crew=time_special + VALUES(time_special), time_ghost=time_ghost + VALUES(time_ghost), time_command=time_command + VALUES(time_command), time_engineering=time_engineering + VALUES(time_engineering), time_medical=time_medical + VALUES(time_medical), time_science=time_science + VALUES(time_science), time_supply=time_supply + VALUES(time_supply), time_security=time_security + VALUES(time_security), time_silicon=time_silicon + VALUES(time_silicon), time_service=time_service + VALUES(time_service)"},
 			list(
 				"ckey" = C.ckey,
-				"addedliving" = added_living,
-				"addedghost" = added_ghost
+				"addedliving" = added_differential[EXP_TYPE_LIVING],
+				"addedcrew" = added_differential[EXP_TYPE_CREW],
+				"addedspecial" = added_differential[EXP_TYPE_SPECIAL],
+				"addedghost" = added_differential[EXP_TYPE_GHOST],
+				"addedcommand" = added_differential[EXP_TYPE_COMMAND],
+				"addedengineering" = added_differential[EXP_TYPE_ENGINEERING],
+				"addedmedical" = added_differential[EXP_TYPE_MEDICAL],
+				"addedscience" = added_differential[EXP_TYPE_SCIENCE],
+				"addedsupply" = added_differential[EXP_TYPE_SUPPLY],
+				"addedsecurity" = added_differential[EXP_TYPE_SECURITY],
+				"addedsilicon" = added_differential[EXP_TYPE_SILICON],
+				"addedservice" = added_differential[EXP_TYPE_SERVICE]
 			)
 		)
 

--- a/config/example/config.toml
+++ b/config/example/config.toml
@@ -144,7 +144,7 @@ ipc_screens = [
 # Enable/disable the database on a whole
 sql_enabled = false
 # SQL version. If this is a mismatch, round start will be delayed
-sql_version = 51
+sql_version = 52
 # SQL server address. Can be an IP or DNS name
 sql_address = "127.0.0.1"
 # SQL server port


### PR DESCRIPTION
## What Does This PR Do
Logs data in the `playtime_history` table for all departments, not just `living` and `ghost`.

Realistically we should:
- Make this one table with exp_type and a value as another column, but that can wait
- Track this on a per-job basis for stupid detail on stats

But this will do. 

## Why It's Good For The Game
More stats are always good.

## Testing
Loaded up the server and selected RD
![image](https://github.com/ParadiseSS13/Paradise/assets/25063394/c711167a-b10d-41a2-8379-18c5f8943822)

## Changelog
Nothing player facing
