### PR TITLE
Stops you from grabbing someone if you are horizontal

### DIFF
--- a/code/modules/martial_arts/brawling.dm
+++ b/code/modules/martial_arts/brawling.dm
@@ -45,6 +45,7 @@
 /datum/martial_art/drunk_brawling
 	name = "Drunken Brawling"
 	weight = 2
+	can_horizontally_grab = FALSE
 
 /datum/martial_art/drunk_brawling/grab_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	if(prob(70))

--- a/code/modules/martial_arts/judo.dm
+++ b/code/modules/martial_arts/judo.dm
@@ -58,6 +58,11 @@
 	add_attack_logs(A, D, "Melee attacked with [src]")
 	return TRUE
 
+/datum/martial_art/judo/grab_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
+	if(IS_HORIZONTAL(A))
+		return FALSE
+	return ..()
+
 /datum/martial_art/judo/explaination_header(user)
 	to_chat(user, "<b><i>You recall the teachings of Corporate Judo.</i></b>")
 

--- a/code/modules/martial_arts/judo.dm
+++ b/code/modules/martial_arts/judo.dm
@@ -58,8 +58,8 @@
 	add_attack_logs(A, D, "Melee attacked with [src]")
 	return TRUE
 
-/datum/martial_art/judo/grab_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
-	if(IS_HORIZONTAL(A))
+/datum/martial_art/judo/grab_act(mob/living/carbon/human/attacker, mob/living/carbon/human/defender)
+	if(IS_HORIZONTAL(attacker))
 		return FALSE
 	return ..()
 

--- a/code/modules/martial_arts/judo.dm
+++ b/code/modules/martial_arts/judo.dm
@@ -5,6 +5,7 @@
 	combos = list(/datum/martial_combo/judo/discombobulate, /datum/martial_combo/judo/eyepoke, /datum/martial_combo/judo/judothrow, /datum/martial_combo/judo/armbar, /datum/martial_combo/judo/wheelthrow)
 	weight = 5 //takes priority over boxing and drunkneness, less priority than krav or CQC/carp
 	no_baton_reason = "<span class='warning'>The baton feels off balance in your hand due to your judo training!</span>"
+	can_horizontally_grab = FALSE
 
 //Corporate Judo Belt
 

--- a/code/modules/martial_arts/krav_maga.dm
+++ b/code/modules/martial_arts/krav_maga.dm
@@ -5,6 +5,7 @@
 	var/datum/action/leg_sweep/legsweep = new/datum/action/leg_sweep()
 	var/datum/action/lung_punch/lungpunch = new/datum/action/lung_punch()
 	var/datum/action/neutral_stance/neutral = new/datum/action/neutral_stance()
+	can_horizontally_grab = FALSE
 
 /datum/action/neutral_stance
 	name = "Neutral Stance - You relax, cancelling your last Krav Maga stance attack."

--- a/code/modules/martial_arts/martial.dm
+++ b/code/modules/martial_arts/martial.dm
@@ -39,6 +39,8 @@
 	var/weight = 0
 	/// Message displayed when someone uses a baton when its forbidden by a martial art
 	var/no_baton_reason = "Your martial arts training prevents you from wielding batons."
+	/// Whether or not you can grab someone while horizontal with this Martial Art
+	var/can_horizontally_grab = TRUE
 
 /datum/martial_art/New()
 	. = ..()

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -269,7 +269,7 @@
 	if(user.pull_force < move_force)
 		return FALSE
 	// This if-statement checks if the user is horizontal, and if the user either has no martial art, or has judo, drunk fighting or krav, in which case it should also fail
-	if(IS_HORIZONTAL(user) && (!user.mind.martial_art || istype(user.mind.martial_art, /datum/martial_art/judo) || istype(user.mind.martial_art, /datum/martial_art/drunk_brawling) || istype(user.mind.martial_art, /datum/martial_art/krav_maga)))
+	if(IS_HORIZONTAL(user) && (!user.mind.martial_art || is_type_in_list(user.mind.martial_art, list(/datum/martial_art/judo, /datum/martial_art/drunk_brawling, /datum/martial_art/krav_maga))))
 		to_chat(user, "<span class='warning'>You fail to get a good grip on [src]!</span>")
 		return
 

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -268,7 +268,8 @@
 		return FALSE
 	if(user.pull_force < move_force)
 		return FALSE
-	if(IS_HORIZONTAL(user))
+	// This if-statement checks if the user is horizontal, and if the user either has no martial art, or has judo, drunk fighting or krav, in which case it should also fail
+	if(IS_HORIZONTAL(user) && (!user.mind.martial_art || istype(user.mind.martial_art, /datum/martial_art/judo) || istype(user.mind.martial_art, /datum/martial_art/drunk_brawling) || istype(user.mind.martial_art, /datum/martial_art/krav_maga)))
 		to_chat(user, "<span class='warning'>You fail to get a good grip on [src]!</span>")
 		return
 

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -269,7 +269,7 @@
 	if(user.pull_force < move_force)
 		return FALSE
 	if(IS_HORIZONTAL(user))
-		to_chat(user, "<span class='notice'>You fail to get a good grip on [src]!</span>")
+		to_chat(user, "<span class='warning'>You fail to get a good grip on [src]!</span>")
 		return
 
 	for(var/obj/item/grab/G in grabbed_by)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -268,6 +268,9 @@
 		return FALSE
 	if(user.pull_force < move_force)
 		return FALSE
+	if(IS_HORIZONTAL(user))
+		to_chat(user, "<span class='notice'>You fail to get a good grip on [src]!</span>")
+		return
 
 	for(var/obj/item/grab/G in grabbed_by)
 		if(G.assailant == user)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -269,7 +269,7 @@
 	if(user.pull_force < move_force)
 		return FALSE
 	// This if-statement checks if the user is horizontal, and if the user either has no martial art, or has judo, drunk fighting or krav, in which case it should also fail
-	if(IS_HORIZONTAL(user) && (!user.mind.martial_art || is_type_in_list(user.mind.martial_art, list(/datum/martial_art/judo, /datum/martial_art/drunk_brawling, /datum/martial_art/krav_maga))))
+	if(IS_HORIZONTAL(user) && (!user.mind.martial_art || !user.mind.martial_art.can_horizontally_grab))
 		to_chat(user, "<span class='warning'>You fail to get a good grip on [src]!</span>")
 		return
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Stops people from being able to grab other people while they're on the ground. Does not apply to anyone with a martial art, except for: Judo, Krav and Drunken Brawling.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

![image](https://github.com/ParadiseSS13/Paradise/assets/108773801/cb75f8f0-51ba-4265-9e0e-eab50421780e)

Nah but more seriously, you can already not reinforce your grab if you're prone. This just stops you from also stopping the cuffed prisoner that you're dragging behind you.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
![image](https://github.com/ParadiseSS13/Paradise/assets/108773801/129438e8-7cd4-40a5-af69-0b0967a7d7f4)

<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: You can now not grab someone if you're lying on the ground, unless you know a Martial Art
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
