### PR TITLE
you can no longer kidnap people with the syndicate teleporter

### DIFF
--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -102,6 +102,8 @@
 	icon_state = icons_charges[charges + 1]
 
 /obj/item/teleporter/proc/attempt_teleport(mob/user, EMP_D = FALSE)
+	for(var/obj/item/grab/G in user)
+		qdel(G)
 	dir_correction(user)
 	if(!charges && !EMP_D) //If it's empd, you are moving no matter what.
 		to_chat(user, "<span class='warning'>[src] is still recharging.</span>")


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Syndicate teleporter now breaks grabs when teleporting someone.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Unlike the veil shifter, syndicate teleporter should not be able to kidnap people. It now breaks grabs apon teleporting, to prevent the niche situation where one can grab someone, then teleport to teleport them with you

## Testing
<!-- How did you test the PR, if at all? -->

I teleported with a skrell in a neck lock and all I got was this hacktober fest shirt. Wait a minute.

## Changelog
:cl:
fix: You can no longer kidnap people with the syndicate teleporter.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
