### PR TITLE
Adds a progressbar to heating up reagent containers.

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -28,7 +28,7 @@
 		return TRUE
 	if(is_hot(src) && A.reagents && !ismob(A))
 		var/reagent_temp = A.reagents.chem_temp
-		var/time = ((reagent_temp / 10) / (is_hot(src) / 1000))
+		var/time = (reagent_temp / 10) / (is_hot(src) / 1000)
 		if(do_after_once(user, time, TRUE, user, TRUE, attempt_cancel_message = "You stop lighting [A]."))
 			to_chat(user, "<span class='notice'>You heat [A] with [src].</span>")
 			A.reagents.temperature_reagents(is_hot(src))

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -28,6 +28,8 @@
 		return TRUE
 	if(is_hot(src) && A.reagents && !ismob(A))
 		var/reagent_temp = A.reagents.chem_temp
+		var/time = ((reagent_temp / 10) / (is_hot(src) / 1000))
+		if(do_after_once(user, time, TRUE, user, TRUE, attempt_cancel_message = "You stop heating up [A]."))
 			to_chat(user, "<span class='notice'>You heat [A] with [src].</span>")
 			A.reagents.temperature_reagents(is_hot(src))
 	return TRUE //return FALSE to avoid calling attackby after this proc does stuff

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -27,8 +27,11 @@
 	if(SEND_SIGNAL(src, COMSIG_ITEM_PRE_ATTACK, A, user, params) & COMPONENT_CANCEL_ATTACK_CHAIN)
 		return TRUE
 	if(is_hot(src) && A.reagents && !ismob(A))
-		to_chat(user, "<span class='notice'>You heat [A] with [src].</span>")
-		A.reagents.temperature_reagents(is_hot(src))
+		var/reagent_temp = A.reagents.chem_temp
+		var/time = ((reagent_temp / 10) / (is_hot(src) / 1000))
+		if(do_after_once(user, time, TRUE, user, TRUE, attempt_cancel_message = "You stop lighting [A]."))
+			to_chat(user, "<span class='notice'>You heat [A] with [src].</span>")
+			A.reagents.temperature_reagents(is_hot(src))
 	return TRUE //return FALSE to avoid calling attackby after this proc does stuff
 
 // No comment

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -28,7 +28,7 @@
 		return TRUE
 	if(is_hot(src) && A.reagents && !ismob(A))
 		var/reagent_temp = A.reagents.chem_temp
-		var/time = ((reagent_temp / 10) / (is_hot(src) / 1000))
+		var/time = (reagent_temp / 10) / (is_hot(src) / 1000)
 		if(do_after_once(user, time, TRUE, user, TRUE, attempt_cancel_message = "You stop heating up [A]."))
 			to_chat(user, "<span class='notice'>You heat [A] with [src].</span>")
 			A.reagents.temperature_reagents(is_hot(src))


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Does what it says on the tin. Adds a progress bar to heating up any reagent container.
The formula for the timer is `((reagent_temp / 10) / (is_hot(src) / 1000))`
`is_hot()` is a function that gives us an estimate of how hot the thing is that we're trying to heat something up with.
As an example: at 0 degrees C, it'll take a lighter about 2,7 seconds to heat the beaker up.
So, the hotter the reagents in the beaker, the slower the timer
The better the tool, the faster the timer.
Oh, and you can only queue up one progressbar.

Lighter:
293 K - 2,93 seconds
500 K - 5 seconds
800 K - 8 seconds

Welder:
293 K - 0,83 seconds
500 K - 1,42 seconds
800 K - 2,28 seconds
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Heating up chemical mixes with lighters/welders/zippos etc was always a major gripe. It made the chemical heater so unused that people barely know how it works, and most people who teach chemistry to newer players will just also say things like "Don't use the heater, just grab a welder and heat it up like that." In my - and a very good amount of others - opinion this is not a positive system to keep in place like this, hence this attempt to make it more inferior to the chemical heater.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
I made some beakers quite hot with multiple tools
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Heating a reagent container with a hot item , such as lighters and welders, now takes a little bit of time
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
