### PR TITLE
Fixes lack of body customization options for the handheld mirror

### DIFF
--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -416,6 +416,7 @@
 /obj/item/handheld_mirror/attack_self(mob/user)
 	if(ishuman(user))
 		appearance_changer_holder = new(src, user)
+		appearance_changer_holder.flags = APPEARANCE_ALL_BODY
 		ui_interact(user)
 
 /obj/item/handheld_mirror/Initialize(mapload)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes handheld mirrors so you can now alter body accessory and other body marking options, bringing it in line with the mirrors placed around the station. I am assuming body customization options should have been included given this from the PR that added the mirror. ``allowing all the same customization options as the ones scattered across the station in a pocket item.``
Fixes #22966 
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Bugs are bad, and the handheld mirror should be useful to species without hair to change.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://github.com/ParadiseSS13/Paradise/assets/107899953/4c4ef333-e47a-49ea-915e-abc83e757e6e)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Spawned in as nian, unathi, and human. Checked that they all had the option to alter body markings and accessories. 
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Handheld mirrors now properly allow you to alter body appearance.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
