### PR TITLE
Fix prayer breads making it actually smite clowns

### DIFF
--- a/code/__HELPERS/AnimationLibrary.dm
+++ b/code/__HELPERS/AnimationLibrary.dm
@@ -8,7 +8,12 @@
 	if(!istype(A) && !isclient(A))
 		return
 	A.color = null
-	animate(A, color = MATRIX_GREYSCALE, time = time, easing = SINE_EASING)
+	animate(A, color = MATRIX_GREYSCALE, time = time, easing = SINE_EASING, flags = ANIMATION_PARALLEL)
+
+/proc/animate_fade_colored(atom/A, time = 5)
+	if(!istype(A) && !isclient(A))
+		return
+	animate(A, color = null, time = time, easing = SINE_EASING, flags = ANIMATION_PARALLEL)
 
 /proc/animate_melt_pixel(atom/A)
 	if(!istype(A))

--- a/code/game/objects/items/weapons/holy_weapons.dm
+++ b/code/game/objects/items/weapons/holy_weapons.dm
@@ -611,19 +611,42 @@
 	icon = 'icons/obj/food/food.dmi'
 	icon_state = "baguette"
 	desc = "a staple of worshipers of the Silentfather, this holy mime artifact has an odd effect on clowns."
+	var/list/smited_clowns
+
+/obj/item/nullrod/rosary/bread/equipped(mob/user, slot, initial = FALSE)
+	. = ..()
+	if(ishuman(user) && (slot == SLOT_HUD_LEFT_HAND || slot == SLOT_HUD_RIGHT_HAND))
+		START_PROCESSING(SSobj, src)
+	else
+		STOP_PROCESSING(SSobj, src)
+
+/obj/item/nullrod/rosary/bread/dropped(mob/user, silent)
+	. = ..()
+	STOP_PROCESSING(SSobj, src)
+
+/obj/item/nullrod/rosary/bread/Destroy()
+	STOP_PROCESSING(SSobj, src)
+	for(var/clown in smited_clowns)
+		unsmite_clown(clown)
+	return ..()
 
 /obj/item/nullrod/rosary/bread/process()
-	if(ishuman(loc))
-		var/mob/living/carbon/human/holder = loc
-		//would like to make the holder mime if they have it in on thier person in general
-		if(src == holder.l_hand || src == holder.r_hand)
-			for(var/mob/living/carbon/human/H in range(5, loc))
-				if(H.mind.assigned_role == "Clown")
-					H.Silence(20 SECONDS)
-					animate_fade_grayscale(H,20)
-					if(prob(10))
-						to_chat(H, "<span class='userdanger'>Being in the presence of [holder]'s [src] is interfering with your honk!</span>")
+	var/mob/living/carbon/human/holder = loc
+	//would like to make the holder mime if they have it in on thier person in general
+	for(var/mob/living/carbon/human/H in range(5, loc))
+		if(H.mind.assigned_role == "Clown" && !LAZYACCESS(smited_clowns, H))
+			LAZYSET(smited_clowns, H, TRUE)
+			H.Silence(20 SECONDS)
+			animate_fade_grayscale(H, 2 SECONDS)
 
+			addtimer(CALLBACK(src, PROC_REF(unsmite_clown), H), 20 SECONDS)
+
+			if(prob(10))
+				to_chat(H, "<span class='userdanger'>Being in the presence of [holder]'s [src] is interfering with your honk!</span>")
+
+/obj/item/nullrod/rosary/bread/proc/unsmite_clown(mob/living/carbon/human/hell_spawn)
+	animate_fade_colored(hell_spawn, 2 SECONDS)
+	LAZYREMOVE(smited_clowns, hell_spawn)
 
 /obj/item/nullrod/missionary_staff
 	name = "holy staff"


### PR DESCRIPTION
## What Does This PR Do
Fixes #23039 and makes the item actually function somewhat properly.
If you just enable it, then the clown will be greyscaled forever. While funny, this is a bit too much I'd say.

One issue I found was that moving around as the clown would instantly zap you to greyscale or back. Don't have much time to look more into it sadly.

## Why It's Good For The Game
Fixes bugs

## Testing
Spawn as a clown and spawn prayer breads and hold it.
Equip it afterwards in my pockets or so and watch the clown turn normal again.
Drop it for the same effect
Delete it as well

## Changelog
:cl:
fix: Makes prayer breads actually work
/:cl: