### PR TITLE
Apply living checks to dispenser stations.

### DIFF
--- a/code/game/objects/structures/transit_tubes/station.dm
+++ b/code/game/objects/structures/transit_tubes/station.dm
@@ -224,15 +224,17 @@
 			return TRUE
 	return FALSE
 
-/obj/structure/transit_tube/station/dispenser/Bumped(atom/movable/AM)
-	if(!(istype(AM) && AM.dir == boarding_dir) || AM.anchored)
+/obj/structure/transit_tube/station/dispenser/Bumped(mob/living/L)
+	if(!(istype(L) && L.dir == boarding_dir) || L.anchored)
 		return
-	var/obj/structure/transit_tube_pod/dispensed/pod = new(loc)
-	AM.visible_message("<span class='notice'>[pod] forms around [AM].</span>", "<span class='notice'>[pod] materializes around you.</span>")
-	playsound(src, 'sound/weapons/emitter2.ogg', 50, TRUE)
-	pod.dir = turn(dir, -90)
-	pod.move_into(AM)
-	launch_pod()
+
+	if(isliving(L) && !is_type_in_list(L, disallowed_mobs))
+		var/obj/structure/transit_tube_pod/dispensed/pod = new(loc)
+		L.visible_message("<span class='notice'>[pod] forms around [L].</span>", "<span class='notice'>[pod] materializes around you.</span>")
+		playsound(src, 'sound/weapons/emitter2.ogg', 50, TRUE)
+		pod.dir = turn(dir, -90)
+		pod.move_into(L)
+		launch_pod()
 
 /obj/structure/transit_tube/station/dispenser/pod_stopped(obj/structure/transit_tube_pod/pod)
 	playsound(src, 'sound/machines/ding.ogg', 50, TRUE)


### PR DESCRIPTION
## What Does This PR Do
This PR applies some checks to dispenser stations in Bumped that were missing and passes in a mob instead of an atom to prevent inanimate passengers. I didn't generalize this because there's only two types involved and the checks. I also split the logic into two conditionals to make it easier to read/reason about.

## Why It's Good For The Game
These checks belong here and cause all kinds of problems if not. For example bumping into the dispenser tube while riding a janicart sends the cart off while leaving the player buckled to nothing.

## Images of changes
No visual changes.

## Testing
Tested dispenser tubes while buckled to an object, attempted to throw non-mobs into the dispenser.

## Changelog
NPFC (these dispensers aren't mapped in anywhere right now)