### PR TITLE
Buffs Cult Door Damage Reflection to 20. Ups Runed Metal cost to 3

### DIFF
--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -482,7 +482,7 @@
 	icon = 'icons/obj/doors/airlocks/cult/runed/cult.dmi'
 	overlays_file = 'icons/obj/doors/airlocks/cult/runed/cult-overlays.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_cult
-	damage_deflection = 15
+	damage_deflection = 20
 	hackProof = TRUE
 	aiControlDisabled = AICONTROLDISABLED_ON
 	paintable = FALSE

--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -482,7 +482,7 @@
 	icon = 'icons/obj/doors/airlocks/cult/runed/cult.dmi'
 	overlays_file = 'icons/obj/doors/airlocks/cult/runed/cult-overlays.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_cult
-	damage_deflection = 10
+	damage_deflection = 15
 	hackProof = TRUE
 	aiControlDisabled = AICONTROLDISABLED_ON
 	paintable = FALSE

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -439,7 +439,7 @@ GLOBAL_LIST_INIT(cardboard_recipes, list (
  */
 
 GLOBAL_LIST_INIT(cult_recipes, list (
-	new /datum/stack_recipe/cult("runed door (stuns non-cultists)", /obj/machinery/door/airlock/cult, 1, time = 5 SECONDS, one_per_turf = TRUE, on_floor = TRUE, cult_structure = TRUE),
+	new /datum/stack_recipe/cult("runed door (stuns non-cultists)", /obj/machinery/door/airlock/cult, 3, time = 5 SECONDS, one_per_turf = TRUE, on_floor = TRUE, cult_structure = TRUE),
 	new /datum/stack_recipe/cult("runed girder (used to make cult walls)", /obj/structure/girder/cult, 1, time = 1 SECONDS, one_per_turf = TRUE, on_floor = TRUE, cult_structure = TRUE),
 	new /datum/stack_recipe/cult("pylon (heals nearby cultists)", /obj/structure/cult/functional/pylon, 4, time = 4 SECONDS, one_per_turf = TRUE, on_floor = TRUE, cult_structure = TRUE),
 	new /datum/stack_recipe/cult("forge (crafts shielded robes, flagellant's robes, and mirror shields)", /obj/structure/cult/functional/forge, 3, time = 4 SECONDS, one_per_turf = TRUE, on_floor = TRUE, cult_structure = TRUE),


### PR DESCRIPTION
## What Does This PR Do
Does precisely what it says on the tin. Doubles cult door damage reflection from 10 to 20. Ups the runed metal cost to 3.

## Why It's Good For The Game

Cult doors are honestly weak. The fact that over 100 objects in the game, including a stunbaton and even just chucking a piece of metal at it, can quickly and easily break them is kind of bad. 

My hope is that it will help encourage on-station cult bases more if they have better means of defending said bases.

EDIT: After a brief discussion on Discord I have decided to go with upping damage reflection to 20 and tripling the cost to compensate. Cult doors must now be shot, speared, or axed down. After the discussion I thought it over and realized that they could still be pretty easily destroyed and could honestly stand to be a bit better.

## Testing
1. Upped value
2. Tried to bonk door
3. Could not bonk door

## Changelog
:cl:
tweak: Cult Doors now require a minimum of 20 force to destroy, can no longer be broken simply by harmbatoning it.
tweak: Cult Doors now require 3 Runed Metal to build.
/:cl:
