### PR TITLE
adds a pulse demon demon heart

### DIFF
--- a/code/game/gamemodes/miniantags/demons/shadow_demon/shadow_demon.dm
+++ b/code/game/gamemodes/miniantags/demons/shadow_demon/shadow_demon.dm
@@ -215,6 +215,6 @@
 		M.mind.AddSpell(new /obj/effect/proc_holder/spell/fireball/shadow_grapple)
 
 /obj/item/organ/internal/heart/demon/shadow/remove(mob/living/carbon/M, special = 0)
-	..()
+	. = ..()
 	if(M.mind)
 		M.mind.RemoveSpell(/obj/effect/proc_holder/spell/fireball/shadow_grapple)

--- a/code/game/gamemodes/miniantags/demons/slaughter demon/slaughter.dm
+++ b/code/game/gamemodes/miniantags/demons/slaughter demon/slaughter.dm
@@ -257,7 +257,7 @@
 		M.mind.AddSpell(new /obj/effect/proc_holder/spell/bloodcrawl(null))
 
 /obj/item/organ/internal/heart/demon/slaughter/remove(mob/living/carbon/M, special = 0)
-	..()
+	. = ..()
 	if(M.mind)
 		REMOVE_TRAIT(M, TRAIT_BLOODCRAWL, "bloodcrawl")
 		REMOVE_TRAIT(M, TRAIT_BLOODCRAWL_EAT, "bloodcrawl_eat")

--- a/code/game/gamemodes/miniantags/pulsedemon/cross_shock_component.dm
+++ b/code/game/gamemodes/miniantags/pulsedemon/cross_shock_component.dm
@@ -1,0 +1,47 @@
+/datum/component/cross_shock
+	var/shock_damage
+	var/energy_cost
+	var/delay_between_shocks
+	var/requires_cable
+	COOLDOWN_DECLARE(last_shock)
+
+/datum/component/cross_shock/Initialize(_shock_damage, _energy_cost, _delay_between_shocks, _requires_cable = TRUE)
+	if(ismovable(parent))
+		RegisterSignal(parent, list(COMSIG_MOVABLE_CROSSED, COMSIG_CROSSED_MOVABLE), PROC_REF(do_shock))
+	else if(isarea(parent))
+		RegisterSignal(parent, COMSIG_ATOM_EXITED, PROC_REF(do_shock))
+	else if(isturf(parent))
+		RegisterSignal(parent, COMSIG_ATOM_ENTERED, PROC_REF(do_shock))
+	else
+		return COMPONENT_INCOMPATIBLE
+
+	shock_damage = _shock_damage
+	energy_cost = _energy_cost
+	delay_between_shocks = _delay_between_shocks
+	requires_cable = _requires_cable
+
+/datum/component/cross_shock/proc/do_shock(datum/source, mob/living/thing_were_gonna_shock)
+	SIGNAL_HANDLER
+	if(!COOLDOWN_FINISHED(src, last_shock))
+		return
+	if(!istype(thing_were_gonna_shock))
+		return
+	if(isliving(parent))
+		var/mob/living/M = parent
+		if(M.stat == DEAD || !IS_HORIZONTAL(M))
+			return
+	if(requires_cable)
+		var/turf/our_turf = get_turf(parent)
+		if(our_turf.transparent_floor || our_turf.intact || HAS_TRAIT(our_turf, TRAIT_TURF_COVERED))
+			return
+		var/obj/structure/cable/our_cable =	locate(/obj/structure/cable) in our_turf
+		if(!our_cable || !our_cable.powernet || !our_cable.powernet.available_power)
+			return
+		var/area/to_deduct_from = get_area(our_cable)
+		thing_were_gonna_shock.electrocute_act(shock_damage, src)
+		to_deduct_from.powernet.use_active_power(energy_cost)
+		playsound(get_turf(parent), 'sound/effects/eleczap.ogg', 30, TRUE)
+	else
+		thing_were_gonna_shock.electrocute_act(shock_damage, src)
+		playsound(get_turf(parent), 'sound/effects/eleczap.ogg', 30, TRUE)
+	COOLDOWN_START(src, last_shock, delay_between_shocks)

--- a/code/game/gamemodes/miniantags/pulsedemon/cross_shock_component.dm
+++ b/code/game/gamemodes/miniantags/pulsedemon/cross_shock_component.dm
@@ -8,6 +8,8 @@
 /datum/component/cross_shock/Initialize(_shock_damage, _energy_cost, _delay_between_shocks, _requires_cable = TRUE)
 	if(ismovable(parent))
 		RegisterSignal(parent, list(COMSIG_MOVABLE_CROSSED, COMSIG_CROSSED_MOVABLE), PROC_REF(do_shock))
+		if(ismob(parent))
+			RegisterSignal(parent, COMSIG_CARBON_LOSE_ORGAN, PROC_REF(on_organ_removal))
 	else if(isarea(parent))
 		RegisterSignal(parent, COMSIG_ATOM_EXITED, PROC_REF(do_shock))
 	else if(isturf(parent))
@@ -45,3 +47,7 @@
 		thing_were_gonna_shock.electrocute_act(shock_damage, src)
 		playsound(get_turf(parent), 'sound/effects/eleczap.ogg', 30, TRUE)
 	COOLDOWN_START(src, last_shock, delay_between_shocks)
+
+/datum/component/cross_shock/proc/on_organ_removal(datum/source)
+	SIGNAL_HANDLER
+	qdel(src)

--- a/code/game/gamemodes/miniantags/pulsedemon/pulsedemon.dm
+++ b/code/game/gamemodes/miniantags/pulsedemon/pulsedemon.dm
@@ -51,6 +51,7 @@
 	has_unlimited_silicon_privilege = TRUE
 	// this makes the demon able to speak through holopads, due to the overriden say, PD cannot speak normally regardless
 	universal_speak = TRUE
+	loot = list(/obj/item/organ/internal/heart/demon/pulse)
 
 	/// List of sounds that is picked from when the demon speaks.
 	var/list/speech_sounds = list("sound/voice/pdvoice1.ogg", "sound/voice/pdvoice2.ogg", "sound/voice/pdvoice3.ogg")
@@ -802,6 +803,32 @@
 
 /mob/living/simple_animal/demon/pulse_demon/mob_has_gravity()
 	return TRUE
+
+/obj/item/organ/internal/heart/demon/pulse
+	name = "perpetual pacemaker"
+	desc = "It still beats furiously, thousands of bright lights shine within it."
+	color = COLOR_YELLOW
+
+/obj/item/organ/internal/heart/demon/pulse/Initialize(mapload)
+	. = ..()
+	set_light(20, 2, "#bbbb00")
+
+/obj/item/organ/internal/heart/demon/pulse/attack_self(mob/living/user)
+	. = ..()
+	user.drop_item()
+	insert(user)
+
+/obj/item/organ/internal/heart/demon/pulse/insert(mob/living/carbon/M, special, dont_remove_slot)
+	. = ..()
+	M.AddComponent(/datum/component/cross_shock, 30, 500, 2 SECONDS)
+	ADD_TRAIT(M, TRAIT_SHOCKIMMUNE, UNIQUE_TRAIT_SOURCE(src))
+	M.set_light(3, 2, "#bbbb00")
+
+/obj/item/organ/internal/heart/demon/pulse/remove(mob/living/carbon/M, special)
+	..()
+	qdel(M.GetComponent(/datum/component/cross_shock))
+	REMOVE_TRAIT(M, TRAIT_SHOCKIMMUNE, UNIQUE_TRAIT_SOURCE(src))
+	M.remove_light()
 
 /obj/screen/alert/pulse_nopower
 	name = "No Power"

--- a/code/game/gamemodes/miniantags/pulsedemon/pulsedemon.dm
+++ b/code/game/gamemodes/miniantags/pulsedemon/pulsedemon.dm
@@ -811,7 +811,7 @@
 
 /obj/item/organ/internal/heart/demon/pulse/Initialize(mapload)
 	. = ..()
-	set_light(20, 2, "#bbbb00")
+	set_light(13, 2, "#bbbb00")
 
 /obj/item/organ/internal/heart/demon/pulse/attack_self(mob/living/user)
 	. = ..()
@@ -825,10 +825,21 @@
 	M.set_light(3, 2, "#bbbb00")
 
 /obj/item/organ/internal/heart/demon/pulse/remove(mob/living/carbon/M, special)
-	..()
-	qdel(M.GetComponent(/datum/component/cross_shock))
+	. = ..()
 	REMOVE_TRAIT(M, TRAIT_SHOCKIMMUNE, UNIQUE_TRAIT_SOURCE(src))
 	M.remove_light()
+
+/obj/item/organ/internal/heart/demon/pulse/on_life()
+	if(!owner)
+		return
+	for(var/obj/item/stock_parts/cell/cell_to_charge in owner.GetAllContents())
+		var/newcharge = min(0.05 * cell_to_charge.maxcharge + cell_to_charge.charge, cell_to_charge.maxcharge)
+		if(cell_to_charge.charge < newcharge)
+			cell_to_charge.charge = newcharge
+			if(isobj(cell_to_charge.loc))
+				var/obj/cell_location = cell_to_charge.loc
+				cell_location.update_icon() //update power meters and such
+			cell_to_charge.update_icon()
 
 /obj/screen/alert/pulse_nopower
 	name = "No Power"

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -50,6 +50,7 @@
 /obj/item/organ/internal/remove(mob/living/carbon/M, special = 0)
 	if(!owner)
 		stack_trace("\'remove\' called on [src] without an owner! Mob: [M], [atom_loc_line(M)]")
+	SEND_SIGNAL(owner, COMSIG_CARBON_LOSE_ORGAN)
 	owner = null
 	if(M)
 		M.internal_organs -= src

--- a/paradise.dme
+++ b/paradise.dme
@@ -682,6 +682,7 @@
 #include "code\game\gamemodes\miniantags\morph\spells\open_vent.dm"
 #include "code\game\gamemodes\miniantags\morph\spells\pass_airlock.dm"
 #include "code\game\gamemodes\miniantags\morph\spells\reproduce.dm"
+#include "code\game\gamemodes\miniantags\pulsedemon\cross_shock_component.dm"
 #include "code\game\gamemodes\miniantags\pulsedemon\pulsedemon.dm"
 #include "code\game\gamemodes\miniantags\pulsedemon\pulsedemon_abilities.dm"
 #include "code\game\gamemodes\miniantags\pulsedemon\pulsedemon_event.dm"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
adds a pulse demon demon heart, the perpetual pacemaker
Functions as a very powerful light source if you refuse to eat it, but if you do you gain the following stats:
1. A nerfed version of the pulse demons shock
2. A slow recharge on cells within your person
3. Shock immunity
4. A permanent glow around yourself 

This, like the other hearts is just recolored using the color var

## Why It's Good For The Game
We do this for all the other demons, why not pulse? Gives wizards for example more to do and a crew member can put this to good use if they get access to it. It's also easy to miss a pulsedemon death so this fixes that

## Testing
millions of skrells were turned into fried seafood today

## Changelog
:cl:
tweak: adds a pulse demon demon heart, the perpetual pacemaker 
fix: fixes demon hearts being nulled when removed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
