### PR TITLE
Floorbot bug fix + Bridgemode Removal

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/floorbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/floorbot.dm
@@ -83,13 +83,14 @@
 		dat += "Repair damaged tiles and platings: <A href='?src=[UID()];operation=fix'>[fixfloors ? "Yes" : "No"]</A><BR>"
 		dat += "Traction Magnets: <A href='?src=[UID()];operation=anchor'>[anchored ? "Engaged" : "Disengaged"]</A><BR>"
 		dat += "Patrol Station: <A href='?src=[UID()];operation=patrol'>[auto_patrol ? "Yes" : "No"]</A><BR>"
+/*
 		var/bmode
 		if(targetdirection)
 			bmode = dir2text(targetdirection)
 		else
 			bmode = "disabled"
 		dat += "Bridge Mode : <A href='?src=[UID()];operation=bridgemode'>[bmode]</A><BR>"
-
+*/
 	return dat
 
 
@@ -174,6 +175,7 @@
 	if(prob(5))
 		audible_message("[src] makes an excited booping beeping sound!")
 
+/*
 	//Normal scanning procedure. We have tiles loaded, are not emagged.
 	if(!target && emagged < 2 && amount > 0)
 		if(targetdirection != null) //The bot is in bridge mode.
@@ -185,7 +187,7 @@
 			else //Find a space tile farther way!
 				target = scan(/turf/space)
 			process_type = BRIDGE_MODE
-
+*/
 		if(!target)
 			process_type = HULL_BREACH //Ensures the floorbot does not try to "fix" space areas or shuttle docking zones.
 			target = scan(/turf/space)

--- a/code/modules/mob/living/simple_animal/bot/floorbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/floorbot.dm
@@ -306,17 +306,17 @@
 	target = null
 
 /mob/living/simple_animal/bot/floorbot/proc/make_bridge_plating(turf/target_turf)
+	var/turf/simulated/floor/F = target
 	if(mode != BOT_REPAIRING)
 		return
 
 	if(replacetiles)
+		F.break_tile_to_plating()
 		target_turf.ChangeTurf(/turf/simulated/floor/plasteel)
 	else
 		if(autotile) //Build the floor and include a tile.
-			var/turf/simulated/floor/F = target
 			F.break_tile_to_plating()
 			target_turf.ChangeTurf(/turf/simulated/floor/plasteel)
-
 		else //Build a hull plating without a floor tile.
 			target_turf.ChangeTurf(/turf/simulated/floor/plating)
 	mode = BOT_IDLE

--- a/code/modules/mob/living/simple_animal/bot/floorbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/floorbot.dm
@@ -313,7 +313,10 @@
 		target_turf.ChangeTurf(/turf/simulated/floor/plasteel)
 	else
 		if(autotile) //Build the floor and include a tile.
+			var/turf/simulated/floor/F = target
+			F.break_tile_to_plating()
 			target_turf.ChangeTurf(/turf/simulated/floor/plasteel)
+
 		else //Build a hull plating without a floor tile.
 			target_turf.ChangeTurf(/turf/simulated/floor/plating)
 	mode = BOT_IDLE

--- a/code/modules/mob/living/simple_animal/bot/floorbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/floorbot.dm
@@ -280,7 +280,7 @@
 	anchored = TRUE
 
 	if(isspaceturf(target_turf)) //If we are fixing an area not part of pure space, it is
-		visible_message("<span class='notice'>["[src] begins to repair the hole."] </span>")
+		visible_message("<span class='notice'>[src] begins to repair the hole.</span>")
 		mode = BOT_REPAIRING
 		update_icon(UPDATE_ICON_STATE)
 		addtimer(CALLBACK(src, PROC_REF(make_bridge_plating), target_turf), 5 SECONDS)

--- a/code/modules/mob/living/simple_animal/bot/floorbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/floorbot.dm
@@ -309,10 +309,13 @@
 	if(mode != BOT_REPAIRING)
 		return
 
-	if(autotile) //Build the floor and include a tile.
+	if(replacetiles)
 		target_turf.ChangeTurf(/turf/simulated/floor/plasteel)
-	else //Build a hull plating without a floor tile.
-		target_turf.ChangeTurf(/turf/simulated/floor/plating)
+	else
+		if(autotile) //Build the floor and include a tile.
+			target_turf.ChangeTurf(/turf/simulated/floor/plasteel)
+		else //Build a hull plating without a floor tile.
+			target_turf.ChangeTurf(/turf/simulated/floor/plating)
 	mode = BOT_IDLE
 	amount--
 	update_icon(UPDATE_ICON_STATE)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #22472
Fixes #22478 
Fixes floorbot eating up tiles nonstop.
Removes bridge mode from floorbot
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Floorbot usage is rare, and discussed with people randomly and seems like, floorbot in on itself is not used much, but bridge mode function isnt even known in general. Removes this old and ancient mode/option
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Flame Thrower an area, remove some tiles and space some. Watch the bot suffer
![image](https://github.com/ParadiseSS13/Paradise/assets/66401072/305471a2-a9b7-46de-9917-692528d1720a)

<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: No longer gets stuck and eats up tiles, actually does place a tile
del: Removed Bridge Mode option
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
