### PR TITLE
Fixes infestation not using a valid name

### DIFF
--- a/code/modules/events/infestation.dm
+++ b/code/modules/events/infestation.dm
@@ -13,16 +13,16 @@
 	var/area/spawn_area_type
 	/// All possible areas for spawning, matched with their pretty names
 	var/static/list/spawn_areas = list(
-		/area/station/service/kitchen = "the kitchen",
-		/area/station/engineering/atmos = "atmospherics",
-		/area/station/maintenance/incinerator = "the incinerator",
-		/area/station/service/chapel = "the chapel",
-		/area/station/service/library = "the library",
-		/area/station/service/hydroponics = "hydroponics",
-		/area/station/command/vault = "the vault",
-		/area/station/public/construction = "the construction area",
-		/area/station/engineering/tech_storage = "technical storage",
-		/area/station/security/armory/secure = "the armory"
+		/area/station/service/kitchen,
+		/area/station/engineering/atmos,
+		/area/station/maintenance/incinerator,
+		/area/station/service/chapel,
+		/area/station/service/library,
+		/area/station/service/hydroponics,
+		/area/station/command/vault,
+		/area/station/public/construction,
+		/area/station/engineering/tech_storage,
+		/area/station/security/armory/secure
 	)
 
 /datum/event/infestation/start()

--- a/code/modules/events/infestation.dm
+++ b/code/modules/events/infestation.dm
@@ -5,10 +5,13 @@
 /datum/event/infestation
 	announceWhen = 10
 	endWhen = 11
-	var/location
-	var/locstring
+	/// Which kind of vermin we'll be spawning (one of the three defines)
 	var/vermin
+	/// Pretty name for the vermin we're spawning
 	var/vermstring
+	/// The area we'll be spawning things in
+	var/area/spawn_area_type
+	/// All possible areas for spawning, matched with their pretty names
 	var/static/list/spawn_areas = list(
 		/area/station/service/kitchen = "the kitchen",
 		/area/station/engineering/atmos = "atmospherics",
@@ -24,8 +27,7 @@
 
 /datum/event/infestation/start()
 	var/list/turf/simulated/floor/turfs = list()
-	var/area/spawn_area_type = pick(spawn_areas)
-	locstring = spawn_areas[location]
+	spawn_area_type = pick(spawn_areas)
 	for(var/areapath in typesof(spawn_area_type))
 		var/area/A = locate(areapath)
 		if(!A)
@@ -67,12 +69,14 @@
 
 /datum/event/infestation/announce(false_alarm)
 	var/vermin_chosen = vermstring || pick("spiders", "lizards", "mice")
-	var/location_str = locstring
-	if(false_alarm)
-		var/area/loc_area = pick(spawn_areas)
-		location_str = spawn_areas[loc_area]
+	if(!spawn_area_type)
+		if(false_alarm)
+			spawn_area_type = pick(spawn_areas)
+		else
+			log_debug("Infestation Event didn't provide an area to announce(), something is likely broken.")
+			kill()
 
-	GLOB.minor_announcement.Announce("Bioscans indicate that [vermin_chosen] have been breeding in [location_str]. Clear them out, before this starts to affect productivity.", "Lifesign Alert")
+	GLOB.minor_announcement.Announce("Bioscans indicate that [vermin_chosen] have been breeding in \the [initial(spawn_area_type.name)]. Clear them out, before this starts to affect productivity.", "Lifesign Alert")
 
 #undef VERM_MICE
 #undef VERM_LIZARDS


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes a bug with infestations introduced during https://github.com/ParadiseSS13/Paradise/pull/22010 which caused locations to go unannounced.
Also, refactors infestation code slightly so the message string is automatically pulled from the area's name, instead of being a separately defined list.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
The crew should probably know where spiders are breeding.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://github.com/ParadiseSS13/Paradise/assets/89928798/b99a179d-d608-4c77-b303-12dd1355b2c1)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
See above.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Infestation events now properly notify about the areas in which they are occurring.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
