### PR TITLE
Buffs the chem heater

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_heater.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_heater.dm
@@ -26,7 +26,7 @@
 /obj/machinery/chem_heater/RefreshParts()
 	speed_increase = initial(speed_increase)
 	for(var/obj/item/stock_parts/micro_laser/M in component_parts)
-		speed_increase += 5 * (M.rating - 1)
+		speed_increase += 10 * (M.rating - 1) + 20
 
 /obj/machinery/chem_heater/process()
 	..()
@@ -37,7 +37,7 @@
 			if(!beaker.reagents.total_volume)
 				on = FALSE
 				return
-			beaker.reagents.temperature_reagents(desired_temp, max(1, 35 - speed_increase))
+			beaker.reagents.change_reagent_temp(speed_increase, desired_temp)
 			if(round(beaker.reagents.chem_temp) == round(desired_temp))
 				playsound(loc, 'sound/machines/ding.ogg', 50, 1)
 				on = FALSE

--- a/code/modules/reagents/chemistry/machinery/chem_heater.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_heater.dm
@@ -37,7 +37,7 @@
 			if(!beaker.reagents.total_volume)
 				on = FALSE
 				return
-			beaker.reagents.change_reagent_temp(speed_increase, desired_temp)
+			beaker.reagents.adjust_reagent_temp(speed_increase, desired_temp)
 			if(round(beaker.reagents.chem_temp) == round(desired_temp))
 				playsound(loc, 'sound/machines/ding.ogg', 50, 1)
 				on = FALSE

--- a/code/modules/reagents/chemistry/machinery/chem_heater.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_heater.dm
@@ -37,7 +37,8 @@
 			if(!beaker.reagents.total_volume)
 				on = FALSE
 				return
-			beaker.reagents.adjust_reagent_temp(speed_increase, desired_temp)
+			var/sign = SIGN(desired_temp - beaker.reagents.chem_temp)
+			beaker.reagents.adjust_reagent_temp(speed_increase * sign, desired_temp)
 			if(round(beaker.reagents.chem_temp) == round(desired_temp))
 				playsound(loc, 'sound/machines/ding.ogg', 50, 1)
 				on = FALSE

--- a/code/modules/reagents/chemistry/machinery/chem_heater.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_heater.dm
@@ -13,7 +13,7 @@
 	/// Whether this should auto-eject the beaker once done heating/cooling.
 	var/auto_eject = FALSE
 	/// The higher this number, the faster reagents will heat/cool.
-	var/speed_increase = 0
+	var/speed_increase = 40
 
 /obj/machinery/chem_heater/Initialize(mapload)
 	. = ..()
@@ -26,7 +26,7 @@
 /obj/machinery/chem_heater/RefreshParts()
 	speed_increase = initial(speed_increase)
 	for(var/obj/item/stock_parts/micro_laser/M in component_parts)
-		speed_increase += 10 * (M.rating - 1) + 20
+		speed_increase += 20 * (M.rating - 1)
 
 /obj/machinery/chem_heater/process()
 	..()

--- a/code/modules/reagents/chemistry/reagents_holder.dm
+++ b/code/modules/reagents/chemistry/reagents_holder.dm
@@ -251,7 +251,7 @@
 /datum/reagents/proc/adjust_reagent_temp(amount, temperature_bound)
 	if(chem_temp == temperature_bound || !amount) // We don't need to do the mathy math
 		return
-	if(temperature_bound != null) // If we have a target temp, we only go until that temperature
+	if(!isnull(temperature_bound)) // If we have a target temp, we only go until that temperature
 		chem_temp = directional_bounded_sum(chem_temp, amount, temperature_bound, temperature_bound)
 	else
 		chem_temp += amount

--- a/code/modules/reagents/chemistry/reagents_holder.dm
+++ b/code/modules/reagents/chemistry/reagents_holder.dm
@@ -259,6 +259,8 @@
 		chem_temp += difference
 	else if(target_temp < chem_temp)
 		chem_temp -= difference
