### PR TITLE
Expanded Passive Gate Functionality

### DIFF
--- a/code/modules/atmospherics/machinery/components/binary_devices/passive_gate.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/passive_gate.dm
@@ -42,6 +42,10 @@
 		//Need at least 10 KPa difference to overcome friction in the mechanism
 		return 1
 
+	if(target_pressure >= input_starting_pressure-10)
+		//Gas will not pump if the input pressure is lower than the target
+		return 1
+
 	//Calculate necessary moles to transfer using PV = nRT
 	if((air1.total_moles() > 0) && (air1.temperature>0))
 		var/pressure_delta = min(target_pressure - output_starting_pressure, (input_starting_pressure - output_starting_pressure)/2)

--- a/code/modules/atmospherics/machinery/components/binary_devices/passive_gate.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/passive_gate.dm
@@ -37,7 +37,7 @@
 	var/output_starting_pressure = air2.return_pressure()
 	var/input_starting_pressure = air1.return_pressure()
 
-	if(output_starting_pressure >= min(target_pressure,input_starting_pressure-10))
+	if(output_starting_pressure >= min(target_pressure,input_starting_pressure - 10))
 		//No need to pump gas if target is already reached or input pressure is too low
 		//Need at least 10 KPa difference to overcome friction in the mechanism
 		return 1
@@ -47,11 +47,11 @@
 		return 1
 
 	//Calculate necessary moles to transfer using PV = nRT
-	if((air1.total_moles() > 0) && (air1.temperature>0))
-		var/pressure_delta = min(target_pressure - output_starting_pressure, (input_starting_pressure - output_starting_pressure)/2)
+	if((air1.total_moles() > 0) && (air1.temperature > 0))
+		var/pressure_delta = min(target_pressure - output_starting_pressure, (input_starting_pressure - output_starting_pressure) / 2)
 		//Can not have a pressure delta that would cause output_pressure > input_pressure
 
-		var/transfer_moles = pressure_delta*air2.volume/(air1.temperature * R_IDEAL_GAS_EQUATION)
+		var/transfer_moles = pressure_delta * air2.volume/(air1.temperature * R_IDEAL_GAS_EQUATION)
 
 		//Actually transfer the gas
 		var/datum/gas_mixture/removed = air1.remove(transfer_moles)

--- a/code/modules/atmospherics/machinery/components/binary_devices/passive_gate.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/passive_gate.dm
@@ -42,7 +42,7 @@
 		//Need at least 10 KPa difference to overcome friction in the mechanism
 		return 1
 
-	if(target_pressure >= input_starting_pressure-10)
+	if(target_pressure >= input_starting_pressure - 10)
 		//Gas will not pump if the input pressure is lower than the target
 		return 1
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This adds a requirement to passive gates that requires the input pressure to be above the target(pressure set in the UI) pressure in order for the gas to move. This adds functionality as a pressure control device for different pipe systems.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
As it stands, passive gates are pretty boring and aren't much different than pressure pumps. Besides passive gates not requiring power, both devices can be applied in almost the exact same instances with very minimal differences. Adding this requirement would allow for passive gates to be used as pressure control or overfill control on pipe networks if setup properly, allowing for a distinction between pressure pumps and passive gates. Pressure control can already be achieved using passive vents and some creative piping, but this would build the same functionality into an otherwise underused atmos pipe device. 
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Setup a test pipe network using a passive gate, checked that gas did not move when the target was above input, checked that the gas moved when target was below input, checked that the gas moved when the target was above output, checked that gas did not move when the target was above output. All worked. 
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Passive gates now require the input pressure to be above the set target pressure in order to move gas through the device.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
