### PR TITLE
Fixes grammatical error in nuke wiring

### DIFF
--- a/code/datums/wires/nuclearbomb_wires.dm
+++ b/code/datums/wires/nuclearbomb_wires.dm
@@ -20,7 +20,7 @@
 	. = ..()
 	var/obj/machinery/nuclearbomb/N = holder
 	. += "The device is [N.timing ? "shaking!" : "still."]"
-	. += "The device is is [N.safety ? "quiet" : "whirring"]."
+	. += "The device is [N.safety ? "quiet" : "whirring"]."
 	. += "The lights are [N.lighthack ? "static" : "functional"]."
 
 /datum/wires/nuclearbomb/on_pulse(wire)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Fixes a grammatical error in the nuke core wiring.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Good grammar is pleasing to read.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
Before
![image](https://github.com/ParadiseSS13/Paradise/assets/142894314/cc72ab02-dc0c-45f7-a48a-f57ced7dc11a)

After
![image](https://github.com/ParadiseSS13/Paradise/assets/142894314/979c343e-9321-4afc-af8c-67b90f6b4402)


## Testing
<!-- How did you test the PR, if at all? -->
Loaded the game, opened nuclear device wiring, checked grammar was correct.

## Changelog
:cl:
spellcheck: Fixed a grammatical error in the nuke core wiring.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
