### PR TITLE
Some fake virus tweaks

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -848,6 +848,7 @@
 #define FAKE_FOOD_POISONING 2
 #define FAKE_RETRO_VIRUS 3
 #define FAKE_TURBERCULOSIS 4
+#define FAKE_BRAINROT 5
 
 /datum/status_effect/fake_virus
 	id = "fake_virus"
@@ -865,7 +866,7 @@
 	var/list/fake_emote
 
 /datum/status_effect/fake_virus/on_creation()
-	current_fake_disease = pick(FAKE_COLD, FAKE_FOOD_POISONING, FAKE_RETRO_VIRUS, FAKE_TURBERCULOSIS)
+	current_fake_disease = pick(FAKE_COLD, FAKE_FOOD_POISONING, FAKE_RETRO_VIRUS, FAKE_TURBERCULOSIS, FAKE_BRAINROT)
 	switch(current_fake_disease)
 		if(FAKE_COLD)
 			fake_msg = list(
@@ -900,7 +901,7 @@
 						list(),
 						list()
 			)
-		else
+		if(FAKE_TURBERCULOSIS)
 			fake_msg = list(
 						list("<span class='danger'>Your chest hurts.</span>", "<span class='danger'>Your stomach violently rumbles!</span>", "<span class='danger'>You feel a cold sweat form.</span>"),
 						list("<span class='danger'>You feel a sharp pain from your lower chest!</span>", "<span class='danger'>You feel air escape from your lungs painfully.</span>"),
@@ -910,6 +911,17 @@
 						list("cough"),
 						list("gasp"),
 						list()
+			)
+		else // FAKE_BRAINROT
+			fake_msg = list(
+						list("<span class='danger'>You don't feel like yourself.</span>"),
+						list("<span class='danger'>Your try to remember something important...but can't.</span>"),
+						list("<span class='danger'>Strange buzzing fills your head, removing all thoughts.</span>")
+			)
+			fake_emote = list(
+						list("blink", "yawn"),
+						list("stare", "drool"),
+						list("stare", "drool")
 			)
 	. = ..()
 
@@ -946,6 +958,7 @@
 #undef FAKE_FOOD_POISONING
 #undef FAKE_RETRO_VIRUS
 #undef FAKE_TURBERCULOSIS
+#undef FAKE_BRAINROT
 
 /datum/status_effect/cryo_beam
 	id = "cryo beam"

--- a/code/modules/events/fake_virus.dm
+++ b/code/modules/events/fake_virus.dm
@@ -7,22 +7,27 @@
 			continue
 		fake_virus_victims += victim
 
-	//first we do hard status effect victims
-	var/defacto_min = min(3, length(fake_virus_victims))
-	if(defacto_min) // event will hit 1-3 people by default, but will do 1-2 or just 1 if only those many candidates are available
-		for(var/i in 1 to rand(1, defacto_min))
-			var/mob/living/carbon/human/hypochondriac = pick(fake_virus_victims)
-			hypochondriac.apply_status_effect(STATUS_EFFECT_FAKE_VIRUS)
-			hypochondriac.create_log(MISC_LOG, "[hypochondriac] has contracted a fake virus.")
-			fake_virus_victims -= hypochondriac
-			notify_ghosts("[hypochondriac] now has a fake virus!")
-	//then we do light one-message victims who simply cough or whatever once (have to repeat the process since the last operation modified our candidates list)
-	defacto_min = min(5, length(fake_virus_victims))
-	if(defacto_min)
-		for(var/i in 1 to rand(1, defacto_min))
-			var/mob/living/carbon/human/onecoughman = pick(fake_virus_victims)
-			if(prob(25)) //1/4 odds to get a spooky message instead of coughing out loud
-				addtimer(CALLBACK(GLOBAL_PROC, PROC_REF(to_chat), onecoughman, "<span class='warning'>[pick("Your head hurts.", "Your head pounds.")]</span>"), rand(30, 150))
-			else
-				addtimer(CALLBACK(onecoughman, TYPE_PROC_REF(/mob/, emote), pick("cough", "sniff", "sneeze")), rand(30, 150)) //deliver the message with a slightly randomized time interval so there arent multiple people coughing at the exact same time
-			fake_virus_victims -= onecoughman
+	if(!length(fake_virus_victims))
+		return
+
+	// First we do hard status effect victims
+	var/defacto_min = max(1, 0.05 * length(fake_virus_victims)) // Event will affect 5% of valid crewmembers
+	for(var/i in 1 to rand(1, defacto_min))
+		var/mob/living/carbon/human/hypochondriac = pick(fake_virus_victims)
+		hypochondriac.apply_status_effect(STATUS_EFFECT_FAKE_VIRUS)
+		hypochondriac.create_log(MISC_LOG, "[hypochondriac] has contracted a fake virus.")
+		fake_virus_victims -= hypochondriac
+		notify_ghosts("[hypochondriac] now has a fake virus!")
+
+	if(!length(fake_virus_victims)) // List has been modified, lets check again
+		return
+
+	// Then we do light one-message victims who simply cough or whatever once (have to repeat the process since the last operation modified our candidates list)
+	defacto_min = max(1, 0.1 * length(fake_virus_victims)) // 10% of the victims remaining
+	for(var/i in 1 to rand(1, defacto_min))
+		var/mob/living/carbon/human/onecoughman = pick(fake_virus_victims)
+		if(prob(25)) // 1/4 odds to get a spooky message instead of coughing out loud
+			addtimer(CALLBACK(GLOBAL_PROC, PROC_REF(to_chat), onecoughman, "<span class='warning'>[pick("Your head hurts.", "Your head pounds.")]</span>"), rand(1, 120) SECONDS)
+		else
+			addtimer(CALLBACK(onecoughman, TYPE_PROC_REF(/mob/, emote), pick("cough", "sniff", "sneeze", "yawn")), rand(1, 120) SECONDS) // Deliver the message with a randomized time interval so there arent multiple people coughing at the same time
+		fake_virus_victims -= onecoughman

