### PR TITLE
Upscales Changeling DNA Costs

### DIFF
--- a/code/modules/antagonists/changeling/datum_changeling.dm
+++ b/code/modules/antagonists/changeling/datum_changeling.dm
@@ -39,7 +39,7 @@
 	/// If the changeling is in the process of absorbing someone.
 	var/is_absorbing = FALSE
 	/// The amount of points available to purchase changeling abilities.
-	var/genetic_points = 100
+	var/genetic_points = 20
 	/// A name that will display in place of the changeling's real name when speaking.
 	var/mimicing = ""
 	/// If the changeling can respec their purchased abilities.

--- a/code/modules/antagonists/changeling/datum_changeling.dm
+++ b/code/modules/antagonists/changeling/datum_changeling.dm
@@ -39,7 +39,7 @@
 	/// If the changeling is in the process of absorbing someone.
 	var/is_absorbing = FALSE
 	/// The amount of points available to purchase changeling abilities.
-	var/genetic_points = 10
+	var/genetic_points = 100
 	/// A name that will display in place of the changeling's real name when speaking.
 	var/mimicing = ""
 	/// If the changeling can respec their purchased abilities.

--- a/code/modules/antagonists/changeling/powers/augmented_eyesight.dm
+++ b/code/modules/antagonists/changeling/powers/augmented_eyesight.dm
@@ -4,7 +4,7 @@
 	helptext = "Grants us x-ray vision or flash protection. We will become a lot more vulnerable to flash-based devices while x-ray vision is active."
 	button_icon_state = "augmented_eyesight"
 	chemical_cost = 0
-	dna_cost = 2
+	dna_cost = 20
 	active = FALSE
 	power_type = CHANGELING_PURCHASABLE_POWER
 

--- a/code/modules/antagonists/changeling/powers/augmented_eyesight.dm
+++ b/code/modules/antagonists/changeling/powers/augmented_eyesight.dm
@@ -4,7 +4,7 @@
 	helptext = "Grants us x-ray vision or flash protection. We will become a lot more vulnerable to flash-based devices while x-ray vision is active."
 	button_icon_state = "augmented_eyesight"
 	chemical_cost = 0
-	dna_cost = 20
+	dna_cost = 4
 	active = FALSE
 	power_type = CHANGELING_PURCHASABLE_POWER
 

--- a/code/modules/antagonists/changeling/powers/become_headslug.dm
+++ b/code/modules/antagonists/changeling/powers/become_headslug.dm
@@ -4,7 +4,7 @@
 	helptext = "We will be placed in control of a small, fragile creature. We may attack a corpse like this to plant an egg which will slowly mature into a new form for us."
 	button_icon_state = "last_resort"
 	chemical_cost = 20
-	dna_cost = 1
+	dna_cost = 10
 	req_human = TRUE
 	power_type = CHANGELING_PURCHASABLE_POWER
 

--- a/code/modules/antagonists/changeling/powers/become_headslug.dm
+++ b/code/modules/antagonists/changeling/powers/become_headslug.dm
@@ -4,7 +4,7 @@
 	helptext = "We will be placed in control of a small, fragile creature. We may attack a corpse like this to plant an egg which will slowly mature into a new form for us."
 	button_icon_state = "last_resort"
 	chemical_cost = 20
-	dna_cost = 10
+	dna_cost = 2
 	req_human = TRUE
 	power_type = CHANGELING_PURCHASABLE_POWER
 

--- a/code/modules/antagonists/changeling/powers/biodegrade.dm
+++ b/code/modules/antagonists/changeling/powers/biodegrade.dm
@@ -4,7 +4,7 @@
 	helptext = "This is obvious to nearby people, and can destroy standard restraints and closets, and break you out of grabs."
 	button_icon_state = "biodegrade"
 	chemical_cost = 30 //High cost to prevent spam
-	dna_cost = 20
+	dna_cost = 4
 	req_human = TRUE
 	power_type = CHANGELING_PURCHASABLE_POWER
 	/// Type of acid hand we give to person

--- a/code/modules/antagonists/changeling/powers/biodegrade.dm
+++ b/code/modules/antagonists/changeling/powers/biodegrade.dm
@@ -4,7 +4,7 @@
 	helptext = "This is obvious to nearby people, and can destroy standard restraints and closets, and break you out of grabs."
 	button_icon_state = "biodegrade"
 	chemical_cost = 30 //High cost to prevent spam
-	dna_cost = 2
+	dna_cost = 20
 	req_human = TRUE
 	power_type = CHANGELING_PURCHASABLE_POWER
 	/// Type of acid hand we give to person

--- a/code/modules/antagonists/changeling/powers/chameleon_skin.dm
+++ b/code/modules/antagonists/changeling/powers/chameleon_skin.dm
@@ -3,7 +3,7 @@
 	desc = "Our skin pigmentation rapidly changes to suit our current environment. Costs 25 chemicals."
 	helptext = "Allows us to become invisible after a few seconds of standing still. Can be toggled on and off."
 	button_icon_state = "chameleon_skin"
-	dna_cost = 2
+	dna_cost = 20
 	chemical_cost = 25
 	req_human = TRUE
 	power_type = CHANGELING_PURCHASABLE_POWER

--- a/code/modules/antagonists/changeling/powers/chameleon_skin.dm
+++ b/code/modules/antagonists/changeling/powers/chameleon_skin.dm
@@ -3,7 +3,7 @@
 	desc = "Our skin pigmentation rapidly changes to suit our current environment. Costs 25 chemicals."
 	helptext = "Allows us to become invisible after a few seconds of standing still. Can be toggled on and off."
 	button_icon_state = "chameleon_skin"
-	dna_cost = 20
+	dna_cost = 4
 	chemical_cost = 25
 	req_human = TRUE
 	power_type = CHANGELING_PURCHASABLE_POWER

--- a/code/modules/antagonists/changeling/powers/contort_body.dm
+++ b/code/modules/antagonists/changeling/powers/contort_body.dm
@@ -3,7 +3,7 @@
 	desc = "We contort our body, allowing us to fit in and under things we normally wouldn't be able to. Costs 25 chemicals."
 	button_icon_state = "contort_body"
 	chemical_cost = 25
-	dna_cost = 20
+	dna_cost = 4
 	power_type = CHANGELING_PURCHASABLE_POWER
 
 /datum/action/changeling/contort_body/Remove(mob/M)

--- a/code/modules/antagonists/changeling/powers/contort_body.dm
+++ b/code/modules/antagonists/changeling/powers/contort_body.dm
@@ -3,7 +3,7 @@
 	desc = "We contort our body, allowing us to fit in and under things we normally wouldn't be able to. Costs 25 chemicals."
 	button_icon_state = "contort_body"
 	chemical_cost = 25
-	dna_cost = 2
+	dna_cost = 20
 	power_type = CHANGELING_PURCHASABLE_POWER
 
 /datum/action/changeling/contort_body/Remove(mob/M)

--- a/code/modules/antagonists/changeling/powers/digitalcamo.dm
+++ b/code/modules/antagonists/changeling/powers/digitalcamo.dm
@@ -3,7 +3,7 @@
 	desc = "By evolving the ability to distort our form and proportions, we defeat common algorithms used to detect lifeforms on cameras."
 	helptext = "We cannot be tracked by camera while using this skill."
 	button_icon_state = "digital_camo"
-	dna_cost = 10
+	dna_cost = 2
 	power_type = CHANGELING_PURCHASABLE_POWER
 
 /datum/action/changeling/digitalcamo/Remove(mob/M)

--- a/code/modules/antagonists/changeling/powers/digitalcamo.dm
+++ b/code/modules/antagonists/changeling/powers/digitalcamo.dm
@@ -3,7 +3,7 @@
 	desc = "By evolving the ability to distort our form and proportions, we defeat common algorithms used to detect lifeforms on cameras."
 	helptext = "We cannot be tracked by camera while using this skill."
 	button_icon_state = "digital_camo"
-	dna_cost = 1
+	dna_cost = 10
 	power_type = CHANGELING_PURCHASABLE_POWER
 
 /datum/action/changeling/digitalcamo/Remove(mob/M)

--- a/code/modules/antagonists/changeling/powers/epinephrine.dm
+++ b/code/modules/antagonists/changeling/powers/epinephrine.dm
@@ -4,7 +4,7 @@
 	helptext = "Removes all stuns instantly and adds a short term reduction in further stuns. Can be used while unconscious. Continued use poisons the body."
 	button_icon_state = "adrenaline"
 	chemical_cost = 30
-	dna_cost = 20
+	dna_cost = 4
 	req_human = TRUE
 	req_stat = UNCONSCIOUS
 	power_type = CHANGELING_PURCHASABLE_POWER

--- a/code/modules/antagonists/changeling/powers/epinephrine.dm
+++ b/code/modules/antagonists/changeling/powers/epinephrine.dm
@@ -4,7 +4,7 @@
 	helptext = "Removes all stuns instantly and adds a short term reduction in further stuns. Can be used while unconscious. Continued use poisons the body."
 	button_icon_state = "adrenaline"
 	chemical_cost = 30
-	dna_cost = 2
+	dna_cost = 20
 	req_human = TRUE
 	req_stat = UNCONSCIOUS
 	power_type = CHANGELING_PURCHASABLE_POWER

--- a/code/modules/antagonists/changeling/powers/fleshmend.dm
+++ b/code/modules/antagonists/changeling/powers/fleshmend.dm
@@ -4,7 +4,7 @@
 	helptext = "Does not regrow limbs. Partially recovers our blood. Functions while unconscious."
 	button_icon_state = "fleshmend"
 	chemical_cost = 20
-	dna_cost = 2
+	dna_cost = 20
 	req_stat = UNCONSCIOUS
 	power_type = CHANGELING_PURCHASABLE_POWER
 

--- a/code/modules/antagonists/changeling/powers/fleshmend.dm
+++ b/code/modules/antagonists/changeling/powers/fleshmend.dm
@@ -4,7 +4,7 @@
 	helptext = "Does not regrow limbs. Partially recovers our blood. Functions while unconscious."
 	button_icon_state = "fleshmend"
 	chemical_cost = 20
-	dna_cost = 20
+	dna_cost = 4
 	req_stat = UNCONSCIOUS
 	power_type = CHANGELING_PURCHASABLE_POWER
 

--- a/code/modules/antagonists/changeling/powers/hivemind.dm
+++ b/code/modules/antagonists/changeling/powers/hivemind.dm
@@ -7,7 +7,7 @@ GLOBAL_LIST_EMPTY(hivemind_bank)
 	helptext = "Tunes our chemical receptors for hivemind communication, which passively grants us access to the Changeling Hivemind."
 	button_icon_state = "hive_absorb"
 	chemical_cost = 10
-	dna_cost = 2
+	dna_cost = 20
 	power_type = CHANGELING_PURCHASABLE_POWER
 
 /datum/action/changeling/hivemind_pick/on_purchase(mob/user, datum/antagonist/changeling/C)

--- a/code/modules/antagonists/changeling/powers/hivemind.dm
+++ b/code/modules/antagonists/changeling/powers/hivemind.dm
@@ -7,7 +7,7 @@ GLOBAL_LIST_EMPTY(hivemind_bank)
 	helptext = "Tunes our chemical receptors for hivemind communication, which passively grants us access to the Changeling Hivemind."
 	button_icon_state = "hive_absorb"
 	chemical_cost = 10
-	dna_cost = 20
+	dna_cost = 4
 	power_type = CHANGELING_PURCHASABLE_POWER
 
 /datum/action/changeling/hivemind_pick/on_purchase(mob/user, datum/antagonist/changeling/C)

--- a/code/modules/antagonists/changeling/powers/lesserform.dm
+++ b/code/modules/antagonists/changeling/powers/lesserform.dm
@@ -4,7 +4,7 @@
 	helptext = "The transformation greatly reduces our size, allowing us to slip out of cuffs and climb through vents."
 	button_icon_state = "lesser_form"
 	chemical_cost = 5
-	dna_cost = 1
+	dna_cost = 10
 	req_human = TRUE
 	power_type = CHANGELING_PURCHASABLE_POWER
 

--- a/code/modules/antagonists/changeling/powers/lesserform.dm
+++ b/code/modules/antagonists/changeling/powers/lesserform.dm
@@ -4,7 +4,7 @@
 	helptext = "The transformation greatly reduces our size, allowing us to slip out of cuffs and climb through vents."
 	button_icon_state = "lesser_form"
 	chemical_cost = 5
-	dna_cost = 10
+	dna_cost = 2
 	req_human = TRUE
 	power_type = CHANGELING_PURCHASABLE_POWER
 

--- a/code/modules/antagonists/changeling/powers/mimic_voice.dm
+++ b/code/modules/antagonists/changeling/powers/mimic_voice.dm
@@ -4,7 +4,7 @@
 	helptext = "Will turn your voice into the name that you enter."
 	button_icon_state = "mimic_voice"
 	chemical_cost = 0
-	dna_cost = 10
+	dna_cost = 2
 	req_human = TRUE
 	power_type = CHANGELING_PURCHASABLE_POWER
 

--- a/code/modules/antagonists/changeling/powers/mimic_voice.dm
+++ b/code/modules/antagonists/changeling/powers/mimic_voice.dm
@@ -4,7 +4,7 @@
 	helptext = "Will turn your voice into the name that you enter."
 	button_icon_state = "mimic_voice"
 	chemical_cost = 0
-	dna_cost = 1
+	dna_cost = 10
 	req_human = TRUE
 	power_type = CHANGELING_PURCHASABLE_POWER
 

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -374,7 +374,7 @@
 	helptext = "Organic tissue cannot resist damage forever. The shield will break after it is hit too much. The more DNA we collect, the stronger it is. Cannot be used while in lesser form."
 	button_icon_state = "organic_shield"
 	chemical_cost = 20
-	dna_cost = 4
+	dna_cost = 2
 	req_human = TRUE
 	weapon_type = /obj/item/shield/changeling
 	weapon_name_simple = "shield"

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -116,7 +116,7 @@
 	helptext = "We may retract our armblade in the same manner as we form it. Cannot be used while in lesser form."
 	button_icon_state = "armblade"
 	chemical_cost = 25
-	dna_cost = 2
+	dna_cost = 20
 	req_human = TRUE
 	weapon_type = /obj/item/melee/arm_blade
 	weapon_name_simple = "blade"
@@ -175,7 +175,7 @@
 	Cannot be used while in our lesser form."
 	button_icon_state = "tentacle"
 	chemical_cost = 10
-	dna_cost = 2
+	dna_cost = 20
 	req_human = TRUE
 	weapon_type = /obj/item/gun/magic/tentacle
 	weapon_name_simple = "tentacle"
@@ -374,7 +374,7 @@
 	helptext = "Organic tissue cannot resist damage forever. The shield will break after it is hit too much. The more DNA we collect, the stronger it is. Cannot be used while in lesser form."
 	button_icon_state = "organic_shield"
 	chemical_cost = 20
-	dna_cost = 1
+	dna_cost = 10
 	req_human = TRUE
 	weapon_type = /obj/item/shield/changeling
 	weapon_name_simple = "shield"
@@ -422,7 +422,7 @@
 	helptext = "We must constantly repair our form to make it space proof, reducing chemical production while we are protected. Cannot be used in lesser form."
 	button_icon_state = "organic_suit"
 	chemical_cost = 20
-	dna_cost = 2
+	dna_cost = 20
 	req_human = TRUE
 	power_type = CHANGELING_PURCHASABLE_POWER
 	suit_type = /obj/item/clothing/suit/space/changeling
