### PR TITLE
Tweaks Load Lawset to differentiate between admins and normal players, admins can choose to not change zeroth laws

### DIFF
--- a/code/datums/ai_laws_datums.dm
+++ b/code/datums/ai_laws_datums.dm
@@ -72,9 +72,10 @@
 		if(istype(AL))
 			sorted_laws += AL
 
-/datum/ai_laws/proc/sync(mob/living/silicon/S, full_sync = 1)
+/datum/ai_laws/proc/sync(mob/living/silicon/S, full_sync = TRUE, change_zeroth = TRUE)
 	// Add directly to laws to avoid log-spam
-	S.sync_zeroth(zeroth_law, zeroth_law_borg)
+	if(change_zeroth)
+		S.sync_zeroth(zeroth_law, zeroth_law_borg)
 
 	if(full_sync || ion_laws.len)
 		S.laws.clear_ion_laws()

--- a/code/modules/tgui/modules/law_manager.dm
+++ b/code/modules/tgui/modules/law_manager.dm
@@ -131,7 +131,7 @@
 			var/datum/ai_laws/ALs = locate(params["transfer_laws"]) in (admin_overwrite ? admin_laws : player_laws)
 			if(!ALs)
 				return
-			if(admin_overwrite && alert("Do you want to overwrite [owner]'s zeroth law? If the chosen lawset has no zeroth law while [owner] has one, it will get removed!","Load Lawset","Yes","No") != "Yes")
+			if(admin_overwrite && alert("Do you want to overwrite [owner]'s zeroth law? If the chosen lawset has no zeroth law while [owner] has one, it will get removed!", "Load Lawset", "Yes", "No") != "Yes")
 				admin_overwrite = FALSE
 			log_and_message_admins("has transfered the [ALs.name] laws to [owner][admin_overwrite ? " and overwrote their zeroth law":""].")
 			ALs.sync(owner, FALSE, admin_overwrite)

--- a/code/modules/tgui/modules/law_manager.dm
+++ b/code/modules/tgui/modules/law_manager.dm
@@ -129,7 +129,7 @@
 				var/datum/ai_laws/ALs = locate(params["transfer_laws"]) in (is_admin(usr) ? admin_laws : player_laws)
 				if(ALs)
 					log_and_message_admins("has transfered the [ALs.name] laws to [owner].")
-					ALs.sync(owner, 0)
+					ALs.sync(owner, FALSE, check_rights(R_ADMIN))
 					current_view = 0
 
 		if("notify_laws")

--- a/code/modules/tgui/modules/law_manager.dm
+++ b/code/modules/tgui/modules/law_manager.dm
@@ -131,7 +131,7 @@
 			var/datum/ai_laws/ALs = locate(params["transfer_laws"]) in (admin_overwrite ? admin_laws : player_laws)
 			if(!ALs)
 				return
-			if(admin_overwrite && alert("Do you want overwrite [owner]'s zeroth law? If the chosen lawset has no zeroth law while [owner] has one, it will get removed!","Load Lawset","Yes","No") != "Yes")
+			if(admin_overwrite && alert("Do you want to overwrite [owner]'s zeroth law? If the chosen lawset has no zeroth law while [owner] has one, it will get removed!","Load Lawset","Yes","No") != "Yes")
 				admin_overwrite = FALSE
 			log_and_message_admins("has transfered the [ALs.name] laws to [owner][admin_overwrite ? " and overwrote their zeroth law":""].")
 			ALs.sync(owner, FALSE, admin_overwrite)

--- a/code/modules/tgui/modules/law_manager.dm
+++ b/code/modules/tgui/modules/law_manager.dm
@@ -125,12 +125,17 @@
 				owner.statelaws(ALs)
 
 		if("transfer_laws")
-			if(is_malf(usr))
-				var/datum/ai_laws/ALs = locate(params["transfer_laws"]) in (is_admin(usr) ? admin_laws : player_laws)
-				if(ALs)
-					log_and_message_admins("has transfered the [ALs.name] laws to [owner].")
-					ALs.sync(owner, FALSE, check_rights(R_ADMIN))
-					current_view = 0
+			if(!is_malf(usr))
+				return
+			var/admin_overwrite = is_admin(usr)
+			var/datum/ai_laws/ALs = locate(params["transfer_laws"]) in (admin_overwrite ? admin_laws : player_laws)
+			if(!ALs)
+				return
+			if(admin_overwrite && alert("Do you want overwrite [owner]'s zeroth law? If the chosen lawset has no zeroth law while [owner] has one, it will get removed!","Load Lawset","Yes","No") != "Yes")
+				admin_overwrite = FALSE
+			log_and_message_admins("has transfered the [ALs.name] laws to [owner][admin_overwrite ? " and overwrote their zeroth law":""].")
+			ALs.sync(owner, FALSE, admin_overwrite)
+			current_view = 0
 
 		if("notify_laws")
 			to_chat(owner, "<span class='danger'>Law Notice</span>")


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This adds an argument that defaults to TRUE to override zeroth laws in the lawset `sync` proc. Overall that means loading lawsets remains the same... Unless you're a simple emagged-non-admin borg. Lawsets will load properly, but will ignore the zeroth law.

Admins are also now warned when changing whole lawsets, and get to choose if the silicon's zeroth law is retained, or overwritten.

Lawset boards and AI syncs will still affect the zeroth law as usual.

## Why It's Good For The Game
Fixes #21577

## Images of changes
https://github.com/ParadiseSS13/Paradise/assets/80771500/a7e9fde8-1968-4e58-8cf0-221c34d5885d

## Testing
Spawned a borg, added a zeroth law, emagged it, then de-admin'd self to use the Load Laws option. As an admin, messed with a borg's laws using both options to either leave or load the preset zeroth, if any.

## Changelog
:cl:
fix: Emagged borgs will not override their own zeroth law when loading a different lawset
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