+	temperature_react()
+	handle_reactions()
 
 /**
  * Same as [/datum/reagents/proc/trans_to] but only for a specific reagent in

--- a/code/modules/reagents/chemistry/reagents_holder.dm
+++ b/code/modules/reagents/chemistry/reagents_holder.dm
@@ -259,6 +259,7 @@
 		chem_temp += difference
 	else if(target_temp < chem_temp)
 		chem_temp -= difference
+	clamp(chem_temp, temperature_min, temperature_max)
 	temperature_react()
 	handle_reactions()
 

--- a/code/modules/reagents/chemistry/reagents_holder.dm
+++ b/code/modules/reagents/chemistry/reagents_holder.dm
@@ -259,7 +259,7 @@
 		chem_temp += difference
 	else if(target_temp < chem_temp)
 		chem_temp -= difference
-	clamp(chem_temp, temperature_min, temperature_max)
+	chem_temp = clamp(chem_temp, temperature_min, temperature_max)
 	temperature_react()
 	handle_reactions()
 

--- a/code/modules/reagents/chemistry/reagents_holder.dm
+++ b/code/modules/reagents/chemistry/reagents_holder.dm
@@ -248,6 +248,16 @@
 
 	handle_reactions()
 
+/datum/reagents/proc/change_reagent_temp(temp_increase, target_temp)
+	var/difference
+	if(abs(target_temp - chem_temp) > temp_increase)
+		difference = temp_increase
+	else
+		difference = target_temp - chem_temp
+	if(target_temp > chem_temp)
+		chem_temp += difference
+	else if(target_temp < chem_temp)
+		chem_temp -= difference
 /**
  * Same as [/datum/reagents/proc/trans_to] but only for a specific reagent in
  * the reagent list. If the specified amount is greater than what is available,

--- a/code/modules/reagents/chemistry/reagents_holder.dm
+++ b/code/modules/reagents/chemistry/reagents_holder.dm
@@ -248,6 +248,7 @@
 
 	handle_reactions()
 
+// This proc increases the temp of reagents by `temp_increase` amount, up until the target temperature, and no more
 /datum/reagents/proc/change_reagent_temp(temp_increase, target_temp)
 	var/difference
 	if(abs(target_temp - chem_temp) > temp_increase)
@@ -258,6 +259,7 @@
 		chem_temp += difference
 	else if(target_temp < chem_temp)
 		chem_temp -= difference
+
 /**
  * Same as [/datum/reagents/proc/trans_to] but only for a specific reagent in
  * the reagent list. If the specified amount is greater than what is available,

--- a/code/modules/reagents/chemistry/reagents_holder.dm
+++ b/code/modules/reagents/chemistry/reagents_holder.dm
@@ -248,16 +248,11 @@
 
 	handle_reactions()
 
-// This proc increases the temp of reagents by `temp_increase` amount, up until the target temperature, and no more
-/datum/reagents/proc/change_reagent_temp(temp_increase, target_temp)
-	if(chem_temp == target_temp || !temp_increase) // We don't need to do the mathy math
+/datum/reagents/proc/adjust_reagent_temp(amount, temperature_bound)
+	if(chem_temp == temperature_bound || !amount) // We don't need to do the mathy math
 		return
-	if(target_temp) // If we have a target temp, we only go until that temperature
-		var/difference = target_temp - chem_temp
-		var/temperature_change = clamp(difference, -temp_increase, temp_increase)
-		chem_temp += temperature_change
-	else
-		chem_temp += temp_increase
+	if(temperature_bound != null) // If we have a target temp, we only go until that temperature
+		chem_temp = directional_bounded_sum(chem_temp, amount, -temperature_bound, temperature_bound)
 	chem_temp = clamp(chem_temp, temperature_min, temperature_max)
 	temperature_react()
 	handle_reactions()

--- a/code/modules/reagents/chemistry/reagents_holder.dm
+++ b/code/modules/reagents/chemistry/reagents_holder.dm
@@ -250,15 +250,11 @@
 
 // This proc increases the temp of reagents by `temp_increase` amount, up until the target temperature, and no more
 /datum/reagents/proc/change_reagent_temp(temp_increase, target_temp)
-	var/difference
-	if(abs(target_temp - chem_temp) > temp_increase)
-		difference = temp_increase
-	else
-		difference = target_temp - chem_temp
-	if(target_temp > chem_temp)
-		chem_temp += difference
-	else if(target_temp < chem_temp)
-		chem_temp -= difference
+	if(chem_temp == target_temp)
+		return
+	var/difference = target_temp - chem_temp
+	var/temperature_change = clamp(difference, -temp_increase, temp_increase)
+	chem_temp += temperature_change
 	chem_temp = clamp(chem_temp, temperature_min, temperature_max)
 	temperature_react()
 	handle_reactions()

--- a/code/modules/reagents/chemistry/reagents_holder.dm
+++ b/code/modules/reagents/chemistry/reagents_holder.dm
@@ -253,6 +253,8 @@
 		return
 	if(temperature_bound != null) // If we have a target temp, we only go until that temperature
 		chem_temp = directional_bounded_sum(chem_temp, amount, -temperature_bound, temperature_bound)
+	else
+		chem_temp += amount
 	chem_temp = clamp(chem_temp, temperature_min, temperature_max)
 	temperature_react()
 	handle_reactions()

--- a/code/modules/reagents/chemistry/reagents_holder.dm
+++ b/code/modules/reagents/chemistry/reagents_holder.dm
@@ -252,7 +252,7 @@
 	if(chem_temp == temperature_bound || !amount) // We don't need to do the mathy math
 		return
 	if(temperature_bound != null) // If we have a target temp, we only go until that temperature
-		chem_temp = directional_bounded_sum(chem_temp, amount, -temperature_bound, temperature_bound)
+		chem_temp = directional_bounded_sum(chem_temp, amount, temperature_bound, temperature_bound)
 	else
 		chem_temp += amount
 	chem_temp = clamp(chem_temp, temperature_min, temperature_max)

--- a/code/modules/reagents/chemistry/reagents_holder.dm
+++ b/code/modules/reagents/chemistry/reagents_holder.dm
@@ -250,11 +250,14 @@
 
 // This proc increases the temp of reagents by `temp_increase` amount, up until the target temperature, and no more
 /datum/reagents/proc/change_reagent_temp(temp_increase, target_temp)
-	if(chem_temp == target_temp)
+	if(chem_temp == target_temp || !temp_increase) // We don't need to do the mathy math
 		return
-	var/difference = target_temp - chem_temp
-	var/temperature_change = clamp(difference, -temp_increase, temp_increase)
-	chem_temp += temperature_change
+	if(target_temp) // If we have a target temp, we only go until that temperature
+		var/difference = target_temp - chem_temp
+		var/temperature_change = clamp(difference, -temp_increase, temp_increase)
+		chem_temp += temperature_change
+	else
+		chem_temp += temp_increase
 	chem_temp = clamp(chem_temp, temperature_min, temperature_max)
 	temperature_react()
 	handle_reactions()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Following up on my previous PR to nerf heating reagent holders with lighters and such, this is buffing the chemical heater to be a lot better than it was.

Before, the chem heater would heat for a portion of the difference in chemical temperature, and the target temperature (with a cap), which would mean that you'd just set the heater to `1000`, which was the best way to make it fast.

With these changes, the chemical heater will now heat the chemicals a certain amount, regardless of the current temperature difference. It will heat in increments of 40 degrees, with every upgrade tier adding 20 degrees on this.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
While heating beakers and such with lighters was not very good for the state of chemistry, it did point out one thing: Chemical heaters suck. People don't like using them as they are just plainly said, slow. This PR should help them on their way.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
I was heating some meth in a beaker, it didn't take too long and was done in under half a minute
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: The chemical heater now works faster
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
