### PR TITLE
fixes magnetic grippers sucking up light-tubes

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -151,6 +151,7 @@
 		var/obj/machinery/light/light = target
 		var/obj/item/light/L = light.drop_light_tube()
 		L.forceMove(src)
+		gripped_item = L
 		user.visible_message("<span class='notice'>[user] removes the light from the fixture.</span>", "<span class='notice'>You dislodge the light from the fixture.</span>")
 
 	return TRUE


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
fixes magnetic grippers sucking up light-tubes
fixes #22930 

## Why It's Good For The Game
Bugfix

## Testing
Why does this work off afterattack, makes lightbulbs have a random chance to break

## Changelog
:cl:
fix: Engineering borgs can properly replace lights
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
