### PR TITLE
Updates the name of cloning data disks

### DIFF
--- a/code/game/machinery/clonepod.dm
+++ b/code/game/machinery/clonepod.dm
@@ -122,7 +122,7 @@ GLOBAL_LIST_INIT(cloner_biomass_items, list(\
 //The return of data disks?? Just for transferring between genetics machine/cloning machine.
 //TO-DO: Make the genetics machine accept them.
 /obj/item/disk/data
-	name = "Cloning Data Disk"
+	name = "Genetics Data Disk"
 	icon_state = "datadisk0" //Gosh I hope syndies don't mistake them for the nuke disk.
 	var/datum/dna2/record/buf = null
 	var/read_only = FALSE //Well,it's still a floppy disk
@@ -610,21 +610,16 @@ GLOBAL_LIST_INIT(cloner_biomass_items, list(\
 			occupant.reagents.add_reagent(bt, 1)
 
 /*
- *	Diskette Box
+ *	Genetics Diskette Box
  */
 
 /obj/item/storage/box/disks
-	name = "Diskette Box"
+	name = "Genetics Diskette Box"
 	icon_state = "disk_kit"
 
 /obj/item/storage/box/disks/populate_contents()
-	new /obj/item/disk/data(src)
-	new /obj/item/disk/data(src)
-	new /obj/item/disk/data(src)
-	new /obj/item/disk/data(src)
-	new /obj/item/disk/data(src)
-	new /obj/item/disk/data(src)
-	new /obj/item/disk/data(src)
+	for(var/i in 1 to 7)
+		new /obj/item/disk/data(src)
 
 /*
  *	Manual -- A big ol' manual.


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->Updates the name of cloning data disks to genetic data disks. The box name has also been updated from Diskette Box to Genetics Diskette box.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->These disks no longer have anything to do with cloning.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![image](https://github.com/ParadiseSS13/Paradise/assets/91113370/4487613a-edb9-41a8-9545-4bbb87f831ea)

## Testing
<!-- How did you test the PR, if at all? -->
See above, and verified that 7 disks were in the box.

## Changelog
:cl:
tweak: Cloning Data Disks are now called Genetics Data Disks. The box they come in has also been updated to reflect this.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
