### PR TITLE
Removes Silicon Bolt/Shock timer

### DIFF
--- a/code/_onclick/ai_onclick.dm
+++ b/code/_onclick/ai_onclick.dm
@@ -206,8 +206,7 @@
 /obj/machinery/door/airlock/AICtrlClick(mob/living/silicon/user) // Bolts doors
 	if(!ai_control_check(user))
 		return
-	if(user.can_instant_lockdown() || do_after_once(user, 3 SECONDS, needhand = FALSE, target = src, allow_moving = TRUE, attempt_cancel_message = "Bolting [src] cancelled.", special_identifier = "Bolt"))
-		toggle_bolt(user)
+	toggle_bolt(user)
 
 
 /obj/machinery/door/airlock/AIAltClick(mob/living/silicon/user) // Electrifies doors.
@@ -218,9 +217,8 @@
 	if(isElectrified())
 		electrify(0, user, TRUE) // un-shock
 	else
-		if(user.can_instant_lockdown() || do_after_once(user, 3 SECONDS, target = src, allow_moving = TRUE, attempt_cancel_message = "Shocking [src] cancelled.", special_identifier = "Shock"))
-			electrify(-1, user, TRUE) // permanent shock + audio cue
-			playsound(loc, "sparks", 100, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
+		electrify(-1, user, TRUE) // permanent shock + audio cue
+		playsound(loc, "sparks", 100, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
 
 
 /obj/machinery/door/airlock/AIMiddleClick(mob/living/user) // Toggles door bolt lights.

--- a/code/modules/mob/living/silicon/robot/robot_mob.dm
+++ b/code/modules/mob/living/silicon/robot/robot_mob.dm
@@ -1606,7 +1606,4 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 	else
 		to_chat(src, "<span class='warning'>You can only use this emote when you're out of charge.</span>")
 
-/mob/living/silicon/robot/can_instant_lockdown()
-	if(emagged || ("syndicate" in faction))
-		return TRUE
-	return FALSE
+

--- a/code/modules/mob/living/silicon/silicon_mob.dm
+++ b/code/modules/mob/living/silicon/silicon_mob.dm
@@ -78,11 +78,6 @@
 	QDEL_NULL(aiCamera)
 	return ..()
 
-/mob/living/silicon/proc/can_instant_lockdown()
-	if(isAntag(src))
-		return TRUE
-	return FALSE
-
 /mob/living/silicon/proc/get_radio()
 	return
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Removes the bolt and shock timers introduced in #21491 (but retains the electrification sound when doors are shocked).
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
#21491 is a mechanical alteration that is tries to fix a player mindset issue. Overly aggressive silicons are still capable of trapping people inside rooms by bolting them whilst they are distracted, or depowering rooms to give them time to bolt additional doors.

This would be better addressed by an OOC rule, as the change punishes all silicons for the actions of a few. It has also resulted in instances of players dying due to being trapped in a room with a fatal hazard capable of incapacitating them in the span of the bolt timer (such as plasma fires or, ironically, an antagonist). It also defeats the entire point of having hotkeys, being a QOL downgrade.


<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Loaded into game as cyborg. Bolted and shocked some doors. Both functions worked as intended.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
del: Removes the timer for bolting and shocking doors.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
