### PR TITLE
Drastically Reduces Execution Time for Handguns + Makes it Weapon-Dependent

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -33,6 +33,7 @@
 	var/fire_delay = 0					//rate of fire for burst firing and semi auto
 	var/firing_burst = 0				//Prevent the weapon from firing again while already firing
 	var/semicd = 0						//cooldown handler
+	var/execution_speed = 6 SECONDS
 	var/weapon_weight = WEAPON_LIGHT
 	var/list/restricted_species
 
@@ -447,7 +448,7 @@
 
 	semicd = 1
 
-	if(!do_mob(user, target, 120) || user.zone_selected != "mouth")
+	if(!do_mob(user, target, execution_speed) || user.zone_selected != "mouth")
 		if(user)
 			if(user == target)
 				user.visible_message("<span class='notice'>[user] decided life was worth living.</span>")

--- a/code/modules/projectiles/guns/energy/energy.dm
+++ b/code/modules/projectiles/guns/energy/energy.dm
@@ -10,6 +10,7 @@
 	flight_x_offset = 20
 	flight_y_offset = 10
 	shaded_charge = TRUE
+	execution_speed = 5 SECONDS
 
 
 /obj/item/gun/energy/gun/cyborg
@@ -34,6 +35,7 @@
 	actions_types = list(/datum/action/item_action/toggle_gunlight)
 	shaded_charge = FALSE
 	can_holster = TRUE  // Pistol sized, so it should fit into a holster
+	execution_speed = 4 SECONDS
 
 /obj/item/gun/energy/gun/mini/Initialize(mapload, ...)
 	gun_light = new /obj/item/flashlight/seclite(src)
@@ -74,6 +76,7 @@
 	ammo_x_offset = 1
 	shaded_charge = TRUE
 	can_holster = TRUE
+	execution_speed = 5 SECONDS
 
 /obj/item/gun/energy/gun/blueshield/pdw9
 	name = "\improper PDW-9 energy pistol"
@@ -94,6 +97,7 @@
 	trigger_guard = TRIGGER_GUARD_NONE
 	ammo_x_offset = 2
 	shaded_charge = FALSE
+	execution_speed = 8 SECONDS
 
 /obj/item/gun/energy/gun/nuclear
 	name = "advanced energy gun"

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -9,6 +9,7 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/lasergun)
 	ammo_x_offset = 1
 	shaded_charge = TRUE
+	execution_speed = 5 SECONDS
 
 /obj/item/gun/energy/laser/practice
 	name = "practice laser gun"
@@ -86,6 +87,7 @@
 	origin_tech = "combat=4;magnets=4;powerstorage=3"
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/accelerator)
 	ammo_x_offset = 3
+	execution_speed = 8 SECONDS
 
 /obj/item/ammo_casing/energy/laser/accelerator
 	projectile_type = /obj/item/projectile/beam/laser/accelerator
@@ -132,6 +134,7 @@
 	/// Is the scope fully online or not?
 	var/scope_active = FALSE
 	var/stored_dir
+	execution_speed = 8 SECONDS
 
 /obj/item/gun/energy/lwap/Initialize(mapload, ...)
 	. = ..()

--- a/code/modules/projectiles/guns/energy/pulse.dm
+++ b/code/modules/projectiles/guns/energy/pulse.dm
@@ -11,6 +11,7 @@
 	slot_flags = SLOT_FLAG_BACK
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/pulse, /obj/item/ammo_casing/energy/electrode, /obj/item/ammo_casing/energy/laser)
 	cell_type = /obj/item/stock_parts/cell/pulse
+	execution_speed = 2 SECONDS
 
 /obj/item/gun/energy/pulse/emp_act(severity)
 	return

--- a/code/modules/projectiles/guns/energy/special_eguns.dm
+++ b/code/modules/projectiles/guns/energy/special_eguns.dm
@@ -272,6 +272,7 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/instakill)
 	force = 60
 	origin_tech = "combat=7;magnets=6"
+	execution_speed = 2 SECONDS
 
 /obj/item/gun/energy/laser/instakill/emp_act() //implying you could stop the instagib
 	return
@@ -319,6 +320,7 @@
 	var/charging = FALSE
 	var/charge_failure = FALSE
 	var/mob/living/carbon/holder = null
+	execution_speed = 4 SECONDS
 
 /obj/item/gun/energy/plasma_pistol/Initialize(mapload)
 	. = ..()

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -53,6 +53,7 @@
 	flight_x_offset = 15
 	flight_y_offset = 10
 	can_holster = TRUE
+	execution_speed = 5 SECONDS
 
 /obj/item/gun/energy/disabler/Initialize(mapload)
 	. = ..()
@@ -85,3 +86,4 @@
 	shaded_charge = TRUE
 	ammo_type = list(/obj/item/ammo_casing/energy/silencer_ammo)
 	suppressed = TRUE
+	execution_speed = 4 SECONDS

--- a/code/modules/projectiles/guns/magic/magic_staff.dm
+++ b/code/modules/projectiles/guns/magic/magic_staff.dm
@@ -4,6 +4,7 @@
 	slot_flags = SLOT_FLAG_BACK
 	ammo_type = /obj/item/ammo_casing/magic
 	flags_2 = NO_MAT_REDEMPTION_2
+	execution_speed = 3 SECONDS
 
 /obj/item/gun/magic/staff/change
 	name = "staff of change"

--- a/code/modules/projectiles/guns/magic/wand.dm
+++ b/code/modules/projectiles/guns/magic/wand.dm
@@ -11,6 +11,7 @@
 	can_charge = FALSE
 	max_charges = 100 //100, 50, 50, 34 (max charge distribution by 25%ths)
 	var/variable_charges = 1
+	execution_speed = 3 SECONDS
 
 /obj/item/gun/magic/wand/Initialize(mapload)
 	. = ..()

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -287,6 +287,7 @@
 	burst_size = 1
 	fire_delay = 0
 	actions_types = list()
+	execution_speed = 5 SECONDS
 
 /obj/item/gun/projectile/automatic/shotgun/bulldog/Initialize(mapload)
 	. = ..()
@@ -333,6 +334,7 @@
 	magout_sound = 'sound/weapons/gun_interactions/batrifle_magout.ogg'
 	can_suppress = FALSE
 	burst_size = 2
+	execution_speed = 5 SECONDS
 
 /obj/item/gun/projectile/automatic/lasercarbine/update_icon_state()
 	icon_state = "lasercarbine[magazine ? "-[CEILING(get_ammo(0)/5, 1)*5]" : ""]"

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -13,6 +13,7 @@
 	can_suppress = TRUE
 	burst_size = 1
 	fire_delay = 0
+	execution_speed = 4 SECONDS
 	actions_types = list()
 
 /obj/item/gun/projectile/automatic/pistol/update_icon_state()

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -7,6 +7,7 @@
 	origin_tech = "combat=3;materials=2"
 	fire_sound = 'sound/weapons/gunshots/gunshot_strong.ogg'
 	can_holster = TRUE
+	execution_speed = 5 SECONDS
 
 /obj/item/gun/projectile/revolver/Initialize(mapload)
 	. = ..()

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -220,6 +220,7 @@
 	can_bayonet = TRUE
 	knife_x_offset = 27
 	knife_y_offset = 13
+	execution_speed = 7 SECONDS
 
 /obj/item/gun/projectile/shotgun/boltaction/pump(mob/M)
 	playsound(M, 'sound/weapons/gun_interactions/rifle_load.ogg', 60, 1)
@@ -320,6 +321,7 @@
 	origin_tech = "combat=6"
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/com
 	w_class = WEIGHT_CLASS_HUGE
+	execution_speed = 5 SECONDS
 
 //Dual Feed Shotgun
 

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -19,6 +19,7 @@
 	zoom_amt = 7 //Long range, enough to see in front of you, but no tiles behind you.
 	slot_flags = SLOT_FLAG_BACK
 	actions_types = list()
+	execution_speed = 8 SECONDS
 
 /obj/item/gun/projectile/automatic/sniper_rifle/process_fire(atom/target, mob/living/user, message = TRUE, params, zone_override, bonus_spread = 0)
 	if(istype(chambered.BB, /obj/item/projectile/bullet/sniper) && !zoomed)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes weapon executions dramatically faster.
It also now depends on the kind of weapon:

`/gun/` Base Value: `6 SECONDS`
Pulse/Admin Weapons: `2 SECONDS`
Pistols: `4 SECONDS` _(includes u-ION, Mini E-Gun, and Blueshield/PDW)_
Laser/Disabler Weapons: `5 SECONDS`
Standard Rifles: `6 SECONDS`
Shotguns: `7 SECONDS`
Combat Weapons: `5 SECONDS` _(Combat Shotguns/ERT IK-60/Bulldogs)_
Snipers/LWAP/ALC: `8 SECONDS`

Wands/Magic Shit: `3 SECONDS`

## Why It's Good For The Game
12 seconds to execute someone is kinda insane. You could do so much more damage by just spam-clicking someone to death or simply grabbing a toolbox and beating them to death.

Also, Rule of Cool.

## Testing
Shot a buncha skrell in the head.

## Changelog
:cl:
tweak: Tweaked headshot execution speed to be set at the weapon level. Reduced drastically across the board.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
