### PR TITLE
Bugfix/issue 22899/vendor restocking unit's description is misleading

### DIFF
--- a/code/game/objects/items/weapons/vending_items.dm
+++ b/code/game/objects/items/weapons/vending_items.dm
@@ -44,10 +44,8 @@
 	for(var/key in premium)
 		. += premium[key]
 
-	if (. > 30)
+	if(. > 30)
 		return INFINITY
-	else
-		return .
 
 /obj/item/vending_refill/boozeomat
 	machine_name = "Booze-O-Mat"

--- a/code/game/objects/items/weapons/vending_items.dm
+++ b/code/game/objects/items/weapons/vending_items.dm
@@ -36,8 +36,6 @@
 		. += "It can restock [num] item\s."
 
 /obj/item/vending_refill/get_part_rating()
-	if (!products || !contraband || !premium)
-		return INFINITY
 	. = 0
 	for(var/key in products)
 		. += products[key]
@@ -45,6 +43,11 @@
 		. += contraband[key]
 	for(var/key in premium)
 		. += premium[key]
+
+	if (. > 30)
+		return INFINITY
+	else
+		return .
 
 /obj/item/vending_refill/boozeomat
 	machine_name = "Booze-O-Mat"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Changes the vendor units code so that the description isn't set as full in every case, sealed tight when there's more than 30 items (arbitrary number), lists the number of items when there's less than 30 and more than zero and finally when there's 0 items it has the empty description.
Fixes #22899 
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Removes a misleading description
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<img width="277" alt="when there's more than 30 items" src="https://github.com/ParadiseSS13/Paradise/assets/42347687/7b90a214-a1cc-4e22-8f65-ce8043bb0b42">
<img width="275" alt="less than 30 items" src="https://github.com/ParadiseSS13/Paradise/assets/42347687/88f6b0cb-46d8-4e4e-9d45-63c37ffec2ee">
<img width="275" alt="0 items" src="https://github.com/ParadiseSS13/Paradise/assets/42347687/345193e3-e707-4e2c-ba6e-c56ece0f23d2">

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Compiled with no errors and I tested it on a nanomed vendor in medbay, worked as expected.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Fixes the vendor restock unit description always being full
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
