### PR TITLE
[s] Martial arts granted by equipped items no longer persist through cloning.

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -140,10 +140,11 @@
 	transfer_antag_huds(hud_to_transfer)				//inherit the antag HUD
 	transfer_actions(new_character)
 	if(martial_art)
-		if(martial_art.temporary)
-			martial_art.remove(current)
-		else
-			martial_art.teach(current)
+		for(var/datum/martial_art/MA in known_martial_arts)
+			if(MA.temporary)
+				MA.remove(current)
+			else
+				MA.teach(current)
 	if(active)
 		new_character.key = key		//now transfer the key to link the client to our new body
 	SEND_SIGNAL(src, COMSIG_MIND_TRANSER_TO, new_character)

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -144,6 +144,7 @@
 			if(MA.temporary)
 				MA.remove(current)
 			else
+				MA.remove(current)
 				MA.teach(current)
 	if(active)
 		new_character.key = key		//now transfer the key to link the client to our new body

--- a/code/game/objects/items/weapons/highlander_swords.dm
+++ b/code/game/objects/items/weapons/highlander_swords.dm
@@ -37,7 +37,7 @@
 		var/obj/item/claymore/highlander/sword = H.is_in_hands(/obj/item/claymore/highlander)
 		if(sword)
 			//if we have a highlander sword in the other hand, relearn the style from that sword.
-			sword.style.teach(H, 1)
+			sword.style.teach(H, TRUE)
 
 /obj/item/claymore/highlander/dropped(mob/user)
 	..()
@@ -49,4 +49,4 @@
 	var/obj/item/claymore/highlander/sword = H.is_in_hands(/obj/item/claymore/highlander)
 	if(sword)
 		//if we have a highlander sword in the other hand, relearn the style from that sword.
-		sword.style.teach(H, 1)
+		sword.style.teach(H, TRUE)

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -155,7 +155,7 @@
 	slowdown_active = SHOES_SLOWDOWN
 	magboot_state = "gravboots"
 	magpulse_name = "micro gravitational traction system"
-	var/datum/martial_art/grav_stomp/style = new //Only works with core and cell installed.
+	var/datum/martial_art/grav_stomp/style //Only works with core and cell installed.
 	var/jumpdistance = 5
 	var/jumpspeed = 3
 	var/recharging_rate = 6 SECONDS
@@ -164,6 +164,10 @@
 	var/power_consumption_rate = 30 // How much power is used by the boots each cycle when magboots are active
 	var/obj/item/assembly/signaler/anomaly/grav/core = null
 	var/obj/item/stock_parts/cell/cell = null
+
+/obj/item/clothing/shoes/magboots/gravity/Initialize()
+	. = ..()
+	style = new()
 
 /obj/item/clothing/shoes/magboots/gravity/Destroy()
 	QDEL_NULL(style)

--- a/code/modules/martial_arts/judo.dm
+++ b/code/modules/martial_arts/judo.dm
@@ -32,7 +32,7 @@
 		if(HAS_TRAIT(user, TRAIT_PACIFISM))
 			to_chat(H, "<span class='warning'>The arts of Corporate Judo echo uselessly in your head, the thought of violence disgusts you!</span>")
 			return
-		style.teach(H, 1)
+		style.teach(H, TRUE)
 		to_chat(H, "<span class='userdanger'>The belt's nanites infuse you with the prowess of a black belt in Corporate Judo!</span>")
 		to_chat(H, "<span class='danger'>See the martial arts tab for an explanation of combos.</span>")
 		return

--- a/code/modules/martial_arts/krav_maga.dm
+++ b/code/modules/martial_arts/krav_maga.dm
@@ -137,16 +137,20 @@
 //Krav Maga Gloves
 
 /obj/item/clothing/gloves/color/black/krav_maga
-	var/datum/martial_art/krav_maga/style = new
+	var/datum/martial_art/krav_maga/style
 	can_be_cut = FALSE
 	resistance_flags = NONE
+
+/obj/item/clothing/gloves/color/black/krav_maga/Initialize()
+	. = ..()
+	style = new()
 
 /obj/item/clothing/gloves/color/black/krav_maga/equipped(mob/user, slot)
 	if(!ishuman(user))
 		return
 	if(slot == slot_gloves)
 		var/mob/living/carbon/human/H = user
-		style.teach(H,1)
+		style.teach(H, TRUE)
 
 /obj/item/clothing/gloves/color/black/krav_maga/dropped(mob/user)
 	..()
@@ -157,7 +161,7 @@
 		style.remove(H)
 
 /obj/item/clothing/gloves/color/black/krav_maga/sec//more obviously named, given to sec
-	name = "krav maga gloves"
+	name = "Krav Maga gloves"
 	desc = "These gloves can teach you to perform Krav Maga using nanochips."
 	icon_state = "fightgloves"
 	item_state = "fightgloves"
@@ -167,7 +171,7 @@
 	RegisterSignal(src, COMSIG_PARENT_QDELETING, PROC_REF(alert_admins_on_destroy))
 
 /obj/item/clothing/gloves/color/black/krav_maga/combat // for nukies
