### PR TITLE
Fixes slime people physique not showing

### DIFF
--- a/code/modules/mob/living/carbon/human/human_examine.dm
+++ b/code/modules/mob/living/carbon/human/human_examine.dm
@@ -54,7 +54,11 @@
 				break
 	if(skip_jumpsuit && skip_face || HAS_TRAIT(src, TRAIT_NOEXAMINE)) //either obscured or on the nospecies list
 		msg += "!"    //omit the species when examining
-	else if(displayed_species == "Slime People") //snowflakey because Slime People are defined as a plural
+	else
+		var/species_name =  lowertext(displayed_species)
+		if(displayed_species == "Slime People") //snowflakey because Slime People are defined as a plural
+			species_name = "slime person"
+		msg += ", \a [height]<b><font color='[examine_color]'> [species_name]</font></b> with \a [physique] physique!"
 		msg += ", \a [height]<b><font color='[examine_color]'> slime person</font></b> with \a [physique] physique!"
 	else
 		msg += ", \a [height]<b><font color='[examine_color]'> [lowertext(displayed_species)]</font></b> with \a [physique] physique!" //Look I know it uses physique twice, lets not think about it too much ok?

--- a/code/modules/mob/living/carbon/human/human_examine.dm
+++ b/code/modules/mob/living/carbon/human/human_examine.dm
@@ -59,9 +59,6 @@
 		if(displayed_species == "Slime People") //snowflakey because Slime People are defined as a plural
 			species_name = "slime person"
 		msg += ", \a [height]<b><font color='[examine_color]'> [species_name]</font></b> with \a [physique] physique!"
-		msg += ", \a [height]<b><font color='[examine_color]'> slime person</font></b> with \a [physique] physique!"
-	else
-		msg += ", \a [height]<b><font color='[examine_color]'> [lowertext(displayed_species)]</font></b> with \a [physique] physique!" //Look I know it uses physique twice, lets not think about it too much ok?
 	return msg
 
 /mob/living/carbon/human/examine_start_damage_block(skip_gloves = FALSE, skip_suit_storage = FALSE, skip_jumpsuit = FALSE, skip_shoes = FALSE, skip_mask = FALSE, skip_ears = FALSE, skip_eyes = FALSE, skip_face = FALSE)

--- a/code/modules/mob/living/carbon/human/human_examine.dm
+++ b/code/modules/mob/living/carbon/human/human_examine.dm
@@ -55,7 +55,7 @@
 	if(skip_jumpsuit && skip_face || HAS_TRAIT(src, TRAIT_NOEXAMINE)) //either obscured or on the nospecies list
 		msg += "!"    //omit the species when examining
 	else if(displayed_species == "Slime People") //snowflakey because Slime People are defined as a plural
-		msg += ", a<b><font color='[examine_color]'> slime person</font></b>!"
+		msg += ", \a [height]<b><font color='[examine_color]'> slime person</font></b> with \a [physique] physique!"
 	else
 		msg += ", \a [height]<b><font color='[examine_color]'> [lowertext(displayed_species)]</font></b> with \a [physique] physique!" //Look I know it uses physique twice, lets not think about it too much ok?
 	return msg


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Title
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
There's no good reason to exclude slime people from this system (and, most likely, it was not intentional for them to be excluded)
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Loaded in, examined myself, CMA'd into a slime, examined myself again
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: You can now see slime people's physiques
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
