### PR TITLE
Changelings now cannot use their shrieks while they are ventcrawling

### DIFF
--- a/code/modules/antagonists/changeling/powers/shriek.dm
+++ b/code/modules/antagonists/changeling/powers/shriek.dm
@@ -10,6 +10,8 @@
 
 //A flashy ability, good for crowd control and sowing chaos.
 /datum/action/changeling/resonant_shriek/sting_action(mob/user)
+	if(istype(user.loc, /obj/machinery/atmospherics))
+		return FALSE
 	for(var/mob/living/M in get_mobs_in_view(4, user))
 		if(iscarbon(M))
 			if(ishuman(M))
@@ -44,6 +46,8 @@
 
 //A flashy ability, good for crowd control and sewing chaos.
 /datum/action/changeling/dissonant_shriek/sting_action(mob/user)
+	if(istype(user.loc, /obj/machinery/atmospherics))
+		return FALSE
 	for(var/obj/machinery/light/L in range(5, usr))
 		L.on = TRUE
 		L.break_light_tube()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Stops changelings from using their shrieks while ventcrawling. Resonant Shriek already had failsaves in place for doing it while in lesser form, but I added it in case they get their hands on some other form of ventcrawling.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Some people enjoy ventcrawling as changelings, spamming their EMP shriek, either to annoy security or to just keep killing their IPC target, which is in both cases very uninteractive for both sides.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
I went on a little ventcrawling adventure, looked at the fancy button animations doing nothing as I couldn't Shriek anymore.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Changelings now cannot use both Shrieks while ventcrawling.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
