### PR TITLE
Pneumatic Cannon Refactor

### DIFF
--- a/code/game/objects/items/weapons/pneumaticCannon.dm
+++ b/code/game/objects/items/weapons/pneumaticCannon.dm
@@ -10,12 +10,20 @@
 	lefthand_file = 'icons/mob/inhands/guns_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/guns_righthand.dmi'
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, RAD = 0, FIRE = 60, ACID = 50)
-	var/max_weight_class = 20 //The max weight of items that can fit into the cannon
-	var/loaded_weight_class = 0 //The weight of items currently in the cannon
-	var/obj/item/tank/internals/tank = null //The gas tank that is drawn from to fire things
-	var/gas_per_throw = 3 //How much gas is drawn from a tank's pressure to fire
-	var/list/loaded_items = list() //The items loaded into the cannon that will be fired out
-	var/pressure_setting = 1 //How powerful the cannon is - higher pressure = more gas but more powerful throws
+	///The max weight of items that can fit into the cannon
+	var/max_weight_class = 20
+	///The weight of items currently in the cannon
+	var/loaded_weight_class = 0
+	///The gas tank that is drawn from to fire things
+	var/obj/item/tank/internals/tank = null
+	///If the cannon needs a tank at all
+	var/requires_tank = TRUE
+	///How much gas is drawn from a tank's pressure to fire
+	var/gas_per_throw = 3
+	///The items loaded into the cannon that will be fired out
+	var/list/loaded_items = list()
+	///How powerful the cannon is - higher pressure = more gas but more powerful throws
+	var/pressure_setting = 1
 
 /obj/item/pneumatic_cannon/Destroy()
 	QDEL_NULL(tank)
@@ -32,54 +40,58 @@
 		for(var/obj/item/I in loaded_items)
 			. += "<span class='info'>[bicon(I)] It has \the [I] loaded.</span>"
 
+/**
+* Arguments:
+* * I - item to load into the cannon
+* * user - the person loading the item in
+* Returns:
+* * True if item was loaded, false if it failed
+*/
+/obj/item/pneumatic_cannon/proc/load_item(obj/item/I, mob/user)
+	if(I.flags & (ABSTRACT | NODROP | DROPDEL))
+		to_chat(user, "<span class='warning'>You can't put [I] into [src]!</span>")
+		return FALSE
+	if((loaded_weight_class + I.w_class) > max_weight_class)
+		to_chat(user, "<span class='warning'>\The [I] won't fit into \the [src]!</span>")
+		return FALSE
+	if(I.w_class > src.w_class)
+		to_chat(user, "<span class='warning'>\The [I] is too large to fit into \the [src]!</span>")
+		return FALSE
+	if(!user.unEquip(I))
+		return FALSE
+	to_chat(user, "<span class='notice'>You load \the [I] into \the [src].</span>")
+	loaded_items.Add(I)
+	loaded_weight_class += I.w_class
+	I.forceMove(src)
+	return TRUE
+
+/obj/item/pneumatic_cannon/wrench_act(mob/living/user, obj/item/I)
+	switch(pressure_setting)
+		if(1)
+			pressure_setting = 2
+		if(2)
+			pressure_setting = 3
+		if(3)
+			pressure_setting = 1
+	to_chat(user, "<span class='notice'>You tweak \the [src]'s pressure output to [pressure_setting].</span>")
+	return TRUE
+
+
 /obj/item/pneumatic_cannon/attackby(obj/item/W, mob/user, params)
 	..()
-	if(istype(W, /obj/item/tank/internals/) && !tank)
+	if(istype(W, /obj/item/tank/internals) && !tank)
 		if(istype(W, /obj/item/tank/internals/emergency_oxygen))
 			to_chat(user, "<span class='warning'>\The [W] is too small for \the [src].</span>")
 			return
-		updateTank(W, 0, user)
+		add_tank(W, user)
 		return
 	if(W.type == type)
 		to_chat(user, "<span class='warning'>You're fairly certain that putting a pneumatic cannon inside another pneumatic cannon would cause a spacetime disruption.</span>")
 		return
-	if(istype(W, /obj/item/wrench))
-		switch(pressure_setting)
-			if(1)
-				pressure_setting = 2
-			if(2)
-				pressure_setting = 3
-			if(3)
-				pressure_setting = 1
-		to_chat(user, "<span class='notice'>You tweak \the [src]'s pressure output to [pressure_setting].</span>")
-		return
-	if(loaded_weight_class >= max_weight_class)
-		to_chat(user, "<span class='warning'>\The [src] can't hold any more items!</span>")
-		return
-	if(isitem(W))
-		var/obj/item/IW = W
-		if(IW.flags & (ABSTRACT | NODROP | DROPDEL))
-			to_chat(user, "<span class='warning'>You can't put [IW] into [src]!</span>")
-			return
-		if((loaded_weight_class + IW.w_class) > max_weight_class)
-			to_chat(user, "<span class='warning'>\The [IW] won't fit into \the [src]!</span>")
-			return
-		if(IW.w_class > src.w_class)
-			to_chat(user, "<span class='warning'>\The [IW] is too large to fit into \the [src]!</span>")
-			return
-		if(!user.unEquip(W))
-			return
-		to_chat(user, "<span class='notice'>You load \the [IW] into \the [src].</span>")
-		loaded_items.Add(IW)
-		loaded_weight_class += IW.w_class
-		IW.loc = src
-		return
+	load_item(W, user)
 
 /obj/item/pneumatic_cannon/screwdriver_act(mob/living/user, obj/item/I)
-	if(!tank)
-		return
-
-	updateTank(tank, 1, user)
+	remove_tank(user)
 	return TRUE
 
 /obj/item/pneumatic_cannon/afterattack(atom/target, mob/living/carbon/human/user, flag, params)
@@ -91,47 +103,52 @@
 		return ..()
 	if(!istype(user))
 		return ..()
-	Fire(user, target)
+	fire(user, target)
 
 
-/obj/item/pneumatic_cannon/proc/Fire(mob/living/carbon/human/user, atom/target)
+/obj/item/pneumatic_cannon/proc/fire(mob/living/carbon/human/user, atom/target)
 	if(!istype(user) && !target)
 		return
-	var/discharge = 0
+	var/has_discharged = FALSE
 	if(!loaded_items || !loaded_weight_class)
 		to_chat(user, "<span class='warning'>\The [src] has nothing loaded.</span>")
 		return
-	if(!tank)
-		to_chat(user, "<span class='warning'>\The [src] can't fire without a source of gas.</span>")
-		return
-	if(tank && !tank.air_contents.remove(gas_per_throw * pressure_setting))
-		to_chat(user, "<span class='warning'>\The [src] lets out a weak hiss and doesn't react!</span>")
-		return
+	if(requires_tank)
+		if(!tank)
+			to_chat(user, "<span class='warning'>\The [src] can't fire without a source of gas.</span>")
+			return
+		if(!tank.air_contents.remove(gas_per_throw * pressure_setting))
+			to_chat(user, "<span class='warning'>\The [src] lets out a weak hiss and doesn't react!</span>")
+			return
 	if(user && HAS_TRAIT(user, TRAIT_CLUMSY) && prob(75))
 		user.visible_message("<span class='warning'>[user] loses [user.p_their()] grip on [src], causing it to go off!</span>", "<span class='userdanger'>[src] slips out of your hands and goes off!</span>")
 		user.drop_item()
+		has_discharged = TRUE
 		if(prob(10))
-			target = get_turf(user)
+			target = user
 		else
 			var/list/possible_targets = range(3,src)
 			target = pick(possible_targets)
-		discharge = 1
-	if(!discharge)
+	if(!has_discharged)
 		user.visible_message("<span class='danger'>[user] fires \the [src]!</span>", \
 							"<span class='danger'>You fire \the [src]!</span>")
 	add_attack_logs(user, target, "Fired [src]")
 	playsound(src.loc, 'sound/weapons/sonic_jackhammer.ogg', 50, 1)
-	for(var/obj/item/ITD in loaded_items) //Item To Discharge
-		spawn(0)
-			loaded_items.Remove(ITD)
-			loaded_weight_class -= ITD.w_class
-			ITD.throw_speed = pressure_setting * 2
-			ITD.loc = get_turf(src)
-			ITD.throw_at(target, pressure_setting * 5, pressure_setting * 2,user)
+	for(var/obj/item/I in loaded_items)
+		loaded_items.Remove(I)
+		loaded_weight_class -= I.w_class
+		I.throw_speed = pressure_setting * 2
+		I.forceMove(get_turf(src))
+		I.throw_at(target, pressure_setting * 5, pressure_setting * 2, user)
 	if(pressure_setting >= 3 && user)
 		user.visible_message("<span class='warning'>[user] is thrown down by the force of the cannon!</span>", "<span class='userdanger'>[src] slams into your shoulder, knocking you down!")
-		user.Weaken(3)
+		user.KnockDown(3 SECONDS)
 
+/obj/item/pneumatic_cannon/admin
+	name = "admin pnuematic cannon"
+	desc = "Infinite gas and infinite capacity, go crazy"
+	requires_tank = FALSE
+	max_weight_class = INFINITY
 
 /obj/item/pneumatic_cannon/ghetto //Obtainable by improvised methods; more gas per use, less capacity, but smaller
 	name = "improvised pneumatic cannon"
@@ -152,24 +169,24 @@
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
 
