### PR TITLE
Expands Changeling DNA extraction pre-requisite to all purchasable evolutions.

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -984,7 +984,7 @@
 			if("changeling")
 				if(!ischangeling(current))
 					add_antag_datum(/datum/antagonist/changeling)
-					to_chat(current, "<span class='biggerdanger'>Your powers have awoken. A flash of memory returns to us... we are a changeling!</span>")
+					to_chat(current, "<span class='danger'>With a flash of light, your gestation is complete. You are a changeling!</span>")
 					log_admin("[key_name(usr)] has changelinged [key_name(current)]")
 					message_admins("[key_name_admin(usr)] has changelinged [key_name_admin(current)]")
 

--- a/code/modules/antagonists/changeling/datum_changeling.dm
+++ b/code/modules/antagonists/changeling/datum_changeling.dm
@@ -21,7 +21,7 @@
 	/// A list of [/datum/action/changeling] typepaths with a `power_type` of `CHANGELING_PURCHASABLE_POWER`.
 	var/static/list/purchaseable_powers
 	/// How many total DNA strands the changeling can store for transformation.
-	var/dna_max = 5
+	var/dna_max = 4
 	/// Number of victims the changeling has absorbed.
 	var/absorbed_count = 1
 	/// The current amount of chemicals the changeling has stored.
@@ -86,10 +86,10 @@
 /datum/antagonist/changeling/greet()
 	. = ..()
 	SEND_SOUND(owner.current, sound('sound/ambience/antag/ling_alert.ogg'))
-	return . += "<span class='danger'>Remember: you get all of their absorbed DNA if you absorb a fellow changeling.</span>"
+	return . += "<span class='danger'>Use your DNA sting to extract identities from the crew to unlock new abilities.</span>"
 
 /datum/antagonist/changeling/farewell()
-	to_chat(owner.current, "<span class='biggerdanger'><B>You grow weak and lose your powers! You are no longer a changeling and are stuck in your current form!</span>")
+	to_chat(owner.current, "<span class='danger'><B>You grow weak and lose your powers! You are no longer a changeling and are stuck in your current form!</span>")
 
 /datum/antagonist/changeling/apply_innate_effects(mob/living/mob_override)
 	var/mob/living/L = ..()

--- a/code/modules/antagonists/changeling/evolution_menu.dm
+++ b/code/modules/antagonists/changeling/evolution_menu.dm
@@ -88,7 +88,7 @@
 		return FALSE
 	var/datum/action/changeling/power = power_type
 	if(cling.absorbed_count < initial(power.req_dna))
-		to_chat(owner, "<span class='warning'>We must absorb more victims before we can evolve this ability!</span>")
+		to_chat(owner, "<span class='warning'>We must extract more DNA before we can evolve this ability!</span>")
 		return FALSE
 	if(cling.genetic_points < initial(power.dna_cost))
 		to_chat(owner, "<span class='warning'>We cannot afford to evolve this ability!</span>")

--- a/code/modules/antagonists/changeling/powers/augmented_eyesight.dm
+++ b/code/modules/antagonists/changeling/powers/augmented_eyesight.dm
@@ -1,10 +1,11 @@
 /datum/action/changeling/augmented_eyesight
 	name = "Augmented Eyesight"
-	desc = "Creates more light sensing rods in our eyes, allowing our vision to penetrate most blocking objects. Protects our vision from flashes while inactive."
+	desc = "Creates more light sensing rods in our eyes, allowing our vision to penetrate most blocking objects. Protects our vision from flashes while inactive. Requires at least 4 stored DNA."
 	helptext = "Grants us x-ray vision or flash protection. We will become a lot more vulnerable to flash-based devices while x-ray vision is active."
 	button_icon_state = "augmented_eyesight"
 	chemical_cost = 0
 	dna_cost = 4
+	req_dna = 4
 	active = FALSE
 	power_type = CHANGELING_PURCHASABLE_POWER
 

--- a/code/modules/antagonists/changeling/powers/become_headslug.dm
+++ b/code/modules/antagonists/changeling/powers/become_headslug.dm
@@ -1,10 +1,11 @@
 /datum/action/changeling/headslug
 	name = "Last Resort"
