### PR TITLE
Changes what reagents are allowed within normal Hyposprays

### DIFF
--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -17,9 +17,11 @@
 	slot_flags = SLOT_FLAG_BELT
 	var/ignore_flags = FALSE
 	var/safety_hypo = FALSE
-	var/static/list/safe_chem_list = list("antihol", "charcoal", "epinephrine", "insulin", "teporone", "salbutamol","omnizine",
-									"stimulants", "synaptizine", "potass_iodide", "oculine", "mannitol", "spaceacillin", "salglu_solution",
-									"sal_acid", "cryoxadone", "blood", "hydrocodone", "mitocholide", "rezadone", "menthol")
+	var/static/list/safe_chem_list = list("antihol", "charcoal", "epinephrine", "insulin", "teporone", "salbutamol", "omnizine",
+									"weak_omnizine", "godblood", "potass_iodide", "oculine", "mannitol", "spaceacillin", "salglu_solution",
+									"sal_acid", "cryoxadone", "sugar", "hydrocodone", "mitocholide", "rezadone", "menthol",
+									"mutadone", "sanguine_reagent", "iron", "ephedrine", "heparin", "corazone", "sodiumchloride",
+									"synaptizine", "bicaridine", "kelotane")
 
 /obj/item/reagent_containers/hypospray/proc/apply(mob/living/M, mob/user)
 	if(!reagents.total_volume)

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -21,7 +21,7 @@
 									"weak_omnizine", "godblood", "potass_iodide", "oculine", "mannitol", "spaceacillin", "salglu_solution",
 									"sal_acid", "cryoxadone", "sugar", "hydrocodone", "mitocholide", "rezadone", "menthol",
 									"mutadone", "sanguine_reagent", "iron", "ephedrine", "heparin", "corazone", "sodiumchloride",
-									"synaptizine", "bicaridine", "kelotane")
+									"lavaland_extract", "synaptizine", "bicaridine", "kelotane")
 
 /obj/item/reagent_containers/hypospray/proc/apply(mob/living/M, mob/user)
 	if(!reagents.total_volume)


### PR DESCRIPTION
## What Does This PR Do
As title. New chemicals have been added into the hypospray allowed list, while some chemicals have been removed. This DOES NOT affect the CMO's Hypospray, as well as emagged hyposprays as they already accept all chemicals.

**Added:** 
- Iron
- Sanguine Reagent
- Sugar
- Sodium Chloride
- Mutadone
- Ephedrine
- Heparin
- Corazone
- Bicaridine
- Kelotane
- Diluted Omnizine (Godblood)
- Lavaland Extract

**Retained:** 
- Charcoal
- Cryoxadone
- Mannitol
- Salbutamol
- Saline Glucose Solution
- Menthol
- Omnizine
- Salicylic Acid
- Antihol
- Epinephrine
- Hydrocodone
- Insulin
- Mitocholide
- Oculine
- Potassium Iodide
- Rezadone
- Spaceacillin
- Synaptizine
- Teporone

**Removed:**
- Stimulants
- Blood

## Why It's Good For The Game
Right. Hyposprays have always had a list of acceptable chemicals that really doesn't adhere to any rules. You have chemicals that can inflict really debilitating effects either when misused but are accepted (Blood is the biggest culprit here), while also disallowing some chemicals that are extremely useful in healing but have really niche downsides. (Iron, for example.)

This PR can be seen as a continuation of #22259 in overhauling the entire hypospray accepted chemical list.

We will be utilising this general guideline here for our list:
![Screenshot (652)](https://github.com/ParadiseSS13/Paradise/assets/108938550/b0a14bae-b6d2-4798-8d68-13dfcc7f3532)
![Screenshot (653)](https://github.com/ParadiseSS13/Paradise/assets/108938550/c12fce25-915a-45c7-a75e-0a792ace7a1d)

This means that some chemicals that have potentially harmful overdoses are still allowed in the hypo-safe list, due to the chemical's original intentions being healing.

Some quick justifications for the current list:

>**Most chemicals that can cause muting or sleeping, even when those effects can only be caused by overdosing**

See above Guidelines. Muting chemicals are not to be allowed at all.

>**Sanguine Reagent, Bicaridine, Kelotane, Diluted Omnizine (Godblood), Lavaland Extract**

Again, see above Guidelines. While some of these chemicals have debilitating overdose effects, their main purpose is for healing.

>**Blood being removed**

There isn't a universal blood type that is accepted by all species - Even O- blood can be rejected by slimepeople and vox, and incorrect blood type rapidly transforms into toxins, which quickly causes toxins damage.

>**Heparin**

Admittedly, this is straddling the line a bit. Heparin worsens bleeding when used on a patient that has bleeding, but being a stabilisation chemical, I'd argue that the main intention is a healing chemical. However, I am amenable to Heparin being removed.

### But Schro, what about X chem? Why does Y chem gets in even though it is directly against the above guidelines?

This list is by no means definitive, and I can make errors. Or maybe I have even misinterpreted what Qwerty and Matt said. You can always reach out to me in DMs or #coding_chat on Discord, or post a comment here in this PR and I will get to it as soon as possible.

## Testing
Booted up local server. Added some of the new accepted chemicals into the hypospray. Tried adding some of the now disallowed chemicals into the hypospray and could not.

## Changelog
:cl:
tweak: Tweaked list of chemicals allowed in normal hyposprays
/:cl:
