### PR TITLE
Makes the /Stat proc about five times faster

### DIFF
--- a/code/__HELPERS/trait_helpers.dm
+++ b/code/__HELPERS/trait_helpers.dm
@@ -215,6 +215,8 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_DODGE_ALL_OBJECTS "dodges_all_objects" /// Allows a mob to dodge all thrown objects
 #define TRAIT_BADASS "trait_badass"
 #define TRAIT_FORCED_STANDING "forced_standing" // The mob cannot be floored, or lie down
+#define TRAIT_HAS_GPS "has_gps" // used for /Stat
+#define TRAIT_CAN_VIEW_HEALTH "can_view_health" // Also used for /Stat
 
 //***** ITEM AND MOB TRAITS *****//
 /// Show what machine/door wires do when held.

--- a/code/modules/assembly/health.dm
+++ b/code/modules/assembly/health.dm
@@ -55,6 +55,14 @@
 		audible_message("[bicon(src)] *beep* *beep*")
 		toggle_scan()
 
+/obj/item/assembly/health/pickup(mob/user)
+	..()
+	ADD_TRAIT(user, TRAIT_CAN_VIEW_HEALTH, "HEALTH[UID()]")
+
+/obj/item/gps/dropped(mob/user, silent)
+	REMOVE_TRAIT(user, TRAIT_CAN_VIEW_HEALTH, "HEALTH[UID()]")
+	return ..()
+
 /obj/item/assembly/health/proc/toggle_scan()
 	if(!secured)
 		return FALSE

--- a/code/modules/mob/dead/observer/observer_base.dm
+++ b/code/modules/mob/dead/observer/observer_base.dm
@@ -277,8 +277,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 /mob/dead/observer/Stat()
 	..()
-	statpanel("Status")
-	if(client.statpanel == "Status")
+	if(statpanel("Status"))
 		show_stat_emergency_shuttle_eta()
 		stat(null, "Respawnability: [(src in GLOB.respawnable_list) ? "Yes" : "No"]")
 

--- a/code/modules/mob/living/carbon/alien/alien_base.dm
+++ b/code/modules/mob/living/carbon/alien/alien_base.dm
@@ -120,10 +120,10 @@
 
 /mob/living/carbon/alien/Stat()
 	..()
-	statpanel("Status")
-	stat(null, "Intent: [a_intent]")
-	stat(null, "Move Mode: [m_intent]")
-	show_stat_emergency_shuttle_eta()
+	if(statpanel("Status"))
+		stat(null, "Intent: [a_intent]")
+		stat(null, "Move Mode: [m_intent]")
+		show_stat_emergency_shuttle_eta()
 
 /mob/living/carbon/alien/SetStunned(amount, updating = TRUE, force = 0)
 	..()

--- a/code/modules/mob/living/carbon/brain/carbon_brain.dm
+++ b/code/modules/mob/living/carbon/brain/carbon_brain.dm
@@ -81,16 +81,12 @@ I'm using this for Stat to give it a more nifty interface to work with
 
 /mob/living/carbon/brain/Stat()
 	..()
-	if(has_synthetic_assistance())
-		statpanel("Status")
+	if(has_synthetic_assistance() && statpanel("Status"))
 		show_stat_emergency_shuttle_eta()
-
-		if(client.statpanel == "Status")
-			//Knowing how well-off your mech is doing is really important as an MMI
-			if(ismecha(src.loc))
-				var/obj/mecha/M = src.loc
-				stat("Exosuit Charge:", "[istype(M.cell) ? "[M.cell.charge] / [M.cell.maxcharge]" : "No cell detected"]")
-				stat("Exosuit Integrity", "[!M.obj_integrity ? "0" : "[(M.obj_integrity / M.max_integrity) * 100]"]%")
+		if(ismecha(loc))
+			var/obj/mecha/M = loc
+			stat("Exosuit Charge:", "[istype(M.cell) ? "[M.cell.charge] / [M.cell.maxcharge]" : "No cell detected"]")
+			stat("Exosuit Integrity", "[!M.obj_integrity ? "0" : "[(M.obj_integrity / M.max_integrity) * 100]"]%")
 
 /mob/living/carbon/brain/can_safely_leave_loc()
 	return 0 //You're not supposed to be ethereal jaunting, brains

--- a/code/modules/mob/living/carbon/human/human_mob.dm
+++ b/code/modules/mob/living/carbon/human/human_mob.dm
@@ -191,11 +191,10 @@
 
 	show_stat_emergency_shuttle_eta()
 
-	var/total_user_contents = GetAllContents() // cache it
-	if(locate(/obj/item/gps) in total_user_contents)
+	if(HAS_TRAIT(src, TRAIT_HAS_GPS))
 		var/turf/T = get_turf(src)
 		stat(null, "GPS: [COORD(T)]")
-	if(locate(/obj/item/assembly/health) in total_user_contents)
+	if(HAS_TRAIT(src, TRAIT_CAN_VIEW_HEALTH))
 		stat(null, "Health: [health]")
 
 	if(internal)

--- a/code/modules/mob/living/carbon/human/human_mob.dm
+++ b/code/modules/mob/living/carbon/human/human_mob.dm
@@ -183,43 +183,42 @@
 
 /mob/living/carbon/human/Stat()
 	..()
-	statpanel("Status")
+	if(!statpanel("Status"))
+		return
 
 	stat(null, "Intent: [a_intent]")
 	stat(null, "Move Mode: [m_intent]")
 
 	show_stat_emergency_shuttle_eta()
 
-	if(client.statpanel == "Status")
-		var/total_user_contents = GetAllContents() // cache it
-		if(locate(/obj/item/gps) in total_user_contents)
-			var/turf/T = get_turf(src)
-			stat(null, "GPS: [COORD(T)]")
-		if(locate(/obj/item/assembly/health) in total_user_contents)
-			stat(null, "Health: [health]")
+	var/total_user_contents = GetAllContents() // cache it
+	if(locate(/obj/item/gps) in total_user_contents)
+		var/turf/T = get_turf(src)
+		stat(null, "GPS: [COORD(T)]")
+	if(locate(/obj/item/assembly/health) in total_user_contents)
+		stat(null, "Health: [health]")
 
-		if(internal)
-			if(!internal.air_contents)
-				qdel(internal)
-			else if(client?.prefs.toggles2 & PREFTOGGLE_2_SIMPLE_STAT_PANEL)
-				stat(null, "Internals Tank Connected")
-			else
-				stat("Internal Atmosphere Info", internal.name)
-				stat("Tank Pressure", internal.air_contents.return_pressure())
-				stat("Distribution Pressure", internal.distribute_pressure)
+	if(internal)
+		if(!internal.air_contents)
+			qdel(internal)
+		else if(client?.prefs.toggles2 & PREFTOGGLE_2_SIMPLE_STAT_PANEL)
+			stat(null, "Internals Tank Connected")
+		else
+			stat("Internal Atmosphere Info", internal.name)
+			stat("Tank Pressure", internal.air_contents.return_pressure())
+			stat("Distribution Pressure", internal.distribute_pressure)
 
-		// I REALLY need to split up status panel things into datums
+	// I REALLY need to split up status panel things into datums
+	if(mind)
+		var/datum/antagonist/changeling/cling = mind.has_antag_datum(/datum/antagonist/changeling)
+		if(cling)
+			stat("Chemical Storage", "[cling.chem_charges]/[cling.chem_storage]")
+			stat("Absorbed DNA", cling.absorbed_count)
 
-		if(mind)
-			var/datum/antagonist/changeling/cling = mind.has_antag_datum(/datum/antagonist/changeling)
-			if(cling)
-				stat("Chemical Storage", "[cling.chem_charges]/[cling.chem_storage]")
-				stat("Absorbed DNA", cling.absorbed_count)
-
-			var/datum/antagonist/vampire/V = mind.has_antag_datum(/datum/antagonist/vampire)
-			if(V)
-				stat("Total Blood", "[V.bloodtotal]")
-				stat("Usable Blood", "[V.bloodusable]")
+		var/datum/antagonist/vampire/V = mind.has_antag_datum(/datum/antagonist/vampire)
+		if(V)
+			stat("Total Blood", "[V.bloodtotal]")
+			stat("Usable Blood", "[V.bloodusable]")
 
 /mob/living/carbon/human/ex_act(severity)
 	if(status_flags & GODMODE)

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -154,13 +154,8 @@
 
 /mob/living/silicon/pai/Stat()
 	..()
-	statpanel("Status")
-	if(client.statpanel == "Status")
+	if(statpanel("Status"))
 		show_silenced()
