### PR TITLE
Fixes FLIP_DIR_HORIZONTALLY/VERTICALLY

### DIFF
--- a/code/__DEFINES/directions.dm
+++ b/code/__DEFINES/directions.dm
@@ -16,9 +16,9 @@
 /// hence  EAST (0010) XOR EAST|WEST (0011) --> WEST (0001)
 
 ///Flips a direction along the horizontal axis, will convert E -> W, W -> E, NE -> NW, SE -> SW, etc
-#define FLIP_DIR_HORIZONTALLY(dir) (dir ^ (EAST|WEST))
+#define FLIP_DIR_HORIZONTALLY(dir) ((dir & (EAST|WEST)) ? dir ^ (EAST|WEST) : dir)
 ///Flips a direction along the vertical axis, will convert N -> S, S -> N, NE -> SE, SW -> NW, etc
-#define FLIP_DIR_VERTICALLY(dir) (dir ^ (NORTH|SOUTH))
+#define FLIP_DIR_VERTICALLY(dir) ((dir & (NORTH|SOUTH)) ? dir ^ (NORTH|SOUTH) : dir)
 
 /// for directions, each cardinal direction only has 1 TRUE bit, so `1000` or `0100` for example, so when you subtract 1
 /// from a cardinal direction it results in that directions initial TRUE bit always switching to FALSE, so if you & check it


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes it so that FLIP_DIR no longer works unreliably when the dir does not contain east/west or north/south.
Fixes: #22331
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Define should work reliably.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
![image](https://github.com/ParadiseSS13/Paradise/assets/19361017/d4bc2c5d-03ef-49ec-b60d-29e7faf87675)

<!-- How did you test the PR, if at all? -->

## Changelog
NPFC.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
