### PR TITLE
Magnetic gripper now works on light bulbs.

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -33,7 +33,8 @@
 		/obj/item/circuitboard,
 		/obj/item/stack/tile/light,
 		/obj/item/stack/ore/bluespace_crystal,
-		/obj/item/assembly/igniter
+		/obj/item/assembly/igniter,
+		/obj/item/light/
 	)
 
 	//Item currently being held.
@@ -145,6 +146,11 @@
 			cell_charger.charging.add_fingerprint(user)
 			cell_charger.charging.forceMove(src)
 			cell_charger.removecell()
+
+	else if(istype(target, /obj/machinery/light))
+		var/obj/machinery/light/light = target
+		light.drop_light_tube()
+		user.visible_message("<span class='warning'>[user] removes the light from the fixture!</span>", "You dislodge the light from the fixture.")
 
 	return TRUE
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
In response to feedback: a better version of PR #22657. This allows engineering cyborgs to add lights to fixtures and replace broken lights using their magnetic gripper. They do not get an internal store of bulbs. This is much less efficient than a light replacer or even a random assistant with a box of lights. The goal is simply to make it possible.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
If no one else is bothering to fix the lights, this allows engineering cyborgs to (slowly) repair them. It also allows them to add lighting to any personal rooms they may construct. 
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Spawned in as a cyborg. Picked up some light bulbs and tubes, and put them into empty fixtures. Used gripper to slap lights out of fixtures. It worked.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Magnetic gripper can now hold light tubes/bulbs and slap them out of light fixtures.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
