### PR TITLE
add CI check for DMI conflict markers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
           python tools/ci/check_file_names.py
           python tools/ci/unticked_files.py ${GITHUB_WORKSPACE}
           python tools/ci/illegal_dme_files.py ${GITHUB_WORKSPACE}
+          python -m tools.ci.check_icon_conflicts
           python -m tools.maplint.source --github
           ~/dreamchecker > ${GITHUB_WORKSPACE}/output-annotations.txt 2>&1
       - name: Annotate Lints

--- a/tools/ci/check_icon_conflicts.py
+++ b/tools/ci/check_icon_conflicts.py
@@ -1,0 +1,37 @@
+from collections import defaultdict
+import glob
+import sys
+import time
+
+from ..dmi import Dmi
+
+
+if __name__ == "__main__":
+    print("check_icon_conflicts started")
+
+    count = 0
+    exit_code = 0
+    start = time.time()
+
+    findings = defaultdict(list)
+
+    for dmi_path in glob.glob("**/*.dmi", recursive=True):
+        dmi = Dmi.from_file(dmi_path)
+        for state in dmi.states:
+            if '!CONFLICT!' in state.name:
+                findings[dmi_path].append(state.name)
+        count += 1
+
+    if findings:
+        exit_code = 1
+
+        for filename in sorted(findings.keys()):
+            states = findings[filename]
+            for state in sorted(states):
+                print(f"{filename}: conflicted state {state}")
+
+
+    end = time.time()
+    print(f"\ncheck_icon_conflicts checked {count} files in {end - start:.2f}s\n")
+
+    sys.exit(exit_code)


### PR DESCRIPTION
## What Does This PR Do
This PR adds a CI check to parse DMI files looking for states with the `!CONFLICT!` token added by the DMI merge driver. It does the whole codebase in 4 seconds which is fine performance-wise. Note that the invocation in the CI file is `python -m tools.ci.check_icon_conflicts` versus `python tools/ci/check_icon_conflicts.py` so that it can reach into the parent module to find the icon file parser.

## Why It's Good For The Game
Currently nothing stops someone from just accepting the conflicted file as is.

## Images of changes
![2023_09_19__17_47_28__Comparing ParadiseSS13_master warriorstar-orion_icon_conflict_ci · ParadiseSS1](https://github.com/ParadiseSS13/Paradise/assets/59303604/03dbb730-a101-4970-909b-7ef000b70165)


## Testing
Tested with a conflicted DMI file, ran CI.

## Changelog
NPFC