### PR TITLE
[s] Fix Syndicate Outpost and Cameras

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/syndie_space_base.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/syndie_space_base.dmm
@@ -2237,15 +2237,13 @@
 	icon_state = "1-2";
 	d1 = 1
 	},
-/obj/structure/disposalpipe/segment/corner{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/disposalpipe/junction,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -2664,6 +2662,12 @@
 	icon_state = "dark"
 	},
 /area/ruin/unpowered/syndicate_space_base/arrivals)
+"oe" = (
+/obj/effect/turf_decal/delivery/green/hollow,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/ruin/unpowered/syndicate_space_base/toxlaunch)
 "ol" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -4537,6 +4541,7 @@
 	name = "west bump";
 	pixel_x = -24
 	},
+/obj/effect/turf_decal/delivery/green/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -7999,15 +8004,15 @@
 	icon_state = "2-4";
 	d1 = 2
 	},
-/obj/structure/disposalpipe/junction/reversed{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
 	initialize_directions = 11
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment/corner{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -9116,7 +9121,9 @@
 	icon_state = "1-2";
 	d1 = 1
 	},
-/obj/structure/disposalpipe/segment/corner,
+/obj/structure/disposalpipe/junction/y{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -9208,6 +9215,7 @@
 	icon_state = "1-2";
 	d1 = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -11045,7 +11053,7 @@ am
 Mw
 IX
 rS
-nw
+oe
 hA
 EV
 EV
@@ -12310,9 +12318,9 @@ hc
 zz
 mn
 Zv
-lo
-lo
-lo
+fP
+fP
+fP
 YU
 mi
 fP

--- a/_maps/map_files/RandomRuins/SpaceRuins/syndie_space_base.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/syndie_space_base.dmm
@@ -89,23 +89,6 @@
 	icon_state = "brown"
 	},
 /area/ruin/unpowered/syndicate_space_base/storage)
-"au" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "4-8";
-	d1 = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/transparent/glass/reinforced,
-/area/ruin/unpowered/syndicate_space_base/service)
 "ax" = (
 /obj/structure/chair{
 	dir = 1
@@ -297,6 +280,7 @@
 	name = "east bump";
 	pixel_x = 24
 	},
+/obj/effect/turf_decal/box/white,
 /turf/simulated/floor/wood,
 /area/ruin/unpowered/syndicate_space_base/service)
 "bS" = (
@@ -366,13 +350,6 @@
 	icon_state = "dark"
 	},
 /area/ruin/unpowered/syndicate_space_base/arrivals)
-"cm" = (
-/obj/structure/table/wood,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/ruin/unpowered/syndicate_space_base/service)
 "cp" = (
 /obj/structure/sign/vacuum/external{
 	pixel_y = 32
@@ -388,6 +365,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/ruin/unpowered/syndicate_space_base/engineering)
+"ct" = (
+/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/grass,
+/area/ruin/unpowered/syndicate_space_base/service)
 "cu" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -518,21 +505,6 @@
 	icon_state = "dark"
 	},
 /area/ruin/unpowered/syndicate_space_base/arrivals)
-"cW" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8;
-	initialize_directions = 11
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "1-2";
-	d1 = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/ruin/unpowered/syndicate_space_base/main)
 "cY" = (
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -669,8 +641,22 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-4"
+	},
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plating,
 /area/ruin/unpowered/syndicate_space_base/engineering)
+"dL" = (
+/obj/effect/turf_decal/woodsiding{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment/corner,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/ruin/unpowered/syndicate_space_base/service)
 "dM" = (
 /obj/structure/cable/green{
 	d2 = 8;
@@ -775,14 +761,6 @@
 	icon_state = "yellow"
 	},
 /area/ruin/unpowered/syndicate_space_base/storage)
-"eq" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/ruin/unpowered/syndicate_space_base/engineering)
 "er" = (
 /obj/structure/cable/green{
 	d2 = 2;
@@ -844,6 +822,20 @@
 /obj/item/reagent_containers/glass/bucket,
 /turf/simulated/floor/wood,
 /area/ruin/unpowered/syndicate_space_base/service)
+"eO" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/ruin/unpowered/syndicate_space_base/service)
 "eP" = (
 /obj/structure/table,
 /obj/structure/window/reinforced,
@@ -854,6 +846,9 @@
 /obj/item/storage/box/disks_plantgene,
 /obj/item/storage/box/disks_plantgene,
 /obj/item/storage/box/disks_plantgene,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/ruin/unpowered/syndicate_space_base/service)
 "eR" = (
@@ -964,8 +959,8 @@
 	pixel_x = -24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -1056,21 +1051,19 @@
 /obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plating,
 /area/ruin/unpowered/syndicate_space_base/engineering)
-"fL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+"fJ" = (
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "4-8";
-	d1 = 4
+/obj/machinery/camera{
+	c_tag = "Syndicate Base Cave South 5";
+	network = list("SyndicateCaves");
+	dir = 6
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/turf/simulated/floor/plating{
+	icon_state = "asteroidplating"
 	},
-/turf/simulated/floor/transparent/glass/reinforced,
-/area/ruin/unpowered/syndicate_space_base/service)
+/area/ruin/unpowered/syndicate_space_base/cave)
 "fM" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
 	dir = 4
@@ -1118,6 +1111,13 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
+/area/ruin/unpowered/syndicate_space_base/service)
+"ga" = (
+/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/grass,
 /area/ruin/unpowered/syndicate_space_base/service)
 "gd" = (
 /obj/machinery/economy/vending/medical/syndicate_access,
@@ -1270,6 +1270,7 @@
 	pixel_x = 12
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/box/white,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkgreen";
 	dir = 4
@@ -1298,7 +1299,9 @@
 	req_access_txt = "150";
 	req_one_access_txt = "150"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
 /turf/simulated/floor/grass,
 /area/ruin/unpowered/syndicate_space_base/service)
 "gX" = (
@@ -1332,6 +1335,19 @@
 	icon_state = "dark"
 	},
 /area/ruin/unpowered/syndicate_space_base/arrivals)
+"hj" = (
+/obj/effect/spawner/window/plastitanium,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/ruin/unpowered/syndicate_space_base/service)
 "hl" = (
 /obj/structure/chair/stool{
 	dir = 1
@@ -1459,23 +1475,6 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
-/area/ruin/unpowered/syndicate_space_base/service)
-"hQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "4-8";
-	d1 = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/transparent/glass/reinforced,
 /area/ruin/unpowered/syndicate_space_base/service)
 "hV" = (
 /obj/machinery/door/airlock/hatch/syndicate,
@@ -1657,6 +1656,8 @@
 	pixel_y = 24;
 	name = "north bump"
 	},
+/obj/item/lightreplacer,
+/obj/item/lightreplacer,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -1668,7 +1669,6 @@
 /obj/item/kirbyplants{
 	icon_state = "plant-22"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -1716,6 +1716,19 @@
 	dir = 1
 	},
 /area/ruin/unpowered/syndicate_space_base/genetics)
+"iU" = (
+/obj/effect/spawner/window/plastitanium,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/ruin/unpowered/syndicate_space_base/service)
 "iV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -1767,6 +1780,17 @@
 	dir = 8
 	},
 /area/ruin/unpowered/syndicate_space_base/genetics)
+"jk" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/ruin/unpowered/syndicate_space_base/main)
 "jl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -1965,23 +1989,10 @@
 /turf/simulated/floor/engine,
 /area/ruin/unpowered/syndicate_space_base/testlab)
 "kK" = (
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-4"
-	},
 /obj/machinery/power/apc/syndicate/south,
+/obj/structure/cable/green,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
-	},
-/area/ruin/unpowered/syndicate_space_base/service)
-"kN" = (
-/obj/effect/turf_decal/woodsiding{
-	dir = 1
-	},
-/obj/structure/chair/comfy/corp,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria"
 	},
 /area/ruin/unpowered/syndicate_space_base/service)
 "kO" = (
@@ -1991,7 +2002,12 @@
 	},
 /area/ruin/unpowered/syndicate_space_base/arrivals)
 "kS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
 /turf/simulated/floor/wood,
 /area/ruin/unpowered/syndicate_space_base/service)
 "kT" = (
@@ -2053,21 +2069,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/ruin/unpowered/syndicate_space_base/engineering)
-"lh" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "1-2";
-	d1 = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/ruin/unpowered/syndicate_space_base/main)
 "lo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2230,27 +2231,29 @@
 /obj/effect/turf_decal/delivery/white/hollow,
 /turf/simulated/floor/plating,
 /area/ruin/unpowered/syndicate_space_base/atmos)
+"mn" = (
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "1-2";
+	d1 = 1
+	},
+/obj/structure/disposalpipe/segment/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/ruin/unpowered/syndicate_space_base/main)
 "mq" = (
 /obj/effect/spawner/window/plastitanium,
 /turf/simulated/floor/plating,
 /area/ruin/unpowered/syndicate_space_base/storage)
-"mt" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "4-8";
-	d1 = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/transparent/glass/reinforced,
-/area/ruin/unpowered/syndicate_space_base/service)
 "mw" = (
 /obj/effect/mob_spawn/human/alive/spacebase_syndicate{
 	dir = 1
@@ -2397,23 +2400,10 @@
 	icon_state = "darkred"
 	},
 /area/ruin/unpowered/syndicate_space_base/arrivals)
-"nh" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "4-8";
-	d1 = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/transparent/glass/reinforced,
-/area/ruin/unpowered/syndicate_space_base/service)
 "nm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
 /turf/simulated/floor/wood,
 /area/ruin/unpowered/syndicate_space_base/service)
 "nn" = (
@@ -2540,8 +2530,23 @@
 /obj/structure/rack{
 	dir = 8
 	},
-/obj/item/storage/bag/trash,
-/obj/item/storage/bag/trash,
+/obj/item/storage/box/lights/mixed{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/storage/box/lights/mixed{
+	pixel_y = 3;
+	pixel_x = 3
+	},
+/obj/item/storage/box/lights/mixed,
+/obj/item/storage/box/lights/mixed{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/storage/box/lights/mixed{
+	pixel_x = -6;
+	pixel_y = -6
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -2571,6 +2576,20 @@
 	},
 /turf/simulated/floor/engine,
 /area/ruin/unpowered/syndicate_space_base/testlab)
+"nS" = (
+/obj/structure/table/wood,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "2-8";
+	d1 = 2
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/ruin/unpowered/syndicate_space_base/service)
 "nT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -2645,10 +2664,6 @@
 	icon_state = "dark"
 	},
 /area/ruin/unpowered/syndicate_space_base/arrivals)
-"oj" = (
-/obj/effect/turf_decal/delivery/hollow,
-/turf/simulated/floor/plating,
-/area/ruin/unpowered/syndicate_space_base/engineering)
 "ol" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -2666,6 +2681,17 @@
 	icon_state = "darkred"
 	},
 /area/ruin/unpowered/syndicate_space_base/dormitories)
+"on" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/ruin/unpowered/syndicate_space_base/main)
 "op" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/glass/fifty,
@@ -2739,6 +2765,19 @@
 	icon_state = "dark"
 	},
 /area/ruin/unpowered/syndicate_space_base/arrivals)
+"oP" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "4-8";
+	d1 = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/ruin/unpowered/syndicate_space_base/service)
 "pe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -2888,6 +2927,9 @@
 /obj/structure/table,
 /obj/machinery/smartfridge/disks,
 /obj/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/ruin/unpowered/syndicate_space_base/service)
 "pG" = (
@@ -2964,15 +3006,6 @@
 	icon_state = "darkgreen"
 	},
 /area/ruin/unpowered/syndicate_space_base/genetics)
-"qb" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "1-2";
-	d1 = 1
-	},
-/turf/simulated/floor/transparent/glass/reinforced,
-/area/ruin/unpowered/syndicate_space_base/service)
 "qf" = (
 /obj/machinery/economy/arcade/claw,
 /turf/simulated/floor/plasteel{
@@ -3227,6 +3260,17 @@
 	icon_state = "dark"
 	},
 /area/ruin/unpowered/syndicate_space_base/toxlaunch)
+"rT" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/ruin/unpowered/syndicate_space_base/service)
 "rW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -3275,6 +3319,23 @@
 	icon_state = "darkblue"
 	},
 /area/ruin/unpowered/syndicate_space_base/dormitories)
+"sc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "4-8";
+	d1 = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/ruin/unpowered/syndicate_space_base/main)
 "sl" = (
 /obj/effect/turf_decal/woodsiding{
 	dir = 1
@@ -3421,20 +3482,18 @@
 	},
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/ruin/unpowered/syndicate_space_base/cave)
-"tq" = (
-/obj/structure/chair/stool/bar,
-/obj/effect/turf_decal/woodsiding{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/ruin/unpowered/syndicate_space_base/service)
 "ts" = (
 /obj/machinery/economy/vending/hydroseeds,
 /obj/structure/window/reinforced,
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/ruin/unpowered/syndicate_space_base/service)
 "tt" = (
@@ -3592,16 +3651,6 @@
 	icon_state = "yellow"
 	},
 /area/ruin/unpowered/syndicate_space_base/storage)
-"ux" = (
-/obj/effect/turf_decal/woodsiding{
-	dir = 1
-	},
-/obj/structure/chair/comfy/corp,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/ruin/unpowered/syndicate_space_base/service)
 "uy" = (
 /obj/item/clothing/accessory/stethoscope,
 /turf/simulated/floor/plasteel{
@@ -3674,6 +3723,24 @@
 	icon_state = "dark"
 	},
 /area/ruin/unpowered/syndicate_space_base/main)
+"uT" = (
+/obj/effect/spawner/window/plastitanium,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "4-8";
+	d1 = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/ruin/unpowered/syndicate_space_base/service)
 "uU" = (
 /obj/structure/foamedmetal,
 /turf/simulated/floor/engine,
@@ -3726,16 +3793,12 @@
 	icon_state = "dark"
 	},
 /area/ruin/unpowered/syndicate_space_base/telecomms)
-"ve" = (
-/obj/structure/table,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/ruin/unpowered/syndicate_space_base/service)
 "vf" = (
 /obj/machinery/seed_extractor,
 /obj/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/ruin/unpowered/syndicate_space_base/service)
 "vh" = (
@@ -3861,6 +3924,16 @@
 	},
 /turf/simulated/floor/engine,
 /area/ruin/unpowered/syndicate_space_base/testlab)
+"vC" = (
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "1-2";
+	d1 = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/ruin/unpowered/syndicate_space_base/service)
 "vD" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4;
@@ -3999,6 +4072,7 @@
 	pixel_y = 2
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/box/white,
 /turf/simulated/floor/wood,
 /area/ruin/unpowered/syndicate_space_base/service)
 "wn" = (
@@ -4235,6 +4309,20 @@
 /obj/machinery/light,
 /turf/simulated/floor/wood,
 /area/ruin/unpowered/syndicate_space_base/arrivals)
+"xw" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/ruin/unpowered/syndicate_space_base/service)
 "xD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -4340,16 +4428,6 @@
 /area/ruin/unpowered/syndicate_space_base/toxlaunch)
 "ym" = (
 /obj/machinery/economy/vending/cigarette/syndicate/free,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/ruin/unpowered/syndicate_space_base/service)
-"yn" = (
-/obj/structure/chair/stool/bar,
-/obj/effect/turf_decal/woodsiding{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -4668,7 +4746,6 @@
 /obj/item/reagent_containers/food/condiment/enzyme{
 	layer = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
@@ -4691,6 +4768,14 @@
 	icon_state = "dark"
 	},
 /area/ruin/unpowered/syndicate_space_base/main)
+"Ak" = (
+/obj/effect/turf_decal/woodsiding{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/ruin/unpowered/syndicate_space_base/service)
 "Al" = (
 /obj/structure/grille,
 /obj/structure/window/plasmareinforced{
@@ -4748,6 +4833,15 @@
 /area/ruin/unpowered/syndicate_space_base/service)
 "AM" = (
 /obj/structure/closet/secure_closet/freezer/fridge/open,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
@@ -4837,6 +4931,14 @@
 	icon_state = "darkredcorners"
 	},
 /area/ruin/unpowered/syndicate_space_base/dormitories)
+"Bi" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/ruin/unpowered/syndicate_space_base/main)
 "Bk" = (
 /obj/structure/extinguisher_cabinet{
 	name = "west bump";
@@ -4861,10 +4963,6 @@
 	icon_state = "dark"
 	},
 /area/ruin/unpowered/syndicate_space_base/virology)
-"Bt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/transparent/glass/reinforced,
-/area/ruin/unpowered/syndicate_space_base/service)
 "Bu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -4886,17 +4984,6 @@
 	icon_state = "dark"
 	},
 /area/ruin/unpowered/syndicate_space_base/engineering)
-"By" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Syndicate Base Cave South 5";
-	network = list("SyndicateCaves");
-	dir = 6
-	},
-/turf/simulated/floor/plating/asteroid/ancient,
-/area/ruin/unpowered/syndicate_space_base/cave)
 "BC" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -4980,6 +5067,25 @@
 	icon_state = "dark"
 	},
 /area/ruin/unpowered/syndicate_space_base/control)
+"BR" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "4-8";
+	d1 = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/ruin/unpowered/syndicate_space_base/service)
 "BW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -5017,6 +5123,15 @@
 	icon_state = "dark"
 	},
 /area/ruin/unpowered/syndicate_space_base/arrivals)
+"Cg" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/ruin/unpowered/syndicate_space_base/main)
 "Cl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -5218,11 +5333,6 @@
 /obj/effect/turf_decal/woodsiding{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "4-8";
-	d1 = 4
-	},
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -5313,7 +5423,12 @@
 /mob/living/simple_animal/chicken{
 	faction = list("neutral","syndicate")
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/grass,
 /area/ruin/unpowered/syndicate_space_base/service)
 "El" = (
@@ -5587,6 +5702,9 @@
 /obj/machinery/biogenerator,
 /obj/structure/window/reinforced,
 /obj/item/reagent_containers/glass/bucket,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/ruin/unpowered/syndicate_space_base/service)
 "Fz" = (
@@ -5616,23 +5734,6 @@
 	icon_state = "brown"
 	},
 /area/ruin/unpowered/syndicate_space_base/storage)
-"FJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "4-8";
-	d1 = 4
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 8
-	},
-/turf/simulated/floor/transparent/glass/reinforced,
-/area/ruin/unpowered/syndicate_space_base/service)
 "FM" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -5950,10 +6051,6 @@
 	icon_state = "brown"
 	},
 /area/ruin/unpowered/syndicate_space_base/storage)
-"Ht" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/transparent/glass/reinforced,
-/area/ruin/unpowered/syndicate_space_base/service)
 "Hu" = (
 /obj/machinery/light,
 /obj/machinery/camera{
@@ -6000,7 +6097,6 @@
 "HO" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/cans/beer,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -6424,6 +6520,22 @@
 	icon_state = "dark"
 	},
 /area/ruin/unpowered/syndicate_space_base/control)
+"Jz" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "4-8";
+	d1 = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/ruin/unpowered/syndicate_space_base/service)
 "JE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -6456,6 +6568,9 @@
 "JH" = (
 /obj/structure/window/reinforced,
 /obj/machinery/chem_dispenser/upgraded,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/ruin/unpowered/syndicate_space_base/service)
 "JL" = (
@@ -6539,6 +6654,13 @@
 	pixel_x = -24;
 	name = "west bump"
 	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/ruin/unpowered/syndicate_space_base/main)
+"Ky" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -6767,14 +6889,6 @@
 /obj/structure/sign/poster/contraband/lamarr,
 /turf/simulated/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/unpowered/syndicate_space_base/arrivals)
-"LT" = (
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "2-8";
-	d1 = 2
-	},
-/turf/simulated/floor/transparent/glass/reinforced,
-/area/ruin/unpowered/syndicate_space_base/service)
 "Mf" = (
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
@@ -6887,6 +7001,9 @@
 "MF" = (
 /obj/machinery/plantgenes,
 /obj/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/ruin/unpowered/syndicate_space_base/service)
 "MK" = (
@@ -6913,6 +7030,17 @@
 	icon_state = "white"
 	},
 /area/ruin/unpowered/syndicate_space_base/medbay)
+"MT" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/ruin/unpowered/syndicate_space_base/service)
 "MX" = (
 /obj/structure/closet/crate/medical,
 /obj/item/clothing/mask/breath/medical,
@@ -7280,10 +7408,6 @@
 	icon_state = "dark"
 	},
 /area/ruin/unpowered/syndicate_space_base/arrivals)
-"PJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/transparent/glass/reinforced,
-/area/ruin/unpowered/syndicate_space_base/service)
 "PK" = (
 /obj/effect/spawner/window/plastitanium,
 /turf/simulated/floor/plating,
@@ -7335,13 +7459,11 @@
 	},
 /area/ruin/unpowered/syndicate_space_base/main)
 "Qa" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