-	name = "combat gloves plus"
+	name = "Combat gloves plus"
 	desc = "These combat gloves have been upgraded with nanochips that teach the wearer Krav Maga."
 	icon_state = "combat"
 	item_state = "swat_gl"

--- a/code/modules/martial_arts/martial.dm
+++ b/code/modules/martial_arts/martial.dm
@@ -262,7 +262,6 @@
 /obj/item/clothing/gloves/boxing/Initialize()
 	. = ..()
 	style = new()
-	style.temporary = TRUE
 
 /obj/item/clothing/gloves/boxing/equipped(mob/user, slot)
 	if(!ishuman(user))
@@ -287,7 +286,6 @@
 /obj/item/storage/belt/champion/wrestling/Initialize()
 	. = ..()
 	style = new()
-	style.temporary = TRUE
 
 /obj/item/storage/belt/champion/wrestling/equipped(mob/user, slot)
 	if(!ishuman(user))
@@ -297,7 +295,6 @@
 		if(HAS_TRAIT(user, TRAIT_PACIFISM))
 			to_chat(user, "<span class='warning'>In spite of the grandiosity of the belt, you don't feel like getting into any fights.</span>")
 			return
-		style.temporary = TRUE
 		style.teach(H, TRUE)
 		to_chat(user, "<span class='sciradio'>You have an urge to flex your muscles and get into a fight. You have the knowledge of a thousand wrestlers before you. You can remember more by using the Recall teaching verb in the wrestling tab.</span>")
 	return

--- a/code/modules/martial_arts/martial.dm
+++ b/code/modules/martial_arts/martial.dm
@@ -158,6 +158,7 @@
 			return
 	if(has_explaination_verb)
 		H.verbs |= /mob/living/carbon/human/proc/martial_arts_help
+	temporary = make_temporary
 	owner_UID = H.UID()
 	H.mind.known_martial_arts.Add(src)
 	H.mind.martial_art = get_highest_weight(H)
@@ -256,7 +257,12 @@
 //ITEMS
 
 /obj/item/clothing/gloves/boxing
-	var/datum/martial_art/boxing/style = new
+	var/datum/martial_art/boxing/style
+
+/obj/item/clothing/gloves/boxing/Initialize()
+	. = ..()
+	style = new()
+	style.temporary = TRUE
 
 /obj/item/clothing/gloves/boxing/equipped(mob/user, slot)
 	if(!ishuman(user))
@@ -276,7 +282,12 @@
 
 /obj/item/storage/belt/champion/wrestling
 	name = "Wrestling Belt"
-	var/datum/martial_art/wrestling/style = new
+	var/datum/martial_art/wrestling/style
+
+/obj/item/storage/belt/champion/wrestling/Initialize()
+	. = ..()
+	style = new()
+	style.temporary = TRUE
 
 /obj/item/storage/belt/champion/wrestling/equipped(mob/user, slot)
 	if(!ishuman(user))
@@ -286,6 +297,7 @@
 		if(HAS_TRAIT(user, TRAIT_PACIFISM))
 			to_chat(user, "<span class='warning'>In spite of the grandiosity of the belt, you don't feel like getting into any fights.</span>")
 			return
+		style.temporary = TRUE
 		style.teach(H, TRUE)
 		to_chat(user, "<span class='sciradio'>You have an urge to flex your muscles and get into a fight. You have the knowledge of a thousand wrestlers before you. You can remember more by using the Recall teaching verb in the wrestling tab.</span>")
 	return

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -571,10 +571,13 @@
 	actions_types = list()
 	var/datum/martial_art/muscle_implant/muscle_implant
 
-/obj/item/organ/internal/cyberimp/arm/muscle/insert(mob/living/carbon/M, special, dont_remove_slot)
+/obj/item/organ/internal/cyberimp/arm/muscle/Initialize()
 	. = ..()
 	muscle_implant = new()
-	muscle_implant.teach(M)
+
+/obj/item/organ/internal/cyberimp/arm/muscle/insert(mob/living/carbon/M, special, dont_remove_slot)
+	. = ..()
+	muscle_implant.teach(M, TRUE)
 
 /obj/item/organ/internal/cyberimp/arm/muscle/remove(mob/living/carbon/M, special)
 	. = ..()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Martial arts that are granted by equipped items (Eg. Krav Maga, wrestling belt, judo belt) no longer persist through cloning when someone is cloned wearing them.
Fixes: #22655

Also fixes a bug where the combo counter would disappear after being cloned
Fixes: #22429
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
This is easily exploitable and should be fixed.
Also bug bad
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Equip Krav Maga gloves, wrestling belt and use the CQC manual
Die and get cloned.
Krav Maga and wrestling martial arts are gone from my mind, CQC remains.
Clone myself while I have CQC.
Combo counter still appears when I hit a monkey
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Martial arts granted by equipped items no longer persist through cloning.
fix: Martial arts combo counter no longer disappear after getting cloned.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
