### PR TITLE
Cargo QOL + Mail Bag Fix

### DIFF
--- a/code/game/jobs/job/support.dm
+++ b/code/game/jobs/job/support.dm
@@ -28,6 +28,7 @@
 	mask = /obj/item/clothing/mask/cigarette/cigar/cohiba
 	id = /obj/item/card/id/quartermaster
 	l_hand = /obj/item/clipboard
+	l_pocket = /obj/item/mail_scanner
 	pda = /obj/item/pda/quartermaster
 	backpack_contents = list(
 		/obj/item/melee/classic_baton/telescopic = 1

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -285,6 +285,7 @@ GLOBAL_LIST_INIT(cloth_recipes, list (
 		new /datum/stack_recipe("chemistry bag", /obj/item/storage/bag/chemistry, 4),
 		new /datum/stack_recipe("bio bag", /obj/item/storage/bag/bio, 4),
 		new /datum/stack_recipe("fish bag", /obj/item/storage/bag/fish, 4),
+		new /datum/stack_recipe("mail bag", /obj/item/storage/bag/mail, 4),
 	)),
 	null,
 	new /datum/stack_recipe("improvised gauze", /obj/item/stack/medical/bruise_pack/improvised, 1, 2, 6),

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -550,5 +550,5 @@
 	storage_slots = 14
 	max_combined_w_class = 28
 	w_class = WEIGHT_CLASS_TINY
-	can_hold = list(/obj/item/envelope, /obj/item/stamp, /obj/item/pen, /obj/item/paper)
+	can_hold = list(/obj/item/envelope, /obj/item/stamp, /obj/item/pen, /obj/item/paper, /obj/item/mail_scanner)
 	resistance_flags = FLAMMABLE

--- a/code/game/objects/structures/crates_lockers/closets/secure/cargo_lockers.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/cargo_lockers.dm
@@ -11,6 +11,7 @@
 	new /obj/item/radio/headset/headset_cargo(src)
 	new /obj/item/clothing/gloves/fingerless(src)
 	new /obj/item/clothing/head/soft(src)
+	new /obj/item/storage/bag/mail(src)
 //		new /obj/item/cartridge/quartermaster(src)
 
 
@@ -34,4 +35,5 @@
 	new /obj/item/destTagger(src)
 	new /obj/item/reagent_containers/food/drinks/mug/qm(src)
 	new /obj/item/flash(src)
+	new /obj/item/storage/bag/mail(src)
 

--- a/code/modules/clothing/suits/misc_suits.dm
+++ b/code/modules/clothing/suits/misc_suits.dm
@@ -501,7 +501,7 @@
 	name = "cargo winter coat"
 	icon_state = "wintercoat_cargo"
 	item_state = "coatcargo"
-	allowed = list(/obj/item/flashlight, /obj/item/tank/internals/emergency_oxygen, /obj/item/toy, /obj/item/storage/fancy/cigarettes, /obj/item/lighter, /obj/item/rcs, /obj/item/clipboard, /obj/item/envelope, /obj/item/storage/bag/mail)
+	allowed = list(/obj/item/flashlight, /obj/item/tank/internals/emergency_oxygen, /obj/item/toy, /obj/item/storage/fancy/cigarettes, /obj/item/lighter, /obj/item/rcs, /obj/item/clipboard, /obj/item/envelope, /obj/item/storage/bag/mail, /obj/item/mail_scanner)
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/cargo
 
 /obj/item/clothing/head/hooded/winterhood/cargo

--- a/code/modules/mod/mod_theme.dm
+++ b/code/modules/mod/mod_theme.dm
@@ -391,18 +391,7 @@
 	complexity_max = DEFAULT_MAX_COMPLEXITY - 5
 	slowdown_inactive = 0.5
 	slowdown_active = 0
-	allowed_suit_storage = list(
-		/obj/item/rpd,
-		/obj/item/rcs,
-		/obj/item/storage/bag/mail,
-		/obj/item/envelope,
-		/obj/item/stamp,
-		/obj/item/pen,
-		/obj/item/paper,
-		/obj/item/mail_scanner,
-		/obj/item/eftpos,
-		/obj/item/melee/classic_baton/telescopic,
-	)
+	allowed_suit_storage = list()
 	inbuilt_modules = list(/obj/item/mod/module/hydraulic, /obj/item/mod/module/clamp/loader, /obj/item/mod/module/magnet)
 	skins = list(
 		"loader" = list(

--- a/code/modules/mod/mod_theme.dm
+++ b/code/modules/mod/mod_theme.dm
@@ -392,6 +392,16 @@
 	slowdown_inactive = 0.5
 	slowdown_active = 0
 	allowed_suit_storage = list(
+		/obj/item/rpd,
+		/obj/item/rcs,
+		/obj/item/storage/bag/mail,
+		/obj/item/envelope,
+		/obj/item/stamp,
+		/obj/item/pen,
+		/obj/item/paper,
+		/obj/item/mail_scanner,
+		/obj/item/eftpos,
+		/obj/item/melee/classic_baton/telescopic,
 	)
 	inbuilt_modules = list(/obj/item/mod/module/hydraulic, /obj/item/mod/module/clamp/loader, /obj/item/mod/module/magnet)
 	skins = list(


### PR DESCRIPTION
## What Does This PR Do
see changelog. I messed up.

## Why It's Good For The Game
This absolutely should have been in the mail PR, I just didn't notice.

## Testing
Logged on, checked..

## Changelog
:cl:
tweak:  Mail bags can now be crafted with cloth.
tweak: Both the Quartermaster and Cargo Techs now start with mail bags in their lockers.
tweak: Quartermaster roundstart loadout changed to include a mail scanner.
tweak: Cargo Winter Coats can now accept more cargo themed items.
tweak: Mail bags can now fit mail scanners.
/:cl: