### PR TITLE
Reason text for sentience potion

### DIFF
--- a/code/controllers/subsystem/SSghost_spawns.dm
+++ b/code/controllers/subsystem/SSghost_spawns.dm
@@ -132,7 +132,7 @@ SUBSYSTEM_DEF(ghost_spawns)
 		if(isatom(source))
 			act_jump = "<a href='?src=[M.UID()];jump=\ref[source]'>\[Teleport]</a>"
 		var/act_signup = "<a href='?src=[A.UID()];signup=1'>\[Sign Up]</a>"
-		to_chat(M, "<big><span class='boldnotice'>Now looking for candidates [role ? "to play as \an [role_cleanname || get_roletext(role)]" : "\"[question]\""]. [act_jump] [act_signup] [reason?"<i>\nReason: [reason]</i>":""]</span></big>")
+		to_chat(M, "<big><span class='boldnotice'>Now looking for candidates [role ? "to play as \an [role_cleanname || get_roletext(role)]" : "\"[question]\""]. [act_jump] [act_signup] [reason?"<i>\nReason: [sanitize(reason)]</i>":""]</span></big>")
 
 		// Start processing it so it updates visually the timer
 		START_PROCESSING(SSprocessing, A)

--- a/code/controllers/subsystem/SSghost_spawns.dm
+++ b/code/controllers/subsystem/SSghost_spawns.dm
@@ -43,7 +43,7 @@ SUBSYSTEM_DEF(ghost_spawns)
   * * source - The atom, atom prototype, icon or mutable appearance to display as an icon in the alert
   * * role_cleanname - The name override to display to clients
   */
-/datum/controller/subsystem/ghost_spawns/proc/poll_candidates(question = "Would you like to play a special role?", role, antag_age_check = FALSE, poll_time = 30 SECONDS, ignore_respawnability = FALSE, min_hours = 0, flash_window = TRUE, check_antaghud = TRUE, source, role_cleanname)
+/datum/controller/subsystem/ghost_spawns/proc/poll_candidates(question = "Would you like to play a special role?", role, antag_age_check = FALSE, poll_time = 30 SECONDS, ignore_respawnability = FALSE, min_hours = 0, flash_window = TRUE, check_antaghud = TRUE, source, role_cleanname, reason)
 	log_debug("Polling candidates [role ? "for [role_cleanname || get_roletext(role)]" : "\"[question]\""] for [poll_time / 10] seconds")
 
 	// Start firing
@@ -132,7 +132,7 @@ SUBSYSTEM_DEF(ghost_spawns)
 		if(isatom(source))
 			act_jump = "<a href='?src=[M.UID()];jump=\ref[source]'>\[Teleport]</a>"
 		var/act_signup = "<a href='?src=[A.UID()];signup=1'>\[Sign Up]</a>"
-		to_chat(M, "<big><span class='boldnotice'>Now looking for candidates [role ? "to play as \an [role_cleanname || get_roletext(role)]" : "\"[question]\""]. [act_jump] [act_signup]</span></big>")
+		to_chat(M, "<big><span class='boldnotice'>Now looking for candidates [role ? "to play as \an [role_cleanname || get_roletext(role)]" : "\"[question]\""]. [act_jump] [act_signup] [reason?"<i>\nReason: [reason]</i>":""]</span></big>")
 
 		// Start processing it so it updates visually the timer
 		START_PROCESSING(SSprocessing, A)

--- a/code/controllers/subsystem/SSghost_spawns.dm
+++ b/code/controllers/subsystem/SSghost_spawns.dm
@@ -132,7 +132,7 @@ SUBSYSTEM_DEF(ghost_spawns)
 		if(isatom(source))
 			act_jump = "<a href='?src=[M.UID()];jump=\ref[source]'>\[Teleport]</a>"
 		var/act_signup = "<a href='?src=[A.UID()];signup=1'>\[Sign Up]</a>"
-		to_chat(M, "<big><span class='boldnotice'>Now looking for candidates [role ? "to play as \an [role_cleanname || get_roletext(role)]" : "\"[question]\""]. [act_jump] [act_signup] [reason?"<i>\nReason: [sanitize(reason)]</i>":""]</span></big>")
+		to_chat(M, "<big><span class='boldnotice'>Now looking for candidates [role ? "to play as \an [role_cleanname || get_roletext(role)]" : "\"[question]\""]. [act_jump] [act_signup] [reason ? "<i>\nReason: [sanitize(reason)]</i>" : ""]</span></big>")
 
 		// Start processing it so it updates visually the timer
 		START_PROCESSING(SSprocessing, A)

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -228,11 +228,12 @@
 			explosion(T, -1, -1, 2, 3)
 		qdel(src)
 		return
+	var/reason_text = input(user, "Enter reason for giving sentience", "Reason for sentience potion", "") as null|text
 	to_chat(user, "<span class='notice'>You offer [src] sentience potion to [SM]...</span>")
 	being_used = TRUE
 
-	var/ghostmsg = "Play as [SM.name], pet of [user.name]?"
-	var/list/candidates = SSghost_spawns.poll_candidates(ghostmsg, ROLE_SENTIENT, FALSE, 10 SECONDS, source = M)
+	var/ghostmsg = "Play as [SM.name], pet of [user.name]?[reason_text? "\nReason: [reason_text]\n":""]"
+	var/list/candidates = SSghost_spawns.poll_candidates(ghostmsg, ROLE_SENTIENT, FALSE, 10 SECONDS, source = M, reason = reason_text)
 
 	if(QDELETED(src) || QDELETED(SM))
 		return

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -232,7 +232,7 @@
 	to_chat(user, "<span class='notice'>You offer [src] sentience potion to [SM]...</span>")
 	being_used = TRUE
 
-	var/ghostmsg = "Play as [SM.name], pet of [user.name]?[reason_text? "\nReason: [reason_text]\n":""]"
+	var/ghostmsg = "Play as [SM.name], pet of [user.name]?[reason_text ? "\nReason: [sanitize(reason_text)]\n" : ""]"
 	var/list/candidates = SSghost_spawns.poll_candidates(ghostmsg, ROLE_SENTIENT, FALSE, 10 SECONDS, source = M, reason = reason_text)
 
 	if(QDELETED(src) || QDELETED(SM))


### PR DESCRIPTION
## What Does This PR Do
Added reason text pop-up when you try to give animal sentience. Now ghosts would know you wanna some new friends or do little silly massacre. 

## Why It's Good For The Game
I guess no one want to see x99 attempt to give some bees sentience without any explains. This PR make easier to find friend to chat, or arise sentience army, leting ghost know your intentions without "LOOC: STOP PLEASE A DONT WANNA BE FLYING HORN POTATO". Much easier to invite ghost for gimmicks. via "I want to turn diamond golem into Senator Armstrong for lulz", not just ordinary boring serve.

## Images of changes
Activating hidden imba creature..
![image](https://github.com/ParadiseSS13/Paradise/assets/114731039/b8b5c45c-5c48-4798-bb66-b5e1e833fa72)

.. and creature realize: HIS TIME HAS COME!
![image](https://github.com/ParadiseSS13/Paradise/assets/114731039/af70c770-baa1-4cbd-abb7-0c147130ec80)



## Testing
Launch 2 player local, give dogo potion with pop-up text reason, ghosts see reason why dude wanna arise dogo ultramind.

## Changelog
:cl:
add: Added reason text pop-up for sentience potion
/:cl:
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
