### PR TITLE
Philly Cheeseteak now correctly uses Onion

### DIFF
--- a/code/modules/food_and_drinks/recipes/recipes_microwave.dm
+++ b/code/modules/food_and_drinks/recipes/recipes_microwave.dm
@@ -548,7 +548,7 @@
 		/obj/item/reagent_containers/food/snacks/breadslice,
 		/obj/item/reagent_containers/food/snacks/cutlet,
 		/obj/item/reagent_containers/food/snacks/cheesewedge,
-		/obj/item/reagent_containers/food/snacks/grown/cabbage
+		/obj/item/reagent_containers/food/snacks/grown/onion
 	)
 	result = /obj/item/reagent_containers/food/snacks/philly_cheesesteak
 


### PR DESCRIPTION
## What Does This PR Do
It fixes my 2 AM coding error. Philly Cheesesteak uses Onion instead of Cabbage.

## Why It's Good For The Game
Who the hell eats Cabbage on a Philly?

## Testing
1. I used an onion.

## Changelog
:cl:
fix: Philly Cheesesteak now correctly uses onions instead of cabbages.
/:cl: