### PR TITLE
Carding AIs now takes time.

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai_mob.dm
+++ b/code/modules/mob/living/silicon/ai/ai_mob.dm
@@ -1327,8 +1327,8 @@ GLOBAL_LIST_INIT(ai_verbs_default, list(
 		if(stat != DEAD)
 			to_chat(user, "<span class='notice'>Beginning active intelligence transfer: please wait.</span>")
 
-			if(!do_after(user, 5 SECONDS, target = src) || !Adjacent(user))
-				to_chat(user, "<span class='warning'>Intelligence transfer interrupted.</span>")
+			if(!do_after_once(user, 5 SECONDS, target = src) || !Adjacent(user))
+				to_chat(user, "<span class='warning'>Intelligence transfer aborted.</span>")
 				return
 
 		new /obj/structure/AIcore/deactivated(loc)//Spawns a deactivated terminal at AI location.

--- a/code/modules/mob/living/silicon/ai/ai_mob.dm
+++ b/code/modules/mob/living/silicon/ai/ai_mob.dm
@@ -1323,6 +1323,14 @@ GLOBAL_LIST_INIT(ai_verbs_default, list(
 		if(!mind)
 			to_chat(user, "<span class='warning'>No intelligence patterns detected.</span>")//No more magical carding of empty cores, AI RETURN TO BODY!!!11
 			return
+
+		if(stat != DEAD)
+			to_chat(user, "<span class='notice'>Beginning active intelligence transfer: please wait.</span>")
+
+			if(!do_after(user, transfer_time, target = src) || !Adjacent(user))
+				to_chat(user, "<span class='warning'>Intelligence transfer interrupted.</span>")
+				return
+
 		new /obj/structure/AIcore/deactivated(loc)//Spawns a deactivated terminal at AI location.
 		aiRestorePowerRoutine = 0//So the AI initially has power.
 		control_disabled = TRUE //Can't control things remotely if you're stuck in a card!

--- a/code/modules/mob/living/silicon/ai/ai_mob.dm
+++ b/code/modules/mob/living/silicon/ai/ai_mob.dm
@@ -1327,7 +1327,7 @@ GLOBAL_LIST_INIT(ai_verbs_default, list(
 		if(stat != DEAD)
 			to_chat(user, "<span class='notice'>Beginning active intelligence transfer: please wait.</span>")
 
-			if(!do_after(user, transfer_time, target = src) || !Adjacent(user))
+			if(!do_after(user, 5 SECONDS, target = src) || !Adjacent(user))
 				to_chat(user, "<span class='warning'>Intelligence transfer interrupted.</span>")
 				return
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds a delay of 5 seconds when carding living AIs. It's no longer an instantaneous click, unless they're dead.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Downloading an AI to a card is kind of a big deal. It's one click to end a malf AI's round, and means that AIs can't really make any form of escape.
Put another way, this should make fighting an AI, especially one who's in a mobile core or has friends, a bit more dynamic.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Carded an AI, waited five seconds before it was transferred to the card. Clicked the core again to instantly put it back.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Carding a living AI now takes five seconds.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
