### PR TITLE
Bumps merge driver deps

### DIFF
--- a/_build_dependencies.sh
+++ b/_build_dependencies.sh
@@ -12,4 +12,4 @@ export BETA_BYOND_MAJOR=515
 # Beta Byond Minor
 export BETA_BYOND_MINOR=1610
 # Python version for mapmerge and other tools
-export PYTHON_VERSION=3.7.9
+export PYTHON_VERSION=3.11.6

--- a/tools/bootstrap/python311._pth
+++ b/tools/bootstrap/python311._pth
@@ -1,4 +1,4 @@
-python37.zip
+python311.zip
 .
 ..\..\..
 

--- a/tools/bootstrap/python_.ps1
+++ b/tools/bootstrap/python_.ps1
@@ -50,7 +50,7 @@ if (!(Test-Path $PythonExe -PathType Leaf)) {
 	[System.IO.Compression.ZipFile]::ExtractToDirectory($Archive, $PythonDir)
 
 	# Copy a ._pth file without "import site" commented, so pip will work
-	Copy-Item "$Bootstrap/python37._pth" $PythonDir `
+	Copy-Item "$Bootstrap/python311._pth" $PythonDir `
 		-ErrorAction Stop
 
 	Remove-Item $Archive

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,8 +1,8 @@
-pygit2==1.7.2
-bidict==0.22.0
+pygit2==1.13.1
+bidict==0.22.1
 Pillow==10.0.1
 json5==0.9.14
 
 # changelogs
 PyYaml==6.0.1 # maplint also
-beautifulsoup4==4.9.3
+beautifulsoup4==4.12.2


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes the issues that will be introduced by https://github.com/ParadiseSS13/Paradise/pull/22728 preventing users with merge hooks from making commits.
Moves us from an end-of-life python release used in mapmerge, dmi merge (icon conflict fixer), etc.
Bumps beautifulsoup4, pygit2, bidict, and pillow to latest stable versions.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Users with merge hooks should be allowed to make commits.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
I made some commits, they worked?
<!-- How did you test the PR, if at all? -->

