### PR TITLE
Tweaks SOO/NNO/Syndie Officer Outfits

### DIFF
--- a/code/game/jobs/job/central.dm
+++ b/code/game/jobs/job/central.dm
@@ -28,7 +28,6 @@
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
 	id = /obj/item/card/id/centcom
 	pda = /obj/item/pda/centcom
-	belt = /obj/item/gun/energy/pulse/pistol
 	implants = list(
 		/obj/item/implant/mindshield,
 		/obj/item/implant/dust
@@ -39,7 +38,8 @@
 	)
 	box = /obj/item/storage/box/centcomofficer
 	cybernetic_implants = list(
-		/obj/item/organ/internal/cyberimp/chest/nutriment/plus/hardened
+		/obj/item/organ/internal/cyberimp/chest/nutriment/plus/hardened,
+		/obj/item/organ/internal/cyberimp/arm/combat/centcom
 	)
 
 /datum/outfit/job/ntnavyofficer/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
@@ -75,7 +75,7 @@
 	belt = /obj/item/storage/belt/military/assault
 	gloves = /obj/item/clothing/gloves/combat
 	shoes = /obj/item/clothing/shoes/combat
-	mask = /obj/item/clothing/mask/cigarette/cigar/cohiba
+	mask = /obj/item/clothing/mask/holo_cigar
 	head = /obj/item/clothing/head/helmet/space/deathsquad/beret
 	l_ear = /obj/item/radio/headset/centcom
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
@@ -114,6 +114,7 @@
 	uniform = /obj/item/clothing/under/rank/centcom/captain/solgov
 	suit = /obj/item/clothing/suit/space/deathsquad/officer/solgov
 	head = /obj/item/clothing/head/helmet/space/deathsquad/beret/solgov
+	mask = /obj/item/clothing/mask/holo_cigar
 
 /datum/outfit/job/ntspecops/solgovspecops/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()

--- a/code/game/jobs/job/syndicate_jobs.dm
+++ b/code/game/jobs/job/syndicate_jobs.dm
@@ -23,27 +23,28 @@
 	back = /obj/item/storage/backpack
 	head = /obj/item/clothing/head/beret
 	gloves = /obj/item/clothing/gloves/combat
-	shoes = /obj/item/clothing/shoes/combat
-	mask = /obj/item/clothing/mask/cigarette/cigar/havana
-	belt = /obj/item/gun/projectile/automatic/pistol/deagle/camo
+	shoes = /obj/item/clothing/shoes/magboots/syndie/advance
+	mask = /obj/item/clothing/mask/holo_cigar
+	belt = /obj/item/storage/belt/military
 	l_ear = /obj/item/radio/headset/syndicate/alt/syndteam
 	pda = /obj/item/pinpointer/advpinpointer
 	id = /obj/item/card/id/syndicate/command
 	box = /obj/item/storage/box/survival_syndi
 	backpack_contents = list(
 		/obj/item/flashlight = 1,
-		/obj/item/reagent_containers/food/snacks/syndidonkpocket = 1,
 		/obj/item/ammo_box/magazine/m50 = 2,
-		/obj/item/clothing/shoes/magboots/syndie/advance = 1,
-		/obj/item/lighter/zippo/gonzofist = 1,
-		/obj/item/storage/box/matches = 1
+		/obj/item/gun/projectile/automatic/pistol/deagle/camo = 1,
+		/obj/item/clothing/accessory/holster = 1
 	)
 	implants = list(
-		/obj/item/implant/dust
+		/obj/item/implant/dust,
+		/obj/item/implant/freedom,
+		/obj/item/implant/adrenalin
 	)
 
 	cybernetic_implants = list(
-		/obj/item/organ/internal/cyberimp/chest/nutriment/plus/hardened
+		/obj/item/organ/internal/cyberimp/chest/nutriment/plus/hardened,
+		/obj/item/organ/internal/eyes/cybernetic/xray/hardened
 	)
 
 /datum/outfit/job/syndicateofficer/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
**Syndicate Officer**
- Gives them a Holo Cigar instead of a standard one.
- Removes the Deagle from their belt, places it in their bag with a holster, and replaces it with a military belt.
- Removes meth donks, replaces with freedoms + adrenals.
- Gives them xray eyes (like SOOs have)
- Places the Syndie Advanced Magboots on their feet.

**Special Operations Officer**
- Replaces the cigar with a Holo Cigar.

**Nanotrasen Naval Officer**
- Adds the Centcom Combat Implant to NNOs. Every GA's NNO tends to have this in my experience via JSON, so might as well add it here too.

**SolGov General**
- Gives them a Holo Cigar.

## Why It's Good For The Game
Having to manually JSON these items every round is a headache.

This will rarely effect players, as these rolls should rarely be on Station. However, if for some reason they are, they should be on similar footing as SOOs given their roles as Central Command officials.

## Testing
Played dress-up in CentCom for a bit.

## Changelog
:cl:
tweak: Tweaked various CentCom and Syndicate Officer outfits.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
