### PR TITLE
You can now altclick lockboxes to open them

### DIFF
--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -382,6 +382,14 @@
 	else
 		. += "ledb"
 
+/obj/item/storage/lockbox/vials/AltClick(mob/user)
+	if(Adjacent(user) && allowed(user))
+		locked = !locked
+		to_chat(user, "<span class='notice'>You [locked ? "lock" : "unlock"] \the [src].</span>")
+		update_icon()
+	else
+		to_chat(user, "<span class='warning'>Access denied.</span>")
+
 /obj/item/storage/lockbox/vials/attackby(obj/item/I, mob/user, params)
 	..()
 	update_icon()

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -387,7 +387,7 @@
 		return
 	if(allowed(user))
 		locked = !locked
-		to_chat(user, "<span class='notice'>You [locked ? "lock" : "unlock"] \the [src].</span>")
+		to_chat(user, "<span class='notice'>You [locked ? "lock" : "unlock"] [src].</span>")
 		update_icon()
 	else
 		to_chat(user, "<span class='warning'>Access denied.</span>")

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -383,7 +383,9 @@
 		. += "ledb"
 
 /obj/item/storage/lockbox/vials/AltClick(mob/user)
-	if(Adjacent(user) && allowed(user))
+	if(!Adjacent(user))
+		return
+	if(allowed(user))
 		locked = !locked
 		to_chat(user, "<span class='notice'>You [locked ? "lock" : "unlock"] \the [src].</span>")
 		update_icon()

--- a/code/game/objects/items/weapons/storage/lockbox.dm
+++ b/code/game/objects/items/weapons/storage/lockbox.dm
@@ -45,7 +45,9 @@
 	return
 
 /obj/item/storage/lockbox/AltClick(mob/user)
-	if(Adjacent(user) && allowed(user))
+	if(!Adjacent(user))
+		return
+	if(allowed(user))
 		locked = !locked
 		to_chat(user, "<span class='notice'>You [locked ? "lock" : "unlock"] \the [src] interface.</span>")
 		icon_state = "[locked ? icon_locked : icon_closed]"

--- a/code/game/objects/items/weapons/storage/lockbox.dm
+++ b/code/game/objects/items/weapons/storage/lockbox.dm
@@ -44,6 +44,13 @@
 		to_chat(user, "<span class='warning'>It's locked!</span>")
 	return
 
+/obj/item/storage/lockbox/AltClick(mob/user)
+	if(Adjacent(user) && allowed(user))
+		locked = !locked
+		to_chat(user, "<span class='notice'>You [locked ? "lock" : "unlock"] \the [src] interface.</span>")
+		icon_state = "[locked ? icon_locked : icon_closed]"
+	else
+		to_chat(user, "<span class='warning'>Access denied.</span>")
 
 /obj/item/storage/lockbox/show_to(mob/user as mob)
 	if(locked)

--- a/code/game/objects/items/weapons/storage/lockbox.dm
+++ b/code/game/objects/items/weapons/storage/lockbox.dm
@@ -49,7 +49,7 @@
 		return
 	if(allowed(user))
 		locked = !locked
-		to_chat(user, "<span class='notice'>You [locked ? "lock" : "unlock"] \the [src] interface.</span>")
+		to_chat(user, "<span class='notice'>You [locked ? "lock" : "unlock"] [src].</span>")
 		icon_state = "[locked ? icon_locked : icon_closed]"
 	else
 		to_chat(user, "<span class='warning'>Access denied.</span>")


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
This lets you alt+click to lock and unlock lockboxes

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Apcs', air alarms, secure lockers, secure crates can already be locked and unlocked via altclick, this is just bringing lockboxes in line with that.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

https://github.com/ParadiseSS13/Paradise/assets/21987702/45229320-9256-4509-8d49-729320c55b84


## Testing
<!-- How did you test the PR, if at all? -->
See Above

## Changelog
:cl: ppi
add: Added the ability to lock and unlock lockboxes with altclick.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
