### PR TITLE
Silicon un-bolting is now instant. Bolting doors down is not affected.

### DIFF
--- a/code/_onclick/ai_onclick.dm
+++ b/code/_onclick/ai_onclick.dm
@@ -179,7 +179,7 @@
 /obj/machinery/power/apc/AICtrlClick(mob/living/user) // turns off/on APCs.
 	if(stat & BROKEN)
 		return
-		
+
 	if(aidisabled)
 		to_chat(user, "<span class='warning'>Unable to interface: Connection refused.</span>")
 		return
@@ -212,8 +212,11 @@
 /obj/machinery/door/airlock/AICtrlClick(mob/living/silicon/user) // Bolts doors
 	if(!ai_control_check(user))
 		return
-	if(user.can_instant_lockdown() || do_after_once(user, 3 SECONDS, needhand = FALSE, target = src, allow_moving = TRUE, attempt_cancel_message = "Bolting [src] cancelled.", special_identifier = "Bolt"))
-		toggle_bolt(user)
+	if(locked)
+		toggle_bolt(user) // Un-bolt immediately.
+	else
+		if(user.can_instant_lockdown() || do_after_once(user, 3 SECONDS, needhand = FALSE, target = src, allow_moving = TRUE, attempt_cancel_message = "Bolting [src] cancelled.", special_identifier = "Bolt"))
+			toggle_bolt(user) // Bolt after a delay unless emagged.
 
 
 /obj/machinery/door/airlock/AIAltClick(mob/living/silicon/user) // Electrifies doors.
@@ -222,10 +225,10 @@
 	if(wires.is_cut(WIRE_ELECTRIFY))
 		to_chat(user, "<span class='warning'>The electrification wire is cut - Cannot electrify the door.</span>")
 	if(isElectrified())
-		electrify(0, user, TRUE) // un-shock
+		electrify(0, user, TRUE) // Un-shock immediately.
 	else
 		if(user.can_instant_lockdown() || do_after_once(user, 3 SECONDS, target = src, allow_moving = TRUE, attempt_cancel_message = "Shocking [src] cancelled.", special_identifier = "Shock"))
-			electrify(-1, user, TRUE) // permanent shock + audio cue
+			electrify(-1, user, TRUE) // Permanent shock after a delay unless emagged + audio cue.
 			playsound(loc, "sparks", 100, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
 
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Silicons have the ability to unbolt doors instantly. Bolting doors shut still has a delay unless they are a malf AI or an emagged cyborg.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
The purpose of #21491 was to counteract silicons bolting antagonists into rooms. This is fine. Most of the QOL issues caused by the change have been with regards to the delay introduced to _un-bolting_ (navigation, unbolting doors to the exits of hazardous rooms, etc). Door un-shocking is already instant, leaving un-bolting on a timer is inconsistent with this.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Loaded local server, checked that doors still took time to bolt. Checked that un-bolting was instant. Checked to see if spam clicking either could break anything. All worked fine.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Un-bolting doors is now instant.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
