### PR TITLE
Fixes zaps focusing APCs over everything*

### DIFF
--- a/code/modules/power/engines/tesla/energy_ball.dm
+++ b/code/modules/power/engines/tesla/energy_ball.dm
@@ -2,10 +2,10 @@
 #define TESLA_MINI_POWER 869130
 //Zap constants, speeds up targeting
 #define COIL (ROD + 1)
-#define ROD (APC + 1)
-#define APC (RIDE + 1)
+#define ROD (RIDE + 1)
 #define RIDE (LIVING + 1)
-#define LIVING (MACHINERY + 1)
+#define LIVING (APC + 1)
+#define APC (MACHINERY + 1)
 #define MACHINERY (BLOB + 1)
 #define BLOB (STRUCTURE + 1)
 #define STRUCTURE (1)
@@ -296,10 +296,6 @@
 			closest_type = ROD
 			closest_atom = A
 
-		else if(istype(A, /obj/machinery/power/apc))
-			closest_type = APC
-			closest_atom = A
-
 		else if(closest_type >= RIDE)
 			continue
 
@@ -317,6 +313,10 @@
 			if(L.stat != DEAD && !(HAS_TRAIT(L, TRAIT_TESLA_SHOCKIMMUNE)) && !(L.flags_2 & SHOCKED_2))
 				closest_type = LIVING
 				closest_atom = A
+
+		else if(istype(A, /obj/machinery/power/apc))
+			closest_type = APC
+			closest_atom = A
 
 		else if(closest_type >= MACHINERY)
 			continue
@@ -385,9 +385,9 @@
 
 #undef COIL
 #undef ROD
-#undef APC
 #undef RIDE
 #undef LIVING
+#undef APC
 #undef MACHINERY
 #undef BLOB
 #undef STRUCTURE

--- a/code/modules/power/engines/tesla/energy_ball.dm
+++ b/code/modules/power/engines/tesla/energy_ball.dm
@@ -314,6 +314,9 @@
 				closest_type = LIVING
 				closest_atom = A
 
+		else if(closest_type >= APC)
+			continue
+
 		else if(istype(A, /obj/machinery/power/apc))
 			closest_type = APC
 			closest_atom = A


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
*Everything except grounding rods and tesla coils

Makes every zap follow normal targeting before the Tesla rework PR, with the slight change that APCs are preferred over all other machinery. This way, things like flux anomalies will actually target mobs again, instead of just going to that APC 3 rooms next.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
I accidentally heavily nerfed flux anomalies for 3 months, this will help them get back into it again.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Flux anomalies actually were dangerous again
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Fixed zaps targeting APCs over anything else
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
