### PR TITLE
Fixes a possible runtime with observers logging out

### DIFF
--- a/code/modules/mob/dead/observer/observer_logout.dm
+++ b/code/modules/mob/dead/observer/observer_logout.dm
@@ -5,5 +5,5 @@
 	spawn(0)
 		if(src && !key)	//we've transferred to another mob. This ghost should be deleted.
 			qdel(src)
-		if(mind?.current)
+		if(isliving(mind?.current))
 			mind.current.med_hud_set_status()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->Fixes a possible runtime with observers logging out

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->This is less critical than the other PR, but this should probably be changed for consistency.

## Testing
<!-- How did you test the PR, if at all? -->
I can logout as an observer without any runtimes

## Changelog
NPFC

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
