### PR TITLE
Tweaks the protector guardian

### DIFF
--- a/code/game/gamemodes/miniantags/guardian/types/protector.dm
+++ b/code/game/gamemodes/miniantags/guardian/types/protector.dm
@@ -25,7 +25,7 @@
 
 /mob/living/simple_animal/hostile/guardian/protector/Manifest()
 	. = ..()
-	if(toggle && cooldown > world.time)
+	if(toggle && cooldown < world.time)
 		var/dir_left = turn(dir, -90)
 		var/dir_right = turn(dir, 90)
 		connected_shields += new /obj/effect/guardianshield(get_step(src, dir_left), src, FALSE)
@@ -62,6 +62,10 @@
 		toggle = FALSE
 		QDEL_LIST_CONTENTS(connected_shields)
 	else
+		if(!isturf(loc))
+			return
+		if(get_turf(summoner) == get_turf(src))
+			return
 		var/icon/shield_overlay = icon('icons/effects/effects.dmi', "shield-grey")
 		shield_overlay *= name_color
 		overlays.Add(shield_overlay)
@@ -69,7 +73,7 @@
 		melee_damage_upper = 2
 		obj_damage = 6 //40/7.5 rounded up, we don't want a protector guardian 2 shotting blob tiles while taking 5% damage, thats just silly.
 		move_resist = MOVE_FORCE_STRONG
-		speed = 1
+		speed = 2
 		damage_transfer = 0.1 //damage? what's damage?
 		to_chat(src, "<span class='danger'>You switch to protection mode.</span>")
 		toggle = TRUE
@@ -121,7 +125,7 @@
 	shield_orientation = left_or_right
 
 /obj/effect/guardianshield/CanPass(atom/movable/mover, turf/target)
-	if(mover == linked_guardian || mover == linked_guardian.summoner)
+	if(mover == linked_guardian)
 		return TRUE
 	return FALSE
 

--- a/code/game/gamemodes/miniantags/guardian/types/protector.dm
+++ b/code/game/gamemodes/miniantags/guardian/types/protector.dm
@@ -65,6 +65,7 @@
 		if(!isturf(loc))
 			return
 		if(get_turf(summoner) == get_turf(src))
+			to_chat(src, "<span class='warning'>You cannot deploy your shield while on your host!</span>")
 			return
 		var/icon/shield_overlay = icon('icons/effects/effects.dmi', "shield-grey")
 		shield_overlay *= name_color
@@ -73,7 +74,7 @@
 		melee_damage_upper = 2
 		obj_damage = 6 //40/7.5 rounded up, we don't want a protector guardian 2 shotting blob tiles while taking 5% damage, thats just silly.
 		move_resist = MOVE_FORCE_STRONG
-		speed = 2
+		speed = 1
 		damage_transfer = 0.1 //damage? what's damage?
 		to_chat(src, "<span class='danger'>You switch to protection mode.</span>")
 		toggle = TRUE

--- a/code/game/gamemodes/miniantags/guardian/types/protector.dm
+++ b/code/game/gamemodes/miniantags/guardian/types/protector.dm
@@ -6,7 +6,7 @@
 	melee_damage_upper = 15
 	range = 15 //worse for it due to how it leashes
 	damage_transfer = 0.4
-	playstyle_string = "As a <b>Protector</b> type you cause your summoner to leash to you instead of you leashing to them and have two modes; Combat Mode, where you do and take medium damage, and Protection Mode, where you do and take almost no damage, but move slightly slower, as well as have a protective shield."
+	playstyle_string = "As a <b>Protector</b> type you cause your summoner to leash to you instead of you leashing to them and have two modes; Combat Mode, where you do and take medium damage, and Protection Mode, where you do and take almost no damage, but move slightly slower, as well as have a protective shield. Nobody can walk through your shield, but you can still move your shield through them."
 	magic_fluff_string = "..And draw the Guardian, a stalwart protector that never leaves the side of its charge."
 	tech_fluff_string = "Boot sequence complete. Protector modules loaded. Holoparasite swarm online."
 	bio_fluff_string = "Your scarab swarm finishes mutating and stirs to life, ready to defend you."


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes some weird behavior with the protector guardian, you can't project your shields in your host or project your shields on your host anymore
You can no longer move through a guardian wall as the summoner, and the speed of a projecting holopara is decreased to 2 from 1

## Why It's Good For The Game
bugfixes are good and this is rather overtuned right now. You can put the holo on the same tile you're on and you can't really hurt em. Making people play more carefully instead of using it like forcewall where you can just walk through it

## Testing
dd is pain
## Changelog
:cl:
tweak: Protector guardian now has more reduced speed while moving, summoner cannot move through guardian walls, and you cannot project your shields while you're on the same tile as your host
fix: You can no longer project guardian shields in your host
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
