### PR TITLE
fixes new players not always being able to use their keybinds

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -15,6 +15,7 @@
 	if(initialized)
 		stack_trace("Warning: [src]([type]) initialized multiple times!")
 	initialized = TRUE
+	input_focus = src
 	GLOB.mob_list += src
 	return INITIALIZE_HINT_NORMAL
 

--- a/code/modules/mob/new_player/new_player_login.dm
+++ b/code/modules/mob/new_player/new_player_login.dm
@@ -30,6 +30,7 @@
 		client.verbs += /client/proc/readmin
 
 	client?.playtitlemusic()
+	client?.update_active_keybindings()
 
 	//Overflow rerouting, if set, forces players to be moved to a different server once a player cap is reached. Less rough than a pure kick.
 	if(GLOB.configuration.overflow.reroute_cap && GLOB.configuration.overflow.overflow_server_location)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
fixes new players not always being able to use their keybinds

## Why It's Good For The Game
I wanna look at the debug menu without needing to hit the funny rebind button first

## Testing
yippie 80k gc queue

## Changelog
:cl:
fix: New players should now always be able to use their keybinds
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
