### PR TITLE
You can no longer reattach limbs when the required parent limb is not there.

### DIFF
--- a/code/modules/surgery/limb_reattach.dm
+++ b/code/modules/surgery/limb_reattach.dm
@@ -108,6 +108,9 @@
 	if(isnull(organ_data))
 		to_chat(user, "<span class='warning'>[target.dna.species] don't have the anatomy for [E.name]!</span>")
 		return SURGERY_BEGINSTEP_ABORT
+	if(!target.bodyparts_by_name[E.parent_organ])
+		to_chat(user, "<span class='warning'>[target] doesn't have a [parse_zone(E.parent_organ)] to attach the [E.name] to!</span>")
+		return SURGERY_BEGINSTEP_ABORT
 	if(length(E.search_contents_for(/obj/item/organ/internal/brain)) && target.get_int_organ(/obj/item/organ/internal/brain))
 		to_chat(user, "<span class='warning'>Both [target] and [E.name] contain a brain, and [target] can't have two brains!</span>")
 		return SURGERY_BEGINSTEP_ABORT


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
You can no longer reattach limbs when the required parent limb is not there, eg. you cannot attach a left hand when the left arm isn't there.

Fixes: #22817
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Bug bad.

Goodbye Rayman.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Remove a skrell's hand, then arm.
Try to reattach just the hand, doesn't work.
Try to reattach the arm, then the hand, works.
Remove a IPC's hand, then arm.
Try to reattach just the hand, doesn't work.
Try to reattach the arm, then the hand, works.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: You can no longer reattach limbs when the required parent limb is not there.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
