### PR TITLE
Buffs a few spells

### DIFF
--- a/code/datums/spells/mind_transfer.dm
+++ b/code/datums/spells/mind_transfer.dm
@@ -11,8 +11,8 @@
 	selection_deactivated_message = "<span class='notice'>You decide that your current form is good enough.</span>"
 	cooldown_min = 200 //100 deciseconds reduction per rank
 	var/list/protected_roles = list(SPECIAL_ROLE_WIZARD, SPECIAL_ROLE_CHANGELING, SPECIAL_ROLE_CULTIST) //which roles are immune to the spell
-	var/paralysis_amount_caster = 40 SECONDS //how much the caster is paralysed for after the spell
-	var/paralysis_amount_victim = 40 SECONDS //how much the victim is paralysed for after the spell
+	var/paralysis_amount_caster = 10 SECONDS //how much the caster is paralysed for after the spell
+	var/paralysis_amount_victim = 15 SECONDS //how much the victim is paralysed for after the spell
 	action_icon_state = "mindswap"
 
 /obj/effect/proc_holder/spell/mind_transfer/create_new_targeting()

--- a/code/datums/spells/wizard_spells.dm
+++ b/code/datums/spells/wizard_spells.dm
@@ -12,10 +12,11 @@
 	proj_icon_state = "magicm"
 	proj_name = "a magic missile"
 	proj_lingering = 1
+	pass_flags = PASSDOOR
 	proj_type = "/obj/effect/proc_holder/spell/inflict_handler/magic_missile"
 
 	proj_lifespan = 20
-	proj_step_delay = 5
+	proj_step_delay = 2
 
 	proj_trail = 1
 	proj_trail_lifespan = 5
@@ -283,12 +284,12 @@
 	desc = "This spell temporarily blinds a single person and does not require wizard garb."
 
 	school = "transmutation"
-	base_cooldown = 300
+	base_cooldown = 10 SECONDS
 	clothes_req = FALSE
 	invocation = "STI KALY"
 	invocation_type = "whisper"
 	message = "<span class='notice'>Your eyes cry out in pain!</span>"
-	cooldown_min = 50 //12 deciseconds reduction per rank
+	cooldown_min = 2 SECONDS
 
 	starting_spells = list("/obj/effect/proc_holder/spell/inflict_handler/blind","/obj/effect/proc_holder/spell/genetic/blind")
 

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -302,7 +302,7 @@
 	name = "Remove Clothes Requirement"
 	spell_type = /obj/effect/proc_holder/spell/noclothes
 	category = "Assistance"
-
+	cost = 1
 //Rituals
 /datum/spellbook_entry/summon
 	name = "Summon Stuff"

--- a/code/modules/projectiles/projectile/homing_projectiles.dm
+++ b/code/modules/projectiles/projectile/homing_projectiles.dm
@@ -37,6 +37,7 @@
 	icon_state = "toolbox_default"
 	hitsound = 'sound/weapons/smash.ogg'
 	damage = 30
+	nodamage = FALSE
 	damage_type = BRUTE
 
 /obj/item/projectile/homing/magic/toolbox/on_range()


### PR DESCRIPTION

## What Does This PR Do
Buffs several not-good spells in the wizard's arsenal to make them more useful and functional.

To wit:

Magic Missile- Increased projectile speed and gives the projectiles PASSDOOR.

No clothes: Decreases cost to one point

Blind: Decreases base cooldown to 15 seconds and minimum cooldown to 2 seconds.

Mindswap: Decreases paralysis on the caster to 10 seconds and the target to 15 seconds.

Homing Toolbox: Fixes the spell so it actually deals damage.

## Why It's Good For The Game
A good chunk of the wizard's lineup are kind of ass. This should help remedy the issue.

Additionally, mindswap paralyzing you for 40 seconds is stupid, and the Homing Toolbox should actually do damage considering it's an offensive spell.

More buffs to follow.

## Testing
- Loaded in
- We love castin spells
- Everything works as intended
- Shot and blinded many tajaran in my gray jumpsuit.

## Changelog
:cl:
tweak: Buffed several crappy wizard spells, reduced the paralysis times on Mindswap.
fix: Homing Toolbox does damage now
/:cl: