### PR TITLE
Properly informs CQC Headkick does Brain Damage

### DIFF
--- a/code/modules/martial_arts/combos/cqc/kick.dm
+++ b/code/modules/martial_arts/combos/cqc/kick.dm
@@ -1,7 +1,7 @@
 /datum/martial_combo/cqc/kick
 	name = "CQC Kick"
 	steps = list(MARTIAL_COMBO_STEP_HARM, MARTIAL_COMBO_STEP_HARM)
-	explaination_text = "Knocks opponent away and slows them. Will instead deal massive stamina damage while inflicting minor brain damage and muting opponents who are on the ground."
+	explaination_text = "Knocks opponent away and slows them. Will instead deal massive stamina damage, inflict minor brain damage, and mute opponents who are on the ground."
 
 /datum/martial_combo/cqc/kick/perform_combo(mob/living/carbon/human/user, mob/living/target, datum/martial_art/MA)
 	. = MARTIAL_COMBO_FAIL

--- a/code/modules/martial_arts/combos/cqc/kick.dm
+++ b/code/modules/martial_arts/combos/cqc/kick.dm
@@ -1,7 +1,7 @@
 /datum/martial_combo/cqc/kick
 	name = "CQC Kick"
 	steps = list(MARTIAL_COMBO_STEP_HARM, MARTIAL_COMBO_STEP_HARM)
-	explaination_text = "Knocks opponent away and slows them. Will instead deal massive stamina damage, and mute opponents who are on the ground."
+	explaination_text = "Knocks opponent away and slows them. Will instead deal massive stamina damage while inflicting minor brain damage and muting opponents who are on the ground."
 
 /datum/martial_combo/cqc/kick/perform_combo(mob/living/carbon/human/user, mob/living/target, datum/martial_art/MA)
 	. = MARTIAL_COMBO_FAIL


### PR DESCRIPTION
## What Does This PR Do
Remembering the Basics of CQC will now inform the player that Combo Harm'ing people while they're down with CQC inflicts brain damage.

## Why It's Good For The Game
As it stands, it's proper noob bait for chefs that do not have code knowledge that Head Kicking does brain damage. It's not informed anywhere but the Martial Arts page on the wiki. Players, especially new players, shouldn't have to read an out of the way wiki page to know this. Will hopefully lead to less cases of Chef players getting into admin trouble from not knowing that repeatedly kicking a dude isn't just dealing large amounts of stamina like it originally claimed.

Information good.

## Testing
I compiled it and verified I edited the right text line in game.

## Changelog
:cl:
tweak: CQC Kick now properly informs the player that it does minor brain damage to prone targets.
/:cl:
