### PR TITLE
Gives drones respawnability, improves killing yourself as a drone

### DIFF
--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -63,6 +63,9 @@
 	//put em at -175
 	adjustOxyLoss(max(maxHealth * 2 - getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
 
+/mob/living/silicon/robot/drone/do_suicide()
+	shut_down()
+
 /mob/living/silicon/pai/do_suicide()
 	if(mobility_flags & MOBILITY_MOVE)
 		close_up()

--- a/code/modules/mob/living/silicon/robot/drone/maint_drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/maint_drone.dm
@@ -108,6 +108,7 @@
 
 	aiCamera = new /obj/item/camera/siliconcam/drone_camera(src)
 	additional_law_channels["Drone"] = ";"
+	ADD_TRAIT(src, TRAIT_RESPAWNABLE, UNIQUE_TRAIT_SOURCE(src))
 
 	playsound(loc, 'sound/machines/twobeep.ogg', 50)
 
@@ -220,7 +221,7 @@
 		SSticker.mode.replace_jobbanned_player(src, ROLE_SYNDICATE)
 
 	to_chat(src, "<span class='warning'>You feel a sudden burst of malware loaded into your execute-as-root buffer. Your tiny brain methodically parses, loads and executes the script. You sense you have <b>five minutes</b> before the drone server detects this and automatically shuts you down.</span>")
-
+	REMOVE_TRAIT(src, TRAIT_RESPAWNABLE, UNIQUE_TRAIT_SOURCE(src))
 	message_admins("[key_name_admin(user)] emagged drone [key_name_admin(src)].  Laws overridden.")
 	log_game("[key_name(user)] emagged drone [key_name(src)].  Laws overridden.")
 	var/time = time2text(world.realtime,"hh:mm:ss")
@@ -258,7 +259,6 @@
 /mob/living/silicon/robot/drone/death(gibbed)
 	. = ..(gibbed)
 	adjustBruteLoss(health)
-
 
 //CONSOLE PROCS
 /mob/living/silicon/robot/drone/proc/law_resync()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Gives drones respawnability, gets removed if the drone gets emmaged
Drones shut off when suiciding

## Why It's Good For The Game
Drones are already an observer like role so I don't really see a reason they shouldn't be able to join as a ghost role if one ends up happening, not like they can share any information on what's going on with them.
Drones now shut off when suiciding, generally more consistent than oxyloss

## Testing
Suicided as a drone, still thinking if I really need to make an override for some drone dusting stuff

## Changelog
:cl:
tweak: Drones can respawn while in round
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
