### PR TITLE
Fixes runtime when clicking an empty coat hanger with empty hand.

### DIFF
--- a/code/game/objects/structures/coathanger.dm
+++ b/code/game/objects/structures/coathanger.dm
@@ -9,7 +9,7 @@
 /obj/structure/coatrack/attack_hand(mob/user)
 	if(isnull(coat))
 		return
-	user.visible_message("[user] takes [coat] off [src].", "You take [coat] off the [src]")
+	user.visible_message("[user] takes [coat] off [src].", "You take [coat] off [src]")
 	if(!user.put_in_active_hand(coat))
 		coat.forceMove(get_turf(user))
 	coat = null

--- a/code/game/objects/structures/coathanger.dm
+++ b/code/game/objects/structures/coathanger.dm
@@ -6,15 +6,14 @@
 	var/obj/item/clothing/suit/coat
 	var/list/allowed = list(/obj/item/clothing/suit/storage/labcoat, /obj/item/clothing/suit/storage/det_suit)
 
-/obj/structure/coatrack/attack_hand(mob/user as mob)
+/obj/structure/coatrack/attack_hand(mob/user)
 	if(isnull(coat))
 		return
-	else
-		user.visible_message("[user] takes [coat] off \the [src].", "You take [coat] off the \the [src]")
-		if(!user.put_in_active_hand(coat))
-			coat.forceMove(get_turf(user))
-		coat = null
-		update_icon(UPDATE_OVERLAYS)
+	user.visible_message("[user] takes [coat] off [src].", "You take [coat] off the [src]")
+	if(!user.put_in_active_hand(coat))
+		coat.forceMove(get_turf(user))
+	coat = null
+	update_icon(UPDATE_OVERLAYS)
 
 /obj/structure/coatrack/attackby(obj/item/W as obj, mob/user as mob, params)
 	var/can_hang = FALSE

--- a/code/game/objects/structures/coathanger.dm
+++ b/code/game/objects/structures/coathanger.dm
@@ -7,11 +7,14 @@
 	var/list/allowed = list(/obj/item/clothing/suit/storage/labcoat, /obj/item/clothing/suit/storage/det_suit)
 
 /obj/structure/coatrack/attack_hand(mob/user as mob)
-	user.visible_message("[user] takes [coat] off \the [src].", "You take [coat] off the \the [src]")
-	if(!user.put_in_active_hand(coat))
-		coat.forceMove(get_turf(user))
-	coat = null
-	update_icon(UPDATE_OVERLAYS)
+	if(isnull(coat))
+		return
+	else
+		user.visible_message("[user] takes [coat] off \the [src].", "You take [coat] off the \the [src]")
+		if(!user.put_in_active_hand(coat))
+			coat.forceMove(get_turf(user))
+		coat = null
+		update_icon(UPDATE_OVERLAYS)
 
 /obj/structure/coatrack/attackby(obj/item/W as obj, mob/user as mob, params)
 	var/can_hang = FALSE


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes runtime when clicking an empty coathanger with empty hand.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Runtimes bad, spamming admin logs too.
fixes #22561
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


## Testing
I tested all functionalities of the coat hanger a few times and there were no runtimes, and the hanger still works. (before coding chat recommendations that is...)
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Fixed a runtime when clicking empty coat hanger.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
