### PR TITLE
Changeling eggs now chestburst instead of gibbing

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/headslug.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headslug.dm
@@ -112,7 +112,7 @@
 	owner.bleed(BLOOD_VOLUME_NORMAL)
 	var/obj/item/organ/external/chest = owner.get_organ(BODY_ZONE_CHEST)
 	chest.fracture()
-	chest.droplimb()
+	chest.disembowel()
 
 #undef EGG_INCUBATION_DEAD_TIME
 #undef EGG_INCUBATION_LIVING_TIME

--- a/code/modules/mob/living/simple_animal/hostile/headslug.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headslug.dm
@@ -107,8 +107,7 @@
 		cling.give_power(new /datum/action/changeling/humanform)
 		M.key = origin.key
 		M.revive() // better make sure some weird shit doesn't happen, because it has in the pas
-		var/turf/output_loc = owner.loc
-		M.forceMove(output_loc) // So that they are not stuck inside
+		M.forceMove(get_turf(owner)) // So that they are not stuck inside
 	owner.apply_damage(300, BRUTE, BODY_ZONE_CHEST)
 	owner.bleed(BLOOD_VOLUME_NORMAL)
 	var/obj/item/organ/external/chest = owner.get_organ(BODY_ZONE_CHEST)

--- a/code/modules/mob/living/simple_animal/hostile/headslug.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headslug.dm
@@ -106,8 +106,14 @@
 
 		cling.give_power(new /datum/action/changeling/humanform)
 		M.key = origin.key
-		M.revive() // better make sure some weird shit doesn't happen, because it has in the past
-	owner.gib()
+		M.revive() // better make sure some weird shit doesn't happen, because it has in the pas
+		var/turf/output_loc = owner.loc
+		M.forceMove(output_loc) // So that they are not stuck inside
+	owner.apply_damage(300, BRUTE, BODY_ZONE_CHEST)
+	owner.bleed(BLOOD_VOLUME_NORMAL)
+	var/obj/item/organ/external/chest = owner.get_organ(BODY_ZONE_CHEST)
+	chest.fracture()
+	chest.droplimb()
 
 #undef EGG_INCUBATION_DEAD_TIME
 #undef EGG_INCUBATION_LIVING_TIME


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
This give changeling eggs the xenomorph treatment, so that instead of gibbing, they will burst outta their chest!

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Gibbing is bad, you now have a more valid reason to hide in the comfy darkness that is maint, and get to keep your body!

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
<!-- How did you test the PR, if at all? -->

https://github.com/ParadiseSS13/Paradise/assets/21987702/d3951c8c-5dfe-49c2-93c3-3d673194538c



## Changelog
:cl: ppi
tweak: Changeling eggs now chestburst instead of gibbing.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
