### PR TITLE
[s]Ensure the fake death power checks the status again after input

### DIFF
--- a/code/modules/antagonists/changeling/powers/fakedeath.dm
+++ b/code/modules/antagonists/changeling/powers/fakedeath.dm
@@ -35,4 +35,10 @@
 		switch(alert("Are we sure we wish to fake our death?",,"Yes","No"))
 			if("No")
 				return FALSE
+		// Do the checks again since we had user input
+		if(cling.owner != user.mind)
+			return FALSE
+		if(HAS_TRAIT(user, TRAIT_FAKEDEATH))
+			to_chat(user, "<span class='warning'>We are already regenerating.</span>")
+			return FALSE
 	return ..()


### PR DESCRIPTION
## What Does This PR Do
Ensures faking your death checks your status after the user input

## Why It's Good For The Game
Gotta fake your death properly

## Testing
Faked my death. Don't tell the tax people

## Changelog
:cl:
fix: Faking your death as a cling checks the status properly now
/:cl: