### PR TITLE
blackbox: record ruin placements

### DIFF
--- a/code/modules/awaymissions/zlevel_helpers.dm
+++ b/code/modules/awaymissions/zlevel_helpers.dm
@@ -78,7 +78,10 @@
 
 		var/map_filename = splittext(mappath, "/")
 		map_filename = map_filename[length(map_filename)]
-		SSblackbox.record_feedback("nested tally", "ruin_placement", 1, list(map_filename, "[central_turf.z]"))
+		SSblackbox.record_feedback("associative", "ruin_placement", 1, list(
+			"map" = map_filename,
+			"coords" = "[central_turf.x],[central_turf.y],[central_turf.z]"
+		))
 
 		return TRUE
 	return FALSE

--- a/code/modules/awaymissions/zlevel_helpers.dm
+++ b/code/modules/awaymissions/zlevel_helpers.dm
@@ -75,5 +75,10 @@
 			T.flags |= NO_RUINS
 
 		new /obj/effect/landmark/ruin(central_turf, src)
+
+		var/map_filename = splittext(mappath, "/")
+		map_filename = map_filename[length(map_filename)]
+		SSblackbox.record_feedback("nested tally", "ruin_placement", 1, list(map_filename, "[central_turf.z]"))
+
 		return TRUE
 	return FALSE


### PR DESCRIPTION
## What Does This PR Do
This adds an associated feedback of ruin filename -> placement coordinates to the feedback DB.

## Why It's Good For The Game
I want to get a better look at some aspects of ruin spawning, namely the practical rarity, duplication, and density of ruins in-game. If we record placement in this way we can also answer more interesting questions like "how many ruins with teleporters spawn on average in a given sector?" or "how many tiles on a space z-level are not ruins on average?"

Ruins and placement are logged in log_world but not in an easily consumable format and not accessible via parastats.

It also makes it easy for developers to sanity check if certain ruins are spawning or not.

Affected can make post-round maps of z-levels with this information, because we're not using enough storage on pictures of maps.

## Images of changes

![2023_10_07__15_11_01__Unnamed_paradise_gamedb_feedback_ - HeidiSQL 11 0 0 5919](https://github.com/ParadiseSS13/Paradise/assets/59303604/d813a421-fbf8-40cd-a3d2-5c89e1009e81)


## Testing
Ran rounds, checked DB.

## Changelog
NPFC
