### PR TITLE
Fixes firealarms

### DIFF
--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -37,14 +37,8 @@ FIRE ALARM
 
 	var/last_time_pulled //used to prevent pulling spam by same persons
 
-/obj/machinery/firealarm/Initialize(mapload, location, direction, building)
+/obj/machinery/firealarm/Initialize(mapload)
 	. = ..()
-
-	if(building)
-		buildstage = 0
-		wiresexposed = TRUE
-		setDir(direction)
-		set_pixel_offsets_from_dir(26, -26, 26, -26)
 
 	LAZYADD(get_area(src).firealarms, src)
 
@@ -54,6 +48,15 @@ FIRE ALARM
 	name = "fire alarm"
 	set_light(1, LIGHTING_MINIMUM_POWER) //for emissives
 	update_icon()
+
+/obj/machinery/firealarm/New(location, direction, building = 0)
+	..()
+	if(building)
+		buildstage = 0
+		wiresexposed = TRUE
+		setDir(direction)
+		set_pixel_offsets_from_dir(26, -26, 26, -26)
+		update_icon()
 
 /obj/machinery/firealarm/no_alarm
 	report_fire_alarms = FALSE

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -37,8 +37,14 @@ FIRE ALARM
 
 	var/last_time_pulled //used to prevent pulling spam by same persons
 
-/obj/machinery/firealarm/Initialize(mapload)
+/obj/machinery/firealarm/Initialize(mapload, direction, building)
 	. = ..()
+
+	if(building)
+		buildstage = 0
+		wiresexposed = TRUE
+		setDir(direction)
+		set_pixel_offsets_from_dir(26, -26, 26, -26)
 
 	LAZYADD(get_area(src).firealarms, src)
 
@@ -48,15 +54,6 @@ FIRE ALARM
 	name = "fire alarm"
 	set_light(1, LIGHTING_MINIMUM_POWER) //for emissives
 	update_icon()
-
-/obj/machinery/firealarm/New(location, direction, building = 0)
-	..()
-	if(building)
-		buildstage = 0
-		wiresexposed = TRUE
-		setDir(direction)
-		set_pixel_offsets_from_dir(26, -26, 26, -26)
-		update_icon()
 
 /obj/machinery/firealarm/no_alarm
 	report_fire_alarms = FALSE


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Fixes the following issues:
fixes #22836 
Fire alarm being constructed at builders location
Fire alarm assembly appearing to be completely built

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Fire alarms works as intended, now exploit free!

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
<!-- How did you test the PR, if at all? -->
Compiled and ran, deconstructed a fire alarm, rebuilt it, checked that the fire alarm was added to that area, and it updates properly during every alert level.

## Changelog
:cl: ppi
fix: Fire alarms can now be properly built
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
