### PR TITLE
Changes the powerfist to work off pressure

### DIFF
--- a/code/game/objects/items/weapons/powerfist.dm
+++ b/code/game/objects/items/weapons/powerfist.dm
@@ -90,7 +90,7 @@
 	if(!tank)
 		to_chat(user, "<span class='warning'>[src] can't operate without a source of gas!</span>")
 		return
-	if(tank && !tank.air_contents.boolean_remove(((gasperfist * fisto_setting) * tank.air_contents.return_volume()) / (8.3145 * tank.air_contents.return_temperature())))
+	if(tank && !tank.air_contents.boolean_remove(((gasperfist * fisto_setting) * tank.air_contents.return_volume()) / (R_IDEAL_GAS_EQUATION * tank.air_contents.return_temperature())))
 		to_chat(user, "<span class='warning'>[src]'s piston-ram lets out a weak hiss, it needs more gas!</span>")
 		playsound(loc, 'sound/effects/refill.ogg', 50, 1)
 		return

--- a/code/game/objects/items/weapons/powerfist.dm
+++ b/code/game/objects/items/weapons/powerfist.dm
@@ -14,7 +14,8 @@
 	origin_tech = "combat=5;powerstorage=3;syndicate=3"
 	var/click_delay = 1.5
 	var/fisto_setting = 1
-	var/gasperfist = 0.5
+	///base pressure in kpa used by the powerfist per hit
+	var/gasperfist = 17.5
 	var/obj/item/tank/internals/tank = null //Tank used for the gauntlet's piston-ram.
 
 /obj/item/melee/powerfist/Destroy()
@@ -89,7 +90,7 @@
 	if(!tank)
 		to_chat(user, "<span class='warning'>[src] can't operate without a source of gas!</span>")
 		return
-	if(tank && !tank.air_contents.boolean_remove(gasperfist * fisto_setting))
+	if(tank && !tank.air_contents.boolean_remove(((gasperfist * fisto_setting) * tank.air_contents.return_volume()) / (8.3145 * tank.air_contents.return_temperature())))
 		to_chat(user, "<span class='warning'>[src]'s piston-ram lets out a weak hiss, it needs more gas!</span>")
 		playsound(loc, 'sound/effects/refill.ogg', 50, 1)
 		return


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Changes the powerfist to drain a set amount of pressure per hit instead of moles from the attached air tank. This means cooling down tanks will no longer provide additional hits. Pressure drain is kept the same.
Level 1: 58 hits
Level 2: 29 hits
Level 3: 19 hits
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Powerfist balance is dubiously based around a gas drain that is supposed to limit the amount of hits per level. This system works off of the moles inside of the tank instead of pressure, which would realistically be what generates the force. Draining moles means that if you cool down the air to increase the moles inside, a tank of the same pressure would provide a drastic increase in hits, effectively nullifying any cost per use and allowing the user to set it to the highest level all the time. At level 3, a tank at room temp(273 K) provides 19 hits, at 73 kelvin, you get 53 hits, and at 3 kelvin, you get 251. This scaling is absurd. With a pressure drain instead of a mole drain, max capacity tanks will all provide the same number of hits per level regardless of how many moles are stored inside. Ideally this will limit the use of level 3 or force the user to sacrifice a significant portion of their inventory to store tanks and require them to swap out more often in combat.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Spawned in, used both a room temp and cooled tank, counted hits per level, all added up as intended.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: The powerfist now uses a set amount of pressure per hit instead of moles of gas.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
