### PR TITLE
Adds a Condiment Crate, Orderable from Cargo.

### DIFF
--- a/code/modules/food_and_drinks/food/condiment.dm
+++ b/code/modules/food_and_drinks/food/condiment.dm
@@ -276,6 +276,20 @@
 	list_reagents = list("wasabi" = 50)
 	possible_states = list()
 
+/obj/item/reagent_containers/food/condiment/vinegar
+	name = "vinegar"
+	desc = "Useful for pickling, or putting on chips."
+	icon_state = "vinegar"
+	list_reagents = list("vinegar" = 50)
+	possible_states = list()
+
+/obj/item/reagent_containers/food/condiment/ketchup
+	name = "ketchup"
+	desc = "You feel more American already."
+	icon_state = "ketchup"
+	list_reagents = list("ketchup" = 50)
+	possible_states = list()
+
 //Food packs. To easily apply deadly toxi... delicious sauces to your food!
 
 /obj/item/reagent_containers/food/condiment/pack

--- a/code/modules/supply/supply_packs/pack_organic.dm
+++ b/code/modules/supply/supply_packs/pack_organic.dm
@@ -58,6 +58,23 @@
 	containertype = /obj/structure/closet/crate/freezer
 	department_restrictions = list(DEPARTMENT_SERVICE)
 
+/datum/supply_packs/organic/condiments
+	name = "Condiment Crate"
+	contains = list(/obj/item/reagent_containers/food/condiment/ketchup,
+					/obj/item/reagent_containers/food/condiment/bbqsauce,
+					/obj/item/reagent_containers/food/condiment/soysauce,
+					/obj/item/reagent_containers/food/condiment/mayonnaise,
+					/obj/item/reagent_containers/food/condiment/cherryjelly,
+					/obj/item/reagent_containers/food/condiment/peanutbutter,
+					/obj/item/reagent_containers/food/condiment/honey,
+					/obj/item/reagent_containers/food/condiment/oliveoil,
+					/obj/item/reagent_containers/food/condiment/frostoil,
+					/obj/item/reagent_containers/food/condiment/capsaicin,
+					/obj/item/reagent_containers/food/condiment/wasabi,
+					/obj/item/reagent_containers/food/condiment/vinegar)
+	cost = 300
+	containername = "condiment crate"
+	group = SUPPLY_ORGANIC
 /datum/supply_packs/organic/monkey
 	name = "Monkey Crate"
 	contains = list (/obj/item/storage/box/monkeycubes)

--- a/code/modules/supply/supply_packs/pack_organic.dm
+++ b/code/modules/supply/supply_packs/pack_organic.dm
@@ -74,7 +74,7 @@
 					/obj/item/reagent_containers/food/condiment/vinegar)
 	cost = 300
 	containername = "condiment crate"
-	group = SUPPLY_ORGANIC
+
 /datum/supply_packs/organic/monkey
 	name = "Monkey Crate"
 	contains = list (/obj/item/storage/box/monkeycubes)


### PR DESCRIPTION
## What Does This PR Do
Adds a crate for 300 credits that includes a bottle of every condiment.

## Why It's Good For The Game
Perfect for rounds when botany is slacking, non-existent, or you're wanting more condiments than a newbie botany team can reasonably manage and you want to have plenty of different condiments for your food. I do have concerns with frost oil being orderable as it's cold sauce...but it shouldn't be that horrible, really, probably. It can be removed from the crate if it's deemed an issue.

Price can also, of course, be raised or lowered if needed.

## Images of changes
![dreamseeker_R2V6XHYflF](https://github.com/ParadiseSS13/Paradise/assets/12178527/07319c02-bb7f-4864-83d3-7e08b87c6277)


## Testing
1. Loaded game.
2. Ordered and Spawned a crate.
3. Confirmed contents of both.
4. Ate the mayonnaise.

## Changelog
:cl:
add: You can now purchase a crate of condiments from cargo for 300 credits.
/:cl:
