### PR TITLE
Standardize(s?) vendors.dm lists. Also fixes a typo(?)

### DIFF
--- a/code/game/machinery/vendors/contraband_vendors.dm
+++ b/code/game/machinery/vendors/contraband_vendors.dm
@@ -136,7 +136,7 @@
 	contraband = list(/obj/item/clothing/under/costume/patriotsuit = 1,
 					/obj/item/bedsheet/patriot = 3)
 
-	armor = list(melee = 100, bullet = 100, laser = 100, energy = 100, bomb = 0, rad = 0, fire = 100, acid = 50)
+	armor = list(MELEE = 100, BULLET = 100, LASER = 100, ENERGY = 100, BOMB = 0, RAD = 0, FIRE = 100, ACID = 50)
 	resistance_flags = FIRE_PROOF
 
 /obj/machinery/economy/vending/toyliberationstation
@@ -177,5 +177,5 @@
 					/obj/item/dualsaber/toy = 5,
 					/obj/item/deck/cards/syndicate = 10) //Gambling and it hurts, making it a +18 item
 
-	armor = list(melee = 100, bullet = 100, laser = 100, energy = 100, bomb = 0, rad = 0, fire = 100, acid = 50)
+	armor = list(MELEE = 100, BULLET = 100, LASER = 100, ENERGY = 100, BOMB = 0, RAD = 0, FIRE = 100, ACID = 50)
 	resistance_flags = FIRE_PROOF

--- a/code/game/machinery/vendors/contraband_vendors.dm
+++ b/code/game/machinery/vendors/contraband_vendors.dm
@@ -5,12 +5,20 @@
 	desc = "<b>EVIL</b> wall-mounted Medical Equipment dispenser."
 	icon_state = "syndimed"
 	icon_deny = "syndimed_deny"
-	ads_list = list("Go end some lives!", "The best stuff for your ship.", "Only the finest tools.", "Natural chemicals!", "This stuff saves lives.", "Don't you want some?", "Ping!")
+	ads_list = list("Go end some lives!",
+					"The best stuff for your ship.",
+					"Only the finest tools.",
+					"Natural chemicals!",
+					"This stuff saves lives.",
+					"Don't you want some?",
+					"Ping!")
+
 	req_access_txt = "150"
 	products = list(/obj/item/stack/medical/bruise_pack = 2,
 					/obj/item/stack/medical/ointment = 2,
 					/obj/item/reagent_containers/hypospray/autoinjector/epinephrine = 4,
 					/obj/item/healthanalyzer = 1)
+
 	contraband = list(/obj/item/reagent_containers/syringe/charcoal = 4,
 						/obj/item/reagent_containers/syringe/antiviral = 4,
 						/obj/item/reagent_containers/food/pill/tox = 1)
@@ -18,8 +26,20 @@
 /obj/machinery/economy/vending/syndicigs
 	name = "\improper Suspicious Cigarette Machine"
 	desc = "Smoke 'em if you've got 'em."
-	slogan_list = list("Space cigs taste good like a cigarette should.", "I'd rather toolbox than switch.", "Smoke!", "Don't believe the reports - smoke today!")
-	ads_list = list("Probably not bad for you!", "Don't believe the scientists!", "It's good for you!", "Don't quit, buy more!", "Smoke!", "Nicotine heaven.", "Best cigarettes since 2150.", "Award-winning cigs.")
+	slogan_list = list("Space cigs taste good like a cigarette should.",
+					"I'd rather toolbox than switch.",
+					"Smoke!",
+					"Don't believe the reports - smoke today!")
+
+	ads_list = list("Probably not bad for you!",
+					"Don't believe the scientists!",
+					"It's good for you!",
+					"Don't quit, buy more!",
+					"Smoke!",
+					"Nicotine heaven.",
+					"Best cigarettes since 2150.",
+					"Award-winning cigs.")
+
 	category = VENDOR_TYPE_RECREATION
 	vend_delay = 34
 	icon_state = "cigs"
@@ -29,15 +49,29 @@
 /obj/machinery/economy/vending/syndisnack
 	name = "\improper Getmore Chocolate Corp"
 	desc = "A modified snack machine courtesy of the Getmore Chocolate Corporation, based out of Mars"
-	slogan_list = list("Try our new nougat bar!", "Twice the calories for half the price!")
-	ads_list = list("The healthiest!", "Award-winning chocolate bars!", "Mmm! So good!", "Oh my god it's so juicy!", "Have a snack.", "Snacks are good for you!", "Have some more Getmore!", "Best quality snacks straight from mars.", "We love chocolate!", "Try our new jerky!")
+	slogan_list = list("Try our new nougat bar!",
+					"Twice the calories for half the price!")
+
+	ads_list = list("The healthiest!",
+					"Award-winning chocolate bars!",
+					"Mmm! So good!",
+					"Oh my god it's so juicy!",
+					"Have a snack.",
+					"Snacks are good for you!",
+					"Have some more Getmore!",
+					"Best quality snacks straight from mars.",
+					"We love chocolate!",
+					"Try our new jerky!")
+
 	icon_state = "snack"
 	icon_lightmask = "nutri"
 	icon_off = "nutri"
 	icon_panel = "thin_vendor"
 	category = VENDOR_TYPE_FOOD
-	products = list(/obj/item/reagent_containers/food/snacks/chips = 6,/obj/item/reagent_containers/food/snacks/sosjerky = 6,
-					/obj/item/reagent_containers/food/snacks/syndicake = 6, /obj/item/reagent_containers/food/snacks/cheesiehonkers = 6)
+	products = list(/obj/item/reagent_containers/food/snacks/chips = 6,
+					/obj/item/reagent_containers/food/snacks/sosjerky = 6,
+					/obj/item/reagent_containers/food/snacks/syndicake = 6,
+					/obj/item/reagent_containers/food/snacks/cheesiehonkers = 6)
 
 /obj/machinery/economy/vending/hydroseeds/syndicate_druglab
 	products = list(/obj/item/seeds/ambrosia/deus = 2,
@@ -47,6 +81,7 @@
 					/obj/item/seeds/cannabis/rainbow = 1,
 					/obj/item/seeds/reishi = 2,
 					/obj/item/seeds/tobacco = 1)
+
 	contraband = list()
 	refill_canister = null
 
@@ -62,6 +97,7 @@
 					/obj/item/plant_analyzer = 2,
 					/obj/item/reagent_containers/glass/bottle/ammonia = 6,
 					/obj/item/reagent_containers/glass/bottle/diethylamine = 8)
+
 	contraband = list()
 
 /obj/machinery/economy/vending/liberationstation
@@ -70,8 +106,16 @@
 	icon_state = "liberationstation"
 	icon_lightmask = "liberationstation"
 	req_access_txt = "1"
-	slogan_list = list("Liberation Station: Your one-stop shop for all things second amendment!", "Be a patriot today, pick up a gun!", "Quality weapons for cheap prices!", "Better dead than red!")
-	ads_list = list("Float like an astronaut, sting like a bullet!", "Express your second amendment today!", "Guns don't kill people, but you can!", "Who needs responsibilities when you have guns?")
+	slogan_list = list("Liberation Station: Your one-stop shop for all things second amendment!",
+					"Be a patriot today, pick up a gun!",
+					"Quality weapons for cheap prices!",
+					"Better dead than red!")
+
+	ads_list = list("Float like an astronaut, sting like a bullet!",
+					"Express your second amendment today!",
+					"Guns don't kill people, but you can!",
+					"Who needs responsibilities when you have guns?")
+
 	vend_reply = "Remember the name: Liberation Station!"
 	products = list(/obj/item/gun/projectile/automatic/pistol/deagle/gold = 2,
 					/obj/item/gun/projectile/automatic/pistol/deagle/camo = 2,
@@ -88,7 +132,10 @@
 					/obj/item/ammo_box/magazine/m75 = 2,
 					/obj/item/ammo_box/magazine/m556/arg = 2,
 					/obj/item/ammo_box/magazine/ak814 = 2)
-	contraband = list(/obj/item/clothing/under/costume/patriotsuit = 1, /obj/item/bedsheet/patriot = 3)
+
+	contraband = list(/obj/item/clothing/under/costume/patriotsuit = 1,
+					/obj/item/bedsheet/patriot = 3)
+
 	armor = list(melee = 100, bullet = 100, laser = 100, energy = 100, bomb = 0, rad = 0, fire = 100, acid = 50)
 	resistance_flags = FIRE_PROOF
 
@@ -97,8 +144,18 @@
 	desc = "An ages 8 and up approved vendor that dispenses toys. If you were to find the right wires, you can unlock the adult mode setting!"
 	icon_state = "syndi"
 	icon_lightmask = "syndi"
-	slogan_list = list("Get your cool toys today!", "Trigger a valid hunter today!", "Quality toy weapons for cheap prices!", "Give them to HoPs for all access!", "Give them to HoS to get permabrigged!")
-	ads_list = list("Feel robust with your toys!", "Express your inner child today!", "Toy weapons don't kill people, but valid hunters do!", "Who needs responsibilities when you have toy weapons?", "Make your next murder FUN!")
+	slogan_list = list("Get your cool toys today!",
+					"Trigger a valid hunter today!",
+					"Quality toy weapons for cheap prices!",
+					"Give them to HoPs for all access!",
+					"Give them to HoS to get permabrigged!")
+
+	ads_list = list("Feel robust with your toys!",
+					"Express your inner child today!",
+					"Toy weapons don't kill people, but valid hunters do!",
+					"Who needs responsibilities when you have toy weapons?",
+					"Make your next murder FUN!")
+
 	vend_reply = "Come back for more!"
 	category = VENDOR_TYPE_RECREATION
 	products = list(/obj/item/gun/projectile/automatic/toy = 10,
@@ -110,6 +167,7 @@
 					/obj/item/toy/syndicateballoon = 10,
 					/obj/item/clothing/suit/syndicatefake = 5,
 					/obj/item/clothing/head/syndicatefake = 5) //OPS IN DORMS oh wait it's just an assistant
+
 	contraband = list(/obj/item/gun/projectile/shotgun/toy/crossbow = 10,   //Congrats, you unlocked the +18 setting!
 					/obj/item/gun/projectile/automatic/c20r/toy/riot = 10,
 					/obj/item/gun/projectile/automatic/l6_saw/toy/riot = 10,
@@ -118,5 +176,6 @@
 					/obj/item/toy/katana = 10,
 					/obj/item/dualsaber/toy = 5,
 					/obj/item/deck/cards/syndicate = 10) //Gambling and it hurts, making it a +18 item
+
 	armor = list(melee = 100, bullet = 100, laser = 100, energy = 100, bomb = 0, rad = 0, fire = 100, acid = 50)
 	resistance_flags = FIRE_PROOF

--- a/code/game/machinery/vendors/departmental_vendors.dm
+++ b/code/game/machinery/vendors/departmental_vendors.dm
@@ -6,8 +6,19 @@
 	icon_panel = "generic"
 	category = VENDOR_TYPE_DEPARTMENTAL
 	req_one_access_txt = "11;24" // Engineers and atmos techs can use this
-	products = list(/obj/item/clothing/glasses/meson/engine = 2, /obj/item/multitool = 4, /obj/item/geiger_counter = 5,  /obj/item/airlock_electronics = 10, /obj/item/firelock_electronics = 10, /obj/item/firealarm_electronics = 10, /obj/item/apc_electronics = 10, /obj/item/airalarm_electronics = 10, /obj/item/stock_parts/cell/high = 10, /obj/item/camera_assembly = 10)
+	products = list(/obj/item/clothing/glasses/meson/engine = 2,
+					/obj/item/multitool = 4,
+					/obj/item/geiger_counter = 5,
+					/obj/item/airlock_electronics = 10,
+					/obj/item/firelock_electronics = 10,
+					/obj/item/firealarm_electronics = 10,
+					/obj/item/apc_electronics = 10,
+					/obj/item/airalarm_electronics = 10,
+					/obj/item/stock_parts/cell/high = 10,
+					/obj/item/camera_assembly = 10)
+
 	contraband = list(/obj/item/stock_parts/cell/potato = 3)
+
 	refill_canister = /obj/item/vending_refill/engivend
 
 /obj/machinery/economy/vending/engineering
@@ -17,12 +28,30 @@
 	icon_deny = "engi_deny"
 	category = VENDOR_TYPE_DEPARTMENTAL
 	req_access_txt = "11"
-	products = list(/obj/item/clothing/under/rank/engineering/chief_engineer = 4, /obj/item/clothing/under/rank/engineering/engineer = 40, /obj/item/clothing/shoes/workboots = 4, /obj/item/clothing/head/hardhat = 4,
-					/obj/item/storage/belt/utility = 4, /obj/item/clothing/glasses/meson/engine = 4,/obj/item/clothing/gloves/color/yellow = 4, /obj/item/screwdriver = 12,
-					/obj/item/crowbar = 12, /obj/item/wirecutters = 12, /obj/item/multitool = 12,/obj/item/wrench = 12, /obj/item/t_scanner = 12,
-					/obj/item/stack/cable_coil = 8, /obj/item/stock_parts/cell = 8, /obj/item/weldingtool = 8, /obj/item/clothing/head/welding = 8,
-					/obj/item/light/tube = 10, /obj/item/clothing/suit/fire = 4, /obj/item/stock_parts/scanning_module = 5, /obj/item/stock_parts/micro_laser = 5,
-					/obj/item/stock_parts/matter_bin = 5, /obj/item/stock_parts/manipulator = 5)
+	products = list(/obj/item/clothing/under/rank/engineering/chief_engineer = 4,
+					/obj/item/clothing/under/rank/engineering/engineer = 40,
+					/obj/item/clothing/shoes/workboots = 4,
+					/obj/item/clothing/head/hardhat = 4,
+					/obj/item/storage/belt/utility = 4,
+					/obj/item/clothing/glasses/meson/engine = 4,
+					/obj/item/clothing/gloves/color/yellow = 4,
+					/obj/item/screwdriver = 12,
+					/obj/item/crowbar = 12,
+					/obj/item/wirecutters = 12,
+					/obj/item/multitool = 12,
+					/obj/item/wrench = 12,
+					/obj/item/t_scanner = 12,
+					/obj/item/stack/cable_coil = 8,
+					/obj/item/stock_parts/cell = 8,
+					/obj/item/weldingtool = 8,
+					/obj/item/clothing/head/welding = 8,
+					/obj/item/light/tube = 10,
+					/obj/item/clothing/suit/fire = 4,
+					/obj/item/stock_parts/scanning_module = 5,
+					/obj/item/stock_parts/micro_laser = 5,
+					/obj/item/stock_parts/matter_bin = 5,
+					/obj/item/stock_parts/manipulator = 5)
+
 	refill_canister = /obj/item/vending_refill/engineering
 
 /obj/machinery/economy/vending/robotics
@@ -33,16 +62,33 @@
 	category = VENDOR_TYPE_DEPARTMENTAL
 	icon_lightmask = "robotics"
 	req_access_txt = "29"
-	products = list(/obj/item/clothing/suit/storage/labcoat = 4, /obj/item/clothing/under/rank/rnd/roboticist = 4, /obj/item/stack/cable_coil = 4, /obj/item/flash = 4,
-					/obj/item/stock_parts/cell/high = 12, /obj/item/assembly/prox_sensor = 3, /obj/item/assembly/signaler = 3, /obj/item/healthanalyzer = 3,
-					/obj/item/scalpel = 2, /obj/item/circular_saw = 2, /obj/item/tank/internals/anesthetic = 2, /obj/item/clothing/mask/breath/medical = 5,
-					/obj/item/screwdriver = 5, /obj/item/crowbar = 5)
+	products = list(/obj/item/clothing/suit/storage/labcoat = 4,
+					/obj/item/clothing/under/rank/rnd/roboticist = 4,
+					/obj/item/stack/cable_coil = 4, /obj/item/flash = 4,
+					/obj/item/stock_parts/cell/high = 12,
+					/obj/item/assembly/prox_sensor = 3,
+					/obj/item/assembly/signaler = 3,
+					/obj/item/healthanalyzer = 3,
+					/obj/item/scalpel = 2,
+					/obj/item/circular_saw = 2,
+					/obj/item/tank/internals/anesthetic = 2,
+					/obj/item/clothing/mask/breath/medical = 5,
+					/obj/item/screwdriver = 5,
+					/obj/item/crowbar = 5)
+
 	refill_canister = /obj/item/vending_refill/robotics
 
 /obj/machinery/economy/vending/dinnerware
 	name = "\improper Plasteel Chef's Dinnerware Vendor"
 	desc = "A kitchen and restaurant equipment vendor."
-	ads_list = list("Mm, food stuffs!","Food and food accessories.","Get your plates!","You like forks?","I like forks.","Woo, utensils.","You don't really need these...")
+	ads_list = list("Mm, food stuffs!",
+					"Food and food accessories.",
+					"Get your plates!",
+					"You like forks?",
+					"I like forks.",
+					"Woo, utensils.",
+					"You don't really need these...")
+
 	icon_state = "dinnerware"
 	icon_lightmask = "dinnerware"
 	category = VENDOR_TYPE_DEPARTMENTAL
@@ -62,34 +108,65 @@
 					/obj/item/reagent_containers/food/condiment/peppermill =5,
 					/obj/item/whetstone = 2,
 					/obj/item/mixing_bowl = 10,
-					/obj/item/kitchen/mould/bear = 1, /obj/item/kitchen/mould/worm = 1,
-					/obj/item/kitchen/mould/bean = 1, /obj/item/kitchen/mould/ball = 1,
-					/obj/item/kitchen/mould/cane = 1, /obj/item/kitchen/mould/cash = 1,
-					/obj/item/kitchen/mould/coin = 1, /obj/item/kitchen/mould/loli = 1,
+					/obj/item/kitchen/mould/bear = 1,
+					/obj/item/kitchen/mould/worm = 1,
+					/obj/item/kitchen/mould/bean = 1,
+					/obj/item/kitchen/mould/ball = 1,
+					/obj/item/kitchen/mould/cane = 1,
+					/obj/item/kitchen/mould/cash = 1,
+					/obj/item/kitchen/mould/coin = 1,
+					/obj/item/kitchen/mould/loli = 1,
 					/obj/item/kitchen/cutter = 2)
-	contraband = list(/obj/item/kitchen/rollingpin = 2, /obj/item/kitchen/knife/butcher = 2)
+
+	contraband = list(/obj/item/kitchen/rollingpin = 2,
+					/obj/item/kitchen/knife/butcher = 2)
+
 	refill_canister = /obj/item/vending_refill/dinnerware
 
 /obj/machinery/economy/vending/hydronutrients
 	name = "\improper NutriMax"
 	desc = "A plant nutrients vendor."
-	slogan_list = list("Aren't you glad you don't have to fertilize the natural way?","Now with 50% less stink!","Plants are people too!")
-	ads_list = list("We like plants!","Don't you want some?","The greenest thumbs ever.","We like big plants.","Soft soil...")
+	slogan_list = list("Aren't you glad you don't have to fertilize the natural way?",
+					"Now with 50% less stink!","Plants are people too!")
+
+	ads_list = list("We like plants!",
+					"Don't you want some?",
+					"The greenest thumbs ever.",
+					"We like big plants.",
+					"Soft soil...")
+
 	icon_state = "nutri"
 	icon_deny = "nutri_deny"
 	icon_lightmask = "nutri"
 	icon_panel = "thin_vendor"
 	category = VENDOR_TYPE_DEPARTMENTAL
-	products = list(/obj/item/reagent_containers/glass/bottle/nutrient/ez = 20, /obj/item/reagent_containers/glass/bottle/nutrient/l4z = 13, /obj/item/reagent_containers/glass/bottle/nutrient/rh = 6, /obj/item/reagent_containers/spray/pestspray = 20,
-					/obj/item/reagent_containers/syringe = 5, /obj/item/storage/bag/plants = 5, /obj/item/cultivator = 3, /obj/item/shovel/spade = 3, /obj/item/plant_analyzer = 4)
-	contraband = list(/obj/item/reagent_containers/glass/bottle/ammonia = 10, /obj/item/reagent_containers/glass/bottle/diethylamine = 5)
+	products = list(/obj/item/reagent_containers/glass/bottle/nutrient/ez = 20,
+					/obj/item/reagent_containers/glass/bottle/nutrient/l4z = 13,
+					/obj/item/reagent_containers/glass/bottle/nutrient/rh = 6,
+					/obj/item/reagent_containers/spray/pestspray = 20,
+					/obj/item/reagent_containers/syringe = 5,
+					/obj/item/storage/bag/plants = 5,
+					/obj/item/cultivator = 3,
+					/obj/item/shovel/spade = 3,
+					/obj/item/plant_analyzer = 4)
+
+	contraband = list(/obj/item/reagent_containers/glass/bottle/ammonia = 10,
+					/obj/item/reagent_containers/glass/bottle/diethylamine = 5)
+
 	refill_canister = /obj/item/vending_refill/hydronutrients
 
 /obj/machinery/economy/vending/hydroseeds
 	name = "\improper MegaSeed Servitor"
 	desc = "When you need seeds fast!"
-	slogan_list = list("THIS'S WHERE TH' SEEDS LIVE! GIT YOU SOME!","Hands down the best seed selection on the station!","Also certain mushroom varieties available, more for experts! Get certified today!")
-	ads_list = list("We like plants!","Grow some crops!","Grow, baby, growww!","Aw h'yeah son!")
+	slogan_list = list("THIS'S WHERE TH' SEEDS LIVE! GIT YOU SOME!",
+					"Hands down the best seed selection on the station!",
+					"Also certain mushroom varieties available, more for experts! Get certified today!")
+
+	ads_list = list("We like plants!",
+					"Grow some crops!",
+					"Grow, baby, growww!",
+					"Aw h'yeah son!")
+
 	icon_state = "seeds"
 	icon_lightmask = "seeds"
 	icon_panel = "thin_vendor"
@@ -137,6 +214,7 @@
 					/obj/item/seeds/watermelon = 3,
 					/obj/item/seeds/wheat = 3,
 					/obj/item/seeds/whitebeet = 3)
+
 	contraband = list(/obj/item/seeds/cannabis = 3,
 					/obj/item/seeds/amanita = 2,
 					/obj/item/seeds/fungus = 3,
@@ -147,6 +225,7 @@
 					/obj/item/seeds/reishi = 2,
 					/obj/item/seeds/starthistle = 2,
 					/obj/item/seeds/random = 2)
+
 	refill_canister = /obj/item/vending_refill/hydroseeds
 
 /obj/machinery/economy/vending/medical
@@ -156,7 +235,14 @@
 	icon_lightmask = "med"
 	icon_deny = "med_deny"
 	icon_panel = "wide_vendor"
-	ads_list = list("Go save some lives!","The best stuff for your medbay.","Only the finest tools.","Natural chemicals!","This stuff saves lives.","Don't you want some?","Ping!")
+	ads_list = list("Go save some lives!",
+					"The best stuff for your medbay.",
+					"Only the finest tools.",
+					"Natural chemicals!",
+					"This stuff saves lives.",
+					"Don't you want some?",
+					"Ping!")
+
 	req_access_txt = "5"
 	category = VENDOR_TYPE_DEPARTMENTAL
 	products = list(/obj/item/reagent_containers/hypospray/autoinjector/epinephrine = 4,
@@ -189,9 +275,11 @@
 					/obj/item/healthanalyzer/advanced = 3,
 					/obj/item/sensor_device = 2,
 					/obj/item/pinpointer/crew = 2)
+
 	contraband = list(/obj/item/reagent_containers/syringe/insulin = 4,
 					/obj/item/reagent_containers/glass/bottle/sulfonal = 1,
 					/obj/item/reagent_containers/glass/bottle/pancuronium = 1)
+
 	armor = list(melee = 50, bullet = 20, laser = 20, energy = 20, bomb = 0, rad = 0, fire = 100, acid = 70)
 	resistance_flags = FIRE_PROOF
 	refill_canister = /obj/item/vending_refill/medical
@@ -204,14 +292,29 @@
 	name = "\improper Toximate 3000"
 	desc = "All the fine parts you need in one vending machine!"
 	category = VENDOR_TYPE_DEPARTMENTAL
-	products = list(/obj/item/assembly/prox_sensor = 8, /obj/item/assembly/igniter = 8, /obj/item/assembly/signaler = 8,
-					/obj/item/wirecutters = 1, /obj/item/assembly/timer = 8)
-	contraband = list(/obj/item/flashlight = 5, /obj/item/assembly/voice = 3, /obj/item/assembly/health = 3, /obj/item/assembly/infra = 3)
+	products = list(/obj/item/assembly/prox_sensor = 8,
+					/obj/item/assembly/igniter = 8,
+					/obj/item/assembly/signaler = 8,
+					/obj/item/wirecutters = 1,
+					/obj/item/assembly/timer = 8)
+
+	contraband = list(/obj/item/flashlight = 5,
+					/obj/item/assembly/voice = 3,
+					/obj/item/assembly/health = 3,
+					/obj/item/assembly/infra = 3)
 
 /obj/machinery/economy/vending/security
 	name = "\improper SecTech"
 	desc = "A security equipment vendor."
-	ads_list = list("Crack capitalist skulls!","Beat some heads in!","Don't forget - harm is good!","Your weapons are right here.","Handcuffs!","Freeze, scumbag!","Don't tase me bro!","Tase them, bro.","Why not have a donut?")
+	ads_list = list("Crack capitalist skulls!",
+					"Beat some heads in!",
+					"Don't forget - harm is good!",
+					"Your weapons are right here.",
+					"Handcuffs!","Freeze, scumbag!",
+					"Don't tase me bro!",
+					"Tase them, bro.",
+					"Why not have a donut?")
+
 	icon_state = "sec"
 	icon_lightmask = "sec"
 	icon_deny = "sec_deny"
@@ -229,7 +332,11 @@
 					/obj/item/restraints/legcuffs/bola/energy = 7,
 					/obj/item/clothing/mask/muzzle/safety = 4,
 					/obj/item/judobelt = 3)
-	contraband = list(/obj/item/clothing/glasses/sunglasses = 2, /obj/item/storage/fancy/donut_box = 2, /obj/item/hailer = 5)
+
+	contraband = list(/obj/item/clothing/glasses/sunglasses = 2,
+					/obj/item/storage/fancy/donut_box = 2,
+					/obj/item/hailer = 5)
+
 	refill_canister = /obj/item/vending_refill/security
 	prices = list(/obj/item/reagent_containers/food/snacks/donut = 40,
-					/obj/item/storage/fancy/donut_box = 200) //Bulk discount
+				/obj/item/storage/fancy/donut_box = 200) //Bulk discount

--- a/code/game/machinery/vendors/departmental_vendors.dm
+++ b/code/game/machinery/vendors/departmental_vendors.dm
@@ -280,7 +280,7 @@
 					/obj/item/reagent_containers/glass/bottle/sulfonal = 1,
 					/obj/item/reagent_containers/glass/bottle/pancuronium = 1)
 
-	armor = list(melee = 50, bullet = 20, laser = 20, energy = 20, bomb = 0, rad = 0, fire = 100, acid = 70)
+	armor = list(MELEE = 50, BULLET = 20, LASER = 20, ENERGY = 20, BOMB = 0, RAD = 0, FIRE = 100, ACID = 70)
 	resistance_flags = FIRE_PROOF
 	refill_canister = /obj/item/vending_refill/medical
 

--- a/code/game/machinery/vendors/generic_vendors.dm
+++ b/code/game/machinery/vendors/generic_vendors.dm
@@ -6,7 +6,8 @@
 					"The finest gear in space!")
 
 	products = list(/obj/item/assembly/prox_sensor = 4,
-					/obj/item/assembly/igniter = 4, /obj/item/assembly/signaler = 4,
+					/obj/item/assembly/igniter = 4,
+					/obj/item/assembly/signaler = 4,
 					/obj/item/wirecutters = 2,
 					/obj/item/cartridge/signal = 4)
 
@@ -570,8 +571,7 @@
 					/obj/item/staff = 2)
 
 	contraband = list(/obj/item/reagent_containers/glass/bottle/wizarditis = 1)
-
-	armor = list(melee = 100, bullet = 100, laser = 100, energy = 100, bomb = 0, rad = 0, fire = 100, acid = 50)
+	armor = list(MELEE = 100, BULLET = 100, LASER = 100, ENERGY = 100, BOMB = 0, RAD = 0, FIRE = 100, ACID = 50)
 	resistance_flags = FIRE_PROOF
 	tiltable = FALSE  // don't let a poor wizard screw themselves
 
@@ -1113,7 +1113,7 @@
 					/obj/item/fish_eggs/shrimp = 10,
 					/obj/item/toy/pet_rock = 5,
 					/obj/item/toy/pet_rock/fred = 1,
-					/obj/item/toy/pet_rock/roxie = 1,)
+					/obj/item/toy/pet_rock/roxie = 1)
 
 	prices = list(/obj/item/petcollar = 75,
 				/obj/item/storage/firstaid/aquatic_kit/full = 50,
@@ -1128,7 +1128,7 @@
 				/obj/item/fish_eggs/shrimp = 10,
 				/obj/item/toy/pet_rock = 50,
 				/obj/item/toy/pet_rock/fred = 75,
-				/obj/item/toy/pet_rock/roxie = 75,)
+				/obj/item/toy/pet_rock/roxie = 75)
 
 	contraband = list(/obj/item/fish_eggs/babycarp = 5)
 
@@ -1257,7 +1257,7 @@
 					/obj/item/reagent_containers/syringe/antiviral = 4,
 					/obj/item/reagent_containers/food/pill/tox = 1)
 
-	armor = list(melee = 50, bullet = 20, laser = 20, energy = 20, bomb = 0, rad = 0, fire = 100, acid = 70)
+	armor = list(MELEE = 50, BULLET = 20, LASER = 20, ENERGY = 20, BOMB = 0, RAD = 0, FIRE = 100, ACID = 70)
 	//this shouldn't be priced
 	resistance_flags = FIRE_PROOF
 	refill_canister = /obj/item/vending_refill/wallmed

--- a/code/game/machinery/vendors/generic_vendors.dm
+++ b/code/game/machinery/vendors/generic_vendors.dm
@@ -1,12 +1,30 @@
 //general-use clothing vendors, wardrobe vendors are in another file
 /obj/machinery/economy/vending/assist
-	ads_list = list("Only the finest!",  "Have some tools.",  "The most robust equipment.",  "The finest gear in space!")
-	products = list(/obj/item/assembly/prox_sensor = 4, /obj/item/assembly/igniter = 4, /obj/item/assembly/signaler = 4,
-						/obj/item/wirecutters = 2, /obj/item/cartridge/signal = 4)
-	contraband = list(/obj/item/flashlight = 4, /obj/item/assembly/timer = 2, /obj/item/assembly/voice = 2, /obj/item/assembly/health = 2)
-	prices = list(/obj/item/assembly/prox_sensor = 20, /obj/item/assembly/igniter = 20, /obj/item/assembly/signaler = 30,
-					/obj/item/wirecutters = 50, /obj/item/cartridge/signal = 75, /obj/item/flashlight = 40,
-					/obj/item/assembly/timer = 20, /obj/item/assembly/voice = 20, /obj/item/assembly/health = 20)
+	ads_list = list("Only the finest!",
+					"Have some tools.",
+					"The most robust equipment.",
+					"The finest gear in space!")
+
+	products = list(/obj/item/assembly/prox_sensor = 4,
+					/obj/item/assembly/igniter = 4, /obj/item/assembly/signaler = 4,
+					/obj/item/wirecutters = 2,
+					/obj/item/cartridge/signal = 4)
+
+	contraband = list(/obj/item/flashlight = 4,
+					/obj/item/assembly/timer = 2,
+					/obj/item/assembly/voice = 2,
+					/obj/item/assembly/health = 2)
+
+	prices = list(/obj/item/assembly/prox_sensor = 20,
+				/obj/item/assembly/igniter = 20,
+				/obj/item/assembly/signaler = 30,
+				/obj/item/wirecutters = 50,
+				/obj/item/cartridge/signal = 75,
+				/obj/item/flashlight = 40,
+				/obj/item/assembly/timer = 20,
+				/obj/item/assembly/voice = 20,
+				/obj/item/assembly/health = 20)
+
 	refill_canister = /obj/item/vending_refill/assist
 	category = VENDOR_TYPE_SUPPLIES
 
@@ -45,11 +63,31 @@
 					/obj/item/reagent_containers/food/drinks/drinkingglass = 30,
 					/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass = 30,
 					/obj/item/reagent_containers/food/drinks/ice = 9)
+
 	contraband = list(/obj/item/reagent_containers/food/drinks/tea = 10,
 					/obj/item/reagent_containers/food/drinks/bottle/fernet = 5)
+
 	vend_delay = 15
-	slogan_list = list("I hope nobody asks me for a bloody cup o' tea...","Alcohol is humanity's friend. Would you abandon a friend?","Quite delighted to serve you!","Is nobody thirsty on this station?")
-	ads_list = list("Drink up!","Booze is good for you!","Alcohol is humanity's best friend.","Quite delighted to serve you!","Care for a nice, cold beer?","Nothing cures you like booze!","Have a sip!","Have a drink!","Have a beer!","Beer is good for you!","Only the finest alcohol!","Best quality booze since 2053!","Award-winning wine!","Maximum alcohol!","Man loves beer.","A toast for progress!")
+	slogan_list = list("I hope nobody asks me for a bloody cup o' tea...",
+						"Alcohol is humanity's friend. Would you abandon a friend?",
+						"Quite delighted to serve you!",
+						"Is nobody thirsty on this station?")
+
+	ads_list = list("Drink up!",
+					"Booze is good for you!",
+					"Alcohol is humanity's best friend.",
+					"Quite delighted to serve you!",
+					"Care for a nice, cold beer?",
+					"Nothing cures you like booze!",
+					"Have a sip!","Have a drink!",
+					"Have a beer!","Beer is good for you!",
+					"Only the finest alcohol!",
+					"Best quality booze since 2053!",
+					"Award-winning wine!",
+					"Maximum alcohol!",
+					"Man loves beer.",
+					"A toast for progress!")
+
 	refill_canister = /obj/item/vending_refill/boozeomat
 
 /obj/machinery/economy/vending/boozeomat/syndicate_access
@@ -59,7 +97,21 @@
 /obj/machinery/economy/vending/coffee
 	name = "\improper Solar's Best Hot Drinks"
 	desc = "A vending machine which dispenses hot drinks."
-	ads_list = list("Have a drink!","Drink up!","It's good for you!","Would you like a hot joe?","I'd kill for some coffee!","The best beans in the galaxy.","Only the finest brew for you.","Mmmm. Nothing like a coffee.","I like coffee, don't you?","Coffee helps you work!","Try some tea.","We hope you like the best!","Try our new chocolate!","Admin conspiracies")
+	ads_list = list("Have a drink!",
+					"Drink up!",
+					"It's good for you!",
+					"Would you like a hot joe?",
+					"I'd kill for some coffee!",
+					"The best beans in the galaxy.",
+					"Only the finest brew for you.",
+					"Mmmm. Nothing like a coffee.",
+					"I like coffee, don't you?",
+					"Coffee helps you work!",
+					"Try some tea.",
+					"We hope you like the best!",
+					"Try our new chocolate!",
+					"Admin conspiracies")
+
 	icon_state = "coffee"
 	icon_lightmask = "coffee"
 	icon_vend = "coffee_vend"
@@ -67,12 +119,26 @@
 	item_slot = TRUE
 	vend_delay = 34
 	category = VENDOR_TYPE_DRINK
-	products = list(/obj/item/reagent_containers/food/drinks/coffee = 25, /obj/item/reagent_containers/food/drinks/tea = 25, /obj/item/reagent_containers/food/drinks/h_chocolate = 25,
-					/obj/item/reagent_containers/food/drinks/chocolate = 10, /obj/item/reagent_containers/food/drinks/chicken_soup = 10, /obj/item/reagent_containers/food/drinks/weightloss = 10,
-					/obj/item/reagent_containers/food/drinks/mug = 15, /obj/item/reagent_containers/food/drinks/mug/novelty = 5)
+	products = list(/obj/item/reagent_containers/food/drinks/coffee = 25,
+					/obj/item/reagent_containers/food/drinks/tea = 25,
+					/obj/item/reagent_containers/food/drinks/h_chocolate = 25,
+					/obj/item/reagent_containers/food/drinks/chocolate = 10,
+					/obj/item/reagent_containers/food/drinks/chicken_soup = 10,
+					/obj/item/reagent_containers/food/drinks/weightloss = 10,
+					/obj/item/reagent_containers/food/drinks/mug = 15,
+					/obj/item/reagent_containers/food/drinks/mug/novelty = 5)
+
 	contraband = list(/obj/item/reagent_containers/food/drinks/ice = 10)
-	prices = list(/obj/item/reagent_containers/food/drinks/coffee = 80, /obj/item/reagent_containers/food/drinks/tea = 80, /obj/item/reagent_containers/food/drinks/h_chocolate = 64, /obj/item/reagent_containers/food/drinks/chocolate = 120,
-				/obj/item/reagent_containers/food/drinks/chicken_soup = 100, /obj/item/reagent_containers/food/drinks/weightloss = 50, /obj/item/reagent_containers/food/drinks/mug = 75, /obj/item/reagent_containers/food/drinks/mug/novelty = 100)
+
+	prices = list(/obj/item/reagent_containers/food/drinks/coffee = 80,
+				/obj/item/reagent_containers/food/drinks/tea = 80,
+				/obj/item/reagent_containers/food/drinks/h_chocolate = 64,
+				/obj/item/reagent_containers/food/drinks/chocolate = 120,
+				/obj/item/reagent_containers/food/drinks/chicken_soup = 100,
+				/obj/item/reagent_containers/food/drinks/weightloss = 50,
+				/obj/item/reagent_containers/food/drinks/mug = 75,
+				/obj/item/reagent_containers/food/drinks/mug/novelty = 100)
+
 	refill_canister = /obj/item/vending_refill/coffee
 
 /obj/machinery/economy/vending/coffee/free
@@ -124,7 +190,11 @@
 	icon_panel = "syndi"
 	icon_broken = "wide_vendor"
 	category = VENDOR_TYPE_CLOTHING
-	ads_list = list("Warning, not all hats are dog/monkey compatible. Apply forcefully with care.","Apply directly to the forehead.","Who doesn't love spending cash on hats?!","From the people that brought you collectable hat crates, Hatlord!")
+	ads_list = list("Warning, not all hats are dog/monkey compatible. Apply forcefully with care.",
+					"Apply directly to the forehead.",
+					"Who doesn't love spending cash on hats?!",
+					"From the people that brought you collectable hat crates, Hatlord!")
+
 	products = list(/obj/item/clothing/head/that = 2,
 					/obj/item/clothing/head/bowlerhat = 10,
 					/obj/item/clothing/head/beaverhat = 10,
@@ -139,7 +209,9 @@
 					/obj/item/clothing/head/hairflower = 10,
 					/obj/item/clothing/head/mailman = 1,
 					/obj/item/clothing/head/soft/rainbow = 1)
+
 	contraband = list(/obj/item/clothing/head/bearpelt = 5)
+
 	prices = list(/obj/item/clothing/head/that = 30,
 				/obj/item/clothing/head/bowlerhat = 20,
 				/obj/item/clothing/head/beaverhat = 20,
@@ -155,6 +227,7 @@
 				/obj/item/clothing/head/mailman = 60,
 				/obj/item/clothing/head/soft/rainbow = 40,
 				/obj/item/clothing/head/bearpelt = 30)
+
 	refill_canister = /obj/item/vending_refill/hatdispenser
 
 /obj/machinery/economy/vending/suitdispenser
@@ -165,7 +238,12 @@
 	icon_panel = "syndi"
 	icon_broken = "wide_vendor"
 	category = VENDOR_TYPE_CLOTHING
-	ads_list = list("Pre-Ironed, Pre-Washed, Pre-Wor-*BZZT*","Blood of your enemies washes right out!","Who are YOU wearing?","Look dapper! Look like an idiot!","Dont carry your size? How about you shave off some pounds you fat lazy- *BZZT*")
+	ads_list = list("Pre-Ironed, Pre-Washed, Pre-Wor-*BZZT*",
+					"Blood of your enemies washes right out!",
+					"Who are YOU wearing?",
+					"Look dapper! Look like an idiot!",
+					"Dont carry your size? How about you shave off some pounds you fat lazy- *BZZT*")
+
 	products = list(/obj/item/clothing/under/color/black = 10,
 					/obj/item/clothing/under/dress/blackskirt = 10,
 					/obj/item/clothing/under/color/grey = 10,
@@ -188,8 +266,10 @@
 					/obj/item/clothing/under/color/lightpurple = 10,
 					/obj/item/clothing/under/color/pink = 10,
 					/obj/item/clothing/under/color/rainbow = 1)
+
 	contraband = list(/obj/item/clothing/under/syndicate/tacticool = 5,
 					/obj/item/clothing/under/color/orange/prison = 5)
+
 	prices = list(/obj/item/clothing/under/color/black = 30,
 				/obj/item/clothing/under/dress/blackskirt = 30,
 				/obj/item/clothing/under/color/grey = 30,
@@ -214,6 +294,7 @@
 				/obj/item/clothing/under/color/rainbow = 100,
 				/obj/item/clothing/under/syndicate/tacticool = 75,
 				/obj/item/clothing/under/color/orange/prison = 75)
+
 	refill_canister = /obj/item/vending_refill/suitdispenser
 
 /obj/machinery/economy/vending/shoedispenser
@@ -224,7 +305,12 @@
 	icon_panel = "syndi"
 	icon_broken = "wide_vendor"
 	category = VENDOR_TYPE_CLOTHING
-	ads_list = list("Put your foot down!","One size fits all!","IM WALKING ON SUNSHINE!","No hobbits allowed.","NO PLEASE WILLY, DONT HURT ME- *BZZT*")
+	ads_list = list("Put your foot down!",
+					"One size fits all!",
+					"IM WALKING ON SUNSHINE!",
+					"No hobbits allowed.",
+					"NO PLEASE WILLY, DONT HURT ME- *BZZT*")
+
 	products = list(/obj/item/clothing/shoes/black = 10,
 					/obj/item/clothing/shoes/brown = 10,
 					/obj/item/clothing/shoes/blue = 10,
@@ -240,7 +326,9 @@
 					/obj/item/clothing/shoes/cowboy = 10,
 					/obj/item/clothing/shoes/cowboy/black = 10,
 					/obj/item/clothing/shoes/rainbow = 1)
+
 	contraband = list(/obj/item/clothing/shoes/orange = 5)
+
 	prices= list(/obj/item/clothing/shoes/black = 20,
 				/obj/item/clothing/shoes/brown = 20,
 				/obj/item/clothing/shoes/blue = 20,
@@ -257,6 +345,7 @@
 				/obj/item/clothing/shoes/cowboy/black = 20,
 				/obj/item/clothing/shoes/orange = 40,
 				/obj/item/clothing/shoes/rainbow = 40)
+
 	refill_canister = /obj/item/vending_refill/shoedispenser
 
 //don't forget to change the refill size if you change the machine's contents!
@@ -266,7 +355,10 @@
 	icon_state = "clothes"
 	icon_lightmask = "base_drobe"
 	icon_panel = "drobe"
-	slogan_list = list("Dress for success!","Prepare to look swagalicious!","Look at all this free swag!","Why leave style up to fate? Use the ClothesMate!")
+	slogan_list = list("Dress for success!",
+					"Prepare to look swagalicious!",
+					"Look at all this free swag!",
+					"Why leave style up to fate? Use the ClothesMate!")
 	vend_delay = 15
 	vend_reply = "Thank you for using the ClothesMate!"
 	category = VENDOR_TYPE_CLOTHING
@@ -444,11 +536,22 @@
 	name = "\improper MagiVend"
 	desc = "A magic vending machine."
 	icon_state = "MagiVend"
-	slogan_list = list("Sling spells the proper way with MagiVend!","Be your own Houdini! Use MagiVend!")
+	slogan_list = list("Sling spells the proper way with MagiVend!",
+					"Be your own Houdini! Use MagiVend!")
 	vend_delay = 15
 	vend_reply = "Have an enchanted evening!"
 	category = VENDOR_TYPE_CLOTHING
-	ads_list = list("FJKLFJSD","AJKFLBJAKL","1234 LOONIES LOL!",">MFW","Kill them fuckers!","GET DAT FUKKEN DISK","HONK!","EI NATH","Destroy the station!","Admin conspiracies since forever!","Space-time bending hardware!")
+	ads_list = list("FJKLFJSD",
+					"AJKFLBJAKL",
+					"1234 LOONIES LOL!",
+					">MFW",
+					"Kill them fuckers!",
+					"GET DAT FUKKEN DISK",
+					"HONK!","EI NATH",
+					"Destroy the station!",
+					"Admin conspiracies since forever!",
+					"Space-time bending hardware!")
+
 	products = list(/obj/item/clothing/head/wizard = 1,
 					/obj/item/clothing/suit/wizrobe = 1,
 					/obj/item/clothing/head/wizard/red = 1,
@@ -465,7 +568,9 @@
 					/obj/item/clothing/mask/gas/mime/wizard = 1,
 					/obj/item/clothing/shoes/sandal/marisa = 1,
 					/obj/item/staff = 2)
+
 	contraband = list(/obj/item/reagent_containers/glass/bottle/wizarditis = 1)
+
 	armor = list(melee = 100, bullet = 100, laser = 100, energy = 100, bomb = 0, rad = 0, fire = 100, acid = 50)
 	resistance_flags = FIRE_PROOF
 	tiltable = FALSE  // don't let a poor wizard screw themselves
@@ -476,7 +581,11 @@
 	icon_state = "theater"
 	icon_lightmask = "theater"
 	icon_deny = "theater_deny"
-	slogan_list = list("Dress for success!","Suited and booted!","It's show time!","Why leave style up to fate? Use AutoDrobe!")
+	slogan_list = list("Dress for success!",
+					"Suited and booted!",
+					"It's show time!",
+					"Why leave style up to fate? Use AutoDrobe!")
+
 	vend_delay = 15
 	vend_reply = "Thank you for using AutoDrobe!"
 	category = VENDOR_TYPE_CLOTHING
@@ -587,6 +696,7 @@
 					/obj/item/shield/riot/roman/fake = 1,
 					/obj/item/clothing/under/costume/cuban_suit = 1,
 					/obj/item/clothing/head/cuban_hat = 1)
+
 	contraband = list(/obj/item/clothing/suit/judgerobe = 1,
 					/obj/item/clothing/head/powdered_wig = 1,
 					/obj/item/gun/magic/wand = 1,
@@ -594,112 +704,113 @@
 					/obj/item/clothing/mask/horsehead = 2)
 
 	prices = list(/obj/item/clothing/suit/chickensuit = 100,
-					/obj/item/clothing/head/chicken = 50,
-					/obj/item/clothing/under/costume/gladiator = 100,
-					/obj/item/clothing/head/helmet/gladiator = 50,
-					/obj/item/clothing/under/misc/gimmick/rank/captain/suit = 100,
-					/obj/item/clothing/head/flatcap = 30,
-					/obj/item/clothing/suit/storage/labcoat/mad = 75,
-					/obj/item/clothing/glasses/gglasses = 20,
-					/obj/item/clothing/under/dress/schoolgirl = 75,
-					/obj/item/clothing/suit/toggle/owlwings = 120,
-					/obj/item/clothing/under/costume/owl = 100,
-					/obj/item/clothing/mask/gas/owl_mask = 50,
-					/obj/item/clothing/suit/toggle/owlwings/griffinwings = 120,
-					/obj/item/clothing/under/costume/griffin = 100,
-					/obj/item/clothing/shoes/griffin = 30,
-					/obj/item/clothing/head/griffin = 50,
-					/obj/item/clothing/under/suit/black = 75,
-					/obj/item/clothing/head/that = 30,
-					/obj/item/clothing/under/costume/kilt = 75,
-					/obj/item/clothing/glasses/monocle = 30,
-					/obj/item/clothing/head/bowlerhat = 20,
-					/obj/item/cane = 50,
-					/obj/item/clothing/under/misc/sl_suit = 75,
-					/obj/item/clothing/mask/fakemoustache = 20,
-					/obj/item/clothing/suit/bio_suit/plaguedoctorsuit = 100,
-					/obj/item/clothing/head/plaguedoctorhat = 40,
-					/obj/item/clothing/mask/gas/plaguedoctor = 50,
-					/obj/item/clothing/suit/apron = 75,
-					/obj/item/clothing/under/misc/waiter = 75,
-					/obj/item/clothing/accessory/cowboyshirt = 75,
-					/obj/item/clothing/accessory/cowboyshirt/navy = 75,
-					/obj/item/clothing/under/costume/pirate = 100,
-					/obj/item/clothing/suit/pirate_brown = 100,
-					/obj/item/clothing/suit/pirate_black = 100,
-					/obj/item/clothing/under/costume/pirate_rags = 100,
-					/obj/item/clothing/head/pirate = 50,
-					/obj/item/clothing/under/costume/soviet = 100,
-					/obj/item/clothing/head/ushanka = 50,
-					/obj/item/clothing/suit/imperium_monk = 120,
-					/obj/item/clothing/mask/gas/cyborg = 50,
-					/obj/item/clothing/suit/holidaypriest = 100,
-					/obj/item/clothing/head/wizard/marisa/fake = 50,
-					/obj/item/clothing/suit/wizrobe/marisa/fake = 100,
-					/obj/item/clothing/under/dress/sundress = 75,
-					/obj/item/clothing/head/witchwig = 50,
-					/obj/item/staff/broom = 50,
-					/obj/item/clothing/suit/wizrobe/fake = 75,
-					/obj/item/clothing/head/wizard/fake = 75,
-					/obj/item/staff = 50,
-					/obj/item/clothing/mask/gas/clown_hat/sexy = 100,
-					/obj/item/clothing/under/rank/civilian/clown/sexy = 100,
-					/obj/item/clothing/mask/gas/sexymime = 100,
-					/obj/item/clothing/under/rank/civilian/mime/sexy = 100,
-					/obj/item/clothing/mask/face/bat = 100,
-					/obj/item/clothing/mask/face/bee = 100,
-					/obj/item/clothing/mask/face/bear = 100,
-					/obj/item/clothing/mask/face/raven = 100,
-					/obj/item/clothing/mask/face/jackal = 100,
-					/obj/item/clothing/mask/face/fox = 100,
-					/obj/item/clothing/mask/face/tribal = 100,
-					/obj/item/clothing/mask/face/rat = 100,
-					/obj/item/clothing/suit/apron/overalls = 75,
-					/obj/item/clothing/head/rabbitears = 75,
-					/obj/item/clothing/head/sombrero = 40,
-					/obj/item/clothing/suit/poncho = 75,
-					/obj/item/clothing/suit/poncho/green = 75,
-					/obj/item/clothing/suit/poncho/red = 75,
-					/obj/item/clothing/accessory/horrible = 30,
-					/obj/item/clothing/under/costume/maid = 75,
-					/obj/item/clothing/under/costume/janimaid = 75,
-					/obj/item/clothing/under/costume/jester = 100,
-					/obj/item/clothing/head/jester = 50,
-					/obj/item/clothing/under/pants/camo = 75,
-					/obj/item/clothing/shoes/singery = 20,
-					/obj/item/clothing/under/costume/singery = 75,
-					/obj/item/clothing/shoes/singerb = 20,
-					/obj/item/clothing/under/costume/singerb = 75,
-					/obj/item/clothing/suit/hooded/carp_costume = 120,
-					/obj/item/clothing/suit/hooded/bee_costume = 120,
-					/obj/item/clothing/suit/snowman = 120,
-					/obj/item/clothing/head/snowman = 50,
-					/obj/item/clothing/head/cueball = 50,
-					/obj/item/clothing/under/misc/scratch = 75,
-					/obj/item/clothing/under/dress/victdress = 100,
-					/obj/item/clothing/under/dress/victdress/red = 100,
-					/obj/item/clothing/suit/victcoat = 100,
-					/obj/item/clothing/suit/victcoat/red = 100,
-					/obj/item/clothing/under/suit/victsuit = 100,
-					/obj/item/clothing/under/suit/victsuit/redblk = 100,
-					/obj/item/clothing/under/suit/victsuit/red = 100,
-					/obj/item/clothing/suit/tailcoat = 75,
-					/obj/item/clothing/under/costume/tourist_suit = 75,
-					/obj/item/clothing/suit/draculacoat = 100,
-					/obj/item/clothing/head/zepelli = 50,
-					/obj/item/clothing/under/misc/redhawaiianshirt = 75,
-					/obj/item/clothing/under/misc/pinkhawaiianshirt = 75,
-					/obj/item/clothing/under/misc/bluehawaiianshirt = 75,
-					/obj/item/clothing/under/misc/orangehawaiianshirt = 75,
-					/obj/item/clothing/suit/hgpirate = 125,
-					/obj/item/clothing/head/hgpiratecap = 75,
-					/obj/item/clothing/head/helmet/roman/fake = 75,
-					/obj/item/clothing/head/helmet/roman/legionaire/fake = 75,
-					/obj/item/clothing/under/costume/roman = 125,
-					/obj/item/clothing/shoes/roman = 40,
-					/obj/item/shield/riot/roman/fake = 75,
-					/obj/item/clothing/under/costume/cuban_suit = 125,
-					/obj/item/clothing/head/cuban_hat = 75)
+				/obj/item/clothing/head/chicken = 50,
+				/obj/item/clothing/under/costume/gladiator = 100,
+				/obj/item/clothing/head/helmet/gladiator = 50,
+				/obj/item/clothing/under/misc/gimmick/rank/captain/suit = 100,
+				/obj/item/clothing/head/flatcap = 30,
+				/obj/item/clothing/suit/storage/labcoat/mad = 75,
+				/obj/item/clothing/glasses/gglasses = 20,
+				/obj/item/clothing/under/dress/schoolgirl = 75,
+				/obj/item/clothing/suit/toggle/owlwings = 120,
+				/obj/item/clothing/under/costume/owl = 100,
+				/obj/item/clothing/mask/gas/owl_mask = 50,
+				/obj/item/clothing/suit/toggle/owlwings/griffinwings = 120,
+				/obj/item/clothing/under/costume/griffin = 100,
+				/obj/item/clothing/shoes/griffin = 30,
+				/obj/item/clothing/head/griffin = 50,
+				/obj/item/clothing/under/suit/black = 75,
+				/obj/item/clothing/head/that = 30,
+				/obj/item/clothing/under/costume/kilt = 75,
+				/obj/item/clothing/glasses/monocle = 30,
+				/obj/item/clothing/head/bowlerhat = 20,
+				/obj/item/cane = 50,
+				/obj/item/clothing/under/misc/sl_suit = 75,
+				/obj/item/clothing/mask/fakemoustache = 20,
+				/obj/item/clothing/suit/bio_suit/plaguedoctorsuit = 100,
+				/obj/item/clothing/head/plaguedoctorhat = 40,
+				/obj/item/clothing/mask/gas/plaguedoctor = 50,
+				/obj/item/clothing/suit/apron = 75,
+				/obj/item/clothing/under/misc/waiter = 75,
+				/obj/item/clothing/accessory/cowboyshirt = 75,
+				/obj/item/clothing/accessory/cowboyshirt/navy = 75,
+				/obj/item/clothing/under/costume/pirate = 100,
+				/obj/item/clothing/suit/pirate_brown = 100,
+				/obj/item/clothing/suit/pirate_black = 100,
+				/obj/item/clothing/under/costume/pirate_rags = 100,
+				/obj/item/clothing/head/pirate = 50,
+				/obj/item/clothing/under/costume/soviet = 100,
+				/obj/item/clothing/head/ushanka = 50,
+				/obj/item/clothing/suit/imperium_monk = 120,
+				/obj/item/clothing/mask/gas/cyborg = 50,
+				/obj/item/clothing/suit/holidaypriest = 100,
+				/obj/item/clothing/head/wizard/marisa/fake = 50,
+				/obj/item/clothing/suit/wizrobe/marisa/fake = 100,
+				/obj/item/clothing/under/dress/sundress = 75,
+				/obj/item/clothing/head/witchwig = 50,
+				/obj/item/staff/broom = 50,
+				/obj/item/clothing/suit/wizrobe/fake = 75,
+				/obj/item/clothing/head/wizard/fake = 75,
+				/obj/item/staff = 50,
+				/obj/item/clothing/mask/gas/clown_hat/sexy = 100,
+				/obj/item/clothing/under/rank/civilian/clown/sexy = 100,
+				/obj/item/clothing/mask/gas/sexymime = 100,
+				/obj/item/clothing/under/rank/civilian/mime/sexy = 100,
+				/obj/item/clothing/mask/face/bat = 100,
+				/obj/item/clothing/mask/face/bee = 100,
+				/obj/item/clothing/mask/face/bear = 100,
+				/obj/item/clothing/mask/face/raven = 100,
+				/obj/item/clothing/mask/face/jackal = 100,
+				/obj/item/clothing/mask/face/fox = 100,
+				/obj/item/clothing/mask/face/tribal = 100,
+				/obj/item/clothing/mask/face/rat = 100,
+				/obj/item/clothing/suit/apron/overalls = 75,
+				/obj/item/clothing/head/rabbitears = 75,
+				/obj/item/clothing/head/sombrero = 40,
+				/obj/item/clothing/suit/poncho = 75,
+				/obj/item/clothing/suit/poncho/green = 75,
+				/obj/item/clothing/suit/poncho/red = 75,
+				/obj/item/clothing/accessory/horrible = 30,
+				/obj/item/clothing/under/costume/maid = 75,
+				/obj/item/clothing/under/costume/janimaid = 75,
+				/obj/item/clothing/under/costume/jester = 100,
+				/obj/item/clothing/head/jester = 50,
+				/obj/item/clothing/under/pants/camo = 75,
+				/obj/item/clothing/shoes/singery = 20,
+				/obj/item/clothing/under/costume/singery = 75,
+				/obj/item/clothing/shoes/singerb = 20,
+				/obj/item/clothing/under/costume/singerb = 75,
+				/obj/item/clothing/suit/hooded/carp_costume = 120,
+				/obj/item/clothing/suit/hooded/bee_costume = 120,
+				/obj/item/clothing/suit/snowman = 120,
+				/obj/item/clothing/head/snowman = 50,
+				/obj/item/clothing/head/cueball = 50,
+				/obj/item/clothing/under/misc/scratch = 75,
+				/obj/item/clothing/under/dress/victdress = 100,
+				/obj/item/clothing/under/dress/victdress/red = 100,
+				/obj/item/clothing/suit/victcoat = 100,
+				/obj/item/clothing/suit/victcoat/red = 100,
+				/obj/item/clothing/under/suit/victsuit = 100,
+				/obj/item/clothing/under/suit/victsuit/redblk = 100,
+				/obj/item/clothing/under/suit/victsuit/red = 100,
+				/obj/item/clothing/suit/tailcoat = 75,
+				/obj/item/clothing/under/costume/tourist_suit = 75,
+				/obj/item/clothing/suit/draculacoat = 100,
+				/obj/item/clothing/head/zepelli = 50,
+				/obj/item/clothing/under/misc/redhawaiianshirt = 75,
+				/obj/item/clothing/under/misc/pinkhawaiianshirt = 75,
+				/obj/item/clothing/under/misc/bluehawaiianshirt = 75,
+				/obj/item/clothing/under/misc/orangehawaiianshirt = 75,
+				/obj/item/clothing/suit/hgpirate = 125,
+				/obj/item/clothing/head/hgpiratecap = 75,
+				/obj/item/clothing/head/helmet/roman/fake = 75,
+				/obj/item/clothing/head/helmet/roman/legionaire/fake = 75,
+				/obj/item/clothing/under/costume/roman = 125,
+				/obj/item/clothing/shoes/roman = 40,
+				/obj/item/shield/riot/roman/fake = 75,
+				/obj/item/clothing/under/costume/cuban_suit = 125,
+				/obj/item/clothing/head/cuban_hat = 75)
+
 	refill_canister = /obj/item/vending_refill/autodrobe
 
 
@@ -709,8 +820,20 @@
 /obj/machinery/economy/vending/sustenance
 	name = "\improper Sustenance Vendor"
 	desc = "A vending machine which vends food, as required by section 47-C of the NT's Prisoner Ethical Treatment Agreement."
-	slogan_list = list("Enjoy your meal.","Enough calories to support strenuous labor.")
-	ads_list = list("The healthiest!","Award-winning chocolate bars!","Mmm! So good!","Oh my god it's so juicy!","Have a snack.","Snacks are good for you!","Have some more Getmore!","Best quality snacks straight from mars.","We love chocolate!","Try our new jerky!")
+	slogan_list = list("Enjoy your meal.",
+					"Enough calories to support strenuous labor.")
+
+	ads_list = list("The healthiest!",
+					"Award-winning chocolate bars!",
+					"Mmm! So good!",
+					"Oh my god it's so juicy!",
+					"Have a snack.",
+					"Snacks are good for you!",
+					"Have some more Getmore!",
+					"Best quality snacks straight from mars.",
+					"We love chocolate!",
+					"Try our new jerky!")
+
 	icon_state = "sustenance"
 	icon_lightmask = "nutri"
 	icon_off = "nutri"
@@ -719,10 +842,12 @@
 	products = list(/obj/item/reagent_containers/food/snacks/tofu = 24,
 					/obj/item/reagent_containers/food/drinks/ice = 12,
 					/obj/item/reagent_containers/food/snacks/candy/candy_corn = 6)
+
 	contraband = list(/obj/item/kitchen/knife = 6,
 					/obj/item/reagent_containers/food/drinks/coffee = 12,
 					/obj/item/tank/internals/emergency_oxygen = 6,
 					/obj/item/clothing/mask/breath = 6)
+
 	refill_canister = /obj/item/vending_refill/sustenance
 
 /obj/machinery/economy/vending/sovietsoda
@@ -731,30 +856,68 @@
 	icon_state = "sovietsoda"
 	icon_lightmask = "sovietsoda"
 	category = VENDOR_TYPE_DRINK
-	ads_list = list("For Tsar and Country.","Have you fulfilled your nutrition quota today?","Very nice!","We are simple people, for this is all we eat.","If there is a person, there is a problem. If there is no person, then there is no problem.")
+	ads_list = list("For Tsar and Country.",
+					"Have you fulfilled your nutrition quota today?",
+					"Very nice!",
+					"We are simple people, for this is all we eat.",
+					"If there is a person, there is a problem. If there is no person, then there is no problem.")
+
 	products = list(/obj/item/reagent_containers/food/drinks/cans/sodawater = 10)
+
 	contraband = list(/obj/item/reagent_containers/food/drinks/cans/cola = 7)
+
 	resistance_flags = FIRE_PROOF
 	refill_canister = /obj/item/vending_refill/sovietsoda
 
 /obj/machinery/economy/vending/snack
 	name = "\improper Getmore Chocolate Corp"
 	desc = "A snack machine courtesy of the Getmore Chocolate Corporation, based out of Mars."
-	slogan_list = list("Try our new nougat bar!","Twice the calories for half the price!")
-	ads_list = list("The healthiest!","Award-winning chocolate bars!","Mmm! So good!","Oh my god it's so juicy!","Have a snack.","Snacks are good for you!","Have some more Getmore!","Best quality snacks straight from mars.","We love chocolate!","Try our new jerky!")
+	slogan_list = list("Try our new nougat bar!",
+					"Twice the calories for half the price!")
+
+	ads_list = list("The healthiest!",
+					"Award-winning chocolate bars!",
+					"Mmm! So good!",
+					"Oh my god it's so juicy!",
+					"Have a snack.",
+					"Snacks are good for you!",
+					"Have some more Getmore!",
+					"Best quality snacks straight from mars.",
+					"We love chocolate!",
+					"Try our new jerky!")
+
 	icon_state = "snack"
 	icon_lightmask = "nutri"
 	icon_off = "nutri"
 	icon_panel = "thin_vendor"
 	category = VENDOR_TYPE_FOOD
-	products = list(/obj/item/reagent_containers/food/snacks/candy/candybar = 6, /obj/item/reagent_containers/food/drinks/dry_ramen = 6, /obj/item/reagent_containers/food/snacks/chips = 6, /obj/item/reagent_containers/food/snacks/twimsts = 6,
-					/obj/item/reagent_containers/food/snacks/sosjerky = 6, /obj/item/reagent_containers/food/snacks/no_raisin = 6, /obj/item/reagent_containers/food/snacks/pistachios = 6,
-					/obj/item/reagent_containers/food/snacks/spacetwinkie = 6, /obj/item/reagent_containers/food/snacks/cheesiehonkers = 6, /obj/item/reagent_containers/food/snacks/tastybread = 6, /obj/item/reagent_containers/food/snacks/stroopwafel = 2)
+	products = list(/obj/item/reagent_containers/food/snacks/candy/candybar = 6,
+					/obj/item/reagent_containers/food/drinks/dry_ramen = 6,
+					/obj/item/reagent_containers/food/snacks/chips = 6,
+					/obj/item/reagent_containers/food/snacks/twimsts = 6,
+					/obj/item/reagent_containers/food/snacks/sosjerky = 6,
+					/obj/item/reagent_containers/food/snacks/no_raisin = 6,
+					/obj/item/reagent_containers/food/snacks/pistachios = 6,
+					/obj/item/reagent_containers/food/snacks/spacetwinkie = 6,
+					/obj/item/reagent_containers/food/snacks/cheesiehonkers = 6,
+					/obj/item/reagent_containers/food/snacks/tastybread = 6,
+					/obj/item/reagent_containers/food/snacks/stroopwafel = 2)
+
 	contraband = list(/obj/item/reagent_containers/food/snacks/syndicake = 6)
-	prices = list(/obj/item/reagent_containers/food/snacks/candy/candybar = 64, /obj/item/reagent_containers/food/drinks/dry_ramen = 32, /obj/item/reagent_containers/food/snacks/chips = 64, /obj/item/reagent_containers/food/snacks/twimsts = 64,
-					/obj/item/reagent_containers/food/snacks/sosjerky = 64, /obj/item/reagent_containers/food/snacks/no_raisin = 80, /obj/item/reagent_containers/food/snacks/pistachios = 80,
-					/obj/item/reagent_containers/food/snacks/spacetwinkie = 64, /obj/item/reagent_containers/food/snacks/cheesiehonkers = 64,/obj/item/reagent_containers/food/snacks/tastybread = 80,
-					/obj/item/reagent_containers/food/snacks/stroopwafel = 100, /obj/item/reagent_containers/food/snacks/syndicake = 175) //syndicakes are genuinely kind of powerful
+
+	prices = list(/obj/item/reagent_containers/food/snacks/candy/candybar = 64,
+				/obj/item/reagent_containers/food/drinks/dry_ramen = 32,
+				/obj/item/reagent_containers/food/snacks/chips = 64,
+				/obj/item/reagent_containers/food/snacks/twimsts = 64,
+				/obj/item/reagent_containers/food/snacks/sosjerky = 64,
+				/obj/item/reagent_containers/food/snacks/no_raisin = 80,
+				/obj/item/reagent_containers/food/snacks/pistachios = 80,
+				/obj/item/reagent_containers/food/snacks/spacetwinkie = 64,
+				/obj/item/reagent_containers/food/snacks/cheesiehonkers = 64,
+				/obj/item/reagent_containers/food/snacks/tastybread = 80,
+				/obj/item/reagent_containers/food/snacks/stroopwafel = 100,
+				/obj/item/reagent_containers/food/snacks/syndicake = 175) //syndicakes are genuinely kind of powerful
+
 	refill_canister = /obj/item/vending_refill/snack
 
 /obj/machinery/economy/vending/snack/free
@@ -763,14 +926,28 @@
 /obj/machinery/economy/vending/chinese
 	name = "\improper Mr. Chang"
 	desc = "A self-serving Chinese food machine, for all your Chinese food needs."
-	slogan_list = list("Taste 5000 years of culture!","Mr. Chang, approved for safe consumption in over 10 sectors!","Chinese food is great for a date night, or a lonely night!","You can't go wrong with Mr. Chang's authentic Chinese food!")
+	slogan_list = list("Taste 5000 years of culture!",
+					"Mr. Chang, approved for safe consumption in over 10 sectors!",
+					"Chinese food is great for a date night, or a lonely night!",
+					"You can't go wrong with Mr. Chang's authentic Chinese food!")
+
 	icon_state = "chang"
 	icon_lightmask = "chang"
 	category = VENDOR_TYPE_FOOD
