### PR TITLE
Fix: Anti-drop causing permanent nodrop items when dropped item picked up by user.

### DIFF
--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -112,10 +112,10 @@
 	active = FALSE
 	if(!l_hand_ignore && l_hand_obj)
 		if((l_hand_obj == owner.l_hand))
-			l_hand_obj.flags ^= NODROP
+			l_hand_obj.flags &= ~NODROP
 	if(!r_hand_ignore && r_hand_obj)
 		if(r_hand_obj == owner.r_hand)
-			r_hand_obj.flags ^= NODROP
+			r_hand_obj.flags &= ~NODROP
 
 /obj/item/organ/internal/cyberimp/brain/anti_drop/remove(mob/living/carbon/M, special = 0)
 	if(active)

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -110,12 +110,10 @@
 
 /obj/item/organ/internal/cyberimp/brain/anti_drop/proc/release_items()
 	active = FALSE
-	if(!l_hand_ignore && l_hand_obj)
-		if((l_hand_obj == owner.l_hand))
-			l_hand_obj.flags &= ~NODROP
-	if(!r_hand_ignore && r_hand_obj)
-		if(r_hand_obj == owner.r_hand)
-			r_hand_obj.flags &= ~NODROP
+	if(!l_hand_ignore && l_hand_obj && (l_hand_obj == owner.l_hand))
+		l_hand_obj.flags &= ~NODROP
+	if(!r_hand_ignore && r_hand_obj && (r_hand_obj == owner.r_hand))
+		r_hand_obj.flags &= ~NODROP
 
 /obj/item/organ/internal/cyberimp/brain/anti_drop/remove(mob/living/carbon/M, special = 0)
 	if(active)

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -110,10 +110,12 @@
 
 /obj/item/organ/internal/cyberimp/brain/anti_drop/proc/release_items()
 	active = FALSE
-	if(!l_hand_ignore && (l_hand_obj in owner.contents))
-		l_hand_obj.flags ^= NODROP
-	if(!r_hand_ignore && (r_hand_obj in owner.contents))
-		r_hand_obj.flags ^= NODROP
+	if(!l_hand_ignore && l_hand_obj)
+		if((l_hand_obj == owner.l_hand))
+			l_hand_obj.flags ^= NODROP
+	if(!r_hand_ignore && r_hand_obj)
+		if(r_hand_obj == owner.r_hand)
+			r_hand_obj.flags ^= NODROP
 
 /obj/item/organ/internal/cyberimp/brain/anti_drop/remove(mob/living/carbon/M, special = 0)
 	if(active)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes a bug where if an anti-drop user lost the item they were holding (Eg. it got amputated), picks it up with the other hand, then tried to relax the hand, causing the item to stay nodrop permanently.

Fixes: #22651
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Bug bad.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Hold an item, use antidrop, I can't drop the item, turn antidrop off, I can drop the item again.
Hold an item, use antidrop, cut off the hand holding the item, pick the item up with my other hand, turn antidrop off, I can still drop the item, turn antidrop on, I can no longer drop the item.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Anti-drop can no longer cause permanent nodrop items for its user.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
