### PR TITLE
Belts and some select belt slot items no longer require a jumpsuit to wear

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -81,6 +81,8 @@
 #define CRITICAL_ATOM_2			(1<<18)
 /// Use this flag for items that can block randomly
 #define RANDOM_BLOCKER_2		(1<<19)
+/// This flag allows for wearing of a belt item, even if you're not wearing a jumpsuit
+#define ALLOW_BELT_NO_JUMPSUIT_2	(1<<20)
 
 //Reagent flags
 #define REAGENT_NOREACT			1

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -42,6 +42,7 @@ GLOBAL_DATUM_INIT(welding_sparks, /mutable_appearance, mutable_appearance('icons
 	var/attack_effect_override
 	var/list/attack_verb //Used in attackby() to say how something was attacked "[x] has been [z.attack_verb] by [y] with [z]"
 	var/w_class = WEIGHT_CLASS_NORMAL
+	var/ignoreunder = FALSE //Used to specify if we want an item to ignore being unequipped when the wearer has no jumpsuits
 	var/slot_flags = 0		//This is used to determine on which slots an item can fit.
 	pass_flags = PASSTABLE
 	pressure_resistance = 4

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -42,7 +42,6 @@ GLOBAL_DATUM_INIT(welding_sparks, /mutable_appearance, mutable_appearance('icons
 	var/attack_effect_override
 	var/list/attack_verb //Used in attackby() to say how something was attacked "[x] has been [z.attack_verb] by [y] with [z]"
 	var/w_class = WEIGHT_CLASS_NORMAL
-	var/ignoreunder = FALSE //Used to specify if we want an item to ignore being unequipped when the wearer has no jumpsuits
 	var/slot_flags = 0		//This is used to determine on which slots an item can fit.
 	pass_flags = PASSTABLE
 	pressure_resistance = 4

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -259,6 +259,7 @@
 	item_state = "katana"
 	flags = CONDUCT
 	slot_flags = SLOT_FLAG_BELT | SLOT_FLAG_BACK
+	ignoreunder = TRUE //Look, you can strap it to your back. You can strap it to your waist too.
 	force = 5
 	throwforce = 5
 	w_class = WEIGHT_CLASS_NORMAL
@@ -441,6 +442,7 @@
 	item_state = "inflatable"
 	icon = 'icons/obj/clothing/belts.dmi'
 	slot_flags = SLOT_FLAG_BELT
+	ignoreunder = TRUE
 
 /*
  * Fake meteor

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -259,7 +259,7 @@
 	item_state = "katana"
 	flags = CONDUCT
 	slot_flags = SLOT_FLAG_BELT | SLOT_FLAG_BACK
-	ignoreunder = TRUE //Look, you can strap it to your back. You can strap it to your waist too.
+	flags_2 = ALLOW_BELT_NO_JUMPSUIT_2 //Look, you can strap it to your back. You can strap it to your waist too.
 	force = 5
 	throwforce = 5
 	w_class = WEIGHT_CLASS_NORMAL
@@ -442,7 +442,7 @@
 	item_state = "inflatable"
 	icon = 'icons/obj/clothing/belts.dmi'
 	slot_flags = SLOT_FLAG_BELT
-	ignoreunder = TRUE
+	flags_2 = ALLOW_BELT_NO_JUMPSUIT_2
 
 /*
  * Fake meteor

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -209,7 +209,7 @@
 	sprite_sheets = null //Because Vox had the belt defibrillator sprites in back.dm
 	w_class = WEIGHT_CLASS_NORMAL
 	slot_flags = SLOT_FLAG_BELT
-	ignoreunder = TRUE
+	flags_2 = ALLOW_BELT_NO_JUMPSUIT_2
 	origin_tech = "biotech=5"
 
 /obj/item/defibrillator/compact/loaded/Initialize(mapload)

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -209,6 +209,7 @@
 	sprite_sheets = null //Because Vox had the belt defibrillator sprites in back.dm
 	w_class = WEIGHT_CLASS_NORMAL
 	slot_flags = SLOT_FLAG_BELT
+	ignoreunder = TRUE
 	origin_tech = "biotech=5"
 
 /obj/item/defibrillator/compact/loaded/Initialize(mapload)

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -10,6 +10,7 @@
 	attack_verb = list("whipped", "lashed", "disciplined")
 	max_integrity = 300
 	equip_sound = 'sound/items/equip/toolbelt_equip.ogg'
+	ignoreunder = TRUE
 	/// Do we have overlays for items held inside the belt?
 	var/use_item_overlays = FALSE
 	/// Bypasses the "belt in bag" prevention if TRUE

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -7,10 +7,10 @@
 	lefthand_file = 'icons/mob/inhands/equipment/belt_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/belt_righthand.dmi'
 	slot_flags = SLOT_FLAG_BELT
+	flags_2 = ALLOW_BELT_NO_JUMPSUIT_2 | BLOCKS_LIGHT_2
 	attack_verb = list("whipped", "lashed", "disciplined")
 	max_integrity = 300
 	equip_sound = 'sound/items/equip/toolbelt_equip.ogg'
-	ignoreunder = TRUE
 	/// Do we have overlays for items held inside the belt?
 	var/use_item_overlays = FALSE
 	/// Bypasses the "belt in bag" prevention if TRUE

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -294,6 +294,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	hitcost = 2000
 	slot_flags = SLOT_FLAG_BACK | SLOT_FLAG_BELT
+	ignoreunder = TRUE //Look, you can strap it to your back. You can strap it to your waist too.
 	var/obj/item/assembly/igniter/sparkler = null
 
 /obj/item/melee/baton/cattleprod/Initialize(mapload)

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -294,7 +294,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	hitcost = 2000
 	slot_flags = SLOT_FLAG_BACK | SLOT_FLAG_BELT
-	ignoreunder = TRUE //Look, you can strap it to your back. You can strap it to your waist too.
+	flags_2 = ALLOW_BELT_NO_JUMPSUIT_2 //Look, you can strap it to your back. You can strap it to your waist too.
 	var/obj/item/assembly/igniter/sparkler = null
 
 /obj/item/melee/baton/cattleprod/Initialize(mapload)

--- a/code/game/objects/items/weapons/tanks/tank_types.dm
+++ b/code/game/objects/items/weapons/tanks/tank_types.dm
@@ -104,6 +104,7 @@
 	icon_state = "plasmaman_tank_belt"
 	item_state = "plasmaman_tank_belt"
 	slot_flags = SLOT_FLAG_BELT
+	ignoreunder = TRUE
 	force = 5
 	volume = 35
 	w_class = WEIGHT_CLASS_SMALL
@@ -131,6 +132,7 @@
 	icon_state = "emergency"
 	flags = CONDUCT
 	slot_flags = SLOT_FLAG_BELT
+	ignoreunder = TRUE
 	w_class = WEIGHT_CLASS_SMALL
 	force = 4
 	distribute_pressure = TANK_DEFAULT_RELEASE_PRESSURE

--- a/code/game/objects/items/weapons/tanks/tank_types.dm
+++ b/code/game/objects/items/weapons/tanks/tank_types.dm
@@ -104,7 +104,7 @@
 	icon_state = "plasmaman_tank_belt"
 	item_state = "plasmaman_tank_belt"
 	slot_flags = SLOT_FLAG_BELT
-	ignoreunder = TRUE
+	flags_2 = ALLOW_BELT_NO_JUMPSUIT_2
 	force = 5
 	volume = 35
 	w_class = WEIGHT_CLASS_SMALL
@@ -132,7 +132,7 @@
 	icon_state = "emergency"
 	flags = CONDUCT
 	slot_flags = SLOT_FLAG_BELT
-	ignoreunder = TRUE
+	flags_2 = ALLOW_BELT_NO_JUMPSUIT_2
 	w_class = WEIGHT_CLASS_SMALL
 	force = 4
 	distribute_pressure = TANK_DEFAULT_RELEASE_PRESSURE

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -83,6 +83,7 @@
 	item_state = "katana"
 	flags = CONDUCT
 	slot_flags = SLOT_FLAG_BELT | SLOT_FLAG_BACK
+	ignoreunder = TRUE //Look, you can strap it to your back. You can strap it to your waist too.
 	force = 40
 	throwforce = 10
 	sharp = TRUE

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -83,7 +83,7 @@
 	item_state = "katana"
 	flags = CONDUCT
 	slot_flags = SLOT_FLAG_BELT | SLOT_FLAG_BACK
-	ignoreunder = TRUE //Look, you can strap it to your back. You can strap it to your waist too.
+	flags_2 = ALLOW_BELT_NO_JUMPSUIT_2 //Look, you can strap it to your back. You can strap it to your waist too.
 	force = 40
 	throwforce = 10
 	sharp = TRUE

--- a/code/modules/martial_arts/judo.dm
+++ b/code/modules/martial_arts/judo.dm
@@ -18,7 +18,7 @@
 	icon_state = "judobelt"
 	item_state = "judo"
 	slot_flags = SLOT_FLAG_BELT
-	ignoreunder = TRUE
+	flags_2 = ALLOW_BELT_NO_JUMPSUIT_2
 	w_class = WEIGHT_CLASS_BULKY
 	var/datum/martial_art/judo/style
 

--- a/code/modules/martial_arts/judo.dm
+++ b/code/modules/martial_arts/judo.dm
@@ -18,6 +18,7 @@
 	icon_state = "judobelt"
 	item_state = "judo"
 	slot_flags = SLOT_FLAG_BELT
+	ignoreunder = TRUE
 	w_class = WEIGHT_CLASS_BULKY
 	var/datum/martial_art/judo/style
 

--- a/code/modules/mob/living/carbon/human/human_inventory.dm
+++ b/code/modules/mob/living/carbon/human/human_inventory.dm
@@ -87,7 +87,7 @@
 			unEquip(l_store, 1)
 		if(wear_id)
 			unEquip(wear_id)
-		if(belt)
+		if(belt && !belt.ignoreunder)
 			unEquip(belt)
 		w_uniform = null
 		update_inv_w_uniform()

--- a/code/modules/mob/living/carbon/human/human_inventory.dm
+++ b/code/modules/mob/living/carbon/human/human_inventory.dm
@@ -87,7 +87,7 @@
 			unEquip(l_store, 1)
 		if(wear_id)
 			unEquip(wear_id)
-		if(belt && !belt.ignoreunder)
+		if(belt && !(belt.flags_2 & ALLOW_BELT_NO_JUMPSUIT_2))
 			unEquip(belt)
 		w_uniform = null
 		update_inv_w_uniform()

--- a/code/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/code/modules/mob/living/carbon/human/human_update_icons.dm
@@ -614,7 +614,8 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 		standing.alpha = w_uniform.alpha
 		standing.color = w_uniform.color
 		overlays_standing[UNIFORM_LAYER] = standing
-	else if(!dna.species.nojumpsuit)
+	//If anyone asks, /mob/living/carbon/human/unEquip in human_inventory.dm already handles unequip code
+	/* else if(!dna.species.nojumpsuit)
 		var/list/uniform_slots = list()
 		var/obj/item/organ/external/L = get_organ(BODY_ZONE_L_LEG)
 		if(!(L?.status & ORGAN_ROBOT))
@@ -639,7 +640,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 					thing.forceMove(drop_location())											//
 					thing.dropped(src)															//
 					thing.layer = initial(thing.layer)
-					thing.plane = initial(thing.plane)
+					thing.plane = initial(thing.plane) */
 	apply_overlay(UNIFORM_LAYER)
 	update_hands_layer()
 

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -757,7 +757,7 @@
 				return FALSE
 			var/obj/item/organ/external/O = H.get_organ(BODY_ZONE_CHEST)
 
-			if(!H.w_uniform && !nojumpsuit && !(O?.status & ORGAN_ROBOT))
+			if(!H.w_uniform && !nojumpsuit && !(O?.status & ORGAN_ROBOT) && !I.ignoreunder)
 				if(!disable_warning)
 					to_chat(H, "<span class='alert'>You need a jumpsuit before you can attach this [I.name].</span>")
 				return FALSE

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -757,7 +757,7 @@
 				return FALSE
 			var/obj/item/organ/external/O = H.get_organ(BODY_ZONE_CHEST)
 
-			if(!H.w_uniform && !nojumpsuit && !(O?.status & ORGAN_ROBOT) && !I.ignoreunder)
+			if(!H.w_uniform && !nojumpsuit && !(O?.status & ORGAN_ROBOT) && !(I.flags_2 & ALLOW_BELT_NO_JUMPSUIT_2))
 				if(!disable_warning)
 					to_chat(H, "<span class='alert'>You need a jumpsuit before you can attach this [I.name].</span>")
 				return FALSE


### PR DESCRIPTION
## What Does This PR Do
All belts and some belt slot items now could be worn if you do not have a jumpsuit, and they also do not get unequipped when a jumpsuit is unequipped.

Full list of items:

- All belts, including the Judo Belt and Belt Defibs
- All emergency tanks (Oxygen, Nitrogen, Plasma) and specialised belt tanks (Plasma and Nitrogen)
- Katanas and Toy Katanas (NOT energy katanas)
- Stunprods
- And of course, inflatable ducks (How could I forget?)

Also comments out redundant code in regards to unequipping items in `human_update_icons.dm`.

## Why It's Good For The Game
It always makes me unsure why you can't wear a toolbelt while you don't have a jumpsuit, considering that you can do that easily IRL, so this PR aims to change that behaviour.

This also has the added benefit of making it so vox and plasmamen don't lose their tanks that easily - Permaing vox prisoners is always a chore and involves them getting toxins damage because they are cuffed (And thus cannot hold on to their N2 tanks) while the Warden has to change their jumpsuits into prison uniforms, thus dropping their tanks on the floor.

Katanas, toy katanas and stunprods also could be equipped in belts and back at all times, which implies some sort of strap that you could use to tie around your waist as well.

As for the redundant code, `/mob/living/carbon/human/unEquip` in `human_inventory.dm` already handles unequipping items, so the code in `human_update_icons.dm` should not longer be needed. 

Inventory code should also not be in icon code (Not to mention I can only get it to work by removing the code in there), but because I'm not sure if it would break anything else I left it in just commented out.

## Testing
Loaded up local server, put on a bunch of belts and belt slot items while being naked, then put on a jumpsuit and took it off again to verify that my belt slot items didn't get unequipped.

Did the same with belt items that are supposed to be unequippable and verified that they cannot be equipped, and taking off my jumpsuit while they are equipped causes them to fall on the floor.

Also tested unequipping and reequipping items as well as storage containers to ensure removing redundant code didn't break anything.

## Changelog
:cl:
tweak: Belts and certain belt slot items are now able to be worn without jumpsuits
/:cl:
