### PR TITLE
makes the chasm handling system better for megafauna

### DIFF
--- a/code/game/turfs/simulated/floor/chasm.dm
+++ b/code/game/turfs/simulated/floor/chasm.dm
@@ -45,12 +45,6 @@
 	if(!drop_stuff())
 		STOP_PROCESSING(SSprocessing, src)
 
-/turf/simulated/floor/chasm/CanPathfindPass(obj/item/card/id/ID, to_dir, caller, no_id = FALSE)
-	if(!isliving(caller))
-		return TRUE
-	var/mob/living/L = caller
-	return (L.flying || ismegafauna(caller))
-
 /turf/simulated/floor/chasm/get_smooth_underlay_icon(mutable_appearance/underlay_appearance, turf/asking_turf, adjacency_dir)
 	underlay_appearance.icon = 'icons/turf/floors.dmi'
 	underlay_appearance.icon_state = "basalt"

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -415,7 +415,7 @@
 		return P
 
 /mob/living/simple_animal/hostile/proc/CanSmashTurfs(turf/T)
-	return iswallturf(T) || ismineralturf(T)
+	return iswallturf(T) || ismineralturf(T) || (istype(T, /turf/simulated/floor/chasm) && (ismegafauna(src) || flying))
 
 /mob/living/simple_animal/hostile/Move(atom/newloc, dir , step_x , step_y)
 	if(!client && dodging && approaching_target && prob(dodge_prob) && !moving_diagonally && isturf(loc) && isturf(newloc))
@@ -439,6 +439,9 @@
 		return
 	if(T.Adjacent(targets_from))
 		if(CanSmashTurfs(T))
+			if(istype(T, /turf/simulated/floor/chasm))
+				forceMove(T)
+				return
 			T.attack_animal(src)
 			return
 	for(var/obj/O in T.contents)

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -415,7 +415,7 @@
 		return P
 
 /mob/living/simple_animal/hostile/proc/CanSmashTurfs(turf/T)
-	return iswallturf(T) || ismineralturf(T) || (istype(T, /turf/simulated/floor/chasm) && (ismegafauna(src) || flying))
+	return iswallturf(T) || ismineralturf(T) || (ischasm(T) && (ismegafauna(src) || flying))
 
 /mob/living/simple_animal/hostile/Move(atom/newloc, dir , step_x , step_y)
 	if(!client && dodging && approaching_target && prob(dodge_prob) && !moving_diagonally && isturf(loc) && isturf(newloc))
@@ -439,7 +439,7 @@
 		return
 	if(T.Adjacent(targets_from))
 		if(CanSmashTurfs(T))
-			if(istype(T, /turf/simulated/floor/chasm))
+			if(ischasm(T))
 				forceMove(T)
 				return
 			T.attack_animal(src)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/ancient_robot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/ancient_robot.dm
@@ -295,6 +295,7 @@ Difficulty: Hard
 
 /mob/living/simple_animal/hostile/megafauna/ancient_robot/Bump(atom/A, yes)
 	if(charging)
+		DestroySurroundings()
 		if(isliving(A) && yes)
 			var/mob/living/L = A
 			if(!istype(A, /mob/living/simple_animal/hostile/ancient_robot_leg))
@@ -575,6 +576,7 @@ Difficulty: Hard
 	if(Dir)
 		leg_walking_controler(Dir)
 		if(charging)
+			DestroySurroundings()
 			if(mode == PYRO)
 				var/turf/C = get_turf(src)
 				new /obj/effect/temp_visual/lava_warning(C, enraged ? 18 SECONDS : 6 SECONDS)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -530,6 +530,8 @@ Difficulty: Hard
 	..()
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/Moved(atom/OldLoc, Dir, Forced = FALSE)
+	if(charging)
+		DestroySurroundings()
 	if(Dir)
 		new /obj/effect/decal/cleanable/blood/bubblegum(loc)
 	playsound(src, 'sound/effects/meteorimpact.ogg', 200, TRUE, 2, TRUE)
@@ -539,6 +541,7 @@ Difficulty: Hard
 	if(charging && yes)
 		if(isturf(A) || isobj(A) && A.density)
 			A.ex_act(EXPLODE_HEAVY)
+		DestroySurroundings()
 		if(isliving(A))
 			var/mob/living/L = A
 			L.visible_message("<span class='danger'>[src] slams into [L]!</span>", "<span class='userdanger'>[src] tramples you into the ground!</span>")

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
@@ -148,8 +148,10 @@
 
 /mob/living/simple_animal/hostile/megafauna/proc/do_chasm()
 	for(var/turf/simulated/floor/chasm/C in circlerangeturfs(src, 1))
+		if(!C.density)
+			continue
 		C.density = FALSE //I hate it.
-		addtimer(VARSET_CALLBACK(C, density, TRUE), 2 SECONDS) // Needed to make them path. I hate it.
+		addtimer(VARSET_CALLBACK(C, density, TRUE), 2.25 SECONDS) // Needed to make them path. I hate it.
 
 /// This proc is called by the HRD-MDE grenade to enrage the megafauna. This should increase the megafaunas attack speed if possible, give it new moves, or disable weak moves. This should be reverseable, and reverses on zlvl change.
 /mob/living/simple_animal/hostile/megafauna/proc/enrage()

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
@@ -57,9 +57,12 @@
 	QDEL_NULL(internal_gps)
 	return ..()
 
+/mob/living/simple_animal/hostile/megafauna/Life(seconds, times_fired)
+	. = ..()
+	do_chasm()
+
 /mob/living/simple_animal/hostile/megafauna/Moved()
-	if(target)
-		DestroySurroundings() //So they can path through chasms.
+	do_chasm()
 	if(nest && nest.parent && get_dist(nest.parent, src) > nest_range)
 		var/turf/closest = get_turf(nest.parent)
 		for(var/i = 1 to nest_range)
@@ -143,6 +146,11 @@
 	recovery_time = world.time + buffer_time
 	ranged_cooldown = world.time + buffer_time
 
+/mob/living/simple_animal/hostile/megafauna/proc/do_chasm()
+	for(var/turf/simulated/floor/chasm/C in circlerangeturfs(src, 1))
+		C.density = FALSE //I hate it.
+		addtimer(VARSET_CALLBACK(C, density, TRUE), 2 SECONDS) // Needed to make them path. I hate it.
+
 /// This proc is called by the HRD-MDE grenade to enrage the megafauna. This should increase the megafaunas attack speed if possible, give it new moves, or disable weak moves. This should be reverseable, and reverses on zlvl change.
 /mob/living/simple_animal/hostile/megafauna/proc/enrage()
 	if(enraged || ((health / maxHealth) * 100 <= 80))
@@ -151,12 +159,6 @@
 
 /mob/living/simple_animal/hostile/megafauna/proc/unrage()
 	enraged = FALSE
-
-/mob/living/simple_animal/hostile/megafauna/DestroySurroundings()
-	. = ..()
-	for(var/turf/simulated/floor/chasm/C in circlerangeturfs(src, 1))
-		C.density = FALSE //I hate it.
-		addtimer(VARSET_CALLBACK(C, density, TRUE), 2 SECONDS) // Needed to make them path. I hate it.
 
 /datum/action/innate/megafauna_attack
 	name = "Megafauna Attack"

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
@@ -151,7 +151,7 @@
 		if(!C.density)
 			continue
 		C.density = FALSE //I hate it.
-		addtimer(VARSET_CALLBACK(C, density, TRUE), 2.25 SECONDS) // Needed to make them path. I hate it.
+		addtimer(VARSET_CALLBACK(C, density, TRUE), 2.25 SECONDS) // Needed to make them path. 2.25 seconds so it doesn't expire till after the next life tick
 
 /// This proc is called by the HRD-MDE grenade to enrage the megafauna. This should increase the megafaunas attack speed if possible, give it new moves, or disable weak moves. This should be reverseable, and reverses on zlvl change.
 /mob/living/simple_animal/hostile/megafauna/proc/enrage()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Megafauna will path through chasms even more reliably now, and will not be trapped if placed on a chasm tiled surrounded by chasm tiles.
Megafauna no longer constantly destroy surroundings, should make some fauna like bubblegum easier for crusher, and colossus easier in general

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Previous system was a bit flawed and could be handled better, while using destroy surroundings sounded good on paper it probably was not good for all megafauna to have this. Having it run on life ensures they always have the option to move, and we can directly call the proc on move vs destroy surroundings.

## Testing
<!-- How did you test the PR, if at all? -->

confirmed megafauna would not be stuck in 3x3 baby jail

## Changelog
:cl:
tweak: Improved megafaunas abilities to move over chasms more.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
