### PR TITLE
Changeling Headslug Buff + Incubation Changes

### DIFF
--- a/code/modules/antagonists/changeling/powers/become_headslug.dm
+++ b/code/modules/antagonists/changeling/powers/become_headslug.dm
@@ -6,6 +6,8 @@
 	chemical_cost = 20
 	dna_cost = 2
 	req_human = TRUE
+	req_stat = DEAD
+	bypass_fake_death = TRUE
 	power_type = CHANGELING_PURCHASABLE_POWER
 
 /datum/action/changeling/headslug/try_to_sting(mob/user, mob/target)

--- a/code/modules/mob/living/simple_animal/hostile/headslug.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headslug.dm
@@ -9,8 +9,8 @@
 	icon = 'icons/mob/mob.dmi'
 	health = 60
 	maxHealth = 60
-	melee_damage_lower = 35
-	melee_damage_upper = 30
+	melee_damage_lower = 30
+	melee_damage_upper = 35
 	melee_damage_type = STAMINA
 	attacktext = "gnaws"
 	attack_sound = 'sound/weapons/bite.ogg'
@@ -24,7 +24,7 @@
 	density = FALSE
 	ventcrawler = 2
 	a_intent = INTENT_HARM
-	speed = 0.2
+	speed = 0.3
 	can_hide = TRUE
 	pass_door_while_hidden = TRUE
 	var/datum/mind/origin

--- a/code/modules/mob/living/simple_animal/hostile/headslug.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headslug.dm
@@ -1,5 +1,5 @@
-#define EGG_INCUBATION_DEAD_TIME 120
-#define EGG_INCUBATION_LIVING_TIME 200
+#define EGG_INCUBATION_DEAD_TIME 60
+#define EGG_INCUBATION_LIVING_TIME 120
 /mob/living/simple_animal/hostile/headslug
 	name = "headslug"
 	desc = "Absolutely not de-beaked or harmless. Keep away from corpses."
@@ -7,11 +7,12 @@
 	icon_living = "headslug"
 	icon_dead = "headslug_dead"
 	icon = 'icons/mob/mob.dmi'
-	health = 50
-	maxHealth = 50
-	melee_damage_lower = 5
-	melee_damage_upper = 5
-	attacktext = "chomps"
+	health = 60
+	maxHealth = 60
+	melee_damage_lower = 35
+	melee_damage_upper = 30
+	melee_damage_type = STAMINA
+	attacktext = "gnaws"
 	attack_sound = 'sound/weapons/bite.ogg'
 	faction = list("creature")
 	robust_searching = TRUE
@@ -23,7 +24,7 @@
 	density = FALSE
 	ventcrawler = 2
 	a_intent = INTENT_HARM
-	speed = 0.3
+	speed = 0.2
 	can_hide = TRUE
 	pass_door_while_hidden = TRUE
 	var/datum/mind/origin
@@ -65,13 +66,14 @@
 /obj/item/organ/internal/body_egg/changeling_egg/egg_process()
 	// Changeling eggs grow in everyone
 	time++
-	if(time >= 30 && prob(30))
+	if(time >= 30 && prob(40))
 		owner.bleed(5)
-	if(time >= 60 && prob(5))
+	if(time >= 60 && prob(10))
 		to_chat(owner, pick("<span class='danger'>We feel great!</span>", "<span class='danger'>Something hurts for a moment but it's gone now.</span>", "<span class='danger'>You feel like you should go to a dark place.</span>", "<span class='danger'>You feel really tired.</span>"))
-	if(time >= 90 && prob(5))
+		owner.adjustToxLoss(30)
+	if(time >= 90 && prob(15))
 		to_chat(owner, pick("<span class='danger'>Something hurts.</span>", "<span class='danger'>Someone is thinking, but it's not you.</span>", "<span class='danger'>You feel at peace.</span>", "<span class='danger'>Close your eyes.</span>"))
-		owner.adjustToxLoss(5)
+		owner.adjustStaminaLoss(50)
 	if(time >= EGG_INCUBATION_DEAD_TIME && owner.stat == DEAD || time >= EGG_INCUBATION_LIVING_TIME)
 		Pop()
 		STOP_PROCESSING(SSobj, src)

--- a/code/modules/mob/living/simple_animal/hostile/headslug.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headslug.dm
@@ -1,5 +1,5 @@
-#define EGG_INCUBATION_DEAD_TIME 60
-#define EGG_INCUBATION_LIVING_TIME 120
+#define EGG_INCUBATION_DEAD_CYCLE 60
+#define EGG_INCUBATION_LIVING_CYCLE 120
 /mob/living/simple_animal/hostile/headslug
 	name = "headslug"
 	desc = "Absolutely not de-beaked or harmless. Keep away from corpses."
@@ -74,7 +74,7 @@
 	if(time >= 90 && prob(15))
 		to_chat(owner, pick("<span class='danger'>Something hurts.</span>", "<span class='danger'>Someone is thinking, but it's not you.</span>", "<span class='danger'>You feel at peace.</span>", "<span class='danger'>Close your eyes.</span>"))
 		owner.adjustStaminaLoss(50)
-	if(time >= EGG_INCUBATION_DEAD_TIME && owner.stat == DEAD || time >= EGG_INCUBATION_LIVING_TIME)
+	if(time >= EGG_INCUBATION_DEAD_CYCLE && owner.stat == DEAD || time >= EGG_INCUBATION_LIVING_CYCLE)
 		Pop()
 		STOP_PROCESSING(SSobj, src)
 		qdel(src)
@@ -116,5 +116,5 @@
 	chest.fracture()
 	chest.disembowel()
 
-#undef EGG_INCUBATION_DEAD_TIME
-#undef EGG_INCUBATION_LIVING_TIME
+#undef EGG_INCUBATION_DEAD_CYCLE
+#undef EGG_INCUBATION_LIVING_CYCLE


### PR DESCRIPTION
## What Does This PR Do
Marginally buffs the health of headslugs, and makes them deal stamina damage on bite.

- 50>60 HP.

- Last resort can now be used when incapacitated or dead.

- 30-35 stamina damage per bite.

Time for incubation has been lowered to 60 seconds for dead bodies, and 120 seconds for living people.

In later stages of incubation, victims will now actually go into crit and start taking heavy stamina damage.

## Why It's Good For The Game
We're gradually moving away from changelings dying and reviving constantly in combat and death warring security, its best we give changelings a more interactive 'out', previous headslug buffs have made them viable but they're still quite squishy and struggle to live past popping out of the vent.

## Testing
I'm sick and tired of using headslug, I've had to tweak numbers so much.

## Changelog
:cl:
tweak: Buffs headslugs, they're now tougher and deal stamina damage.
tweak: Lowers incubation time for changeling eggs.
tweak: Later stages of incubation or changeling eggs is now deadlier for the victim.
tweak: Last resort now functions when dead or incapacitated.
/:cl: