### PR TITLE
Makes Runes actually invisible to AIs

### DIFF
--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -27,6 +27,7 @@ To draw a rune, use a ritual dagger.
 	mouse_opacity = MOUSE_OPACITY_OPAQUE // So that runes aren't so hard to click
 	var/visibility = 0
 	var/view_range = 7
+	invisibility = 25
 	layer = SIGIL_LAYER
 	color = COLOR_BLOOD_BASE
 
@@ -126,7 +127,7 @@ To draw a rune, use a ritual dagger.
 	alpha = 100 //To help ghosts distinguish hidden runes
 
 /obj/effect/rune/cult_reveal() //for revealing spell
-	invisibility = 0
+	invisibility = initial(invisibility)
 	visible_message("<span class='danger'>[src] suddenly appears!</span>")
 	alpha = initial(alpha)
 

--- a/code/modules/mob/living/silicon/ai/ai_login.dm
+++ b/code/modules/mob/living/silicon/ai/ai_login.dm
@@ -1,10 +1,5 @@
 /mob/living/silicon/ai/Login()	//ThisIsDumb(TM) TODO: tidy this up �_� ~Carn
 	..()
-	for(var/obj/effect/rune/rune in world)
-		var/image/blood = image(loc = rune)
-		blood.override = 1
-		client.images += blood
-	regenerate_icons()
 
 	if(stat != DEAD)
 		for(var/obj/machinery/ai_status_display/O as anything in GLOB.ai_displays) //change status


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes Runes actually invisible to AIs, you no longer get screentips from the runes
fixes #16604

## Why It's Good For The Game
The original coder here had a very clever workaround, that workaround also didn't work and searches world contents. Another day another weird oldcode laced with illicit substances slain. 


## Testing
I can see a skrell but I'm afraid I can't see that rune in front of it, can't see the skrell either if I change it's invis

## Changelog
:cl:
fix: You can't see the screentips on runes now as the AI
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
