### PR TITLE
Gives Engineering ERTs Rapid Pipe Dispensers

### DIFF
--- a/code/modules/response_team/ert_outfits.dm
+++ b/code/modules/response_team/ert_outfits.dm
@@ -233,7 +233,8 @@
 		/obj/item/t_scanner = 1,
 		/obj/item/stack/sheet/glass/fifty = 1,
 		/obj/item/stack/sheet/metal/fifty = 1,
-		/obj/item/flashlight = 1
+		/obj/item/flashlight = 1,
+		/obj/item/rpd = 1
 	)
 
 	cybernetic_implants = list(
@@ -254,7 +255,8 @@
 	backpack_contents = list(
 		/obj/item/rcd/preloaded = 1,
 		/obj/item/rcd_ammo = 3,
-		/obj/item/gun/energy/gun = 1
+		/obj/item/gun/energy/gun = 1,
+		/obj/item/rpd = 1
 	)
 
 	cybernetic_implants = list(
@@ -280,7 +282,8 @@
 	backpack_contents = list(
 		/obj/item/rcd/combat = 1,
 		/obj/item/rcd_ammo/large = 3,
-		/obj/item/gun/energy/gun/blueshield/pdw9 = 1
+		/obj/item/gun/energy/gun/blueshield/pdw9 = 1,
+		/obj/item/rpd = 1
 	)
 
 	cybernetic_implants = list(


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Gives all engineering ERTs (amber, red, and gamma) an RPD in their bag. 
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Engineering ERTs should be able to fix up the atmos pipes alongside their other work without shelling out for the ridiculously expensive autolathe cost for an RPD. This will let them fully do their job without robbing the station of materials or the atmos lockers and avoid the pain of hunting down scattered pipes. 
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://github.com/ParadiseSS13/Paradise/assets/107899953/2d38ed06-a195-449b-8004-696ffd1143ab)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Spawned in all three engineering ERTs and checked their bags for RPDs
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: All levels of Engineering ERTs now spawn with an RPD.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
