### PR TITLE
Add viewer_state for TGUI, an observational state

### DIFF
--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -334,7 +334,10 @@ GLOBAL_VAR(bomb_set)
 	update_icon(UPDATE_OVERLAYS)
 
 /obj/machinery/nuclearbomb/attack_ghost(mob/user as mob)
-	attack_hand(user)
+	if(!panel_open)
+		return ui_interact(user, state = GLOB.viewer_state)
+	if(removal_stage != NUKE_CORE_FULLY_EXPOSED || !core)
+		return wires.Interact(user, state = GLOB.viewer_state)
 
 /obj/machinery/nuclearbomb/attack_hand(mob/user as mob)
 	if(!panel_open)

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -337,7 +337,7 @@ GLOBAL_VAR(bomb_set)
 	if(!panel_open)
 		return ui_interact(user, state = GLOB.viewer_state)
 	if(removal_stage != NUKE_CORE_FULLY_EXPOSED || !core)
-		return wires.Interact(user, state = GLOB.viewer_state)
+		return wires.Interact(user)
 
 /obj/machinery/nuclearbomb/attack_hand(mob/user as mob)
 	if(!panel_open)

--- a/code/modules/tgui/states/viewer_state.dm
+++ b/code/modules/tgui/states/viewer_state.dm
@@ -1,0 +1,10 @@
+/**
+ * tgui state: viewer_state
+ *
+ * State for only viewing, regardless of distance. Different from observer_state, which grants interactivity exclusively if an observer/admin.
+ */
+
+GLOBAL_DATUM_INIT(viewer_state, /datum/ui_state/viewer_state, new)
+
+/datum/ui_state/viewer_state/can_use_topic(src_object, mob/user)
+	return STATUS_UPDATE

--- a/paradise.dme
+++ b/paradise.dme
@@ -2733,6 +2733,7 @@
 #include "code\modules\tgui\states\observer_state.dm"
 #include "code\modules\tgui\states\physical.dm"
 #include "code\modules\tgui\states\self.dm"
+#include "code\modules\tgui\states\viewer_state.dm"
 #include "code\modules\tgui\states\zlevel_state.dm"
 #include "code\modules\tooltip\tooltip.dm"
 #include "code\modules\unit_tests\_unit_tests.dm"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
While there's an `observer_state`, it specifically grants full interaction to observers and admins. So in comes `viewer_state`, which only grants observational interaction, regardless of anything. A variant of `always_state`, basically.

## Why It's Good For The Game
Fixes #21475. There are use cases for just being able to see/keep track of the UI while not an admin.

## Images of changes
https://github.com/ParadiseSS13/Paradise/assets/80771500/2d337755-52e2-432f-84c5-d9cd6a9a7cb5

## Testing
Spawned a nuke, clicked on it as a ghost, and moved rather far away.

## Changelog
:cl:
fix: Observers can keep the nuclear bomb interaction window open regardless of distance
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
