### PR TITLE
Fix wrestling explanation

### DIFF
--- a/code/modules/martial_arts/martial.dm
+++ b/code/modules/martial_arts/martial.dm
@@ -298,7 +298,7 @@
 			to_chat(user, "<span class='warning'>In spite of the grandiosity of the belt, you don't feel like getting into any fights.</span>")
 			return
 		style.teach(H, TRUE)
-		to_chat(user, "<span class='sciradio'>You have an urge to flex your muscles and get into a fight. You have the knowledge of a thousand wrestlers before you. You can remember more by using the Recall teaching verb in the wrestling tab.</span>")
+		to_chat(user, "<span class='sciradio'>You have an urge to flex your muscles and get into a fight. You have the knowledge of a thousand wrestlers before you. You can remember more by using the verb in the martial arts tab.</span>")
 	return
 
 /obj/item/storage/belt/champion/wrestling/dropped(mob/user)

--- a/code/modules/martial_arts/wrestling.dm
+++ b/code/modules/martial_arts/wrestling.dm
@@ -1,7 +1,7 @@
 /datum/martial_art/wrestling
 	name = "Wrestling"
 	weight = 3
-	help_verb = /mob/living/carbon/human/proc/wrestling_help
+	has_explaination_verb = TRUE
 
 //	combo refence since wrestling uses a different format to sleeping carp and plasma fist.
 //	Clinch "G"
@@ -57,12 +57,12 @@
 	D.apply_damage(10, STAMINA, affecting, armor_block)
 	return 1
 
-/mob/living/carbon/human/proc/wrestling_help()
-	set name = "Recall Teachings"
-	set desc = "Remember how to wrestle."
-	set category = "Wrestling"
+/datum/martial_art/wrestling/explaination_header(user)
+	. = ..()
+	to_chat(user, "<b><i>You flex your muscles and have a revelation...</i></b>")
 
-	to_chat(usr, "<b><i>You flex your muscles and have a revelation...</i></b>")
-	to_chat(usr, "<span class='notice'>Clinch</span>: Grab. Passively gives you a chance to immediately aggressively grab someone. Not always successful.")
-	to_chat(usr, "<span class='notice'>Suplex</span>: Disarm someone you are grabbing. Suplexes your target to the floor. Greatly injures them and leaves both you and your target on the floor.")
-	to_chat(usr, "<span class='notice'>Advanced grab</span>: Grab. Passively causes stamina damage when grabbing someone.")
+/datum/martial_art/wrestling/explaination_combos(user)
+	. = ..()
+	to_chat(user, "<span class='notice'>Clinch</span>: Grab. Passively gives you a chance to immediately aggressively grab someone. Not always successful.")
+	to_chat(user, "<span class='notice'>Suplex</span>: Disarm someone you are grabbing. Suplexes your target to the floor. Greatly injures them and leaves both you and your target on the floor.")
+	to_chat(user, "<span class='notice'>Advanced grab</span>: Grab. Passively causes stamina damage when grabbing someone.")


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes the explanation text for wrestling by bringing it more in line with other martial arts.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
The current code refers to a tab that doesn't work, and suggests using a verb that doesn't work. While the martial arts tab still isn't great, it's the best we've got.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Loaded in, was able to learn how to suplex a vulp.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: You can now properly get an explanation in-game for how to use the wrestling belt's moves.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
