### PR TITLE
Fix/Tweak: Now admin logout messages are more important than mentor ones

### DIFF
--- a/code/modules/mob/mob_logout_base.dm
+++ b/code/modules/mob/mob_logout_base.dm
@@ -17,7 +17,7 @@
 		else if(temp_admin.rights & R_MENTOR)
 			var/list/mentorcounter = staff_countup(R_MENTOR)
 			if(mentorcounter[1] == 0) // No active mentors
-				GLOB.discord_manager.send2discord_simple(DISCORD_WEBHOOK_MENTOR, "[key_name(src)] 	 0 active mentors, [mentorcounter[2]] non-mentor staff, [mentorcounter[3]] inactive mentors.")
+				GLOB.discord_manager.send2discord_simple(DISCORD_WEBHOOK_MENTOR, "[key_name(src)] logged out - 0 active mentors, [mentorcounter[2]] non-mentor staff, [mentorcounter[3]] inactive mentors.")
 
 	..()
 	update_morgue()

--- a/code/modules/mob/mob_logout_base.dm
+++ b/code/modules/mob/mob_logout_base.dm
@@ -6,19 +6,18 @@
 	create_attack_log("<font color='red'>Logged out at [atom_loc_line(get_turf(src))]</font>")
 	create_log(MISC_LOG, "Logged out")
 	// `holder` is nil'd out by now, so we check the `admin_datums` array directly
-	//Only report this stuff if we are currently playing.
+	// Only report this stuff if we are currently playing.
 	if(GLOB.admin_datums[ckey] && SSticker.current_state == GAME_STATE_PLAYING)
 		var/datum/admins/temp_admin = GLOB.admin_datums[ckey]
-		if(temp_admin.rights & R_MENTOR)
-			var/list/mentorcounter = staff_countup(R_MENTOR)
-			if(mentorcounter[1] == 0) // No active mentors
-				GLOB.discord_manager.send2discord_simple(DISCORD_WEBHOOK_MENTOR, "[key_name(src)] logged out - 0 active mentors, [mentorcounter[2]] non-mentor staff, [mentorcounter[3]] inactive mentors.")
-
-		else if(temp_admin.rights & R_BAN)
+		if(temp_admin.rights & R_BAN)
 			message_admins("Admin logout: [key_name_admin(src)]")
 			var/list/admincounter = staff_countup(R_BAN)
 			if(admincounter[1] == 0) // No active admins
 				GLOB.discord_manager.send2discord_simple(DISCORD_WEBHOOK_ADMIN, "[key_name(src)] logged out - 0 active admins, [admincounter[2]] non-admin staff, [admincounter[3]] inactive staff.")
+		else if(temp_admin.rights & R_MENTOR)
+			var/list/mentorcounter = staff_countup(R_MENTOR)
+			if(mentorcounter[1] == 0) // No active mentors
+				GLOB.discord_manager.send2discord_simple(DISCORD_WEBHOOK_MENTOR, "[key_name(src)] 	 0 active mentors, [mentorcounter[2]] non-mentor staff, [mentorcounter[3]] inactive mentors.")
 
 	..()
 	update_morgue()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Changes the order of logout rights check. Previously if an admin had R_MENTOR their logout didnt trigger admin logout message, but mentor one instead. Now its fixed.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Admin: now if an admin has both R_MENTOR and R_BAN their logout message will apear in-game and in discord
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
