### PR TITLE
Janitorial ERT rekit/buff and a few additions for the jani ert squad.

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -522,7 +522,7 @@
 /obj/item/storage/belt/janitor/full/populate_contents()
 	new /obj/item/holosign_creator/janitor(src)
 	new /obj/item/reagent_containers/spray/cleaner/advanced(src)
-	new/obj/item/storage/bag/trash/bluespace(src)
+	new /obj/item/storage/bag/trash/bluespace(src)
 	new /obj/item/soap/deluxe(src)
 	new /obj/item/grenade/chem_grenade/cleaner(src)
 	new /obj/item/grenade/chem_grenade/cleaner(src)

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -522,7 +522,7 @@
 /obj/item/storage/belt/janitor/full/populate_contents()
 	new /obj/item/holosign_creator/janitor(src)
 	new /obj/item/reagent_containers/spray/cleaner/advanced(src)
-	new /obj/item/reagent_containers/spray/cleaner/advanced(src)
+	new/obj/item/storage/bag/trash/bluespace(src)
 	new /obj/item/soap/deluxe(src)
 	new /obj/item/grenade/chem_grenade/cleaner(src)
 	new /obj/item/grenade/chem_grenade/cleaner(src)

--- a/code/modules/clothing/shoes/misc_shoes.dm
+++ b/code/modules/clothing/shoes/misc_shoes.dm
@@ -58,9 +58,8 @@
 	icon_state = "galoshes_dry"
 
 /obj/item/clothing/shoes/galoshes/dry/lightweight /// for red janitor ert.
-	name = "Lightweight absorbent galoshes"
+	name = "lightweight absorbent galoshes"
 	desc = "A pair of expensive looking lightweight rubber boots, designed to prevent slipping on wet surfaces while also drying them."
-	icon_state = "galoshes_dry"
 	slowdown = NONE
 
 /obj/item/clothing/shoes/galoshes/dry/Initialize(mapload)

--- a/code/modules/clothing/shoes/misc_shoes.dm
+++ b/code/modules/clothing/shoes/misc_shoes.dm
@@ -57,7 +57,7 @@
 	desc = "A pair of purple rubber boots, designed to prevent slipping on wet surfaces while also drying them."
 	icon_state = "galoshes_dry"
 
-/obj/item/clothing/shoes/galoshes/dry/lightweight
+/obj/item/clothing/shoes/galoshes/dry/lightweight /// for red janitor ert.
 	name = "Lightweight absorbent galoshes"
 	desc = "A pair of expensive looking lightweight rubber boots, designed to prevent slipping on wet surfaces while also drying them."
 	icon_state = "galoshes_dry"

--- a/code/modules/clothing/shoes/misc_shoes.dm
+++ b/code/modules/clothing/shoes/misc_shoes.dm
@@ -57,6 +57,12 @@
 	desc = "A pair of purple rubber boots, designed to prevent slipping on wet surfaces while also drying them."
 	icon_state = "galoshes_dry"
 
+/obj/item/clothing/shoes/galoshes/dry/lightweight
+	name = "Lightweight absorbent galoshes"
+	desc = "A pair of expensive looking lightweight rubber boots, designed to prevent slipping on wet surfaces while also drying them."
+	icon_state = "galoshes_dry"
+	slowdown = NONE
+
 /obj/item/clothing/shoes/galoshes/dry/Initialize(mapload)
 	. = ..()
 	RegisterSignal(src, COMSIG_SHOES_STEP_ACTION, PROC_REF(on_step))

--- a/code/modules/mod/mod_types.dm
+++ b/code/modules/mod/mod_types.dm
@@ -333,7 +333,7 @@
 
 /obj/item/mod/control/pre_equipped/responsory/janitor
 	insignia_type = /obj/item/mod/module/insignia/janitor
-	additional_module = /obj/item/mod/module/clamp
+	additional_module = list(/obj/item/mod/module/clamp, /obj/item/mod/module/boot_heating)
 
 /obj/item/mod/control/pre_equipped/responsory/clown
 	insignia_type = /obj/item/mod/module/insignia/clown

--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -465,4 +465,3 @@
 
 /obj/item/mod/module/plasma_stabilizer/on_unequip()
 	REMOVE_TRAIT(mod.wearer, TRAIT_NOSELFIGNITION_HEAD_ONLY, MODSUIT_TRAIT)
-

--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -466,22 +466,3 @@
 /obj/item/mod/module/plasma_stabilizer/on_unequip()
 	REMOVE_TRAIT(mod.wearer, TRAIT_NOSELFIGNITION_HEAD_ONLY, MODSUIT_TRAIT)
 
