### PR TITLE
Fulton extraction properly unbuckles mobs

### DIFF
--- a/code/modules/mining/fulton.dm
+++ b/code/modules/mining/fulton.dm
@@ -74,7 +74,7 @@ GLOBAL_LIST_EMPTY(total_extraction_beacons)
 			if(isliving(A))
 				var/mob/living/M = A
 				M.Weaken(32 SECONDS) // Keep them from moving during the duration of the extraction
-				M.buckled = 0 // Unbuckle them to prevent anchoring problems
+				unbuckle_mob(M, force = TRUE) // Unbuckle them to prevent anchoring problems
 			else
 				A.anchored = TRUE
 				A.density = FALSE


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes fulton packs use the proper unbuckling proc instead of doing `buckled = 0` like a madman.

## Why It's Good For The Game
Fixes #22372, possibly other buckled cases as well.

## Images of changes
https://github.com/ParadiseSS13/Paradise/assets/80771500/bb6df1c4-f047-4bb2-be92-87281b3cfe1a

## Testing
Spawned an extraction point and a pack in Lavaland, strapped a tajaran on a wheelchair, and watched them fly. Then pushed around the wheelchair and the mob.

## Changelog
:cl:
fix: Mobs do not rubberband back when fulton extracted while buckled to something
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
