### PR TITLE
Deletes the Useless Altar in the Library

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -50565,7 +50565,6 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/service/library)
 "cvo" = (
-/obj/structure/cult/archives,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -32507,8 +32507,6 @@
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_x = 30
 	},
-/obj/structure/cult/archives,
-/obj/item/book/codex_gigas,
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/plasteel{
 	icon_state = "cult"
@@ -38024,6 +38022,7 @@
 "cox" = (
 /obj/structure/table/wood,
 /obj/item/storage/photo_album,
+/obj/item/book/codex_gigas,
 /turf/simulated/floor/plasteel{
 	icon_state = "cult"
 	},

--- a/_maps/map_files/cerestation/cerestation.dmm
+++ b/_maps/map_files/cerestation/cerestation.dmm
@@ -61011,6 +61011,7 @@
 /obj/structure/table/wood,
 /obj/item/camera,
 /obj/item/taperecorder,
+/obj/item/book/codex_gigas,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -94585,8 +94586,6 @@
 	pixel_y = 28;
 	name = "custom placement"
 	},
-/obj/item/book/codex_gigas,
-/obj/structure/cult/archives,
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -23612,7 +23612,6 @@
 	},
 /area/station/service/library)
 "bmF" = (
-/obj/structure/cult/archives,
 /obj/machinery/light_switch{
 	dir = 1;
 	name = "south bump";


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
![StrongDMM_THP89Hbhfa](https://github.com/ParadiseSS13/Paradise/assets/62493359/81592ccf-8864-4565-b071-878fa4b04b8a)
 


## Why It's Good For The Game
![image](https://github.com/ParadiseSS13/Paradise/assets/62493359/935d2a6e-bb67-4e58-a0f8-97c30782e7d7)
This is leftover from Devil, aside the grasping straws of it being the same sprites cult use, it would be better to remove. I think I see more people destroy it then ever think of a creative way to use it for roleplay, otherwise its shit. Deletes it from the other maps as well.

## Images of changes
Look above

## Testing
yep

## Changelog
:cl: Octus
del: Deletes the useless library altar from all maps
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
