### PR TITLE
Swaps Atmos Tray scanners with engineering goggles

### DIFF
--- a/code/game/machinery/vendors/departmental_vendors.dm
+++ b/code/game/machinery/vendors/departmental_vendors.dm
@@ -7,6 +7,7 @@
 	category = VENDOR_TYPE_DEPARTMENTAL
 	req_one_access_txt = "11;24" // Engineers and atmos techs can use this
 	products = list(/obj/item/clothing/glasses/meson/engine = 2,
+					/obj/item/clothing/glasses/meson/engine/tray = 4,
 					/obj/item/multitool = 4,
 					/obj/item/geiger_counter = 5,
 					/obj/item/airlock_electronics = 10,

--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering_lockers.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering_lockers.dm
@@ -119,6 +119,6 @@
 	new /obj/item/watertank/atmos(src)
 	new /obj/item/clothing/suit/fire/atmos(src)
 	new /obj/item/clothing/head/hardhat/atmos(src)
-	new /obj/item/clothing/glasses/meson/engine/tray(src)
+	new /obj/item/clothing/glasses/meson/engine(src)
 	new /obj/item/rpd(src)
 	new /obj/item/destTagger(src)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This replaces the t-ray scanners in atmospheric lockers with full engineering goggles. T-ray scanners only have the t-ray mode while engineering goggles have meson alongside several other modes, which provides protection from the SM induced hallucinations.

Added 4 tray scanner goggles to the engi-vend to compensate as they have a higher scanning range than the base goggles.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
When mesons were refactored, the hallucination protection was changed from just the goggles to the meson specific mode. This meant that atmos techs no longer had protection from hallucinations and have to hack or steal engineering goggles in order to be protected from the SM hallucinations. As the role that interacts with the supermatter engine as much, or even more than station engineers, they shouldn't need to steal equipment to not suffer the rather annoying effects of hallucination spam.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://github.com/ParadiseSS13/Paradise/assets/107899953/89726a19-a906-4682-9cf9-5340cd698d1d)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Spawned in, checked the atmos lockers for engineering goggles, checked they were correct and had all of the modes, all worked as intended
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Swaps the T-ray scanners for engineering goggles in the Atmospheric Technician's Lockers.
tweak: Adds 4 T-ray scanners to the Engi-vend to compensate.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
