### PR TITLE
Increases the duration of Regenerative Stasis to 50 seconds

### DIFF
--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -1,4 +1,4 @@
-#define LING_FAKEDEATH_TIME					40 SECONDS
+#define LING_FAKEDEATH_TIME					60 SECONDS
 #define LING_ABSORB_RECENT_SPEECH			8	//The amount of recent spoken lines to gain on absorbing a mob
 
 GLOBAL_LIST_INIT(possible_changeling_IDs, list("Alpha","Beta","Gamma","Delta","Epsilon","Zeta","Eta","Theta","Iota","Kappa","Lambda","Mu","Nu","Xi","Omicron","Pi","Rho","Sigma","Tau","Upsilon","Phi","Chi","Psi","Omega"))

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -1,4 +1,4 @@
-#define LING_FAKEDEATH_TIME					60 SECONDS
+#define LING_FAKEDEATH_TIME					50 SECONDS
 #define LING_ABSORB_RECENT_SPEECH			8	//The amount of recent spoken lines to gain on absorbing a mob
 
 GLOBAL_LIST_INIT(possible_changeling_IDs, list("Alpha","Beta","Gamma","Delta","Epsilon","Zeta","Eta","Theta","Iota","Kappa","Lambda","Mu","Nu","Xi","Omicron","Pi","Rho","Sigma","Tau","Upsilon","Phi","Chi","Psi","Omega"))


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Regenerative Stasis will now take **50** seconds up from 40 seconds.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Ignore any time I said "one minute" or "sixty seconds" below, balance team requested it changed to 50 seconds and I'm too lazy to edit every instance of the time mention.

As stated in my pitch to Mr. Balance Man, "Cling has gotten a lot of love and attention over the last year, significant power increase, and we cut out the most common ways to kill it - now there's only usually static places to kill it. Combine this with the fact we've been introducing larger maps like Farragus, Clings now enjoy a massive degree of safety armblading security so long as they just do it somewhere away from a gibber/cremator or by destroying these first." The 40 second revive existed before we cut down on the options available to kill clings (removing decapitation), before we tripled their chemical regen, and before we started using larger maps (looking at you, Farragus). One minute still isn't the most punishing but does make it much less of a viable option to just run up, armblade sec, regen stasis, revive before you get cremated, and return to armblading security.

Ultimately, I hope that by going for a simple numbers change like this, super-loud-grug Cling will be less viable and as such played less (or less impactful when done), which seems like a good thing all around to me - it's not particularly engaging for Security to fight as their options are either die to the unstunnable regenerating guy with an undisarmable weapon or use some gamey way to kill the Cling (which isn't fun). Changeling does already have some pretty useful skills for stealth and shifting identity if they're suspected, which I hope get used more as a result. Lastly, the concept that "death is nothing" to a Cling unless you're within half a minute walk (because they'll need 10 seconds to strip you) of a cremator or gibber is a bit shit honestly, death should be scary and have consequences, just... less, for Changelings.

Also, this was cleared with one member of the balance team before opening the PR. Yay!

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
N/A, numbers change
## Testing
<!-- How did you test the PR, if at all? -->
Just a numbers change, but I still checked it built, launched, and then rejuvenated as a Changeling. Ran a timer, even - 1 minute and 0.82 seconds, the latter of which is just my delay in starting and stopping the timer :)
Ignore the above, just ticked it down to 50 seconds from 60 which will work fiiiiiiiiiiiiine.
## Changelog
:cl:
tweak: Changeling revive takes 50 seconds, up from 40 seconds.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
