### PR TITLE
Lets you fake wearing handcuffs by wielding them, automatically doing this on resist out

### DIFF
--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -40,6 +40,8 @@
 	user.overlays_standing[HANDCUFF_LAYER] = mutable_appearance('icons/mob/mob.dmi', cuffed_state, layer = -HANDCUFF_LAYER, color = color)
 	user.apply_overlay(HANDCUFF_LAYER)
 	item_state = "weijf2349-h238h9f23"  // thanks for the string contra
+	user.update_inv_l_hand()
+	user.update_inv_r_hand()
 
 /obj/item/restraints/handcuffs/proc/unwield(obj/item/source, mob/living/carbon/human/user)
 	if(!istype(user))

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -25,6 +25,29 @@
 	var/trashtype = null //For disposable cuffs
 	var/ignoresClumsy = FALSE
 
+/obj/item/restraints/handcuffs/Initialize(mapload)
+	. = ..()
+	// yes, this is an empty icon. Make it not visible in hand.
+	AddComponent(/datum/component/two_handed, \
+		wield_callback = CALLBACK(src, PROC_REF(wield)), \
+		unwield_callback = CALLBACK(src, PROC_REF(unwield)) \
+	)
+
+/obj/item/restraints/handcuffs/proc/wield(obj/item/source, mob/living/carbon/human/user)
+	if(!istype(user))
+		return
+	user.remove_overlay(HANDCUFF_LAYER)
+	user.overlays_standing[HANDCUFF_LAYER] = mutable_appearance('icons/mob/mob.dmi', cuffed_state, layer = -HANDCUFF_LAYER, color = color)
+	user.apply_overlay(HANDCUFF_LAYER)
+	item_state = "weijf2349-h238h9f23"  // thanks for the string contra
+
+/obj/item/restraints/handcuffs/proc/unwield(obj/item/source, mob/living/carbon/human/user)
+	if(!istype(user))
+		return
+	user.remove_overlay(HANDCUFF_LAYER)
+	user.apply_overlay(HANDCUFF_LAYER)
+	item_state = initial(item_state)
+
 /obj/item/restraints/handcuffs/attack(mob/living/carbon/C, mob/user)
 	if(!user.IsAdvancedToolUser())
 		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -984,6 +984,12 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 				if(buckled && buckled.buckle_requires_restraints)
 					buckled.unbuckle_mob(src)
 				update_handcuffed()
+				var/anything_was_in_hands = l_hand || r_hand  // check for weird things like chainsaws
+				if(put_in_any_hand_if_possible())
+					if(!anything_was_in_hands)
+						// force-wield it
+						to_chat("<span class='warning'>You quietly keep [I] on your hands. Use them in-hand to remove them.</span>")
+						I.attack_hand(src)
 				return
 			if(I == legcuffed)
 				legcuffed.forceMove(drop_location())

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -985,11 +985,11 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 					buckled.unbuckle_mob(src)
 				update_handcuffed()
 				var/anything_was_in_hands = l_hand || r_hand  // check for weird things like chainsaws
-				if(put_in_any_hand_if_possible())
+				if(put_in_active_hand(I))
 					if(!anything_was_in_hands)
 						// force-wield it
-						to_chat("<span class='warning'>You quietly keep [I] on your hands. Use them in-hand to remove them.</span>")
-						I.attack_hand(src)
+						to_chat(src, "<span class='warning'>You quietly keep [I] on your hands. Use them in-hand to remove them.</span>")
+						I.attack_self(src)
 				return
 			if(I == legcuffed)
 				legcuffed.forceMove(drop_location())

--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -97,6 +97,12 @@
 	var/skipeyes = FALSE
 	var/skipface = FALSE
 
+	var/obj/item/restraints/handcuffs/fake_cuffs
+	if(isnull(handcuffed) && (istype(l_hand, /obj/item/restraints/handcuffs) || istype(r_hand, /obj/item/restraints/handcuffs)))
+		var/obj/item/restraints/handcuffs/possible_cuffs = istype(l_hand, /obj/item/restraints/handcuffs) ? l_hand : r_hand
+		if(HAS_TRAIT(possible_cuffs, TRAIT_WIELDED))
+			fake_cuffs = possible_cuffs
+
 	//exosuits and helmets obscure our view and stuff.
 	if(wear_suit)
 		skipgloves = wear_suit.flags_inv & HIDEGLOVES
@@ -135,6 +141,8 @@
 			accessories = parts[5]
 
 		if(item && !(item.flags & ABSTRACT))
+			if(item == fake_cuffs)
+				continue  // silently skip this
 			var/item_words = item.name
 			if(item.blood_DNA)
 				item_words = "[item.blood_color != "#030303" ? "blood-stained" : "oil-stained"] [item_words]"
@@ -152,16 +160,22 @@
 			// add any extra info on the limbs themselves
 			msg += examine_handle_individual_limb(limb_name)
 
+	var/active_cuffs = handcuffed
+	if(isnull(active_cuffs) && (istype(l_hand, /obj/item/restraints/handcuffs) || istype(r_hand, /obj/item/restraints/handcuffs)))
+		var/obj/item/restraints/handcuffs/possible_cuffs = istype(l_hand, /obj/item/restraints/handcuffs) ? l_hand : r_hand
+		if(HAS_TRAIT(possible_cuffs, TRAIT_WIELDED))
+			active_cuffs = possible_cuffs
+
 	//handcuffed?
-	if(handcuffed)
-		if(istype(handcuffed, /obj/item/restraints/handcuffs/cable/zipties))
-			msg += "<span class='warning'>[p_they(TRUE)] [p_are()] [bicon(handcuffed)] restrained with zipties!</span>\n"
-		else if(istype(handcuffed, /obj/item/restraints/handcuffs/twimsts))
-			msg += "<span class='warning'>[p_they(TRUE)] [p_are()] [bicon(handcuffed)] restrained with twimsts cuffs!</span>\n"
-		else if(istype(handcuffed, /obj/item/restraints/handcuffs/cable))
-			msg += "<span class='warning'>[p_they(TRUE)] [p_are()] [bicon(handcuffed)] restrained with cable!</span>\n"
+	if(!isnull(active_cuffs))
+		if(istype(active_cuffs, /obj/item/restraints/handcuffs/cable/zipties))
+			msg += "<span class='warning'>[p_they(TRUE)] [p_are()] [bicon(active_cuffs)] restrained with zipties!</span>\n"
+		else if(istype(active_cuffs, /obj/item/restraints/handcuffs/twimsts))
+			msg += "<span class='warning'>[p_they(TRUE)] [p_are()] [bicon(active_cuffs)] restrained with twimsts cuffs!</span>\n"
+		else if(istype(active_cuffs, /obj/item/restraints/handcuffs/cable))
+			msg += "<span class='warning'>[p_they(TRUE)] [p_are()] [bicon(active_cuffs)] restrained with cable!</span>\n"
 		else
-			msg += "<span class='warning'>[p_they(TRUE)] [p_are()] [bicon(handcuffed)] handcuffed!</span>\n"
+			msg += "<span class='warning'>[p_they(TRUE)] [p_are()] [bicon(active_cuffs)] handcuffed!</span>\n"
 
 	//legcuffed?
 	if(legcuffed)

--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -161,10 +161,8 @@
 			msg += examine_handle_individual_limb(limb_name)
 
 	var/active_cuffs = handcuffed
-	if(isnull(active_cuffs) && (istype(l_hand, /obj/item/restraints/handcuffs) || istype(r_hand, /obj/item/restraints/handcuffs)))
-		var/obj/item/restraints/handcuffs/possible_cuffs = istype(l_hand, /obj/item/restraints/handcuffs) ? l_hand : r_hand
-		if(HAS_TRAIT(possible_cuffs, TRAIT_WIELDED))
-			active_cuffs = possible_cuffs
+	if(isnull(active_cuffs) && fake_cuffs && HAS_TRAIT(fake_cuffs, TRAIT_WIELDED))
+		active_cuffs = fake_cuffs
 
 	//handcuffed?
 	if(!isnull(active_cuffs))


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Lets you fake wearing handcuffs by wielding them. Also, if you resist out of handcuffs that don't break on removal (regular handcuffs, toy handcuffs, but not zipties), you'll also silently put them into your hands once you break out of them/
This fake handcuffing will look on examine to be a normal handcuffing, but it'll be immediately obvious that you're pulling a fast one under any scrutiny.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
This changes how "silent" unbuckling works. If you're paying attention, you'll catch the chat message. Otherwise, if you're able to slip out of real handcuffs, you might get the chance to pull a fast one and pretend to be handcuffed.
This might be useful in other circumstances, too. You can put handcuffs on yourself and pretend to be the victim, for example, only to quickly take your cuffs off and apply them to whoever was unlucky enough to believe you!
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

https://github.com/ParadiseSS13/Paradise/assets/89928798/4e0ec778-91c5-45e6-a674-602b8ae6dddb

![image](https://github.com/ParadiseSS13/Paradise/assets/89928798/c9589e90-1e92-4642-814f-8ecfd336e815)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Handcuffed myself a bunch and resisted out, as well as just wielding the cuffs.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: You can now fake-wear handcuffs by using them in-hand.
tweak: Resisting out of reusable handcuffs will put the cuffs into your hand, and fake the handcuffing.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
