### PR TITLE
makes paper stack burning more consistent

### DIFF
--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -53,7 +53,7 @@
 		to_chat(user, "<span class='notice'>You add [(W.name == "photo") ? "the photo" : W.name] to [(src.name == "paper bundle") ? "the paper bundle" : src.name].</span>")
 		user.unEquip(W)
 		W.loc = src
-	else if(istype(W, /obj/item/lighter))
+	else if(is_hot(W))
 		burnpaper(W, user)
 	else if(istype(W, /obj/item/paper_bundle))
 		user.unEquip(W)
@@ -77,29 +77,24 @@
 	add_fingerprint(usr)
 	return
 
-/obj/item/paper_bundle/proc/burnpaper(obj/item/lighter/P, mob/user)
+/obj/item/paper_bundle/proc/burnpaper(obj/item/heating_object, mob/user)
 	var/class = "<span class='warning'>"
 
-	if(P.lit && !user.restrained())
-		if(istype(P, /obj/item/lighter/zippo))
-			class = "<span class='rose'>"
+	if(istype(heating_object, /obj/item/lighter/zippo))
+		class = "<span class='rose'>"
 
-		user.visible_message("[class][user] holds [P] up to [src], it looks like [user.p_theyre()] trying to burn it!</span>", \
-		"[class]You hold [P] up to [src], burning it slowly.</span>")
+	user.visible_message("[class][user] holds [heating_object] up to [src], it looks like [user.p_theyre()] trying to burn it!</span>", "[class]You hold [heating_object] up to [src], burning it slowly.</span>")
 
-		spawn(20)
-			if(get_dist(src, user) < 2 && user.get_active_hand() == P && P.lit)
-				user.visible_message("[class][user] burns right through \the [src], turning it to ash. It flutters through the air before settling on the floor in a heap.</span>", \
-				"[class]You burn right through \the [src], turning it to ash. It flutters through the air before settling on the floor in a heap.</span>")
+	if(!do_after(user, 2 SECONDS, target = src))
+		return
+	user.visible_message("[class][user] burns right through \the [src], turning it to ash. It flutters through the air before settling on the floor in a heap.</span>", \
+	"[class]You burn right through \the [src], turning it to ash. It flutters through the air before settling on the floor in a heap.</span>")
 
-				if(user.is_in_inactive_hand(src))
-					user.unEquip(src)
+	if(user.is_in_inactive_hand(src))
+		user.unEquip(src)
 
-				new /obj/effect/decal/cleanable/ash(get_turf(src))
-				qdel(src)
-
-			else
-				to_chat(user, "<span class='warning'>You must hold \the [P] steady to burn \the [src].</span>")
+	new /obj/effect/decal/cleanable/ash(get_turf(src))
+	qdel(src)
 
 /obj/item/paper_bundle/examine(mob/user)
 	. = ..()

--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -85,7 +85,7 @@
 
 	user.visible_message("[class][user] holds [heating_object] up to [src], it looks like [user.p_theyre()] trying to burn it!</span>", "[class]You hold [heating_object] up to [src], burning it slowly.</span>")
 
-	if(!do_after(user, 2 SECONDS, target = src))
+	if(!do_after(user, 2 SECONDS, target = src) && is_hot(heating_object))
 		return
 	user.visible_message("[class][user] burns right through \the [src], turning it to ash. It flutters through the air before settling on the floor in a heap.</span>", \
 	"[class]You burn right through \the [src], turning it to ash. It flutters through the air before settling on the floor in a heap.</span>")

--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -90,8 +90,7 @@
 	user.visible_message("[class][user] burns right through \the [src], turning it to ash. It flutters through the air before settling on the floor in a heap.</span>", \
 	"[class]You burn right through \the [src], turning it to ash. It flutters through the air before settling on the floor in a heap.</span>")
 
-	if(user.is_in_inactive_hand(src))
-		user.unEquip(src)
+	user.unEquip(src)
 
 	new /obj/effect/decal/cleanable/ash(get_turf(src))
 	qdel(src)

--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -87,8 +87,8 @@
 
 	if(!do_after(user, 2 SECONDS, target = src) && is_hot(heating_object))
 		return
-	user.visible_message("[class][user] burns right through \the [src], turning it to ash. It flutters through the air before settling on the floor in a heap.</span>", \
-	"[class]You burn right through \the [src], turning it to ash. It flutters through the air before settling on the floor in a heap.</span>")
+	user.visible_message("[class][user] burns right through [src], turning it to ash. It flutters through the air before settling on the floor in a heap.</span>", \
+	"[class]You burn right through [src], turning it to ash. It flutters through the air before settling on the floor in a heap.</span>")
 
 	user.unEquip(src)
 

--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -85,7 +85,7 @@
 
 	user.visible_message("[class][user] holds [heating_object] up to [src], it looks like [user.p_theyre()] trying to burn it!</span>", "[class]You hold [heating_object] up to [src], burning it slowly.</span>")
 
-	if(!do_after(user, 2 SECONDS, target = src) && is_hot(heating_object))
+	if(!do_after(user, 2 SECONDS, target = src) || !is_hot(heating_object))
 		return
 	user.visible_message("[class][user] burns right through [src], turning it to ash. It flutters through the air before settling on the floor in a heap.</span>", \
 	"[class]You burn right through [src], turning it to ash. It flutters through the air before settling on the floor in a heap.</span>")

--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -78,17 +78,17 @@
 	return
 
 /obj/item/paper_bundle/proc/burnpaper(obj/item/heating_object, mob/user)
-	var/class = "<span class='warning'>"
+	var/class = "warning"
 
 	if(istype(heating_object, /obj/item/lighter/zippo))
-		class = "<span class='rose'>"
+		class = "rose"
 
-	user.visible_message("[class][user] holds [heating_object] up to [src], it looks like [user.p_theyre()] trying to burn it!</span>", "[class]You hold [heating_object] up to [src], burning it slowly.</span>")
+	user.visible_message("<span class='[class]'>[user] holds [heating_object] up to [src], it looks like [user.p_theyre()] trying to burn it!</span>", "<span class='[class]'>You hold [heating_object] up to [src], burning it slowly.</span>")
 
 	if(!do_after(user, 2 SECONDS, target = src) || !is_hot(heating_object))
 		return
-	user.visible_message("[class][user] burns right through [src], turning it to ash. It flutters through the air before settling on the floor in a heap.</span>", \
-	"[class]You burn right through [src], turning it to ash. It flutters through the air before settling on the floor in a heap.</span>")
+	user.visible_message("<span class='[class]'>[user] burns right through [src], turning it to ash. It flutters through the air before settling on the floor in a heap.</span>", \
+	"<span class='[class]'>You burn right through [src], turning it to ash. It flutters through the air before settling on the floor in a heap.</span>")
 
 	user.unEquip(src)
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
makes paper stack burning more consistent, uses ishot (any hot object) instead of checking for only lighters
You now always burn the entire stack
also fixes a bunch of runtimes
fixes https://github.com/ParadiseSS13/Paradise/issues/16218

## Why It's Good For The Game
This is just better, more consistent with other stuff and less jank to use

## Testing
Compiled, ran, burned some books

## Changelog
:cl:
tweak: paper stack burning is more consistent and no longer requires just a lighter
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
