### PR TITLE
Syndicate bots no longer show up on security bot control PDA menu

### DIFF
--- a/code/modules/pda/cart_apps.dm
+++ b/code/modules/pda/cart_apps.dm
@@ -223,7 +223,8 @@
 		for(var/mob/living/simple_animal/bot/secbot/SB in GLOB.bots_list)
 			bots += SB
 		for(var/mob/living/simple_animal/bot/ed209/ED in GLOB.bots_list)
-			bots += ED
+			if(!"syndicate" in ED.faction)
+				bots += ED
 
 		for(var/mob/living/simple_animal/bot/B in bots)
 			botsCount++

--- a/code/modules/pda/cart_apps.dm
+++ b/code/modules/pda/cart_apps.dm
@@ -223,7 +223,7 @@
 		for(var/mob/living/simple_animal/bot/secbot/SB in GLOB.bots_list)
 			bots += SB
 		for(var/mob/living/simple_animal/bot/ed209/ED in GLOB.bots_list)
-			if(!"syndicate" in ED.faction)
+			if(!("syndicate" in ED.faction))
 				bots += ED
 
 		for(var/mob/living/simple_animal/bot/B in bots)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Syndicate bot is no longer visible on bot control pda menu.
fixes #20865
If you make me use "faction_check_mob" and it won't work it ain't my fault cuz it didn't work for me.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Kinda immersion breaking to see syndicate bots (Z levels away too) as a security member of nanotrasen space station.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
I tested basic functionality of the existing, NT friendly bots and they do work and follow commands, syndie bots  are not visible there and there were no runtimes.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Syndicate bots no longer show up on security bot control PDA menu
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