-	desc = "We sacrifice our current body in a moment of need, placing us in control of a vessel that can plant our likeness in a new host. Costs 20 chemicals."
+	desc = "We sacrifice our current body in a moment of need, placing us in control of a vessel that can plant our likeness in a new host. Costs 20 chemicals. Requires at least 6 stored DNA."
 	helptext = "We will be placed in control of a small, fragile creature. We may attack a corpse like this to plant an egg which will slowly mature into a new form for us."
 	button_icon_state = "last_resort"
 	chemical_cost = 20
 	dna_cost = 2
+	req_dna = 6
 	req_human = TRUE
 	power_type = CHANGELING_PURCHASABLE_POWER
 

--- a/code/modules/antagonists/changeling/powers/biodegrade.dm
+++ b/code/modules/antagonists/changeling/powers/biodegrade.dm
@@ -1,10 +1,11 @@
 /datum/action/changeling/biodegrade
 	name = "Biodegrade"
-	desc = "Dissolves restraints or other objects preventing free movement if we are restrained. Prepares hand to vomit acid on other objects, doesn't work on living targets. Costs 30 chemicals."
+	desc = "Dissolves restraints or other objects preventing free movement if we are restrained. Prepares hand to vomit acid on other objects, doesn't work on living targets. Costs 30 chemicals. Requires at least 6 stored DNA."
 	helptext = "This is obvious to nearby people, and can destroy standard restraints and closets, and break you out of grabs."
 	button_icon_state = "biodegrade"
 	chemical_cost = 30 //High cost to prevent spam
 	dna_cost = 4
+	req_dna = 6
 	req_human = TRUE
 	power_type = CHANGELING_PURCHASABLE_POWER
 	/// Type of acid hand we give to person

--- a/code/modules/antagonists/changeling/powers/chameleon_skin.dm
+++ b/code/modules/antagonists/changeling/powers/chameleon_skin.dm
@@ -1,9 +1,10 @@
 /datum/action/changeling/chameleon_skin
 	name = "Chameleon Skin"
-	desc = "Our skin pigmentation rapidly changes to suit our current environment. Costs 25 chemicals."
+	desc = "Our skin pigmentation rapidly changes to suit our current environment. Costs 25 chemicals. Requires at least 4 stored DNA."
 	helptext = "Allows us to become invisible after a few seconds of standing still. Can be toggled on and off."
 	button_icon_state = "chameleon_skin"
 	dna_cost = 4
+	req_dna = 4
 	chemical_cost = 25
 	req_human = TRUE
 	power_type = CHANGELING_PURCHASABLE_POWER

--- a/code/modules/antagonists/changeling/powers/contort_body.dm
+++ b/code/modules/antagonists/changeling/powers/contort_body.dm
@@ -1,9 +1,10 @@
 /datum/action/changeling/contort_body
 	name = "Contort Body"
-	desc = "We contort our body, allowing us to fit in and under things we normally wouldn't be able to. Costs 25 chemicals."
+	desc = "We contort our body, allowing us to fit in and under things we normally wouldn't be able to. Costs 25 chemicals. Requires at least 6 stored DNA."
 	button_icon_state = "contort_body"
 	chemical_cost = 25
 	dna_cost = 4
+	req_dna = 6
 	power_type = CHANGELING_PURCHASABLE_POWER
 
 /datum/action/changeling/contort_body/Remove(mob/M)

--- a/code/modules/antagonists/changeling/powers/digitalcamo.dm
+++ b/code/modules/antagonists/changeling/powers/digitalcamo.dm
@@ -1,9 +1,10 @@
 /datum/action/changeling/digitalcamo
 	name = "Digital Camouflage"
-	desc = "By evolving the ability to distort our form and proportions, we defeat common algorithms used to detect lifeforms on cameras."
+	desc = "By evolving the ability to distort our form and proportions, we defeat common algorithms used to detect lifeforms on cameras. Requires at least 4 stored DNA."
 	helptext = "We cannot be tracked by camera while using this skill."
 	button_icon_state = "digital_camo"
 	dna_cost = 2
+	req_dna = 4
 	power_type = CHANGELING_PURCHASABLE_POWER
 
 /datum/action/changeling/digitalcamo/Remove(mob/M)

--- a/code/modules/antagonists/changeling/powers/epinephrine.dm
+++ b/code/modules/antagonists/changeling/powers/epinephrine.dm
@@ -1,10 +1,11 @@
 /datum/action/changeling/epinephrine
 	name = "Epinephrine Overdose"
-	desc = "We evolve additional sacs of adrenaline throughout our body. Costs 30 chemicals."
+	desc = "We evolve additional sacs of adrenaline throughout our body. Costs 30 chemicals. Requires at least 4 stored DNA."
 	helptext = "Removes all stuns instantly and adds a short term reduction in further stuns. Can be used while unconscious. Continued use poisons the body."
 	button_icon_state = "adrenaline"
 	chemical_cost = 30
 	dna_cost = 4
+	req_dna = 4
 	req_human = TRUE
 	req_stat = UNCONSCIOUS
 	power_type = CHANGELING_PURCHASABLE_POWER

--- a/code/modules/antagonists/changeling/powers/fleshmend.dm
+++ b/code/modules/antagonists/changeling/powers/fleshmend.dm
@@ -1,10 +1,11 @@
 /datum/action/changeling/fleshmend
 	name = "Fleshmend"
-	desc = "Our flesh rapidly regenerates, healing our burns, bruises, and shortness of breath. Costs 20 chemicals."
+	desc = "Our flesh rapidly regenerates, healing our burns, bruises, and shortness of breath. Costs 20 chemicals. Requires at least 4 stored DNA."
 	helptext = "Does not regrow limbs. Partially recovers our blood. Functions while unconscious."
 	button_icon_state = "fleshmend"
 	chemical_cost = 20
 	dna_cost = 4
+	req_dna = 4
 	req_stat = UNCONSCIOUS
 	power_type = CHANGELING_PURCHASABLE_POWER
 

--- a/code/modules/antagonists/changeling/powers/hivemind.dm
+++ b/code/modules/antagonists/changeling/powers/hivemind.dm
@@ -3,11 +3,12 @@ GLOBAL_LIST_EMPTY(hivemind_bank)
 
 /datum/action/changeling/hivemind_pick
 	name = "Hivemind Access"
-	desc = "Allows us to upload or absorb DNA in the airwaves. Does not count towards absorb objectives. Allows us to speak over the Changeling Hivemind using :g. Costs 10 chemicals."
+	desc = "Allows us to upload or absorb DNA in the airwaves. Does not count towards absorb objectives. Allows us to speak over the Changeling Hivemind using :g. Costs 10 chemicals. Requires at least 4 stored DNA."
 	helptext = "Tunes our chemical receptors for hivemind communication, which passively grants us access to the Changeling Hivemind."
 	button_icon_state = "hive_absorb"
 	chemical_cost = 10
 	dna_cost = 4
+	req_dna = 4
 	power_type = CHANGELING_PURCHASABLE_POWER
 
 /datum/action/changeling/hivemind_pick/on_purchase(mob/user, datum/antagonist/changeling/C)

--- a/code/modules/antagonists/changeling/powers/lesserform.dm
+++ b/code/modules/antagonists/changeling/powers/lesserform.dm
@@ -1,10 +1,11 @@
 /datum/action/changeling/lesserform
 	name = "Lesser form"
-	desc = "We debase ourselves and become lesser. We become a monkey. Costs 5 chemicals."
+	desc = "We debase ourselves and become lesser. We become a monkey. Costs 5 chemicals. Requires at least 4 stored DNA."
 	helptext = "The transformation greatly reduces our size, allowing us to slip out of cuffs and climb through vents."
 	button_icon_state = "lesser_form"
 	chemical_cost = 5
 	dna_cost = 2
+	req_dna = 4
 	req_human = TRUE
 	power_type = CHANGELING_PURCHASABLE_POWER
 

--- a/code/modules/antagonists/changeling/powers/mimic_voice.dm
+++ b/code/modules/antagonists/changeling/powers/mimic_voice.dm
@@ -1,10 +1,11 @@
 /datum/action/changeling/mimicvoice
 	name = "Mimic Voice"
-	desc = "We shape our vocal glands to sound like a desired voice."
+	desc = "We shape our vocal glands to sound like a desired voice. Requires at least 4 stored DNA."
 	helptext = "Will turn your voice into the name that you enter."
 	button_icon_state = "mimic_voice"
 	chemical_cost = 0
 	dna_cost = 2
+	req_dna = 4
 	req_human = TRUE
 	power_type = CHANGELING_PURCHASABLE_POWER
 

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -112,11 +112,12 @@
 \***************************************/
 /datum/action/changeling/weapon/arm_blade
 	name = "Arm Blade"
