### PR TITLE
Does the most contriversial thing ever: Nerfs welders

### DIFF
--- a/code/game/objects/items/tools/welder.dm
+++ b/code/game/objects/items/tools/welder.dm
@@ -95,7 +95,7 @@
 	if(tool_enabled)
 		START_PROCESSING(SSobj, src)
 		damtype = BURN
-		force = 15
+		force = 12
 		hitsound = 'sound/items/welder.ogg'
 		playsound(loc, activation_sound, 50, 1)
 		set_light(light_intensity)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->Nerfs the welder from 15 active damage to 12 active damage. To do >= 100 damage it previously took 7 hits with no armor. Now it takes 9 hits with no armor. Its not a major nerf, but it makes a slight difference.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
For a long time, I've hated that this is the meta weapon for everybody. Everyone from assistants, cargo, sci, engi, and even occassionally medical/sec carries some kind of welder. They do about the same amount or more of damage as other crew weapons, such as saws, knives, batons, telebatons, etc. They also have WAY more versatility than any other weapon, because they're one of the major tools.

If you want to kill someone as crew, this is the meta. And I hate it. Its also the meta weapon against blobs, or hell, any biohazard. Blob doesn't have a burn weakness, so why do people only use welders? I don't know. You never see someone using a survival knife (same damage), or a circular saw/dental drill(same damage) or hell, the jaws of life (same damage). Hell, 15 damage is the same amount that the default HIS GRACE does.

I think that while still keeping the welder a good weapon as a back up, it shouldnt be the be-all and end-all of melee crew combat (without illegal things like spears). It incentivizes players to think outside the box in their weapon choice, not just reaching into their belt and turning on their welder. There is a LOT of alternatives, and I'd like to see some more of them used without people just charging head first into combat without thinking. Nearly everyone carries something, so get something from your job niche.

Its also the major weapon used against blob, which has 30 health per tile. This means people will be incentivized for getting more creative with their weaponry by being able to do a 2 hit kill per tile instead of the new 3 hit kill.

(Correction: Blob does not take extra burn damage, but blobs take half damage from brute sources)

If really needed, I could alter the code so that welders still do the same amount of damage to blob tiles.

## Testing
<!-- How did you test the PR, if at all? -->
Took just a few seconds longer to kill a skrell.

## Changelog
:cl:
tweak: Welders now do 12 damage instead of 15
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
