### PR TITLE
Adding unloading of botanical discs from boxes

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -188,8 +188,8 @@
 		user.visible_message("<span class='notice'>[user] has added \the [O] to \the [src].</span>", "<span class='notice'>You add \the [O] to \the [src].</span>")
 		SStgui.update_uis(src)
 		update_icon(UPDATE_OVERLAYS)
-	else if(istype(O, /obj/item/storage/bag))
-		var/obj/item/storage/bag/P = O
+	else if(istype(O, /obj/item/storage/bag) || istype(O, /obj/item/storage/box))
+		var/obj/item/storage/P = O
 		var/items_loaded = 0
 		for(var/obj/G in P.contents)
 			if(load(G, user))


### PR DESCRIPTION
## What Does This PR Do
'disk compartmentalizer' does not accept unloading discs from boxes, it adds the ability to unload discs from boxes in addition to bags

## Why It's Good For The Game
Helps botanists unload disks from 'plant data disks box' into 'disk compartmentalizer'

## Testing
Checked the unloading of boxes and bags with various items

## Changelog
🆑
tweak:  You can now unload botanical discs from boxes into disk compartmentalizer
/🆑
