### PR TITLE
Logs Toy Cuffs/Twimsts Differently from Standard Cuffs

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -1696,4 +1696,5 @@
 	desc = "Toy handcuffs. Plastic and extremely cheaply made."
 	throwforce = 0
 	breakouttime = 0
+	secure = FALSE
 	ignoresClumsy = TRUE

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -1696,5 +1696,4 @@
 	desc = "Toy handcuffs. Plastic and extremely cheaply made."
 	throwforce = 0
 	breakouttime = 0
-	secure = FALSE
 	ignoresClumsy = TRUE

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -66,7 +66,7 @@
 			if(breakouttime != 0)
 				add_attack_logs(user, C, "Handcuffed ([src])")
 			else
-				add_attack_logs(user, C, "Unsecurely Handcuffed ([src])")
+				add_attack_logs(user, C, "Handcuffed (Fake/Breakable!) ([src])")
 		else
 			to_chat(user, "<span class='warning'>You fail to handcuff [C].</span>")
 			return FALSE

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -19,6 +19,7 @@
 	materials = list(MAT_METAL=500)
 	origin_tech = "engineering=3;combat=3"
 	breakouttime = 1 MINUTES
+	secure = TRUE
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, RAD = 0, FIRE = 50, ACID = 50)
 	var/cuffsound = 'sound/weapons/handcuffs.ogg'
 	// Icon state for cuffed overlay on a mob
@@ -63,8 +64,10 @@
 			apply_cuffs(C, user, remove_src)
 			to_chat(user, "<span class='notice'>You handcuff [C].</span>")
 			SSblackbox.record_feedback("tally", "handcuffs", 1, type)
-
-			add_attack_logs(user, C, "Handcuffed ([src])")
+			if(secure)
+				add_attack_logs(user, C, "Handcuffed ([src])")
+			else
+				add_attack_logs(user, C, "Unsecurely Handcuffed ([src])")
 		else
 			to_chat(user, "<span class='warning'>You fail to handcuff [C].</span>")
 			return FALSE
@@ -224,4 +227,5 @@
 	color = "#E31818"
 	throwforce = 0
 	breakouttime = 0
+	secure = FALSE
 	cuffsound = 'sound/weapons/cablecuff.ogg'

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -19,7 +19,7 @@
 	materials = list(MAT_METAL=500)
 	origin_tech = "engineering=3;combat=3"
 	breakouttime = 1 MINUTES
-	secure = TRUE
+	var/secure = TRUE
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, RAD = 0, FIRE = 50, ACID = 50)
 	var/cuffsound = 'sound/weapons/handcuffs.ogg'
 	// Icon state for cuffed overlay on a mob

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -19,7 +19,6 @@
 	materials = list(MAT_METAL=500)
 	origin_tech = "engineering=3;combat=3"
 	breakouttime = 1 MINUTES
-	var/secure = TRUE
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, RAD = 0, FIRE = 50, ACID = 50)
 	var/cuffsound = 'sound/weapons/handcuffs.ogg'
 	// Icon state for cuffed overlay on a mob
@@ -64,7 +63,7 @@
 			apply_cuffs(C, user, remove_src)
 			to_chat(user, "<span class='notice'>You handcuff [C].</span>")
 			SSblackbox.record_feedback("tally", "handcuffs", 1, type)
-			if(secure)
+			if(breakouttime != 0)
 				add_attack_logs(user, C, "Handcuffed ([src])")
 			else
 				add_attack_logs(user, C, "Unsecurely Handcuffed ([src])")
@@ -227,5 +226,4 @@
 	color = "#E31818"
 	throwforce = 0
 	breakouttime = 0
-	secure = FALSE
 	cuffsound = 'sound/weapons/cablecuff.ogg'


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
"Unsecure" cuffs are logged differently to attack logs.

## Why It's Good For The Game
I cant tell if an Officer is an idiot or not when they scream "FREEDOMS" and lethal some poor nerd.

## Testing
Checked the logs.

## Changelog
add: [ADMIN] toy cuffs/twimsts are logged differently from regular cuffs

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
