### PR TITLE
[s] Seed extractor no longer broadscasts to the world when a seed is taken out.

### DIFF
--- a/code/modules/hydroponics/seed_extractor.dm
+++ b/code/modules/hydroponics/seed_extractor.dm
@@ -170,8 +170,6 @@
 /obj/machinery/seed_extractor/proc/vend_seed(seed_id, seed_variant, amount, mob/user)
 	if(!seed_id)
 		return
-	if(!seed_variant)
-		to_chat(user, "<span class='warning'>No variant available!</span>")
 	var/datum/seed_pile/selected_pile
 	for(var/datum/seed_pile/N in piles)
 		if(N.id == seed_id && (N.variant == seed_variant || !seed_variant))

--- a/code/modules/hydroponics/seed_extractor.dm
+++ b/code/modules/hydroponics/seed_extractor.dm
@@ -157,7 +157,7 @@
 	. = FALSE
 	switch(action)
 		if("vend")
-			vend_seed(text2num(params["seedid"]), params["seedvariant"], vend_amount, ui.user)
+			vend_seed(text2num(params["seedid"]), params["seedvariant"], vend_amount)
 			add_fingerprint(usr)
 			. = TRUE
 		if("set_vend_amount")
@@ -167,7 +167,7 @@
 			add_fingerprint(usr)
 			. = TRUE
 
-/obj/machinery/seed_extractor/proc/vend_seed(seed_id, seed_variant, amount, mob/user)
+/obj/machinery/seed_extractor/proc/vend_seed(seed_id, seed_variant, amount)
 	if(!seed_id)
 		return
 	var/datum/seed_pile/selected_pile

--- a/code/modules/hydroponics/seed_extractor.dm
+++ b/code/modules/hydroponics/seed_extractor.dm
@@ -157,7 +157,7 @@
 	. = FALSE
 	switch(action)
 		if("vend")
-			vend_seed(text2num(params["seedid"]), params["seedvariant"], vend_amount)
+			vend_seed(text2num(params["seedid"]), params["seedvariant"], vend_amount, ui.user)
 			add_fingerprint(usr)
 			. = TRUE
 		if("set_vend_amount")
@@ -167,11 +167,11 @@
 			add_fingerprint(usr)
 			. = TRUE
 
-/obj/machinery/seed_extractor/proc/vend_seed(seed_id, seed_variant, amount)
+/obj/machinery/seed_extractor/proc/vend_seed(seed_id, seed_variant, amount, mob/user)
 	if(!seed_id)
 		return
 	if(!seed_variant)
-		to_chat(world,"<span class='warning'>no variant</span>")
+		to_chat(user, "<span class='warning'>No variant available!</span>")
 	var/datum/seed_pile/selected_pile
 	for(var/datum/seed_pile/N in piles)
 		if(N.id == seed_id && (N.variant == seed_variant || !seed_variant))


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Removes an unnecessary to_chat in the seed extractor that happened to be targeting world.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
I don't think we need to inform the entire server that this seed isn't a variant.
I don't think the entire server needs to know there are no variants.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Put a seed into the seed extractor
Take a seed out of the seed extractor
The entire server remains uninformed about my dastardly deed.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Seed extractor no longer broadscasts to the world when a seed is taken out.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