--- a/code/modules/events/fake_virus.dm
+++ b/code/modules/events/fake_virus.dm
@@ -1,33 +1,33 @@
 /datum/event/fake_virus/start()
-	var/list/fake_virus_victims = list()
+	var/list/valid_targets = list()
 	for(var/mob/living/carbon/human/victim in shuffle(GLOB.player_list))
 		if(HAS_TRAIT(victim, TRAIT_VIRUSIMMUNE))
 			continue
 		if(victim.stat == DEAD || victim.InCritical() || victim.mind?.assigned_role == victim.mind?.special_role || victim.mind?.offstation_role)
 			continue
-		fake_virus_victims += victim
+		valid_targets += victim
 
-	if(!length(fake_virus_victims))
+	if(!length(valid_targets))
 		return
 
 	// First we do hard status effect victims
-	var/defacto_min = max(1, 0.05 * length(fake_virus_victims)) // Event will affect 5% of valid crewmembers
-	for(var/i in 1 to rand(1, defacto_min))
-		var/mob/living/carbon/human/hypochondriac = pick(fake_virus_victims)
+	var/fake_virus_victims = max(1, 0.05 * length(valid_targets)) // Event will affect 5% of valid crewmembers
+	for(var/i in 1 to rand(1, fake_virus_victims))
+		var/mob/living/carbon/human/hypochondriac = pick(valid_targets)
 		hypochondriac.apply_status_effect(STATUS_EFFECT_FAKE_VIRUS)
 		hypochondriac.create_log(MISC_LOG, "[hypochondriac] has contracted a fake virus.")
-		fake_virus_victims -= hypochondriac
+		valid_targets -= hypochondriac
 		notify_ghosts("[hypochondriac] now has a fake virus!")
 
-	if(!length(fake_virus_victims)) // List has been modified, lets check again
+	if(!length(valid_targets)) // List has been modified, lets check again
 		return
 
 	// Then we do light one-message victims who simply cough or whatever once (have to repeat the process since the last operation modified our candidates list)
-	defacto_min = max(1, 0.1 * length(fake_virus_victims)) // 10% of the victims remaining
-	for(var/i in 1 to rand(1, defacto_min))
-		var/mob/living/carbon/human/onecoughman = pick(fake_virus_victims)
+	fake_virus_victims = max(1, 0.1 * length(valid_targets)) // 10% of the victims remaining
+	for(var/i in 1 to rand(1, fake_virus_victims))
+		var/mob/living/carbon/human/one_cough_man = pick(valid_targets)
 		if(prob(25)) // 1/4 odds to get a spooky message instead of coughing out loud
-			addtimer(CALLBACK(GLOBAL_PROC, PROC_REF(to_chat), onecoughman, "<span class='warning'>[pick("Your head hurts.", "Your head pounds.")]</span>"), rand(1, 120) SECONDS)
+			addtimer(CALLBACK(GLOBAL_PROC, PROC_REF(to_chat), one_cough_man, "<span class='warning'>[pick("Your head hurts.", "Your head pounds.")]</span>"), rand(1, 120) SECONDS)
 		else
-			addtimer(CALLBACK(onecoughman, TYPE_PROC_REF(/mob/, emote), pick("cough", "sniff", "sneeze", "yawn")), rand(1, 120) SECONDS) // Deliver the message with a randomized time interval so there arent multiple people coughing at the same time
-		fake_virus_victims -= onecoughman
+			addtimer(CALLBACK(one_cough_man, TYPE_PROC_REF(/mob/, emote), pick("cough", "sniff", "sneeze", "yawn")), rand(1, 120) SECONDS) // Deliver the message with a randomized time interval so there arent multiple people coughing at the same time
+		valid_targets -= one_cough_man


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Fake virus now simulates brainrot too.
Number of victims is no longer a fixed amount (5% for status effect victims and roughly 10% for one-message ones)
one-message victims: Added "yawn" to  emotes and increased the random time it can take for it to trigger.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Allowing it to scale is good to avoid it affecting too few people during highpop rounds.

## Testing
<!-- How did you test the PR, if at all? -->
- Spawned lots of skrells and triggered the event multiple times to verify the changes
## Changelog
:cl:
tweak: Fake virus: Added a new virus that it can fake
tweak: Fake virus: Number of victims now scales with total amount of valid targets
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
