### PR TITLE
Nerfs the basic plasma cutter. Yep.

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/medical_lockers.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical_lockers.dm
@@ -215,7 +215,7 @@
 	new /obj/item/fulton_core(src)
 	new /obj/item/extraction_pack(src)
 	new /obj/item/gps/mining(src)
-	new /obj/item/gun/energy/plasmacutter(src)
+	new /obj/item/pickaxe/drill(src)
 
 /obj/structure/closet/secure_closet/reagents
 	name = "chemical storage closet"

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -239,7 +239,7 @@
   * * redeemer - The person holding it
   */
 /obj/machinery/mineral/equipment_vendor/proc/redeem_voucher(obj/item/mining_voucher/voucher, mob/redeemer)
-	var/items = list("Survival Capsule and Explorer's Webbing", "Resonator Kit", "Minebot Kit", "Extraction and Rescue Kit", "Crusher Kit", "Plasma Cutter Kit", "Jaunter Kit", "Mining Conscription Kit")
+	var/items = list("Survival Capsule and Explorer's Webbing", "Resonator Kit", "Minebot Kit", "Extraction and Rescue Kit", "Crusher Kit", "Plasma Cutter", "Jaunter Kit", "Mining Conscription Kit")
 
 	var/selection = input(redeemer, "Pick your equipment", "Mining Voucher Redemption") as null|anything in items
 	if(!selection || !Adjacent(redeemer) || QDELETED(voucher) || voucher.loc != redeemer)
@@ -263,9 +263,8 @@
 		if("Crusher Kit")
 			new /obj/item/extinguisher/mini(drop_location)
 			new /obj/item/kinetic_crusher(drop_location)
-		if("Plasma Cutter Kit")
+		if("Plasma Cutter")
 			new /obj/item/gun/energy/plasmacutter(drop_location)
-			new /obj/item/survivalcapsule(drop_location)
 		if("Jaunter Kit")
 			new /obj/item/wormhole_jaunter(drop_location)
 			new /obj/item/stack/medical/bruise_pack/advanced(drop_location)

--- a/code/modules/projectiles/ammunition/energy_lens.dm
+++ b/code/modules/projectiles/ammunition/energy_lens.dm
@@ -178,7 +178,7 @@
 	select_name = "plasma burst"
 	fire_sound = 'sound/weapons/plasma_cutter.ogg'
 	delay = 15
-	e_cost = 25
+	e_cost = 75
 
 /obj/item/ammo_casing/energy/plasma/adv
 	projectile_type = /obj/item/projectile/plasma/adv


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicilty asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
- triples the charge required to fire one shot with the BASIC (read: **NOT ADVANCED**) plasma cutter. This means you now only get 13 shots (and 2% left) from a full mag. 
- removes a bonus shelter capsule from the plasma cutter kit (also renames it to just "plasma cutter")
- gives paramed a drill instead of a cutter
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Remember #22153? I have SEVERELY underestimated basic cutter's power. I have, accidently, created a new meta and I'm not sure whether I like it.
I thought a while about how to make it more balanced - my idea was messing with it's charge.
The more a shot costs, the more you have to recharge. The more you have to recharge, the more plasma you waste. The more plasma you waste, the less points you get from ORM.
I don't want to fully kill the option - I just want to make it have SOME kind of a downside. Maybe it will still be meta, who knows. We'll see.

An alternative to this would be decreasing power gained from a plasma sheet, which is actually less of an early game nerf, so not exactly what I'm trying to do here.

As for the free shelter capsule removal - it was NEVER needed. I added it in fear this beast will be too weak, which was rather foolish of me now that I think about it.

I've been reminded in discord that paramed also gets a plasma cutter - since it will be worthless for paramed after the nerf, most people seemed to agree that they can just get a drill instead.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Spawned in, redeemed my voucher for a cutter, shot into the void a bit.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
del: removed the free shelter capsule from plasma cutter kit in mining vendors
tweak: basic plasma cutter now takes 3x the charge to fire
tweak: paramedic now gets a drill instead of a plasma cutter
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
