### PR TITLE
Revert "Bump pillow from 9.3.0 to 10.0.1 in /tools"

### DIFF
--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,6 +1,6 @@
 pygit2==1.7.2
 bidict==0.22.0
-Pillow==10.0.1
+Pillow==9.3.0
 json5==0.9.14
 
 # changelogs


### PR DESCRIPTION
Reverts ParadiseSS13/Paradise#22712

Need to upgrade Python before we can do this.