### PR TITLE
[s] Fix cyberiad research windoor.

### DIFF
--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -81866,23 +81866,23 @@
 	id_tag = "Biohazard";
 	name = "Biohazard Shutter"
 	},
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
 /obj/machinery/navbeacon{
 	codes_txt = "delivery";
 	dir = 8;
 	location = "Research Division"
 	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/mule_bot{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/science/research{
-	dir = 8
-	},
 /obj/machinery/door/window/classic/reversed{
 	name = "Research Division Delivery";
-	dir = 8
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/mule_bot{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/science/research{
+	dir = 4
+	},
+/obj/structure/plasticflaps{
+	opacity = 1
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -81874,14 +81874,14 @@
 	dir = 8;
 	location = "Research Division"
 	},
-/obj/machinery/door/window/classic/reversed{
-	name = "Research Division Delivery";
-	dir = 4
-	},
 /obj/effect/mapping_helpers/airlock/windoor/access/any/supply/mule_bot{
 	dir = 8
 	},
 /obj/effect/mapping_helpers/airlock/windoor/access/any/science/research{
+	dir = 8
+	},
+/obj/machinery/door/window/classic/reversed{
+	name = "Research Division Delivery";
 	dir = 8
 	},
 /turf/simulated/floor/plating,


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fix research delivery windoor on cyberiad, it was rotated in wrong direction

## Why It's Good For The Game
oversight bad.

## Images of changes
[i am lazy, look at code]

## Testing
Rotated, VSC compiled, done.

## Changelog
:cl: Venuska1117
tweak: Rotate Cyberiad research delivery windoor to correct position.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
