### PR TITLE
add dmi mergedriver to gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 ## Merger hooks, run tools/hooks/install.bat or install.sh to set up
 *.dmm text eol=lf merge=dmm
+*.dmi binary merge=dmi


### PR DESCRIPTION
## What Does This PR Do
This PR enables the custom DMI file merge driver by default.

## Why It's Good For The Game
DMI merge conflict is a special hell

## Images of changes
![2023_09_19__17_23_26__ gitattributes - Paradise - Visual Studio Code](https://github.com/ParadiseSS13/Paradise/assets/59303604/b7a987e8-8f7f-4066-b9a4-875732705d63)
![2023_09_19__17_24_16__paradise  icons_obj_decals dmi  - Dream Maker](https://github.com/ParadiseSS13/Paradise/assets/59303604/c22932b2-1b64-464c-9619-813ee0ab09f7)


## Testing
Made two branches, merged them.

## Changelog
NPFC
