### PR TITLE
Gives janicart a radial menu

### DIFF
--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -37,7 +37,6 @@
 /obj/structure/janitorialcart/proc/put_in_cart(obj/item/I, mob/user)
 	user.drop_item()
 	I.forceMove(src)
-	updateUsrDialog()
 	to_chat(user, "<span class='notice'>You put [I] into [src].</span>")
 	update_icon(UPDATE_OVERLAYS)
 	return
@@ -115,58 +114,65 @@
 		to_chat(usr, "<span class='warning'>You cannot interface your modules [src]!</span>")
 
 /obj/structure/janitorialcart/attack_hand(mob/user)
-	user.set_machine(src)
-	var/dat
-	if(mybag)
-		dat += "<a href='?src=[UID()];garbage=1'>[mybag.name]</a><br>"
-	if(mymop)
-		dat += "<a href='?src=[UID()];mop=1'>[mymop.name]</a><br>"
-	if(mybroom)
-		dat += "<a href='?src=[UID()];broom=1'>[mybroom.name]</a><br>"
-	if(myspray)
-		dat += "<a href='?src=[UID()];spray=1'>[myspray.name]</a><br>"
-	if(myreplacer)
-		dat += "<a href='?src=[UID()];replacer=1'>[myreplacer.name]</a><br>"
-	if(signs)
-		dat += "<a href='?src=[UID()];sign=1'>[signs] sign\s</a><br>"
-	var/datum/browser/popup = new(user, "janicart", name, 240, 160)
-	popup.set_content(dat)
-	popup.open()
+	var/list/cart_items = list()
 
-/obj/structure/janitorialcart/Topic(href, href_list)
-	if(!in_range(src, usr))
+	if(mybag)
+		cart_items += list("Trash Bag" = image(icon = mybag.icon, icon_state = mybag.icon_state))
+	if(mymop)
+		cart_items += list("Mop" = image(icon = mymop.icon, icon_state = mymop.icon_state))
+	if(mybroom)
+		cart_items += list("Broom" = image(icon = mybroom.icon, icon_state = mybroom.icon_state))
+	if(myspray)
+		cart_items += list("Spray Bottle" = image(icon = myspray.icon, icon_state = myspray.icon_state))
+	if(myreplacer)
+		cart_items += list("Light Replacer" = image(icon = myreplacer.icon, icon_state = myreplacer.icon_state))
+	var/obj/item/caution/Sign = locate() in src
+	if(Sign)
+		cart_items += list("Sign" = image(icon = Sign.icon, icon_state = Sign.icon_state))
+
+	if(!length(cart_items))
 		return
-	if(!isliving(usr))
+
+	cart_items = sortList(cart_items)
+	var/pick = show_radial_menu(user, src, cart_items, custom_check = CALLBACK(src, PROC_REF(check_menu), user), radius = 38, require_near = TRUE)
+
+	if(!pick)
 		return
-	var/mob/living/user = usr
-	if(href_list["garbage"])
-		if(mybag)
+
+	switch(pick)
+		if("Trash Bag")
+			if(!mybag)
+				return
 			user.put_in_hands(mybag)
 			to_chat(user, "<span class='notice'>You take [mybag] from [src].</span>")
 			mybag = null
-	if(href_list["mop"])
-		if(mymop)
+		if("Mop")
+			if(!mymop)
+				return
 			user.put_in_hands(mymop)
 			to_chat(user, "<span class='notice'>You take [mymop] from [src].</span>")
 			mymop = null
-	if(href_list["broom"])
-		if(mybroom)
+		if("Broom")
+			if(!mybroom)
+				return
 			user.put_in_hands(mybroom)
 			to_chat(user, "<span class='notice'>You take [mybroom] from [src].</span>")
 			mybroom = null
-	if(href_list["spray"])
-		if(myspray)
+		if("Spray Bottle")
+			if(!myspray)
+				return
 			user.put_in_hands(myspray)
 			to_chat(user, "<span class='notice'>You take [myspray] from [src].</span>")
 			myspray = null
-	if(href_list["replacer"])
-		if(myreplacer)
+		if("Light Replacer")
+			if(!myreplacer)
+				return
 			user.put_in_hands(myreplacer)
 			to_chat(user, "<span class='notice'>You take [myreplacer] from [src].</span>")
 			myreplacer = null
