### PR TITLE
Modsuit flashlights are now properly extinguished

### DIFF
--- a/code/modules/mod/mod_control.dm
+++ b/code/modules/mod/mod_control.dm
@@ -744,3 +744,8 @@
 		if(ishuman(loc))
 			var/mob/living/carbon/human/H = loc
 			H.regenerate_icons()
+
+/obj/item/mod/control/extinguish_light(force)
+	. = ..()
+	for(var/obj/item/mod/module/module as anything in modules)
+		module.extinguish_light(force)

--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -223,11 +223,19 @@
 	var/min_range = 2
 	/// Maximum range we can set.
 	var/max_range = 5
+	/// The cooldown before we can re-activate this after having it forcefully extinguished
+	COOLDOWN_DECLARE(activation_cooldown)
 
 /obj/item/mod/module/flashlight/on_activation()
+	if(!COOLDOWN_FINISHED(src, activation_cooldown))
+		to_chat(mod.wearer, "<span class='warning'>[src] isn't ready after being shut down!</span>")
+		return
 	. = ..()
 	if(!.)
 		return
+
+	COOLDOWN_RESET(src, activation_cooldown)
+
 	active_power_cost = base_power * mod_light_range
 	mod.set_light(mod_light_range, mod_light_power, light_color)
 
@@ -262,6 +270,14 @@
 	mod.set_light(0, mod_light_power, light_color)
 	mod_color_overide = light_color
 	on_deactivation()
+
+/obj/item/mod/module/flashlight/extinguish_light(force)
+	. = ..()
+	on_deactivation(FALSE)
+	if(force)
+		COOLDOWN_START(src, activation_cooldown, 20 SECONDS)
+
+	to_chat(mod.wearer, "<span class='warning'>Your [src] shuts off!</span>")
 
 ///Dispenser - Dispenses an item after a time passes.
 /obj/item/mod/module/dispenser

--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -274,10 +274,9 @@
 /obj/item/mod/module/flashlight/extinguish_light(force)
 	. = ..()
 	on_deactivation(FALSE)
-	if(force)
-		COOLDOWN_START(src, activation_cooldown, 20 SECONDS)
+	COOLDOWN_START(src, activation_cooldown, 20 SECONDS)
 
-	to_chat(mod.wearer, "<span class='warning'>Your [src] shuts off!</span>")
+	to_chat(mod.wearer, "<span class='warning'>Your [name] shuts off!</span>")
 
 ///Dispenser - Dispenses an item after a time passes.
 /obj/item/mod/module/dispenser


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Ensures that modsuit lights are properly extinguished by external sources (e.g. shadow demon grasps).
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Modsuits are currently a hard counter to shadow demons because their lights aren't extinguished properly, which is kind of an oversight. This fixes that.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


## Testing
Loaded in a vulp with an engi modsuit and flashlight enabled, shadow demon grasped said vulp, switched over to them, wasn't able to turn on my modsuit's flashlight until the cooldown expired.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Shadow demons and other sources can now properly extinguish modsuit flashlights.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
