### PR TITLE
Drones now have pacifism + You can click on a drone fab as a ghost to become a drone

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
@@ -82,7 +82,7 @@
 	drone_progress = 0
 
 /obj/machinery/drone_fabricator/attack_ghost(mob/user as mob)
-	if(!drone_prepared() && isobserver(user))
+	if(!drone_prepared() || !isobserver(user))
 		return
 	var/mob/dead/observer/ghost = user
 	ghost.join_as_drone()

--- a/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
@@ -53,7 +53,7 @@
 		. += "<BR><B>A drone is prepared. Select 'Join As Drone' from the Ghost tab to spawn as a maintenance drone.</B>"
 
 /obj/machinery/drone_fabricator/proc/drone_prepared()
-	return (produce_drones && drone_progress >= 100 && count_drones() < MAX_MAINT_DRONES)
+	return (produce_drones && drone_progress >= 100 && (count_drones() < MAX_MAINT_DRONES))
 
 /obj/machinery/drone_fabricator/proc/count_drones()
 	var/drones = 0

--- a/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
@@ -49,8 +49,11 @@
 
 /obj/machinery/drone_fabricator/examine(mob/user)
 	. = ..()
-	if(produce_drones && drone_progress >= 100 && isobserver(user) && count_drones() < MAX_MAINT_DRONES)
+	if(isobserver(user) && drone_prepared())
 		. += "<BR><B>A drone is prepared. Select 'Join As Drone' from the Ghost tab to spawn as a maintenance drone.</B>"
+
+/obj/machinery/drone_fabricator/proc/drone_prepared()
+	return (produce_drones && drone_progress >= 100 && count_drones() < MAX_MAINT_DRONES)
 
 /obj/machinery/drone_fabricator/proc/count_drones()
 	var/drones = 0
@@ -78,7 +81,11 @@
 
 	drone_progress = 0
 
-
+/obj/machinery/drone_fabricator/attack_ghost(mob/user as mob)
+	if(!drone_prepared() && isobserver(user))
+		return
+	var/mob/dead/observer/ghost = user
+	ghost.join_as_drone()
 
 /mob/dead/verb/join_as_drone()
 	set category = "Ghost"

--- a/code/modules/mob/living/silicon/robot/drone/maint_drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/maint_drone.dm
@@ -99,6 +99,9 @@
 	scanner.Grant(src)
 	update_icons()
 
+	// Drones have laws to not attack people
+	ADD_TRAIT(src, TRAIT_PACIFISM, INNATE_TRAIT)
+
 /mob/living/silicon/robot/drone/init(alien = FALSE, mob/living/silicon/ai/ai_to_sync_to = null)
 	laws = new /datum/ai_laws/drone()
 	connected_ai = null
@@ -234,6 +237,7 @@
 	clear_supplied_laws()
 	clear_inherent_laws()
 	laws = new /datum/ai_laws/syndicate_override
+	REMOVE_TRAIT(src, TRAIT_PACIFISM, INNATE_TRAIT)
 	set_zeroth_law("Only [H.real_name] and people [H.real_name] designates as being such are Syndicate Agents.")
 
 	to_chat(src, "<b>Obey these laws:</b>")


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->Drones now have pacifism (except when emagged). As an observer, you can now click on a drone fabricator to become a drone.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Drones have laws that are meant to stop them from attacking people at all, but we don't use the in-code system that stops that. This fixes that. Also, QOL for becoming a drone by clicking on the fab.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
<!-- How did you test the PR, if at all? -->
Clicked on the fabricator as a ghost, became a drone.
Tried to attack a skrell, couldnt.
Tried to repair a damaged drone on help intent, and I could.
Had the skrell emag the drone, and now as a drone I could attack people.

## Changelog
:cl:
tweak: Maintenance Drones are now pacificists
tweak: Observers can click on the drone fabricator to become a drone.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
