### PR TITLE
Holo Cigar Allows One-Hand Large Gun Firing

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -186,7 +186,7 @@
 				user.drop_item()
 				return
 
-	if(weapon_weight == WEAPON_HEAVY && user.get_inactive_hand())
+	if(!HAS_TRAIT(user, TRAIT_BADASS) && weapon_weight == WEAPON_HEAVY && user.get_inactive_hand())
 		to_chat(user, "<span class='userdanger'>You need both hands free to fire \the [src]!</span>")
 		return
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Allows you to one-hand fire some of the larger guns available when using the Holo Cigar.
- Shotguns
- LWAP
- BSG
- L6 SAW (if you somehow got one)
- Sniper Rifle (if you somehow got one)

## Why It's Good For The Game
Opens up more weapon choices with the Holo Cigar.

Does **NOT** allow you to double-fire these weapons. Only use them one-handed.

Nuclear Operatives CANNOT obtain a Holo Cigar, so not worried about it affecting Nuke Ops balance.

## Testing
Shot some skrell in the face.

## Changelog
:cl:
tweak: Holo Cigars allow you to one-hand large weapons.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
