### PR TITLE
make surge better / surge and crank no longer boil people and perma confuse

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drugs.dm
+++ b/code/modules/reagents/chemistry/reagents/drugs.dm
@@ -186,8 +186,8 @@
 		M.emote(pick("laugh", "giggle"))
 	if(prob(5 * DRAWBACK_CHANCE_MODIFIER(recent_consumption)))
 		to_chat(M, "<span class='notice'>You feel warm.</span>") // fever, gets worse with volume
-		M.bodytemperature += 30 * recent_consumption
-		M.Confused(1 SECONDS * recent_consumption) //let us see how this feels
+		M.bodytemperature += 30 * DRAWBACK_CHANCE_MODIFIER(recent_consumption * 2)
+		M.Confused(1 SECONDS * DRAWBACK_CHANCE_MODIFIER(recent_consumption * 2)) //let us see how this feels
 
 	if(prob(4))
 		to_chat(M, "<span class='notice'>You feel kinda awful!</span>")
@@ -902,8 +902,8 @@
 		to_chat(M, "<span class='notice'>[high_message]</span>")
 	if(prob(5 * DRAWBACK_CHANCE_MODIFIER(recent_consumption)))
 		to_chat(M, "<span class='notice'>Your circuits overheat!</span>") // synth fever
-		M.bodytemperature += 30 * recent_consumption
-		M.Confused(2 SECONDS * recent_consumption)
+		M.bodytemperature += 30 * DRAWBACK_CHANCE_MODIFIER(recent_consumption * 2)
+		M.Confused(1 SECONDS * DRAWBACK_CHANCE_MODIFIER(recent_consumption * 2))
 
 	return ..() | update_flags
 
@@ -966,8 +966,8 @@
 	M.Stuttering(10 SECONDS)
 	if(prob(5 * DRAWBACK_CHANCE_MODIFIER(recent_consumption)))
 		to_chat(M, "<span class='notice'>Your circuits overheat!</span>") // synth fever
-		M.bodytemperature += 30 * recent_consumption
-		M.Confused(2 SECONDS * recent_consumption)
+		M.bodytemperature += 30 * DRAWBACK_CHANCE_MODIFIER(recent_consumption * 2)
+		M.Confused(1 SECONDS * DRAWBACK_CHANCE_MODIFIER(recent_consumption * 2))
 	if(prob(10))
 		to_chat(M, "<span class='danger'>You experience a violent electrical discharge!</span>")
 		playsound(get_turf(M), 'sound/effects/eleczap.ogg', 75, TRUE)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Surge now matches crank in confusion, being equal drugs, one just ipc.
Confusion / heat on surge and crank scale 5x slower

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Surge and crank should be identical.
For context:
Surge before this pr would confuse people for 20 seconds and add 300 to body tempature after 10 units. After 20 units, 40 seconds and 600 tempature with a prob 20. It was insane, and needed drastic tuning down.

## Testing
<!-- How did you test the PR, if at all? -->

Confirmed drugs felt good.
And by good I mean downsides being reasonable

## Changelog
:cl:
fix: Surge and cranks downside mirrors each other again.
tweak: Crank / surge now scale heat and confusion more reasonably
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