+/obj/structure/disposalpipe/junction/y,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment/corner,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -7398,6 +7520,24 @@
 	icon_state = "whiteblue"
 	},
 /area/ruin/unpowered/syndicate_space_base/medbay)
+"QD" = (
+/obj/structure/disposalpipe/junction/reversed,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "2-4";
+	d1 = 2
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8;
+	initialize_directions = 11
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/ruin/unpowered/syndicate_space_base/main)
 "QG" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -7448,25 +7588,11 @@
 	pixel_x = 24;
 	name = "east bump"
 	},
+/obj/effect/turf_decal/box/white,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/ruin/unpowered/syndicate_space_base/virology)
-"QP" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "4-8";
-	d1 = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/transparent/glass/reinforced,
-/area/ruin/unpowered/syndicate_space_base/service)
 "QT" = (
 /obj/item/clothing/gloves/color/fyellow/old,
 /turf/simulated/floor/plating/asteroid/airless,
@@ -7482,6 +7608,16 @@
 /obj/structure/bookcase/random,
 /turf/simulated/floor/wood,
 /area/ruin/unpowered/syndicate_space_base/arrivals)
+"Rb" = (
+/obj/effect/spawner/window/plastitanium,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/ruin/unpowered/syndicate_space_base/service)
 "Rf" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -7566,24 +7702,6 @@
 	icon_state = "darkpurple"
 	},
 /area/ruin/unpowered/syndicate_space_base/chemistry)
-"RJ" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "4-8";
-	d1 = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/transparent/glass/reinforced,
-/area/ruin/unpowered/syndicate_space_base/service)
 "RN" = (
 /obj/machinery/reagentgrinder,
 /obj/item/stack/sheet/mineral/plasma{
@@ -7650,11 +7768,14 @@
 	icon_state = "dark"
 	},
 /area/ruin/unpowered/syndicate_space_base/chemistry)
-"Sd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+"Sl" = (
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkredcorners"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/area/ruin/unpowered/syndicate_space_base/dormitories)
+"Sn" = (
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable/green{
@@ -7662,29 +7783,13 @@
 	icon_state = "4-8";
 	d1 = 4
 	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "1-8";
-	d1 = 1
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "1-4";
-	d1 = 1
-	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "grimy"
 	},
-/area/ruin/unpowered/syndicate_space_base/main)
-"Sl" = (
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "darkredcorners"
-	},
-/area/ruin/unpowered/syndicate_space_base/dormitories)
+/area/ruin/unpowered/syndicate_space_base/service)
 "Sq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -7889,29 +7994,20 @@
 	},
 /area/ruin/unpowered/syndicate_space_base/medbay)
 "SW" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
 /obj/structure/cable/green{
 	d2 = 4;
 	icon_state = "2-4";
 	d1 = 2
 	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "4-8";
-	d1 = 4
+/obj/structure/disposalpipe/junction/reversed{
+	dir = 8
 	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "2-8";
-	d1 = 2
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8;
+	initialize_directions = 11
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -8131,6 +8227,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/ruin/unpowered/syndicate_space_base/engineering)
+"Um" = (
+/obj/effect/turf_decal/woodsiding{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment/corner{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/ruin/unpowered/syndicate_space_base/service)
 "Ut" = (
 /obj/machinery/light{
 	dir = 8
@@ -8178,23 +8285,6 @@
 	icon_state = "dark"
 	},
 /area/ruin/unpowered/syndicate_space_base/arrivals)
-"Uy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "4-8";
-	d1 = 4
-	},
-/obj/structure/disposalpipe/junction/reversed{
-	dir = 8
-	},
-/turf/simulated/floor/transparent/glass/reinforced,
-/area/ruin/unpowered/syndicate_space_base/service)
 "UC" = (
 /obj/machinery/alarm/syndicate{
 	pixel_x = -24;
@@ -8209,6 +8299,14 @@
 	icon_state = "dark"
 	},
 /area/ruin/unpowered/syndicate_space_base/telecomms)
+"UJ" = (
+/obj/effect/turf_decal/woodsiding{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/ruin/unpowered/syndicate_space_base/service)
 "UK" = (
 /obj/structure/foamedmetal,
 /obj/structure/foamedmetal,
@@ -8292,6 +8390,25 @@
 	icon_state = "dark"
 	},
 /area/ruin/unpowered/syndicate_space_base/main)
+"UX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "4-8";
+	d1 = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/ruin/unpowered/syndicate_space_base/service)
 "Vh" = (
 /obj/machinery/economy/vending/toyliberationstation/secured,
 /turf/simulated/floor/plasteel{
@@ -8458,7 +8575,6 @@
 /obj/item/kirbyplants{
 	icon_state = "plant-22"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
@@ -8549,6 +8665,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
+/obj/item/storage/bag/trash,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -8723,6 +8840,9 @@
 	pixel_y = 6
 	},
 /obj/item/kitchen/rollingpin,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
@@ -9093,19 +9213,9 @@
 	},
 /area/ruin/unpowered/syndicate_space_base/main)
 "ZB" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8;
