### PR TITLE
Updates some cloner error messages to be clearer

### DIFF
--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -349,19 +349,18 @@
 		set_scan_temp("Subject has committed suicide and is not clonable.", "bad")
 		SStgui.update_uis(src)
 		return
+	if(HAS_TRAIT(subject, TRAIT_BADDNA) && src.scanner.scan_level < 2)
+		set_scan_temp("Insufficient level of biofluids detected within subject. Scanner upgrades may be required to improve scan capabilities.", "bad")
+		SStgui.update_uis(src)
+		return
+	if(HAS_TRAIT(subject, TRAIT_HUSK) && src.scanner.scan_level < 2)
+		set_scan_temp("Subject is husked. Treat condition or upgrade scanning module to proceed with scan.", "bad")
+		SStgui.update_uis(src)
+		return
 	if((!subject.ckey) || (!subject.client))
 		set_scan_temp("Subject's brain is not responding. Further attempts after a short delay may succeed.", "bad")
 		SStgui.update_uis(src)
 		return
-	if(HAS_TRAIT(subject, TRAIT_HUSK) && src.scanner.scan_level < 2)
-		if(HAS_TRAIT(subject, TRAIT_BADDNA))
-			set_scan_temp("Insufficient level of biofluids detected within subject. Scanner upgrades may be required to improve scan capabilities.", "bad")
-			SStgui.update_uis(src)
-			return
-		set_scan_temp("Subject is husked. Treat condition or upgrade scanning module to proceed with scan.", "bad")
-		SStgui.update_uis(src)
-		return
-
 	if(!isnull(find_record(subject.ckey)))
 		set_scan_temp("Subject already in database.")
 		SStgui.update_uis(src)

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -322,19 +322,23 @@
 		return
 	if(isnull(subject) || (!(ishuman(subject))) || (!subject.dna))
 		if(isalien(subject))
-			set_scan_temp("Xenomorphs are not scannable.", "bad")
+			set_scan_temp("Safety interlocks engaged. Nanotrasen Directive 7b forbids the cloning of biohazardous alien species.", "bad")
 			SStgui.update_uis(src)
 			return
 		// can add more conditions for specific non-human messages here
 		else
-			set_scan_temp("Subject species is not scannable.", "bad")
+			set_scan_temp("Subject species is not clonable.", "bad")
 			SStgui.update_uis(src)
 			return
 	if(subject.get_int_organ(/obj/item/organ/internal/brain))
 		var/obj/item/organ/internal/brain/Brn = subject.get_int_organ(/obj/item/organ/internal/brain)
 		if(istype(Brn))
+			if(Brn.dna.species.name == "Machine")
+				set_scan_temp("No organic tissue detected within subject. Alternative revival methods recommended.", "bad")
+				SStgui.update_uis(src)
+				return
 			if(NO_CLONESCAN in Brn.dna.species.species_traits)
-				set_scan_temp("[Brn.dna.species.name_plural] are not scannable.", "bad")
+				set_scan_temp("[Brn.dna.species.name_plural] are not clonable. Alternative revival methods recommended.", "bad")
 				SStgui.update_uis(src)
 				return
 	if(!subject.get_int_organ(/obj/item/organ/internal/brain))
@@ -342,17 +346,22 @@
 		SStgui.update_uis(src)
 		return
 	if(subject.suiciding)
-		set_scan_temp("Subject has committed suicide and is not scannable.", "bad")
+		set_scan_temp("Subject has committed suicide and is not clonable.", "bad")
 		SStgui.update_uis(src)
 		return
 	if((!subject.ckey) || (!subject.client))
 		set_scan_temp("Subject's brain is not responding. Further attempts after a short delay may succeed.", "bad")
 		SStgui.update_uis(src)
 		return
-	if(HAS_TRAIT(subject, TRAIT_BADDNA) && src.scanner.scan_level < 2)
-		set_scan_temp("Subject has incompatible genetic mutations.", "bad")
+	if(HAS_TRAIT(subject, TRAIT_HUSK) && src.scanner.scan_level < 2)
+		if(HAS_TRAIT(subject, TRAIT_BADDNA))
+			set_scan_temp("Insufficient level of biofluids detected within subject. Scanner upgrades may be required to improve scan capabilities.", "bad")
+			SStgui.update_uis(src)
+			return
+		set_scan_temp("Subject is husked. Treat condition or upgrade scanning module to proceed with scan.", "bad")
 		SStgui.update_uis(src)
 		return
+
 	if(!isnull(find_record(subject.ckey)))
 		set_scan_temp("Subject already in database.")
 		SStgui.update_uis(src)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Changes some cloner error messages to be clearer to new players by suggesting other ways to continue, as well as replacing most instances of 'scanning' with 'cloning' in cloner error messages. Also adds a new error message if a burn husk victim is placed inside the cloner, differentiating from changeling absorb husks.

## Why It's Good For The Game
I have been told that some of the cloner error messages are not very initutive. This change should help with newer players identifying cloning issues.

## Images of changes
Xenomorphs:
![Screenshot (663)](https://github.com/ParadiseSS13/Paradise/assets/108938550/72c8e2ba-54ff-4b04-b247-698470df1fd3)
Slimepeople:
![Screenshot (664)](https://github.com/ParadiseSS13/Paradise/assets/108938550/9d90fb25-5b78-4908-bea5-7cec7f9f6a43)
Vox:
![Screenshot (666)](https://github.com/ParadiseSS13/Paradise/assets/108938550/6869de63-f863-43af-9b9b-032816db32d7)
IPCs:
![Screenshot (662)](https://github.com/ParadiseSS13/Paradise/assets/108938550/d2682c11-38dd-451f-9c1c-84319f0377ab)
Burn husks:
![Screenshot (667)](https://github.com/ParadiseSS13/Paradise/assets/108938550/6c6b2397-bfaa-4e4d-a551-52e041ff4166)
Changeling Absorb Husks:
![Screenshot (665)](https://github.com/ParadiseSS13/Paradise/assets/108938550/e4da077b-5fd8-4e96-b7c4-9530afddfb95)

## Testing
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Changed cloning messages to be more user friendly to new players
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the fir
![Screenshot (662)](https://github.com/ParadiseSS13/Paradise/assets/108938550/d2682c11-38dd-451f-9c1c-84319f0377ab)
st :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
