### PR TITLE
Fixes RCDs requiring grilles under windows for deconning

### DIFF
--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -510,9 +510,7 @@
 		playsound(loc, 'sound/machines/click.ogg', 50, 1)
 		return FALSE
 
-	if(istype(A, /obj/structure/window)) // You mean the grille of course, do you?
-		A = locate(/obj/structure/grille) in A.loc
-	if(istype(A, /obj/structure/grille))
+	if(istype(A, /obj/structure/window))
 		if(!checkResource(2, user))
 			playsound(loc, 'sound/machines/click.ogg', 50, 1)
 			return FALSE
@@ -527,8 +525,8 @@
 		playsound(loc, usesound, 50, 1)
 		var/turf/T1 = get_turf(A)
 		QDEL_NULL(A)
-		for(var/obj/structure/window/W in T1.contents)
-			qdel(W)
+		for(var/obj/structure/grille/G in T1.contents)
+			qdel(G)
 		return TRUE
 	return FALSE
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes RCDs not require grilles on a window to be deconned.
Still deletes the grille under a window if there is one present.
Fixes #22974
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
With the degrilling, this weird issue has been found. It works completely counterintuitive, and is a very weird design choice.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Could decon windows with and without grilles without any issues
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Fixed RCDs not being able to decon windows without grilles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
