### PR TITLE
Adds the NT drunk dialer, chasm recovery grenade

### DIFF
--- a/code/game/turfs/simulated/floor/chasm.dm
+++ b/code/game/turfs/simulated/floor/chasm.dm
@@ -217,7 +217,7 @@
 		fallen_mob.notransform = FALSE
 		if(fallen_mob.stat != DEAD)
 			fallen_mob.death(TRUE)
-			fallen_mob.adjustBruteLoss(300)
+			fallen_mob.adjustBruteLoss(1000) //crunch from long fall, want it to be like legion in damage
 		fallen_mob.forceMove(storage)
 		return
 
@@ -269,7 +269,7 @@
 		ourturf.ChangeTurf(ourturf.baseturf)
 	escapee.flying = TRUE
 	escapee.forceMove(ourturf)
-	escapee.throw_at(get_edge_target_turf(ourturf, pick(GLOB.alldirs)), rand(1, 10), rand(1, 10))
+	escapee.throw_at(get_edge_target_turf(ourturf, pick(GLOB.alldirs)), rand(2, 10), rand(2, 10))
 	escapee.flying = FALSE
 	escapee.Sleeping(20 SECONDS)
 	UnregisterSignal(escapee, COMSIG_LIVING_REVIVE)

--- a/code/game/turfs/simulated/floor/chasm.dm
+++ b/code/game/turfs/simulated/floor/chasm.dm
@@ -152,8 +152,18 @@
 			L.adjustBruteLoss(30)
 	falling_atoms -= AM
 
+/turf/simulated/floor/chasm/straight_down
+	var/obj/effect/abstract/chasm_storage/storage
+
 /turf/simulated/floor/chasm/straight_down/Initialize()
 	. = ..()
+	var/found_storage = FALSE
+	for(var/obj/effect/abstract/chasm_storage/C in contents)
+		storage = C
+		found_storage = TRUE
+		break
+	if(!found_storage)
+		storage = new /obj/effect/abstract/chasm_storage(src)
 	drop_x = x
 	drop_y = y
 	drop_z = z - 1
@@ -166,7 +176,7 @@
 	baseturf = /turf/simulated/floor/chasm/straight_down/lava_land_surface //Chasms should not turn into lava
 	light_range = 2
 	light_power = 0.75
-	light_color = LIGHT_COLOR_LAVA //let's just say you're falling into lava, that makes sense right
+	light_color = LIGHT_COLOR_LAVA //let's just say you're falling into lava, that makes sense right. Ignore the fact the people you pull out are not burning.
 
 /turf/simulated/floor/chasm/straight_down/lava_land_surface/Initialize()
 	. = ..()
@@ -182,7 +192,7 @@
 	if(isliving(AM))
 		var/mob/living/L = AM
 		L.notransform = TRUE
-		L.Weaken(400 SECONDS)
+		L.Weaken(20 SECONDS)
 	var/oldtransform = AM.transform
 	var/oldcolor = AM.color
 	var/oldalpha = AM.alpha
@@ -198,20 +208,73 @@
 	if(!AM || QDELETED(AM))
 		return
 
-	if(isrobot(AM))
-		var/mob/living/silicon/robot/S = AM
-		qdel(S.mmi)
-
 	falling_atoms -= AM
-
-	qdel(AM)
-
-	if(AM && !QDELETED(AM))	//It's indestructible
-		visible_message("<span class='boldwarning'>[src] spits out [AM]!</span>")
+	if(isliving(AM))
 		AM.alpha = oldalpha
 		AM.color = oldcolor
 		AM.transform = oldtransform
-		AM.throw_at(get_edge_target_turf(src,pick(GLOB.alldirs)),rand(1, 10),rand(1, 10))
+		var/mob/living/fallen_mob = AM
+		fallen_mob.notransform = FALSE
+		if(fallen_mob.stat != DEAD)
+			fallen_mob.death(TRUE)
+			fallen_mob.adjustBruteLoss(300)
+		fallen_mob.forceMove(storage)
+		return
+
+	if(istype(AM, /obj/item/grenade/jaunter_grenade))
+		AM.forceMove(storage)
+		return
+	else
+		for(var/mob/M in AM.contents)
+			M.forceMove(src)
+
+	qdel(AM)
+
+
+/**
+ * An abstract object which is basically just a bag that the chasm puts people inside
+ */
+
+/obj/effect/abstract/chasm_storage
+	name = "chasm depths"
+	desc = "The bottom of a hole. You shouldn't be able to interact with this."
+	anchored = TRUE
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+
+/obj/effect/abstract/chasm_storage/Entered(atom/movable/arrived)
+	. = ..()
+	if(isliving(arrived))
+		RegisterSignal(arrived, COMSIG_LIVING_REVIVE, PROC_REF(on_revive))
+
+/obj/effect/abstract/chasm_storage/Exited(atom/movable/gone)
+	. = ..()
+	if(isliving(gone))
+		UnregisterSignal(gone, COMSIG_LIVING_REVIVE)
+
+#define CHASM_TRAIT "chasm trait"
+/**
+ * Called if something comes back to life inside the pit. Expected sources are badmins and changelings.
+ * Ethereals should take enough damage to be smashed and not revive.
+ * Arguments
+ * escapee - Lucky guy who just came back to life at the bottom of a hole.
+ */
+/obj/effect/abstract/chasm_storage/proc/on_revive(mob/living/escapee)
+	SIGNAL_HANDLER
+	var/turf/ourturf = get_turf(src)
+	if(istype(ourturf, /turf/simulated/floor/chasm/straight_down/lava_land_surface))
+		ourturf.visible_message("<span class='boldwarning'>After a long climb, [escapee] leaps out of [ourturf]!</span>")
+	else
+		playsound(ourturf, 'sound/effects/bang.ogg', 50, TRUE)
+		ourturf.visible_message("<span class='boldwarning'>[escapee] busts through [ourturf], leaping out of the chasm below!</span>")
+		ourturf.ChangeTurf(ourturf.baseturf)
+	escapee.flying = TRUE
+	escapee.forceMove(ourturf)
+	escapee.throw_at(get_edge_target_turf(ourturf, pick(GLOB.alldirs)), rand(1, 10), rand(1, 10))
+	escapee.flying = FALSE
+	escapee.Sleeping(20 SECONDS)
+	UnregisterSignal(escapee, COMSIG_LIVING_REVIVE)
+
+#undef CHASM_TRAIT
 
 /turf/simulated/floor/chasm/straight_down/lava_land_surface/normal_air
 	oxygen = MOLES_O2STANDARD

--- a/code/game/turfs/simulated/floor/chasm.dm
+++ b/code/game/turfs/simulated/floor/chasm.dm
@@ -216,7 +216,7 @@
 		var/mob/living/fallen_mob = AM
 		fallen_mob.notransform = FALSE
 		if(fallen_mob.stat != DEAD)
-			fallen_mob.death(TRUE)
+			fallen_mob.death()
 			fallen_mob.adjustBruteLoss(1000) //crunch from long fall, want it to be like legion in damage
 		fallen_mob.forceMove(storage)
 		return

--- a/code/game/turfs/simulated/floor/chasm.dm
+++ b/code/game/turfs/simulated/floor/chasm.dm
@@ -229,7 +229,6 @@
 
 	qdel(AM)
 
-
 /**
  * An abstract object which is basically just a bag that the chasm puts people inside
  */

--- a/code/game/turfs/simulated/floor/chasm.dm
+++ b/code/game/turfs/simulated/floor/chasm.dm
@@ -224,9 +224,8 @@
 	if(istype(AM, /obj/item/grenade/jaunter_grenade))
 		AM.forceMove(storage)
 		return
-	else
-		for(var/mob/M in AM.contents)
-			M.forceMove(src)
+	for(var/mob/M in AM.contents)
+		M.forceMove(src)
 
 	qdel(AM)
 
@@ -272,7 +271,6 @@
 	escapee.flying = FALSE
 	escapee.Sleeping(20 SECONDS)
 	UnregisterSignal(escapee, COMSIG_LIVING_REVIVE)
-
 
 /turf/simulated/floor/chasm/straight_down/lava_land_surface/normal_air
 	oxygen = MOLES_O2STANDARD

--- a/code/game/turfs/simulated/floor/chasm.dm
+++ b/code/game/turfs/simulated/floor/chasm.dm
@@ -251,7 +251,6 @@
 	if(isliving(gone))
 		UnregisterSignal(gone, COMSIG_LIVING_REVIVE)
 
-#define CHASM_TRAIT "chasm trait"
 /**
  * Called if something comes back to life inside the pit. Expected sources are badmins and changelings.
  * Ethereals should take enough damage to be smashed and not revive.
@@ -274,7 +273,6 @@
 	escapee.Sleeping(20 SECONDS)
 	UnregisterSignal(escapee, COMSIG_LIVING_REVIVE)
 
-#undef CHASM_TRAIT
 
 /turf/simulated/floor/chasm/straight_down/lava_land_surface/normal_air
 	oxygen = MOLES_O2STANDARD

--- a/code/game/turfs/simulated/floor/chasm.dm
+++ b/code/game/turfs/simulated/floor/chasm.dm
@@ -270,7 +270,6 @@
 	escapee.throw_at(get_edge_target_turf(ourturf, pick(GLOB.alldirs)), rand(2, 10), rand(2, 10))
 	escapee.flying = FALSE
 	escapee.Sleeping(20 SECONDS)
-	UnregisterSignal(escapee, COMSIG_LIVING_REVIVE)
 
 /turf/simulated/floor/chasm/straight_down/lava_land_surface/normal_air
 	oxygen = MOLES_O2STANDARD

--- a/code/modules/mining/equipment/wormhole_jaunter.dm
+++ b/code/modules/mining/equipment/wormhole_jaunter.dm
@@ -176,7 +176,7 @@
 
 /obj/item/grenade/jaunter_grenade
 	name = "chasm jaunter recovery grenade"
-	desc = "NT-Drunk Dialer Grenade. Originally built by NT for locating all beacons in an area and creating wormholes to them, it now finds use to miners for recovering allies from chasms"
+	desc = "NT-Drunk Dialer Grenade. Originally built by NT for locating all beacons in an area and creating wormholes to them, it now finds use to miners for recovering allies from chasms."
 	icon_state = "mirage"
 	/// Mob that threw the grenade.
 	var/mob/living/thrower

--- a/code/modules/mining/equipment/wormhole_jaunter.dm
+++ b/code/modules/mining/equipment/wormhole_jaunter.dm
@@ -173,3 +173,49 @@
 	. = ..()
 	playsound(loc, 'sound/goonstation/misc/matchstick_light.ogg', 50, TRUE)
 	set_light(8, l_color = "#FFD165")
+
+/obj/item/grenade/jaunter_grenade
+	name = "chasm jaunter recovery grenade"
+	desc = "NT-Drunk Dialer Grenade. Originally built by NT for locating all beacons in an area and creating wormholes to them, it now finds use to miners for recovering allies from chasms"
+	icon_state = "mirage"
+	/// Mob that threw the grenade.
+	var/mob/living/thrower
+
+
+/obj/item/grenade/jaunter_grenade/Destroy()
+	thrower = null
+	return ..()
+
+/obj/item/grenade/jaunter_grenade/attack_self(mob/user)
+	. = ..()
+	thrower = user
+
+/obj/item/grenade/jaunter_grenade/prime()
+	update_mob()
+	var/list/destinations = list()
+	for(var/obj/item/radio/beacon/B in GLOB.global_radios)
+		var/turf/BT = get_turf(B)
+		if(is_station_level(BT.z))
+			destinations += BT
+	var/turf/T = get_turf(src)
+	if(istype(T, /turf/simulated/floor/chasm/straight_down/lava_land_surface))
+		for(var/obj/effect/abstract/chasm_storage/C in T)
+			var/found_mob = FALSE
+			for(var/mob/M in C)
+				found_mob = TRUE
+				do_teleport(M, pick(destinations))
+			if(found_mob)
+				new /obj/effect/temp_visual/thunderbolt(T) //Visual feedback it worked.
+				playsound(src, 'sound/magic/lightningbolt.ogg', 100, TRUE)
+		qdel(src)
+	else
+		var/list/portal_turfs = list()
+		for(var/turf/PT in circleviewturfs(T, 3))
+			if(!PT.density)
+				portal_turfs += PT
+		playsound(src, 'sound/magic/lightningbolt.ogg', 100, TRUE)
+		for(var/turf/drunk_dial in shuffle(destinations))
+			var/drunken_opening = pick_n_take(portal_turfs)
+			new /obj/effect/portal/jaunt_tunnel(drunken_opening, drunk_dial, src, 100, thrower)
+			new /obj/effect/temp_visual/thunderbolt(drunken_opening)
+		qdel(src)

--- a/code/modules/mining/equipment/wormhole_jaunter.dm
+++ b/code/modules/mining/equipment/wormhole_jaunter.dm
@@ -181,7 +181,6 @@
 	/// Mob that threw the grenade.
 	var/mob/living/thrower
 
-
 /obj/item/grenade/jaunter_grenade/Destroy()
 	thrower = null
 	return ..()
@@ -208,14 +207,15 @@
 				new /obj/effect/temp_visual/thunderbolt(T) //Visual feedback it worked.
 				playsound(src, 'sound/magic/lightningbolt.ogg', 100, TRUE)
 		qdel(src)
-	else
-		var/list/portal_turfs = list()
-		for(var/turf/PT in circleviewturfs(T, 3))
-			if(!PT.density)
-				portal_turfs += PT
-		playsound(src, 'sound/magic/lightningbolt.ogg', 100, TRUE)
-		for(var/turf/drunk_dial in shuffle(destinations))
-			var/drunken_opening = pick_n_take(portal_turfs)
-			new /obj/effect/portal/jaunt_tunnel(drunken_opening, drunk_dial, src, 100, thrower)
-			new /obj/effect/temp_visual/thunderbolt(drunken_opening)
-		qdel(src)
+		return
+		
+	var/list/portal_turfs = list()
+	for(var/turf/PT in circleviewturfs(T, 3))
+		if(!PT.density)
+			portal_turfs += PT
+	playsound(src, 'sound/magic/lightningbolt.ogg', 100, TRUE)
+	for(var/turf/drunk_dial in shuffle(destinations))
+		var/drunken_opening = pick_n_take(portal_turfs)
+		new /obj/effect/portal/jaunt_tunnel(drunken_opening, drunk_dial, src, 100, thrower)
+		new /obj/effect/temp_visual/thunderbolt(drunken_opening)
+	qdel(src)

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -48,6 +48,7 @@
 		EQUIPMENT("Brute First-Aid Kit", /obj/item/storage/firstaid/brute, 600),
 		EQUIPMENT("Fulton Pack", /obj/item/extraction_pack, 1000),
 		EQUIPMENT("Jaunter", /obj/item/wormhole_jaunter, 750),
+		EQUIPMENT("Chasm Jaunter Recovery Grenade", /obj/item/grenade/jaunter_grenade, 1500),
 		EQUIPMENT("Lazarus Injector", /obj/item/lazarus_injector, 1000),
 		EQUIPMENT("Point Transfer Card", /obj/item/card/mining_point_card, 500),
 		EQUIPMENT("Shelter Capsule", /obj/item/survivalcapsule, 400),


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Chasms now store mobs in a storage object, persists across turf changes.
Clings can crawl out via revival
A chasm recovery grenade can be used on the chasm to teleport *all* mobs in *that* chasm tile to random beacons on station.
Chasm recovery grenade can be used outside of chasms to make a shit load of wormholes to station beacons.
1500 points from mining vendor.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Getting permakilled to chasms via lag sucks, this adds a recovery function, as well as a funny grenade for more evil uses.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

slightly outdated videos:

https://imgur.com/a/pEsrz3M

https://imgur.com/a/mi1Qtrf

## Testing
<!-- How did you test the PR, if at all? -->

Chasmed, revived, grenaded stuff

## Changelog
:cl:
tweak: Clings can climb out of chasms
tweak: Chasms no longer delete mobs but hold them inside
tweak: Adds the NT drunk dialer, a jaunter grenade that can make a bunch of wormholes, or save someone from a chasm!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
