### PR TITLE
Shelter areas use mining ambience instead of station ones

### DIFF
--- a/code/modules/mining/equipment/survival_pod.dm
+++ b/code/modules/mining/equipment/survival_pod.dm
@@ -4,6 +4,7 @@
 	requires_power = FALSE
 	has_gravity = TRUE
 	dynamic_lighting = DYNAMIC_LIGHTING_FORCED
+	ambientsounds = MINING_SOUNDS
 
 /obj/item/survivalcapsule
 	name = "bluespace shelter capsule"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Sets the ambience for the shelter areas to be mining, as the default one is for the station. That'll make station shelters sound like mining, but that's a tradeoff and most of the time the shelters will be on lavaland anyways.

## Why It's Good For The Game
Fixes #22611

## Images of changes
https://github.com/ParadiseSS13/Paradise/assets/80771500/3e97efc7-e51a-4f69-ae92-5f3e04c16520

## Testing
Deployed a shelter and waited a bit inside to trigger the ambience sounds.

## Changelog
:cl:
fix: Shelters do not use station ambience noises
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