-/obj/item/pneumatic_cannon/proc/updateTank(obj/item/tank/thetank, removing = 0, mob/living/carbon/human/user)
-	if(removing)
-		if(!src.tank)
-			return
-		to_chat(user, "<span class='notice'>You detach \the [thetank] from \the [src].</span>")
-		src.tank.loc = get_turf(user)
-		user.put_in_hands(tank)
-		src.tank = null
-	if(!removing)
-		if(src.tank)
-			to_chat(user, "<span class='warning'>\The [src] already has a tank.</span>")
-			return
-		if(!user.unEquip(thetank))
-			return
-		to_chat(user, "<span class='notice'>You hook \the [thetank] up to \the [src].</span>")
-		src.tank = thetank
-		thetank.loc = src
-	src.update_icons()
+/obj/item/pneumatic_cannon/proc/add_tank(obj/item/tank/new_tank, mob/living/carbon/human/user)
+	if(tank)
+		to_chat(user, "<span class='warning'>\The [src] already has a tank.</span>")
+		return
+	if(!user.unEquip(new_tank))
+		return
+	to_chat(user, "<span class='notice'>You hook \the [new_tank] up to \the [src].</span>")
+	new_tank.forceMove(src)
+	tank = new_tank
+	update_icons()
+
+/obj/item/pneumatic_cannon/proc/remove_tank(mob/living/carbon/human/user)
+	if(!tank)
+		return FALSE
+	to_chat(user, "<span class='notice'>You detach \the [tank] from \the [src].</span>")
+	user.put_in_hands(tank)
+	tank = null
+	update_icons()
 
 /obj/item/pneumatic_cannon/proc/update_icons()
 	src.overlays.Cut()

--- a/code/game/objects/items/weapons/pneumaticCannon.dm
+++ b/code/game/objects/items/weapons/pneumaticCannon.dm
@@ -10,16 +10,16 @@
 	lefthand_file = 'icons/mob/inhands/guns_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/guns_righthand.dmi'
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, RAD = 0, FIRE = 60, ACID = 50)
-	var/maxWeightClass = 20 //The max weight of items that can fit into the cannon
-	var/loadedWeightClass = 0 //The weight of items currently in the cannon
+	var/max_weight_class = 20 //The max weight of items that can fit into the cannon
+	var/loaded_weight_class = 0 //The weight of items currently in the cannon
 	var/obj/item/tank/internals/tank = null //The gas tank that is drawn from to fire things
-	var/gasPerThrow = 3 //How much gas is drawn from a tank's pressure to fire
-	var/list/loadedItems = list() //The items loaded into the cannon that will be fired out
-	var/pressureSetting = 1 //How powerful the cannon is - higher pressure = more gas but more powerful throws
+	var/gas_per_throw = 3 //How much gas is drawn from a tank's pressure to fire
+	var/list/loaded_items = list() //The items loaded into the cannon that will be fired out
+	var/pressure_setting = 1 //How powerful the cannon is - higher pressure = more gas but more powerful throws
 
 /obj/item/pneumatic_cannon/Destroy()
 	QDEL_NULL(tank)
-	QDEL_LIST_CONTENTS(loadedItems)
+	QDEL_LIST_CONTENTS(loaded_items)
 	return ..()
 
 /obj/item/pneumatic_cannon/examine(mob/user)
@@ -29,7 +29,7 @@
 	else
 		if(tank)
 			. += "<span class='notice'>[bicon(tank)] It has \the [tank] mounted onto it.</span>"
-		for(var/obj/item/I in loadedItems)
+		for(var/obj/item/I in loaded_items)
 			. += "<span class='info'>[bicon(I)] It has \the [I] loaded.</span>"
 
 /obj/item/pneumatic_cannon/attackby(obj/item/W, mob/user, params)
@@ -44,16 +44,16 @@
 		to_chat(user, "<span class='warning'>You're fairly certain that putting a pneumatic cannon inside another pneumatic cannon would cause a spacetime disruption.</span>")
 		return
 	if(istype(W, /obj/item/wrench))
-		switch(pressureSetting)
+		switch(pressure_setting)
 			if(1)
-				pressureSetting = 2
+				pressure_setting = 2
 			if(2)
-				pressureSetting = 3
+				pressure_setting = 3
 			if(3)
-				pressureSetting = 1
-		to_chat(user, "<span class='notice'>You tweak \the [src]'s pressure output to [pressureSetting].</span>")
+				pressure_setting = 1
+		to_chat(user, "<span class='notice'>You tweak \the [src]'s pressure output to [pressure_setting].</span>")
 		return
-	if(loadedWeightClass >= maxWeightClass)
+	if(loaded_weight_class >= max_weight_class)
 		to_chat(user, "<span class='warning'>\The [src] can't hold any more items!</span>")
 		return
 	if(isitem(W))
@@ -61,7 +61,7 @@
 		if(IW.flags & (ABSTRACT | NODROP | DROPDEL))
 			to_chat(user, "<span class='warning'>You can't put [IW] into [src]!</span>")
 			return
-		if((loadedWeightClass + IW.w_class) > maxWeightClass)
+		if((loaded_weight_class + IW.w_class) > max_weight_class)
 			to_chat(user, "<span class='warning'>\The [IW] won't fit into \the [src]!</span>")
 			return
 		if(IW.w_class > src.w_class)
@@ -70,8 +70,8 @@
 		if(!user.unEquip(W))
 			return
 		to_chat(user, "<span class='notice'>You load \the [IW] into \the [src].</span>")
-		loadedItems.Add(IW)
-		loadedWeightClass += IW.w_class
+		loaded_items.Add(IW)
+		loaded_weight_class += IW.w_class
 		IW.loc = src
 		return
 
@@ -98,13 +98,13 @@
 	if(!istype(user) && !target)
 		return
 	var/discharge = 0
-	if(!loadedItems || !loadedWeightClass)
+	if(!loaded_items || !loaded_weight_class)
 		to_chat(user, "<span class='warning'>\The [src] has nothing loaded.</span>")
 		return
 	if(!tank)
 		to_chat(user, "<span class='warning'>\The [src] can't fire without a source of gas.</span>")
 		return
-	if(tank && !tank.air_contents.remove(gasPerThrow * pressureSetting))
+	if(tank && !tank.air_contents.remove(gas_per_throw * pressure_setting))
 		to_chat(user, "<span class='warning'>\The [src] lets out a weak hiss and doesn't react!</span>")
 		return
 	if(user && HAS_TRAIT(user, TRAIT_CLUMSY) && prob(75))
@@ -121,14 +121,14 @@
 							"<span class='danger'>You fire \the [src]!</span>")
 	add_attack_logs(user, target, "Fired [src]")
 	playsound(src.loc, 'sound/weapons/sonic_jackhammer.ogg', 50, 1)
-	for(var/obj/item/ITD in loadedItems) //Item To Discharge
+	for(var/obj/item/ITD in loaded_items) //Item To Discharge
 		spawn(0)
-			loadedItems.Remove(ITD)
-			loadedWeightClass -= ITD.w_class
-			ITD.throw_speed = pressureSetting * 2
+			loaded_items.Remove(ITD)
+			loaded_weight_class -= ITD.w_class
+			ITD.throw_speed = pressure_setting * 2
 			ITD.loc = get_turf(src)
-			ITD.throw_at(target, pressureSetting * 5, pressureSetting * 2,user)
-	if(pressureSetting >= 3 && user)
+			ITD.throw_at(target, pressure_setting * 5, pressure_setting * 2,user)
+	if(pressure_setting >= 3 && user)
 		user.visible_message("<span class='warning'>[user] is thrown down by the force of the cannon!</span>", "<span class='userdanger'>[src] slams into your shoulder, knocking you down!")
 		user.Weaken(3)
 
@@ -138,8 +138,8 @@
 	desc = "A gas-powered, object-firing cannon made out of common parts."
 	force = 5
 	w_class = WEIGHT_CLASS_NORMAL
-	maxWeightClass = 7
-	gasPerThrow = 5
+	max_weight_class = 7
+	gas_per_throw = 5
 
 /datum/crafting_recipe/improvised_pneumatic_cannon //Pretty easy to obtain but
 	name = "Pneumatic Cannon"

--- a/code/game/objects/items/weapons/pneumaticCannon.dm
+++ b/code/game/objects/items/weapons/pneumaticCannon.dm
@@ -18,7 +18,7 @@
 	var/obj/item/tank/internals/tank = null
 	///If the cannon needs a tank at all
 	var/requires_tank = TRUE
-	///How much gas is drawn from a tank's pressure to fire
+	///How many moles of gas is drawn from a tank's pressure to fire
 	var/gas_per_throw = 3
 	///The items loaded into the cannon that will be fired out
 	var/list/loaded_items = list()
@@ -52,14 +52,14 @@
 		to_chat(user, "<span class='warning'>You can't put [I] into [src]!</span>")
 		return FALSE
 	if((loaded_weight_class + I.w_class) > max_weight_class)
-		to_chat(user, "<span class='warning'>\The [I] won't fit into \the [src]!</span>")
+		to_chat(user, "<span class='warning'>[I] won't fit into \the [src]!</span>")
 		return FALSE
 	if(I.w_class > src.w_class)
-		to_chat(user, "<span class='warning'>\The [I] is too large to fit into \the [src]!</span>")
+		to_chat(user, "<span class='warning'>[I] is too large to fit into \the [src]!</span>")
 		return FALSE
 	if(!user.unEquip(I))
 		return FALSE
-	to_chat(user, "<span class='notice'>You load \the [I] into \the [src].</span>")
+	to_chat(user, "<span class='notice'>You load[I] into \the [src].</span>")
 	loaded_items.Add(I)
 	loaded_weight_class += I.w_class
 	I.forceMove(src)
@@ -73,7 +73,7 @@
 			pressure_setting = 3
 		if(3)
 			pressure_setting = 1
-	to_chat(user, "<span class='notice'>You tweak \the [src]'s pressure output to [pressure_setting].</span>")
+	to_chat(user, "<span class='notice'>You tweak [src]'s pressure output to [pressure_setting].</span>")
 	return TRUE
 
 
@@ -81,7 +81,7 @@
 	..()
 	if(istype(W, /obj/item/tank/internals) && !tank)
 		if(istype(W, /obj/item/tank/internals/emergency_oxygen))
-			to_chat(user, "<span class='warning'>\The [W] is too small for \the [src].</span>")
+			to_chat(user, "<span class='warning'>[W] is too small for \the [src].</span>")
 			return
 		add_tank(W, user)
 		return
@@ -111,14 +111,14 @@
 		return
 	var/has_discharged = FALSE
 	if(!loaded_items || !loaded_weight_class)
-		to_chat(user, "<span class='warning'>\The [src] has nothing loaded.</span>")
+		to_chat(user, "<span class='warning'>[src] has nothing loaded.</span>")
 		return
 	if(requires_tank)
 		if(!tank)
-			to_chat(user, "<span class='warning'>\The [src] can't fire without a source of gas.</span>")
+			to_chat(user, "<span class='warning'>[src] can't fire without a source of gas.</span>")
 			return
 		if(!tank.air_contents.remove(gas_per_throw * pressure_setting))
-			to_chat(user, "<span class='warning'>\The [src] lets out a weak hiss and doesn't react!</span>")
+			to_chat(user, "<span class='warning'>[src] lets out a weak hiss and doesn't react!</span>")
 			return
 	if(user && HAS_TRAIT(user, TRAIT_CLUMSY) && prob(75))
 		user.visible_message("<span class='warning'>[user] loses [user.p_their()] grip on [src], causing it to go off!</span>", "<span class='userdanger'>[src] slips out of your hands and goes off!</span>")
@@ -130,8 +130,8 @@
 			var/list/possible_targets = range(3,src)
 			target = pick(possible_targets)
 	if(!has_discharged)
-		user.visible_message("<span class='danger'>[user] fires \the [src]!</span>", \
-							"<span class='danger'>You fire \the [src]!</span>")
+		user.visible_message("<span class='danger'>[user] fires [src]!</span>", \
+							"<span class='danger'>You fire [src]!</span>")
 	add_attack_logs(user, target, "Fired [src]")
 	playsound(src.loc, 'sound/weapons/sonic_jackhammer.ogg', 50, 1)
 	for(var/obj/item/I in loaded_items)

--- a/code/game/objects/items/weapons/pneumaticCannon.dm
+++ b/code/game/objects/items/weapons/pneumaticCannon.dm
@@ -134,12 +134,12 @@
 							"<span class='danger'>You fire [src]!</span>")
 	add_attack_logs(user, target, "Fired [src]")
 	playsound(src.loc, 'sound/weapons/sonic_jackhammer.ogg', 50, 1)
-	for(var/obj/item/I in loaded_items)
-		loaded_items.Remove(I)
-		loaded_weight_class -= I.w_class
-		I.throw_speed = pressure_setting * 2
-		I.forceMove(get_turf(src))
-		I.throw_at(target, pressure_setting * 5, pressure_setting * 2, user)
+	for(var/obj/item/loaded_item in loaded_items)
+		loaded_items.Remove(loaded_item)
+		loaded_weight_class -= loaded_item.w_class
+		loaded_item.throw_speed = pressure_setting * 2
+		loaded_item.forceMove(get_turf(src))
+		loaded_item.throw_at(target, pressure_setting * 5, pressure_setting * 2, user)
 	if(pressure_setting >= 3 && user)
 		user.visible_message("<span class='warning'>[user] is thrown down by the force of the cannon!</span>", "<span class='userdanger'>[src] slams into your shoulder, knocking you down!")
 		user.KnockDown(3 SECONDS)

--- a/code/game/objects/items/weapons/pneumaticCannon.dm
+++ b/code/game/objects/items/weapons/pneumaticCannon.dm
@@ -146,7 +146,7 @@
 
 /obj/item/pneumatic_cannon/admin
 	name = "admin pnuematic cannon"
-	desc = "Infinite gas and infinite capacity, go crazy"
+	desc = "Infinite gas and infinite capacity, go crazy."
 	requires_tank = FALSE
 	max_weight_class = INFINITY
 

--- a/code/game/objects/items/weapons/pneumaticCannon.dm
+++ b/code/game/objects/items/weapons/pneumaticCannon.dm
@@ -97,8 +97,6 @@
 /obj/item/pneumatic_cannon/afterattack(atom/target, mob/living/carbon/human/user, flag, params)
 	if(isstorage(target)) //So you can store it in backpacks
 		return ..()
-	if(istype(target, /obj/structure/closet)) //So you can store it in closets
-		return ..()
 	if(istype(target, /obj/structure/rack)) //So you can store it on racks
 		return ..()
 	if(!istype(user))

--- a/code/game/objects/items/weapons/pneumaticCannon.dm
+++ b/code/game/objects/items/weapons/pneumaticCannon.dm
@@ -38,7 +38,7 @@
 		if(tank)
 			. += "<span class='notice'>[bicon(tank)] It has [tank] mounted onto it.</span>"
 		for(var/obj/item/I in loaded_items)
-			. += "<span class='info'>[bicon(I)] It has \the [I] loaded.</span>"
+			. += "<span class='info'>[bicon(I)] It has [I] loaded.</span>"
 
 /**
 * Arguments:

--- a/code/game/objects/items/weapons/pneumaticCannon.dm
+++ b/code/game/objects/items/weapons/pneumaticCannon.dm
@@ -52,7 +52,7 @@
 		to_chat(user, "<span class='warning'>You can't put [I] into [src]!</span>")
 		return FALSE
 	if((loaded_weight_class + I.w_class) > max_weight_class)
-		to_chat(user, "<span class='warning'>[I] won't fit into \the [src]!</span>")
+		to_chat(user, "<span class='warning'>[I] won't fit into [src]!</span>")
 		return FALSE
 	if(I.w_class > src.w_class)
 		to_chat(user, "<span class='warning'>[I] is too large to fit into \the [src]!</span>")

--- a/code/game/objects/items/weapons/pneumaticCannon.dm
+++ b/code/game/objects/items/weapons/pneumaticCannon.dm
@@ -59,7 +59,7 @@
 		return FALSE
 	if(!user.unEquip(I))
 		return FALSE
-	to_chat(user, "<span class='notice'>You load[I] into \the [src].</span>")
+	to_chat(user, "<span class='notice'>You load [I] into [src].</span>")
 	loaded_items.Add(I)
 	loaded_weight_class += I.w_class
 	I.forceMove(src)

--- a/code/game/objects/items/weapons/pneumaticCannon.dm
+++ b/code/game/objects/items/weapons/pneumaticCannon.dm
@@ -81,7 +81,7 @@
 	..()
 	if(istype(W, /obj/item/tank/internals) && !tank)
 		if(istype(W, /obj/item/tank/internals/emergency_oxygen))
-			to_chat(user, "<span class='warning'>[W] is too small for \the [src].</span>")
+			to_chat(user, "<span class='warning'>[W] is too small for [src].</span>")
 			return
 		add_tank(W, user)
 		return

--- a/code/game/objects/items/weapons/pneumaticCannon.dm
+++ b/code/game/objects/items/weapons/pneumaticCannon.dm
@@ -112,7 +112,7 @@
 		if(!tank)
 			to_chat(user, "<span class='warning'>[src] can't fire without a source of gas.</span>")
 			return
-		if(!tank.air_contents.remove(gas_per_throw * pressure_setting))
+		if(!tank.air_contents.boolean_remove(gas_per_throw * pressure_setting))
 			to_chat(user, "<span class='warning'>[src] lets out a weak hiss and doesn't react!</span>")
 			return
 	if(user && HAS_TRAIT(user, TRAIT_CLUMSY) && prob(75))

--- a/code/game/objects/items/weapons/pneumaticCannon.dm
+++ b/code/game/objects/items/weapons/pneumaticCannon.dm
@@ -54,7 +54,7 @@
 	if((loaded_weight_class + I.w_class) > max_weight_class)
 		to_chat(user, "<span class='warning'>[I] won't fit into [src]!</span>")
 		return FALSE
-	if(I.w_class > src.w_class)
+	if(I.w_class > w_class)
 		to_chat(user, "<span class='warning'>[I] is too large to fit into [src]!</span>")
 		return FALSE
 	if(!user.unEquip(I))

--- a/code/game/objects/items/weapons/pneumaticCannon.dm
+++ b/code/game/objects/items/weapons/pneumaticCannon.dm
@@ -169,11 +169,11 @@
 
 /obj/item/pneumatic_cannon/proc/add_tank(obj/item/tank/new_tank, mob/living/carbon/human/user)
 	if(tank)
-		to_chat(user, "<span class='warning'>\The [src] already has a tank.</span>")
+		to_chat(user, "<span class='warning'>[src] already has a tank.</span>")
 		return
 	if(!user.unEquip(new_tank))
 		return
-	to_chat(user, "<span class='notice'>You hook \the [new_tank] up to \the [src].</span>")
+	to_chat(user, "<span class='notice'>You hook [new_tank] up to [src].</span>")
 	new_tank.forceMove(src)
 	tank = new_tank
 	update_icons()

--- a/code/game/objects/items/weapons/pneumaticCannon.dm
+++ b/code/game/objects/items/weapons/pneumaticCannon.dm
@@ -24,6 +24,8 @@
 	var/list/loaded_items = list()
 	///How powerful the cannon is - higher pressure = more gas but more powerful throws
 	var/pressure_setting = 1
+	///In case we want a really strong cannon
+	var/max_pressure_setting = 3
 
 /obj/item/pneumatic_cannon/Destroy()
 	QDEL_NULL(tank)
@@ -48,16 +50,14 @@
 * * True if item was loaded, false if it failed
 */
 /obj/item/pneumatic_cannon/proc/load_item(obj/item/I, mob/user)
-	if(I.flags & (ABSTRACT | NODROP | DROPDEL))
-		to_chat(user, "<span class='warning'>You can't put [I] into [src]!</span>")
-		return FALSE
 	if((loaded_weight_class + I.w_class) > max_weight_class)
 		to_chat(user, "<span class='warning'>[I] won't fit into [src]!</span>")
 		return FALSE
 	if(I.w_class > w_class)
 		to_chat(user, "<span class='warning'>[I] is too large to fit into [src]!</span>")
 		return FALSE
-	if(!user.unEquip(I))
+	if(!user.unEquip(I) || I.flags & (ABSTRACT | NODROP | DROPDEL))
+		to_chat(user, "<span class='warning'>You can't put [I] into [src]!</span>")
 		return FALSE
 	to_chat(user, "<span class='notice'>You load [I] into [src].</span>")
 	loaded_items.Add(I)
@@ -66,13 +66,10 @@
 	return TRUE
 
 /obj/item/pneumatic_cannon/wrench_act(mob/living/user, obj/item/I)
-	switch(pressure_setting)
-		if(1)
-			pressure_setting = 2
-		if(2)
-			pressure_setting = 3
-		if(3)
-			pressure_setting = 1
+	if(pressure_setting == max_pressure_setting)
+		pressure_setting = 1
+	else
+		pressure_setting++
 	to_chat(user, "<span class='notice'>You tweak [src]'s pressure output to [pressure_setting].</span>")
 	return TRUE
 

--- a/code/game/objects/items/weapons/pneumaticCannon.dm
+++ b/code/game/objects/items/weapons/pneumaticCannon.dm
@@ -181,7 +181,7 @@
 /obj/item/pneumatic_cannon/proc/remove_tank(mob/living/carbon/human/user)
 	if(!tank)
 		return FALSE
-	to_chat(user, "<span class='notice'>You detach \the [tank] from \the [src].</span>")
+	to_chat(user, "<span class='notice'>You detach [tank] from [src].</span>")
 	user.put_in_hands(tank)
 	tank = null
 	update_icons()

--- a/code/game/objects/items/weapons/pneumaticCannon.dm
+++ b/code/game/objects/items/weapons/pneumaticCannon.dm
@@ -36,7 +36,7 @@
 		. += "<span class='notice'>You'll need to get closer to see any more.</span>"
 	else
 		if(tank)
-			. += "<span class='notice'>[bicon(tank)] It has \the [tank] mounted onto it.</span>"
+			. += "<span class='notice'>[bicon(tank)] It has [tank] mounted onto it.</span>"
 		for(var/obj/item/I in loaded_items)
 			. += "<span class='info'>[bicon(I)] It has \the [I] loaded.</span>"
 

--- a/code/game/objects/items/weapons/pneumaticCannon.dm
+++ b/code/game/objects/items/weapons/pneumaticCannon.dm
@@ -55,7 +55,7 @@
 		to_chat(user, "<span class='warning'>[I] won't fit into [src]!</span>")
 		return FALSE
 	if(I.w_class > src.w_class)
-		to_chat(user, "<span class='warning'>[I] is too large to fit into \the [src]!</span>")
+		to_chat(user, "<span class='warning'>[I] is too large to fit into [src]!</span>")
 		return FALSE
 	if(!user.unEquip(I))
 		return FALSE

--- a/code/game/objects/items/weapons/pneumaticCannon.dm
+++ b/code/game/objects/items/weapons/pneumaticCannon.dm
@@ -141,31 +141,6 @@
 		user.visible_message("<span class='warning'>[user] is thrown down by the force of the cannon!</span>", "<span class='userdanger'>[src] slams into your shoulder, knocking you down!")
 		user.KnockDown(3 SECONDS)
 
-/obj/item/pneumatic_cannon/admin
-	name = "admin pnuematic cannon"
-	desc = "Infinite gas and infinite capacity, go crazy."
-	requires_tank = FALSE
-	max_weight_class = INFINITY
-
-/obj/item/pneumatic_cannon/ghetto //Obtainable by improvised methods; more gas per use, less capacity, but smaller
-	name = "improvised pneumatic cannon"
-	desc = "A gas-powered, object-firing cannon made out of common parts."
-	force = 5
-	w_class = WEIGHT_CLASS_NORMAL
-	max_weight_class = 7
-	gas_per_throw = 5
-
-/datum/crafting_recipe/improvised_pneumatic_cannon //Pretty easy to obtain but
-	name = "Pneumatic Cannon"
-	result = list(/obj/item/pneumatic_cannon/ghetto)
-	tools = list(TOOL_WELDER, TOOL_WRENCH)
-	reqs = list(/obj/item/stack/sheet/metal = 4,
-				/obj/item/stack/packageWrap = 8,
-				/obj/item/pipe = 2)
-	time = 300
-	category = CAT_WEAPONRY
-	subcategory = CAT_WEAPON
-
 /obj/item/pneumatic_cannon/proc/add_tank(obj/item/tank/new_tank, mob/living/carbon/human/user)
 	if(tank)
 		to_chat(user, "<span class='warning'>[src] already has a tank.</span>")
@@ -191,3 +166,17 @@
 		return
 	src.overlays += image('icons/obj/pneumaticCannon.dmi', "[tank.icon_state]")
 	src.update_icon()
+
+/obj/item/pneumatic_cannon/admin
+	name = "admin pnuematic cannon"
+	desc = "Infinite gas and infinite capacity, go crazy."
+	requires_tank = FALSE
+	max_weight_class = INFINITY
+
+/obj/item/pneumatic_cannon/ghetto //Obtainable by improvised methods; more gas per use, less capacity, but smaller
+	name = "improvised pneumatic cannon"
+	desc = "A gas-powered, object-firing cannon made out of common parts."
+	force = 5
+	w_class = WEIGHT_CLASS_NORMAL
+	max_weight_class = 7
+	gas_per_throw = 5

--- a/code/game/objects/items/weapons/pneumaticCannon.dm
+++ b/code/game/objects/items/weapons/pneumaticCannon.dm
@@ -66,13 +66,15 @@
 	return TRUE
 
 /obj/item/pneumatic_cannon/wrench_act(mob/living/user, obj/item/I)
+	adjust_setting(user)
+	return TRUE
+
+/obj/item/pneumatic_cannon/proc/adjust_setting(mob/living/user)
 	if(pressure_setting == max_pressure_setting)
 		pressure_setting = 1
 	else
 		pressure_setting++
 	to_chat(user, "<span class='notice'>You tweak [src]'s pressure output to [pressure_setting].</span>")
-	return TRUE
-
 
 /obj/item/pneumatic_cannon/attackby(obj/item/W, mob/user, params)
 	..()

--- a/code/game/objects/items/weapons/pneumaticCannon.dm
+++ b/code/game/objects/items/weapons/pneumaticCannon.dm
@@ -128,7 +128,7 @@
 		user.visible_message("<span class='danger'>[user] fires [src]!</span>", \
 							"<span class='danger'>You fire [src]!</span>")
 	add_attack_logs(user, target, "Fired [src]")
-	playsound(src.loc, 'sound/weapons/sonic_jackhammer.ogg', 50, 1)
+	playsound(loc, 'sound/weapons/sonic_jackhammer.ogg', 50, TRUE)
 	for(var/obj/item/loaded_item in loaded_items)
 		loaded_items.Remove(loaded_item)
 		loaded_weight_class -= loaded_item.w_class

--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -77,6 +77,17 @@
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
 
+/datum/crafting_recipe/improvised_pneumatic_cannon
+	name = "Pneumatic Cannon"
+	result = list(/obj/item/pneumatic_cannon/ghetto)
+	tools = list(TOOL_WELDER, TOOL_WRENCH)
+	reqs = list(/obj/item/stack/sheet/metal = 4,
+				/obj/item/stack/packageWrap = 8,
+				/obj/item/pipe = 2)
+	time = 300
+	category = CAT_WEAPONRY
+	subcategory = CAT_WEAPON
+
 /datum/crafting_recipe/throwing_croissant
 	name = "Throwing croissant"
 	reqs = list(


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
This updates pneumaticCannon.dm to more modern standards and buffs the cannon itself to knockdown the user when fired at max power, instead of weakening them.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
It makes life easier if we want to add new pneumatic cannon subtypes (foreshadowing) later down the line, and is hopefully much easier to read and understand.

I also imagine the weaken not being changed was an oversight from when crawling was added, though I am fine with removing that part if it's too much of a balance change.
## Testing
<!-- How did you test the PR, if at all? -->
Shot some skrells, learned a bit about how thrown items work, and made sure the tools had their act procs set properly.
## Changelog
:cl:
tweak: Max power pneumatic cannons now knock you down, instead of weakening you.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
