### PR TITLE
fix runtimes setting empty crayon message

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -94,8 +94,9 @@
 			var/new_preset = input(usr, "Set the message. Max length [CRAYON_MESSAGE_MAX_LENGTH] characters.")
 			new_preset = copytext(new_preset, 1, CRAYON_MESSAGE_MAX_LENGTH)
 			preset_message = lowertext(graffiti_chars.Replace(new_preset, ""))
-			log_admin("[key_name(usr)] has set the message of [src] to \"[preset_message]\".")
-			preset_message_index = 1
+			if(preset_message != "")
+				log_admin("[key_name(usr)] has set the message of [src] to \"[preset_message]\".")
+				preset_message_index = 1
 		else
 			temp = href_list["type"]
 	if((usr.restrained() || usr.stat || !usr.is_in_active_hand(src)))


### PR DESCRIPTION
## What Does This PR Do
This PR fixes two runtimes that might occur when 1) setting a crayon message to the empty string and 2) using a crayon with an  empty string as a message. In these cases the crayon will just be reset to print "A".

If there's a better helper for checking the empty string here let me know but since the regex takes out everything that isn't one of the printable characters, and spaces aren't printable, the string shouldn't have to be trimmed of whitespace.

## Why It's Good For The Game
These runtimes are bad. Luckily they don't break the UI.

## Testing
Spawned in, set crayon messages, checked runtime logs.

## Changelog
:cl:
fix: Crayons will no longer runtime when set to an empty message.
/:cl:
