### PR TITLE
CPR effectiveness messages now properly reflect effectiveness

### DIFF
--- a/code/modules/mob/living/carbon/human/human_mob.dm
+++ b/code/modules/mob/living/carbon/human/human_mob.dm
@@ -1709,7 +1709,7 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 			SEND_SIGNAL(H, COMSIG_HUMAN_RECEIVE_CPR, (new_time SECONDS))
 
 			if(prob(5))
-				if(timer_restored > 4 SECONDS)
+				if(timer_restored >= 4 SECONDS)
 					to_chat(src, pick(effective_cpr_messages))
 				else
 					to_chat(src, pick(ineffective_cpr_messages))

--- a/code/modules/mob/living/carbon/human/human_mob.dm
+++ b/code/modules/mob/living/carbon/human/human_mob.dm
@@ -1709,7 +1709,7 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 			SEND_SIGNAL(H, COMSIG_HUMAN_RECEIVE_CPR, (new_time SECONDS))
 
 			if(prob(5))
-				if(timer_restored >= 4 SECONDS)
+				if(timer_restored >= CPR_BREATHS_RESTORATION)
 					to_chat(src, pick(effective_cpr_messages))
 				else
 					to_chat(src, pick(ineffective_cpr_messages))


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
There are two sets of positive and negative flavor messages you can occasionally get while giving CPR, depending on how effective the CPR is - except due to a bug only the negative set would ever show up. This PR fixes this so the proper message shows up during effective CPR.
Fixes: #23004
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Immersion restored.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

- Kill someone
- Start doing CPR with chest compressions and rescue breaths
- Observe the positive flavor messages

<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: CPR effectiveness messages now properly reflect effectiveness
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
