### PR TITLE
move 'Jump to Ruin' from an admin to a ghost verb

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -164,7 +164,6 @@ GLOBAL_LIST_INIT(admin_verbs_debug, list(
 	/client/proc/map_template_upload,
 	/client/proc/view_runtimes,
 	/client/proc/admin_serialize,
-	/client/proc/jump_to_ruin,
 	/client/proc/uid_log,
 	/client/proc/visualise_active_turfs,
 	/client/proc/reestablish_db_connection,

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -916,49 +916,6 @@ GLOBAL_PROTECT(AdminProcCallSpamPrevention)
 
 	GLOB.error_cache.showTo(usr)
 
-/client/proc/jump_to_ruin()
-	set category = "Debug"
-	set name = "Jump to Ruin"
-	set desc = "Displays a list of all placed ruins to teleport to."
-
-	if(!check_rights(R_DEBUG))
-		return
-
-	var/list/names = list()
-	for(var/i in GLOB.ruin_landmarks)
-		var/obj/effect/landmark/ruin/ruin_landmark = i
-		var/datum/map_template/ruin/template = ruin_landmark.ruin_template
-
-		var/count = 1
-		var/name = template.name
-		var/original_name = name
-
-		while(name in names)
-			count++
-			name = "[original_name] ([count])"
-
-		names[name] = ruin_landmark
-
-	var/ruinname = input("Select ruin", "Jump to Ruin") as null|anything in names
-
-	var/obj/effect/landmark/ruin/landmark = names[ruinname]
-
-	if(istype(landmark))
-		var/datum/map_template/ruin/template = landmark.ruin_template
-		if(isobj(usr.loc))
-			var/obj/O = usr.loc
-			O.force_eject_occupant(usr)
-		admin_forcemove(usr, get_turf(landmark))
-
-		to_chat(usr, "<span class='name'>[template.name]</span>")
-		to_chat(usr, "<span class='italics'>[template.description]</span>")
-
-		log_admin("[key_name(usr)] jumped to ruin [ruinname]")
-		if(!isobserver(usr))
-			message_admins("[key_name_admin(usr)] jumped to ruin [ruinname]", 1)
-
-		SSblackbox.record_feedback("tally", "admin_verb", 1, "Jump To Ruin") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-
 /client/proc/visualise_active_turfs()
 	set category = "Debug"
 	set name = "Visualise Active Turfs"

--- a/code/modules/mob/dead/observer/observer_base.dm
+++ b/code/modules/mob/dead/observer/observer_base.dm
@@ -450,7 +450,6 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	var/obj/effect/landmark/ruin/landmark = names[ruinname]
 
 	if(istype(landmark))
-		var/datum/map_template/ruin/template = landmark.ruin_template
 		forceMove(get_turf(landmark))
 		update_parallax_contents()
 

--- a/code/modules/mob/dead/observer/observer_base.dm
+++ b/code/modules/mob/dead/observer/observer_base.dm
@@ -42,6 +42,7 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 	see_in_dark = 100
 	verbs += list(
 		/mob/dead/observer/proc/dead_tele,
+		/mob/dead/observer/proc/jump_to_ruin,
 		/mob/dead/observer/proc/open_spawners_menu)
 
 	// Our new boo spell.
@@ -419,6 +420,39 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		return
 	var/target = input("Area to teleport to", "Teleport to a location") as null|anything in SSmapping.ghostteleportlocs
 	teleport(SSmapping.ghostteleportlocs[target])
+
+/mob/dead/observer/proc/jump_to_ruin()
+	set category = "Ghost"
+	set name = "Jump to Ruin"
+	set desc = "Displays a list of all placed ruins to teleport to."
+
+	if(!isobserver(usr))
+		to_chat(usr, "Not when you're not dead!")
+		return
+
+	var/list/names = list()
+	for(var/i in GLOB.ruin_landmarks)
+		var/obj/effect/landmark/ruin/ruin_landmark = i
+		var/datum/map_template/ruin/template = ruin_landmark.ruin_template
+
+		var/count = 1
+		var/name = template.name
+		var/original_name = name
+
+		while(name in names)
+			count++
+			name = "[original_name] ([count])"
+
+		names[name] = ruin_landmark
+
+	var/ruinname = input("Select ruin", "Jump to Ruin") as null|anything in names
+
+	var/obj/effect/landmark/ruin/landmark = names[ruinname]
+
+	if(istype(landmark))
+		var/datum/map_template/ruin/template = landmark.ruin_template
+		forceMove(get_turf(landmark))
+		update_parallax_contents()
 
 /mob/dead/observer/proc/teleport(area/A)
 	if(!A || !isobserver(usr))


### PR DESCRIPTION
## What Does This PR Do
This PR moves the "Jump to Ruin" action from admin-restricted to available as a ghost. It also removes some behavior from the proc to make it more appropriate for ghost use (changing the use of `admin_forcemove`, doesn't message admins). The ruin names and descriptions are also not printed to chat; some of these are not well-written/lore-accurate.

## Why It's Good For The Game
There's currently no good way as a ghost to find ruins on the planet/in space -- they don't (necessarily) have unique areas and so can't easily be listed in the existing Teleport menu. Since ghosts can already teleport and travel the whole world space having this available to them doesn't seem unreasonable.

## Images of changes
![2023_10_18__11_24_53__Paradise Station 13](https://github.com/ParadiseSS13/Paradise/assets/59303604/9bcf50a6-c258-4b07-8ef5-a8e128a8890c)
![2023_10_18__11_24_59__Paradise Station 13](https://github.com/ParadiseSS13/Paradise/assets/59303604/9bbb6ed6-fc7d-40a6-9db4-3eef091dbe24)

## Testing
Logged in, ghosted, made sure verb was available, used verb.

## Changelog
:cl:
add: "Jump to Ruin" now available as a ghost action for ashland/space ruins.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
