### PR TITLE
Add serialization support to Modsuit modules

### DIFF
--- a/code/modules/mod/mod_control.dm
+++ b/code/modules/mod/mod_control.dm
@@ -91,6 +91,30 @@
 	/// Is the jetpack on so we should make ion effects?
 	var/jetpack_active = FALSE
 
+/obj/item/mod/control/serialize()
+	var/list/data = ..()
+	var/list/module_list = list()
+	data["modules"] = module_list
+	for(var/atom/movable/M in modules)
+		// Copied from storage serialization. Yes, it has to be done that way. serialize will just duplicate entries otherwise if you try to add to a list normally.
+		module_list.len++
+		module_list[module_list.len] = M.serialize()
+	return data
+
+/obj/item/mod/control/deserialize(list/data)
+	if(length(data["modules"]))
+		for(var/old_mods in modules)
+			uninstall(old_mods, deleting = TRUE)
+	for(var/new_modules in data["modules"])
+		if(islist(new_modules))
+			var/obj/item/mod/module/new_mod = list_to_object(new_modules, src)
+			install(new_mod)
+		else if(new_modules == null)
+			stack_trace("Null entry found in modules/deserialize.")
+		else
+			stack_trace("Non-list thing found in modules (Mod: [new_modules])")
+	..()
+
 /obj/item/mod/control/Initialize(mapload, datum/mod_theme/new_theme, new_skin, obj/item/mod/core/new_core)
 	. = ..()
 	if(new_theme)

--- a/code/modules/mod/mod_control.dm
+++ b/code/modules/mod/mod_control.dm
@@ -105,14 +105,14 @@
 	if(length(data["modules"]))
 		for(var/old_mods in modules)
 			uninstall(old_mods, deleting = TRUE)
-	for(var/new_modules in data["modules"])
-		if(islist(new_modules))
-			var/obj/item/mod/module/new_mod = list_to_object(new_modules, src)
-			install(new_mod)
-		else if(new_modules == null)
-			stack_trace("Null entry found in modules/deserialize.")
-		else
-			stack_trace("Non-list thing found in modules (Mod: [new_modules])")
+		for(var/new_modules in data["modules"])
+			if(islist(new_modules))
+				var/obj/item/mod/module/new_mod = list_to_object(new_modules, src)
+				install(new_mod)
+			else if(new_modules == null)
+				stack_trace("Null entry found in modules/deserialize.")
+			else
+				stack_trace("Non-list thing found in modules (Mod: [new_modules])")
 	..()
 
 /obj/item/mod/control/Initialize(mapload, datum/mod_theme/new_theme, new_skin, obj/item/mod/core/new_core)

--- a/code/modules/mod/mod_control.dm
+++ b/code/modules/mod/mod_control.dm
@@ -93,26 +93,19 @@
 
 /obj/item/mod/control/serialize()
 	var/list/data = ..()
-	var/list/module_list = list()
-	data["modules"] = module_list
-	for(var/atom/movable/M in modules)
-		// Copied from storage serialization. Yes, it has to be done that way. serialize will just duplicate entries otherwise if you try to add to a list normally.
-		module_list.len++
-		module_list[module_list.len] = M.serialize()
+	var/list/modules_list = list()
+	for(var/obj/item/mod/module/mod as anything in modules)
+		modules_list.Add(list(mod.serialize()))
+	data["modules"] = modules_list
 	return data
 
 /obj/item/mod/control/deserialize(list/data)
-	if(length(data["modules"]))
+	if(data["modules"])
 		for(var/old_mods in modules)
 			uninstall(old_mods, deleting = TRUE)
-		for(var/new_modules in data["modules"])
-			if(islist(new_modules))
-				var/obj/item/mod/module/new_mod = list_to_object(new_modules, src)
-				install(new_mod)
-			else if(new_modules == null)
-				stack_trace("Null entry found in modules/deserialize.")
-			else
-				stack_trace("Non-list thing found in modules (Mod: [new_modules])")
+		for(var/obj/item/mod/module/module as anything in data["modules"])
+			module = list_to_object(module, src)
+			install(module)
 	..()
 
 /obj/item/mod/control/Initialize(mapload, datum/mod_theme/new_theme, new_skin, obj/item/mod/core/new_core)

--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -17,25 +17,15 @@
 	var/obj/item/storage/backpack/modstorage/bag
 
 /obj/item/mod/module/storage/serialize()
-	var/data = ..()
-	var/list/content_list = list()
-	data["content"] = content_list
-	for(var/old_bag in bag.contents)
-		var/atom/movable/AM = old_bag
-		// Copied from storage serialization.
-		content_list.len++
-		content_list[content_list.len] = AM.serialize()
+	var/list/data = ..()
+	data["bag"] = bag.serialize()
 	return data
 
 /obj/item/mod/module/storage/deserialize(list/data)
-	for(var/old_bag in data["content"])
-		if(islist(old_bag))
-			list_to_object(old_bag, bag)
-		else if(old_bag == null)
-			stack_trace("Null entry found in storage/deserialize.")
-		else
-			stack_trace("Non-list thing found in storage/deserialize (Storage: [old_bag])")
-	..()
+	. = ..()
+	qdel(bag)
+	bag = list_to_object(data["bag"], src)
+	bag.source = src
 
 /obj/item/mod/module/storage/Initialize(mapload)
 	. = ..()

--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -16,6 +16,27 @@
 	var/max_items = 7
 	var/obj/item/storage/backpack/modstorage/bag
 
+/obj/item/mod/module/storage/serialize()
+	var/data = ..()
+	var/list/content_list = list()
+	data["content"] = content_list
+	for(var/old_bag in bag.contents)
+		var/atom/movable/AM = old_bag
+		// Copied from storage serialization.
+		content_list.len++
+		content_list[content_list.len] = AM.serialize()
+	return data
+
+/obj/item/mod/module/storage/deserialize(list/data)
+	for(var/old_bag in data["content"])
+		if(islist(old_bag))
+			list_to_object(old_bag, bag)
+		else if(old_bag == null)
+			stack_trace("Null entry found in storage/deserialize.")
+		else
+			stack_trace("Non-list thing found in storage/deserialize (Storage: [old_bag])")
+	..()
+
 /obj/item/mod/module/storage/Initialize(mapload)
 	. = ..()
 	var/obj/item/storage/backpack/modstorage/S = new(src)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This adds some basic support for modsuit serialization, specifically for modules. I tried doing the core as well, but ran into issues when it comes to standard cores and their cell, so I'm limiting the scope to just installed mods.

## Why It's Good For The Game
Fixes #22483

## Images of changes
![YouGetAMod](https://github.com/ParadiseSS13/Paradise/assets/80771500/17f0425e-5084-4323-853c-b2a67024d3c1)

## Testing
Serialized a character, and a modsuit on its own with objects stored. Deserialized both, making sure there wasn't duplicated modules, or left overs from copying over new objects.

## Changelog
N/A

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
