### PR TITLE
Removes the ability to disassemble and unwrench the donksoft vendor in the syndie research base.

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/syndie_space_base.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/syndie_space_base.dmm
@@ -1577,15 +1577,13 @@
 /turf/simulated/floor/plating,
 /area/ruin/unpowered/syndicate_space_base/engineering)
 "rp" = (
-/obj/machinery/economy/vending/toyliberationstation{
-	req_access_txt = "150"
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
 	tag = ""
 	},
+/obj/machinery/economy/vending/toyliberationstation/secured,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "brown"

--- a/code/game/machinery/vendors/contraband_vendors.dm
+++ b/code/game/machinery/vendors/contraband_vendors.dm
@@ -181,54 +181,14 @@
 	resistance_flags = FIRE_PROOF
 
 /obj/machinery/economy/vending/toyliberationstation/secured
-	name = "\improper Syndicate Donksoft Toy Vendor"
-	desc = "An ages 8 and up approved vendor that dispenses toys. If you were to find the right wires, you can unlock the adult mode setting!"
-	icon_state = "syndi"
-	icon_lightmask = "syndi"
-	slogan_list = list("Get your cool toys today!",
-					"Trigger a valid hunter today!",
-					"Quality toy weapons for cheap prices!",
-					"Give them to HoPs for all access!",
-					"Give them to HoS to get permabrigged!")
-
-	ads_list = list("Feel robust with your toys!",
-					"Express your inner child today!",
-					"Toy weapons don't kill people, but valid hunters do!",
-					"Who needs responsibilities when you have toy weapons?",
-					"Make your next murder FUN!")
-
-	vend_reply = "Come back for more!"
-	category = VENDOR_TYPE_RECREATION
-	products = list(/obj/item/gun/projectile/automatic/toy = 10,
-					/obj/item/gun/projectile/automatic/toy/pistol= 10,
-					/obj/item/gun/projectile/shotgun/toy = 10,
-					/obj/item/toy/sword = 10,
-					/obj/item/ammo_box/foambox = 20,
-					/obj/item/toy/foamblade = 10,
-					/obj/item/toy/syndicateballoon = 10,
-					/obj/item/clothing/suit/syndicatefake = 5,
-					/obj/item/clothing/head/syndicatefake = 5) //OPS IN DORMS oh wait it's just an assistant
-
-	contraband = list(/obj/item/gun/projectile/shotgun/toy/crossbow = 10,   //Congrats, you unlocked the +18 setting!
-					/obj/item/gun/projectile/automatic/c20r/toy/riot = 10,
-					/obj/item/gun/projectile/automatic/l6_saw/toy/riot = 10,
-					/obj/item/gun/projectile/automatic/sniper_rifle/toy = 10,
-					/obj/item/ammo_box/foambox/riot = 20,
-					/obj/item/toy/katana = 10,
-					/obj/item/dualsaber/toy = 5,
-					/obj/item/deck/cards/syndicate = 10) //Gambling and it hurts, making it a +18 item
-
-	armor = list(MELEE = 100, BULLET = 100, LASER = 100, ENERGY = 100, BOMB = 0, RAD = 0, FIRE = 100, ACID = 50)
-	resistance_flags = FIRE_PROOF
 
 /obj/machinery/economy/vending/toyliberationstation/secured/crowbar_act(mob/user, obj/item/I)
-	if(!component_parts)
-		return
-	. = TRUE
 	if(tilted)
-		to_chat(user, "<span class='warning'>You'll need to right it first!</span>")
+		to_chat(user, "<span class='warning'>The fastening bolts aren't on the ground, you'll need to right it first!</span>")
 		return
-	to_chat(user, "<span class='warning'>You find yourself unable to pry the components out of the vending machine!</span>")
+	if(!I.use_tool(src, user, 0, volume = 0))
+		return
+	to_chat(user, "<span class='warning'>You are unable to remove the electronics from the vendor!</span>")
 
 /obj/machinery/economy/vending/toyliberationstation/secured/wrench_act(mob/user, obj/item/I)
 	if(tilted)

--- a/code/game/machinery/vendors/contraband_vendors.dm
+++ b/code/game/machinery/vendors/contraband_vendors.dm
@@ -179,3 +179,20 @@
 
 	armor = list(MELEE = 100, BULLET = 100, LASER = 100, ENERGY = 100, BOMB = 0, RAD = 0, FIRE = 100, ACID = 50)
 	resistance_flags = FIRE_PROOF
+
+/obj/machinery/economy/vending/toyliberationstation/crowbar_act(mob/user, obj/item/I)
+	if(!component_parts)
+		return
+	. = TRUE
+	if(tilted)
+		to_chat(user, "<span class='warning'>You'll need to right it first!</span>")
+		return
+	to_chat(user, "<span class='warning'>You find yourself unable to pry the components out of the vending machine!</span>")
+
+/obj/machinery/economy/vending/toyliberationstation/wrench_act(mob/user, obj/item/I)
+	if(tilted)
+		to_chat(user, "<span class='warning'>The fastening bolts aren't on the ground, you'll need to right it first!</span>")
+		return
+	if(!I.use_tool(src, user, 0, volume = 0))
+		return
+	to_chat(user, "<span class='warning'>You are unable to loosen the bolts!</span>")

--- a/code/game/machinery/vendors/contraband_vendors.dm
+++ b/code/game/machinery/vendors/contraband_vendors.dm
@@ -196,3 +196,44 @@
 	if(!I.use_tool(src, user, 0, volume = 0))
 		return
 	to_chat(user, "<span class='warning'>You are unable to loosen the bolts!</span>")
+
+/obj/machinery/economy/vending/moveabletoyliberationstation
+	name = "\improper Syndicate Donksoft Toy Vendor"
+	desc = "An ages 8 and up approved vendor that dispenses toys. If you were to find the right wires, you can unlock the adult mode setting!"
+	icon_state = "syndi"
+	icon_lightmask = "syndi"
+	slogan_list = list("Get your cool toys today!",
+					"Trigger a valid hunter today!",
+					"Quality toy weapons for cheap prices!",
+					"Give them to HoPs for all access!",
+					"Give them to HoS to get permabrigged!")
+
+	ads_list = list("Feel robust with your toys!",
+					"Express your inner child today!",
+					"Toy weapons don't kill people, but valid hunters do!",
+					"Who needs responsibilities when you have toy weapons?",
+					"Make your next murder FUN!")
+
+	vend_reply = "Come back for more!"
+	category = VENDOR_TYPE_RECREATION
+	products = list(/obj/item/gun/projectile/automatic/toy = 10,
+					/obj/item/gun/projectile/automatic/toy/pistol= 10,
+					/obj/item/gun/projectile/shotgun/toy = 10,
+					/obj/item/toy/sword = 10,
+					/obj/item/ammo_box/foambox = 20,
+					/obj/item/toy/foamblade = 10,
+					/obj/item/toy/syndicateballoon = 10,
+					/obj/item/clothing/suit/syndicatefake = 5,
+					/obj/item/clothing/head/syndicatefake = 5) //OPS IN DORMS oh wait it's just an assistant
+
+	contraband = list(/obj/item/gun/projectile/shotgun/toy/crossbow = 10,   //Congrats, you unlocked the +18 setting!
+					/obj/item/gun/projectile/automatic/c20r/toy/riot = 10,
+					/obj/item/gun/projectile/automatic/l6_saw/toy/riot = 10,
+					/obj/item/gun/projectile/automatic/sniper_rifle/toy = 10,
+					/obj/item/ammo_box/foambox/riot = 20,
+					/obj/item/toy/katana = 10,
+					/obj/item/dualsaber/toy = 5,
+					/obj/item/deck/cards/syndicate = 10) //Gambling and it hurts, making it a +18 item
+
+	armor = list(MELEE = 100, BULLET = 100, LASER = 100, ENERGY = 100, BOMB = 0, RAD = 0, FIRE = 100, ACID = 50)
+	resistance_flags = FIRE_PROOF

--- a/code/game/machinery/vendors/contraband_vendors.dm
+++ b/code/game/machinery/vendors/contraband_vendors.dm
@@ -180,24 +180,7 @@
 	armor = list(MELEE = 100, BULLET = 100, LASER = 100, ENERGY = 100, BOMB = 0, RAD = 0, FIRE = 100, ACID = 50)
 	resistance_flags = FIRE_PROOF
 
-/obj/machinery/economy/vending/toyliberationstation/crowbar_act(mob/user, obj/item/I)
-	if(!component_parts)
-		return
-	. = TRUE
-	if(tilted)
-		to_chat(user, "<span class='warning'>You'll need to right it first!</span>")
-		return
-	to_chat(user, "<span class='warning'>You find yourself unable to pry the components out of the vending machine!</span>")
-
-/obj/machinery/economy/vending/toyliberationstation/wrench_act(mob/user, obj/item/I)
-	if(tilted)
-		to_chat(user, "<span class='warning'>The fastening bolts aren't on the ground, you'll need to right it first!</span>")
-		return
-	if(!I.use_tool(src, user, 0, volume = 0))
-		return
-	to_chat(user, "<span class='warning'>You are unable to loosen the bolts!</span>")
-
-/obj/machinery/economy/vending/moveabletoyliberationstation
+/obj/machinery/economy/vending/toyliberationstation/secured
 	name = "\improper Syndicate Donksoft Toy Vendor"
 	desc = "An ages 8 and up approved vendor that dispenses toys. If you were to find the right wires, you can unlock the adult mode setting!"
 	icon_state = "syndi"
@@ -237,3 +220,20 @@
 
 	armor = list(MELEE = 100, BULLET = 100, LASER = 100, ENERGY = 100, BOMB = 0, RAD = 0, FIRE = 100, ACID = 50)
 	resistance_flags = FIRE_PROOF
+
+/obj/machinery/economy/vending/toyliberationstation/secured/crowbar_act(mob/user, obj/item/I)
+	if(!component_parts)
+		return
+	. = TRUE
+	if(tilted)
+		to_chat(user, "<span class='warning'>You'll need to right it first!</span>")
+		return
+	to_chat(user, "<span class='warning'>You find yourself unable to pry the components out of the vending machine!</span>")
+
+/obj/machinery/economy/vending/toyliberationstation/secured/wrench_act(mob/user, obj/item/I)
+	if(tilted)
+		to_chat(user, "<span class='warning'>The fastening bolts aren't on the ground, you'll need to right it first!</span>")
+		return
+	if(!I.use_tool(src, user, 0, volume = 0))
+		return
+	to_chat(user, "<span class='warning'>You are unable to loosen the bolts!</span>")


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR makes it so the donksoft vendor located in the syndie research base can no longer be disassembled or unbolted from the floor. Using these tools will smack the vendor, leaving the user at risk of the vendor falling on them.

## Why It's Good For The Game
Crew should not have access to a vendor full of automatic riot dart firing weapons. Its fully problematic from a balance perspective, and should be removed. Explorers who dare to enter the research base will still be able to access the vendor, so acquiring them is still possible, but highly risky. 

## Testing
Spawn a donksoft vendor, attempt to disassemble it and un-wrench it, lose my head trying.

## Changelog
:cl:
tweak: Donksoft vendor can no longer be unwrenched/disassembled. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
