### PR TITLE
mapmerge: one last fix for diff size

### DIFF
--- a/tools/mapmerge2/dmm.py
+++ b/tools/mapmerge2/dmm.py
@@ -56,6 +56,7 @@ class DMM:
     def set_tile(self, coord, tile):
         tile = tuple(tile)
         self.grid[coord] = self.get_or_generate_key(tile)
+        return self.grid[coord]
 
     def generate_new_key(self):
         self._ensure_free_keys(1)


### PR DESCRIPTION
## What Does This PR Do
Last PR for this I swear, and not urgent. This PR brings diff size back in line with before #22737. When testing against the Meta cryodorms/restroom swap I realized that more keys were being generated than I expected, and the diff ended up being a lot noisier. This is a better version of my original implementation.

## Why It's Good For The Game
Maps using the DMM merge driver will continue to have more straightforward diffs.

## Images of changes
~4,000 lines of the left versus ~400 lines on the right for the same map.
![2023_10_06__06_32_23__output3 diff - Paradise - Visual Studio Code](https://github.com/ParadiseSS13/Paradise/assets/59303604/869e5d13-ffac-4924-b97c-92da1e260210)

## Changelog
NPFC
