### PR TITLE
LWAP now descopes more accurately to movement, instead of on process

### DIFF
--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -111,8 +111,6 @@
 /obj/item/gun/energy/lasercannon/cyborg/emp_act()
 	return
 
-#define PROCESS_TIME_PLUS_DECISECOND 2.1 SECONDS //This ensures that you cant move and scope the lwap.
-
 /obj/item/gun/energy/lwap
 	name = "LWAP laser sniper"
 	desc = "A highly advanced laser sniper that does more damage the farther away the target is, but fires slowly. Comes with a super advanced scope, which can highlight threats through walls, and pierce one object, after being deployed for a while."
@@ -132,15 +130,6 @@
 	/// Is the scope fully online or not?
 	var/scope_active = FALSE
 	var/stored_dir
-
-/obj/item/gun/energy/lwap/Initialize(mapload, ...)
-	. = ..()
-	START_PROCESSING(SSobj, src)
-
-/obj/item/gun/energy/lwap/Destroy()
-	STOP_PROCESSING(SSobj, src)
-	return ..()
-
 
 /obj/item/gun/energy/lwap/zoom(mob/living/user, forced_zoom)
 	. = ..()
@@ -163,19 +152,14 @@
 	if(zoomed)
 		zoom(user, FALSE) //Moved while scope was booting, so we unzoom
 
-/obj/item/gun/energy/lwap/process()
-	. = ..()
-	if(!isliving(loc))
-		return
-	var/mob/living/M = loc
-	if(world.time - M.last_movement <= PROCESS_TIME_PLUS_DECISECOND && scope_active) //If they have moved in the last process cycle.
-		to_chat(M, "<span class='warning'>[src]'s scope is overloaded by movement and shuts down!</span>")
-		zoom(M, FALSE)
+/obj/item/gun/energy/lwap/on_mob_move(dir, mob/user)
+	if(scope_active)
+		to_chat(user, "<span class='warning'>[src]'s scope is overloaded by movement and shuts down!</span>")
+		zoom(user, FALSE)
 
 /obj/item/gun/energy/lwap/attack_self()
 	return //no manual ammo changing.
 
-#undef PROCESS_TIME_PLUS_DECISECOND
 /obj/item/ammo_casing/energy/laser/sniper
 	projectile_type = /obj/item/projectile/beam/laser/sniper
 	muzzle_flash_color = LIGHT_COLOR_PINK


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

LWAP now uses on_mob_move instead of checking if the mob has moved every process. You can still turn / shoot without breaking the zoom, just not move off the tile

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

More accurate movement tracking is good.
Not having the lwap process and check every 2 seconds is also good.

## Testing
<!-- How did you test the PR, if at all? -->

Confirmed lwap descoped as expected.

## Changelog
:cl:
tweak: LWAP now descopes more accurately to movement, instead of every 2 seconds
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