-/// Boot heater - for janitoral gamma ert
-/obj/item/mod/module/heated_shoes
-	name = "MOD boot heater"
-	desc = "This module heats the users boots externally to assist in drying wet floors."
-	icon_state = "regulator"
-	complexity = 1
-
-/obj/item/mod/module/heated_shoes/on_equip()
-	ADD_TRAIT(RegisterSignal, COMSIG_SHOES_STEP_ACTION, MODSUIT_TRAIT)
-
-/obj/item/mod/module/heated_shoes/on_unequip()
-	REMOVE_TRAIT(RegisterSignal, COMSIG_SHOES_STEP_ACTION, MODSUIT_TRAIT)
-
-/obj/item/clothing/shoes/mod/proc/on_step()
-	SIGNAL_HANDLER
-
-	var/turf/simulated/t_loc = get_turf(src)
-	if(istype(t_loc) && t_loc.wet)
-		t_loc.MakeDry(TURF_WET_WATER)

--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -465,3 +465,23 @@
 
 /obj/item/mod/module/plasma_stabilizer/on_unequip()
 	REMOVE_TRAIT(mod.wearer, TRAIT_NOSELFIGNITION_HEAD_ONLY, MODSUIT_TRAIT)
+
+/// Boot heater - for janitoral gamma ert
+/obj/item/mod/module/heated_shoes
+	name = "MOD boot heater"
+	desc = "This module heats the users boots externally to assist in drying wet floors."
+	icon_state = "regulator"
+	complexity = 1
+
+/obj/item/mod/module/heated_shoes/on_equip()
+	ADD_TRAIT(RegisterSignal, COMSIG_SHOES_STEP_ACTION, MODSUIT_TRAIT)
+
+/obj/item/mod/module/heated_shoes/on_unequip()
+	REMOVE_TRAIT(RegisterSignal, COMSIG_SHOES_STEP_ACTION, MODSUIT_TRAIT)
+
+/obj/item/clothing/shoes/mod/proc/on_step()
+	SIGNAL_HANDLER
+
+	var/turf/simulated/t_loc = get_turf(src)
+	if(istype(t_loc) && t_loc.wet)
+		t_loc.MakeDry(TURF_WET_WATER)

--- a/code/modules/mod/modules/modules_service.dm
+++ b/code/modules/mod/modules/modules_service.dm
@@ -40,3 +40,25 @@
 	if(!deleting)
 		qdel(mod.boots.GetComponent(/datum/component/squeak))
 	mod.wearer.RemoveElement(/datum/element/waddling)
+
+//Boot heating - dries floors like galoshes/dry
+/obj/item/mod/module/boot_heating
+	name = "MOD boot heating module"
+	desc = "A MOD suit boot heating module. Heats the bottom of the boots to assist in drying wet floors as you clean. Only for the most well trained of janitorial staff." /// Kinda small comparied to the other descriptions, but its ERT only, so..
+	icon_state = "regulator"
+	complexity = 1
+	idle_power_cost = DEFAULT_CHARGE_DRAIN * 0.2
+	incompatible_modules = list(/obj/item/mod/module/boot_heating)
+
+/obj/item/mod/module/boot_heating/on_suit_activation()
+	RegisterSignal(mod.wearer, COMSIG_MOVABLE_MOVED, PROC_REF(on_step))
+
+/obj/item/mod/module/boot_heating/on_suit_deactivation(deleting = FALSE)
+	UnregisterSignal(mod.wearer, COMSIG_MOVABLE_MOVED)
+
+/obj/item/mod/module/boot_heating/proc/on_step()
+	SIGNAL_HANDLER
+
+	var/turf/simulated/t_loc = get_turf(src)
+	if(istype(t_loc) && t_loc.wet)
+		t_loc.MakeDry(TURF_WET_WATER)

--- a/code/modules/response_team/ert_outfits.dm
+++ b/code/modules/response_team/ert_outfits.dm
@@ -541,7 +541,7 @@
 		/obj/item/grenade/chem_grenade/antiweed = 2,
 		/obj/item/grenade/clusterbuster/cleaner = 1,
 		/obj/item/storage/box/lights/mixed = 1,
-		/obj/item/push_broom,
+		/obj/item/push_broom = 1,
 		/obj/item/gun/energy/gun/nuclear = 1
 	)
 

--- a/code/modules/response_team/ert_outfits.dm
+++ b/code/modules/response_team/ert_outfits.dm
@@ -487,7 +487,7 @@
 	uniform = /obj/item/clothing/under/rank/centcom/ert/janitor
 	back = /obj/item/storage/backpack/ert/janitor
 	belt = /obj/item/storage/belt/janitor/full
-	shoes = /obj/item/clothing/shoes/galoshes
+	shoes = /obj/item/clothing/shoes/galoshes/dry/lightweight
 	l_ear = /obj/item/radio/headset/ert/alt
 	id = /obj/item/card/id/ert/janitorial
 	pda = /obj/item/pda/heads/ert/janitor
@@ -495,8 +495,6 @@
 
 	backpack_contents = list(
 		/obj/item/grenade/chem_grenade/antiweed = 2,
-		/obj/item/lightreplacer = 1,
-		/obj/item/storage/bag/trash = 1,
 		/obj/item/push_broom,
 		/obj/item/storage/box/lights/mixed = 1,
 		/obj/item/melee/flyswatter = 1
@@ -507,11 +505,11 @@
 	suit = /obj/item/clothing/suit/armor/vest/ert/janitor
 	head = /obj/item/clothing/head/helmet/ert/janitor
 	glasses = /obj/item/clothing/glasses/sunglasses
-	r_pocket = /obj/item/flashlight
+	r_pocket = /obj/item/flashlight/seclite
 	suit_store = /obj/item/gun/energy/disabler
 
 	cybernetic_implants = list(
-		/obj/item/organ/internal/cyberimp/arm/advmop
+		/obj/item/organ/internal/cyberimp/arm/janitorial/advanced
 	)
 
 /datum/outfit/job/centcom/response_team/janitorial/red
@@ -519,10 +517,10 @@
 	suit = /obj/item/clothing/suit/space/hardsuit/ert/janitor
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
 	r_pocket = /obj/item/scythe/tele
-	suit_store = /obj/item/gun/energy/gun/mini
+	suit_store = /obj/item/gun/energy/gun
 
 	cybernetic_implants = list(
-		/obj/item/organ/internal/cyberimp/arm/janitorial,
+		/obj/item/organ/internal/cyberimp/arm/janitorial/advanced,
 		/obj/item/organ/internal/cyberimp/chest/nutriment/hardened
 	)
 
@@ -542,15 +540,13 @@
 		/obj/item/grenade/chem_grenade/antiweed = 2,
 		/obj/item/grenade/clusterbuster/cleaner = 1,
 		/obj/item/storage/box/lights/mixed = 1,
-		/obj/item/storage/bag/trash/bluespace = 1,
-		/obj/item/lightreplacer/bluespace = 1,
-		/obj/item/melee/flyswatter = 1,
-		/obj/item/gun/energy/gun = 1
+		/obj/item/push_broom,
+		/obj/item/gun/energy/gun/nuclear = 1
 	)
 
 	cybernetic_implants = list(
 		/obj/item/organ/internal/cyberimp/chest/nutriment/plus/hardened,
-		/obj/item/organ/internal/cyberimp/arm/advmop,
+		/obj/item/organ/internal/cyberimp/arm/janitorial/advanced,
 		/obj/item/organ/internal/cyberimp/brain/anti_stam/hardened
 	)
 

--- a/code/modules/response_team/ert_outfits.dm
+++ b/code/modules/response_team/ert_outfits.dm
@@ -487,7 +487,7 @@
 	uniform = /obj/item/clothing/under/rank/centcom/ert/janitor
 	back = /obj/item/storage/backpack/ert/janitor
 	belt = /obj/item/storage/belt/janitor/full
-	shoes = /obj/item/clothing/shoes/galoshes/dry/lightweight
+	shoes = /obj/item/clothing/shoes/galoshes/dry
 	l_ear = /obj/item/radio/headset/ert/alt
 	id = /obj/item/card/id/ert/janitorial
 	pda = /obj/item/pda/heads/ert/janitor
@@ -516,6 +516,7 @@
 	name = "RT Janitor (Red)"
 	suit = /obj/item/clothing/suit/space/hardsuit/ert/janitor
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
+	shoes = /obj/item/clothing/shoes/galoshes/dry/lightweight
 	r_pocket = /obj/item/scythe/tele
 	suit_store = /obj/item/gun/energy/gun
 

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -323,7 +323,7 @@
 	parent_organ = "l_arm"
 	slot = "l_arm_device"
 
-/obj/item/organ/internal/cyberimp/arm/janitorial/advanced
+/obj/item/organ/internal/cyberimp/arm/janitorial/advanced /// ERT implant, i dont overly expect this to get into the hands of crew
 	name = "advanced janitorial toolset implant"
 	desc = "A set of advanced janitorial tools hidden behind a concealed panel on the user's arm"
 	contents = newlist(/obj/item/mop/advanced, /obj/item/soap/deluxe, /obj/item/lightreplacer/bluespace, /obj/item/holosign_creator/janitor, /obj/item/melee/flyswatter, /obj/item/reagent_containers/spray/cleaner/advanced)
