### PR TITLE
fixes pdas not being able to have their ids removed/added while on the ground

### DIFF
--- a/code/modules/pda/PDA.dm
+++ b/code/modules/pda/PDA.dm
@@ -165,7 +165,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 		to_chat(usr, "<span class='notice'>You cannot do this while restrained.</span>")
 
 /obj/item/pda/AltClick(mob/user)
-	if(!HAS_TRAIT(user, TRAIT_HANDS_BLOCKED) && ((src in user)|| (isturf(loc) && in_range(src, user))))
+	if(!HAS_TRAIT(user, TRAIT_HANDS_BLOCKED) && ((src in user) || (isturf(loc) && in_range(src, user))))
 		return
 
 	if(issilicon(user))

--- a/code/modules/pda/PDA.dm
+++ b/code/modules/pda/PDA.dm
@@ -165,15 +165,16 @@ GLOBAL_LIST_EMPTY(PDAs)
 		to_chat(usr, "<span class='notice'>You cannot do this while restrained.</span>")
 
 /obj/item/pda/AltClick(mob/user)
-	..()
+	if(!HAS_TRAIT(user, TRAIT_HANDS_BLOCKED) && ((src in user)|| (isturf(loc) && in_range(src, user))))
+		return
+
 	if(issilicon(user))
 		return
 
-	if(can_use(user))
-		if(id)
-			remove_id(user)
-		else
-			to_chat(user, "<span class='warning'>This PDA does not have an ID in it!</span>")
+	if(id)
+		remove_id(user)
+	else
+		to_chat(user, "<span class='warning'>This PDA does not have an ID in it!</span>")
 
 /obj/item/pda/CtrlClick(mob/user)
 	..()
@@ -298,12 +299,11 @@ GLOBAL_LIST_EMPTY(PDAs)
 				playsound(src, 'sound/machines/terminal_success.ogg', 50, TRUE)
 		else
 			//Basic safety check. If either both objects are held by user or PDA is on ground and card is in hand.
-			if(((src in user.contents) && (C in user.contents)) || (isturf(loc) && in_range(src, user) && (C in user.contents)) )
-				if( can_use(user) )//If they can still act.
-					id_check(user, 2)
-					to_chat(user, "<span class='notice'>You put the ID into \the [src]'s slot.<br>You can remove it with ALT click.</span>")
-					update_icon(UPDATE_OVERLAYS)
-					SStgui.update_uis(src)
+			if(!HAS_TRAIT(user, TRAIT_HANDS_BLOCKED) && ((src in user)|| (isturf(loc) && in_range(src, user))))
+				id_check(user, 2)
+				to_chat(user, "<span class='notice'>You put the ID into \the [src]'s slot.<br>You can remove it with ALT click.</span>")
+				update_icon(UPDATE_OVERLAYS)
+				SStgui.update_uis(src)
 
 	else if(istype(C, /obj/item/paicard) && !src.pai)
 		user.drop_item()

--- a/code/modules/pda/PDA.dm
+++ b/code/modules/pda/PDA.dm
@@ -299,7 +299,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 				playsound(src, 'sound/machines/terminal_success.ogg', 50, TRUE)
 		else
 			//Basic safety check. If either both objects are held by user or PDA is on ground and card is in hand.
-			if(!HAS_TRAIT(user, TRAIT_HANDS_BLOCKED) && ((src in user)|| (isturf(loc) && in_range(src, user))))
+			if(!HAS_TRAIT(user, TRAIT_HANDS_BLOCKED) && ((src in user) || (isturf(loc) && in_range(src, user))))
 				id_check(user, 2)
 				to_chat(user, "<span class='notice'>You put the ID into \the [src]'s slot.<br>You can remove it with ALT click.</span>")
 				update_icon(UPDATE_OVERLAYS)

--- a/code/modules/pda/PDA.dm
+++ b/code/modules/pda/PDA.dm
@@ -165,7 +165,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 		to_chat(usr, "<span class='notice'>You cannot do this while restrained.</span>")
 
 /obj/item/pda/AltClick(mob/user)
-	if(!HAS_TRAIT(user, TRAIT_HANDS_BLOCKED) && ((src in user) || (isturf(loc) && in_range(src, user))))
+	if(!HAS_TRAIT(user, TRAIT_HANDS_BLOCKED) && ((src in user) || (isturf(loc) && Adjacent(src, user))))
 		return
 
 	if(issilicon(user))

--- a/code/modules/pda/PDA.dm
+++ b/code/modules/pda/PDA.dm
@@ -165,7 +165,10 @@ GLOBAL_LIST_EMPTY(PDAs)
 		to_chat(usr, "<span class='notice'>You cannot do this while restrained.</span>")
 
 /obj/item/pda/AltClick(mob/user)
-	if(!HAS_TRAIT(user, TRAIT_HANDS_BLOCKED) && ((src in user) || (isturf(loc) && Adjacent(src, user))))
+	if(HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
+		return
+
+	if(!Adjacent(user) && !(loc == user))
 		return
 
 	if(issilicon(user))


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
fixes pdas not being able to have their ids removed/added while on the ground, you can now insert/remove the ID inside of them while they're on the ground
fixes #22641 

## Why It's Good For The Game
less annoying to drag around a bunch of PDAs and IDs, also a bug

## Testing
I did it

## Changelog
:cl:
fix: PDAs can once again have their IDs removed/added while on the ground
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