-	desc = "We reform one of our arms into a deadly blade. Costs 25 chemicals."
+	desc = "We reform one of our arms into a deadly blade. Costs 25 chemicals. Requires at least 8 stored DNA."
 	helptext = "We may retract our armblade in the same manner as we form it. Cannot be used while in lesser form."
 	button_icon_state = "armblade"
 	chemical_cost = 25
 	dna_cost = 4
+	req_dna = 8
 	req_human = TRUE
 	weapon_type = /obj/item/melee/arm_blade
 	weapon_name_simple = "blade"
@@ -172,7 +173,7 @@
 
 /datum/action/changeling/weapon/tentacle
 	name = "Tentacle"
-	desc = "We ready a tentacle to grab items or victims with. Costs 10 chemicals."
+	desc = "We ready a tentacle to grab items or victims with. Costs 10 chemicals. Requires at least 8 stored DNA."
 	helptext = "We can use it once to retrieve a distant item. If used on living creatures, the effect depends on the intent: \
 	Help will drag the target closer and shake them up. \
 	Disarm will grab whatever the target is holding, and knock them down if they are not holding anything. \
@@ -182,6 +183,7 @@
 	button_icon_state = "tentacle"
 	chemical_cost = 10
 	dna_cost = 4
+	req_dna = 8
 	req_human = TRUE
 	weapon_type = /obj/item/gun/magic/tentacle
 	weapon_name_simple = "tentacle"
@@ -382,11 +384,12 @@
 \***************************************/
 /datum/action/changeling/weapon/shield
 	name = "Organic Shield"
-	desc = "We reform one of our arms into a hard shield. Costs 20 chemicals."
+	desc = "We reform one of our arms into a hard shield. Costs 20 chemicals. Requires at least 8 stored DNA."
 	helptext = "Organic tissue cannot resist damage forever. The shield will break after it is hit too much. The more DNA we collect, the stronger it is. Cannot be used while in lesser form."
 	button_icon_state = "organic_shield"
 	chemical_cost = 20
 	dna_cost = 2
+	req_dna = 8
 	req_human = TRUE
 	weapon_type = /obj/item/shield/changeling
 	weapon_name_simple = "shield"
@@ -430,11 +433,12 @@
 \***************************************/
 /datum/action/changeling/suit/organic_space_suit
 	name = "Organic Space Suit"
-	desc = "We grow an organic suit to protect ourselves from space exposure. Costs 20 chemicals."
+	desc = "We grow an organic suit to protect ourselves from space exposure. Costs 20 chemicals. Requires at least 8 stored DNA."
 	helptext = "We must constantly repair our form to make it space proof, reducing chemical production while we are protected. Cannot be used in lesser form."
 	button_icon_state = "organic_suit"
 	chemical_cost = 20
 	dna_cost = 4
+	req_dna = 8
 	req_human = TRUE
 	power_type = CHANGELING_PURCHASABLE_POWER
 	suit_type = /obj/item/clothing/suit/space/changeling
@@ -476,11 +480,12 @@
 \***************************************/
 /datum/action/changeling/suit/armor
 	name = "Chitinous Armor"
-	desc = "We turn our skin into tough chitin to protect us from damage. Costs 25 chemicals."
+	desc = "We turn our skin into tough chitin to protect us from damage. Costs 25 chemicals. Requires at least 8 stored DNA."
 	helptext = "Upkeep of the armor requires a low expenditure of chemicals. The armor is strong against brute force, but does not provide much protection from lasers. Cannot be used in lesser form."
 	button_icon_state = "chitinous_armor"
 	chemical_cost = 25
 	dna_cost = 4
+	req_dna = 8
 	req_human = TRUE
 	power_type = CHANGELING_PURCHASABLE_POWER
 	suit_type = /obj/item/clothing/suit/armor/changeling

--- a/code/modules/antagonists/changeling/powers/panacea.dm
+++ b/code/modules/antagonists/changeling/powers/panacea.dm
@@ -1,10 +1,11 @@
 /datum/action/changeling/panacea
 	name = "Anatomic Panacea"
-	desc = "Expels impurifications from our form, curing diseases, removing parasites, sobering us, purging toxins and radiation, and resetting our genetic code completely. Costs 20 chemicals."
+	desc = "Expels impurifications from our form, curing diseases, removing parasites, sobering us, purging toxins and radiation, and resetting our genetic code completely. Costs 20 chemicals. Requires at least 4 stored DNA."
 	helptext = "Can be used while unconscious."
 	button_icon_state = "panacea"
 	chemical_cost = 20
 	dna_cost = 2
+	req_dna = 4
 	req_stat = UNCONSCIOUS
 	power_type = CHANGELING_PURCHASABLE_POWER
 

--- a/code/modules/antagonists/changeling/powers/shriek.dm
+++ b/code/modules/antagonists/changeling/powers/shriek.dm
@@ -1,10 +1,11 @@
 /datum/action/changeling/resonant_shriek
 	name = "Resonant Shriek"
-	desc = "Our lungs and vocal cords shift, allowing us to briefly emit a noise that deafens and confuses the weak minded. Costs 30 chemicals."
+	desc = "Our lungs and vocal cords shift, allowing us to briefly emit a noise that deafens and confuses the weak minded. Costs 30 chemicals. Requires at least 6 stored DNA."
 	helptext = "Emits a high frequency sound that confuses and deafens humans, blows out nearby lights and overloads cyborg sensors."
 	button_icon_state = "resonant_shriek"
 	chemical_cost = 30
 	dna_cost = 2
+	req_dna = 6
 	req_human = TRUE
 	power_type = CHANGELING_PURCHASABLE_POWER
 
@@ -38,10 +39,11 @@
 
 /datum/action/changeling/dissonant_shriek
 	name = "Dissonant Shriek"
-	desc = "We shift our vocal cords to release a high frequency sound that overloads nearby electronics. Costs 30 chemicals."
+	desc = "We shift our vocal cords to release a high frequency sound that overloads nearby electronics. Costs 30 chemicals. Requires at least 6 stored DNA."
 	button_icon_state = "dissonant_shriek"
 	chemical_cost = 30
 	dna_cost = 2
+	req_dna = 6
 	power_type = CHANGELING_PURCHASABLE_POWER
 
 //A flashy ability, good for crowd control and sewing chaos.

--- a/code/modules/antagonists/changeling/powers/strained_muscles.dm
+++ b/code/modules/antagonists/changeling/powers/strained_muscles.dm
@@ -3,11 +3,12 @@
 
 /datum/action/changeling/strained_muscles
 	name = "Strained Muscles"
-	desc = "We evolve the ability to reduce the acid buildup in our muscles, allowing us to move much faster."
+	desc = "We evolve the ability to reduce the acid buildup in our muscles, allowing us to move much faster. Requires at least 6 stored DNA."
 	helptext = "The strain will use up our chemicals faster over time, and is not sustainable. Can not be used in lesser form."
 	button_icon_state = "strained_muscles"
 	chemical_cost = 0
 	dna_cost = 2
+	req_dna = 6
 	req_human = TRUE
 	power_type = CHANGELING_PURCHASABLE_POWER
 

--- a/code/modules/antagonists/changeling/powers/summon_spiders.dm
+++ b/code/modules/antagonists/changeling/powers/summon_spiders.dm
@@ -5,12 +5,12 @@
 
 /datum/action/changeling/spiders
 	name = "Spread Infestation"
-	desc = "Our form divides, creating an aggressive arachnid which will regard us as a friend. Costs 45 chemicals."
-	helptext = "The spiders are thoughtless creatures, but will not attack their creators. Requires at least 7 stored DNA. Their orders can be changed via remote hivemind (Alt+Shift click)."
+	desc = "Our form divides, creating an aggressive arachnid which will regard us as a friend. Costs 45 chemicals. Requires at least 6 stored DNA."
+	helptext = "The spiders are thoughtless creatures, but will not attack their creators. Their orders can be changed via remote hivemind (Alt+Shift click)."
 	button_icon_state = "spread_infestation"
 	chemical_cost = 45
 	dna_cost = 4
-	req_dna = 7
+	req_dna = 6
 	/// This var keeps track of the changeling's spider count
 	var/spider_counter = 0
 	/// Checks if changeling is already spawning a spider

--- a/code/modules/antagonists/changeling/powers/swap_form.dm
+++ b/code/modules/antagonists/changeling/powers/swap_form.dm
@@ -1,10 +1,11 @@
 /datum/action/changeling/swap_form
 	name = "Swap Forms"
-	desc = "We force ourselves into the body of another form, pushing their consciousness into the form we left behind. Costs 40 chemicals."
+	desc = "We force ourselves into the body of another form, pushing their consciousness into the form we left behind. Costs 40 chemicals. Requires at least 6 stored DNA."
 	helptext = "We will bring all our abilities with us, but we will lose our old form DNA in exchange for the new one. The process will seem suspicious to any observers."
 	button_icon_state = "cling_mindswap"
 	chemical_cost = 40
 	dna_cost = 2
+	req_dna = 6
 	req_human = TRUE //Monkeys can't grab
 	power_type = CHANGELING_PURCHASABLE_POWER
 

--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -93,12 +93,13 @@
 
 /datum/action/changeling/sting/mute
 	name = "Mute Sting"
-	desc = "We silently sting a human, completely silencing them for a short time. Costs 20 chemicals."
+	desc = "We silently sting a human, completely silencing them for a short time. Costs 20 chemicals. Requires at least 4 stored DNA."
 	helptext = "Does not provide a warning to the victim that they have been stung, until they try to speak and cannot."
 	button_icon_state = "sting_mute"
 	sting_icon = "sting_mute"
 	chemical_cost = 20
 	dna_cost = 4
+	req_dna = 4
 	power_type = CHANGELING_PURCHASABLE_POWER
 
 /datum/action/changeling/sting/mute/sting_action(mob/user, mob/living/carbon/target)
@@ -109,12 +110,13 @@
 
 /datum/action/changeling/sting/blind
 	name = "Blind Sting"
-	desc = "We temporarily blind our victim. Costs 25 chemicals."
+	desc = "We temporarily blind our victim. Costs 25 chemicals. Requires at least 4 stored DNA."
 	helptext = "This sting completely blinds a target for a short time, and leaves them with blurred vision for a long time."
 	button_icon_state = "sting_blind"
 	sting_icon = "sting_blind"
 	chemical_cost = 25
 	dna_cost = 2
+	req_dna = 4
 	power_type = CHANGELING_PURCHASABLE_POWER
 
 /datum/action/changeling/sting/blind/sting_action(mob/living/user, mob/living/target)
@@ -128,12 +130,13 @@
 
 /datum/action/changeling/sting/cryo //Enable when mob cooling is fixed so that frostoil actually makes you cold, instead of mostly just hungry.
 	name = "Cryogenic Sting"
-	desc = "We silently sting our victim with a cocktail of chemicals that freezes them from the inside. Costs 15 chemicals."
+	desc = "We silently sting our victim with a cocktail of chemicals that freezes them from the inside. Costs 15 chemicals. Requires at least 4 stored DNA."
 	helptext = "Does not provide a warning to the victim, though they will likely realize they are suddenly freezing."
 	button_icon_state = "sting_cryo"
 	sting_icon = "sting_cryo"
 	chemical_cost = 15
 	dna_cost = 4
+	req_dna = 4
 	power_type = CHANGELING_PURCHASABLE_POWER
 
 /datum/action/changeling/sting/cryo/sting_action(mob/user, mob/target)


### PR DESCRIPTION
## What Does This PR Do
Adds the DNA pre-requisite present on changeling's spider infestation ability to all purchasable changeling abilities with new scaling pre-requisites. (4, 6, 8).

Changeling DNA will now go stale at 4 stings instead of 5.

Cleans up messages that encourage changelings to absorb people when DNA sting is preferable by administration for non kill targets.

Changes font on changeling greeting message to look less ugly, rewords it to accommodate.

Adds DNA pre-requisites to description of changeling abilities.

## Why It's Good For The Game
There's been a push recently to make stealth changeling more viable to be played, and I feel a big part of that needs to be making armblade and other similarly loud abilities less convenient of a purchase.

Expanding on DNA pre-requisites allows for changelings to have more of a gameplay loop besides logging in, rolling changeling, immediately buying armblade and going to town in the medbay two minutes in.

I think this will open the door to us discussing scaling of changeling abilities.

## Images of changes
![image](https://github.com/ParadiseSS13/Paradise/assets/85680653/dfbc1843-c1be-44a5-9420-40c62782f70a)


## Testing
A lot of stinging, a lot of buying, a lot of reloading.

## Changelog
:cl:
tweak: Changeling abilities now require a certain number of DNA to purchase.
tweak: Rewords changeling introduction greeting.
/:cl: