### PR TITLE
Add edge cases to summon item spell, and tweak to feedback if object is hidden

### DIFF
--- a/code/datums/spells/summonitem.dm
+++ b/code/datums/spells/summonitem.dm
@@ -59,13 +59,13 @@
 			var/infinite_recursion = 0 //I don't want to know how someone could put something inside itself but these are wizards so let's be safe
 
 			while(!isturf(item_to_retrieve.loc) && infinite_recursion < 10) //if it's in something you get the whole thing.
-				if(istype(item_to_retrieve.loc,/obj/item/organ/internal/headpocket))
+				if(istype(item_to_retrieve.loc, /obj/item/organ/internal/headpocket))
 					var/obj/item/organ/internal/headpocket/pocket = item_to_retrieve.loc
 					if(pocket.owner)
 						to_chat(pocket.owner, "<span class='warning'>Your [pocket.name] suddenly feels lighter. How strange!</span>")
 					visible_item = FALSE
 					break
-				if(istype(item_to_retrieve.loc,/obj/item/storage/hidden/implant)) //The implant should be left alone
+				if(istype(item_to_retrieve.loc, /obj/item/storage/hidden/implant)) //The implant should be left alone
 					var/obj/item/storage/S = item_to_retrieve.loc
 					for(var/mob/M in S.mobs_viewing)
 						to_chat(M, "<span class='warning'>[item_to_retrieve] suddenly disappears!</span>")
@@ -98,7 +98,7 @@
 								break
 
 				else
-					if(istype(item_to_retrieve.loc,/obj/machinery/atmospherics/portable/)) //Edge cases for moved machinery
+					if(istype(item_to_retrieve.loc, /obj/machinery/atmospherics/portable/)) //Edge cases for moved machinery
 						var/obj/machinery/atmospherics/portable/P = item_to_retrieve.loc
 						P.disconnect()
 						P.update_icon()

--- a/code/datums/spells/summonitem.dm
+++ b/code/datums/spells/summonitem.dm
@@ -59,7 +59,7 @@
 			var/infinite_recursion = 0 //I don't want to know how someone could put something inside itself but these are wizards so let's be safe
 
 			while(!isturf(item_to_retrieve.loc) && infinite_recursion < 10) //if it's in something you get the whole thing.
-				if(istype(item_to_retrieve.loc, /obj/item/organ/internal/headpocket))
+				if(istype(item_to_retrieve.loc,/obj/item/organ/internal/headpocket))
 					var/obj/item/organ/internal/headpocket/pocket = item_to_retrieve.loc
 					if(pocket.owner)
 						to_chat(pocket.owner, "<span class='warning'>Your [pocket.name] suddenly feels lighter. How strange!</span>")

--- a/code/datums/spells/summonitem.dm
+++ b/code/datums/spells/summonitem.dm
@@ -55,9 +55,22 @@
 
 		else	//Getting previously marked item
 			var/obj/item_to_retrieve = marked_item
+			var/visible_item = TRUE //Items that silently disappear will have the message suppressed
 			var/infinite_recursion = 0 //I don't want to know how someone could put something inside itself but these are wizards so let's be safe
 
 			while(!isturf(item_to_retrieve.loc) && infinite_recursion < 10) //if it's in something you get the whole thing.
+				if(istype(item_to_retrieve.loc, /obj/item/organ/internal/headpocket))
+					var/obj/item/organ/internal/headpocket/pocket = item_to_retrieve.loc
+					if(pocket.owner)
+						to_chat(pocket.owner, "<span class='warning'>Your [pocket.name] suddenly feels lighter. How strange!</span>")
+					visible_item = FALSE
+					break
+				if(istype(item_to_retrieve.loc,/obj/item/storage/hidden/implant)) //The implant should be left alone
+					var/obj/item/storage/S = item_to_retrieve.loc
+					for(var/mob/M in S.mobs_viewing)
+						to_chat(M, "<span class='warning'>[item_to_retrieve] suddenly disappears!</span>")
+					visible_item = FALSE
+					break
 				if(ismob(item_to_retrieve.loc)) //If its on someone, properly drop it
 					var/mob/M = item_to_retrieve.loc
 
@@ -79,6 +92,7 @@
 									C.clear_alert("embeddedobject")
 								break
 							if(item_to_retrieve == part.hidden)
+								visible_item = FALSE
 								part.hidden = null
 								to_chat(C, "<span class='warning'>Your [part.name] suddenly feels emptier. How weird!</span>")
 								break
@@ -88,8 +102,6 @@
 						var/obj/machinery/atmospherics/portable/P = item_to_retrieve.loc
 						P.disconnect()
 						P.update_icon()
-					if(istype(item_to_retrieve.loc,/obj/item/storage/hidden/implant/)) //The implant should be left alone
-						break
 					if(is_type_in_typecache(item_to_retrieve.loc, blacklisted_summons))
 						break
 					item_to_retrieve = item_to_retrieve.loc
@@ -106,8 +118,8 @@
 			if(!isturf(target.loc))
 				to_chat(target, "<span class='caution'>You attempt to cast the spell, but it fails! Perhaps you aren't available?</span>")
 				return
-
-			item_to_retrieve.loc.visible_message("<span class='warning'>[item_to_retrieve] suddenly disappears!</span>")
+			if(visible_item)
+				item_to_retrieve.loc.visible_message("<span class='warning'>[item_to_retrieve] suddenly disappears!</span>")
 
 
 			if(target.hand) //left active hand

--- a/code/datums/spells/summonitem.dm
+++ b/code/datums/spells/summonitem.dm
@@ -78,12 +78,18 @@
 								if(!C.has_embedded_objects())
 									C.clear_alert("embeddedobject")
 								break
+							if(item_to_retrieve == part.hidden)
+								part.hidden = null
+								to_chat(C, "<span class='warning'>Your [part.name] suddenly feels emptier. How weird!</span>")
+								break
 
 				else
 					if(istype(item_to_retrieve.loc,/obj/machinery/atmospherics/portable/)) //Edge cases for moved machinery
 						var/obj/machinery/atmospherics/portable/P = item_to_retrieve.loc
 						P.disconnect()
 						P.update_icon()
+					if(istype(item_to_retrieve.loc,/obj/item/storage/hidden/implant/)) //The implant should be left alone
+						break
 					if(is_type_in_typecache(item_to_retrieve.loc, blacklisted_summons))
 						break
 					item_to_retrieve = item_to_retrieve.loc


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR
The summon item spell still had some odd interactions and feedback, in order:
Cavities would not get cleared properly, it now does so.
Headpockets would just cause the spell to runtime due to being in nullspace, and gets its own check now.
Storage implants just got deleted by the spell, and now it just pulls the item out, leaving the implant in place.

Feedback for the disappearing item now has a check to see if it's intended to be seen. It doesn't make sense for people who can't even see the item to be told that X suddenly disappeared. The storage implant in particular gives no feedback unless its content are being viewed while the item is recalled.

## Why It's Good For The Game
Fixes #22400. More sensible feedback based on what happens is better as well.

## Images of changes
![Summon-Cavity](https://github.com/ParadiseSS13/Paradise/assets/80771500/95507c15-d951-430e-a1f3-596e270f5e50)
![Summon-Pocket](https://github.com/ParadiseSS13/Paradise/assets/80771500/39da99d8-9840-4d30-8be5-7c6f7fdccc44)

## Testing
Used summon item on an object that was stored in a headpocket, cavity, and storage implant.

## Changelog
:cl:
fix: Instant Summons can recall items out of headpockets
fix: Instant Summons properly recalls items in body cavities
fix: Instant Summons does not delete storage implants anymore
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
