### PR TITLE
Fixes Sweet and Sour Chickenballs icon

### DIFF
--- a/code/modules/food_and_drinks/food/foods/ethnic.dm
+++ b/code/modules/food_and_drinks/food/foods/ethnic.dm
@@ -65,6 +65,7 @@
 /obj/item/reagent_containers/food/snacks/chinese/sweetsourchickenball
 	name = "sweet & sour chicken balls"
 	desc = "Is this chicken cooked? The odds are better than wok paper scissors."
+	icon = 'icons/obj/food/soupsalad.dmi'
 	icon_state = "chickenball"
 	item_state = "chinese3"
 	junkiness = 25


### PR DESCRIPTION
## What Does This PR Do
I didn't realize that the sweet and sour meatballs was a vendor food or coded to have an icon of it showing in the Chang vendor. This makes it show a proper icon instead of a broken sprite sheet.

Fixes #23100 

## Why It's Good For The Game
Broken spritesheet bad.

## Testing
I loaded the game and clicked the vendor.

## Changelog
:cl:
fix: Mr. Chang now correctly displays an icon for Sweet and Sour Chickenballs
/:cl:
