### PR TITLE
Gives Amber RT Engineers CE Belt and Welding Protection

### DIFF
--- a/code/modules/response_team/ert_outfits.dm
+++ b/code/modules/response_team/ert_outfits.dm
@@ -219,6 +219,7 @@
 	belt = /obj/item/storage/belt/utility/full/multitool
 	pda = /obj/item/pda/heads/ert/engineering
 	id = /obj/item/card/id/ert/engineering
+	belt = /obj/item/storage/belt/utility/chief/full
 
 /datum/outfit/job/centcom/response_team/engineer/amber
 	name = "RT Engineer (Amber)"
@@ -227,7 +228,6 @@
 	suit_store = /obj/item/tank/internals/emergency_oxygen/engi
 	glasses = /obj/item/clothing/glasses/meson/engine
 	mask = /obj/item/clothing/mask/gas
-	belt = /obj/item/storage/belt/utility/chief/full
 
 	cybernetic_implants = list(
 		/obj/item/organ/internal/cyberimp/brain/wire_interface/hardened,
@@ -247,7 +247,6 @@
 /datum/outfit/job/centcom/response_team/engineer/red
 	name = "RT Engineer (Red)"
 	shoes = /obj/item/clothing/shoes/magboots/advance
-	belt = /obj/item/storage/belt/utility/chief/full
 	suit = /obj/item/clothing/suit/space/hardsuit/ert/engineer/gamma
 	suit_store = /obj/item/tank/internals/emergency_oxygen/engi
 	glasses = /obj/item/clothing/glasses/meson/engine
@@ -274,7 +273,6 @@
 	name = "RT Engineer (Gamma)"
 	shoes = /obj/item/clothing/shoes/magboots/advance
 	back = /obj/item/mod/control/pre_equipped/responsory/engineer
-	belt = /obj/item/storage/belt/utility/chief/full
 	glasses = /obj/item/clothing/glasses/meson/night
 	mask = /obj/item/clothing/mask/gas/sechailer/swat
 

--- a/code/modules/response_team/ert_outfits.dm
+++ b/code/modules/response_team/ert_outfits.dm
@@ -227,7 +227,12 @@
 	suit_store = /obj/item/tank/internals/emergency_oxygen/engi
 	glasses = /obj/item/clothing/glasses/meson/engine
 	mask = /obj/item/clothing/mask/gas
-	cybernetic_implants = list(/obj/item/organ/internal/cyberimp/brain/wire_interface/hardened)
+	belt = /obj/item/storage/belt/utility/chief/full
+
+	cybernetic_implants = list(
+		/obj/item/organ/internal/cyberimp/brain/wire_interface/hardened,
+		/obj/item/organ/internal/eyes/cybernetic/shield
+	)
 
 	l_pocket = /obj/item/gun/energy/gun/mini
 	r_pocket = /obj/item/melee/classic_baton/telescopic

--- a/code/modules/response_team/ert_outfits.dm
+++ b/code/modules/response_team/ert_outfits.dm
@@ -216,7 +216,6 @@
 	rt_mob_job = "ERT Engineering"
 	back = /obj/item/storage/backpack/ert/engineer
 	uniform = /obj/item/clothing/under/rank/centcom/ert/engineer
-	belt = /obj/item/storage/belt/utility/full/multitool
 	pda = /obj/item/pda/heads/ert/engineering
 	id = /obj/item/card/id/ert/engineering
 	belt = /obj/item/storage/belt/utility/chief/full


### PR DESCRIPTION
## What Does This PR Do
This PR adds a full Chief Engineer's belt and Shield eyes to the Amber Response Team Engineer.
This is a reopening of https://github.com/ParadiseSS13/Paradise/pull/21872 with the addition of the welding protection.
## Why It's Good For The Game
As an emergency response team member, the player should have the equipment necessary to be able to handle emergencies on station for which they were requested for.
## Testing
Spawned an Amber RT Engineer.
Checked to see if a full utility belt with power tools was present.
Checked to see if shield eyes were present.
## Changelog
:cl:
add: Added shield eyes to Amber Engineer 
tweak: Tweaked belt type that is given to Amber Engineer
/:cl: