### PR TITLE
Sentry bot no longer drops ed209 loot when destroyed

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/syndicate_bots.dm
+++ b/code/modules/mob/living/simple_animal/bot/syndicate_bots.dm
@@ -162,7 +162,7 @@
 		wreck.name = "sentry bot wreckage"
 
 		raise_alert("[src] destroyed.")
-		..()
+		qdel(src)
 
 /mob/living/simple_animal/bot/ed209/syndicate/set_weapon()
 	projectile = /obj/item/projectile/bullet/a40mm


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
title
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
It is a sentry bot not an ed209
## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
BEFORE
![broke](https://github.com/ParadiseSS13/Paradise/assets/77684085/401ad9e1-3701-406e-824a-21bd1834f1ec)


AFTER
![image](https://github.com/ParadiseSS13/Paradise/assets/77684085/5c0b6c20-331f-4943-8fe6-038cbd945c2c)

## Testing
<!-- How did you test the PR, if at all? -->
- Destroyed it multiple times to verify its remains
## Changelog
:cl:
fix: Sentry bot no longer drops ed209 loot when destroyed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