@@ -468,7 +468,7 @@
 	helptext = "Upkeep of the armor requires a low expenditure of chemicals. The armor is strong against brute force, but does not provide much protection from lasers. Cannot be used in lesser form."
 	button_icon_state = "chitinous_armor"
 	chemical_cost = 25
-	dna_cost = 2
+	dna_cost = 20
 	req_human = TRUE
 	power_type = CHANGELING_PURCHASABLE_POWER
 	suit_type = /obj/item/clothing/suit/armor/changeling

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -116,7 +116,7 @@
 	helptext = "We may retract our armblade in the same manner as we form it. Cannot be used while in lesser form."
 	button_icon_state = "armblade"
 	chemical_cost = 25
-	dna_cost = 20
+	dna_cost = 4
 	req_human = TRUE
 	weapon_type = /obj/item/melee/arm_blade
 	weapon_name_simple = "blade"
@@ -175,7 +175,7 @@
 	Cannot be used while in our lesser form."
 	button_icon_state = "tentacle"
 	chemical_cost = 10
-	dna_cost = 20
+	dna_cost = 4
 	req_human = TRUE
 	weapon_type = /obj/item/gun/magic/tentacle
 	weapon_name_simple = "tentacle"
@@ -374,7 +374,7 @@
 	helptext = "Organic tissue cannot resist damage forever. The shield will break after it is hit too much. The more DNA we collect, the stronger it is. Cannot be used while in lesser form."
 	button_icon_state = "organic_shield"
 	chemical_cost = 20
-	dna_cost = 10
+	dna_cost = 4
 	req_human = TRUE
 	weapon_type = /obj/item/shield/changeling
 	weapon_name_simple = "shield"
@@ -422,7 +422,7 @@
 	helptext = "We must constantly repair our form to make it space proof, reducing chemical production while we are protected. Cannot be used in lesser form."
 	button_icon_state = "organic_suit"
 	chemical_cost = 20
-	dna_cost = 20
+	dna_cost = 4
 	req_human = TRUE
 	power_type = CHANGELING_PURCHASABLE_POWER
 	suit_type = /obj/item/clothing/suit/space/changeling
@@ -468,7 +468,7 @@
 	helptext = "Upkeep of the armor requires a low expenditure of chemicals. The armor is strong against brute force, but does not provide much protection from lasers. Cannot be used in lesser form."
 	button_icon_state = "chitinous_armor"
 	chemical_cost = 25
-	dna_cost = 20
+	dna_cost = 4
 	req_human = TRUE
 	power_type = CHANGELING_PURCHASABLE_POWER
 	suit_type = /obj/item/clothing/suit/armor/changeling

--- a/code/modules/antagonists/changeling/powers/panacea.dm
+++ b/code/modules/antagonists/changeling/powers/panacea.dm
@@ -4,7 +4,7 @@
 	helptext = "Can be used while unconscious."
 	button_icon_state = "panacea"
 	chemical_cost = 20
-	dna_cost = 10
+	dna_cost = 2
 	req_stat = UNCONSCIOUS
 	power_type = CHANGELING_PURCHASABLE_POWER
 

--- a/code/modules/antagonists/changeling/powers/panacea.dm
+++ b/code/modules/antagonists/changeling/powers/panacea.dm
@@ -4,7 +4,7 @@
 	helptext = "Can be used while unconscious."
 	button_icon_state = "panacea"
 	chemical_cost = 20
-	dna_cost = 1
+	dna_cost = 10
 	req_stat = UNCONSCIOUS
 	power_type = CHANGELING_PURCHASABLE_POWER
 

--- a/code/modules/antagonists/changeling/powers/shriek.dm
+++ b/code/modules/antagonists/changeling/powers/shriek.dm
@@ -4,7 +4,7 @@
 	helptext = "Emits a high frequency sound that confuses and deafens humans, blows out nearby lights and overloads cyborg sensors."
 	button_icon_state = "resonant_shriek"
 	chemical_cost = 30
