### PR TITLE
add blackbox stats for mail scans/deliveries

### DIFF
--- a/code/game/objects/mail.dm
+++ b/code/game/objects/mail.dm
@@ -242,6 +242,7 @@
 		to_chat(user, "<span class='notice'>You add [envelope] to the active database.</span>")
 		playsound(loc, 'sound/mail/mailscanned.ogg', 50, TRUE)
 		saved = A
+		SSblackbox.record_feedback("amount", "successful_mail_scan", 1)
 		return
 	if(isliving(A))
 		var/mob/living/M = A
@@ -270,3 +271,4 @@
 		to_chat(user, "<span class='notice'>Successful delivery acknowledged! [MAIL_DELIVERY_BONUS] credits added to Supply account!</span>")
 		playsound(loc, 'sound/mail/mailapproved.ogg', 50, TRUE)
 		GLOB.station_money_database.credit_account(SSeconomy.cargo_account, MAIL_DELIVERY_BONUS, "Mail Delivery Compensation", "Messaging and Intergalactic Letters", supress_log = FALSE)
+		SSblackbox.record_feedback("amount", "successful_mail_delivery", 1)


### PR DESCRIPTION
## What Does This PR Do
This PR adds two feedback stats for mail: successful scans and successful deliveries.

## Why It's Good For The Game
These are stats worth having for this feature for posterity, especially fun stuff like year end stats reports.

## Testing
Performed actions in round, confirmed rows were added to DB.

![2023_09_20__02_51_30__Unnamed_paradise_gamedb_feedback_ - HeidiSQL 11 0 0 5919](https://github.com/ParadiseSS13/Paradise/assets/59303604/024533a5-40b8-40c9-85f5-1b5f7b3d3942)


## Changelog
NPFC
