### PR TITLE
Tweaks *twirl

### DIFF
--- a/code/modules/mob/living/carbon/carbon_emote.dm
+++ b/code/modules/mob/living/carbon/carbon_emote.dm
@@ -168,23 +168,38 @@
 	if(!.)
 		return
 
-	if(user.l_hand || user.r_hand)
-		return TRUE
+	if(user.get_active_hand() || user.get_inactive_hand())
+		var/obj/item/thing
+
+		if(user.get_active_hand())
+			thing = user.get_active_hand()
+		else
+			thing = user.get_inactive_hand()
+
+		if(thing.flags & ABSTRACT && !istype(thing, /obj/item/grab))
+			to_chat(user, "<span class='warning'>You cannot twirl [thing]!</span>")
+			return FALSE
+		else
+			return TRUE
 
 	to_chat(user, "<span class='warning'>You need something in your hand to use this emote!</span>")
 	return FALSE
 
 /datum/emote/living/carbon/twirl/run_emote(mob/user, params, type_override, intentional)
 
-	var/obj/item/thing = user.l_hand || user.r_hand
-	if(thing.flags & ABSTRACT)
-		if(istype(thing, /obj/item/grab))
-			var/obj/item/grab/grabbed = thing
-			message = "twirls [grabbed.affecting.name] around!"
-			grabbed.affecting.emote("spin")
-		else
-			return
+	var/obj/item/thing
+
+	if(user.get_active_hand())
+		thing = user.get_active_hand()
+	else
+		thing = user.get_inactive_hand()
+
+	if(istype(thing, /obj/item/grab))
+		var/obj/item/grab/grabbed = thing
+		message = "twirls [grabbed.affecting.name] around!"
+		grabbed.affecting.emote("spin")
 	else
 		message = "twirls [thing] around in their hand!"
+
 	. = ..()
 	message = initial(message)

--- a/code/modules/mob/living/carbon/carbon_emote.dm
+++ b/code/modules/mob/living/carbon/carbon_emote.dm
@@ -177,6 +177,14 @@
 /datum/emote/living/carbon/twirl/run_emote(mob/user, params, type_override, intentional)
 
 	var/obj/item/thing = user.l_hand || user.r_hand
-	message = "twirls [thing] around in their hand!"
+	if(thing.flags & ABSTRACT)
+		if(istype(thing, /obj/item/grab))
+			var/obj/item/grab/grabbed = thing
+			message = "twirls [grabbed.affecting.name] around!"
+			grabbed.affecting.emote("spin")
+		else
+			return
+	else
+		message = "twirls [thing] around in their hand!"
 	. = ..()
 	message = initial(message)

--- a/code/modules/mob/living/carbon/carbon_emote.dm
+++ b/code/modules/mob/living/carbon/carbon_emote.dm
@@ -163,10 +163,7 @@
 	message = "twirls something around in their hand."
 	hands_use_check = TRUE
 
-/datum/emote/living/carbon/twirl/can_run_emote(mob/living/user, status_check, intentional)
-	. = ..()
-	if(!.)
-		return
+/datum/emote/living/carbon/twirl/run_emote(mob/user, params, type_override, intentional)
 
 	if(user.get_active_hand() || user.get_inactive_hand())
 		var/obj/item/thing
@@ -176,30 +173,18 @@
 		else
 			thing = user.get_inactive_hand()
 
-		if(thing.flags & ABSTRACT && !istype(thing, /obj/item/grab))
-			to_chat(user, "<span class='warning'>You cannot twirl [thing]!</span>")
-			return FALSE
+		if(istype(thing, /obj/item/grab))
+			var/obj/item/grab/grabbed = thing
+			message = "twirls [grabbed.affecting.name] around!"
+			grabbed.affecting.emote("spin")
+		else if(!(thing.flags & ABSTRACT))
+			message = "twirls [thing] around in their hand!"
 		else
+			to_chat(user, "<span class='warning'>You cannot twirl [thing]!</span>")
 			return TRUE
 
-	to_chat(user, "<span class='warning'>You need something in your hand to use this emote!</span>")
-	return FALSE
-
-/datum/emote/living/carbon/twirl/run_emote(mob/user, params, type_override, intentional)
-
-	var/obj/item/thing
-
-	if(user.get_active_hand())
-		thing = user.get_active_hand()
 	else
-		thing = user.get_inactive_hand()
-
-	if(istype(thing, /obj/item/grab))
-		var/obj/item/grab/grabbed = thing
-		message = "twirls [grabbed.affecting.name] around!"
-		grabbed.affecting.emote("spin")
-	else
-		message = "twirls [thing] around in their hand!"
-
+		to_chat(user, "<span class='warning'>You need something in your hand to use this emote!</span>")
+		return TRUE
 	. = ..()
 	message = initial(message)

--- a/code/modules/mob/living/carbon/carbon_emote.dm
+++ b/code/modules/mob/living/carbon/carbon_emote.dm
@@ -165,26 +165,26 @@
 
 /datum/emote/living/carbon/twirl/run_emote(mob/user, params, type_override, intentional)
 
-	if(user.get_active_hand() || user.get_inactive_hand())
-		var/obj/item/thing
-
-		if(user.get_active_hand())
-			thing = user.get_active_hand()
-		else
-			thing = user.get_inactive_hand()
-
-		if(istype(thing, /obj/item/grab))
-			var/obj/item/grab/grabbed = thing
-			message = "twirls [grabbed.affecting.name] around!"
-			grabbed.affecting.emote("spin")
-		else if(!(thing.flags & ABSTRACT))
-			message = "twirls [thing] around in their hand!"
-		else
-			to_chat(user, "<span class='warning'>You cannot twirl [thing]!</span>")
-			return TRUE
-
-	else
+	if(!(user.get_active_hand() || user.get_inactive_hand()))
 		to_chat(user, "<span class='warning'>You need something in your hand to use this emote!</span>")
 		return TRUE
+
+	var/obj/item/thing
+
+	if(user.get_active_hand())
+		thing = user.get_active_hand()
+	else
+		thing = user.get_inactive_hand()
+
+	if(istype(thing, /obj/item/grab))
+		var/obj/item/grab/grabbed = thing
+		message = "twirls [grabbed.affecting.name] around!"
+		grabbed.affecting.emote("spin")
+	else if(!(thing.flags & ABSTRACT))
+		message = "twirls [thing] around in their hand!"
+	else
+		to_chat(user, "<span class='warning'>You cannot twirl [thing]!</span>")
+		return TRUE
+
 	. = ..()
 	message = initial(message)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Changes up *twirl a bit.
- You will always twirl the item in your active hand (you can still twirl things in your offhand).
- You can no longer *twirl abstract items, except grabs.
- If you *twirl a grab, you twirl around the person you're grabbing.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Adds a fun interaction and makes *twirl more intuitive. (Also, twirling abstract items isn't great - how do you even twirl an armblade or a slapper?)
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of Changes
![dreamseeker_CAegUYIEyU](https://github.com/ParadiseSS13/Paradise/assets/47290811/96e0cefe-83d6-4835-bc9c-24fa02707a48)

## Testing
Recorded the above gif and twirled a couple other items in my bag. Also, failed to *twirl a slapper and an armblade
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
add: You can now *twirl people!
tweak: You can no longer twirl abstract items
tweak: *twirl now prioritizes your active hand
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