-	dna_cost = 1
+	dna_cost = 10
 	req_human = TRUE
 	power_type = CHANGELING_PURCHASABLE_POWER
 
@@ -41,7 +41,7 @@
 	desc = "We shift our vocal cords to release a high frequency sound that overloads nearby electronics. Costs 30 chemicals."
 	button_icon_state = "dissonant_shriek"
 	chemical_cost = 30
-	dna_cost = 1
+	dna_cost = 10
 	power_type = CHANGELING_PURCHASABLE_POWER
 
 //A flashy ability, good for crowd control and sewing chaos.

--- a/code/modules/antagonists/changeling/powers/shriek.dm
+++ b/code/modules/antagonists/changeling/powers/shriek.dm
@@ -4,7 +4,7 @@
 	helptext = "Emits a high frequency sound that confuses and deafens humans, blows out nearby lights and overloads cyborg sensors."
 	button_icon_state = "resonant_shriek"
 	chemical_cost = 30
-	dna_cost = 10
+	dna_cost = 2
 	req_human = TRUE
 	power_type = CHANGELING_PURCHASABLE_POWER
 
@@ -41,7 +41,7 @@
 	desc = "We shift our vocal cords to release a high frequency sound that overloads nearby electronics. Costs 30 chemicals."
 	button_icon_state = "dissonant_shriek"
 	chemical_cost = 30
-	dna_cost = 10
+	dna_cost = 2
 	power_type = CHANGELING_PURCHASABLE_POWER
 
 //A flashy ability, good for crowd control and sewing chaos.

--- a/code/modules/antagonists/changeling/powers/strained_muscles.dm
+++ b/code/modules/antagonists/changeling/powers/strained_muscles.dm
@@ -7,7 +7,7 @@
 	helptext = "The strain will use up our chemicals faster over time, and is not sustainable. Can not be used in lesser form."
 	button_icon_state = "strained_muscles"
 	chemical_cost = 0
-	dna_cost = 1
+	dna_cost = 10
 	req_human = TRUE
 	power_type = CHANGELING_PURCHASABLE_POWER
 

--- a/code/modules/antagonists/changeling/powers/strained_muscles.dm
+++ b/code/modules/antagonists/changeling/powers/strained_muscles.dm
@@ -7,7 +7,7 @@
 	helptext = "The strain will use up our chemicals faster over time, and is not sustainable. Can not be used in lesser form."
 	button_icon_state = "strained_muscles"
 	chemical_cost = 0
-	dna_cost = 10
+	dna_cost = 2
 	req_human = TRUE
 	power_type = CHANGELING_PURCHASABLE_POWER
 

--- a/code/modules/antagonists/changeling/powers/summon_spiders.dm
+++ b/code/modules/antagonists/changeling/powers/summon_spiders.dm
@@ -9,7 +9,7 @@
 	helptext = "The spiders are thoughtless creatures, but will not attack their creators. Requires at least 7 stored DNA. Their orders can be changed via remote hivemind (Alt+Shift click)."
 	button_icon_state = "spread_infestation"
 	chemical_cost = 45
-	dna_cost = 2
+	dna_cost = 20
 	req_dna = 7
 	/// This var keeps track of the changeling's spider count
 	var/spider_counter = 0

--- a/code/modules/antagonists/changeling/powers/summon_spiders.dm
+++ b/code/modules/antagonists/changeling/powers/summon_spiders.dm
@@ -9,7 +9,7 @@
 	helptext = "The spiders are thoughtless creatures, but will not attack their creators. Requires at least 7 stored DNA. Their orders can be changed via remote hivemind (Alt+Shift click)."
 	button_icon_state = "spread_infestation"
 	chemical_cost = 45
-	dna_cost = 20
+	dna_cost = 4
 	req_dna = 7
 	/// This var keeps track of the changeling's spider count
 	var/spider_counter = 0

--- a/code/modules/antagonists/changeling/powers/swap_form.dm
+++ b/code/modules/antagonists/changeling/powers/swap_form.dm
@@ -4,7 +4,7 @@
 	helptext = "We will bring all our abilities with us, but we will lose our old form DNA in exchange for the new one. The process will seem suspicious to any observers."
 	button_icon_state = "cling_mindswap"
 	chemical_cost = 40
-	dna_cost = 1
+	dna_cost = 10
 	req_human = TRUE //Monkeys can't grab
 	power_type = CHANGELING_PURCHASABLE_POWER
 

--- a/code/modules/antagonists/changeling/powers/swap_form.dm
+++ b/code/modules/antagonists/changeling/powers/swap_form.dm
@@ -4,7 +4,7 @@
 	helptext = "We will bring all our abilities with us, but we will lose our old form DNA in exchange for the new one. The process will seem suspicious to any observers."
 	button_icon_state = "cling_mindswap"
 	chemical_cost = 40
-	dna_cost = 10
+	dna_cost = 2
 	req_human = TRUE //Monkeys can't grab
 	power_type = CHANGELING_PURCHASABLE_POWER
 

--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -98,7 +98,7 @@
 	button_icon_state = "sting_mute"
 	sting_icon = "sting_mute"
 	chemical_cost = 20
-	dna_cost = 20
+	dna_cost = 4
 	power_type = CHANGELING_PURCHASABLE_POWER
 
 /datum/action/changeling/sting/mute/sting_action(mob/user, mob/living/carbon/target)
@@ -114,7 +114,7 @@
 	button_icon_state = "sting_blind"
 	sting_icon = "sting_blind"
 	chemical_cost = 25
-	dna_cost = 10
+	dna_cost = 2
 	power_type = CHANGELING_PURCHASABLE_POWER
 
 /datum/action/changeling/sting/blind/sting_action(mob/living/user, mob/living/target)
@@ -133,7 +133,7 @@
 	button_icon_state = "sting_cryo"
 	sting_icon = "sting_cryo"
 	chemical_cost = 15
-	dna_cost = 20
+	dna_cost = 4
 	power_type = CHANGELING_PURCHASABLE_POWER
 
 /datum/action/changeling/sting/cryo/sting_action(mob/user, mob/target)

--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -98,7 +98,7 @@
 	button_icon_state = "sting_mute"
 	sting_icon = "sting_mute"
 	chemical_cost = 20
-	dna_cost = 2
+	dna_cost = 20
 	power_type = CHANGELING_PURCHASABLE_POWER
 
 /datum/action/changeling/sting/mute/sting_action(mob/user, mob/living/carbon/target)
@@ -114,7 +114,7 @@
 	button_icon_state = "sting_blind"
 	sting_icon = "sting_blind"
 	chemical_cost = 25
-	dna_cost = 1
+	dna_cost = 10
 	power_type = CHANGELING_PURCHASABLE_POWER
 
 /datum/action/changeling/sting/blind/sting_action(mob/living/user, mob/living/target)
@@ -133,7 +133,7 @@
 	button_icon_state = "sting_cryo"
 	sting_icon = "sting_cryo"
 	chemical_cost = 15
-	dna_cost = 2
+	dna_cost = 20
 	power_type = CHANGELING_PURCHASABLE_POWER
 
 /datum/action/changeling/sting/cryo/sting_action(mob/user, mob/target)


### PR DESCRIPTION
## What Does This PR Do
Upscales changeling DNA from 10 to 20. Multiplies the cost of changeling abilities to compensate.

## Why It's Good For The Game
Have we considered that trying to balance changeling abilities around them costing rather 1 or 2 may be a poor idea? I feel this would open up the door for actual balance discussion regarding the cost of abilities.

## Testing
Loaded the game. Checked costs. They were as planned. Bought things. Things worked fine.

## Changelog
:cl:
tweak: Changelings now have 20 DNA points to spend instead of 10. Ability cost have been changed to compensate.
/:cl: