### PR TITLE
Summon cheese no longer summons cheeseless cheese

### DIFF
--- a/code/game/objects/items/granters/action_granters/summon_cheese.dm
+++ b/code/game/objects/items/granters/action_granters/summon_cheese.dm
@@ -35,7 +35,7 @@
 	overlay = null
 	action_icon_state = "cheese_wedge"
 	action_background_icon_state = "bg_spell"
-	summon_type = list(/obj/item/reagent_containers/food/snacks/cheesewedge)
+	summon_type = list(/obj/item/reagent_containers/food/snacks/cheesewedge/presliced)
 	summon_amt = 9
 	aoe_range = 1
 	summon_ignore_prev_spawn_points = TRUE

--- a/code/modules/food_and_drinks/food/foods/ingredients.dm
+++ b/code/modules/food_and_drinks/food/foods/ingredients.dm
@@ -53,6 +53,9 @@
 	filling_color = "#FFF700"
 	tastes = list("cheese" = 1)
 
+/obj/item/reagent_containers/food/snacks/cheesewedge/presliced
+	list_reagents = list("nutriment" = 3, "vitamin" = 1, "cheese" = 4)
+	
 /obj/item/reagent_containers/food/snacks/weirdcheesewedge
 	name = "weird cheese"
 	desc = "Some kind of... gooey, messy, gloopy thing. Similar to cheese, but only in the broad sense of the word."


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Fixes a bug with summon cheese by adding a subtype of cheese wedge that has the cheese reagents pre-installed.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
I will never forget the moment I discovered this bug. I was walking down the hallways of the NSS cyberiad, and heard whispers of an explorer whom found magical treasures beyond belief. Lo and behold, a man dressed in a wizard costume appeared before me. I gasped, expected to be met with a swift end at the hands of an EI NATH!, but no such fate befell me. Instead, he simply spoke a short invocation. To my delight, he was quickly surrounded by cheese! In my delighted fervor, I very quickly picked up the wedge, only to find out that my beloved cheese slice contained no cheese at all, and simply vanished before my eyes! For a moment, I was stunned. "There's nothing left of the cheese wedge?" How could that be?! It was conjured in front of my very eyes! After the shock wore off, I wept, not just from the loss of what could have been, but because I knew at that moment that this tragedy would befall every single person who picked up one of those cheeses. I then swore I'd do my duty as a certified ParaDise Station Git Hub User to make sure no one ever has a cheeseless cheese experience in their life.
## Testing
<!-- How did you test the PR, if at all? -->
Checked the reagents list of the summoned cheese to make sure it had the reagents, also ate cheese, yommy.
## Changelog
:cl:
fix: Summoned cheese now has cheese in it
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
