### PR TITLE
Adds Burzah to the Review Team in Documentation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -758,6 +758,7 @@ Each role inherits the lower role's responsibilities (IE: Headcoders also have c
 * [S34N](https://github.com/S34NW)
 * [Sirryan2002](https://github.com/Sirryan2002)
 * [Contrabang](https://github.com/Contrabang)
+* [Burzah](https://github.com/Burzah)
 
 ---
 


### PR DESCRIPTION
## What Does This PR Do
Adds Burza as a member of the Review Team in the documentation.
## Why It's Good For The Game
Updates documentation to reflect team addition accurately. 
## Testing
Examined file for appropriate information.
## Changelog
**@Burzah**