@@ -332,7 +332,7 @@
 	action_icon_state = list(/datum/action/item_action/organ_action/toggle = "janibelt")
 	emp_proof = TRUE
 
-/obj/item/organ/internal/cyberimp/arm/janitorial/advanced/l
+/obj/item/organ/internal/cyberimp/arm/janitorial/advanced/l /// its for ERT, but still probably a good idea.
 	parent_organ = "l_arm"
 	slot = "l_arm_device"
 

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -323,6 +323,19 @@
 	parent_organ = "l_arm"
 	slot = "l_arm_device"
 
+/obj/item/organ/internal/cyberimp/arm/janitorial/advanced
+	name = "advanced janitorial toolset implant"
+	desc = "A set of advanced janitorial tools hidden behind a concealed panel on the user's arm"
+	contents = newlist(/obj/item/mop/advanced, /obj/item/soap/deluxe, /obj/item/lightreplacer/bluespace, /obj/item/holosign_creator/janitor, /obj/item/melee/flyswatter, /obj/item/reagent_containers/spray/cleaner/advanced)
+	origin_tech = "materials=5;engineering=6;biotech=5"
+	action_icon = list(/datum/action/item_action/organ_action/toggle = 'icons/obj/clothing/belts.dmi')
+	action_icon_state = list(/datum/action/item_action/organ_action/toggle = "janibelt")
+	emp_proof = TRUE
+
+/obj/item/organ/internal/cyberimp/arm/janitorial/advanced/l
+	parent_organ = "l_arm"
+	slot = "l_arm_device"
+
 /obj/item/organ/internal/cyberimp/arm/botanical
 	name = "botanical toolset implant"
 	desc = "A set of botanical tools hidden behind a concealed panel on the user's arm"

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -325,7 +325,7 @@
 
 /obj/item/organ/internal/cyberimp/arm/janitorial/advanced /// ERT implant, i dont overly expect this to get into the hands of crew
 	name = "advanced janitorial toolset implant"
-	desc = "A set of advanced janitorial tools hidden behind a concealed panel on the user's arm"
+	desc = "A set of advanced janitorial tools hidden behind a concealed panel on the user's arm."
 	contents = newlist(/obj/item/mop/advanced, /obj/item/soap/deluxe, /obj/item/lightreplacer/bluespace, /obj/item/holosign_creator/janitor, /obj/item/melee/flyswatter, /obj/item/reagent_containers/spray/cleaner/advanced)
 	origin_tech = "materials=5;engineering=6;biotech=5"
 	action_icon = list(/datum/action/item_action/organ_action/toggle = 'icons/obj/clothing/belts.dmi')


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Adds a new janitorial toolset implant, that is mostly the same, but with a bluespace light replacer, the big space cleaner spray bottle and deluxe soap, the implant is also EMP proof.
Removes the bluespace light replacer, and a spray bottle form their bags/belt, as they're in the implant now and dont need two, and moves the bluespace trash bag to the belt.
Adds a new MODsuit module, "boot heating" to dry floors as you walk, much like the dry galoshes, for GAMMA jani ert.
Gives amber ert dry galoshes, adds and gives red ert lightweight dry galoshes, as they have heavy armor already, they don't need double slowdown.
Replaces the Red ert mini egun with a normal one, and replaces the Gamma ert egun with a advanced energy gun, for fighting those pesky mice and man eater kudzu, and for self defense. 
Amber ert now get a bluespace trashbag, and light replacer.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Janitorial ERT are largely a jokey send/bait for people to sign up, so bringing them ahead of the stations janitors in the context of tools is something i have wanted to do for a while. 
So this PR brings them quite abit ahead of the uncommon robust/knowledgeable janitors that sometimes come around, as well as some QOL stuff, and less rushing to RND to get basic upgrades in the case of amber ert, and less slowdown in the case of red.

## Testing
<!-- How did you test the PR, if at all? -->
Compiled, checked if all my changes and additions functioned correctly, and they did.
## Changelog
:cl:
add: Added a new advanced janitorial implant for ERT janitors 
add: Added a new modsuit module for GAMMA janitors, that allow the modsuit shoes to act as dry galoshes.
add: Added lightweight galoshes for Red janitorial ert.
tweak: Tweaked the contents of the bags and belts of the janitorial ert, they no longer get a light replacer, and they're down a advanced space cleaner, as they're in the implant now, and the BS trashbag is in the belt now.
tweak: Red ert janitors now get a basic energy gun, and GAMMA gets a advanced energy gun.
tweak: Amber janitor ert now get a seclite rather than a flashlight
tweak: GAMMA janitor ert now have a push broom in their bags.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
