### PR TITLE
Removes a number of items from being able to be rolled by surplus crates.

### DIFF
--- a/code/datums/uplink_items/uplink_general.dm
+++ b/code/datums/uplink_items/uplink_general.dm
@@ -215,6 +215,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "CH"
 	item = /obj/item/butcher_chainsaw
 	cost = 65
+	surplus = 0 // This has caused major problems with un-needed chainsaw massacres. Bwoink bait.
 
 /datum/uplink_item/dangerous/universal_gun_kit
 	name = "Universal Self Assembling Gun Kit"
@@ -242,6 +243,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "10MM"
 	item = /obj/item/ammo_box/magazine/m10mm
 	cost = 5
+	surplus = 0 // Miserable
 
 /datum/uplink_item/ammo/pistolap
 	name = "Stechkin - 10mm Armour Piercing Magazine"
@@ -249,6 +251,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "10MMAP"
 	item = /obj/item/ammo_box/magazine/m10mm/ap
 	cost = 10
+	surplus = 0 // Miserable
 
 /datum/uplink_item/ammo/pistolfire
 	name = "Stechkin - 10mm Incendiary Magazine"
@@ -256,6 +259,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "10MMFIRE"
 	item = /obj/item/ammo_box/magazine/m10mm/fire
 	cost = 10
+	surplus = 0 // Miserable
 
 /datum/uplink_item/ammo/pistolhp
 	name = "Stechkin - 10mm Hollow Point Magazine"
@@ -263,6 +267,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "10MMHP"
 	item = /obj/item/ammo_box/magazine/m10mm/hp
 	cost = 10
+	surplus = 0 // Miserable
 
 /datum/uplink_item/ammo/revolver
 	name = ".357 Revolver - Speedloader"
@@ -270,6 +275,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "357"
 	item = /obj/item/ammo_box/a357
 	cost = 15
+	surplus = 0 // Miserable
 
 // STEALTHY WEAPONS
 
@@ -344,6 +350,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "TPB"
 	item = /obj/item/reagent_containers/glass/bottle/traitor
 	cost = 10
+	surplus = 0 // Requires another item to function.
 
 /datum/uplink_item/stealthy_weapons/silencer
 	name = "Universal Suppressor"
@@ -528,6 +535,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "SCK"
 	item = /obj/item/storage/box/syndie_kit/safecracking
 	cost = 5
+	surplus = 0 // Far too objective specific.
 
 /datum/uplink_item/stealthy_tools/handheld_mirror
 	name = "Hand Held Mirror"

--- a/code/datums/uplink_items/uplink_traitor.dm
+++ b/code/datums/uplink_items/uplink_traitor.dm
@@ -66,6 +66,7 @@
 	item = /obj/item/storage/box/syndie_kit/mimery
 	cost = 50
 	job = list("Mime")
+	surplus = 0 // I feel this just isn't healthy to be in these crates.
 
 /datum/uplink_item/jobspecific/combat_baking
 	name = "Combat Bakery Kit"
@@ -83,6 +84,7 @@
 	item = /obj/item/borg/upgrade/modkit/indoors
 	cost = 25 //you need two for full damage, so total of 50 for maximum damage
 	job = list("Shaft Miner")
+	surplus = 0 // Requires a KA to even be used.
 
 //Chef
 /datum/uplink_item/jobspecific/specialsauce
@@ -92,6 +94,7 @@
 	item = /obj/item/reagent_containers/food/condiment/syndisauce
 	cost = 10
 	job = list("Chef")
+	surplus = 0 // Far too specific in its use.
 
 /datum/uplink_item/jobspecific/meatcleaver
 	name = "Meat Cleaver"
@@ -118,6 +121,7 @@
 	item = /obj/item/storage/box/syndie_kit/missionary_set
 	cost = 75
 	job = list("Chaplain")
+	surplus = 0 // Controversial maybe, but with the ease of mindslaving with this item I'd prefer it stay chaplain specific.
 
 /datum/uplink_item/jobspecific/artistic_toolbox
 	name = "His Grace"
@@ -260,6 +264,7 @@
 	item = /obj/item/seeds/ambrosia/cruciatus
 	cost = 5
 	job = list("Botanist")
+	surplus = 0 // Even botanists would struggle to use this effectively, nevermind a coroner.
 
 //Atmos Tech
 /datum/uplink_item/jobspecific/contortionist
@@ -393,6 +398,7 @@
 	cost = 60
 	refund_path = /obj/item/guardiancreator/tech/choose
 	refundable = TRUE
+	surplus = 0 // This being refundable makes this a big no no in my mind.
 	cant_discount = TRUE
 
 /datum/uplink_item/stealthy_weapons/martialarts
@@ -474,6 +480,7 @@
 	reference = "DRL"
 	item = /obj/item/thermal_drill/syndicate
 	cost = 5
+	surplus = 0 // I feel like its amazing for one objective and one objective only. Far too specific.
 	excludefrom = list(UPLINK_TYPE_NUCLEAR, UPLINK_TYPE_SST)
 
 /datum/uplink_item/suits/modsuit


### PR DESCRIPTION

![image](https://github.com/ParadiseSS13/Paradise/assets/85680653/f39d17d5-26b1-4c0c-8dd8-456e596a6638)


## What Does This PR Do
Removes the following items from being able to be rolled by surplus crates.

The list is as follows.

- Ambrosia Cruciatus Seeds
- Boozey Shotgun Shells
- Meat Cleaver
- Chef Excellence's Special Sauce
- Kinetic Accelerator Pressure Mod
- Guide to Advanced Mimery Series
- Safe-cracking Kit
- Poison Bottle
- .357 Revolver - Speedloader
- Stechkin - 10mm Hollow Point Magazine
- Stechkin - 10mm Incendiary Magazine
- Stechkin - 10mm Armour Piercing Magazine
- Stechkin - 10mm Magazine
- Chainsaw
- Missionary Starter Kit
- The E20
- Holoparasites
- Amplifying Thermal Safe Drill

## Why It's Good For The Game
For a good while, surplus crates have been a bit two-fold. Rather they are utterly trash, useless and barely usable by whichever traitor or team or traitors that have bought them, or they are the least balanaced, most murderbone kits you have ever seen.
Currently there are a good amount of items such as the chainsaw or meat cleaver that can round remove people by mistake, e20s that can do hijack level damage in one accidental throw, stetchkin ammo- completely unused due to the lack of a stetchkin or a holoparasite injector you can just refund for free adrenals alongside your powerfist, elite modsuit, stealth implant kit.

This PR overall makes surplus crates on the whole... Better, but lowers the overall power level of them. I hope it makes them less of a problem.

## Testing
I bought a lot of surplus crates and recoiled in misery at round balance.

## Changelog
:cl:
tweak: Surplus crate contents have been tweaked with certain louder, job specific traitor items, poisons and ammunition no longer being able to be rolled by the crate.
/:cl:
