### PR TITLE
Makes gauze/ointment craftable; refactors a bit of crafting code

### DIFF
--- a/code/modules/crafting/craft.dm
+++ b/code/modules/crafting/craft.dm
@@ -195,8 +195,8 @@
 /datum/personal_crafting/proc/requirements_deletion(datum/crafting_recipe/recipe, mob/user)
 	var/list/surroundings = get_environment(user)
 	var/list/parts_used = list()
-	var/list/reagent_containers_for_deletion = list()
 	var/list/item_stacks_for_deletion = list()
+	var/list/reagent_list_for_deletion = list()
 
 	for(var/thing in recipe.reqs)
 		var/needed_amount = recipe.reqs[thing]
@@ -206,13 +206,13 @@
 				part_reagent = new thing()
 				parts_used += part_reagent
 
-			for(var/obj/item/reagent_containers/container in (surroundings - reagent_containers_for_deletion))
+			for(var/obj/item/reagent_containers/container in surroundings)
 				var/datum/reagent/contained_reagent = container.reagents.get_reagent(thing)
 				if(!contained_reagent)
 					continue
 
 				var/extracted_amount = min(contained_reagent.volume, needed_amount)
-				reagent_containers_for_deletion[container] = list(contained_reagent, extracted_amount)
+				reagent_list_for_deletion[thing] += list(list(container, extracted_amount))
 				part_reagent.volume += extracted_amount
 				part_reagent.data += contained_reagent.data
 				needed_amount -= extracted_amount
@@ -258,16 +258,12 @@
 					continue
 				parts_used += part_atom
 
-	for(var/obj/item/reagent_containers/container_to_clear as anything in reagent_containers_for_deletion)
-		var/datum/reagent/reagent_to_delete = reagent_containers_for_deletion[container_to_clear][1]
-		var/amount_to_delete = reagent_containers_for_deletion[container_to_clear][2]
+	for(var/datum/reagent/reagent_to_delete as anything in reagent_list_for_deletion)
+		for(var/list/reagent_info in reagent_list_for_deletion[reagent_to_delete])
+			var/obj/item/reagent_containers/container = reagent_info[1]
+			var/amount_to_delete = reagent_info[2]
 
-		if(amount_to_delete < reagent_to_delete.volume)
-			reagent_to_delete.volume -= amount_to_delete
-		else
-			container_to_clear.reagents.reagent_list -= reagent_to_delete
-		container_to_clear.reagents.conditional_update(container_to_clear)
-		container_to_clear.update_icon()
+			container.reagents.remove_reagent(reagent_to_delete.id, amount_to_delete)
 
 	for(var/obj/item/stack/stack_to_delete as anything in item_stacks_for_deletion)
 		var/amount_to_delete = item_stacks_for_deletion[stack_to_delete]

--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -1354,7 +1354,7 @@
 	subcategory = CAT_LARGE_DECORATIONS
 
 /datum/crafting_recipe/gauze
-	name = "Treated Gauze"
+	name = "Treated gauze"
 	time = 3 SECONDS
 	result = list(/obj/item/stack/medical/bruise_pack)
 	reqs = list(/obj/item/stack/medical/bruise_pack/improvised = 6,

--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -1352,3 +1352,22 @@
 				/obj/item/toy/crayon/red)
 	category = CAT_DECORATIONS
 	subcategory = CAT_LARGE_DECORATIONS
+
+/datum/crafting_recipe/gauze
+	name = "Treated Gauze"
+	time = 3 SECONDS
+	result = list(/obj/item/stack/medical/bruise_pack)
+	reqs = list(/obj/item/stack/medical/bruise_pack/improvised = 6,
+				/datum/reagent/medicine/styptic_powder = 30,
+				/datum/reagent/medicine/sterilizine = 10)
+	category = CAT_MISC
+
+/datum/crafting_recipe/ointment
+	name = "Ointment"
+	time = 3 SECONDS
+	result = list(/obj/item/stack/medical/ointment)
+	reqs = list(/obj/item/stack/sheet/plastic = 2,
+				/datum/reagent/water = 10,
+				/datum/reagent/medicine/silver_sulfadiazine = 30,
+				/datum/reagent/medicine/sterilizine = 10)
+	category = CAT_MISC

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -620,6 +620,7 @@
 		/obj/item/reagent_containers/applicator,
 		/obj/item/storage/pill_bottle,
 		/obj/item/reagent_containers/food/pill,
+		/obj/item/stack/medical
 	))
 
 /**

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -581,6 +581,7 @@
 		/obj/item/reagent_containers/applicator,
 		/obj/item/storage/pill_bottle,
 		/obj/item/reagent_containers/food/pill,
+		/obj/item/stack/medical
 	))
 
 /**


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Title. Improvised gauze (from cloth) can be treated with medicine and made into normal gauze (which heals damages on application), and ointment can be crafted with plastic and some reagents.
### Gauze Recipe
- 6 Improvised Gauze
- 30u Styptic Powder
- 10u Sterilizine
... makes 6 normal gauze

### Ointment Recipe
- 2 Plastic Sheets
- 10u Water
- 30u Silver Sulfadiazine
- 10u Sterilizine
... makes 6 ointment

The PR also refactors crafting code to properly work with multiple reagents and allows `/obj/item/stack/medical` to be put in medical smartfridges.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Giving medchem more to make than patches and pills is good, and gauze/ointment are useful alternatives to straight styptic powder/silver sulfadiazine patches. Sterilizine is also a chemical that doesn't see much use, and this application makes sense for it (to sterilize the cloth and to sterilize burn wounds).
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Loaded in, made gauze, made ointment, tried various combinations of beakers and ensured they all drained properly, crafted FRAG-12
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
add: You can now craft (non-improvised) gauze and ointment!
add: All medical stacks can now be added to medical smartfridges; gauze, ointment, adv. trauma kits, etc
fix: Fixed some peculiar behavior in recipes with multiple reagent components
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