-	initialize_directions = 11
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "2-4";
-	d1 = 2
-	},
 /obj/structure/disposalpipe/junction/reversed,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -9144,6 +9254,20 @@
 	icon_state = "dark"
 	},
 /area/ruin/unpowered/syndicate_space_base/virology)
+"ZQ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/ruin/unpowered/syndicate_space_base/main)
 "ZS" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -10121,7 +10245,7 @@ iW
 eW
 iW
 tG
-oj
+qF
 JU
 qF
 qF
@@ -10486,7 +10610,7 @@ dw
 dw
 iF
 PS
-eq
+OQ
 Cm
 ET
 qF
@@ -10742,9 +10866,9 @@ Qr
 Qa
 fq
 ZB
-mi
-hc
-zz
+Cg
+on
+QD
 hN
 kF
 fP
@@ -10811,12 +10935,12 @@ Lj
 am
 LN
 am
-Fe
-am
-Mw
+ZQ
+xZ
+Bi
 Gi
-am
-tW
+GA
+sc
 xS
 In
 am
@@ -10883,12 +11007,12 @@ Dy
 Dy
 Dy
 OC
-OC
+iU
 Dg
-RJ
+Dg
 Dy
 Dy
-OC
+uT
 Dy
 Dy
 am
@@ -10956,11 +11080,11 @@ KZ
 wf
 AZ
 ts
-Ht
-FJ
+oM
+oM
 um
 CC
-GL
+UX
 vV
 Dy
 Dy
@@ -11028,12 +11152,12 @@ AJ
 aq
 Gq
 kS
-PJ
-QP
-yn
-cm
+oM
+oM
+WW
+Rm
+BR
 IQ
-GL
 vy
 Dy
 am
@@ -11101,10 +11225,10 @@ aq
 aq
 vf
 oM
-hQ
+oM
 WW
 HC
-GL
+Sn
 GL
 YJ
 Dy
@@ -11173,11 +11297,11 @@ aq
 aq
 MF
 oM
-mt
-tq
+oM
+WW
 HO
+Jz
 fv
-GL
 Uv
 Dy
 am
@@ -11245,10 +11369,10 @@ aq
 aq
 pF
 oM
-hQ
+oM
 jp
 Rm
-GL
+oP
 GL
 ym
 tO
@@ -11317,11 +11441,11 @@ aq
 aq
 JH
 oM
-hQ
+oM
 jp
 Rm
-Rm
-GL
+nS
+vC
 kK
 Dy
 am
@@ -11389,10 +11513,10 @@ aq
 aq
 Fw
 oM
-Uy
+oM
 iH
-VP
-VP
+Ak
+dL
 VP
 DU
 OC
@@ -11461,15 +11585,15 @@ aq
 aq
 eP
 oM
-hQ
 oM
 oM
 oM
 oM
-LT
-qb
-vN
-Sd
+oM
+oM
+Dg
+am
+Mw
 IJ
 bq
 pG
@@ -11532,8 +11656,8 @@ rs
 aq
 kX
 nm
-Bt
-fL
+oM
+oM
 oM
 oM
 oM
@@ -11605,10 +11729,10 @@ fb
 fb
 fb
 oM
-Uy
+oM
 Wa
-Nv
-Nv
+UJ
+Um
 Nv
 sy
 OC
@@ -11677,7 +11801,7 @@ jV
 dH
 eN
 oM
