### PR TITLE
Adds logging for injecting food via syringe

### DIFF
--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -144,14 +144,13 @@
 				add_attack_logs(user, L, "Injected with [name] containing [contained], transfered [amount_per_transfer_from_this] units", reagents.harmless_helper() ? ATKLOG_ALMOSTALL : null)
 
 			if(istype(target, /obj/item/reagent_containers/food))
-				var/food_item = target
 
 				var/list/chemicals = list()
 				for(var/datum/reagent/chem in reagents.reagent_list)
 					chemicals += chem.name
 				var/contained_chemicals = english_list(chemicals)
 
-				add_attack_logs(user, food_item, "Injected [amount_per_transfer_from_this]u [contained_chemicals] into food item")
+				add_attack_logs(user, target, "Injected [amount_per_transfer_from_this]u [contained_chemicals] into food item")
 
 			var/fraction = min(amount_per_transfer_from_this / reagents.total_volume, 1)
 			reagents.reaction(L, REAGENT_INGEST, fraction)

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -143,6 +143,16 @@
 
 				add_attack_logs(user, L, "Injected with [name] containing [contained], transfered [amount_per_transfer_from_this] units", reagents.harmless_helper() ? ATKLOG_ALMOSTALL : null)
 
+			if(istype(target, /obj/item/reagent_containers/food))
+				var/food_item = target
+
+				var/list/chemicals = list()
+				for(var/datum/reagent/chem in reagents.reagent_list)
+					chemicals += chem.name
+				var/contained_chemicals = english_list(chemicals)
+
+				add_attack_logs(user, food_item, "Injected [amount_per_transfer_from_this]u [contained_chemicals] into food item")
+
 			var/fraction = min(amount_per_transfer_from_this / reagents.total_volume, 1)
 			reagents.reaction(L, REAGENT_INGEST, fraction)
 			reagents.trans_to(target, amount_per_transfer_from_this)


### PR DESCRIPTION
## What Does This PR Do
This PR creates a new attack log when a player injects reagents into food items using a syringe. 
## Why It's Good For The Game
Allows admins to combat kitchen grief by tracking who is injecting food and what reagent they are injecting.
## Images of changes
![wCMoDfuPkv](https://github.com/ParadiseSS13/Paradise/assets/116982774/c58ca3df-94c7-4e6b-aeac-2995bd51f64a)
## Testing
Spawned cheeseburger.
Injected chemicals into burger.
## Changelog
NPFC