### PR TITLE
Make Modsuit Module devices NODROP by default instead of being applied by the module

### DIFF
--- a/code/modules/mod/modules/_modules.dm
+++ b/code/modules/mod/modules/_modules.dm
@@ -63,7 +63,6 @@
 		return
 	if(ispath(device))
 		device = new device(src)
-		device.flags |= NODROP
 		device.resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 		device.slot_flags = null
 		device.w_class = WEIGHT_CLASS_HUGE

--- a/code/modules/mod/modules/modules_maint.dm
+++ b/code/modules/mod/modules/modules_maint.dm
@@ -120,6 +120,7 @@
 /obj/item/stamp/mod
 	name = "MOD electronic stamp"
 	desc = "A high-power stamp, able to switch between accept and deny mode when used."
+	flags = NODROP
 
 /obj/item/stamp/mod/attack_self(mob/user, modifiers)
 	. = ..()

--- a/code/modules/mod/modules/modules_medical.dm
+++ b/code/modules/mod/modules/modules_medical.dm
@@ -18,6 +18,7 @@
 	name = "MOD injector syringe"
 	desc = "A high-capacity syringe, with a tip fine enough to locate \
 		the emergency injection ports on any suit of armor, penetrating it with ease. Even yours."
+	flags = NODROP
 	amount_per_transfer_from_this = 30
 	possible_transfer_amounts = list(5, 10, 15, 20, 30)
 	volume = 30
@@ -55,6 +56,7 @@
 	desc = "A pair of paddles with flat metal surfaces that are used to deliver powerful electric shocks."
 	icon = 'icons/obj/defib.dmi'
 	icon_state = "defibgauntlets0" //Inhands handled by the module overlays
+	flags = NODROP
 	force = 0
 	w_class = WEIGHT_CLASS_BULKY
 	toolspeed = 1

--- a/code/modules/mod/modules/modules_supply.dm
+++ b/code/modules/mod/modules/modules_supply.dm
@@ -21,6 +21,7 @@
 		However, this design has been locked by Nanotrasen to be primarily utilized for lifting various crates. \
 		A lot of people would say that loading cargo is a dull job, but you could not disagree more."
 	icon_state = "clamp"
+	flags = NODROP
 	module_type = MODULE_ACTIVE
 	complexity = 3
 	use_power_cost = DEFAULT_CHARGE_DRAIN


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This tweaks how module devices are handled, with them now having `NODROP` as an initial flag rather than being applied by their associated module on init. Why? Because `unEquip()` will strip `NODROP` if it's not an initial flag when forced.

## Why It's Good For The Game
Fixes ##22383. Other mods were probably affected as well.

## Images of changes
![Mods](https://github.com/ParadiseSS13/Paradise/assets/80771500/4bd75f23-4da3-488e-9165-acd70126f695)

## Testing
Equipped a modsuit, and deployed a mod. Looked at the flags for it, then retracted the mod and back to see that the flags were unaffected.

## Changelog
:cl:
fix: Deployed modules cannot be placed onto tables, closets or crates.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
