### PR TITLE
Fixes projectiles passing through the Desecrated Duel arena

### DIFF
--- a/code/modules/antagonists/vampire/vampire_powers/gargantua_powers.dm
+++ b/code/modules/antagonists/vampire/vampire_powers/gargantua_powers.dm
@@ -271,7 +271,7 @@
 
 /obj/effect/proc_holder/spell/vampire/arena/proc/arena_trap(turf/target_turf)
 	for(var/tumor_range_turfs in circle_edge_turfs(target_turf, ARENA_SIZE))
-		tumor_range_turfs = new /obj/effect/temp_visual/elite_tumor_wall(tumor_range_turfs, src)
+		tumor_range_turfs = new /obj/effect/temp_visual/elite_tumor_wall/gargantua(tumor_range_turfs, src)
 		all_temp_walls += tumor_range_turfs
 
 /obj/effect/proc_holder/spell/vampire/arena/proc/fighters_check(mob/living/user)

--- a/code/modules/mob/living/simple_animal/hostile/mining/elites/elite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/elites/elite.dm
@@ -477,6 +477,7 @@ While using this makes the system rely on OnFire, it still gives options for tim
 	. = ..()
 	if(istype(mover, /obj/item/projectile))
 		return FALSE
+		
 /obj/item/gps/internal/tumor
 	icon_state = null
 	gpstag = "Cancerous Signal"

--- a/code/modules/mob/living/simple_animal/hostile/mining/elites/elite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/elites/elite.dm
@@ -470,7 +470,7 @@ While using this makes the system rely on OnFire, it still gives options for tim
 
 /obj/effect/temp_visual/elite_tumor_wall/CanPass(atom/movable/mover, border_dir)
 	. = ..()
-	if(isliving(mover))
+	if(isliving(mover) || istype(mover, /obj/item/projectile))
 		return FALSE
 
 /obj/item/gps/internal/tumor

--- a/code/modules/mob/living/simple_animal/hostile/mining/elites/elite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/elites/elite.dm
@@ -470,9 +470,13 @@ While using this makes the system rely on OnFire, it still gives options for tim
 
 /obj/effect/temp_visual/elite_tumor_wall/CanPass(atom/movable/mover, border_dir)
 	. = ..()
-	if(isliving(mover) || istype(mover, /obj/item/projectile))
+	if(isliving(mover))
 		return FALSE
 
+/obj/effect/temp_visual/elite_tumor_wall/gargantua/CanPass(atom/movable/mover, border_dir)
+	. = ..()
+	if(istype(mover, /obj/item/projectile))
+		return FALSE
 /obj/item/gps/internal/tumor
 	icon_state = null
 	gpstag = "Cancerous Signal"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes an oversight I made in the original PR, I assume that the walls were automatically blocking projectiles
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Oversights bad, I meant for it to be a melee duel, not a cage for the garg to be executed by firing squad.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
![image](https://github.com/ParadiseSS13/Paradise/assets/108773801/9423557c-e938-4b68-92d4-6306bd532b8a)

<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Fixed projectiles passing through the Desecrated Duel arena
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
