### PR TITLE
makes caves only narrow on blocked burrows

### DIFF
--- a/code/game/turfs/simulated/floor/asteroid_floors.dm
+++ b/code/game/turfs/simulated/floor/asteroid_floors.dm
@@ -253,7 +253,7 @@ GLOBAL_LIST_INIT(megafauna_spawn_list, list(/mob/living/simple_animal/hostile/me
 			break
 
 		var/list/L = list(45)
-		if(ISODD(dir2angle(dir)) && (!SSmapping.cave_theme == BLOCKED_BURROWS || prob(33))) // We're going at an angle and we want thick angled tunnels.
+		if(ISODD(dir2angle(dir)) && SSmapping.cave_theme == BLOCKED_BURROWS) // We're going at an angle and we want thick angled tunnels.
 			L += -45
 
 		// Expand the edges of our tunnel

--- a/code/game/turfs/simulated/floor/asteroid_floors.dm
+++ b/code/game/turfs/simulated/floor/asteroid_floors.dm
@@ -253,7 +253,7 @@ GLOBAL_LIST_INIT(megafauna_spawn_list, list(/mob/living/simple_animal/hostile/me
 			break
 
 		var/list/L = list(45)
-		if(ISODD(dir2angle(dir)) && SSmapping.cave_theme == BLOCKED_BURROWS) // We're going at an angle and we want thick angled tunnels.
+		if(ISODD(dir2angle(dir)) && (!(SSmapping.cave_theme == BLOCKED_BURROWS) || prob(15)))
 			L += -45
 
 		// Expand the edges of our tunnel


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Caves no longer have a 33% chance to be skinny for a tile when going sideways on map generation rules other than Blocked Burrows
Blocked burrows now have a 15% chance per diagonal path to have a tile to be wider. Basically makes it look a little more natural.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

The idea was 1/3 diagonal paths would be skinny. The outcome is 1/3 diagonal tiles is skinny. Looks strange and basically makes everything a bit blocked in that regard. So I'll change this back.

Instead, some tiles on blocked burrows will be wider now and then. Not the entire cave, just sections. Looks a little more natural, at  least when it comes to what you can do with square tiles.

## Testing
<!-- How did you test the PR, if at all? -->

Confirmed caves looked normal. After struggling before realising if(!A == B) is not the same as if(!(A == B))

## Changelog
:cl:
tweak: Makes caves only narrow on blocked burrows. (AKA classic caves generates like before)
tweak: Blocked burrows diagonal caves are now slightly wider randomly to look better
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
