### PR TITLE
Shuttles transit copies color and lights from turfs properly

### DIFF
--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -991,8 +991,13 @@
 	if(T.icon != icon)
 		T.icon = icon
 	if(color)
-		T.atom_colours = atom_colours.Copy()
-		T.update_atom_colour()
+		if(length(atom_colours))
+			T.atom_colours = atom_colours.Copy()
+			T.update_atom_colour()
+		else
+			T.color = color // If you don't have atom_colours then you're working off an absolute color
+	if(light)
+		T.set_light(light_range, light_power, light_color)
 	if(T.dir != dir)
 		T.setDir(dir)
 	return T


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes shuttles take into account all turf color types and lights for transit. Light tiles would runtime as it'd try to copy over layered `atom_colours`, but not hard set `color`. Lights are copied over as well since as it wasn't taken into account originally.

## Why It's Good For The Game
Fixes #21679

## Images of changes
https://github.com/ParadiseSS13/Paradise/assets/80771500/63845b79-81c8-491b-ae74-75de8001dd34

## Testing
Placed a light tile in the mining shuttle, changed its color, and had the shuttle transit.

## Changelog
:cl:
fix: Light tiles in shuttles keep their color and light when in transit
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
