### PR TITLE
Antimatter now innacurate without zooming. Sniper projectiles are faster / pass through weak stuff.

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -127,14 +127,15 @@
 #define SAFE	16
 
 //flags for pass_flags
-#define PASSTABLE		1
-#define PASSGLASS		2
-#define PASSGRILLE		4
-#define PASSBLOB		8
-#define PASSMOB			16
-#define LETPASSTHROW	32
-#define PASSFENCE		64
-#define PASSDOOR		128
+#define PASSTABLE		(1<<0)
+#define PASSGLASS		(1<<1)
+#define PASSGRILLE		(1<<2)
+#define PASSBLOB		(1<<3)
+#define PASSMOB			(1<<4)
+#define LETPASSTHROW	(1<<5)
+#define PASSFENCE		(1<<6)
+#define PASSDOOR		(1<<7)
+#define PASSGIRDER		(1<<8)
 
 //turf-only flags
 #define NOJAUNT		1

--- a/code/datums/uplink_items/uplink_nuclear.dm
+++ b/code/datums/uplink_items/uplink_nuclear.dm
@@ -294,7 +294,7 @@
 /datum/uplink_item/ammo/sniper/antimatter
 	name = "Sniper - .50 Antimatter Magazine"
 	desc = "A 6-round magazine of antimatter ammo for use with .50 sniper rifles. \
-	Able to heavily damage objects, and delimb people."
+	Able to heavily damage objects, and delimb people. Requires zooming for accurate aiming."
 	reference = "50A"
 	item = /obj/item/ammo_box/magazine/sniper_rounds/antimatter
 	cost = 30

--- a/code/datums/uplink_items/uplink_nuclear.dm
+++ b/code/datums/uplink_items/uplink_nuclear.dm
@@ -294,7 +294,7 @@
 /datum/uplink_item/ammo/sniper/antimatter
 	name = "Sniper - .50 Antimatter Magazine"
 	desc = "A 6-round magazine of antimatter ammo for use with .50 sniper rifles. \
-	Able to heavily damage objects, and delimb people. Requires zooming for accurate aiming."
+	Able to heavily damage objects, and delimb people. Requires zooming in for accurate aiming."
 	reference = "50A"
 	item = /obj/item/ammo_box/magazine/sniper_rounds/antimatter
 	cost = 30

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -399,8 +399,8 @@
 		qdel(src)
 
 /obj/structure/girder/CanPass(atom/movable/mover, turf/target, height=0)
-	if(height==0)
-		return 1
+	if(!height)
+		return TRUE
 	if(istype(mover) && mover.checkpass(PASSGIRDER))
 		return TRUE
 	if(istype(mover) && mover.checkpass(PASSGRILLE))

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -401,6 +401,8 @@
 /obj/structure/girder/CanPass(atom/movable/mover, turf/target, height=0)
 	if(height==0)
 		return 1
+	if(istype(mover) && mover.checkpass(PASSGIRDER))
+		return TRUE
 	if(istype(mover) && mover.checkpass(PASSGRILLE))
 		return prob(girderpasschance)
 	else

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -20,6 +20,12 @@
 	slot_flags = SLOT_BACK
 	actions_types = list()
 
+/obj/item/gun/projectile/automatic/sniper_rifle/process_fire(atom/target, mob/living/user, message = TRUE, params, zone_override, bonus_spread = 0)
+	if(istype(chambered.BB, /obj/item/projectile/bullet/sniper/antimatter) && !zoomed)
+		to_chat(user, "<span class='warning'>[src] must be zoomed in to fire this ammunition accurately!</span>")
+		bonus_spread += 60
+	return ..()
+
 /obj/item/gun/projectile/automatic/sniper_rifle/syndicate
 	name = "syndicate sniper rifle"
 	desc = "Syndicate flavoured sniper rifle, it packs quite a punch, a punch to your face."
@@ -59,10 +65,12 @@
 	weaken = 10 SECONDS
 	armour_penetration_flat = 70
 	forced_accuracy = TRUE
+	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE | PASSGIRDER
+	speed = 0.5
 
 /obj/item/ammo_box/magazine/sniper_rounds/antimatter
 	name = "sniper rounds (Antimatter)"
-	desc = "Antimatter sniper rounds, for when you really don't like something."
+	desc = "Antimatter sniper rounds, for when you really don't like something. Requires zooming to fire accurately."
 	icon_state = "antimatter"
 	ammo_type = /obj/item/ammo_casing/antimatter
 
@@ -109,8 +117,6 @@
 		L.SetSleeping(40 SECONDS)
 
 	return ..()
-
-
 
 //hemorrhage ammo
 /obj/item/ammo_box/magazine/sniper_rounds/haemorrhage
@@ -159,6 +165,8 @@
 	damage = 60
 	forcedodge = -1
 	weaken = 0
+	speed = 0.75
+	pass_flags = PASSTABLE //damage glass
 
 //toy magazine
 /obj/item/ammo_box/magazine/toy/sniper_rounds

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -70,7 +70,7 @@
 
 /obj/item/ammo_box/magazine/sniper_rounds/antimatter
 	name = "sniper rounds (Antimatter)"
-	desc = "Antimatter sniper rounds, for when you really don't like something. Requires zooming to fire accurately."
+	desc = "Antimatter sniper rounds, for when you really don't like something. Requires zooming in to fire accurately."
 	icon_state = "antimatter"
 	ammo_type = /obj/item/ammo_casing/antimatter
 

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -21,9 +21,11 @@
 	actions_types = list()
 
 /obj/item/gun/projectile/automatic/sniper_rifle/process_fire(atom/target, mob/living/user, message = TRUE, params, zone_override, bonus_spread = 0)
-	if(istype(chambered.BB, /obj/item/projectile/bullet/sniper/antimatter) && !zoomed)
-		to_chat(user, "<span class='warning'>[src] must be zoomed in to fire this ammunition accurately!</span>")
-		bonus_spread += 60
+	if(istype(chambered.BB, /obj/item/projectile/bullet/sniper) && !zoomed)
+		var/obj/item/projectile/bullet/sniper/S = chambered.BB
+		if(S.non_zoom_spread)
+			to_chat(user, "<span class='warning'>[src] must be zoomed in to fire this ammunition accurately!</span>")
+			bonus_spread += S.non_zoom_spread
 	return ..()
 
 /obj/item/gun/projectile/automatic/sniper_rifle/syndicate
@@ -67,6 +69,7 @@
 	forced_accuracy = TRUE
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE | PASSGIRDER
 	speed = 0.5
+	var/non_zoom_spread = 0
 
 /obj/item/ammo_box/magazine/sniper_rounds/antimatter
 	name = "sniper rounds (Antimatter)"
@@ -83,6 +86,7 @@
 /obj/item/projectile/bullet/sniper/antimatter
 	name = "antimatter bullet"
 	dismemberment = 50
+	non_zoom_spread = 60
 
 /obj/item/projectile/bullet/sniper/antimatter/on_hit(atom/target, blocked = 0, hit_zone)
 	if((blocked != 100) && (!ismob(target)))

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -552,6 +552,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 				"<span class='danger'>\The [owner]'s [name] explodes[gore]!</span>",\
 				"<span class='moderate'><b>Your [name] explodes[gore]!</b></span>",\
 				"<span class='danger'>You hear the [gore_sound].</span>")
+			disembowel(limb_name)
 
 	var/mob/living/carbon/human/victim = owner //Keep a reference for post-removed().
 	// Let people make limbs become fun things when removed
@@ -612,7 +613,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 		var/org_zone = check_zone(O.parent_organ)
 		if(org_zone == spillage_zone)
 			O.remove(C)
-			O.forceMove(T)
+a			O.forceMove(T)
 			organ_spilled = TRUE
 
 	if(organ_spilled)

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -613,7 +613,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 		var/org_zone = check_zone(O.parent_organ)
 		if(org_zone == spillage_zone)
 			O.remove(C)
-a			O.forceMove(T)
+			O.forceMove(T)
 			organ_spilled = TRUE
 
 	if(organ_spilled)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
converts passflags.
Adds PASSGIRDERS, for passing girders.
Sniper bullets are now faster and pass through weak blockages like glass, grills, and girders, due to their high caliber. Walls still stops them, or other objects. This should allow for longer range shooting to be more viable.
Pen rounds are slightly faster but not as fast, due to penetration. They also still break glass and such.
Antimatter rounds are now inaccurate unless zoomed in, and will drop organs when gibbing a limb.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Permakill sniper rounds are not as fun, makes a bit more work to one shot someone, but better at longer ranges, and glass barricades will not make the weapon useless.

## Testing
<!-- How did you test the PR, if at all? -->

Shot a bunch of skrell with antimatter, shot other weapons.

## Changelog
:cl:
tweak: Sniper bullets are faster and pass through weak barricades such as glass and girders.
tweak: Antimatter rounds no longer delete organs when gibbing a limb, and must be zoomed in to fire accurately.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
