### PR TITLE
Reworks the Holobadge (allows Deputizing) + QoL Tweaks

### DIFF
--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -452,10 +452,6 @@
 		return
 	return ..()
 
-
-/datum/action/item_action/remove_badge
-	name = "Remove Holobadge"
-
 /datum/action/item_action/drop_gripped_item
 	name = "Drop gripped item"
 

--- a/code/game/objects/structures/crates_lockers/closets/secure/security_lockers.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security_lockers.dm
@@ -56,6 +56,7 @@
 	new /obj/item/radio/headset/heads/hos/alt(src)
 	new /obj/item/storage/lockbox/mindshield(src)
 	new /obj/item/storage/box/flashbangs(src)
+	new /obj/item/storage/box/holobadge(src)
 	new /obj/item/holosign_creator/security(src)
 	new /obj/item/shield/riot/tele(src)
 	new /obj/item/flashlight/seclite(src)

--- a/code/modules/clothing/suits/armor_suits.dm
+++ b/code/modules/clothing/suits/armor_suits.dm
@@ -14,6 +14,35 @@
 		"Vox" = 'icons/mob/clothing/species/vox/suit.dmi',
 		)
 	w_class = WEIGHT_CLASS_NORMAL
+	var/obj/item/clothing/accessory/holobadge/attached_badge
+
+/obj/item/clothing/suit/armor/attackby(obj/item/I, mob/user, params)
+	if(istype(I, /obj/item/clothing/accessory/holobadge))
+		var/obj/item/clothing/accessory/holobadge/badge = I
+		if(!badge.stored_name)
+			to_chat(user, "<span class='warn'>Attaching a badge before swiping an ID would be pretty pointless!</span>")
+			return
+		if(user.unEquip(I))
+			add_fingerprint(user)
+			I.forceMove(src)
+			attached_badge = I
+
+			to_chat(user, "<span class='notice'>You attach [attached_badge] to [src].</span>")
+		return
+	..()
+
+/obj/item/clothing/suit/armor/AltClick(mob/user)
+	if(attached_badge)
+		add_fingerprint(user)
+		user.put_in_hands(attached_badge)
+
+		to_chat(user, "<span class='notice'>You remove [attached_badge] from [src].</span>")
+		attached_badge = null
+
+/obj/item/clothing/suit/armor/examine(mob/user)
+	. = ..()
+	if(attached_badge)
+		. += "<span class='notice'>This one has [attached_badge] attached to it.</span>"
 
 /obj/item/clothing/suit/armor/vest
 	name = "armor"
@@ -42,44 +71,12 @@
 
 /obj/item/clothing/suit/armor/vest/security
 	name = "security armor"
-	desc = "An armored vest that protects against some damage. This one has a clip for a holobadge."
+	desc = "An armored vest that protects against some damage."
 	sprite_sheets = list(
 		"Grey" = 'icons/mob/clothing/species/grey/suit.dmi'
 	)
 	icon_state = "armor"
 	item_state = "armor"
-	var/obj/item/clothing/accessory/holobadge/attached_badge
-
-/obj/item/clothing/suit/armor/vest/security/attackby(obj/item/I, mob/user, params)
-	if(istype(I, /obj/item/clothing/accessory/holobadge))
-		if(user.unEquip(I))
-			add_fingerprint(user)
-			I.forceMove(src)
-			attached_badge = I
-			var/datum/action/A = new /datum/action/item_action/remove_badge(src)
-			A.Grant(user)
-			icon_state = "armorsec"
-			user.update_inv_wear_suit()
-			desc = "An armored vest that protects against some damage. This one has [attached_badge] attached to it."
-			to_chat(user, "<span class='notice'>You attach [attached_badge] to [src].</span>")
-		return
-	..()
-
-/obj/item/clothing/suit/armor/vest/security/attack_self(mob/user)
-	if(attached_badge)
-		add_fingerprint(user)
-		user.put_in_hands(attached_badge)
-
-		QDEL_LIST_CONTENTS(actions)
-
-		icon_state = "armor"
-		user.update_inv_wear_suit()
-		desc = "An armored vest that protects against some damage. This one has a clip for a holobadge."
-		to_chat(user, "<span class='notice'>You remove [attached_badge] from [src].</span>")
-		attached_badge = null
-
-		return
-	..()
 
 /obj/item/clothing/suit/armor/vest/street_judge
 	name = "judge's security armor"

--- a/code/modules/clothing/under/accessories/accessory.dm
+++ b/code/modules/clothing/under/accessories/accessory.dm
@@ -290,6 +290,7 @@
 	slot_flags = SLOT_BELT | SLOT_TIE
 
 	var/stored_name = null
+	var/deputy_badge = FALSE
 
 /obj/item/clothing/accessory/holobadge/cord
 	icon_state = "holobadge-cord"
@@ -297,11 +298,11 @@
 
 /obj/item/clothing/accessory/holobadge/attack_self(mob/user)
 	if(!stored_name)
-		to_chat(user, "Waving around a badge before swiping an ID would be pretty pointless.")
+		to_chat(user, "Waving around a badge before swiping an ID would be pretty pointless!")
 		return
 	if(isliving(user))
-		user.visible_message("<span class='warning'>[user] displays [user.p_their()] Nanotrasen Internal Security Legal Authorization Badge.\nIt reads: [stored_name], NT Security.</span>",
-		"<span class='warning'>You display your Nanotrasen Internal Security Legal Authorization Badge.\nIt reads: [stored_name], NT Security.</span>")
+		user.visible_message("<span class='warning'>[user] displays [user.p_their()] <b>Nanotrasen Internal Security Legal Authorization Badge</b>.\nIt reads: [stored_name], NT Security.</span>",
+		"<span class='warning'>You display your <b>Nanotrasen Internal Security Legal Authorization Badge</b>.\nIt reads: [stored_name], NT Security.</span>")
 
 /obj/item/clothing/accessory/holobadge/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/card/id) || istype(I, /obj/item/pda))
@@ -314,11 +315,22 @@
 			var/obj/item/pda/pda = I
 			id_card = pda.id
 
+		if(ACCESS_ARMORY in id_card.access)
+			switch(alert(user, "Would you like to activate this Holobadge as a Deputy's Holobadge?", "Choose", "Yes", "No"))
+				if("Yes")
+					deputy_badge = TRUE
+					return
+
 		if(ACCESS_SEC_DOORS in id_card.access || emagged)
 			to_chat(user, "<span class='notice'>You imprint your ID details onto the badge.</span>")
 			stored_name = id_card.registered_name
 			name = "holobadge ([stored_name])"
 			desc = "This glowing blue badge marks [stored_name] as THE LAW."
+		else if(deputy_badge)
+			to_chat(user, "<span class='notice'>You imprint your ID details onto the badge.</span>")
+			stored_name = id_card.registered_name
+			name = "deputy holobadge ([stored_name])"
+			desc = "This glowing blue badge marks [stored_name] as a deputy of THE LAW."
 		else
 			to_chat(user, "<span class='warning'>[src] rejects your insufficient access rights.</span>")
 		return

--- a/code/modules/clothing/under/accessories/accessory.dm
+++ b/code/modules/clothing/under/accessories/accessory.dm
@@ -319,6 +319,8 @@
 			switch(alert(user, "Would you like to activate this Holobadge as a Deputy's Holobadge?", "Choose", "Yes", "No"))
 				if("Yes")
 					deputy_badge = TRUE
+					name = "deputy's holobadge"
+					desc = "This glowing blue badge marks the holder as a Deputy of THE LAW"
 					return
 
 		if(ACCESS_SEC_DOORS in id_card.access || emagged)
@@ -330,7 +332,7 @@
 			to_chat(user, "<span class='notice'>You imprint your ID details onto the badge.</span>")
 			stored_name = id_card.registered_name
 			name = "deputy holobadge ([stored_name])"
-			desc = "This glowing blue badge marks [stored_name] as a deputy of THE LAW."
+			desc = "This glowing blue badge marks [stored_name] as a Deputy of THE LAW."
 		else
 			to_chat(user, "<span class='warning'>[src] rejects your insufficient access rights.</span>")
 		return


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
You can now put the Holobadge onto any `/obj/item/clothing/suit/armor` type.
You can `alt-click` the Holobadge off of armor that you place it on. No more crowding up your action bar.

`ACCESS_ARMORY` (so HoS, Warden, and the Captain) can now turn Holobadges into a "Deputy's Holobadge". 

## TODO Stuff
- [ ] Make overlays work on armor suits.

**If Deputizing is Approved:**
- [ ] Make Badges give VERY basic Sec Door Access?

## Why It's Good For The Game
The main part of this PR is a QoL pass on Holobadges. Theyre clunky to pull on and off your armor and I personally hate anything that gives Action Bar bloat when you could just make it a keybind. I went with `alt-click` since it's already used to remove the Badge from your jumpsuit if you attach it there.

All Armor Suits can now have a Holobadge attached. 
Want it on your Riot or Bulletproofs? Now you can!
Got some sick reactive armor from RND? Pop the Badge on for high-tech lawkeeping!
Want to wear a jacket instead of an armored vest? Drip is no excuse to not have a Badge!

Something I notice in LowPop/when rounds get chaotic is Security losing their footing and Departments becoming a "free for all, fend for yourselves" kinda time. Allowing the HoS/Warden/Captain to deputize members of the Crew as a way to manage those simple tiders/minor crimes while the LowPop/mostly dead Security Team deals with the Big Baddies is useful. This also allows Security to make use of the Assistants/people sitting about if they want to help keep general chaos to a lower level. SoP will be put in place to ensure that these Deputies are not able to join in on lethaling/major Security operations, but moreso assist with communication and dealing with low-level issues.

If the Deputizing part is too much, I'm fully fine axing it and sticking to only the QoL stuff.

## SoP Changes
`TBD`

## Testing
Smacked a buncha holobadges on and off of me.

## Changelog
:cl:
tweak: Tweaked Holobadge interactions
tweak: allows Holobadges to be given out to non-Security to deputize them by Crew with Warden/HoS access.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
