### PR TITLE
Fix invisible depot fusion reactor

### DIFF
--- a/code/game/objects/structures/depot_structures.dm
+++ b/code/game/objects/structures/depot_structures.dm
@@ -2,7 +2,7 @@
 /obj/structure/fusionreactor
 	name = "syndicate fusion reactor"
 	desc = "Significantly less cool than a supermatter crystal, but just as likely to fuck up."
-	icon = 'icons/obj/device.dmi'
+	icon = 'icons/goonstation/objects/powersink.dmi'
 	icon_state = "powersink1"
 	anchored = TRUE
 	max_integrity = 50


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fix https://github.com/ParadiseSS13/Paradise/issues/22448, which was brought about by https://github.com/ParadiseSS13/Paradise/pull/22313. 
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Objects not having invisible sprites is generally better than the alternative.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
![image](https://github.com/ParadiseSS13/Paradise/assets/89928798/28fe274f-5edd-4938-a296-bc8dff84ac76)

<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: The Syndicate have rolled back their invisible fusion reactor experiment after a series of Space OSHA reports
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