-
-	if(proc_holder_list.len)//Generic list for proc_holder objects.
-		for(var/obj/effect/proc_holder/P in proc_holder_list)
-			statpanel("[P.panel]","",P)
 
 /mob/living/silicon/pai/blob_act()
 	if(stat != DEAD)

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -123,7 +123,8 @@
 
 /mob/living/simple_animal/parrot/Stat()
 	..()
-	stat("Held Item", held_item)
+	if(statpanel("Status"))
+		stat("Held Item", held_item)
 
 /*
  * Inventory

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -971,20 +971,21 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 	return FALSE
 
 /mob/Stat()
-	..()
-
 	show_stat_turf_contents()
 
-	statpanel("Status") // We only want alt-clicked turfs to come before Status
-	stat(null, "Round ID: [GLOB.round_id ? GLOB.round_id : "NULL"]")
-	stat(null, "Map: [SSmapping.map_datum.fluff_name]")
-	if(SSmapping.next_map)
-		stat(null, "Next Map: [SSmapping.next_map.fluff_name]")
+	if(statpanel("Status"))
+		stat(null, "Round ID: [GLOB.round_id ? GLOB.round_id : "NULL"]")
+		stat(null, "Map: [SSmapping.map_datum.fluff_name]")
+		if(SSmapping.next_map)
+			stat(null, "Next Map: [SSmapping.next_map.fluff_name]")
+		if(SSticker)
+			show_stat_station_time()
+		stat(null, "Players Connected: [length(GLOB.clients)]")
 
-	if(mob_spell_list && mob_spell_list.len)
+	if(length(mob_spell_list))
 		for(var/obj/effect/proc_holder/spell/S in mob_spell_list)
 			add_spell_to_statpanel(S)
-	if(mind && isliving(src) && mind.spell_list && mind.spell_list.len)
+	if(length(mind.spell_list))
 		for(var/obj/effect/proc_holder/spell/S in mind.spell_list)
 			add_spell_to_statpanel(S)
 
@@ -1042,13 +1043,6 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 				for(var/datum/controller/subsystem/SS as anything in Master.subsystems)
 					if((SS.cpu_display == SS_CPUDISPLAY_HIGH) && !(SS.flags & SS_NO_FIRE))
 						SS.stat_entry()
-
-	statpanel("Status") // Switch to the Status panel again, for the sake of the lazy Stat procs
-
-	if(client?.statpanel == "Status")
-		if(SSticker)
-			show_stat_station_time()
-		stat(null, "Players Connected: [length(GLOB.clients)]")
 
 // this function displays the station time in the status panel
 /mob/proc/show_stat_station_time()

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -90,7 +90,7 @@
 	return
 
 /mob/new_player/Stat()
-	. = ..()
+	..()
 	if(statpanel("Status") && SSticker)
 		if(!SSticker.hide_mode)
 			stat("Game Mode: [GLOB.master_mode]")

--- a/code/modules/telesci/gps.dm
+++ b/code/modules/telesci/gps.dm
@@ -48,6 +48,14 @@ GLOBAL_LIST_EMPTY(GPS_list)
 	else if(tracking)
 		. += "working"
 
+/obj/item/gps/pickup(mob/user)
+	..()
+	ADD_TRAIT(user, TRAIT_HAS_GPS, "GPS[UID()]")
+
+/obj/item/gps/dropped(mob/user, silent)
+	REMOVE_TRAIT(user, TRAIT_HAS_GPS, "GPS[UID()]")
+	return ..()
+
 /obj/item/gps/emp_act(severity)
 	emped = TRUE
 	update_icon(UPDATE_OVERLAYS)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
I am going to scream I'm actually just angry that we've had it like this for so long
Stops /Stat from processing panels that you don't have focused
stops calling stat's parent value because it doesn't exist and just adds overhead
Before:
``/mob/Stat                                                                                   0.016        0.057        0.059        0.000          459``
After:
``/mob/Stat                                                                                   0.006        0.008        0.009        0.000          567``

## Why It's Good For The Game
this was more expensive than fucking **SSmachines**

``/mob/living/carbon/human/Stat 74.076``
this is bad to see throughout a round

## Testing
it just works my bros

## Changelog
:cl:
fix: Removed a lot of status panel related lag
tweak: GPSes and health assemblies only show info in the stat panel while they're in your inventory 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
