### PR TITLE
Fixed the AI Fixer's Power Problem

### DIFF
--- a/code/game/machinery/computer/aifixer.dm
+++ b/code/game/machinery/computer/aifixer.dm
@@ -95,7 +95,7 @@
 
 /obj/machinery/computer/aifixer/update_overlays()
 	. = ..()
-	if((stat & (BROKEN|NOPOWER)))
+	if(stat & (BROKEN|NOPOWER))
 		return
 	if(active)
 		. += "ai-fixer-on"

--- a/code/game/machinery/computer/aifixer.dm
+++ b/code/game/machinery/computer/aifixer.dm
@@ -95,6 +95,8 @@
 
 /obj/machinery/computer/aifixer/update_overlays()
 	. = ..()
+	if((stat & (BROKEN|NOPOWER)))
+		return
 	if(active)
 		. += "ai-fixer-on"
 	if(occupant)
@@ -103,7 +105,7 @@
 				. += "ai-fixer-full"
 			if(2)
 				. += "ai-fixer-404"
-	if(!(stat & (BROKEN|NOPOWER)))
+	else
 		. += "ai-fixer-empty"
 
 /obj/machinery/computer/aifixer/transfer_ai(interaction, mob/user, mob/living/silicon/ai/AI, obj/item/aicard/card)

--- a/code/game/machinery/computer/aifixer.dm
+++ b/code/game/machinery/computer/aifixer.dm
@@ -103,7 +103,7 @@
 				. += "ai-fixer-full"
 			if(2)
 				. += "ai-fixer-404"
-	else
+	if(!(stat & (BROKEN|NOPOWER)))
 		. += "ai-fixer-empty"
 
 /obj/machinery/computer/aifixer/transfer_ai(interaction, mob/user, mob/living/silicon/ai/AI, obj/item/aicard/card)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Fixes #23002 
The AI fixer no longer has an overlay when powered off.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Bugs are bad, yaya?

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![image](https://github.com/ParadiseSS13/Paradise/assets/144391971/69b76952-57d2-4e2a-90da-71c26a62a56d)
![image](https://github.com/ParadiseSS13/Paradise/assets/144391971/826bd67c-feee-4b98-9a05-15d3cf03fc9d)

## Testing
<!-- How did you test the PR, if at all? -->
Spawned an AI fixer. Cut the power.

## Changelog
:cl:
fix: Fixed AI integrity Restorer Overlay's displaying when powered off
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
