### PR TITLE
Prevents alien resin from growing over chasms/lava

### DIFF
--- a/code/game/objects/structures/aliens.dm
+++ b/code/game/objects/structures/aliens.dm
@@ -298,6 +298,7 @@
 		clear_wall_weed()
 		return
 
+
 	var/list/wall_dirs = list()
 	for(var/turf/W in nearby_dense_turfs)
 		if(iswallturf(W))
@@ -350,7 +351,7 @@
 		return
 
 	for(var/turf/T in U.GetAtmosAdjacentTurfs())
-		if(locate(/obj/structure/alien/weeds) in T || isspaceturf(T))
+		if((locate(/obj/structure/alien/weeds) in T) || isspaceturf(T) || islava(T) || ischasm(T))
 			continue
 		new /obj/structure/alien/weeds(T, linked_node)
 		check_surroundings()

--- a/code/game/objects/structures/aliens.dm
+++ b/code/game/objects/structures/aliens.dm
@@ -298,7 +298,6 @@
 		clear_wall_weed()
 		return
 
-
 	var/list/wall_dirs = list()
 	for(var/turf/W in nearby_dense_turfs)
 		if(iswallturf(W))


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Prevents alien resin from growing over chasms/lava
Fixes #20885
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
You can safely navigate around resin covered area without a worry there is 50 tiles of lava, plasmalava and chasms hidden by resin.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
I checked how the resin behaves around all 3 obstacles that appear on lavaland.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Alien resin no longer grows over lava/chasms
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
