### PR TITLE
Fixes dusting part 2

### DIFF
--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -324,7 +324,13 @@
 	var/atom/movable/M
 	for(var/thing in src)
 		M = thing
-		if(!M.anchored && !M.pulledby && M.last_high_pressure_movement_air_cycle < SSair.times_fired)
+		if(QDELETED(M))
+			continue
+		if(M.anchored)
+			continue
+		if(M.pulledby)
+			continue
+		if(M.last_high_pressure_movement_air_cycle < SSair.times_fired)
 			M.experience_pressure_difference(pressure_difference, pressure_direction)
 
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -5,6 +5,8 @@
 /mob/living/carbon/Destroy()
 	// This clause is here due to items falling off from limb deletion
 	for(var/obj/item in get_all_slots())
+		if(QDELETED(item))
+			continue
 		unEquip(item, silent = TRUE)
 		qdel(item)
 	QDEL_LIST_CONTENTS(internal_organs)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->This PR makes sure that objects that are on a human that are about to be qdel'd, aren't already qdel'd. Now you may think this may be a "roundabout" fix, but the real problem here is the objects about to be qdel'd have already been gotten from get_all_slots(). I've also made it so that qdel'd objects are not affected by atmos pressure differentials, this means if something like this happens again, we wont get infinite dusting because of SM atmos.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Fixes #22698

## Testing
<!-- How did you test the PR, if at all? -->
Dusted myself a lot.

## Changelog
:cl:
fix: Wearing a modsuit while being dusted on the SM will no longer cause the items to be infinitely stuck in a loop of dusting
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
