### PR TITLE
Clowns now need banana juice in them to be slippery.

### DIFF
--- a/code/game/jobs/job/support.dm
+++ b/code/game/jobs/job/support.dm
@@ -320,7 +320,7 @@
 		H.dna.default_blocks.Add(GLOB.comicblock)
 	H.check_mutations = TRUE
 	H.add_language("Clownish")
-	H.AddComponent(/datum/component/slippery, H, 8 SECONDS, 100, 0, FALSE, TRUE, "slip", TRUE)
+	///H.AddComponent(/datum/component/slippery, H, 8 SECONDS, 100, 0, FALSE, TRUE, "slip", TRUE)
 
 //action given to antag clowns
 /datum/action/innate/toggle_clumsy

--- a/code/modules/reagents/chemistry/reagents/drinks_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks_reagents.dm
@@ -183,7 +183,14 @@
 	if(HAS_TRAIT(M, TRAIT_COMIC_SANS) || issmall(M))
 		update_flags |= M.adjustBruteLoss(-1, FALSE)
 		update_flags |= M.adjustFireLoss(-1, FALSE)
+	if(M.mind.assigned_role == "Clown")
+		M.AddComponent(/datum/component/slippery, M, 8 SECONDS, 100, 0, FALSE, TRUE, "slip", TRUE)
+
 	return ..() | update_flags
+
+/datum/reagent/consumable/drink/banana/on_mob_delete(mob/living/M)
+	qdel(M.GetComponent(/datum/component/slippery))
+	return
 
 /datum/reagent/consumable/drink/nothing
 	name = "Nothing"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Pretty much the title.
As a clown you need banana juice(that you spawn with) to be slippery.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Ever since the passive slippery pr was merged, the amount of pain and griefing i've seen some clowns do constantly is absurd.
While some of it can be actually funny, Most of it involves slipping people in dire situations, be it intentionally or out of malice, theres also the lavaland side of things, having a body that can slip you on lavaland is VERY annoying, and frankly not needed..

## Testing
<!-- How did you test the PR, if at all? -->
Spawned in as a clown, swapped to a spawned mob, shoved the clown over, checked if slippery, swapped back to the clown, drank some nana juice, checked if slippery, waited for the juice to go away, checked if it was removed.

Its worth noting that for whatever reason the mind isn't assigned as "Clown" if you've been player panel spawned in as the job clown, and making it go off of the same as healing isn't really ideal. Im not entirely sure why this is the case, but attending to that is somewhat out of the scope of this pr.

## Changelog
:cl:
tweak: Clowns are no longer passively slippery, and now need to drink banana juice to be slippery again. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
