### PR TITLE
Updates the title, and inspect message of portable pumps, and scrubbers.

### DIFF
--- a/code/modules/atmospherics/machinery/portable/portable_pump.dm
+++ b/code/modules/atmospherics/machinery/portable/portable_pump.dm
@@ -7,7 +7,7 @@
 #define DIRECTION_OUT 1
 
 /obj/machinery/atmospherics/portable/pump
-	name = "Portable Air Pump"
+	name = "portable air pump"
 	icon = 'icons/obj/atmos.dmi'
 	icon_state = "psiphon:0"
 	density = TRUE
@@ -21,8 +21,9 @@
 /obj/machinery/atmospherics/portable/pump/examine(mob/user)
 	. = ..()
 	. += "<span class='notice'>Invaluable for filling air in a room rapidly after a breach repair. The internal gas container can be filled by \
-			connecting it to a connector port. The pump can pump the air in (sucking) or out (blowing), at a specific target pressure. The powercell inside can be \
-			replaced by using a screwdriver, and then adding a new cell. A tank of gas can also be attached to the air pump.</span>"
+			connecting it to a connector port, you're unable to have [src] both connected, and on at the same time. \
+			[src] can pump the air in (sucking) or out (blowing), at a specific target pressure. \
+			A tank of gas can also be attached to the air pump, alowing you to fill or empty the tank, via the internal one.</span>"
 
 /obj/machinery/atmospherics/portable/pump/update_icon_state()
 	icon_state = "psiphon:[on]"

--- a/code/modules/atmospherics/machinery/portable/portable_pump.dm
+++ b/code/modules/atmospherics/machinery/portable/portable_pump.dm
@@ -21,9 +21,9 @@
 /obj/machinery/atmospherics/portable/pump/examine(mob/user)
 	. = ..()
 	. += "<span class='notice'>Invaluable for filling air in a room rapidly after a breach repair. The internal gas container can be filled by \
-			connecting it to a connector port, you're unable to have [src] both connected, and on at the same time. \
+			connecting it to a connector port, you're unable to have it both connected, and on at the same time. \
 			[src] can pump the air in (sucking) or out (blowing), at a specific target pressure. \
-			A tank of gas can also be attached to the air pump, alowing you to fill or empty the tank, via the internal one.</span>"
+			A tank of gas can also be attached to the air pump, allowing you to fill or empty the tank, via the internal one.</span>"
 
 /obj/machinery/atmospherics/portable/pump/update_icon_state()
 	icon_state = "psiphon:[on]"

--- a/code/modules/atmospherics/machinery/portable/scrubber.dm
+++ b/code/modules/atmospherics/machinery/portable/scrubber.dm
@@ -18,7 +18,7 @@
 	. += "<span class='notice'>Filters the air, placing harmful gases into the internal gas container. The container can be emptied by \
 			connecting it to a connector port, you're unable to have [src] both connected, and on at the same time. \
 			Changing the target pressure will result in faster or slower filter speeds, higher pressure is faster. \
-			A tank of gas can also be attached to [src], allowing you to remove harmful gases from the attached tank.</span>"
+			A tank of gas can also be attached, allowing you to remove harmful gases from the attached tank.</span>"
 
 /obj/machinery/atmospherics/portable/scrubber/emp_act(severity)
 	if(stat & (BROKEN|NOPOWER))

--- a/code/modules/atmospherics/machinery/portable/scrubber.dm
+++ b/code/modules/atmospherics/machinery/portable/scrubber.dm
@@ -2,7 +2,7 @@
 #define MAX_RATE 10 * ONE_ATMOSPHERE
 
 /obj/machinery/atmospherics/portable/scrubber
-	name = "Portable Air Scrubber"
+	name = "portable air scrubber"
 	icon = 'icons/obj/atmos.dmi'
 	icon_state = "pscrubber:0"
 	density = TRUE
@@ -16,8 +16,9 @@
 /obj/machinery/atmospherics/portable/scrubber/examine(mob/user)
 	. = ..()
 	. += "<span class='notice'>Filters the air, placing harmful gases into the internal gas container. The container can be emptied by \
-			connecting it to a connector port. The pump can pump the air in (sucking) or out (blowing), at a specific target pressure. The powercell inside can be \
-			replaced by using a screwdriver, and then adding a new cell. A tank of gas can also be attached to the scrubber.</span>"
+			connecting it to a connector port, you're unable to have [src] both connected, and on at the same time. \
+			Changing the target pressure will result in faster or slower filter speeds, higher pressure is faster. \
+			A tank of gas can also be attached to [src], allowing you to remove harmful gases from the attached tank.</span>"
 
 /obj/machinery/atmospherics/portable/scrubber/emp_act(severity)
 	if(stat & (BROKEN|NOPOWER))


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Updates the title, and inspect description of portable pumps, and scrubbers, to be better, and actually reflect what they do better.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
The current inspect description is flat out copy pasted, and mostly incorrect/out dated in the scrubbers case. this fixes it.

## Images of changes
![image](https://github.com/ParadiseSS13/Paradise/assets/96908085/6ee0eb3c-2139-4693-83da-d4fa303cc3d1)


![image](https://github.com/ParadiseSS13/Paradise/assets/96908085/2356c9b5-4903-4668-875b-cf3c06944489)


## Testing
<!-- How did you test the PR, if at all? -->
see above.
## Changelog
:cl:
tweak: Changed the inspect message of both portable scrubbers, and pumps, to be more reflective of what they actually do.
tweak: Changed how the title of the portable scrubber, and pump is capitalized.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
