### PR TITLE
Transit tube hotfixes

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/oldstation.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/oldstation.dmm
@@ -639,13 +639,13 @@
 /turf/template_noop,
 /area/template_noop)
 "bW" = (
-/obj/structure/transit_tube,
 /obj/effect/spawner/window/reinforced/grilled,
+/obj/structure/transit_tube/horizontal,
 /turf/simulated/floor/plating/airless,
 /area/ruin/ancientstation/betanorth)
 "bX" = (
-/obj/structure/transit_tube,
 /obj/effect/spawner/window/reinforced/grilled,
+/obj/structure/transit_tube/horizontal,
 /turf/simulated/floor/plating,
 /area/ruin/ancientstation)
 "bY" = (
@@ -742,8 +742,8 @@
 /turf/simulated/floor/plasteel,
 /area/ruin/ancientstation)
 "cj" = (
-/obj/structure/transit_tube,
 /obj/effect/spawner/window/reinforced/grilled,
+/obj/structure/transit_tube/horizontal,
 /turf/simulated/floor/plating,
 /area/ruin/ancientstation/thetacorridor)
 "ck" = (
@@ -1088,9 +1088,7 @@
 /turf/simulated/floor/plating,
 /area/ruin/ancientstation)
 "de" = (
-/obj/structure/transit_tube{
-	icon_state = "E-W-Pass"
-	},
+/obj/structure/transit_tube/crossing/horizontal,
 /turf/template_noop,
 /area/space/nearstation)
 "df" = (
@@ -1145,12 +1143,6 @@
 /obj/machinery/door/airlock/research,
 /turf/simulated/floor/plasteel,
 /area/ruin/ancientstation/rnd)
-"dn" = (
-/obj/structure/transit_tube{
-	icon_state = "N-S"
-	},
-/turf/template_noop,
-/area/space/nearstation)
 "do" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -5055,6 +5047,16 @@
 /obj/machinery/power/tesla_coil,
 /turf/simulated/floor/plating,
 /area/ruin/ancientstation/thetacorridor)
+"Db" = (
+/obj/structure/transit_tube/crossing,
+/turf/template_noop,
+/area/space/nearstation)
+"Lu" = (
+/obj/structure/transit_tube/horizontal{
+	dir = 4
+	},
+/turf/template_noop,
+/area/space/nearstation)
 "LD" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -5070,6 +5072,10 @@
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating/airless,
 /area/ruin/ancientstation/betanorth)
+"VT" = (
+/obj/structure/transit_tube/horizontal,
+/turf/template_noop,
+/area/space/nearstation)
 "Xq" = (
 /mob/living/simple_animal/hostile/hivebot,
 /obj/effect/decal/cleanable/dirt,
@@ -5571,7 +5577,7 @@ aa
 aa
 aa
 aa
-cX
+VT
 aH
 bf
 aW
@@ -5619,7 +5625,7 @@ aa
 uQ
 aa
 aa
-cX
+VT
 aa
 aa
 uQ
@@ -5667,7 +5673,7 @@ aa
 aa
 aa
 aa
-de
+VT
 aa
 aa
 uQ
@@ -5715,7 +5721,7 @@ aa
 aa
 aa
 aa
-cX
+VT
 aa
 aa
 ae
@@ -5763,7 +5769,7 @@ aa
 aa
 aa
 aa
-cX
+Lu
 aa
 uQ
 ck
@@ -5811,7 +5817,7 @@ aa
 aa
 aa
 aa
-cX
+VT
 aa
 aa
 ae
@@ -5859,7 +5865,7 @@ aa
 aa
 aa
 aa
-cX
+de
 aa
 uQ
 ck
@@ -5907,7 +5913,7 @@ aa
 aa
 aa
 aa
-cX
+VT
 aa
 aa
 ae
@@ -5955,7 +5961,7 @@ aa
 aa
 aa
 aa
-cX
+VT
 aa
 uQ
 eK
@@ -6003,7 +6009,7 @@ aa
 aa
 aa
 aa
-cX
+VT
 aa
 aa
 dp
@@ -6051,7 +6057,7 @@ aa
 aa
 aa
 aa
-cX
+VT
 aa
 aa
 uQ
@@ -6099,7 +6105,7 @@ aa
 aa
 aa
 aa
-cX
+VT
 aa
 aa
 uQ
@@ -6147,7 +6153,7 @@ aa
 aa
 aa
 aa
-de
+VT
 aa
 aa
 cU
@@ -6195,7 +6201,7 @@ aa
 aa
 aa
 aa
-cX
+VT
 aa
 aa
 cU
@@ -6243,7 +6249,7 @@ aa
 aa
 aa
 aa
-cX
+VT
 aa
 cU
 cU
@@ -7395,7 +7401,7 @@ aa
 aa
 aa
 aa
-cX
+VT
 aa
 dg
 dA
@@ -7411,7 +7417,7 @@ lH
 dg
 dg
 aa
-cX
+VT
 aa
 aa
 aa
@@ -7442,7 +7448,7 @@ aa
 aa
 aa
 aa
-cX
+VT
 aa
 aa
 aa
@@ -7459,7 +7465,7 @@ lI
 dg
 aa
 aa
-cX
+VT
 aa
 aa
 aa
@@ -7492,7 +7498,7 @@ aa
 aa
 aa
 dk
-cX
+Db
 aa
 dg
 dg
@@ -7507,7 +7513,7 @@ dg
 dg
 aa
 aa
-cX
+VT
 aa
 aa
 aa
@@ -7591,7 +7597,7 @@ aa
 aa
 aa
 aa
-dn
+VT
 aa
 aa
 uQ
@@ -7603,7 +7609,7 @@ aa
 aa
 aa
 aa
-cX
+VT
 aa
 aa
 aa
@@ -7635,7 +7641,7 @@ aa
 aa
 aa
 aa
-dn
+aa
 aa
 aa
 ab
@@ -7651,7 +7657,7 @@ aa
 aa
 aa
 aa
-cX
+VT
 aa
 aa
 aa
@@ -7683,7 +7689,7 @@ aa
 aa
 aa
 aa
-cX
+VT
 aa
 aa
 ab
@@ -7699,7 +7705,7 @@ aa
 aa
 aa
 aa
-cX
+VT
 aa
 aa
 aa

--- a/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
@@ -34,8 +34,11 @@
 	air_contents.temperature = T20C
 
 	// Give auto tubes time to align before trying to start moving
-	spawn(5)
-		follow_tube()
+
+	for(var/obj/structure/transit_tube/tube in loc)
+		dir = pick(tube.directions())
+		break
+	follow_tube()
 
 /obj/structure/transit_tube_pod/update_icon_state()
 	. = ..()
@@ -224,9 +227,9 @@
 
 		if(!moving)
 			for(var/obj/structure/transit_tube/station/station in loc)
-				if(dir in station.directions())
+				if((dir in station.directions()) || (turn(dir, 180) in station.directions()))
 					if(!station.pod_moving)
-						if(direction == station.dir)
+						if(direction == turn(station.boarding_dir, 180))
 							if(station.hatch_state == TRANSIT_TUBE_OPEN)
 								eject(mob, direction)
 

--- a/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
@@ -33,8 +33,6 @@
 	air_contents.nitrogen = MOLES_N2STANDARD
 	air_contents.temperature = T20C
 
-	// Give auto tubes time to align before trying to start moving
-
 	for(var/obj/structure/transit_tube/tube in loc)
 		dir = pick(tube.directions())
 		break


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Because it wouldn't be a big lewcc pr without a hotfix to follow

Fixes the transit tubes on the oldstation ruin, since I completely forgot to update them to the new pipes we use.
Fixes some issues with getting stuck in the kinds of transit tube stations used on oldstation.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
This currently kinda breaks a ruin, sorry about that.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Loaded in, spawned the ruin, was able to take the transit tubes
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Fixes the transit tubes on the oldstation ruin.
fix: You're now much less likely to get stuck in a transit tube at certain station types.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
