### PR TITLE
[s] Fixes an infinite sand/ORM exploit with grass tiles and shovels

### DIFF
--- a/code/game/turfs/simulated/floor/fancy_floor.dm
+++ b/code/game/turfs/simulated/floor/fancy_floor.dm
@@ -64,6 +64,14 @@
 	heavyfootstep = FOOTSTEP_GENERIC_HEAVY
 	transform = matrix(1, 0, -9, 0, 1, -9) //Yes, these sprites are 50x50px, big grass control the industry
 
+/turf/simulated/floor/grass/attackby(obj/item/C, mob/user, params)
+	if(..())
+		return
+	if(istype(C, /obj/item/shovel))
+		to_chat(user, "<span class='notice'>You shovel the grass.</span>")
+		playsound(src, 'sound/effects/shovel_dig.ogg', 50, 1)
+		remove_tile()
+
 /turf/simulated/floor/grass/jungle
 	name = "jungle grass"
 	icon = 'icons/turf/floors/junglegrass.dmi'

--- a/code/game/turfs/simulated/floor/fancy_floor.dm
+++ b/code/game/turfs/simulated/floor/fancy_floor.dm
@@ -64,15 +64,6 @@
 	heavyfootstep = FOOTSTEP_GENERIC_HEAVY
 	transform = matrix(1, 0, -9, 0, 1, -9) //Yes, these sprites are 50x50px, big grass control the industry
 
-/turf/simulated/floor/grass/attackby(obj/item/C, mob/user, params)
-	if(..())
-		return
-	if(istype(C, /obj/item/shovel))
-		new /obj/item/stack/ore/glass(src, 2) //Make some sand if you shovel grass
-		to_chat(user, "<span class='notice'>You shovel the grass.</span>")
-		playsound(src, 'sound/effects/shovel_dig.ogg', 50, 1)
-		make_plating()
-
 /turf/simulated/floor/grass/jungle
 	name = "jungle grass"
 	icon = 'icons/turf/floors/junglegrass.dmi'


### PR DESCRIPTION
## What Does This PR Do

Removes sand being dropped when you shovel a grass tile.

## Why It's Good For The Game

How do miners end up with 2000 sheets of glass in the ORM you ask? They just do this:

1. Place a grass tile
2. Shovel it
3. It returns 2 sand and 1 grass tile
4. Place the grass tile again
5. Repeat infinitely

## Images of changes

![image](https://github.com/ParadiseSS13/Paradise/assets/33333517/5264fef5-020d-43cd-b5c2-a12eb0e098d8)

## Testing

1. Spawn a grass tile
2. Shovel it
3. Tile is returned, no sand

## Changelog
:cl:
del: You can no longer get infinite sand with constantly shoveling grass tiles and placing them back.
/:cl:
