### PR TITLE
Fixes some chatbox errors

### DIFF
--- a/code/game/gamemodes/miniantags/abduction/machinery/experiment.dm
+++ b/code/game/gamemodes/miniantags/abduction/machinery/experiment.dm
@@ -149,7 +149,7 @@
 		var/objtype = pick(subtypesof(/datum/objective/abductee/))
 		var/datum/objective/abductee/O = new objtype()
 		H.mind.add_mind_objective(O)
-		var/list/messages = list(H.mind.prepare_announce_objectives())
+		var/list/messages = H.mind.prepare_announce_objectives()
 		to_chat(H, chat_box_red(messages.Join("<br>"))) // let the player know they have a new objective
 		SSticker.mode.update_abductor_icons_added(H.mind)
 

--- a/code/modules/antagonists/_common/antag_team.dm
+++ b/code/modules/antagonists/_common/antag_team.dm
@@ -204,7 +204,7 @@ GLOBAL_LIST_EMPTY(antagonist_teams)
 	for(var/datum/mind/member in members)
 		if(!member.current || !isliving(member.current))
 			return
-		var/list/messages = list(member.prepare_announce_objectives())
+		var/list/messages = member.prepare_announce_objectives()
 		to_chat(member.current, chat_box_red(messages.Join("<br>")))
 		SEND_SOUND(member.current, sound('sound/ambience/alarm4.ogg'))
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->Ensures that `prepare_announce_objectives()` is not wrapped in a list. I caught one of these in the review of the PR, but not the other ones. This fixes all the remaining ones.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Fixes #22873

## Testing
<!-- How did you test the PR, if at all? -->
It compiles, and it works.

## Changelog
:cl:
fix: Fixes an issue with abductor objectives not showing up
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
