### PR TITLE
LWAP beams will now penetrate infinitely

### DIFF
--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -197,6 +197,11 @@
 	forcedodge = 1 // Can pierce one mob.
 	speed = 0.5
 
+/obj/item/projectile/beam/laser/sniper/pierce/prehit(atom/target)
+    if(isturf(target) && !forcedodge)
+        forcedodge++ //Increases force dodge before turf consumes it.
+    ..()
+
 /obj/item/gun/energy/xray
 	name = "xray laser gun"
 	desc = "A high-power laser gun capable of expelling concentrated xray blasts. These blasts will penetrate solid objects, but will decrease in power the longer they have to travel."


### PR DESCRIPTION
## What Does This PR Do
This PR increases LWAP beam penetration (when zoomed in) to not have a limit on the amount of walls it penetrates (up until the projectile travels its full length)

Code courtesy of Qwerty.

## Why It's Good For The Game
The LWAP currently often lags behind other RND weapons, with the ray gun fulfilling its niche much better due to its ability to angle through walls more effectively.

While doors, vending machines, consoles and other such machines will still prove a difficulty for the weapon, this may help it fulfill its niche more effectively.

## Testing
I shot a lot of skrell in locations I previously could not shoot them, from angles I could not hit from prior to this PR.

## Changelog
:cl:
tweak: LWAP projectiles no longer have a limit to the number of walls they penetrate through.
/:cl: