### PR TITLE
Adds 1911 ammo & gun crates. Makes the autolathe and said guns use non-stamina damage bullets.

### DIFF
--- a/code/modules/projectiles/ammunition/ammo_boxes.dm
+++ b/code/modules/projectiles/ammunition/ammo_boxes.dm
@@ -34,7 +34,7 @@
 	name = "ammo box (.45)"
 	icon_state = "45box"
 	origin_tech = "combat=2"
-	ammo_type = /obj/item/ammo_casing/c45
+	ammo_type = /obj/item/ammo_casing/c45/nostamina
 	max_ammo = 20
 
 /obj/item/ammo_box/rubber45

--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -225,7 +225,7 @@
 /obj/item/ammo_box/magazine/m45
 	name = "handgun magazine (.45)"
 	icon_state = "45"
-	ammo_type = /obj/item/ammo_casing/c45
+	ammo_type = /obj/item/ammo_casing/c45/nostamina
 	caliber = ".45"
 	max_ammo = 8
 	multi_sprite_step = 1

--- a/code/modules/supply/supply_packs/pack_security.dm
+++ b/code/modules/supply/supply_packs/pack_security.dm
@@ -259,9 +259,8 @@
 /datum/supply_packs/security/armory/m1911
 	name = "M1911 Pistol Crate"
 	contains = list(/obj/item/gun/projectile/automatic/pistol/m1911,
-					/obj/item/gun/projectile/automatic/pistol/m1911,
 					/obj/item/gun/projectile/automatic/pistol/m1911)
-	cost = 500
+	cost = 800
 	containername = "1911 crate"
 	contraband = TRUE
 
@@ -270,10 +269,8 @@
 	contains = list(/obj/item/ammo_box/magazine/m45,
 					/obj/item/ammo_box/magazine/m45,
 					/obj/item/ammo_box/magazine/m45,
-					/obj/item/ammo_box/magazine/m45,
-					/obj/item/ammo_box/magazine/m45,
 					/obj/item/ammo_box/magazine/m45)
-	cost = 400
+	cost = 600
 	containername = "1911 ammo crate"
 	contraband = TRUE
 

--- a/code/modules/supply/supply_packs/pack_security.dm
+++ b/code/modules/supply/supply_packs/pack_security.dm
@@ -256,6 +256,27 @@
 	cost = 500
 	containername = "auto rifle ammo crate"
 
+/datum/supply_packs/security/armory/m1911
+	name = "M1911 Pistol Crate"
+	contains = list(/obj/item/gun/projectile/automatic/pistol/m1911,
+					/obj/item/gun/projectile/automatic/pistol/m1911,
+					/obj/item/gun/projectile/automatic/pistol/m1911,)
+	cost = 500
+	containername = "1911 crate"
+	contraband = TRUE
+
+/datum/supply_packs/security/armory/m1911ammo
+	name = "M1911 Ammo Crate"
+	contains = list(/obj/item/ammo_box/magazine/m45,
+					/obj/item/ammo_box/magazine/m45,
+					/obj/item/ammo_box/magazine/m45,
+					/obj/item/ammo_box/magazine/m45,
+					/obj/item/ammo_box/magazine/m45,
+					/obj/item/ammo_box/magazine/m45,)
+	cost = 400
+	containername = "1911 ammo crate"
+	contraband = TRUE
+
 /datum/supply_packs/security/armory/laserrifle
 	name = "IK-30 Security Laser Rifle Crate"
 	contains = list(/obj/item/gun/projectile/automatic/laserrifle,

--- a/code/modules/supply/supply_packs/pack_security.dm
+++ b/code/modules/supply/supply_packs/pack_security.dm
@@ -272,7 +272,7 @@
 					/obj/item/ammo_box/magazine/m45,
 					/obj/item/ammo_box/magazine/m45,
 					/obj/item/ammo_box/magazine/m45,
-					/obj/item/ammo_box/magazine/m45,)
+					/obj/item/ammo_box/magazine/m45)
 	cost = 400
 	containername = "1911 ammo crate"
 	contraband = TRUE

--- a/code/modules/supply/supply_packs/pack_security.dm
+++ b/code/modules/supply/supply_packs/pack_security.dm
@@ -260,7 +260,7 @@
 	name = "M1911 Pistol Crate"
 	contains = list(/obj/item/gun/projectile/automatic/pistol/m1911,
 					/obj/item/gun/projectile/automatic/pistol/m1911,
-					/obj/item/gun/projectile/automatic/pistol/m1911,)
+					/obj/item/gun/projectile/automatic/pistol/m1911)
 	cost = 500
 	containername = "1911 crate"
 	contraband = TRUE


### PR DESCRIPTION
## What Does This PR Do
Adds 1911 gun and ammo crates to cargo, as contraband under the Security tab.

Swaps the .45 ammo in the autolathe and said crates to the non-stamina damage version.

## Why It's Good For The Game
M1911s are really damn cool. 

For a mildly better reason, this gives a neat sidegrade to the WT for officers who'd rather be RP'ing 1980s Miami Vice. Also useful for traitors or QMs who want to arm their goons with the finest pistol America has to offer.

## Testing
- Loaded in
- Multitooled the cargo console board
- Ordered crates 
- Opened crates
- Acquired firepower
- Shot tajaran (stamina damage is gone)
- Printed .45 ammo
- Shot tajaran again (still no stamina damage)

## Changelog
:cl:
add: Added 1911 ammunition and gun crates to cargo
tweak: Swapped the .45 ammo in the autolathe and the 1911 to non-stamina damage variant 
/:cl: