### PR TITLE
Adds additional logging for megaphone

### DIFF
--- a/code/game/objects/items/devices/megaphone.dm
+++ b/code/game/objects/items/devices/megaphone.dm
@@ -82,6 +82,7 @@
 
 	audible_message("<span class='game say'><span class='name'>[user.GetVoice()]</span> [user.GetAltName()] broadcasts, <span class='[span]'>\"[message]\"</span></span>", hearing_distance = 14)
 	log_say(message, user)
+	user.create_log(SAY_LOG, "(megaphone) [message]")
 	for(var/obj/O in view(14, get_turf(src)))
 		O.hear_talk(user, message_to_multilingual("<span class='[span]'>[message]</span>"))
 

--- a/code/game/objects/items/devices/megaphone.dm
+++ b/code/game/objects/items/devices/megaphone.dm
@@ -82,7 +82,7 @@
 
 	audible_message("<span class='game say'><span class='name'>[user.GetVoice()]</span> [user.GetAltName()] broadcasts, <span class='[span]'>\"[message]\"</span></span>", hearing_distance = 14)
 	log_say(message, user)
-	user.create_log(SAY_LOG, "(megaphone) [message]")
+	user.create_log(SAY_LOG, "(megaphone) '[message]'")
 	for(var/obj/O in view(14, get_turf(src)))
 		O.hear_talk(user, message_to_multilingual("<span class='[span]'>[message]</span>"))
 

--- a/code/game/objects/items/devices/megaphone.dm
+++ b/code/game/objects/items/devices/megaphone.dm
@@ -81,7 +81,7 @@
 		playsound(src, "sound/items/megaphone.ogg", 100, FALSE, 5)
 
 	audible_message("<span class='game say'><span class='name'>[user.GetVoice()]</span> [user.GetAltName()] broadcasts, <span class='[span]'>\"[message]\"</span></span>", hearing_distance = 14)
-	log_say(message, user)
+	log_say("MEGAPHONE) [message]", user)
 	user.create_log(SAY_LOG, "(megaphone) '[message]'")
 	for(var/obj/O in view(14, get_turf(src)))
 		O.hear_talk(user, message_to_multilingual("<span class='[span]'>[message]</span>"))

--- a/code/game/objects/items/devices/megaphone.dm
+++ b/code/game/objects/items/devices/megaphone.dm
@@ -81,7 +81,7 @@
 		playsound(src, "sound/items/megaphone.ogg", 100, FALSE, 5)
 
 	audible_message("<span class='game say'><span class='name'>[user.GetVoice()]</span> [user.GetAltName()] broadcasts, <span class='[span]'>\"[message]\"</span></span>", hearing_distance = 14)
-	log_say("MEGAPHONE) [message]", user)
+	log_say("(MEGAPHONE) [message]", user)
 	user.create_log(SAY_LOG, "(megaphone) '[message]'")
 	for(var/obj/O in view(14, get_turf(src)))
 		O.hear_talk(user, message_to_multilingual("<span class='[span]'>[message]</span>"))


### PR DESCRIPTION
## What Does This PR Do
Adds some additional logging when a player uses a megaphone.
## Why It's Good For The Game
This allows easier access to megaphone messages via the in-game log viewer. 
## Images of changes
![o3VavB4ihq](https://github.com/ParadiseSS13/Paradise/assets/116982774/59047eab-a7f4-4d1f-ad3a-a81249cf837f)
## Testing
Used a megaphone.
Viewed in-game logs.
## Changelog
NPFC
