### PR TITLE
Tweaks Flashing from Welding Metal

### DIFF
--- a/code/game/objects/items/tools/welder.dm
+++ b/code/game/objects/items/tools/welder.dm
@@ -152,7 +152,7 @@
 	. = ..()
 	if(!. && user)
 		if(progress_flash_divisor == 0)
-			user.flash_eyes(min(light_intensity, 1))
+			user.flash_eyes(min(light_intensity, 2))
 			progress_flash_divisor = initial(progress_flash_divisor)
 		else
 			progress_flash_divisor--

--- a/code/game/objects/items/tools/welder.dm
+++ b/code/game/objects/items/tools/welder.dm
@@ -126,12 +126,6 @@
 			to_chat(user, "<span class='warning'>You need more welding fuel to complete this task!</span>")
 		return FALSE
 
-// When welding is about to start, run a normal tool_use_check, then flash a mob if it succeeds.
-/obj/item/weldingtool/tool_start_check(atom/target, mob/living/user, amount=0)
-	. = tool_use_check(user, amount)
-	if(. && user && !ismob(target)) // Don't flash the user if they're repairing robo limbs or repairing a borg etc. Only flash them if the target is an object
-		user.flash_eyes(light_intensity)
-
 /obj/item/weldingtool/use(amount)
 	if(GET_FUEL < amount * requires_fuel)
 		return

--- a/code/game/objects/items/tools/welder.dm
+++ b/code/game/objects/items/tools/welder.dm
@@ -32,7 +32,7 @@
 	var/deactivation_sound = 'sound/items/welderdeactivate.ogg'
 	var/light_intensity = 2
 	var/low_fuel_changes_icon = TRUE//More than one icon_state due to low fuel?
-	var/progress_flash_divisor = 10 //Length of time between each "eye flash"
+	var/progress_flash_divisor = 40 //Length of time between each "eye flash"
 
 /obj/item/weldingtool/Initialize(mapload)
 	..()

--- a/code/game/objects/items/tools/welder.dm
+++ b/code/game/objects/items/tools/welder.dm
@@ -32,7 +32,8 @@
 	var/deactivation_sound = 'sound/items/welderdeactivate.ogg'
 	var/light_intensity = 2
 	var/low_fuel_changes_icon = TRUE//More than one icon_state due to low fuel?
-	var/progress_flash_divisor = 40 //Length of time between each "eye flash"
+	var/progress_heavy_flash_divisor = 40 //Length of time between each strong "eye flash"
+	var/progress_light_flash_divisor = 19 //Length of time between each weak "eye flash"
 
 /obj/item/weldingtool/Initialize(mapload)
 	..()
@@ -144,18 +145,29 @@
 	if(did_thing)
 		remove_fuel(1) //Consume some fuel after we do a welding action
 	if(delay)
-		progress_flash_divisor = initial(progress_flash_divisor)
+		progress_heavy_flash_divisor = initial(progress_heavy_flash_divisor)
+	if(delay)
+		progress_light_flash_divisor = initial(progress_light_flash_divisor)
 	target.cut_overlay(GLOB.welding_sparks)
 	return did_thing
 
 /obj/item/weldingtool/tool_check_callback(mob/living/user, amount, datum/callback/extra_checks)
 	. = ..()
 	if(!. && user)
-		if(progress_flash_divisor == 0)
+		if(progress_heavy_flash_divisor == 0)
 			user.flash_eyes(min(light_intensity, 2))
-			progress_flash_divisor = initial(progress_flash_divisor)
+			progress_heavy_flash_divisor = initial(progress_heavy_flash_divisor)
 		else
-			progress_flash_divisor--
+			progress_heavy_flash_divisor--
+
+/obj/item/weldingtool/tool_check_callback(mob/living/user, amount, datum/callback/extra_checks)
+	. = ..()
+	if(!. && user)
+		if(progress_light_flash_divisor == 0)
+			user.flash_eyes(min(light_intensity, 1))
+			progress_light_flash_divisor = initial(progress_light_flash_divisor)
+		else
+			progress_light_flash_divisor--
 
 /obj/item/weldingtool/proc/remove_fuel(amount) //NB: doesn't check if we have enough fuel, it just removes however much is left if there's not enough
 	reagents.remove_reagent("fuel", amount * requires_fuel)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Removes the first immediate flash when welding metal. Provides a brief moment for the person to stop welding if unintended.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
From what I've read and seen, the blinding flash when the welder first hits metal was an unintended Nerf that greatly limits its use. It greatly hinders both conventional and blob combat, as well as being unintuitive. Welders are already limited by fuel use, and the experimental welder is about as advanced as other tools that can deal similar amounts of damage, like the advanced plasma cutter.
In real life, if you graze metal with the tip of a blowtorch's flame, it wouldn't immediately start burning your eyes. This tweak would still make welding realistic/balanced without influencing much except slightly improving combat and QOL.
## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->


https://github.com/ParadiseSS13/Paradise/assets/89031914/4b0e67cf-35e5-4d7b-965b-88d637c07849



## Testing
<!-- How did you test the PR, if at all? -->
Tested welding on walls and vents.
## Changelog
:cl:
tweak: Tweaked welding tool's flashing
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