-	products = list(/obj/item/reagent_containers/food/snacks/chinese/chowmein = 6, /obj/item/reagent_containers/food/snacks/chinese/tao = 6, /obj/item/reagent_containers/food/snacks/chinese/sweetsourchickenball = 6, /obj/item/reagent_containers/food/snacks/chinese/newdles = 6,
-					/obj/item/reagent_containers/food/snacks/chinese/rice = 6, /obj/item/reagent_containers/food/snacks/fortunecookie = 6)
-	prices = list(/obj/item/reagent_containers/food/snacks/chinese/chowmein = 125, /obj/item/reagent_containers/food/snacks/chinese/tao = 125, /obj/item/reagent_containers/food/snacks/chinese/sweetsourchickenball = 125, /obj/item/reagent_containers/food/snacks/chinese/newdles = 100,
-					/obj/item/reagent_containers/food/snacks/chinese/rice = 100, /obj/item/reagent_containers/food/snacks/fortunecookie = 50)
+	products = list(/obj/item/reagent_containers/food/snacks/chinese/chowmein = 6,
+					/obj/item/reagent_containers/food/snacks/chinese/tao = 6,
+					/obj/item/reagent_containers/food/snacks/chinese/sweetsourchickenball = 6,
+					/obj/item/reagent_containers/food/snacks/chinese/newdles = 6,
+					/obj/item/reagent_containers/food/snacks/chinese/rice = 6,
+					/obj/item/reagent_containers/food/snacks/fortunecookie = 6)
+
+	prices = list(/obj/item/reagent_containers/food/snacks/chinese/chowmein = 125,
+				/obj/item/reagent_containers/food/snacks/chinese/tao = 125,
+				/obj/item/reagent_containers/food/snacks/chinese/sweetsourchickenball = 125,
+				/obj/item/reagent_containers/food/snacks/chinese/newdles = 100,
+				/obj/item/reagent_containers/food/snacks/chinese/rice = 100,
+				/obj/item/reagent_containers/food/snacks/fortunecookie = 50)
+
 	refill_canister = /obj/item/vending_refill/chinese
 
 /obj/machinery/economy/vending/chinese/free
@@ -783,15 +960,33 @@
 	icon_lightmask = "Cola_Machine"
 	icon_panel = "thin_vendor"
 	slogan_list = list("Robust Softdrinks: More robust than a toolbox to the head!")
-	ads_list = list("Refreshing!","Hope you're thirsty!","Over 1 million drinks sold!","Thirsty? Why not cola?","Please, have a drink!","Drink up!","The best drinks in space.")
+	ads_list = list("Refreshing!",
+					"Hope you're thirsty!",
+					"Over 1 million drinks sold!",
+					"Thirsty? Why not cola?",
+					"Please, have a drink!",
+					"Drink up!",
+					"The best drinks in space.")
+
 	category = VENDOR_TYPE_DRINK
-	products = list(/obj/item/reagent_containers/food/drinks/cans/cola = 10, /obj/item/reagent_containers/food/drinks/cans/space_mountain_wind = 10,
-					/obj/item/reagent_containers/food/drinks/cans/dr_gibb = 10, /obj/item/reagent_containers/food/drinks/cans/starkist = 10,
-					/obj/item/reagent_containers/food/drinks/cans/space_up = 10, /obj/item/reagent_containers/food/drinks/cans/grape_juice = 10, /obj/item/reagent_containers/glass/beaker/waterbottle = 10)
+	products = list(/obj/item/reagent_containers/food/drinks/cans/cola = 10,
+					/obj/item/reagent_containers/food/drinks/cans/space_mountain_wind = 10,
+					/obj/item/reagent_containers/food/drinks/cans/dr_gibb = 10,
+					/obj/item/reagent_containers/food/drinks/cans/starkist = 10,
+					/obj/item/reagent_containers/food/drinks/cans/space_up = 10,
+					/obj/item/reagent_containers/food/drinks/cans/grape_juice = 10,
+					/obj/item/reagent_containers/glass/beaker/waterbottle = 10)
+
 	contraband = list(/obj/item/reagent_containers/food/drinks/cans/thirteenloko = 5)
-	prices = list(/obj/item/reagent_containers/food/drinks/cans/cola = 45, /obj/item/reagent_containers/food/drinks/cans/space_mountain_wind = 50,
-					/obj/item/reagent_containers/food/drinks/cans/dr_gibb = 50, /obj/item/reagent_containers/food/drinks/cans/starkist = 50,
-					/obj/item/reagent_containers/food/drinks/cans/space_up = 50, /obj/item/reagent_containers/food/drinks/cans/grape_juice = 50, /obj/item/reagent_containers/glass/beaker/waterbottle = 20)
+
+	prices = list(/obj/item/reagent_containers/food/drinks/cans/cola = 45,
+				/obj/item/reagent_containers/food/drinks/cans/space_mountain_wind = 50,
+				/obj/item/reagent_containers/food/drinks/cans/dr_gibb = 50,
+				/obj/item/reagent_containers/food/drinks/cans/starkist = 50,
+				/obj/item/reagent_containers/food/drinks/cans/space_up = 50,
+				/obj/item/reagent_containers/food/drinks/cans/grape_juice = 50,
+				/obj/item/reagent_containers/glass/beaker/waterbottle = 20)
+
 	refill_canister = /obj/item/vending_refill/cola
 
 /obj/machinery/economy/vending/cola/free
@@ -801,8 +996,16 @@
 /obj/machinery/economy/vending/artvend
 	name = "\improper ArtVend"
 	desc = "A vending machine for art supplies."
-	slogan_list = list("Stop by for all your artistic needs!","Color the floors with crayons, not blood!","Don't be a starving artist, use ArtVend. ","Don't fart, do art!")
-	ads_list = list("Just like Kindergarten!","Now with 1000% more vibrant colors!","Screwing with the janitor was never so easy!","Creativity is at the heart of every spessman.")
+	slogan_list = list("Stop by for all your artistic needs!",
+					"Color the floors with crayons, not blood!",
+					"Don't be a starving artist, use ArtVend. ",
+					"Don't fart, do art!")
+
+	ads_list = list("Just like Kindergarten!",
+					"Now with 1000% more vibrant colors!",
+					"Screwing with the janitor was never so easy!",
+					"Creativity is at the heart of every spessman.")
+
 	vend_delay = 15
 	icon_state = "artvend"
 	icon_lightmask = "artvend"
@@ -824,9 +1027,11 @@
 					/obj/item/pen/blue = 5,
 					/obj/item/pen/red = 5,
 					/obj/item/pen/fancy = 2)
+
 	contraband = list(/obj/item/toy/crayon/mime = 1,
 					/obj/item/toy/crayon/rainbow = 1,
 					/obj/item/poster/random_contraband = 5)
+
 	prices = list(/obj/item/stack/cable_coil/random = 20,
 				/obj/item/toner = 40,
 				/obj/item/pen/fancy = 40)
@@ -851,8 +1056,10 @@
 					/obj/item/stack/cable_coil/random = 10,
 					/obj/item/clothing/gloves/color/yellow = 1,
 					/obj/item/crowbar/large = 1)
+
 	contraband = list(/obj/item/clothing/gloves/color/fyellow = 2,
 					/obj/item/weldingtool/hugetank = 2)
+
 	prices = list(/obj/item/crowbar = 75,
 				/obj/item/screwdriver = 50,
 				/obj/item/weldingtool = 100,
@@ -864,6 +1071,7 @@
 				/obj/item/clothing/gloves/color/yellow = 250,
 				/obj/item/weldingtool/hugetank = 120,
 				/obj/item/crowbar/large = 150)
+
 	refill_canister = /obj/item/vending_refill/youtool
 
 /// we want a free version for engineering to use
@@ -874,26 +1082,56 @@
 /obj/machinery/economy/vending/crittercare
 	name = "\improper CritterCare"
 	desc = "A vending machine for pet supplies."
-	slogan_list = list("Stop by for all your animal's needs!","Cuddly pets deserve a stylish collar!","Pets in space, what could be more adorable?","Freshest fish eggs in the system!","Rocks are the perfect pet, buy one today!")
-	ads_list = list("House-training costs extra!","Now with 1000% more cat hair!","Allergies are a sign of weakness!","Dogs are man's best friend. Remember that Vulpkanin!"," Heat lamps for Unathi!"," Vox-y want a cracker?")
+	slogan_list = list("Stop by for all your animal's needs!",
+					"Cuddly pets deserve a stylish collar!",
+					"Pets in space, what could be more adorable?",
+					"Freshest fish eggs in the system!",
+					"Rocks are the perfect pet, buy one today!")
+
+	ads_list = list("House-training costs extra!",
+					"Now with 1000% more cat hair!",
+					"Allergies are a sign of weakness!",
+					"Dogs are man's best friend. Remember that Vulpkanin!",
+					"Heat lamps for Unathi!",
+					"Vox-y want a cracker?")
+
 	vend_delay = 15
 	icon_state = "crittercare"
 	icon_lightmask = "crittercare"
 	icon_panel = "drobe"
 	category = VENDOR_TYPE_SUPPLIES
-	products = list(/obj/item/petcollar = 5, /obj/item/storage/firstaid/aquatic_kit/full =5, /obj/item/fish_eggs/goldfish = 5,
-					/obj/item/fish_eggs/clownfish = 5, /obj/item/fish_eggs/shark = 5, /obj/item/fish_eggs/feederfish = 10,
-					/obj/item/fish_eggs/salmon = 5, /obj/item/fish_eggs/catfish = 5, /obj/item/fish_eggs/glofish = 5,
-					/obj/item/fish_eggs/electric_eel = 5, /obj/item/fish_eggs/shrimp = 10, /obj/item/toy/pet_rock = 5,
-					/obj/item/toy/pet_rock/fred = 1, /obj/item/toy/pet_rock/roxie = 1,
-					)
-	prices = list(/obj/item/petcollar = 75, /obj/item/storage/firstaid/aquatic_kit/full = 50, /obj/item/fish_eggs/goldfish = 10,
-					/obj/item/fish_eggs/clownfish = 30, /obj/item/fish_eggs/shark = 30, /obj/item/fish_eggs/feederfish = 20,
-					/obj/item/fish_eggs/salmon = 30, /obj/item/fish_eggs/catfish = 30, /obj/item/fish_eggs/glofish = 10,
-					/obj/item/fish_eggs/electric_eel = 30, /obj/item/fish_eggs/shrimp = 10, /obj/item/toy/pet_rock = 50,
-					/obj/item/toy/pet_rock/fred = 75, /obj/item/toy/pet_rock/roxie = 75,
-					)
+	products = list(/obj/item/petcollar = 5,
+					/obj/item/storage/firstaid/aquatic_kit/full =5,
+					/obj/item/fish_eggs/goldfish = 5,
+					/obj/item/fish_eggs/clownfish = 5,
+					/obj/item/fish_eggs/shark = 5,
+					/obj/item/fish_eggs/feederfish = 10,
+					/obj/item/fish_eggs/salmon = 5,
+					/obj/item/fish_eggs/catfish = 5,
+					/obj/item/fish_eggs/glofish = 5,
+					/obj/item/fish_eggs/electric_eel = 5,
+					/obj/item/fish_eggs/shrimp = 10,
+					/obj/item/toy/pet_rock = 5,
+					/obj/item/toy/pet_rock/fred = 1,
+					/obj/item/toy/pet_rock/roxie = 1,)
+
+	prices = list(/obj/item/petcollar = 75,
+				/obj/item/storage/firstaid/aquatic_kit/full = 50,
+				/obj/item/fish_eggs/goldfish = 10,
+				/obj/item/fish_eggs/clownfish = 30,
+				/obj/item/fish_eggs/shark = 30,
+				/obj/item/fish_eggs/feederfish = 20,
+				/obj/item/fish_eggs/salmon = 30,
+				/obj/item/fish_eggs/catfish = 30,
+				/obj/item/fish_eggs/glofish = 10,
+				/obj/item/fish_eggs/electric_eel = 30,
+				/obj/item/fish_eggs/shrimp = 10,
+				/obj/item/toy/pet_rock = 50,
+				/obj/item/toy/pet_rock/fred = 75,
+				/obj/item/toy/pet_rock/roxie = 75,)
+
 	contraband = list(/obj/item/fish_eggs/babycarp = 5)
+
 	refill_canister = /obj/item/vending_refill/crittercare
 
 /obj/machinery/economy/vending/crittercare/free
@@ -902,37 +1140,51 @@
 /obj/machinery/economy/vending/cigarette
 	name = "\improper ShadyCigs Deluxe"
 	desc = "If you want to get cancer, might as well do it in style."
-	slogan_list = list("Space cigs taste good like a cigarette should.","I'd rather toolbox than switch.","Smoke!","Don't believe the reports - smoke today!")
-	ads_list = list("Probably not bad for you!","Don't believe the scientists!","It's good for you!","Don't quit, buy more!","Smoke!","Nicotine heaven.","Best cigarettes since 2150.","Award-winning cigs.")
+	slogan_list = list("Space cigs taste good like a cigarette should.",
+					"I'd rather toolbox than switch.",
+					"Smoke!",
+					"Don't believe the reports - smoke today!")
+
+	ads_list = list("Probably not bad for you!",
+					"Don't believe the scientists!",
+					"It's good for you!",
+					"Don't quit, buy more!",
+					"Smoke!",
+					"Nicotine heaven.",
+					"Best cigarettes since 2150.",
+					"Award-winning cigs.")
+
 	vend_delay = 34
 	icon_state = "cigs"
 	icon_lightmask = "cigs"
 	category = VENDOR_TYPE_RECREATION
-	products = list(
-		/obj/item/storage/fancy/cigarettes/cigpack_robust = 6,
-		/obj/item/storage/fancy/cigarettes/cigpack_carp = 6,
-		/obj/item/storage/fancy/cigarettes/cigpack_uplift = 6,
-		/obj/item/storage/fancy/cigarettes/cigpack_midori = 6,
-		/obj/item/storage/fancy/cigarettes/cigpack_random = 6,
-		/obj/item/storage/fancy/cigarettes/cigpack_robustgold = 1,
-		/obj/item/clothing/mask/cigarette/cigar/havana = 2,
-		/obj/item/reagent_containers/food/pill/patch/nicotine = 10,
-		/obj/item/storage/box/matches = 10,
-		/obj/item/lighter/random = 4,
-		/obj/item/lighter/zippo = 2)
+	products = list(/obj/item/storage/fancy/cigarettes/cigpack_robust = 6,
+					/obj/item/storage/fancy/cigarettes/cigpack_carp = 6,
+					/obj/item/storage/fancy/cigarettes/cigpack_uplift = 6,
+					/obj/item/storage/fancy/cigarettes/cigpack_midori = 6,
+					/obj/item/storage/fancy/cigarettes/cigpack_random = 6,
+					/obj/item/storage/fancy/cigarettes/cigpack_robustgold = 1,
+					/obj/item/clothing/mask/cigarette/cigar/havana = 2,
+					/obj/item/reagent_containers/food/pill/patch/nicotine = 10,
+					/obj/item/storage/box/matches = 10,
+					/obj/item/lighter/random = 4,
+					/obj/item/lighter/zippo = 2)
+
 	contraband = list(/obj/item/storage/fancy/rollingpapers = 5)
+
 	prices = list(/obj/item/storage/fancy/cigarettes/cigpack_robust = 25,
-		/obj/item/storage/fancy/cigarettes/cigpack_carp = 25,
-		/obj/item/storage/fancy/cigarettes/cigpack_uplift = 35,
-		/obj/item/storage/fancy/cigarettes/cigpack_midori = 60,
-		/obj/item/storage/fancy/cigarettes/cigpack_random = 80,
-		/obj/item/storage/fancy/cigarettes/cigpack_robustgold = 120,
-		/obj/item/reagent_containers/food/pill/patch/nicotine = 70,
-		/obj/item/storage/box/matches = 20,
-		/obj/item/lighter/random = 40,
-		/obj/item/lighter/zippo = 80,
-		/obj/item/storage/fancy/rollingpapers = 30,
-		/obj/item/clothing/mask/cigarette/cigar/havana = 80)
+				/obj/item/storage/fancy/cigarettes/cigpack_carp = 25,
+				/obj/item/storage/fancy/cigarettes/cigpack_uplift = 35,
+				/obj/item/storage/fancy/cigarettes/cigpack_midori = 60,
+				/obj/item/storage/fancy/cigarettes/cigpack_random = 80,
+				/obj/item/storage/fancy/cigarettes/cigpack_robustgold = 120,
+				/obj/item/reagent_containers/food/pill/patch/nicotine = 70,
+				/obj/item/storage/box/matches = 20,
+				/obj/item/lighter/random = 40,
+				/obj/item/lighter/zippo = 80,
+				/obj/item/storage/fancy/rollingpapers = 30,
+				/obj/item/clothing/mask/cigarette/cigar/havana = 80)
+
 	refill_canister = /obj/item/vending_refill/cigarette
 
 /obj/machinery/economy/vending/cigarette/free
@@ -940,12 +1192,13 @@
 
 /obj/machinery/economy/vending/cigarette/syndicate
 	products = list(/obj/item/storage/fancy/cigarettes/cigpack_syndicate = 7,
-					/obj/item/storage/fancy/cigarettes/cigpack_uplift = 3,
-					/obj/item/storage/fancy/cigarettes/cigpack_robust = 2,
-					/obj/item/storage/fancy/cigarettes/cigpack_carp = 3,
-					/obj/item/storage/fancy/cigarettes/cigpack_midori = 1,
-					/obj/item/storage/box/matches = 10,
-					/obj/item/storage/fancy/rollingpapers = 5)
+				/obj/item/storage/fancy/cigarettes/cigpack_uplift = 3,
+				/obj/item/storage/fancy/cigarettes/cigpack_robust = 2,
+				/obj/item/storage/fancy/cigarettes/cigpack_carp = 3,
+				/obj/item/storage/fancy/cigarettes/cigpack_midori = 1,
+				/obj/item/storage/box/matches = 10,
+				/obj/item/storage/fancy/rollingpapers = 5)
+
 	contraband = list(/obj/item/lighter/zippo = 4)
 
 /obj/machinery/economy/vending/cigarette/syndicate/free
@@ -954,25 +1207,39 @@
 /obj/machinery/economy/vending/cigarette/beach //Used in the lavaland_biodome_beach.dmm ruin
 	name = "\improper ShadyCigs Ultra"
 	desc = "Now with extra premium products!"
-	ads_list = list("Probably not bad for you!","Dope will get you through times of no money better than money will get you through times of no dope!","It's good for you!")
-	slogan_list = list("Turn on, tune in, drop out!","Better living through chemistry!","Toke!","Don't forget to keep a smile on your lips and a song in your heart!")
+	slogan_list = list("Turn on, tune in, drop out!",
+					"Better living through chemistry!",
+					"Toke!",
+					"Don't forget to keep a smile on your lips and a song in your heart!")
+
+	ads_list = list("Probably not bad for you!",
+					"Dope will get you through times of no money better than money will get you through times of no dope!",
+					"It's good for you!")
+
 	products = list(/obj/item/storage/fancy/cigarettes = 5,
-					/obj/item/storage/fancy/cigarettes/cigpack_uplift = 3,
-					/obj/item/storage/fancy/cigarettes/cigpack_robust = 3,
-					/obj/item/storage/fancy/cigarettes/cigpack_carp = 3,
-					/obj/item/storage/fancy/cigarettes/cigpack_midori = 3,
-					/obj/item/storage/fancy/cigarettes/cigpack_robustgold = 1,
-					/obj/item/clothing/mask/cigarette/cigar/havana = 2,
-					/obj/item/storage/box/matches = 10,
-					/obj/item/lighter/zippo = 4,
-					/obj/item/storage/fancy/rollingpapers = 5)
+				/obj/item/storage/fancy/cigarettes/cigpack_uplift = 3,
+				/obj/item/storage/fancy/cigarettes/cigpack_robust = 3,
+				/obj/item/storage/fancy/cigarettes/cigpack_carp = 3,
+				/obj/item/storage/fancy/cigarettes/cigpack_midori = 3,
+				/obj/item/storage/fancy/cigarettes/cigpack_robustgold = 1,
+				/obj/item/clothing/mask/cigarette/cigar/havana = 2,
+				/obj/item/storage/box/matches = 10,
+				/obj/item/lighter/zippo = 4,
+				/obj/item/storage/fancy/rollingpapers = 5)
+
 	contraband = list()
 	prices = list()
 
 /obj/machinery/economy/vending/wallmed
 	name = "\improper NanoMed"
 	desc = "Wall-mounted Medical Equipment dispenser."
-	ads_list = list("Go save some lives!","The best stuff for your medbay.","Only the finest tools.","Natural chemicals!","This stuff saves lives.","Don't you want some?")
+	ads_list = list("Go save some lives!",
+					"The best stuff for your medbay.",
+					"Only the finest tools.",
+					"Natural chemicals!",
+					"This stuff saves lives.",
+					"Don't you want some?")
+
 	icon_state = "wallmed"
 	icon_deny = "wallmed_deny"
 	icon_lightmask = "wallmed"
@@ -985,7 +1252,11 @@
 					/obj/item/stack/medical/ointment = 2,
 					/obj/item/reagent_containers/hypospray/autoinjector/epinephrine = 4,
 					/obj/item/healthanalyzer = 1)
-	contraband = list(/obj/item/reagent_containers/syringe/charcoal = 4, /obj/item/reagent_containers/syringe/antiviral = 4, /obj/item/reagent_containers/food/pill/tox = 1)
+
+	contraband = list(/obj/item/reagent_containers/syringe/charcoal = 4,
+					/obj/item/reagent_containers/syringe/antiviral = 4,
+					/obj/item/reagent_containers/food/pill/tox = 1)
+
 	armor = list(melee = 50, bullet = 20, laser = 20, energy = 20, bomb = 0, rad = 0, fire = 100, acid = 70)
 	//this shouldn't be priced
 	resistance_flags = FIRE_PROOF
@@ -995,18 +1266,35 @@
 	name = "\improper PTech"
 	desc = "Cartridges for PDA's."
 	slogan_list = list("Carts to go!")
+
 	icon_state = "cart"
 	icon_lightmask = "med"
 	icon_deny = "cart_deny"
 	icon_panel = "wide_vendor"
 	category = VENDOR_TYPE_SUPPLIES
-	products = list(/obj/item/pda =10,/obj/item/cartridge/mob_hunt_game = 25, /obj/item/cartridge/medical = 10, /obj/item/cartridge/chemistry = 10,
-					/obj/item/cartridge/engineering = 10, /obj/item/cartridge/atmos = 10, /obj/item/cartridge/janitor = 10,
-					/obj/item/cartridge/signal/toxins = 10, /obj/item/cartridge/signal = 10)
-	contraband = list(/obj/item/cartridge/clown = 1,/obj/item/cartridge/mime = 1)
-	prices = list(/obj/item/pda = 300, /obj/item/cartridge/mob_hunt_game = 50, /obj/item/cartridge/medical = 200,
-					/obj/item/cartridge/chemistry = 150,/obj/item/cartridge/engineering = 100, /obj/item/cartridge/atmos = 75,
-					/obj/item/cartridge/janitor = 100,/obj/item/cartridge/signal/toxins = 150, /obj/item/cartridge/signal = 75)
+	products = list(/obj/item/pda =10,
+					/obj/item/cartridge/mob_hunt_game = 25,
+					/obj/item/cartridge/medical = 10,
+					/obj/item/cartridge/chemistry = 10,
+					/obj/item/cartridge/engineering = 10,
+					/obj/item/cartridge/atmos = 10,
+					/obj/item/cartridge/janitor = 10,
+					/obj/item/cartridge/signal/toxins = 10,
+					/obj/item/cartridge/signal = 10)
+
+	contraband = list(/obj/item/cartridge/clown = 1,
+					/obj/item/cartridge/mime = 1)
+
+	prices = list(/obj/item/pda = 300,
+				/obj/item/cartridge/mob_hunt_game = 50,
+				/obj/item/cartridge/medical = 200,
+				/obj/item/cartridge/chemistry = 150,
+				/obj/item/cartridge/engineering = 100,
+				/obj/item/cartridge/atmos = 75,
+				/obj/item/cartridge/janitor = 100,
+				/obj/item/cartridge/signal/toxins = 150,
+				/obj/item/cartridge/signal = 75)
+
 	refill_canister = /obj/item/vending_refill/cart
 
 /obj/machinery/economy/vending/cart/free

--- a/code/game/machinery/vendors/wardrobe_vendors.dm
+++ b/code/game/machinery/vendors/wardrobe_vendors.dm
@@ -7,7 +7,11 @@
 	icon_lightmask = "base_drobe"
 	icon_panel = "drobe"
 	category = VENDOR_TYPE_CLOTHING
-	ads_list = list("Beat perps in style!", "It's red so you can't see the blood!", "You have the right to be fashionable!", "Now you can be the fashion police you always wanted to be!")
+	ads_list = list("Beat perps in style!",
+					"It's red so you can't see the blood!",
+					"You have the right to be fashionable!",
+					"Now you can be the fashion police you always wanted to be!")
+
 	vend_reply = "Thank you for using the SecDrobe!"
 	products = list(/obj/item/clothing/under/rank/security/officer/corporate = 4,
 					/obj/item/clothing/under/rank/security/officer/skirt/corporate = 4,
@@ -37,41 +41,43 @@
 					/obj/item/storage/backpack/satchel_sec = 2,
 					/obj/item/clothing/gloves/color/black = 4,
 					/obj/item/clothing/accessory/armband/sec = 6)
+
 	contraband = list(/obj/item/clothing/head/helmet/street_judge = 1,
 					/obj/item/clothing/suit/armor/vest/street_judge = 1,
 					/obj/item/toy/figure/crew/hos = 1,
 					/obj/item/toy/figure/crew/secofficer = 1)
 
 	prices = list(/obj/item/clothing/under/rank/security/officer/corporate = 50,
-					/obj/item/clothing/under/rank/security/officer/skirt/corporate = 50,
-					/obj/item/clothing/under/rank/security/officer/dispatch = 50,
-					/obj/item/clothing/under/rank/security/officer/skirt = 50,
-					/obj/item/clothing/under/rank/security/officer = 50,
-					/obj/item/clothing/under/rank/security/officer/uniform = 50,
-					/obj/item/clothing/under/rank/security/formal = 50,
-					/obj/item/clothing/under/rank/security/officer/fancy = 50,
-					/obj/item/clothing/under/rank/security/officer/skirt/fancy = 50,
-					/obj/item/clothing/head/soft/sec/corp = 40,
-					/obj/item/clothing/head/officer = 40,
-					/obj/item/clothing/head/beret/sec = 40,
-					/obj/item/clothing/head/soft/sec = 40,
-					/obj/item/clothing/head/drillsgt = 40,
-					/obj/item/clothing/mask/bandana/red = 40,
-					/obj/item/clothing/mask/balaclava = 60,
-					/obj/item/clothing/mask/gas/sechailer/swat = 60,
-					/obj/item/clothing/suit/jacket/secbomber = 75,
-					/obj/item/clothing/suit/armor/secjacket = 75,
-					/obj/item/clothing/suit/hooded/wintercoat/security = 75,
-					/obj/item/clothing/shoes/jackboots = 20,
-					/obj/item/clothing/shoes/jackboots/jacksandals = 20,
-					/obj/item/clothing/shoes/laceup = 30,
-					/obj/item/clothing/head/helmet/street_judge = 75,
-					/obj/item/clothing/suit/armor/vest/street_judge = 100,
-					/obj/item/storage/backpack/duffel/security = 50,
-					/obj/item/storage/backpack/security = 50,
-					/obj/item/storage/backpack/satchel_sec = 50,
-					/obj/item/clothing/gloves/color/black = 20,
-					/obj/item/clothing/accessory/armband/sec = 20)
+				/obj/item/clothing/under/rank/security/officer/skirt/corporate = 50,
+				/obj/item/clothing/under/rank/security/officer/dispatch = 50,
+				/obj/item/clothing/under/rank/security/officer/skirt = 50,
+				/obj/item/clothing/under/rank/security/officer = 50,
+				/obj/item/clothing/under/rank/security/officer/uniform = 50,
+				/obj/item/clothing/under/rank/security/formal = 50,
+				/obj/item/clothing/under/rank/security/officer/fancy = 50,
+				/obj/item/clothing/under/rank/security/officer/skirt/fancy = 50,
+				/obj/item/clothing/head/soft/sec/corp = 40,
+				/obj/item/clothing/head/officer = 40,
+				/obj/item/clothing/head/beret/sec = 40,
+				/obj/item/clothing/head/soft/sec = 40,
+				/obj/item/clothing/head/drillsgt = 40,
+				/obj/item/clothing/mask/bandana/red = 40,
+				/obj/item/clothing/mask/balaclava = 60,
+				/obj/item/clothing/mask/gas/sechailer/swat = 60,
+				/obj/item/clothing/suit/jacket/secbomber = 75,
+				/obj/item/clothing/suit/armor/secjacket = 75,
+				/obj/item/clothing/suit/hooded/wintercoat/security = 75,
+				/obj/item/clothing/shoes/jackboots = 20,
+				/obj/item/clothing/shoes/jackboots/jacksandals = 20,
+				/obj/item/clothing/shoes/laceup = 30,
+				/obj/item/clothing/head/helmet/street_judge = 75,
+				/obj/item/clothing/suit/armor/vest/street_judge = 100,
+				/obj/item/storage/backpack/duffel/security = 50,
+				/obj/item/storage/backpack/security = 50,
+				/obj/item/storage/backpack/satchel_sec = 50,
+				/obj/item/clothing/gloves/color/black = 20,
+				/obj/item/clothing/accessory/armband/sec = 20)
+
 	refill_canister = /obj/item/vending_refill/secdrobe
 
 /obj/machinery/economy/vending/detdrobe
@@ -81,7 +87,9 @@
 	icon_lightmask = "base_drobe"
 	icon_panel = "drobe"
 	category = VENDOR_TYPE_CLOTHING
-	ads_list = list("Apply your brilliant deductive methods in style!", "They already smell of cigarettes!")
+	ads_list = list("Apply your brilliant deductive methods in style!",
+					"They already smell of cigarettes!")
+
 	vend_reply = "Thank you for using the DetDrobe!"
 	products = list(/obj/item/clothing/under/rank/security/detective = 2,
 					/obj/item/clothing/under/rank/security/detective/black = 1,
@@ -104,28 +112,31 @@
 					/obj/item/clothing/gloves/color/latex = 2,
 					/obj/item/reagent_containers/food/drinks/flask/detflask = 2,
 					/obj/item/storage/fancy/cigarettes/dromedaryco = 5)
+
 	prices = list(/obj/item/clothing/under/rank/security/detective = 50,
-					/obj/item/clothing/under/rank/security/detective/black = 75,
-					/obj/item/clothing/under/rank/security/detective/skirt = 75,
-					/obj/item/clothing/suit/storage/det_suit = 75,
-					/obj/item/clothing/suit/storage/det_suit/forensics/red = 75,
-					/obj/item/clothing/suit/storage/det_suit/forensics/blue = 75,
-					/obj/item/clothing/suit/storage/det_suit/forensics/black = 75,
-					/obj/item/clothing/suit/armor/vest/det_suit = 75,
-					/obj/item/clothing/head/det_hat = 40,
-					/obj/item/clothing/glasses/sunglasses/noir = 30,
-					/obj/item/clothing/accessory/waistcoat = 20,
-					/obj/item/clothing/shoes/laceup = 30,
-					/obj/item/clothing/shoes/brown = 20,
-					/obj/item/clothing/shoes/jackboots = 20,
-					/obj/item/clothing/head/fedora = 20,
-					/obj/item/clothing/head/fedora/brownfedora = 20,
-					/obj/item/clothing/head/fedora/whitefedora = 20,
-					/obj/item/clothing/gloves/color/black = 20,
-					/obj/item/clothing/gloves/color/latex = 20,
-					/obj/item/reagent_containers/food/drinks/flask/detflask = 50,
-					/obj/item/storage/fancy/cigarettes/dromedaryco = 5)
+				/obj/item/clothing/under/rank/security/detective/black = 75,
+				/obj/item/clothing/under/rank/security/detective/skirt = 75,
+				/obj/item/clothing/suit/storage/det_suit = 75,
+				/obj/item/clothing/suit/storage/det_suit/forensics/red = 75,
+				/obj/item/clothing/suit/storage/det_suit/forensics/blue = 75,
+				/obj/item/clothing/suit/storage/det_suit/forensics/black = 75,
+				/obj/item/clothing/suit/armor/vest/det_suit = 75,
+				/obj/item/clothing/head/det_hat = 40,
+				/obj/item/clothing/glasses/sunglasses/noir = 30,
+				/obj/item/clothing/accessory/waistcoat = 20,
+				/obj/item/clothing/shoes/laceup = 30,
+				/obj/item/clothing/shoes/brown = 20,
+				/obj/item/clothing/shoes/jackboots = 20,
+				/obj/item/clothing/head/fedora = 20,
+				/obj/item/clothing/head/fedora/brownfedora = 20,
+				/obj/item/clothing/head/fedora/whitefedora = 20,
+				/obj/item/clothing/gloves/color/black = 20,
+				/obj/item/clothing/gloves/color/latex = 20,
+				/obj/item/reagent_containers/food/drinks/flask/detflask = 50,
+				/obj/item/storage/fancy/cigarettes/dromedaryco = 5)
+
 	contraband = list(/obj/item/toy/figure/crew/detective = 1)
+
 	refill_canister = /obj/item/vending_refill/detdrobe
 
 /obj/machinery/economy/vending/medidrobe
@@ -137,6 +148,7 @@
 	icon_addon = "medidrobe"
 	category = VENDOR_TYPE_CLOTHING
 	ads_list = list("Make those blood stains look fashionable!")
+
 	vend_reply = "Thank you for using the MediDrobe!"
 	products = list(/obj/item/clothing/under/rank/medical/doctor = 3,
 					/obj/item/clothing/under/rank/medical/doctor/skirt = 3,
@@ -164,33 +176,36 @@
 					/obj/item/storage/backpack/satchel_med = 2,
 					/obj/item/storage/backpack/duffel/medical = 2,
 					/obj/item/clothing/gloves/color/latex/nitrile = 3)
+
 	contraband = list(/obj/item/toy/figure/crew/md = 1)
+
 	prices = list(/obj/item/clothing/under/rank/medical/doctor = 50,
-					/obj/item/clothing/under/rank/medical/doctor/skirt = 50,
-					/obj/item/clothing/under/rank/medical/scrubs = 50,
-					/obj/item/clothing/under/rank/medical/scrubs/green = 50,
-					/obj/item/clothing/under/rank/medical/scrubs/purple = 50,
-					/obj/item/clothing/under/rank/medical/nurse = 50,
-					/obj/item/clothing/under/rank/medical/gown = 50,
-					/obj/item/clothing/head/beret/med = 20,
-					/obj/item/clothing/head/surgery/blue = 20,
-					/obj/item/clothing/head/surgery/green = 20,
-					/obj/item/clothing/head/surgery/purple = 20,
-					/obj/item/clothing/head/nursehat = 20,
-					/obj/item/clothing/head/headmirror = 20,
-					/obj/item/clothing/suit/hooded/wintercoat/medical = 75,
-					/obj/item/clothing/suit/storage/fr_jacket = 75,
-					/obj/item/clothing/suit/storage/labcoat = 75,
-					/obj/item/clothing/suit/apron/surgical = 75,
-					/obj/item/clothing/accessory/armband/med = 20,
-					/obj/item/clothing/accessory/armband/medgreen = 20,
-					/obj/item/clothing/shoes/laceup = 30,
-					/obj/item/clothing/shoes/white = 20,
-					/obj/item/clothing/shoes/sandal/white = 20,
-					/obj/item/storage/backpack/medic = 50,
-					/obj/item/storage/backpack/satchel_med = 50,
-					/obj/item/storage/backpack/duffel/medical = 50,
-					/obj/item/clothing/gloves/color/latex/nitrile = 50)
+				/obj/item/clothing/under/rank/medical/doctor/skirt = 50,
+				/obj/item/clothing/under/rank/medical/scrubs = 50,
+				/obj/item/clothing/under/rank/medical/scrubs/green = 50,
+				/obj/item/clothing/under/rank/medical/scrubs/purple = 50,
+				/obj/item/clothing/under/rank/medical/nurse = 50,
+				/obj/item/clothing/under/rank/medical/gown = 50,
+				/obj/item/clothing/head/beret/med = 20,
+				/obj/item/clothing/head/surgery/blue = 20,
+				/obj/item/clothing/head/surgery/green = 20,
+				/obj/item/clothing/head/surgery/purple = 20,
+				/obj/item/clothing/head/nursehat = 20,
+				/obj/item/clothing/head/headmirror = 20,
+				/obj/item/clothing/suit/hooded/wintercoat/medical = 75,
+				/obj/item/clothing/suit/storage/fr_jacket = 75,
+				/obj/item/clothing/suit/storage/labcoat = 75,
+				/obj/item/clothing/suit/apron/surgical = 75,
+				/obj/item/clothing/accessory/armband/med = 20,
+				/obj/item/clothing/accessory/armband/medgreen = 20,
+				/obj/item/clothing/shoes/laceup = 30,
+				/obj/item/clothing/shoes/white = 20,
+				/obj/item/clothing/shoes/sandal/white = 20,
+				/obj/item/storage/backpack/medic = 50,
+				/obj/item/storage/backpack/satchel_med = 50,
+				/obj/item/storage/backpack/duffel/medical = 50,
+				/obj/item/clothing/gloves/color/latex/nitrile = 50)
+
 	refill_canister = /obj/item/vending_refill/medidrobe
 
 /obj/machinery/economy/vending/virodrobe
@@ -201,7 +216,9 @@
 	icon_panel = "drobe"
 	icon_addon = "virodrobe"
 	category = VENDOR_TYPE_CLOTHING
-	ads_list = list("Viruses getting you down? Nothing a change of clothes can't fix!", "Upgrade to sterilized clothing today!")
+	ads_list = list("Viruses getting you down? Nothing a change of clothes can't fix!",
+					"Upgrade to sterilized clothing today!")
+
 	vend_reply = "Thank you for using the ViroDrobe!"
 	products = list(/obj/item/clothing/under/rank/medical/virologist = 2,
 					/obj/item/clothing/under/rank/medical/virologist/skirt = 2,
@@ -215,19 +232,22 @@
 					/obj/item/storage/backpack/virology = 2,
 					/obj/item/storage/backpack/satchel_vir = 2,
 					/obj/item/storage/backpack/duffel/virology = 2)
+
 	contraband = list(/obj/item/toy/figure/crew/virologist = 1)
+
 	prices = list(/obj/item/clothing/under/rank/medical/virologist = 50,
-					/obj/item/clothing/under/rank/medical/virologist/skirt = 50,
-					/obj/item/clothing/head/beret/med = 20,
-					/obj/item/clothing/suit/storage/labcoat/virologist = 75,
-					/obj/item/clothing/accessory/armband/med = 20,
-					/obj/item/clothing/mask/surgical = 20,
-					/obj/item/clothing/shoes/laceup = 30,
-					/obj/item/clothing/shoes/white = 20,
-					/obj/item/clothing/shoes/sandal/white = 20,
-					/obj/item/storage/backpack/virology = 50,
-					/obj/item/storage/backpack/satchel_vir = 50,
-					/obj/item/storage/backpack/duffel/virology = 50)
+				/obj/item/clothing/under/rank/medical/virologist/skirt = 50,
+				/obj/item/clothing/head/beret/med = 20,
+				/obj/item/clothing/suit/storage/labcoat/virologist = 75,
+				/obj/item/clothing/accessory/armband/med = 20,
+				/obj/item/clothing/mask/surgical = 20,
+				/obj/item/clothing/shoes/laceup = 30,
+				/obj/item/clothing/shoes/white = 20,
+				/obj/item/clothing/shoes/sandal/white = 20,
+				/obj/item/storage/backpack/virology = 50,
+				/obj/item/storage/backpack/satchel_vir = 50,
+				/obj/item/storage/backpack/duffel/virology = 50)
+
 	refill_canister = /obj/item/vending_refill/virodrobe
 
 /obj/machinery/economy/vending/chemdrobe
@@ -253,18 +273,21 @@
 					/obj/item/storage/backpack/chemistry = 2,
 					/obj/item/storage/backpack/satchel_chem = 2,
 					/obj/item/storage/backpack/duffel/chemistry = 2)
+
 	prices = list(/obj/item/clothing/under/rank/medical/chemist = 50,
-					/obj/item/clothing/under/rank/medical/chemist/skirt = 50,
-					/obj/item/clothing/head/beret/med = 20,
-					/obj/item/clothing/suit/storage/labcoat/chemist = 75,
-					/obj/item/clothing/accessory/armband/med = 20,
-					/obj/item/clothing/shoes/laceup = 30,
-					/obj/item/clothing/shoes/white = 20,
-					/obj/item/clothing/shoes/sandal/white = 20,
-					/obj/item/storage/backpack/chemistry = 50,
-					/obj/item/storage/backpack/satchel_chem = 50,
-					/obj/item/storage/backpack/duffel/chemistry = 50)
+				/obj/item/clothing/under/rank/medical/chemist/skirt = 50,
+				/obj/item/clothing/head/beret/med = 20,
+				/obj/item/clothing/suit/storage/labcoat/chemist = 75,
+				/obj/item/clothing/accessory/armband/med = 20,
+				/obj/item/clothing/shoes/laceup = 30,
+				/obj/item/clothing/shoes/white = 20,
+				/obj/item/clothing/shoes/sandal/white = 20,
+				/obj/item/storage/backpack/chemistry = 50,
+				/obj/item/storage/backpack/satchel_chem = 50,
+				/obj/item/storage/backpack/duffel/chemistry = 50)
+
 	contraband = list(/obj/item/toy/figure/crew/chemist = 1)
+
 	refill_canister = /obj/item/vending_refill/chemdrobe
 
 /obj/machinery/economy/vending/genedrobe
@@ -284,16 +307,19 @@
 					/obj/item/clothing/shoes/sandal/white = 3,
 					/obj/item/storage/backpack/genetics = 2,
 					/obj/item/storage/backpack/satchel_gen = 2,
-					/obj/item/storage/backpack/duffel/genetics = 2,)
+					/obj/item/storage/backpack/duffel/genetics = 2)
+
 	contraband = list(/obj/item/toy/figure/crew/geneticist = 1)
+
 	prices = list(/obj/item/clothing/under/rank/rnd/geneticist = 50,
-					/obj/item/clothing/suit/storage/labcoat/genetics = 75,
-					/obj/item/clothing/shoes/laceup = 30,
-					/obj/item/clothing/shoes/white = 20,
-					/obj/item/clothing/shoes/sandal/white = 20,
-					/obj/item/storage/backpack/genetics = 50,
-					/obj/item/storage/backpack/satchel_gen = 50,
-					/obj/item/storage/backpack/duffel/genetics = 50,)
+				/obj/item/clothing/suit/storage/labcoat/genetics = 75,
+				/obj/item/clothing/shoes/laceup = 30,
+				/obj/item/clothing/shoes/white = 20,
+				/obj/item/clothing/shoes/sandal/white = 20,
+				/obj/item/storage/backpack/genetics = 50,
+				/obj/item/storage/backpack/satchel_gen = 50,
+				/obj/item/storage/backpack/duffel/genetics = 50)
+
 	refill_canister = /obj/item/vending_refill/genedrobe
 
 
@@ -305,7 +331,10 @@
 	icon_panel = "drobe"
 	icon_addon = "scidrobe"
 	category = VENDOR_TYPE_CLOTHING
-	ads_list = list("Longing for the smell of plasma burnt flesh?", "Buy your science clothing now!", "Made with 10% Auxetics, so you don't have to worry about losing your arm!")
+	ads_list = list("Longing for the smell of plasma burnt flesh?",
+					"Buy your science clothing now!",
+					"Made with 10% Auxetics, so you don't have to worry about losing your arm!")
+
 	vend_reply = "Thank you for using the SciDrobe!"
 	products = list(/obj/item/clothing/under/rank/rnd/scientist = 6,
 					/obj/item/clothing/under/rank/rnd/scientist/skirt = 3,
@@ -318,21 +347,24 @@
 					/obj/item/clothing/shoes/sandal/white = 3,
 					/obj/item/storage/backpack/science = 2,
 					/obj/item/storage/backpack/satchel_tox = 2,
-					/obj/item/storage/backpack/duffel/science = 2,)
+					/obj/item/storage/backpack/duffel/science = 2)
+
 	contraband = list(/obj/item/toy/figure/crew/rd = 1,
 					/obj/item/toy/figure/crew/scientist = 1)
+
 	prices = list(/obj/item/clothing/under/rank/rnd/scientist = 50,
-					/obj/item/clothing/under/rank/rnd/scientist/skirt = 50,
-					/obj/item/clothing/suit/hooded/wintercoat/science = 75,
-					/obj/item/clothing/suit/storage/labcoat/science = 75,
-					/obj/item/clothing/head/beret/sci = 20,
-					/obj/item/clothing/accessory/armband/science = 20,
-					/obj/item/clothing/shoes/laceup = 30,
-					/obj/item/clothing/shoes/white = 20,
-					/obj/item/clothing/shoes/sandal/white = 20,
-					/obj/item/storage/backpack/science = 50,
-					/obj/item/storage/backpack/satchel_tox = 50,
-					/obj/item/storage/backpack/duffel/science = 50,)
+				/obj/item/clothing/under/rank/rnd/scientist/skirt = 50,
+				/obj/item/clothing/suit/hooded/wintercoat/science = 75,
+				/obj/item/clothing/suit/storage/labcoat/science = 75,
+				/obj/item/clothing/head/beret/sci = 20,
+				/obj/item/clothing/accessory/armband/science = 20,
+				/obj/item/clothing/shoes/laceup = 30,
+				/obj/item/clothing/shoes/white = 20,
+				/obj/item/clothing/shoes/sandal/white = 20,
+				/obj/item/storage/backpack/science = 50,
+				/obj/item/storage/backpack/satchel_tox = 50,
+				/obj/item/storage/backpack/duffel/science = 50,)
+
 	refill_canister = /obj/item/vending_refill/scidrobe
 
 /obj/machinery/economy/vending/robodrobe
@@ -343,7 +375,9 @@
 	icon_panel = "drobe"
 	icon_addon = "robodrobe"
 	category = VENDOR_TYPE_CLOTHING
-	ads_list = list("You turn me TRUE, use defines!","0110001101101100011011110111010001101000011001010111001101101000011001010111001001100101")
+	ads_list = list("You turn me TRUE, use defines!",
+					"0110001101101100011011110111010001101000011001010111001101101000011001010111001001100101")
+
 	vend_reply = "Thank you for using the RoboDrobe!"
 	products = list(/obj/item/clothing/under/rank/rnd/roboticist = 3,
 					/obj/item/clothing/under/rank/rnd/roboticist/skirt = 3,
@@ -356,18 +390,21 @@
 					/obj/item/clothing/shoes/laceup = 3,
 					/obj/item/clothing/shoes/white = 3,
 					/obj/item/clothing/shoes/black = 3)
+
 	contraband = list(/obj/item/toy/figure/crew/roboticist = 1)
+
 	prices = list(/obj/item/clothing/under/rank/rnd/roboticist = 50,
-					/obj/item/clothing/under/rank/rnd/roboticist/skirt = 50,
-					/obj/item/clothing/suit/storage/labcoat/roboblack = 75,
-					/obj/item/clothing/suit/storage/labcoat/robowhite = 75,
-					/obj/item/clothing/head/beret/roboblack = 20,
-					/obj/item/clothing/head/beret/robowhite = 20,
-					/obj/item/clothing/head/soft/black = 20,
-					/obj/item/clothing/gloves/fingerless = 20,
-					/obj/item/clothing/shoes/laceup = 30,
-					/obj/item/clothing/shoes/white = 20,
-					/obj/item/clothing/shoes/black = 20)
+				/obj/item/clothing/under/rank/rnd/roboticist/skirt = 50,
+				/obj/item/clothing/suit/storage/labcoat/roboblack = 75,
+				/obj/item/clothing/suit/storage/labcoat/robowhite = 75,
+				/obj/item/clothing/head/beret/roboblack = 20,
+				/obj/item/clothing/head/beret/robowhite = 20,
+				/obj/item/clothing/head/soft/black = 20,
+				/obj/item/clothing/gloves/fingerless = 20,
+				/obj/item/clothing/shoes/laceup = 30,
+				/obj/item/clothing/shoes/white = 20,
+				/obj/item/clothing/shoes/black = 20)
+
 	refill_canister = /obj/item/vending_refill/robodrobe
 
 /obj/machinery/economy/vending/engidrobe
@@ -378,7 +415,9 @@
 	icon_panel = "drobe"
 	icon_addon = "engidrobe"
 	category = VENDOR_TYPE_CLOTHING
-	ads_list = list("Guaranteed to protect your feet from industrial accidents!", "Afraid of radiation? Then wear yellow!")
+	ads_list = list("Guaranteed to protect your feet from industrial accidents!",
+					"Afraid of radiation? Then wear yellow!")
+
 	vend_reply = "Thank you for using the EngiDrobe!"
 	products = list(/obj/item/clothing/under/rank/engineering/engineer = 6,
 					/obj/item/clothing/under/rank/engineering/engineer/skirt = 3,
@@ -397,25 +436,28 @@
 					/obj/item/storage/backpack/duffel/engineering = 2,
 					/obj/item/clothing/gloves/color/yellow = 2,
 					/obj/item/storage/belt/utility = 2)
+
 	contraband = list(/obj/item/toy/figure/crew/ce = 1,
 					/obj/item/toy/figure/crew/engineer = 1)
+
 	prices = list(/obj/item/clothing/under/rank/engineering/engineer = 50,
-					/obj/item/clothing/under/rank/engineering/engineer/skirt = 50,
-					/obj/item/clothing/suit/hooded/wintercoat/engineering = 75,
-					/obj/item/clothing/suit/jacket/engibomber = 75,
-					/obj/item/clothing/suit/storage/hazardvest = 75,
-					/obj/item/clothing/head/beret/eng = 20,
-					/obj/item/clothing/head/hardhat = 20,
-					/obj/item/clothing/head/hardhat/orange = 30,
-					/obj/item/clothing/head/hardhat/dblue = 30,
-					/obj/item/clothing/accessory/armband/engine = 20,
-					/obj/item/clothing/shoes/laceup = 30,
-					/obj/item/clothing/shoes/workboots = 20,
-					/obj/item/storage/backpack/industrial = 50,
-					/obj/item/storage/backpack/satchel_eng = 50,
-					/obj/item/storage/backpack/duffel/engineering = 50,
-					/obj/item/clothing/gloves/color/yellow = 250,
-					/obj/item/storage/belt/utility = 75)
+				/obj/item/clothing/under/rank/engineering/engineer/skirt = 50,
+				/obj/item/clothing/suit/hooded/wintercoat/engineering = 75,
+				/obj/item/clothing/suit/jacket/engibomber = 75,
+				/obj/item/clothing/suit/storage/hazardvest = 75,
+				/obj/item/clothing/head/beret/eng = 20,
+				/obj/item/clothing/head/hardhat = 20,
+				/obj/item/clothing/head/hardhat/orange = 30,
+				/obj/item/clothing/head/hardhat/dblue = 30,
+				/obj/item/clothing/accessory/armband/engine = 20,
+				/obj/item/clothing/shoes/laceup = 30,
+				/obj/item/clothing/shoes/workboots = 20,
+				/obj/item/storage/backpack/industrial = 50,
+				/obj/item/storage/backpack/satchel_eng = 50,
+				/obj/item/storage/backpack/duffel/engineering = 50,
+				/obj/item/clothing/gloves/color/yellow = 250,
+				/obj/item/storage/belt/utility = 75)
+
 	refill_canister = /obj/item/vending_refill/engidrobe
 
 /obj/machinery/economy/vending/atmosdrobe
@@ -426,7 +468,9 @@
 	icon_panel = "drobe"
 	icon_addon = "atmosdrobe"
 	category = VENDOR_TYPE_CLOTHING
-	ads_list = list("Guaranteed to protect your feet from atmospheric accidents!", "Get your inflammable clothing right here!")
+	ads_list = list("Guaranteed to protect your feet from atmospheric accidents!",
+					"Get your inflammable clothing right here!")
+
 	vend_reply = "Thank you for using the AtmosDrobe!"
 	products = list(/obj/item/clothing/under/rank/engineering/atmospheric_technician  = 6,
 					/obj/item/clothing/under/rank/engineering/atmospheric_technician/skirt = 3,
@@ -446,7 +490,9 @@
 					/obj/item/storage/backpack/satchel_atmos = 2,
 					/obj/item/storage/backpack/duffel/atmos = 2,
 					/obj/item/storage/belt/utility = 2)
+
 	contraband = list(/obj/item/toy/figure/crew/atmos = 1)
+
 	prices = list(/obj/item/clothing/under/rank/engineering/atmospheric_technician = 50,
 				/obj/item/clothing/under/rank/engineering/atmospheric_technician/skirt = 50,
 				/obj/item/clothing/suit/hooded/wintercoat/engineering/atmos = 75,
@@ -465,6 +511,7 @@
 				/obj/item/storage/backpack/satchel_atmos = 50,
 				/obj/item/storage/backpack/duffel/atmos = 50,
 				/obj/item/storage/belt/utility = 75)
+
 	refill_canister = /obj/item/vending_refill/atmosdrobe
 
 /obj/machinery/economy/vending/cargodrobe
@@ -475,7 +522,9 @@
 	icon_panel = "drobe"
 	icon_addon = "cargodrobe"
 	category = VENDOR_TYPE_CLOTHING
-	ads_list = list("Upgraded Assistant Style! Pick yours today!", "These shorts are comfy and easy to wear, get yours now!")
+	ads_list = list("Upgraded Assistant Style! Pick yours today!",
+					"These shorts are comfy and easy to wear, get yours now!")
+
 	vend_reply = "Thank you for using the CargoDrobe!"
 	products = list(/obj/item/clothing/under/rank/cargo/tech = 6,
 					/obj/item/clothing/under/rank/cargo/tech/skirt = 3,
@@ -488,19 +537,22 @@
 					/obj/item/clothing/accessory/armband/cargo = 6,
 					/obj/item/clothing/shoes/black = 3,
 					/obj/item/clothing/shoes/workboots = 3)
+
 	contraband = list(/obj/item/toy/figure/crew/qm = 1,
 					/obj/item/toy/figure/crew/cargotech = 1)
+
 	prices = list(/obj/item/clothing/under/rank/cargo/tech = 50,
-					/obj/item/clothing/under/rank/cargo/tech/skirt = 50,
-					/obj/item/clothing/suit/hooded/wintercoat/cargo = 75,
-					/obj/item/clothing/suit/jacket/cargobomber = 75,
-					/obj/item/clothing/suit/storage/hazardvest = 50,
-					/obj/item/clothing/head/soft = 20,
-					/obj/item/clothing/head/hardhat/orange = 30,
-					/obj/item/clothing/gloves/fingerless = 20,
-					/obj/item/clothing/accessory/armband/cargo = 20,
-					/obj/item/clothing/shoes/black = 20,
-					/obj/item/clothing/shoes/workboots = 20)
+				/obj/item/clothing/under/rank/cargo/tech/skirt = 50,
+				/obj/item/clothing/suit/hooded/wintercoat/cargo = 75,
+				/obj/item/clothing/suit/jacket/cargobomber = 75,
+				/obj/item/clothing/suit/storage/hazardvest = 50,
+				/obj/item/clothing/head/soft = 20,
+				/obj/item/clothing/head/hardhat/orange = 30,
+				/obj/item/clothing/gloves/fingerless = 20,
+				/obj/item/clothing/accessory/armband/cargo = 20,
+				/obj/item/clothing/shoes/black = 20,
+				/obj/item/clothing/shoes/workboots = 20)
+
 	refill_canister = /obj/item/vending_refill/cargodrobe
 
 /obj/machinery/economy/vending/chefdrobe
@@ -511,7 +563,9 @@
 	icon_panel = "drobe"
 	icon_addon = "chefdrobe"
 	category = VENDOR_TYPE_CLOTHING
-	ads_list = list("Our clothes are guaranteed to protect you from food splatters!", "Comfortable enough for a CQC practice!")
+	ads_list = list("Our clothes are guaranteed to protect you from food splatters!",
+					"Comfortable enough for a CQC practice!")
+
 	vend_reply = "Thank you for using the ChefDrobe!"
 	products = list(/obj/item/clothing/under/rank/civilian/chef = 2,
 					/obj/item/clothing/under/misc/waiter = 2,
@@ -525,19 +579,22 @@
 					/obj/item/clothing/accessory/waistcoat = 2,
 					/obj/item/reagent_containers/glass/rag = 3,
 					/obj/item/storage/box/dish_drive = 1)
+
 	contraband = list(/obj/item/toy/figure/crew/chef = 1)
+
 	prices = list(/obj/item/clothing/under/rank/civilian/chef = 50,
-					/obj/item/clothing/under/misc/waiter = 50,
-					/obj/item/clothing/suit/chef = 50,
-					/obj/item/clothing/suit/chef/classic = 50,
-					/obj/item/clothing/head/chefhat = 50,
-					/obj/item/clothing/head/soft/mime = 30,
-					/obj/item/clothing/shoes/laceup = 30,
-					/obj/item/clothing/shoes/white = 20,
-					/obj/item/clothing/shoes/black = 20,
-					/obj/item/clothing/accessory/waistcoat = 20,
-					/obj/item/reagent_containers/glass/rag = 5,
-					/obj/item/storage/box/dish_drive = 100)
+				/obj/item/clothing/under/misc/waiter = 50,
+				/obj/item/clothing/suit/chef = 50,
+				/obj/item/clothing/suit/chef/classic = 50,
+				/obj/item/clothing/head/chefhat = 50,
+				/obj/item/clothing/head/soft/mime = 30,
+				/obj/item/clothing/shoes/laceup = 30,
+				/obj/item/clothing/shoes/white = 20,
+				/obj/item/clothing/shoes/black = 20,
+				/obj/item/clothing/accessory/waistcoat = 20,
+				/obj/item/reagent_containers/glass/rag = 5,
+				/obj/item/storage/box/dish_drive = 100)
+
 	refill_canister = /obj/item/vending_refill/chefdrobe
 
 /obj/machinery/economy/vending/bardrobe
@@ -548,6 +605,7 @@
 	icon_panel = "drobe"
 	category = VENDOR_TYPE_CLOTHING
 	ads_list = list("Guaranteed to prevent stains from spilled drinks!")
+
 	vend_reply = "Thank you for using the BarDrobe!"
 	products = list(/obj/item/clothing/under/rank/civilian/bartender = 2,
 					/obj/item/clothing/under/misc/sl_suit = 2,
@@ -559,17 +617,20 @@
 					/obj/item/clothing/accessory/waistcoat = 2,
 					/obj/item/reagent_containers/glass/rag = 3,
 					/obj/item/storage/box/dish_drive = 1)
+
 	contraband = list(/obj/item/toy/figure/crew/bartender = 1)
+
 	prices = list(/obj/item/clothing/under/rank/civilian/bartender = 50,
-					/obj/item/clothing/under/misc/sl_suit = 50,
-					/obj/item/clothing/head/that = 20,
-					/obj/item/clothing/head/soft/black = 20,
-					/obj/item/clothing/suit/blacktrenchcoat = 75,
-					/obj/item/clothing/shoes/laceup = 30,
-					/obj/item/clothing/shoes/black = 20,
-					/obj/item/clothing/accessory/waistcoat = 20,
-					/obj/item/reagent_containers/glass/rag = 5,
-					/obj/item/storage/box/dish_drive = 100)
+				/obj/item/clothing/under/misc/sl_suit = 50,
+				/obj/item/clothing/head/that = 20,
+				/obj/item/clothing/head/soft/black = 20,
+				/obj/item/clothing/suit/blacktrenchcoat = 75,
+				/obj/item/clothing/shoes/laceup = 30,
+				/obj/item/clothing/shoes/black = 20,
+				/obj/item/clothing/accessory/waistcoat = 20,
+				/obj/item/reagent_containers/glass/rag = 5,
+				/obj/item/storage/box/dish_drive = 100)
+
 	refill_canister = /obj/item/vending_refill/bardrobe
 
 /obj/machinery/economy/vending/hydrodrobe
@@ -579,7 +640,9 @@
 	icon_lightmask = "base_drobe"
 	icon_panel = "drobe"
 	category = VENDOR_TYPE_CLOTHING
-	ads_list = list("Do you love soil? Then buy our clothes!", "Get outfits to match your green thumb here!")
+	ads_list = list("Do you love soil? Then buy our clothes!",
+					"Get outfits to match your green thumb here!")
+
 	vend_reply = "Thank you for using the HydroDrobe!"
 	products = list(/obj/item/clothing/under/rank/civilian/hydroponics = 3,
 					/obj/item/reagent_containers/glass/bucket = 3,
@@ -591,19 +654,22 @@
 					/obj/item/clothing/accessory/armband/hydro = 3,
 					/obj/item/storage/backpack/botany = 2,
 					/obj/item/storage/backpack/satchel_hyd = 2,
-					/obj/item/storage/backpack/duffel/hydro = 2,)
+					/obj/item/storage/backpack/duffel/hydro = 2)
+
 	contraband = list(/obj/item/toy/figure/crew/botanist = 1)
+
 	prices = list(/obj/item/clothing/under/rank/civilian/hydroponics = 50,
-					/obj/item/reagent_containers/glass/bucket = 15,
-					/obj/item/clothing/suit/apron = 50,
-					/obj/item/clothing/suit/apron/overalls = 50,
-					/obj/item/clothing/suit/hooded/wintercoat/hydro = 75,
-					/obj/item/clothing/suit/storage/labcoat/hydro = 75,
-					/obj/item/clothing/mask/bandana/botany = 20,
-					/obj/item/clothing/accessory/armband/hydro = 20,
-					/obj/item/storage/backpack/botany = 50,
-					/obj/item/storage/backpack/satchel_hyd = 50,
-					/obj/item/storage/backpack/duffel/hydro = 50)
+				/obj/item/reagent_containers/glass/bucket = 15,
+				/obj/item/clothing/suit/apron = 50,
+				/obj/item/clothing/suit/apron/overalls = 50,
+				/obj/item/clothing/suit/hooded/wintercoat/hydro = 75,
+				/obj/item/clothing/suit/storage/labcoat/hydro = 75,
+				/obj/item/clothing/mask/bandana/botany = 20,
+				/obj/item/clothing/accessory/armband/hydro = 20,
+				/obj/item/storage/backpack/botany = 50,
+				/obj/item/storage/backpack/satchel_hyd = 50,
+				/obj/item/storage/backpack/duffel/hydro = 50)
+
 	refill_canister = /obj/item/vending_refill/hydrodrobe
 
 /obj/machinery/economy/vending/janidrobe
@@ -616,14 +682,18 @@
 	icon_off = "base_drobe"
 	category = VENDOR_TYPE_CLOTHING
 	ads_list = list("Come and get your janitorial clothing, now endorsed by janitors everywhere!")
+
 	vend_reply = "Thank you for using the JaniDrobe!"
 	products = list(/obj/item/clothing/under/rank/civilian/janitor = 3,
 					/obj/item/clothing/head/soft/purple = 3,
 					/obj/item/clothing/gloves/color/black = 3,
 					/obj/item/clothing/shoes/galoshes = 3,
 					/obj/item/storage/belt/janitor = 3)
+
 	contraband = list(/obj/item/toy/figure/crew/janitor = 1)
+
 	prices = list(/obj/item/clothing/under/rank/civilian/janitor = 50)
+
 	refill_canister = /obj/item/vending_refill/janidrobe
 
 /obj/machinery/economy/vending/lawdrobe
@@ -636,6 +706,7 @@
 	icon_off = "base_drobe"
 	category = VENDOR_TYPE_CLOTHING
 	ads_list = list("OBJECTION! Get the rule of law for yourself!")
+
 	vend_reply = "Thank you for using the LawDrobe!"
 	products = list(/obj/item/clothing/under/rank/civilian/internalaffairs = 2,
 					/obj/item/clothing/under/rank/civilian/lawyer/bluesuit = 2,
@@ -652,20 +723,23 @@
 					/obj/item/clothing/shoes/brown = 2,
 					/obj/item/clothing/glasses/sunglasses/big = 2,
 					/obj/item/clothing/accessory/lawyers_badge = 2)
+
 	contraband = list(/obj/item/toy/figure/crew/lawyer = 1)
+
 	prices = list(/obj/item/clothing/under/rank/civilian/internalaffairs = 50,
-					/obj/item/clothing/under/rank/civilian/lawyer/bluesuit = 50,
-					/obj/item/clothing/under/rank/civilian/lawyer/purple = 50,
-					/obj/item/clothing/under/rank/civilian/lawyer/black = 50,
-					/obj/item/clothing/under/rank/civilian/lawyer/red = 50,
-					/obj/item/clothing/under/rank/civilian/lawyer/blue = 50,
-					/obj/item/clothing/under/suit/female = 50,
-					/obj/item/clothing/suit/storage/internalaffairs = 75,
-					/obj/item/clothing/suit/storage/lawyer/bluejacket = 75,
-					/obj/item/clothing/suit/storage/lawyer/purpjacket = 75,
-					/obj/item/clothing/shoes/laceup = 30,
-					/obj/item/clothing/shoes/black = 20,
-					/obj/item/clothing/shoes/brown = 20,
-					/obj/item/clothing/glasses/sunglasses/big = 30,
-					/obj/item/clothing/accessory/lawyers_badge = 50)
+				/obj/item/clothing/under/rank/civilian/lawyer/bluesuit = 50,
+				/obj/item/clothing/under/rank/civilian/lawyer/purple = 50,
+				/obj/item/clothing/under/rank/civilian/lawyer/black = 50,
+				/obj/item/clothing/under/rank/civilian/lawyer/red = 50,
+				/obj/item/clothing/under/rank/civilian/lawyer/blue = 50,
+				/obj/item/clothing/under/suit/female = 50,
+				/obj/item/clothing/suit/storage/internalaffairs = 75,
+				/obj/item/clothing/suit/storage/lawyer/bluejacket = 75,
+				/obj/item/clothing/suit/storage/lawyer/purpjacket = 75,
+				/obj/item/clothing/shoes/laceup = 30,
+				/obj/item/clothing/shoes/black = 20,
+				/obj/item/clothing/shoes/brown = 20,
+				/obj/item/clothing/glasses/sunglasses/big = 30,
+				/obj/item/clothing/accessory/lawyers_badge = 50)
+
 	refill_canister = /obj/item/vending_refill/lawdrobe

--- a/code/game/machinery/vendors/wardrobe_vendors.dm
+++ b/code/game/machinery/vendors/wardrobe_vendors.dm
@@ -363,7 +363,7 @@
 				/obj/item/clothing/shoes/sandal/white = 20,
 				/obj/item/storage/backpack/science = 50,
 				/obj/item/storage/backpack/satchel_tox = 50,
-				/obj/item/storage/backpack/duffel/science = 50,)
+				/obj/item/storage/backpack/duffel/science = 50)
 
 	refill_canister = /obj/item/vending_refill/scidrobe
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Pretty much just the title, standardizes the following files slogans, ads, prices, contraband, and products lists:
Contraband_vendors.dm,
Departmental_vendors.dm,
Generic_vendors.dm,
Annnd wardrobe_vendors.dm.

As well as removes some spaces from the critter care vendor ad list, that didn't look to be correct. 

" Heat lamps for Unathi!" to "Heat lamps for Unathi!" 
" Vox-y want a cracker?" to "Vox-y want a cracker?"

Since changed non-capitalized armor types as per Henri215's request.
 
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Im honestly not too sure what the ads_list is used for, but it was a typo, so.
As for the standardization, i wouldn't say its good for the game per say, but it is very nice for the coding nerds to not have every list be different, and sometimes the same list change partway through. Looking at you dinnerware vendor!


## Testing
<!-- How did you test the PR, if at all? -->
Compiled, not too sure how else to test a code layout change in game, and the ads_list.. list, doesn't seem to be actually used. 
## Changelog
:cl:
spellcheck: Removed a space in the wrong spot from two critter care vendor lines
/:cl:

Rest is ~~hopefully~~ NPFC
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
