### PR TITLE
Nerfs baton throwing

### DIFF
--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -24,6 +24,8 @@
 	var/cooldown = 3.5 SECONDS
 	/// the time it takes before the target falls over
 	var/knockdown_delay = 2.5 SECONDS
+	///Chance for the baton to stun when thrown at someone
+	var/throw_hit_chance = 35
 
 /obj/item/melee/baton/Initialize(mapload)
 	. = ..()
@@ -161,7 +163,7 @@
 
 /obj/item/melee/baton/throw_impact(mob/living/carbon/human/hit_mob)
 	. = ..()
-	if(!. && turned_on && istype(hit_mob))
+	if(!. && turned_on && istype(hit_mob) && prob(throw_hit_chance))
 		thrown_baton_stun(hit_mob)
 
 /obj/item/melee/baton/attack(mob/M, mob/living/user)
@@ -293,6 +295,7 @@
 	knockdown_duration = 6 SECONDS
 	w_class = WEIGHT_CLASS_BULKY
 	hitcost = 2000
+	throw_hit_chance = 10
 	slot_flags = SLOT_FLAG_BACK | SLOT_FLAG_BELT
 	var/obj/item/assembly/igniter/sparkler = null
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This makes stun baton throws only have a 35 percent chance to trigger the stun effect, otherwise it just deals brute. Stunprods only have a 10 percent chance, although these numbers are open to change. The effects of landing a hit are unchanged.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Right now baton throwing is being used as a minimal risk opener to ground your opponent for several seconds, apply 30 stamina damage, and some minorly debilitating confusion effects, providing an easy follow up from a partner, group, disabler shots, a glare, or other. In practice, its a better bola, the target can't effectively predict when a baton will be thrown and every hit guarantees the knockdown.

So why RNG. As throwing a baton is an active choice made by the thrower and not a forced component of combat, I think a bit of chance is appropriate here in limiting its effectiveness in combat. No one forces you to throw the baton and take that chance. I want throwing a baton to be a hail mary/last ditch move that can be used as a getaway or more of a silly play. With only a 35 percent chance to land, the odds are against the thrower and unlike previous iterations of RNG baton throwing, landing that roll does not completely end the targets fight, its potentially debilitating but not a move you can either count on or fully finish with. Ultimately, I want the interaction of just tossing an electrified stick to stay as I find it funny and in line with the atmosphere of the game, but I think it shouldn't be a potent guaranteed combat tool.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


## Testing
Spawned in, threw a lot of batons and prods and skrell, some were affected and some weren't.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Throwing a stunbaton only has a 35 percent chance to land the stun effect, otherwise it deals brute.
tweak: Throwing a stunprod only has a 10 percent chance to land the stun effect, otherwise it deals brute.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
