### PR TITLE
Fix death by brain damage spamming message

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -26,8 +26,8 @@
 				if(use_brain_mod)
 					amount *= dna.species.brain_mod
 			sponge.damage = clamp(sponge.damage + amount, 0, 120)
-			if(sponge.damage >= 120 && death())
-				visible_message("<span class='alert'><B>[src]</B> goes limp, [p_their()] facial expression utterly blank.</span>")
+			if(sponge.damage >= 120)
+				death()
 	if(updating)
 		update_stat("adjustBrainLoss")
 	return STATUS_UPDATE_STAT
@@ -43,8 +43,8 @@
 				if(use_brain_mod)
 					amount *= dna.species.brain_mod
 			sponge.damage = clamp(amount, 0, 120)
-			if(sponge.damage >= 120 && death())
-				visible_message("<span class='alert'><B>[src]</B> goes limp, [p_their()] facial expression utterly blank.</span>")
+			if(sponge.damage >= 120)
+				death()
 	if(updating)
 		update_stat("setBrainLoss")
 	return STATUS_UPDATE_STAT

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -26,9 +26,8 @@
 				if(use_brain_mod)
 					amount *= dna.species.brain_mod
 			sponge.damage = clamp(sponge.damage + amount, 0, 120)
-			if(sponge.damage >= 120)
+			if(sponge.damage >= 120 && death())
 				visible_message("<span class='alert'><B>[src]</B> goes limp, [p_their()] facial expression utterly blank.</span>")
-				death()
 	if(updating)
 		update_stat("adjustBrainLoss")
 	return STATUS_UPDATE_STAT
@@ -44,9 +43,8 @@
 				if(use_brain_mod)
 					amount *= dna.species.brain_mod
 			sponge.damage = clamp(amount, 0, 120)
-			if(sponge.damage >= 120)
+			if(sponge.damage >= 120 && death())
 				visible_message("<span class='alert'><B>[src]</B> goes limp, [p_their()] facial expression utterly blank.</span>")
-				death()
 	if(updating)
 		update_stat("setBrainLoss")
 	return STATUS_UPDATE_STAT


### PR DESCRIPTION
## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Fixes the spam of "X goes limp, their facial expression utterly blank." message caused by excessive brain damage. Could happen with any species, but IPCs specifically take brain damage on electrocution regardless of stat

https://github.com/ParadiseSS13/Paradise/blob/5b4796d3f05766e2f03acc62d3befc8d60022a46/code/modules/mob/living/carbon/human/species/machine.dm#L166-L170

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Less message spam

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
Before
![dreamseeker_zDD3ifUzst](https://github.com/ParadiseSS13/Paradise/assets/1496804/e2bc8f35-1aa4-46d6-af7d-0f764858e027)

After
![dreamseeker_N0NXJ8Ik3F](https://github.com/ParadiseSS13/Paradise/assets/1496804/fc9b024b-0a2d-4d4b-9483-995bfec4b2d9)

## Testing
<!-- How did you test the PR, if at all? -->
Spawn pulse demon and IPC, control pulse demon, cross the IPC multiple times

## Changelog
NPFC

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
