### PR TITLE
Makes the Librarian a little less shit, now they know most languages.

### DIFF
--- a/code/__DEFINES/language_defines.dm
+++ b/code/__DEFINES/language_defines.dm
@@ -17,6 +17,7 @@
 #define NO_TALK_MSG 128		// Do not show the "\The [speaker] talks into \the [radio]" message
 #define NO_STUTTER 256		// No stuttering, slurring, or other speech problems
 #define NOBABEL 512			// Not granted by book of babel. Typically antag languages.
+#define NOLIBRARIAN 1024	// Flag for banning the Librarian from certain languages. (actual 1984)
 
 //Auto-accent level defines.
 #define AUTOHISS_OFF 0

--- a/code/game/jobs/job/support.dm
+++ b/code/game/jobs/job/support.dm
@@ -451,6 +451,11 @@
 	backpack_contents = list(
 		/obj/item/videocam/advanced = 1)
 
+/datum/outfit/job/librarian/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	..()
+	if(H.mind)
+		H.grant_all_babel_languages()
+
 /datum/job/barber
 	title = "Barber"
 	flag = JOB_BARBER

--- a/code/game/jobs/job/support.dm
+++ b/code/game/jobs/job/support.dm
@@ -453,8 +453,13 @@
 
 /datum/outfit/job/librarian/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
-	if(H.mind)
-		H.grant_all_babel_languages()
+	if(!H.mind)
+		return
+	for(var/la in GLOB.all_languages)
+		var/datum/language/new_language = GLOB.all_languages[la]
+		if(new_language.flags & (HIVEMIND| NOLIBRARIAN))
+			continue
+		H.add_language(la)
 
 /datum/job/barber
 	title = "Barber"

--- a/code/game/jobs/job/support.dm
+++ b/code/game/jobs/job/support.dm
@@ -457,7 +457,7 @@
 		return
 	for(var/la in GLOB.all_languages)
 		var/datum/language/new_language = GLOB.all_languages[la]
-		if(new_language.flags & (HIVEMIND| NOLIBRARIAN))
+		if(new_language.flags & (HIVEMIND|NOLIBRARIAN))
 			continue
 		H.add_language(la)
 

--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -257,7 +257,7 @@
 	exclaim_verbs = list("rustles")
 	colour = "diona"
 	key = "q"
-	flags = RESTRICTED
+	flags = RESTRICTED | NOLIBRARIAN
 	syllables = list("hs","zt","kr","st","sh")
 
 /datum/language/diona/get_random_name()
@@ -342,7 +342,7 @@
 	exclaim_verbs = list("imparts")
 	colour = "abductor"
 	key = "^"
-	flags = RESTRICTED | HIVEMIND
+	flags = RESTRICTED | HIVEMIND | NOLIBRARIAN
 	follow = TRUE
 
 /datum/language/grey/broadcast(mob/living/speaker, message, speaker_mask)
@@ -499,7 +499,7 @@
 	ask_verb = "hisses"
 	exclaim_verbs = list("hisses")
 	key = "6"
-	flags = RESTRICTED
+	flags = RESTRICTED | NOLIBRARIAN
 	syllables = list("sss","sSs","SSS")
 
 /datum/language/xenos
@@ -653,7 +653,7 @@
 	ask_verb = "queries"
 	exclaim_verbs = list("declares")
 	key = "]"
-	flags = RESTRICTED
+	flags = RESTRICTED | NOLIBRARIAN
 	follow = TRUE
 	syllables = list ("beep", "boop")
 
@@ -757,6 +757,13 @@
 	for(var/la in GLOB.all_languages)
 		var/datum/language/new_language = GLOB.all_languages[la]
 		if(new_language.flags & NOBABEL)
+			continue
+		languages |= new_language
+
+/mob/proc/grant_all_librarian_languages()
+	for(var/la in GLOB.all_languages)
+		var/datum/language/new_language = GLOB.all_languages[la]
+		if(new_language.flags & NOLIBRARIAN)
 			continue
 		languages |= new_language
 

--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -257,7 +257,7 @@
 	exclaim_verbs = list("rustles")
 	colour = "diona"
 	key = "q"
-	flags = RESTRICTED | NOLIBRARIAN
+	flags = RESTRICTED
 	syllables = list("hs","zt","kr","st","sh")
 
 /datum/language/diona/get_random_name()

--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -760,11 +760,4 @@
 			continue
 		languages |= new_language
 
-/mob/proc/grant_all_librarian_languages()
-	for(var/la in GLOB.all_languages)
-		var/datum/language/new_language = GLOB.all_languages[la]
-		if(new_language.flags & NOLIBRARIAN)
-			continue
-		languages |= new_language
-
 #undef SCRAMBLE_CACHE_LEN


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Essentially gives the Librarian a free built in limited Book of Babel.
## Why It's Good For The Game
Its no shock that the librarian is absolutely one of the worst service roles in the game, it completely is dogshit. Not only is the library one of the most worthless and niche places to visit on station, the job of a librarian is also flawed. People either build bars in the library in desperate attempts to attract people, or they go off and act as shitters from complete boredom.

I think its in need of something that makes it unique or interesting, giving it book of babel knowledge is a *small* remedy to a bigger problem that helps it somewhat, not completely, but it does help.

Firstly, Librarians having extensive knowledge of many languages is not out of the scope of that job, their intelligent. 

Secondly, the ability to have said languages could allow the Librarian to have more channels for roleplay. Languages can sometimes act as barriers, but if a Librarian can interview a xenomorph or alien species with it, that means the role has become more engaging and less shit, always nice to have a negotiator on board. 

Lastly, its not overpowered, language is one of the least important things in the game and I doubt it will break the bank in terms of its usefulness, at most I can see it leading to more dialogue from interviews.

## Testing
yes

## Changelog
:cl:
tweak: The librarian mentally now gets most languages due to being a bookworm
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
