### PR TITLE
Tones down the demand for Ash

### DIFF
--- a/code/modules/reagents/chemistry/reagents/misc_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/misc_reagents.dm
@@ -181,21 +181,21 @@
 	// Let's say burning boiling oil doubles in volume, can our max volume contain that?
 	var/boil_overflow = (holder.total_volume + volume) - holder.maximum_volume
 	var/violent = boil_overflow > 0
-	var/message_type = violent ? "class='boldwarning'" : "class='warning'"
-	holder.my_atom.visible_message("<span [message_type]>The oil [violent ? "boils and burns violently" : "burns"]!</span>")
 
 	var/datum/reagents/old_holder = holder
 	var/turf/T = get_turf(holder.my_atom)
 	var/smoke_type = /datum/effect_system/smoke_spread
 
 	if(violent)
-		// Log -> remove reagent -> fireflash. Else the log fails or fireflash triggers a reaction again
+		holder.my_atom.visible_message("<span class='boldwarning'>The oil boils and burns violently!</span>")
+		// Log -> remove reagent -> fireflash, else the log fails or fireflash triggers a reaction again
 		fire_flash_log(holder, id)
 		holder.del_reagent(id)
 		fireflash(T, clamp(volume / 40, 0, 8))
 
 		smoke_type = /datum/effect_system/smoke_spread/bad
 	else
+		holder.my_atom.visible_message("<span class='warning'>The oil burns!</span>")
 		holder.del_reagent(id)
 
 	// Flavor reaction effects

--- a/code/modules/reagents/chemistry/reagents/misc_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/misc_reagents.dm
@@ -178,7 +178,9 @@
 	if(exposed_temperature <= T0C + 600)
 		return
 
-	var/violent = volume > 30
+	// Let's say burning boiling oil doubles in volume, can our max volume contain that?
+	var/boil_overflow = (holder.total_volume + volume) - holder.maximum_volume
+	var/violent = boil_overflow > 0
 	var/message_type = violent ? "class='boldwarning'" : "class='warning'"
 	holder.my_atom.visible_message("<span [message_type]>The oil [violent ? "boils and burns violently" : "burns"]!</span>")
 

--- a/code/modules/reagents/chemistry/reagents/misc_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/misc_reagents.dm
@@ -191,7 +191,7 @@
 		// Log -> remove reagent -> fireflash, else the log fails or fireflash triggers a reaction again
 		fire_flash_log(holder, id)
 		holder.del_reagent(id)
-		fireflash(T, clamp(volume / 40, 0, 8))
+		fireflash(T, clamp(boil_overflow / 40, 0, 8))
 
 		smoke_type = /datum/effect_system/smoke_spread/bad
 	else

--- a/code/modules/reagents/chemistry/reagents/misc_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/misc_reagents.dm
@@ -187,7 +187,7 @@
 	var/smoke_type = /datum/effect_system/smoke_spread
 
 	if(violent)
-		holder.my_atom.visible_message("<span class='boldwarning'>The oil boils and burns violently!</span>")
+		holder.my_atom.visible_message("<span class='boldwarning'>The oil boils out and burns violently!</span>")
 		// Log -> remove reagent -> fireflash, else the log fails or fireflash triggers a reaction again
 		fire_flash_log(holder, id)
 		holder.del_reagent(id)
@@ -195,7 +195,7 @@
 
 		smoke_type = /datum/effect_system/smoke_spread/bad
 	else
-		holder.my_atom.visible_message("<span class='warning'>The oil burns!</span>")
+		holder.my_atom.visible_message("<span class='notice'>The oil sizzles and burns down into residue.</span>")
 		holder.del_reagent(id)
 
 	// Flavor reaction effects

--- a/code/modules/reagents/chemistry/reagents/misc_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/misc_reagents.dm
@@ -182,7 +182,6 @@
 	var/boil_overflow = (holder.total_volume + volume) - holder.maximum_volume
 	var/violent = boil_overflow > 0
 
-	var/datum/reagents/old_holder = holder
 	var/turf/T = get_turf(holder.my_atom)
 	var/smoke_type = /datum/effect_system/smoke_spread
 
@@ -196,16 +195,15 @@
 		smoke_type = /datum/effect_system/smoke_spread/bad
 	else
 		holder.my_atom.visible_message("<span class='notice'>The oil sizzles and burns down into residue.</span>")
+		var/datum/reagents/old_holder = holder // We might not have space if we add first, so cache this and add after deleting
 		holder.del_reagent(id)
+		old_holder.add_reagent(reagent_after_burning, volume * 0.6)
 
 	// Flavor reaction effects
 	playsound(T, 'sound/goonstation/misc/drinkfizz.ogg', 80, TRUE)
 	var/datum/effect_system/smoke_spread/BS = new smoke_type
 	BS.set_up(1, FALSE, T)
 	BS.start()
-
-	if(!QDELETED(old_holder) && reagent_after_burning)
-		old_holder.add_reagent(reagent_after_burning, round(volume * 0.6))
 
 /datum/reagent/oil/reaction_turf(turf/T, volume)
 	if(volume >= 3 && !isspaceturf(T) && !(locate(/obj/effect/decal/cleanable/blood/oil) in T))
@@ -227,7 +225,6 @@
 	name = "Burned Cooking Oil"
 	description = "It's full of char and mixed with so much crud it's probably useless."
 	id = "cooking_oil_inert"
-	reagent_after_burning = null
 
 /datum/reagent/oil/cooking/inert/reaction_temperature(exposed_temperature, exposed_volume)
 	// don't do anything

--- a/code/modules/reagents/chemistry/reagents/misc_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/misc_reagents.dm
@@ -205,7 +205,7 @@
 	BS.start()
 
 	if(!QDELETED(old_holder) && reagent_after_burning)
-		old_holder.add_reagent(reagent_after_burning, round(volume * 0.5))
+		old_holder.add_reagent(reagent_after_burning, round(volume * 0.6))
 
 /datum/reagent/oil/reaction_turf(turf/T, volume)
 	if(volume >= 3 && !isspaceturf(T) && !(locate(/obj/effect/decal/cleanable/blood/oil) in T))

--- a/code/modules/reagents/chemistry/reagents/misc_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/misc_reagents.dm
@@ -180,12 +180,11 @@
 
 	// Let's say burning boiling oil doubles in volume, can our max volume contain that?
 	var/boil_overflow = (holder.total_volume + volume) - holder.maximum_volume
-	var/violent = boil_overflow > 0
 
 	var/turf/T = get_turf(holder.my_atom)
 	var/smoke_type = /datum/effect_system/smoke_spread
 
-	if(violent)
+	if(boil_overflow > 0)
 		holder.my_atom.visible_message("<span class='boldwarning'>The oil boils out and burns violently!</span>")
 		// Log -> remove reagent -> fireflash, else the log fails or fireflash triggers a reaction again
 		fire_flash_log(holder, id)

--- a/code/modules/reagents/chemistry/recipes/medicine_reactions.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine_reactions.dm
@@ -47,8 +47,8 @@
 	name = "Charcoal"
 	id = "charcoal"
 	result = "charcoal"
-	required_reagents = list("ash" = 1, "sodiumchloride" = 1)
-	result_amount = 2
+	required_reagents = list("ash" = 1, "sodiumchloride" = 5)
+	result_amount = 6
 	mix_message = "The mixture yields a fine black powder."
 	min_temp = T0C + 100
 	mix_sound = 'sound/goonstation/misc/fuse.ogg'


### PR DESCRIPTION
## What Does This PR Do
Slightly ups the produced volume of Ash from Oil's temperature reaction.
Tweaks Oil's temperature reaction to only boil and cause a fire if the beaker doesn't have enough empty space remaining (requiring as much empty volume as the oil's), as opposed to every time if the volume is >30u.
Tweaks the Charcoal reaction to require more Salt, effectively lowering the amount of Ash needed.

## Why It's Good For The Game
While burning paper is fine and dandy, it's a bit ridiculous that the self-reliant method requires you to make a dozen batches of Ash 15u at a time to even get anywhere. The sheer amount of Ash you need to make a decent amount of Charcoal is also quite silly.
These changes allow you to make more Ash per batch (depending on the size of your beaker) and tones down how much of it you blow through while making a basic medical healing drug, overall making not relying on paper more viable.

## Testing
Spawned in a small/large/bluespace beaker, made sure you can safely burn up to 25/50/150u of Oil if the rest of the beaker is empty. Made sure a fireflash still happens if there's not enough empty space. Made sure fireflash size scales with boiling overflow volume and can reach the same size as previously.

## Changelog
:cl:
tweak: Heated oil burndown produces slightly more Ash.
tweak: Heated oil burndown reaction now requires its own volume in empty space in the beaker to contain the boiling and avoid causing a fire. This means larger beakers can be used to make more Ash per batch.
tweak: Chemical recipe for Charcoal now requires more Salt (and results in more Charcoal).
/:cl: