### PR TITLE
Fixes #22934

### DIFF
--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -630,7 +630,7 @@
 					L.gib()
 
 			// Move unanchored atoms
-			if(!AM.anchored)
+			if(!AM.anchored && !ismob(AM))
 				step(AM, dir)
 			else
 				if(AM.simulated) // Don't qdel lighting overlays, they are static


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
This fixes #22934 by adding a check to the variable in charge of pushing to also check if they are a mob or not, thus preventing multiple gibbings of the same creature.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
I call it soul removal, but hey, someone made an issue, and it is technically an issue, irrelevant of soul removal

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
<!-- How did you test the PR, if at all? -->

https://github.com/ParadiseSS13/Paradise/assets/21987702/56506cde-1fbb-4d96-b452-ce4241a63755



## Changelog
:cl: ppi
fix: Fixes shuttle gibbing to not gib multiple times.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
