### PR TITLE
Cult Sound Tweaks

### DIFF
--- a/code/__DEFINES/sound_defines.dm
+++ b/code/__DEFINES/sound_defines.dm
@@ -22,6 +22,8 @@
 
 ///Default range of a sound.
 #define SOUND_RANGE 17
+///Easy-to-math sound range for simpler coding with specific variables. Insert the exact range you wish the sound to be heard from.
+#define SOUND_RANGE_SET(amount) amount - 17
 ///default extra range for sounds considered to be quieter
 #define SHORT_RANGE_SOUND_EXTRARANGE -9
 ///The range deducted from sound range for things that are considered silent / sneaky

--- a/code/game/gamemodes/cult/blood_magic.dm
+++ b/code/game/gamemodes/cult/blood_magic.dm
@@ -318,7 +318,10 @@
 		owner.visible_message("<span class='warning'>Thin grey dust falls from [owner]'s hand!</span>", \
 		"<span class='cultitalic'>You invoke the veiling spell, hiding nearby runes and cult structures.</span>")
 		charges--
-		playsound(owner, 'sound/magic/smoke.ogg', 25, TRUE, -13) // 4 tile range.
+		if(!SSticker.mode.cult_risen || !SSticker.mode.cult_ascendant)
+			playsound(owner, 'sound/magic/smoke.ogg', 25, TRUE, -13) // 4 tile range if Cult is risen/ascendant.
+		else
+			playsound(owner, 'sound/magic/smoke.ogg', 25, TRUE, -16) // 1 tile range if Cult is unpowered.
 		owner.whisper(invocation)
 		for(var/obj/O in range(4, owner))
 			O.cult_conceal()
@@ -331,7 +334,10 @@
 		"<span class='cultitalic'>You invoke the counterspell, revealing nearby runes and cult structures.</span>")
 		charges--
 		owner.whisper(invocation)
-		playsound(owner, 'sound/misc/enter_blood.ogg', 25, TRUE, -10) // 7 tile range.
+		if(!SSticker.mode.cult_risen || !SSticker.mode.cult_ascendant)
+			playsound(owner, 'sound/misc/enter_blood.ogg', 25, TRUE, -10) // 7 tile range if Cult is risen/ascendant.
+		else
+			playsound(owner, 'sound/magic/smoke.ogg', 25, TRUE, -16) // 1 tile range if Cult is unpowered.
 		for(var/obj/O in range(5, owner)) // Slightly higher in case we arent in the exact same spot
 			O.cult_reveal()
 		revealing = FALSE // Switch on use

--- a/code/game/gamemodes/cult/blood_magic.dm
+++ b/code/game/gamemodes/cult/blood_magic.dm
@@ -226,7 +226,7 @@
 	else
 		owner.visible_message("<span class='warning'>A [O.name] appears at [owner]'s feet!</span>", \
 							"<span class='cultitalic'>A [O.name] materializes at your feet.</span>")
-	playsound(owner, 'sound/magic/cult_spell.ogg', 25, TRUE)
+	playsound(owner, 'sound/magic/cult_spell.ogg', 25, TRUE, -13) // 4 tile range
 	charges--
 	desc = base_desc
 	desc += "<br><b><u>Has [charges] use\s remaining</u></b>."
@@ -566,7 +566,7 @@
 
 /obj/item/melee/blood_magic/shackles/proc/CuffAttack(mob/living/carbon/C, mob/living/user)
 	if(!C.handcuffed)
-		playsound(loc, 'sound/weapons/cablecuff.ogg', 30, TRUE, -2)
+		playsound(loc, 'sound/weapons/cablecuff.ogg', 30, TRUE, -10)
 		C.visible_message("<span class='danger'>[user] begins restraining [C] with dark magic!</span>", \
 		"<span class='userdanger'>[user] begins shaping dark magic shackles around your wrists!</span>")
 		if(do_mob(user, C, 30))
@@ -628,7 +628,7 @@
 				uses--
 				to_chat(user, "<span class='warning'>A dark cloud emanates from your hand and swirls around the metal, twisting it into a construct shell!</span>")
 				new /obj/structure/constructshell(T)
-				playsound(user, 'sound/magic/cult_spell.ogg', 25, TRUE)
+				playsound(user, 'sound/magic/cult_spell.ogg', 25, TRUE. -13) // 4 tile range
 			else
 				to_chat(user, "<span class='warning'>You need [METAL_TO_CONSTRUCT_SHELL_CONVERSION] metal to produce a construct shell!</span>")
 				return
@@ -641,18 +641,18 @@
 				uses--
 				new /obj/item/stack/sheet/runed_metal(T, quantity)
 				to_chat(user, "<span class='warning'>A dark cloud emanates from you hand and swirls around the plasteel, transforming it into runed metal!</span>")
-				playsound(user, 'sound/magic/cult_spell.ogg', 25, TRUE)
+				playsound(user, 'sound/magic/cult_spell.ogg', 25, TRUE, -13) // 4 tile range
 
 		//Airlock to cult airlock
 		else if(istype(target, /obj/machinery/door/airlock) && !istype(target, /obj/machinery/door/airlock/cult))
 			channeling = TRUE
-			playsound(T, 'sound/machines/airlockforced.ogg', 50, TRUE)
+			playsound(T, 'sound/machines/airlockforced.ogg', 50, TRUE, -10)  // 7 tile range
 			do_sparks(5, TRUE, target)
 			if(do_after(user, 50, target = target))
 				target.narsie_act(TRUE)
 				uses--
 				user.visible_message("<span class='warning'>Black ribbons suddenly emanate from [user]'s hand and cling to the airlock - twisting and corrupting it!</span>")
-				playsound(user, 'sound/magic/cult_spell.ogg', 25, TRUE)
+				playsound(user, 'sound/magic/cult_spell.ogg', 25, TRUE, -10)  // 7 tile range
 				channeling = FALSE
 			else
 				channeling = FALSE
@@ -704,7 +704,7 @@
 			if(C.current_charges < 3)
 				uses--
 				to_chat(user, "<span class='warning'>You empower [target] with blood, recharging its shields!</span>")
-				playsound(user, 'sound/magic/cult_spell.ogg', 25, TRUE)
+				playsound(user, 'sound/magic/cult_spell.ogg', 25, TRUE, -10)  // 7 tile range
 				C.current_charges = 3
 				C.shield_state = "shield-cult"
 				user.update_inv_wear_suit() // The only way a suit can be clicked on is if its on the floor, in the users bag, or on the user, so we will play it safe if it is on the user.
@@ -718,7 +718,7 @@
 			if(S.uses < 4)
 				uses--
 				to_chat(user, "<span class='warning'>You empower [target] with blood, recharging its ability to shift!</span>")
-				playsound(user, 'sound/magic/cult_spell.ogg', 25, TRUE)
+				playsound(user, 'sound/magic/cult_spell.ogg', 25, TRUE, -10) // 4 tile range
 				S.uses = 4
 				S.icon_state = "shifter"
 			else
@@ -786,7 +786,7 @@
 	H.adjustFireLoss((overall_damage * ratio) * (H.getFireLoss() / overall_damage), FALSE, null, TRUE)
 	H.adjustBruteLoss((overall_damage * ratio) * (H.getBruteLoss() / overall_damage), FALSE, null, TRUE)
 	H.updatehealth()
-	playsound(get_turf(H), 'sound/magic/staff_healing.ogg', 25)
+	playsound(get_turf(H), 'sound/magic/staff_healing.ogg', 25, -10) // 7 tile range
 	new /obj/effect/temp_visual/cult/sparks(get_turf(H))
 	user.Beam(H, icon_state="sendbeam", time = 15)
 
@@ -820,7 +820,7 @@
 		M.visible_message("<span class='warning'>[M] is partially healed by [user]'s blood magic!</span>",
 			"<span class='cultitalic'>You are partially healed by [user]'s blood magic.</span>")
 		uses = 0
-	playsound(get_turf(M), 'sound/magic/staff_healing.ogg', 25)
+	playsound(get_turf(M), 'sound/magic/staff_healing.ogg', 25, -10) // 7 tile range
 	user.Beam(M, icon_state = "sendbeam", time = 10)
 
 /obj/item/melee/blood_magic/manipulator/proc/steal_blood(mob/living/carbon/human/user, mob/living/carbon/human/H)
@@ -839,7 +839,7 @@
 	H.blood_volume -= 100
 	uses += 50
 	user.Beam(H, icon_state = "drainbeam", time = 10)
-	playsound(get_turf(H), 'sound/misc/enter_blood.ogg', 50)
+	playsound(get_turf(H), 'sound/misc/enter_blood.ogg', 50, -10) // 7 tile range
 	H.visible_message("<span class='danger'>[user] has drained some of [H]'s blood!</span>",
 					"<span class='userdanger'>[user] has drained some of your blood!</span>")
 	to_chat(user, "<span class='cultitalic'>Your blood rite gains 50 charges from draining [H]'s blood.</span>")
@@ -868,7 +868,7 @@
 		if(candidate.blood)
 			uses += candidate.blood
 			to_chat(user, "<span class='warning'>You obtain [candidate.blood] blood from the orb of blood!</span>")
-			playsound(user, 'sound/misc/enter_blood.ogg', 50)
+			playsound(user, 'sound/misc/enter_blood.ogg', 50, -10) // 4 tile range
 			qdel(candidate)
 			return
 	blood_draw(target, user)
@@ -892,7 +892,7 @@
 	if(temp)
 		user.Beam(T, icon_state = "drainbeam", time = 15)
 		new /obj/effect/temp_visual/cult/sparks(get_turf(user))
-		playsound(T, 'sound/misc/enter_blood.ogg', 50)
+		playsound(T, 'sound/misc/enter_blood.ogg', 50., -10) // 7 tile range
 		temp = round(temp)
 		to_chat(user, "<span class='cultitalic'>Your blood rite has gained [temp] charge\s from blood sources around you!</span>")
 		uses += max(1, temp)

--- a/code/game/gamemodes/cult/blood_magic.dm
+++ b/code/game/gamemodes/cult/blood_magic.dm
@@ -786,7 +786,7 @@
 	H.adjustFireLoss((overall_damage * ratio) * (H.getFireLoss() / overall_damage), FALSE, null, TRUE)
 	H.adjustBruteLoss((overall_damage * ratio) * (H.getBruteLoss() / overall_damage), FALSE, null, TRUE)
 	H.updatehealth()
-	playsound(get_turf(H), 'sound/magic/staff_healing.ogg', 25, SOUND_RANGE_SET(7))
+	playsound(get_turf(H), 'sound/magic/staff_healing.ogg', 25, extrarange = SOUND_RANGE_SET(7))
 	new /obj/effect/temp_visual/cult/sparks(get_turf(H))
 	user.Beam(H, icon_state="sendbeam", time = 15)
 
@@ -820,7 +820,7 @@
 		M.visible_message("<span class='warning'>[M] is partially healed by [user]'s blood magic!</span>",
 			"<span class='cultitalic'>You are partially healed by [user]'s blood magic.</span>")
 		uses = 0
-	playsound(get_turf(M), 'sound/magic/staff_healing.ogg', 25, SOUND_RANGE_SET(7))
+	playsound(get_turf(M), 'sound/magic/staff_healing.ogg', 25, extrarange = SOUND_RANGE_SET(7))
 	user.Beam(M, icon_state = "sendbeam", time = 10)
 
 /obj/item/melee/blood_magic/manipulator/proc/steal_blood(mob/living/carbon/human/user, mob/living/carbon/human/H)
@@ -839,7 +839,7 @@
 	H.blood_volume -= 100
 	uses += 50
 	user.Beam(H, icon_state = "drainbeam", time = 10)
-	playsound(get_turf(H), 'sound/misc/enter_blood.ogg', 50, SOUND_RANGE_SET(7))
+	playsound(get_turf(H), 'sound/misc/enter_blood.ogg', 50, extrarange = SOUND_RANGE_SET(7))
 	H.visible_message("<span class='danger'>[user] has drained some of [H]'s blood!</span>",
 					"<span class='userdanger'>[user] has drained some of your blood!</span>")
 	to_chat(user, "<span class='cultitalic'>Your blood rite gains 50 charges from draining [H]'s blood.</span>")
@@ -868,7 +868,7 @@
 		if(candidate.blood)
 			uses += candidate.blood
 			to_chat(user, "<span class='warning'>You obtain [candidate.blood] blood from the orb of blood!</span>")
-			playsound(user, 'sound/misc/enter_blood.ogg', 50, SOUND_RANGE_SET(7))
+			playsound(user, 'sound/misc/enter_blood.ogg', 50, extrarange = SOUND_RANGE_SET(7))
 			qdel(candidate)
 			return
 	blood_draw(target, user)
@@ -892,7 +892,7 @@
 	if(temp)
 		user.Beam(T, icon_state = "drainbeam", time = 15)
 		new /obj/effect/temp_visual/cult/sparks(get_turf(user))
-		playsound(T, 'sound/misc/enter_blood.ogg', 50., SOUND_RANGE_SET(7))
+		playsound(T, 'sound/misc/enter_blood.ogg', 50., extrarange = SOUND_RANGE_SET(7))
 		temp = round(temp)
 		to_chat(user, "<span class='cultitalic'>Your blood rite has gained [temp] charge\s from blood sources around you!</span>")
 		uses += max(1, temp)

--- a/code/game/gamemodes/cult/blood_magic.dm
+++ b/code/game/gamemodes/cult/blood_magic.dm
@@ -628,7 +628,7 @@
 				uses--
 				to_chat(user, "<span class='warning'>A dark cloud emanates from your hand and swirls around the metal, twisting it into a construct shell!</span>")
 				new /obj/structure/constructshell(T)
-				playsound(user, 'sound/magic/cult_spell.ogg', 25, TRUE. -13) // 4 tile range
+				playsound(user, 'sound/magic/cult_spell.ogg', 25, TRUE, -13) // 4 tile range
 			else
 				to_chat(user, "<span class='warning'>You need [METAL_TO_CONSTRUCT_SHELL_CONVERSION] metal to produce a construct shell!</span>")
 				return
@@ -718,7 +718,7 @@
 			if(S.uses < 4)
 				uses--
 				to_chat(user, "<span class='warning'>You empower [target] with blood, recharging its ability to shift!</span>")
-				playsound(user, 'sound/magic/cult_spell.ogg', 25, TRUE, -10) // 4 tile range
+				playsound(user, 'sound/magic/cult_spell.ogg', 25, TRUE, -10) // 7 tile range
 				S.uses = 4
 				S.icon_state = "shifter"
 			else
@@ -868,7 +868,7 @@
 		if(candidate.blood)
 			uses += candidate.blood
 			to_chat(user, "<span class='warning'>You obtain [candidate.blood] blood from the orb of blood!</span>")
-			playsound(user, 'sound/misc/enter_blood.ogg', 50, -10) // 4 tile range
+			playsound(user, 'sound/misc/enter_blood.ogg', 50, -10) // 7 tile range
 			qdel(candidate)
 			return
 	blood_draw(target, user)

--- a/code/game/gamemodes/cult/blood_magic.dm
+++ b/code/game/gamemodes/cult/blood_magic.dm
@@ -892,7 +892,7 @@
 	if(temp)
 		user.Beam(T, icon_state = "drainbeam", time = 15)
 		new /obj/effect/temp_visual/cult/sparks(get_turf(user))
-		playsound(T, 'sound/misc/enter_blood.ogg', 50., extrarange = SOUND_RANGE_SET(7))
+		playsound(T, 'sound/misc/enter_blood.ogg', 50, extrarange = SOUND_RANGE_SET(7))
 		temp = round(temp)
 		to_chat(user, "<span class='cultitalic'>Your blood rite has gained [temp] charge\s from blood sources around you!</span>")
 		uses += max(1, temp)

--- a/code/game/gamemodes/cult/blood_magic.dm
+++ b/code/game/gamemodes/cult/blood_magic.dm
@@ -566,7 +566,7 @@
 
 /obj/item/melee/blood_magic/shackles/proc/CuffAttack(mob/living/carbon/C, mob/living/user)
 	if(!C.handcuffed)
-		playsound(loc, 'sound/weapons/cablecuff.ogg', 30, TRUE, -10)
+		playsound(loc, 'sound/weapons/cablecuff.ogg', 30, TRUE, SOUND_RANGE_SET(7))
 		C.visible_message("<span class='danger'>[user] begins restraining [C] with dark magic!</span>", \
 		"<span class='userdanger'>[user] begins shaping dark magic shackles around your wrists!</span>")
 		if(do_mob(user, C, 30))

--- a/code/game/gamemodes/cult/blood_magic.dm
+++ b/code/game/gamemodes/cult/blood_magic.dm
@@ -226,7 +226,7 @@
 	else
 		owner.visible_message("<span class='warning'>A [O.name] appears at [owner]'s feet!</span>", \
 							"<span class='cultitalic'>A [O.name] materializes at your feet.</span>")
-	playsound(owner, 'sound/magic/cult_spell.ogg', 25, TRUE, -13) // 4 tile range
+	playsound(owner, 'sound/magic/cult_spell.ogg', 25, TRUE, SOUND_RANGE_SET(4))
 	charges--
 	desc = base_desc
 	desc += "<br><b><u>Has [charges] use\s remaining</u></b>."
@@ -319,9 +319,9 @@
 		"<span class='cultitalic'>You invoke the veiling spell, hiding nearby runes and cult structures.</span>")
 		charges--
 		if(!SSticker.mode.cult_risen || !SSticker.mode.cult_ascendant)
-			playsound(owner, 'sound/magic/smoke.ogg', 25, TRUE, -13) // 4 tile range if Cult is risen/ascendant.
+			playsound(owner, 'sound/magic/smoke.ogg', 25, TRUE, SOUND_RANGE_SET(4)) // If Cult is risen/ascendant.
 		else
-			playsound(owner, 'sound/magic/smoke.ogg', 25, TRUE, -16) // 1 tile range if Cult is unpowered.
+			playsound(owner, 'sound/magic/smoke.ogg', 25, TRUE, SOUND_RANGE_SET(1)) // If Cult is unpowered.
 		owner.whisper(invocation)
 		for(var/obj/O in range(4, owner))
 			O.cult_conceal()
@@ -335,9 +335,9 @@
 		charges--
 		owner.whisper(invocation)
 		if(!SSticker.mode.cult_risen || !SSticker.mode.cult_ascendant)
-			playsound(owner, 'sound/misc/enter_blood.ogg', 25, TRUE, -10) // 7 tile range if Cult is risen/ascendant.
+			playsound(owner, 'sound/misc/enter_blood.ogg', 25, TRUE, SOUND_RANGE_SET(7)) // If Cult is risen/ascendant.
 		else
-			playsound(owner, 'sound/magic/smoke.ogg', 25, TRUE, -16) // 1 tile range if Cult is unpowered.
+			playsound(owner, 'sound/magic/smoke.ogg', 25, TRUE, SOUND_RANGE_SET(1)) // If Cult is unpowered.
 		for(var/obj/O in range(5, owner)) // Slightly higher in case we arent in the exact same spot
 			O.cult_reveal()
 		revealing = FALSE // Switch on use
@@ -628,7 +628,7 @@
 				uses--
 				to_chat(user, "<span class='warning'>A dark cloud emanates from your hand and swirls around the metal, twisting it into a construct shell!</span>")
 				new /obj/structure/constructshell(T)
-				playsound(user, 'sound/magic/cult_spell.ogg', 25, TRUE, -13) // 4 tile range
+				playsound(user, 'sound/magic/cult_spell.ogg', 25, TRUE, SOUND_RANGE_SET(4))
 			else
 				to_chat(user, "<span class='warning'>You need [METAL_TO_CONSTRUCT_SHELL_CONVERSION] metal to produce a construct shell!</span>")
 				return
@@ -641,18 +641,18 @@
 				uses--
 				new /obj/item/stack/sheet/runed_metal(T, quantity)
 				to_chat(user, "<span class='warning'>A dark cloud emanates from you hand and swirls around the plasteel, transforming it into runed metal!</span>")
-				playsound(user, 'sound/magic/cult_spell.ogg', 25, TRUE, -13) // 4 tile range
+				playsound(user, 'sound/magic/cult_spell.ogg', 25, TRUE, SOUND_RANGE_SET(4))
 
 		//Airlock to cult airlock
 		else if(istype(target, /obj/machinery/door/airlock) && !istype(target, /obj/machinery/door/airlock/cult))
 			channeling = TRUE
-			playsound(T, 'sound/machines/airlockforced.ogg', 50, TRUE, -10)  // 7 tile range
+			playsound(T, 'sound/machines/airlockforced.ogg', 50, TRUE, SOUND_RANGE_SET(7))
 			do_sparks(5, TRUE, target)
 			if(do_after(user, 50, target = target))
 				target.narsie_act(TRUE)
 				uses--
 				user.visible_message("<span class='warning'>Black ribbons suddenly emanate from [user]'s hand and cling to the airlock - twisting and corrupting it!</span>")
-				playsound(user, 'sound/magic/cult_spell.ogg', 25, TRUE, -10)  // 7 tile range
+				playsound(user, 'sound/magic/cult_spell.ogg', 25, TRUE, SOUND_RANGE_SET(7))
 				channeling = FALSE
 			else
 				channeling = FALSE
@@ -704,7 +704,7 @@
 			if(C.current_charges < 3)
 				uses--
 				to_chat(user, "<span class='warning'>You empower [target] with blood, recharging its shields!</span>")
-				playsound(user, 'sound/magic/cult_spell.ogg', 25, TRUE, -10)  // 7 tile range
+				playsound(user, 'sound/magic/cult_spell.ogg', 25, TRUE, SOUND_RANGE_SET(7))
 				C.current_charges = 3
 				C.shield_state = "shield-cult"
 				user.update_inv_wear_suit() // The only way a suit can be clicked on is if its on the floor, in the users bag, or on the user, so we will play it safe if it is on the user.
@@ -718,7 +718,7 @@
 			if(S.uses < 4)
 				uses--
 				to_chat(user, "<span class='warning'>You empower [target] with blood, recharging its ability to shift!</span>")
-				playsound(user, 'sound/magic/cult_spell.ogg', 25, TRUE, -10) // 7 tile range
+				playsound(user, 'sound/magic/cult_spell.ogg', 25, TRUE, SOUND_RANGE_SET(7))
 				S.uses = 4
 				S.icon_state = "shifter"
 			else
@@ -786,7 +786,7 @@
 	H.adjustFireLoss((overall_damage * ratio) * (H.getFireLoss() / overall_damage), FALSE, null, TRUE)
 	H.adjustBruteLoss((overall_damage * ratio) * (H.getBruteLoss() / overall_damage), FALSE, null, TRUE)
 	H.updatehealth()
-	playsound(get_turf(H), 'sound/magic/staff_healing.ogg', 25, -10) // 7 tile range
+	playsound(get_turf(H), 'sound/magic/staff_healing.ogg', 25, SOUND_RANGE_SET(7))
 	new /obj/effect/temp_visual/cult/sparks(get_turf(H))
 	user.Beam(H, icon_state="sendbeam", time = 15)
 
@@ -820,7 +820,7 @@
 		M.visible_message("<span class='warning'>[M] is partially healed by [user]'s blood magic!</span>",
 			"<span class='cultitalic'>You are partially healed by [user]'s blood magic.</span>")
 		uses = 0
-	playsound(get_turf(M), 'sound/magic/staff_healing.ogg', 25, -10) // 7 tile range
+	playsound(get_turf(M), 'sound/magic/staff_healing.ogg', 25, SOUND_RANGE_SET(7))
 	user.Beam(M, icon_state = "sendbeam", time = 10)
 
 /obj/item/melee/blood_magic/manipulator/proc/steal_blood(mob/living/carbon/human/user, mob/living/carbon/human/H)
@@ -839,7 +839,7 @@
 	H.blood_volume -= 100
 	uses += 50
 	user.Beam(H, icon_state = "drainbeam", time = 10)
-	playsound(get_turf(H), 'sound/misc/enter_blood.ogg', 50, -10) // 7 tile range
+	playsound(get_turf(H), 'sound/misc/enter_blood.ogg', 50, SOUND_RANGE_SET(7))
 	H.visible_message("<span class='danger'>[user] has drained some of [H]'s blood!</span>",
 					"<span class='userdanger'>[user] has drained some of your blood!</span>")
 	to_chat(user, "<span class='cultitalic'>Your blood rite gains 50 charges from draining [H]'s blood.</span>")
@@ -868,7 +868,7 @@
 		if(candidate.blood)
 			uses += candidate.blood
 			to_chat(user, "<span class='warning'>You obtain [candidate.blood] blood from the orb of blood!</span>")
-			playsound(user, 'sound/misc/enter_blood.ogg', 50, -10) // 7 tile range
+			playsound(user, 'sound/misc/enter_blood.ogg', 50, SOUND_RANGE_SET(7))
 			qdel(candidate)
 			return
 	blood_draw(target, user)
@@ -892,7 +892,7 @@
 	if(temp)
 		user.Beam(T, icon_state = "drainbeam", time = 15)
 		new /obj/effect/temp_visual/cult/sparks(get_turf(user))
-		playsound(T, 'sound/misc/enter_blood.ogg', 50., -10) // 7 tile range
+		playsound(T, 'sound/misc/enter_blood.ogg', 50., SOUND_RANGE_SET(7))
 		temp = round(temp)
 		to_chat(user, "<span class='cultitalic'>Your blood rite has gained [temp] charge\s from blood sources around you!</span>")
 		uses += max(1, temp)

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -418,7 +418,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 				to_chat(M, "<span class='cultlarge'>\"I accept this sacrifice.\"</span>")
 			else
 				to_chat(M, "<span class='cultlarge'>\"I accept this meager sacrifice.\"</span>")
-	playsound(offering, 'sound/misc/demon_consume.ogg', 100, TRUE, -7)  // 10 tile range
+	playsound(offering, 'sound/misc/demon_consume.ogg', 100, TRUE, SOUND_RANGE_SET(10))
 
 	if(((ishuman(offering) || isrobot(offering) || isbrain(offering)) && offering.mind) && !worthless)
 		var/obj/item/soulstone/stone = new /obj/item/soulstone(get_turf(src))
@@ -430,7 +430,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 			offering.dust() //To prevent the MMI from remaining
 		else
 			offering.gib()
-		playsound(offering, 'sound/magic/disintegrate.ogg', 100, TRUE, -7) // 10 tile range
+		playsound(offering, 'sound/magic/disintegrate.ogg', 100, TRUE, SOUND_RANGE_SET(10))
 	if(sacrifice_fulfilled)
 		gamemode.cult_objs.succesful_sacrifice()
 	return TRUE
@@ -960,7 +960,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 	for(var/obj/item/organ/external/current_organ in new_human.bodyparts)
 		current_organ.limb_flags |= CANNOT_DISMEMBER //you can't chop of the limbs of a ghost, silly
 	ghosts++
-	playsound(src, 'sound/misc/exit_blood.ogg', 50, TRUE, -7)  // 10 tile range
+	playsound(src, 'sound/misc/exit_blood.ogg', 50, TRUE, SOUND_RANGE_SET(10))
 	user.visible_message("<span class='warning'>A cloud of red mist forms above [src], and from within steps... a [new_human.gender == FEMALE ? "wo" : ""]man.</span>",
 						"<span class='cultitalic'>Your blood begins flowing into [src]. You must remain in place and conscious to maintain the forms of those summoned. This will hurt you slowly but surely...</span>")
 

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -418,7 +418,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 				to_chat(M, "<span class='cultlarge'>\"I accept this sacrifice.\"</span>")
 			else
 				to_chat(M, "<span class='cultlarge'>\"I accept this meager sacrifice.\"</span>")
-	playsound(offering, 'sound/misc/demon_consume.ogg', 100, TRUE)
+	playsound(offering, 'sound/misc/demon_consume.ogg', 100, TRUE. -7)  // 10 tile range
 
 	if(((ishuman(offering) || isrobot(offering) || isbrain(offering)) && offering.mind) && !worthless)
 		var/obj/item/soulstone/stone = new /obj/item/soulstone(get_turf(src))
@@ -430,7 +430,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 			offering.dust() //To prevent the MMI from remaining
 		else
 			offering.gib()
-		playsound(offering, 'sound/magic/disintegrate.ogg', 100, TRUE)
+		playsound(offering, 'sound/magic/disintegrate.ogg', 100, TRUE, -7) // 10 tile range
 	if(sacrifice_fulfilled)
 		gamemode.cult_objs.succesful_sacrifice()
 	return TRUE
@@ -960,7 +960,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 	for(var/obj/item/organ/external/current_organ in new_human.bodyparts)
 		current_organ.limb_flags |= CANNOT_DISMEMBER //you can't chop of the limbs of a ghost, silly
 	ghosts++
-	playsound(src, 'sound/misc/exit_blood.ogg', 50, TRUE)
+	playsound(src, 'sound/misc/exit_blood.ogg', 50, TRUE, -7)  // 10 tile range
 	user.visible_message("<span class='warning'>A cloud of red mist forms above [src], and from within steps... a [new_human.gender == FEMALE ? "wo" : ""]man.</span>",
 						"<span class='cultitalic'>Your blood begins flowing into [src]. You must remain in place and conscious to maintain the forms of those summoned. This will hurt you slowly but surely...</span>")
 

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -418,7 +418,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 				to_chat(M, "<span class='cultlarge'>\"I accept this sacrifice.\"</span>")
 			else
 				to_chat(M, "<span class='cultlarge'>\"I accept this meager sacrifice.\"</span>")
-	playsound(offering, 'sound/misc/demon_consume.ogg', 100, TRUE. -7)  // 10 tile range
+	playsound(offering, 'sound/misc/demon_consume.ogg', 100, TRUE, -7)  // 10 tile range
 
 	if(((ishuman(offering) || isrobot(offering) || isbrain(offering)) && offering.mind) && !worthless)
 		var/obj/item/soulstone/stone = new /obj/item/soulstone(get_turf(src))


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Changes a large amount of sound ranges for Cult Spells/Runes.

Summon Dagger: `17` -> `4`
Conceal Runes: `1` Before Rise/Ascend, `4` after. (was `4` constant)
Twist Materials: `17` -> `4`
Twist Airlock: `17` -> `7`
Recharge Item/Heal/Blood Magic: `17` -> `7`

Cult Cuffing: `15` -> `7` (this is in line with all other forms of cuffing)

Sacrifice: `17` -> `10`
Summon Ghost: `17` -> `10`

## Why It's Good For The Game
Right, before you all go and try to crucify me for buffing Cult.

There is nothing fun about getting meta-echolocated as Cult. Security will immediately get lethals and its now the arms race that Cult usually is. People should be rewarded for well-planned stealth operations.

Investigation should find the Cult. Not meta-echolocation from some random Doctor/Engi/etc.

## Testing
Made a buncha spooky sounds in the darkness.

## Changelog
:cl:
tweak: Tweaked the volume on a majority of Cult spells/runes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
