### PR TITLE
Updates the ARG's description

### DIFF
--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -240,7 +240,7 @@
 //ARG Assault Rifle//
 /obj/item/gun/projectile/automatic/ar
 	name = "\improper ARG"
-	desc = "A robust assault rifle used by Nanotrasen fighting forces."
+	desc = "A robust assault rifle used by the forces of the Trans-Solar Federation."
 	icon_state = "arg"
 	item_state = "arg"
 	slot_flags = 0

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -240,7 +240,7 @@
 //ARG Assault Rifle//
 /obj/item/gun/projectile/automatic/ar
 	name = "\improper ARG"
-	desc = "A robust assault rifle used by the forces of the Trans-Solar Federation."
+	desc = "A robust assault rifle used by Trans-Solar Federation forces."
 	icon_state = "arg"
 	item_state = "arg"
 	slot_flags = 0


### PR DESCRIPTION
## What Does This PR Do
Changes the ARG rifle's description to reflect who actually uses it.

## Why It's Good For The Game
THE LORE, JIM, THE LORE.

NT doesn't use this rifle, the TSF does. We don't spread misinformation on the internet in this household.

## Testing
- Loaded in
- Spawned ARG
- Description is updated

## Changelog
:cl:
tweak: Updated the ARG's description
/:cl: