### PR TITLE
Fixes TC amount for admin spawned Syndicate Infiltrator

### DIFF
--- a/code/datums/outfits/outfit_admin.dm
+++ b/code/datums/outfits/outfit_admin.dm
@@ -80,7 +80,7 @@
 	name = "Syndicate Infiltrator"
 
 /datum/outfit/admin/syndicate_infiltrator/equip(mob/living/carbon/human/H, visualsOnly = FALSE)
-	. = H.equip_syndicate_infiltrator(0, 20, FALSE)
+	. = H.equip_syndicate_infiltrator(0, 100, FALSE)
 	H.sec_hud_set_ID()
 	H.faction |= "syndicate"
 

--- a/code/modules/admin/verbs/infiltratorteam_syndicate.dm
+++ b/code/modules/admin/verbs/infiltratorteam_syndicate.dm
@@ -116,7 +116,7 @@ GLOBAL_VAR_INIT(sent_syndicate_infiltration_team, 0)
 
 // ---------------------------------------------------------------------------------------------------------
 
-/client/proc/create_syndicate_infiltrator(obj/spawn_location, syndicate_leader_selected = 0, uplink_tc = 20, is_mgmt = 0)
+/client/proc/create_syndicate_infiltrator(obj/spawn_location, syndicate_leader_selected = 0, uplink_tc = 100, is_mgmt = 0)
 	var/mob/living/carbon/human/new_syndicate_infiltrator = new(spawn_location.loc)
 
 	var/syndicate_infiltrator_name = random_name(pick(MALE,FEMALE))


### PR DESCRIPTION
## What Does This PR Do
This fixes the TC amount in hidden uplink when a Syndicate Infiltrator is created via the Select Equipment menu.
## Why It's Good For The Game
This accounts for the TC Inflation Adjustment. 
## Testing
Spawned a mob.
Used Select Equipment and selected Syndicate Infiltrator.
Checked the starting balance on hidden uplink.
## Changelog
:cl:
tweak: Tweaked the default TC value for admin spawned syndicate infiltrators
/:cl: