### PR TITLE
Adds telescopic batons to the baton cooldown timer

### DIFF
--- a/code/game/objects/items/weapons/batons.dm
+++ b/code/game/objects/items/weapons/batons.dm
@@ -69,6 +69,9 @@
 	if(user.mind?.martial_art?.no_baton && user.mind?.martial_art?.can_use(user))
 		to_chat(user, user.mind.martial_art.no_baton_reason)
 		return
+	var/user_UID = user.UID()
+	if(HAS_TRAIT_FROM(target, TRAIT_WAS_BATONNED, user_UID)) // prevents double baton cheese.
+		return FALSE
 	if(issilicon(target))
 		user.visible_message("<span class='danger'>[user] pulses [target]'s sensors with [src]!</span>",\
 							"<span class='danger'>You pulse [target]'s sensors with [src]!</span>")
@@ -97,6 +100,8 @@
 	target.KnockDown(knockdown_duration)
 	on_cooldown = TRUE
 	addtimer(VARSET_CALLBACK(src, on_cooldown, FALSE), cooldown)
+	ADD_TRAIT(target, TRAIT_WAS_BATONNED, user_UID) // so one person cannot hit the same person with two separate batons
+	addtimer(CALLBACK(src, PROC_REF(baton_delay), target, user_UID), 2 SECONDS)
 	return TRUE
 
 /**
@@ -125,6 +130,9 @@
 	else
 		percentage_reduction = (100 - armour) / 100 // converts the % into a decimal
 	target.adjustStaminaLoss(stamina_damage * percentage_reduction)
+
+/obj/item/melee/classic_baton/proc/baton_delay(mob/living/target, user_UID)
+	REMOVE_TRAIT(target, TRAIT_WAS_BATONNED, user_UID)
 
 /**
   * # Fancy Cane


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Normal stunbatons have a respect of 3.5 Seconds between two actual hits of a stunbaton. Telescopic batons do not have this, and can be used to quickly stun someone with a telescopic baton and a stunbaton. Telescopic batons only make this a cooldown of 2 seconds, to respect them being generally weaker.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
You can use a stunbaton in quick conjuction with a telescopic baton to instantly stun someone, something which was explicitly something you couldn't do with stunbatons.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
I couldn't stunbaton someone who I recently batonged with a telescopic batong, and vice versa.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Telescopic batons now respect the global cooldown on baton stunning.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
