### PR TITLE
Allows chemistry beaker swapping

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -237,10 +237,6 @@
 	if(isrobot(user))
 		return
 
-	if(beaker)
-		to_chat(user, "<span class='warning'>Something is already loaded into the machine.</span>")
-		return
-
 	if((istype(I, /obj/item/reagent_containers/glass) || istype(I, /obj/item/reagent_containers/food/drinks)) && user.a_intent != INTENT_HARM)
 		if(panel_open)
 			to_chat(user, "<span class='notice'>Close the maintenance panel first.</span>")
@@ -248,12 +244,19 @@
 		if(!user.drop_item())
 			to_chat(user, "<span class='warning'>[I] is stuck to you!</span>")
 			return
-		beaker =  I
-		I.forceMove(src)
-		to_chat(user, "<span class='notice'>You set [I] on the machine.</span>")
+		if(beaker)
+			I.forceMove(src)
+			user.put_in_hands(beaker)
+			beaker = I
+			to_chat(user, "<span class='notice'>You swap [I] with [beaker].</span>")
+		else
+			I.forceMove(src)
+			beaker = I
+			to_chat(user, "<span class='notice'>You set [I] on the machine.</span>")
 		SStgui.update_uis(src) // update all UIs attached to src
 		update_icon(UPDATE_ICON_STATE)
 		return
+
 	return ..()
 
 /obj/machinery/chem_dispenser/crowbar_act(mob/user, obj/item/I)

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -244,15 +244,14 @@
 		if(!user.drop_item())
 			to_chat(user, "<span class='warning'>[I] is stuck to you!</span>")
 			return
+		I.forceMove(src)
 		if(beaker)
-			I.forceMove(src)
 			user.put_in_hands(beaker)
-			beaker = I
 			to_chat(user, "<span class='notice'>You swap [I] with [beaker].</span>")
 		else
-			I.forceMove(src)
-			beaker = I
 			to_chat(user, "<span class='notice'>You set [I] on the machine.</span>")
+		beaker = I
+
 		SStgui.update_uis(src) // update all UIs attached to src
 		update_icon(UPDATE_ICON_STATE)
 		return

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -106,7 +106,7 @@
 			user.put_in_hands(beaker)
 			to_chat(user, "<span class='notice'>You swap [I] with [beaker] inside.</span>")
 		else
-			to_chat(user, "<span class='notice'>You add [I] to the machine!</span>")
+			to_chat(user, "<span class='notice'>You add [I] to the machine.</span>")
 		beaker = I
 		SStgui.update_uis(src)
 		update_icon()

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -106,7 +106,7 @@
 			user.put_in_hands(beaker)
 			to_chat(user, "<span class='notice'>You swap [I] with [beaker] inside.</span>")
 		else
-			to_chat(user, "<span class='notice'>You add [I] into the machine!</span>")
+			to_chat(user, "<span class='notice'>You add [I] to the machine!</span>")
 		beaker = I
 		SStgui.update_uis(src)
 		update_icon()

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -98,15 +98,18 @@
 		return TRUE
 
 	if((istype(I, /obj/item/reagent_containers/glass) || istype(I, /obj/item/reagent_containers/food/drinks/drinkingglass)) && user.a_intent != INTENT_HARM)
-		if(beaker)
-			to_chat(user, "<span class='warning'>A beaker is already loaded into the machine.</span>")
-			return
 		if(!user.drop_item())
 			to_chat(user, "<span class='warning'>[I] is stuck to you!</span>")
 			return
-		beaker = I
-		I.forceMove(src)
-		to_chat(user, "<span class='notice'>You add the beaker to the machine!</span>")
+		if(beaker)
+			I.forceMove(src)
+			user.put_in_hands(beaker)
+			beaker = I
+			to_chat(user, "<span class='notice'>You swap [I] with [beaker].</span>")
+		else
+			I.forceMove(src)
+			beaker = I
+			to_chat(user, "<span class='notice'>You set [I] on the machine.</span>")
 		SStgui.update_uis(src)
 		update_icon()
 

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -101,15 +101,13 @@
 		if(!user.drop_item())
 			to_chat(user, "<span class='warning'>[I] is stuck to you!</span>")
 			return
+		I.forceMove(src)
 		if(beaker)
-			I.forceMove(src)
 			user.put_in_hands(beaker)
-			beaker = I
 			to_chat(user, "<span class='notice'>You swap [I] with [beaker].</span>")
 		else
-			I.forceMove(src)
-			beaker = I
 			to_chat(user, "<span class='notice'>You set [I] on the machine.</span>")
+		beaker = I
 		SStgui.update_uis(src)
 		update_icon()
 

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -104,9 +104,9 @@
 		I.forceMove(src)
 		if(beaker)
 			user.put_in_hands(beaker)
-			to_chat(user, "<span class='notice'>You swap [I] with [beaker].</span>")
+			to_chat(user, "<span class='notice'>You swap [I] with [beaker] inside.</span>")
 		else
-			to_chat(user, "<span class='notice'>You set [I] on the machine.</span>")
+			to_chat(user, "<span class='notice'>You add [I] into the machine!</span>")
 		beaker = I
 		SStgui.update_uis(src)
 		update_icon()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Clicking on full Chem-Dispenser or Chem-Master with a beaker will now swap beakers instead of giving a warning.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
I saw it on other SS13 servers and I think it would be a good QoL feature to add.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
https://github.com/ParadiseSS13/Paradise/assets/20885860/6f967e3e-9dbf-4647-ab20-822858ffc704
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Joined as chemist, upgraded chem-master buffer, made some Saline while constantly swapping beakers.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
add: You can now swap beakers inside chemistry machines with beaker in hand.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
