### PR TITLE
Adds logging for chem bio-chip implant

### DIFF
--- a/code/game/objects/items/weapons/implants/implant_chem.dm
+++ b/code/game/objects/items/weapons/implants/implant_chem.dm
@@ -25,11 +25,18 @@
 		return FALSE
 	var/mob/living/carbon/R = imp_in
 	var/injectamount
+
+	var/list/implant_chems = list()
+	for(var/datum/reagent/chems in reagents.reagent_list)
+		implant_chems += chems.name
+	var/contained_chemicals = english_list(implant_chems)
+
 	if(cause == "action_button")
 		injectamount = reagents.total_volume
 	else
 		injectamount = cause
 	reagents.trans_to(R, injectamount)
+	add_attack_logs(usr, R, "Chem bio-chip activated injecting [injectamount]u of [contained_chemicals]")
 	to_chat(R, "<span class='italics'>You hear a faint beep.</span>")
 	if(!reagents.total_volume)
 		to_chat(R, "<span class='italics'>You hear a faint click from your chest.</span>")


### PR DESCRIPTION
## What Does This PR Do
This adds logging for the activation of the chem bio-chip implant. It will now show target, reagent type, and amount injected within the log. 
## Why It's Good For The Game
This allows admins to identify when a chem bio-chip implant was activated, who activated it and what it contained, making it easier to track misuse of the implant when dealing with potential rules violations. 
## Images of changes
![AlPQ2bGxA4](https://github.com/ParadiseSS13/Paradise/assets/116982774/2ed38bfe-06a4-41f0-a514-6938303699eb)
## Testing
Implanted chem bio-chip into a Skrell.
Observed log results.
## Changelog
NPFC