### PR TITLE
Makes Kidan take less damage from pest spray if they have a mask, everyone else takes a very minor amount too

### DIFF
--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -1101,10 +1101,12 @@
 			M.adjustToxLoss(damage)
 		if(iscarbon(M))
 			var/mob/living/carbon/C = M
+			var/damage = 1
 			if(!C.wear_mask) // If not wearing a mask
-				C.adjustToxLoss(2)
+				damage *= 2
 			if(iskidan(C)) //RIP
-				C.adjustToxLoss(18)
+				damage *= 10
+			C.adjustToxLoss(damage) // Kidan get 10 damage if they're wearing a mask, and 20 if they're not
 
 /datum/reagent/capulettium
 	name = "Capulettium"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
- Kidan now get half the toxin damage from pest spray if they are wearing a mask.
- Every other humanoid gets 1 or 2, depending on if they are wearing a mask too, toxin damage from pest spray, because my god that can't be healthy.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
While Diona got an update with their plant killer to have it be reduced by other factors, while Kidan never got that. That is why even when wearing a lot of protection as kidan, you can still get 30 toxin damage if you get hit by pest spray, because of their 70% increased toxin damage - which, if the balance team gives a green light, I'd be happy to knock down like 10-20% - Now, if they *are* wearing a mask, the damage is halved to about 17.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Sprayed a kidan with and without a mask, they took different amounts of damage
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Kidan now take less toxin damage when wearing a mask
tweak: Everyone now takes a small amount of toxin damage from pest spray
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
