### PR TITLE
Fixes the motorcycle overlay

### DIFF
--- a/code/modules/vehicle/motorcycle.dm
+++ b/code/modules/vehicle/motorcycle.dm
@@ -10,7 +10,7 @@
 
 /obj/vehicle/motorcycle/Initialize(mapload)
 	. = ..()
-	bikecover = mutable_appearance(icon, "motorcycle_overlay_4d", ABOVE_MOB_LAYER)
+	bikecover = mutable_appearance(icon, "motorcycle_4dir_overlay", ABOVE_MOB_LAYER)
 
 /obj/vehicle/motorcycle/post_buckle_mob(mob/living/M)
 	add_overlay(bikecover)
@@ -23,7 +23,4 @@
 
 
 /obj/vehicle/motorcycle/handle_vehicle_layer()
-	if(dir == SOUTH)
-		layer = ABOVE_MOB_LAYER
-	else
-		layer = OBJ_LAYER
+	return


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Fixes the motorcycle overlay not being applied properly.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Broken overlay is bad.
## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
**BROKEN**
![image](https://github.com/ParadiseSS13/Paradise/assets/77684085/0078ba8a-1d12-40bd-b8d5-8be22a3fa425)


**FIXED**
![good_overlay](https://github.com/ParadiseSS13/Paradise/assets/77684085/9a3df307-cdcd-42ed-86aa-5266b72651bd)

## Testing
<!-- How did you test the PR, if at all? -->
- Did ride the motorcycle until i ran out of gas
## Changelog
:cl:
fix: Motorcycle sprite overlays have been fixed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