-hQ
+oM
 mk
 Nm
 Xp
@@ -11749,11 +11873,11 @@ va
 OI
 DT
 oM
-au
-ux
-ve
+oM
+mk
+hP
+rT
 yD
-Cw
 BJ
 Dy
 hM
@@ -11820,11 +11944,11 @@ Dy
 aq
 Gq
 gW
-PJ
-nh
+oM
+oM
 mk
 hP
-Cw
+MT
 Cw
 fY
 Dy
@@ -11891,13 +12015,13 @@ kE
 Dy
 nt
 aq
-DT
+ga
 oM
-mt
-kN
+oM
+mk
 Af
+xw
 tL
-Cw
 BL
 Dy
 fA
@@ -11964,11 +12088,11 @@ Dy
 aq
 kX
 Ei
-Bt
-fL
+oM
+oM
 mk
 rD
-Cw
+eO
 Cw
 bS
 Dy
@@ -12035,9 +12159,9 @@ kE
 Dy
 yR
 YS
-DT
+ct
 oM
-hQ
+oM
 sl
 rv
 AM
@@ -12107,12 +12231,12 @@ kE
 Dy
 Dy
 Dy
-OC
+Rb
 Dg
-RJ
+Dg
 Dy
 Dy
-OC
+hj
 Dy
 Dy
 Xh
@@ -12179,12 +12303,12 @@ kE
 RX
 jC
 Lb
-am
-am
+jk
+Ky
 SW
-lh
-cW
-lo
+hc
+zz
+mn
 Zv
 lo
 lo
@@ -12800,7 +12924,7 @@ nv
 nv
 Vl
 Vl
-By
+kE
 Mf
 AD
 kE
@@ -12872,8 +12996,8 @@ nv
 nv
 qT
 Vl
-kE
-kE
+fJ
+AD
 AD
 kE
 kE
@@ -12946,7 +13070,7 @@ nv
 Vl
 Vl
 kE
-kE
+Mf
 Mf
 kE
 kE
@@ -13019,7 +13143,7 @@ qT
 Vl
 kE
 kE
-kE
+AD
 kE
 Ri
 Ri
@@ -13091,7 +13215,7 @@ Vl
 Vl
 Vl
 kE
-kE
+Mf
 kE
 kE
 Ri

--- a/_maps/map_files/RandomRuins/SpaceRuins/syndie_space_base.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/syndie_space_base.dmm
@@ -1562,7 +1562,6 @@
 /area/ruin/unpowered/syndicate_space_base/main)
 "it" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},

--- a/code/_globalvars/lists/misc_lists.dm
+++ b/code/_globalvars/lists/misc_lists.dm
@@ -33,8 +33,8 @@ GLOBAL_LIST_INIT(restricted_camera_networks, list(
 	"UO45R",
 	"UO71",
 	"Xeno",
-	"SyndicateTestLab"
-	"SyndicateToxinsTest"
+	"SyndicateTestLab",
+	"SyndicateToxinsTest",
 	"SyndicateCaves"
 	)) //Those networks can only be accessed by preexisting terminals. AIs and new terminals can't use them.
 

--- a/code/_globalvars/lists/misc_lists.dm
+++ b/code/_globalvars/lists/misc_lists.dm
@@ -34,6 +34,8 @@ GLOBAL_LIST_INIT(restricted_camera_networks, list(
 	"UO71",
 	"Xeno",
 	"SyndicateTestLab"
+	"SyndicateToxinsTest"
+	"SyndicateCaves"
 	)) //Those networks can only be accessed by preexisting terminals. AIs and new terminals can't use them.
 
 GLOBAL_LIST_INIT(ruin_landmarks, list())


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fix syndicate outpost camera network and change pipes/cables placement to be more convinient, on top of that i added some "warning stripes" under sinks to make them more "visible" and added light replacer with boxes to replace lights.

## Why It's Good For The Game
Add some QoL stuff and reduce some shanenigans.

## Images of changes
![image](https://github.com/ParadiseSS13/Paradise/assets/89580971/2beeaf89-10e6-458d-809e-1535ce5b35b5)

## Testing
Compiled and it works.

## Changelog
:cl: Venuska1117
tweak: Fix Syndicate Outpost camera network, moves pipes away from glass floor in "service" section and remove dual pipe in one tile.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