-	if(href_list["sign"])
-		if(signs)
-			var/obj/item/caution/Sign = locate() in src
+		if("Sign")
+			if(!signs)
+				return
 			if(Sign)
 				user.put_in_hands(Sign)
 				to_chat(user, "<span class='notice'>You take \a [Sign] from [src].</span>")
@@ -176,7 +182,19 @@
 				signs = 0
 
 	update_icon(UPDATE_OVERLAYS)
-	updateUsrDialog()
+
+/**
+  * check_menu: Checks if we are allowed to interact with a radial menu
+  *
+  * Arguments:
+  * * user The mob interacting with a menu
+  */
+/obj/structure/janitorialcart/proc/check_menu(mob/living/user)
+	if(!istype(user))
+		return FALSE
+	if(user.incapacitated())
+		return FALSE
+	return TRUE
 
 /obj/structure/janitorialcart/update_overlays()
 	. = ..()

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -117,24 +117,23 @@
 	var/list/cart_items = list()
 
 	if(mybag)
-		cart_items += list("Trash Bag" = image(icon = mybag.icon, icon_state = mybag.icon_state))
+		cart_items["Trash Bag"] = image(icon = mybag.icon, icon_state = mybag.icon_state)
 	if(mymop)
-		cart_items += list("Mop" = image(icon = mymop.icon, icon_state = mymop.icon_state))
+		cart_items["Mop"] = image(icon = mymop.icon, icon_state = mymop.icon_state)
 	if(mybroom)
-		cart_items += list("Broom" = image(icon = mybroom.icon, icon_state = mybroom.icon_state))
+		cart_items["Broom"] = image(icon = mybroom.icon, icon_state = mybroom.icon_state)
 	if(myspray)
-		cart_items += list("Spray Bottle" = image(icon = myspray.icon, icon_state = myspray.icon_state))
+		cart_items["Spray Bottle"] = image(icon = myspray.icon, icon_state = myspray.icon_state)
 	if(myreplacer)
-		cart_items += list("Light Replacer" = image(icon = myreplacer.icon, icon_state = myreplacer.icon_state))
+		cart_items["Light Replacer"] = image(icon = myreplacer.icon, icon_state = myreplacer.icon_state)
 	var/obj/item/caution/Sign = locate() in src
 	if(Sign)
-		cart_items += list("Sign" = image(icon = Sign.icon, icon_state = Sign.icon_state))
+		cart_items["Sign"] = image(icon = Sign.icon, icon_state = Sign.icon_state)
 
 	if(!length(cart_items))
 		return
 
-	cart_items = sortList(cart_items)
-	var/pick = show_radial_menu(user, src, cart_items, custom_check = CALLBACK(src, PROC_REF(check_menu), user), radius = 38, require_near = TRUE)
+	var/pick = show_radial_menu(user, src, cart_items, custom_check = CALLBACK(src, PROC_REF(check_menu), user), require_near = TRUE)
 
 	if(!pick)
 		return
@@ -183,12 +182,6 @@
 
 	update_icon(UPDATE_OVERLAYS)
 
-/**
-  * check_menu: Checks if we are allowed to interact with a radial menu
-  *
-  * Arguments:
-  * * user The mob interacting with a menu
-  */
 /obj/structure/janitorialcart/proc/check_menu(mob/living/user)
 	if(!istype(user))
 		return FALSE

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -183,11 +183,7 @@
 	update_icon(UPDATE_OVERLAYS)
 
 /obj/structure/janitorialcart/proc/check_menu(mob/living/user)
-	if(!istype(user))
-		return FALSE
-	if(user.incapacitated())
-		return FALSE
-	return TRUE
+	return (istype(user) && !HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
 
 /obj/structure/janitorialcart/update_overlays()
 	. = ..()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
title
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Radial menus make it easier to grab something from the janicart without having to open a whole new window.
## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

![image](https://github.com/ParadiseSS13/Paradise/assets/77684085/c0484d1e-081a-4f02-939f-8cb39577530a)

## Testing
<!-- How did you test the PR, if at all? -->
- Inserted and removed all possible items from it
## Changelog
:cl:
tweak: Janicart now uses a radial menu
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
