### PR TITLE
Newer Crit (Hardcrit is fixed to be more lethal)

### DIFF
--- a/code/modules/mob/living/carbon/human/human_life.dm
+++ b/code/modules/mob/living/carbon/human/human_life.dm
@@ -604,7 +604,7 @@
 
 	if(!check_death_method())
 		if(health <= HEALTH_THRESHOLD_DEAD)
-			var/deathchance = min(99, ((getBrainLoss() * -5) + (health + (getOxyLoss() / 2))) * -0.01)
+			var/deathchance = min(99, ((getBrainLoss() / 2) + (health + (getOxyLoss() / -2))) * -0.1)
 			if(prob(deathchance))
 				death()
 				return

--- a/code/modules/mob/living/carbon/human/human_life.dm
+++ b/code/modules/mob/living/carbon/human/human_life.dm
@@ -604,7 +604,7 @@
 
 	if(!check_death_method())
 		if(health <= HEALTH_THRESHOLD_DEAD)
-			var/deathchance = min(99, ((getBrainLoss() / 2) + (health + (getOxyLoss() / -2))) * -0.1)
+			var/deathchance = min(99, ((getBrainLoss() / 5) + (health + (getOxyLoss() / -2))) * -0.1)
 			if(prob(deathchance))
 				death()
 				return


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Fixes the logic of hardcrit to have a set percent chance to kill you per tick, based on overall health, brain damage, and oxyloss.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
The logic for determining if someone should die in hardcrit is currently broken. The variable deathchance is almost always negative, so it'll never kill you. If you've died to crit in the past 3 years, it's been from softcrit. Fixing this makes it so hardcrit is significantly more lethal, as I imagine the intent of the original author was.

[Here](https://www.desmos.com/calculator/w63wbsfhwk) is a tool that will let you check the chance of death per tick in hardcrit, with the formula in this PR.
The variable w represents brain damage.
The variable q represents health.
The variable z represents oxyloss.
Finally, y represents the chance to die on a given tick.

The equation can be tweaked as needed, but to give an example:
With 0 brain damage, -100 health, and 0 oxyloss gives you a 10% chance to die per tick.
20 brain damage, -100 health, and 0 oxyloss bumps it up to 20%

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
<!-- How did you test the PR, if at all? -->
I shot skrells with a bunch of pulse rifles and watched how fast they died (very)
## Changelog
:cl:
fix: Hardcrit now properly kills you quickly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
