### PR TITLE
Morgue tray now updates properly

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -450,8 +450,13 @@
 #define COMSIG_LIVING_FIRE_TICK "living_fire_tick"
 //sent from living mobs when they are ahealed
 #define COMSIG_LIVING_AHEAL "living_aheal"
+//sent from mobs when they exit their body as a ghost
+#define COMSIG_LIVING_GHOSTIZED "ghostized"
+//sent from mobs when they re-enter their body as a ghost
+#define COMSIG_LIVING_REENTERED_BODY "reentered_body"
+//sent from a mob when they set themselves to DNR
+#define COMSIG_LIVING_SET_DNR "set_dnr"
 
-#define COMSIG_LIVING_UPDATE_REVIVABILITY "revivablity"
 
 //ALL OF THESE DO NOT TAKE INTO ACCOUNT WHETHER AMOUNT IS 0 OR LOWER AND ARE SENT REGARDLESS!
 // none of these are called as of right now, as there is nothing listening for them.

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -451,6 +451,8 @@
 //sent from living mobs when they are ahealed
 #define COMSIG_LIVING_AHEAL "living_aheal"
 
+#define COMSIG_LIVING_UPDATE_REVIVABILITY "revivablity"
+
 //ALL OF THESE DO NOT TAKE INTO ACCOUNT WHETHER AMOUNT IS 0 OR LOWER AND ARE SENT REGARDLESS!
 // none of these are called as of right now, as there is nothing listening for them.
 ///from base of mob/living/Stun() (amount, ignore_canstun)

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -54,9 +54,13 @@
 		return
 
 	if(closing)
-		RegisterSignal(M, COMSIG_LIVING_UPDATE_REVIVABILITY, PROC_REF(update_state))
+		RegisterSignal(M, COMSIG_LIVING_GHOSTIZED, PROC_REF(update_state))
+		RegisterSignal(M, COMSIG_LIVING_REENTERED_BODY, PROC_REF(update_state))
+		RegisterSignal(M, COMSIG_LIVING_SET_DNR, PROC_REF(update_state))
 	else
-		UnregisterSignal(M, COMSIG_LIVING_UPDATE_REVIVABILITY)
+		UnregisterSignal(M, COMSIG_LIVING_GHOSTIZED)
+		UnregisterSignal(M, COMSIG_LIVING_REENTERED_BODY)
+		UnregisterSignal(M, COMSIG_LIVING_SET_DNR)
 
 /obj/structure/morgue/proc/update_state()
 	if(connected)

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -44,38 +44,37 @@
 	set_light(1, LIGHTING_MINIMUM_POWER)
 
 /obj/structure/morgue/proc/update_state()
-	. = UPDATE_OVERLAYS
-
 	if(connected)
 		status = EXTENDED_TRAY
+		return update_icon(UPDATE_OVERLAYS)
 
-	else if(!length(contents))
+	if(!length(contents))
 		status = EMPTY_MORGUE
+		return update_icon(UPDATE_OVERLAYS)
 
-	else
-		var/mob/living/M = locate() in contents
-		var/obj/structure/closet/body_bag/B = locate() in contents
+	var/mob/living/M = locate() in contents
+	var/obj/structure/closet/body_bag/B = locate() in contents
 
-		if(!M)
-			M = locate() in B
+	if(!M)
+		M = locate() in B.contents
 
-		if(!M)
-			status = NOT_BODY
+	if(!M)
+		status = NOT_BODY
+		return update_icon(UPDATE_OVERLAYS)
+
+	var/mob/dead/observer/G = M.get_ghost()
+
+	if(M.mind && !M.mind.suicided && !M.suiciding)
+		if(M.client)
+			status = REVIVABLE
 			return update_icon(UPDATE_OVERLAYS)
 
-		var/mob/dead/observer/G = M.get_ghost()
+		if(G && G.client) //There is a ghost and it is connected to the server
+			status = GHOST_CONNECTED
+			return update_icon(UPDATE_OVERLAYS)
 
-		status = UNREVIVABLE
-
-		if(M.mind && !M.mind.suicided && !M.suiciding)
-			if(M.client)
-				status = REVIVABLE
-
-			else if(G && G.client) //There is a ghost and it is connected to the server
-				status = GHOST_CONNECTED
-
+	status = UNREVIVABLE
 	update_icon(UPDATE_OVERLAYS)
-
 
 /obj/structure/morgue/update_overlays()
 	. = ..()
@@ -129,7 +128,7 @@
 		connect()
 
 	add_fingerprint(user)
-	update_icon(update_state())
+	update_state()
 	return
 
 /obj/structure/morgue/attackby(P as obj, mob/user as mob, params)

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -48,34 +48,34 @@
 
 	if(connected)
 		status = EXTENDED_TRAY
-		return
 
-	if(!length(contents))
+	else if(!length(contents))
 		status = EMPTY_MORGUE
-		return
 
-	var/mob/living/M = locate() in contents
-	var/obj/structure/closet/body_bag/B = locate() in contents
+	else
+		var/mob/living/M = locate() in contents
+		var/obj/structure/closet/body_bag/B = locate() in contents
 
-	if(!M)
-		M = locate() in B
+		if(!M)
+			M = locate() in B
 
-	if(!M)
-		status = NOT_BODY
-		return
+		if(!M)
+			status = NOT_BODY
+			return update_icon(UPDATE_OVERLAYS)
 
-	var/mob/dead/observer/G = M.get_ghost()
+		var/mob/dead/observer/G = M.get_ghost()
 
-	if(M.mind && !M.mind.suicided && !M.suiciding)
-		if(M.client)
-			status = REVIVABLE
-			return
+		status = UNREVIVABLE
 
-		if(G && G.client) //There is a ghost and it is connected to the server
-			status = GHOST_CONNECTED
-			return
+		if(M.mind && !M.mind.suicided && !M.suiciding)
+			if(M.client)
+				status = REVIVABLE
 
-	status = UNREVIVABLE
+			else if(G && G.client) //There is a ghost and it is connected to the server
+				status = GHOST_CONNECTED
+
+	update_icon(UPDATE_OVERLAYS)
+
 
 /obj/structure/morgue/update_overlays()
 	. = ..()

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -43,6 +43,21 @@
 	update_icon(update_state())
 	set_light(1, LIGHTING_MINIMUM_POWER)
 
+/obj/structure/morgue/proc/get_revivable(closing)
+	var/mob/living/M = locate() in contents
+	var/obj/structure/closet/body_bag/B = locate() in contents
+
+	if(!M)
+		M = locate() in B
+
+	if(!M)
+		return
+
+	if(closing)
+		RegisterSignal(M, COMSIG_LIVING_UPDATE_REVIVABILITY, PROC_REF(update_state))
+	else
+		UnregisterSignal(M, COMSIG_LIVING_UPDATE_REVIVABILITY)
+
 /obj/structure/morgue/proc/update_state()
 	if(connected)
 		status = EXTENDED_TRAY
@@ -56,7 +71,7 @@
 	var/obj/structure/closet/body_bag/B = locate() in contents
 
 	if(!M)
-		M = locate() in B.contents
+		M = locate() in B
 
 	if(!M)
 		status = NOT_BODY
@@ -119,12 +134,14 @@
 /obj/structure/morgue/attack_hand(mob/user as mob)
 	if(connected)
 		for(var/atom/movable/A in connected.loc)
-			if(!( A.anchored ))
+			if(!(A.anchored))
 				A.forceMove(src)
+		get_revivable(TRUE)
 		playsound(loc, open_sound, 50, 1)
 		QDEL_NULL(connected)
 	else
 		playsound(loc, open_sound, 50, 1)
+		get_revivable(FALSE)
 		connect()
 
 	add_fingerprint(user)

--- a/code/modules/mob/dead/observer/observer_base.dm
+++ b/code/modules/mob/dead/observer/observer_base.dm
@@ -294,7 +294,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 	mind.current.key = key
 
-	SEND_SIGNAL(src, COMSIG_LIVING_UPDATE_REVIVABILITY)
+	SEND_SIGNAL(mind.current, COMSIG_LIVING_UPDATE_REVIVABILITY)
 
 	return 1
 

--- a/code/modules/mob/dead/observer/observer_base.dm
+++ b/code/modules/mob/dead/observer/observer_base.dm
@@ -294,11 +294,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 	mind.current.key = key
 
-	var/obj/structure/morgue/Morgue = locate() in mind.current.loc
-	if(istype(mind.current.loc,/obj/structure/morgue))
-		Morgue = mind.current.loc
-	if(Morgue)
-		Morgue.update_state()
+	SEND_SIGNAL(src, COMSIG_LIVING_UPDATE_REVIVABILITY)
 
 	return 1
 

--- a/code/modules/mob/dead/observer/observer_base.dm
+++ b/code/modules/mob/dead/observer/observer_base.dm
@@ -294,7 +294,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 	mind.current.key = key
 
-	SEND_SIGNAL(mind.current, COMSIG_LIVING_UPDATE_REVIVABILITY)
+	SEND_SIGNAL(mind.current, COMSIG_LIVING_REENTERED_BODY)
 
 	return 1
 
@@ -397,6 +397,8 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		can_reenter_corpse = FALSE
 		if(!QDELETED(mind.current)) // Could change while they're choosing
 			mind.current.remove_status_effect(STATUS_EFFECT_REVIVABLE)
+		SEND_SIGNAL(mind.current, COMSIG_LIVING_SET_DNR)
+		
 
 /mob/dead/observer/proc/dead_tele()
 	set category = "Ghost"

--- a/code/modules/mob/dead/observer/observer_base.dm
+++ b/code/modules/mob/dead/observer/observer_base.dm
@@ -239,13 +239,6 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		// Respawnable
 		ghostize(1)
 
-	// If mob in morgue tray, update tray
-	var/obj/structure/morgue/Morgue = locate() in M.loc
-	if(istype(M.loc, /obj/structure/morgue))
-		Morgue = M.loc
-	if(Morgue)
-		Morgue.update_state()
-
 	// If mob in cryopod, despawn mob
 	if(P)
 		if(!P.control_computer)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -59,12 +59,7 @@
 	if(.)
 		if(ranged_ability && prev_client)
 			ranged_ability.remove_mousepointer(prev_client)
-	// If mob in morgue tray, update tray
-	var/obj/structure/morgue/Morgue = locate() in loc
-	if(istype(loc, /obj/structure/morgue))
-		Morgue = loc
-	if(Morgue)
-		Morgue.update_state()
+	SEND_SIGNAL(src, COMSIG_LIVING_UPDATE_REVIVABILITY)
 
 /mob/living/proc/OpenCraftingMenu()
 	return

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -59,7 +59,7 @@
 	if(.)
 		if(ranged_ability && prev_client)
 			ranged_ability.remove_mousepointer(prev_client)
-	SEND_SIGNAL(src, COMSIG_LIVING_UPDATE_REVIVABILITY)
+	SEND_SIGNAL(src, COMSIG_LIVING_GHOSTIZED)
 
 /mob/living/proc/OpenCraftingMenu()
 	return

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -59,6 +59,12 @@
 	if(.)
 		if(ranged_ability && prev_client)
 			ranged_ability.remove_mousepointer(prev_client)
+	// If mob in morgue tray, update tray
+	var/obj/structure/morgue/Morgue = locate() in loc
+	if(istype(loc, /obj/structure/morgue))
+		Morgue = loc
+	if(Morgue)
+		Morgue.update_state()
 
 /mob/living/proc/OpenCraftingMenu()
 	return


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Morgue tray now updates properly when you re-enter/exit your body.
Fixes: #22876

Currently a draft PR so I can fix some remaining issues

- [x] Update morgue tray state when you DNR
- [x] Use signals to update the morgue tray instead of checking whether we are in a morgue

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Morgue trays should accurately represent whether the corpse inside is currently revivable, or could viably be revived in the future.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Enter a morgue tray and die.
Morgue tray light is now green.
Exit my corpse.
Morgue tray light is now purple.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Morgue tray now updates properly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
