### PR TITLE
Dionae can now drop nymphs they've picked up

### DIFF
--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -419,7 +419,8 @@ Recharging stations are available in robotics, the dormitory bathrooms, and the 
 		D.split()
 	else
 		var/mob/living/simple_animal/diona/D = input("Select a nymph to drop:", "Nymph Dropping", nymphs[1]) as anything in nymphs
-		D.split()
+		if(D in usr.contents)
+			D.split()
 
 //Need to cover all use cases - emag, illegal upgrade module, malf AI hack, traitor cyborg
 /obj/screen/alert/hacked

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -402,6 +402,25 @@ Recharging stations are available in robotics, the dormitory bathrooms, and the 
 		var/mob/living/simple_animal/diona/D = usr
 		return D.resist()
 
+/obj/screen/alert/gestalt
+	name = "Merged nymph"
+	desc = "You have merged with one or more diona nymphs. Click here to drop it (or one of them)."
+
+/obj/screen/alert/gestalt/Click()
+	if(!usr || !usr.client)
+		return
+
+	var/list/nymphs = list()
+	for(var/mob/living/simple_animal/diona/D in usr.contents)
+		nymphs += D
+
+	if(length(nymphs) == 1)
+		var/mob/living/simple_animal/diona/D = nymphs[1]
+		D.split()
+	else
+		var/mob/living/simple_animal/diona/D = input("Select a nymph to drop:", "Nymph Dropping", nymphs[1]) as anything in nymphs
+		D.split()
+
 //Need to cover all use cases - emag, illegal upgrade module, malf AI hack, traitor cyborg
 /obj/screen/alert/hacked
 	name = "Hacked"

--- a/code/modules/mob/living/simple_animal/friendly/diona_nymph.dm
+++ b/code/modules/mob/living/simple_animal/friendly/diona_nymph.dm
@@ -3,6 +3,9 @@
  */
 
 //Mob defines.
+#define GESTALT_ALERT "gestalt screen alert"
+#define NYMPH_ALERT "nymph screen alert"
+
 /mob/living/simple_animal/diona
 	name = "diona nymph"
 	icon = 'icons/mob/monkey.dmi'
@@ -43,8 +46,6 @@
 	can_collar = TRUE
 
 	a_intent = INTENT_HELP
-	var/gestalt_alert = "merged with gestalt" //used in adding and clearing alert
-	var/nymph_alert = "merged with nymph" //As above, but for the gestalt's alert.
 	var/evolve_donors = 5 //amount of blood donors needed before evolving
 	var/awareness_donors = 3 //amount of blood donors needed for understand language
 	var/nutrition_need = 500 //amount of nutrition needed before evolving
@@ -106,8 +107,8 @@
 		if(isdiona(M))
 			to_chat(M, "You feel your being twine with that of [src] as it merges with your biomass.")
 			to_chat(src, "You feel your being twine with that of [M] as you merge with its biomass.")
-			throw_alert(gestalt_alert, /obj/screen/alert/nymph, new_master = src) //adds a screen alert that can call resist
-			M.throw_alert(nymph_alert, /obj/screen/alert/gestalt, new_master = src)
+			throw_alert(GESTALT_ALERT, /obj/screen/alert/nymph, new_master = src) //adds a screen alert that can call resist
+			M.throw_alert(NYMPH_ALERT, /obj/screen/alert/gestalt, new_master = src)
 			forceMove(M)
 		else if(isrobot(M))
 			M.visible_message("<span class='notice'>[M] playfully boops [src] on the head!</span>", "<span class='notice'>You playfully boop [src] on the head!</span>")
@@ -140,8 +141,8 @@
 		M.status_flags |= PASSEMOTES
 		to_chat(src, "You feel your being twine with that of [M] as you merge with its biomass.")
 		forceMove(M)
-		throw_alert(gestalt_alert, /obj/screen/alert/nymph, new_master = src) //adds a screen alert that can call resist
-		M.throw_alert(nymph_alert, /obj/screen/alert/gestalt, new_master = src)
+		throw_alert(GESTALT_ALERT, /obj/screen/alert/nymph, new_master = src) //adds a screen alert that can call resist
+		M.throw_alert(NYMPH_ALERT, /obj/screen/alert/gestalt, new_master = src)
 		return TRUE
 	else
 		return FALSE
@@ -163,9 +164,9 @@
 			hasMobs = TRUE
 	if(!hasMobs)
 		D.status_flags &= ~PASSEMOTES
-		D.clear_alert(nymph_alert)
+		D.clear_alert(NYMPH_ALERT)
 
-	clear_alert(gestalt_alert)
+	clear_alert(GESTALT_ALERT)
 	return TRUE
 
 /mob/living/simple_animal/diona/proc/evolve()

--- a/code/modules/mob/living/simple_animal/friendly/diona_nymph.dm
+++ b/code/modules/mob/living/simple_animal/friendly/diona_nymph.dm
@@ -44,6 +44,7 @@
 
 	a_intent = INTENT_HELP
 	var/gestalt_alert = "merged with gestalt" //used in adding and clearing alert
+	var/nymph_alert = "merged with nymph" //As above, but for the gestalt's alert.
 	var/evolve_donors = 5 //amount of blood donors needed before evolving
 	var/awareness_donors = 3 //amount of blood donors needed for understand language
 	var/nutrition_need = 500 //amount of nutrition needed before evolving
@@ -106,6 +107,7 @@
 			to_chat(M, "You feel your being twine with that of [src] as it merges with your biomass.")
 			to_chat(src, "You feel your being twine with that of [M] as you merge with its biomass.")
 			throw_alert(gestalt_alert, /obj/screen/alert/nymph, new_master = src) //adds a screen alert that can call resist
+			M.throw_alert(nymph_alert, /obj/screen/alert/gestalt, new_master = src)
 			forceMove(M)
 		else if(isrobot(M))
 			M.visible_message("<span class='notice'>[M] playfully boops [src] on the head!</span>", "<span class='notice'>You playfully boop [src] on the head!</span>")
@@ -139,6 +141,7 @@
 		to_chat(src, "You feel your being twine with that of [M] as you merge with its biomass.")
 		forceMove(M)
 		throw_alert(gestalt_alert, /obj/screen/alert/nymph, new_master = src) //adds a screen alert that can call resist
+		M.throw_alert(nymph_alert, /obj/screen/alert/gestalt, new_master = src)
 		return TRUE
 	else
 		return FALSE
@@ -160,6 +163,7 @@
 			hasMobs = TRUE
 	if(!hasMobs)
 		D.status_flags &= ~PASSEMOTES
+		D.clear_alert(nymph_alert)
 
 	clear_alert(gestalt_alert)
 	return TRUE

--- a/code/modules/mob/living/simple_animal/friendly/diona_nymph.dm
+++ b/code/modules/mob/living/simple_animal/friendly/diona_nymph.dm
@@ -285,3 +285,6 @@
 	if(!jobban_isbanned(user, ROLE_NYMPH))
 		return TRUE
 	return FALSE
+
+#undef GESTALT_ALERT
+#undef NYMPH_ALERT


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Lets diona gestalts drop diona nymphs that they've picked up
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
It's kind of weird to be able to pick something up, but not drop it. Also, if a gestalt picks up a dead sentient nymph, there's no easy way to remove it.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://github.com/ParadiseSS13/Paradise/assets/47290811/65465555-8d88-4476-a2b7-cbb9b81913e9)
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Picked up and dropped 1-2 nymphs in various orders
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
add: Dionae can now drop nymphs they've absorbed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
