### PR TITLE
Adds EMP weakness to welding shield eyes

### DIFF
--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -112,6 +112,7 @@
 	desc = "An electronic device designed to mimic the functions of a pair of human eyes. It has no benefits over organic eyes, but is easy to produce."
 	origin_tech = "biotech=4"
 	status = ORGAN_ROBOT
+	var/EMP_flash_strength = 1
 
 /obj/item/organ/internal/eyes/cybernetic/emp_act(severity)
 	if(!owner || emp_proof)
@@ -119,7 +120,7 @@
 	if(prob(10 * severity))
 		return
 	to_chat(owner, "<span class='warning'>Static obfuscates your vision!</span>")
-	owner.flash_eyes(visual = TRUE)
+	owner.flash_eyes(intensity = EMP_flash_strength, visual = TRUE)
 	..()
 
 /obj/item/organ/internal/eyes/cybernetic/meson
@@ -204,9 +205,7 @@
 	flash_protect = FLASH_PROTECTION_WELDER
 	eye_color = "#101010"
 	origin_tech = "materials=4;biotech=3;engineering=4;plasmatech=3"
-
-/obj/item/organ/internal/eyes/cybernetic/shield/emp_act(severity)
-	return
+	EMP_flash_strength = 3
 
 #define INTACT 0
 #define ONE_SHATTERED 1

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -120,7 +120,7 @@
 	if(prob(10 * severity))
 		return
 	to_chat(owner, "<span class='warning'>Static obfuscates your vision!</span>")
-	owner.flash_eyes(intensity = EMP_flash_strength, visual = TRUE)
+	owner.flash_eyes(flash_intensity, visual = TRUE)
 	..()
 
 /obj/item/organ/internal/eyes/cybernetic/meson
@@ -205,7 +205,7 @@
 	flash_protect = FLASH_PROTECTION_WELDER
 	eye_color = "#101010"
 	origin_tech = "materials=4;biotech=3;engineering=4;plasmatech=3"
-	EMP_flash_strength = 3
+	flash_intensity = 3
 
 #define INTACT 0
 #define ONE_SHATTERED 1
@@ -357,3 +357,7 @@
 	icon_state = "shield_reversed"
 	duration = 2 SECONDS
 	invisibility = INVISIBILITY_LEVEL_TWO
+
+#undef INTACT
+#undef ONE_SHATTERED
+#undef BOTH_SHATTERED

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -112,7 +112,7 @@
 	desc = "An electronic device designed to mimic the functions of a pair of human eyes. It has no benefits over organic eyes, but is easy to produce."
 	origin_tech = "biotech=4"
 	status = ORGAN_ROBOT
-	var/EMP_flash_strength = 1
+	var/flash_intensity = 1
 
 /obj/item/organ/internal/eyes/cybernetic/emp_act(severity)
 	if(!owner || emp_proof)


### PR DESCRIPTION
## What Does This PR Do
Adds an EMP weakness to welding shield eyes.

## Why It's Good For The Game
Every other cybernetic eye has a form of weakness to EMPs, except welding shield eyes which grant you flash protection for free with no downside. For consistency sake, and giving the implant a downside, I think filling out 'EMP weakness' on Paradise station balance bingo would be adequate.

## Testing
EMPed myself a few timeswith numerous combinations of cybernetic eyes. Confirmed welding shield eyes both made a flashing effect, and took cybernetic eye damage while retaining their flash protection.

## Changelog
:cl:
tweak: Welding shield eyes now have a weakness to both weak and strong EMPs!
/:cl: