### PR TITLE
Adds a new crutch mechanic

### DIFF
--- a/code/game/objects/items/weapons/misc_items.dm
+++ b/code/game/objects/items/weapons/misc_items.dm
@@ -77,7 +77,7 @@
 	if(!hidden && !isscrewdriver(I) && I.w_class == WEIGHT_CLASS_TINY)
 		if(I.flags & ABSTRACT)
 			return
-		if(!user.drop_item())
+		if(I.flags & NODROP)
 			to_chat(user, "<span class='notice'>[I] is stuck to your hand!</span>")
 			return
 		I.forceMove(src)

--- a/code/game/objects/items/weapons/misc_items.dm
+++ b/code/game/objects/items/weapons/misc_items.dm
@@ -74,7 +74,7 @@
 	. = ..()
 	if(!is_open)
 		return
-	if(!hidden && !isscrewdriver(I) && I.w_class == WEIGHT_CLASS_TINY)
+	if(!hidden && I.tool_behaviour != TOOL_SCREWDRIVER && I.w_class == WEIGHT_CLASS_TINY)
 		if(I.flags & ABSTRACT)
 			return
 		if(I.flags & NODROP)

--- a/code/game/objects/items/weapons/misc_items.dm
+++ b/code/game/objects/items/weapons/misc_items.dm
@@ -66,7 +66,7 @@
 		hidden = null
 	return ..()
 
-/obj/item/crutches/update_icon_state()  //Currently only here to fuck with the on-mob icons.
+/obj/item/crutches/update_icon_state() //Currently only here to fuck with the on-mob icons.
 	icon_state = "crutches0"
 	return ..()
 
@@ -82,14 +82,14 @@
 			return
 		I.forceMove(src)
 		hidden = I
-		to_chat(user, "<span class='notice'>You hide [I] inside the secret compartment.</span>")
+		to_chat(user, "<span class='notice'>You hide [I] inside the crutch tip.</span>")
 
 /obj/item/crutches/attack_hand(mob/user, pickupfireoverride)
 	if(!is_open)
 		return ..()
 	if(hidden)
 		user.put_in_hands(hidden)
-		to_chat(user, "<span class='notice'>You remove [hidden] from the secret compartment!</span>")
+		to_chat(user, "<span class='notice'>You remove [hidden] from the crutch tip!</span>")
 		hidden = null
 
 	add_fingerprint(user)
@@ -97,7 +97,7 @@
 /obj/item/crutches/screwdriver_act(mob/living/user, obj/item/I)
 	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
 		return
-	to_chat(user, "<span class='notice'>You screw the compartment [is_open ? "closed" : "open"].</span>")
+	to_chat(user, "<span class='notice'>You screw the crutch tip [is_open ? "closed" : "open"].</span>")
 	is_open = !is_open
 
 /obj/item/crutches/get_crutch_efficiency()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
You can now hide tiny items inside crutches by screwing their tips.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
![image](https://github.com/ParadiseSS13/Paradise/assets/77684085/5de77981-0b6d-4d31-9218-c564a378bd07)

Considering that crutches are BULKY one could justify the inclusion of this obscure mechanic, allowing people to hide their illegals by pretending to be crippled.

## Testing
<!-- How did you test the PR, if at all? -->
- Did screw and unscrew the crutches multiple time
- Tried to insert items with different sizes
- Deleted it to make sure its dropping the hidden item
## Changelog
:cl:
tweak: You can now hide tiny items inside crutches by screwing their tips
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
