### PR TITLE
Add new "prize list" for Mining Vendors: MODsuit Modules.

### DIFF
--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -51,6 +51,16 @@
 		EQUIPMENT("Stabilizing Serum", /obj/item/hivelordstabilizer, 400),
 		EQUIPMENT("Survival Medipen", /obj/item/reagent_containers/hypospray/autoinjector/survival, 500),
 	)
+	prize_list["Mining MODsuit"] = list(
+		EQUIPMENT("Mining MODsuit", /obj/item/mod/control/pre_equipped/mining/vendor, 3500),
+		EQUIPMENT("Asteroid MODsuit Skin", /obj/item/mod/skin_applier/asteroid, 1000),
+		EQUIPMENT("MOD ion jetpack module", /obj/item/mod/module/jetpack/advanced, 2000),
+		EQUIPMENT("MOD meson visor module", /obj/item/mod/module/visor/meson, 750),
+		EQUIPMENT("MOD flashlight module", /obj/item/mod/module/flashlight, 1000),
+		EQUIPMENT("MOD internal GPS module", /obj/item/mod/module/gps, 1000),
+		EQUIPMENT("MOD drill module", /obj/item/mod/module/drill, 1250),
+		EQUIPMENT("MOD springlock module", /obj/item/mod/module/springlock, 2500),
+	)
 	prize_list["Kinetic Accelerator"] = list(
 		EQUIPMENT("Kinetic Accelerator", /obj/item/gun/energy/kinetic_accelerator, 750),
 		EQUIPMENT("KA Adjustable Tracer Rounds", /obj/item/borg/upgrade/modkit/tracer/adjustable, 150),
@@ -62,16 +72,6 @@
 		EQUIPMENT("KA Range Increase", /obj/item/borg/upgrade/modkit/range, 1000),
 		EQUIPMENT("KA Super Chassis", /obj/item/borg/upgrade/modkit/chassis_mod, 250),
 		EQUIPMENT("KA White Tracer Rounds", /obj/item/borg/upgrade/modkit/tracer, 100),
-	)
-	prize_list["Mining MODsuit"] = list(
-		EQUIPMENT("Mining MODsuit", /obj/item/mod/control/pre_equipped/mining/vendor, 3500),
-		EQUIPMENT("Asteroid MODsuit Skin", /obj/item/mod/skin_applier/asteroid, 1000),
-		EQUIPMENT("MOD ion jetpack module", /obj/item/mod/module/jetpack/advanced, 2000),
-		EQUIPMENT("MOD meson visor module", /obj/item/mod/module/visor/meson, 750),
-		EQUIPMENT("MOD flashlight module", /obj/item/mod/module/flashlight, 1000),
-		EQUIPMENT("MOD internal GPS module", /obj/item/mod/module/gps, 1000),
-		EQUIPMENT("MOD drill module", /obj/item/mod/module/drill, 1250),
-		EQUIPMENT("MOD springlock module", /obj/item/mod/module/springlock, 2000),
 	)
 	prize_list["Digging Tools"] = list(
 		EQUIPMENT("Diamond Pickaxe", /obj/item/pickaxe/diamond, 2000),

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -35,12 +35,9 @@
 		EQUIPMENT("Explorer's Webbing", /obj/item/storage/belt/mining, 500),
 		EQUIPMENT("Fulton Beacon", /obj/item/fulton_core, 400),
 		EQUIPMENT("Mining Conscription Kit", /obj/item/storage/backpack/duffel/mining_conscript, 1500),
-		EQUIPMENT("Advanced Jetpack Module", /obj/item/mod/module/jetpack/advanced, 2000),
 		EQUIPMENT("Jump Boots", /obj/item/clothing/shoes/bhop, 2500),
 		EQUIPMENT("Lazarus Capsule", /obj/item/mobcapsule, 800),
 		EQUIPMENT("Lazarus Capsule belt", /obj/item/storage/belt/lazarus, 200),
-		EQUIPMENT("Mining MODsuit", /obj/item/mod/control/pre_equipped/mining/vendor, 3500),
-		EQUIPMENT("Asteroid MODsuit Skin", /obj/item/mod/skin_applier/asteroid, 1000),
 		EQUIPMENT("Tracking Bio-chip Kit", /obj/item/storage/box/minertracker, 600),
 	)
 	prize_list["Consumables"] = list(
@@ -65,6 +62,16 @@
 		EQUIPMENT("KA Range Increase", /obj/item/borg/upgrade/modkit/range, 1000),
 		EQUIPMENT("KA Super Chassis", /obj/item/borg/upgrade/modkit/chassis_mod, 250),
 		EQUIPMENT("KA White Tracer Rounds", /obj/item/borg/upgrade/modkit/tracer, 100),
+	)
+	prize_list["Mining MODsuit"] = list(
+		EQUIPMENT("Mining MODsuit", /obj/item/mod/control/pre_equipped/mining/vendor, 3500),
+		EQUIPMENT("Asteroid MODsuit Skin", /obj/item/mod/skin_applier/asteroid, 1000),
+		EQUIPMENT("MOD ion jetpack module", /obj/item/mod/module/jetpack/advanced, 2000),
+		EQUIPMENT("MOD meson visor module", /obj/item/mod/module/visor/meson, 750),
+		EQUIPMENT("MOD flashlight module", /obj/item/mod/module/flashlight, 1000),
+		EQUIPMENT("MOD internal GPS module", /obj/item/mod/module/gps, 1000),
+		EQUIPMENT("MOD drill module", /obj/item/mod/module/drill, 1250),
+		EQUIPMENT("MOD springlock module", /obj/item/mod/module/springlock, 2000),
 	)
 	prize_list["Digging Tools"] = list(
 		EQUIPMENT("Diamond Pickaxe", /obj/item/pickaxe/diamond, 2000),


### PR DESCRIPTION
I don't know if prices for modules are too high or too low, and idk if i should request TM or not..

## What Does This PR Do
Add new "Prize list" to Mining Vendor, this new pool is expansion for MODsuit modules, now miners can buy "basic" modules for their mining modsuit.

## Why It's Good For The Game
Now miners can get their MODsuit modules during low-pop or if robotics refuse to do their jobs, of course you still require to go and get better upgrades like extended storage or thermal cooling thing, so it still require interaction with robotics for upgrades.


## Images of changes
![image](https://github.com/ParadiseSS13/Paradise/assets/89580971/fa2bf8c8-7bd7-4563-bae2-a38650380090)

## Testing
i will check in moment.

## Changelog
:cl: Venuska1117
add: Now you can buy "basic" MODsuit modules in mining vendor.
tweak: Changed mining MODsuit and Advanced Jetpack position to new category.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
