### PR TITLE
makes the lwap not pierce infinite r_walls, pierces resin like walls

### DIFF
--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -197,12 +197,23 @@
 	can_knockdown = FALSE //Projectiles that pierce can not knockdown, no wall knockdowns.
 
 /obj/item/projectile/beam/laser/sniper/pierce
-	forcedodge = 1 // Can pierce one mob.
+	forcedodge = 1 // Can pierce one non wall thing.
 	speed = 0.5
+	/// Have we hit an r_wall? If we have, don't pierce it again so we don't become too effective on reinforced locations (AI sat)
+	var/hit_a_r_wall = FALSE
 
 /obj/item/projectile/beam/laser/sniper/pierce/prehit(atom/target)
-	if(isturf(target) && !forcedodge)
-		forcedodge++ //Increases force dodge before turf consumes it.
+	if(!isturf(target))
+		return ..()
+	if(!istype(target, /turf/simulated/wall/r_wall))
+		if(!forcedodge)
+			forcedodge++ //Increases force dodge before turf consumes it.
+		return ..()
+	if(hit_a_r_wall)
+		return ..() //We want it to pierce ONE reinforced wall, sorry, no easy 2 shotting the AI.
+	hit_a_r_wall = TRUE
+	if(!forcedodge)
+		forcedodge++
 	..()
 
 /obj/item/gun/energy/xray

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -204,15 +204,15 @@
 
 /obj/item/projectile/beam/laser/sniper/pierce/prehit(atom/target)
 	if(!isturf(target))
-		return ..()
+		return ..() //Not a wall, act like a normal projectile
 	if(!istype(target, /turf/simulated/wall/r_wall))
-		if(!forcedodge)
+		if(!forcedodge) //We are a wall, do we need to increase pierce so we don't die in a wall?
 			forcedodge++ //Increases force dodge before turf consumes it.
 		return ..()
-	if(hit_a_r_wall)
+	if(hit_a_r_wall) //We are a rwall, have we hit one before and should not pierce?
 		return ..() //We want it to pierce ONE reinforced wall, sorry, no easy 2 shotting the AI.
 	hit_a_r_wall = TRUE
-	if(!forcedodge)
+	if(!forcedodge) //We have not hit an rwall before, let us check if we need to increase
 		forcedodge++
 	..()
 

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -203,16 +203,12 @@
 	var/hit_a_r_wall = FALSE
 
 /obj/item/projectile/beam/laser/sniper/pierce/prehit(atom/target)
-	if(!isturf(target))
-		return ..() //Not a wall, act like a normal projectile
-	if(!istype(target, /turf/simulated/wall/r_wall))
-		if(!forcedodge) //We are a wall, do we need to increase pierce so we don't die in a wall?
-			forcedodge++ //Increases force dodge before turf consumes it.
-		return ..()
-	if(hit_a_r_wall) //We are a rwall, have we hit one before and should not pierce?
-		return ..() //We want it to pierce ONE reinforced wall, sorry, no easy 2 shotting the AI.
-	hit_a_r_wall = TRUE
-	if(!forcedodge) //We have not hit an rwall before, let us check if we need to increase
+	if(istype(target, /turf/simulated/wall/r_wall))
+		if(!hit_a_r_wall)
+			hit_a_r_wall = TRUE
+			if(!forcedodge)
+				forcedodge++
+	else if((isturf(target) || istype(target, /obj/structure/alien/resin)) && !forcedodge)
 		forcedodge++
 	..()
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

The LWAP will only pierce one rwall now
updates code comments for lwap projectile
Lwap now peirces resin structures like normal walls.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Piercing more walls was good for lwap, but let us not have it work on multiple layers of reinforced walls, so things like the AI don't get 2 tapped in 5 seconds. Xray at least is less common, and takes more than one clip to kill and much more time.
Xeno resin structures now get pierced like normal walls

## Testing
<!-- How did you test the PR, if at all? -->

Shot a lot of combinations of objects, walls, rwalls, etc

## Changelog
:cl:
tweak: Lwap can now only pierce one reinforced wall, and pierces resin better
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
