### PR TITLE
No longer drop items in other hand when one hand is lost

### DIFF
--- a/code/modules/surgery/organs/subtypes/standard_organs.dm
+++ b/code/modules/surgery/organs/subtypes/standard_organs.dm
@@ -180,9 +180,9 @@
 		update_hand_missing()
 		if(owner.gloves)
 			owner.unEquip(owner.gloves)
-		if(owner.l_hand)
+		if(owner.l_hand && (body_part == HAND_LEFT))
 			owner.unEquip(owner.l_hand, TRUE)
-		if(owner.r_hand)
+		if(owner.r_hand && (body_part == HAND_RIGHT))
 			owner.unEquip(owner.r_hand, TRUE)
 
 	. = ..()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes it so that when you lose a hand, whatever you are holding in your _other_ hand is not dropped as well.
Fixes: #21975
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Bug bad.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Give a skrell a thing to hold in both hands.
Cut off one hand.
One item drops, the other stays in the hand that is still attached.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: No longer drop items in other hand when one hand is lost
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
