### PR TITLE
removes the fluff item from moonbase, modifies loot

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/moonoutpost19.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/moonoutpost19.dmm
@@ -5151,7 +5151,7 @@
 /obj/effect/decal/cleanable/cobweb2,
 /obj/effect/turf_decal/delivery/hollow,
 /obj/structure/rack,
-/obj/item/assembly/signaler/anomaly/random,
+/obj/item/paper/researchnotes,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -8441,13 +8441,13 @@
 /area/ruin/space/unpowered)
 "Fm" = (
 /obj/structure/safe,
-/obj/item/paper/researchnotes,
-/obj/item/clothing/glasses/hud/security/sunglasses/fluff/eyepro,
 /obj/machinery/light/small{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery/hollow,
+/obj/item/assembly/signaler/anomaly/random,
+/obj/item/storage/lockbox/experimental_weapon,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},

--- a/code/game/objects/items/weapons/storage/lockbox.dm
+++ b/code/game/objects/items/weapons/storage/lockbox.dm
@@ -205,7 +205,7 @@
 	req_access = list(ACCESS_SEC_DOORS) //officers, heads
 
 /obj/item/storage/lockbox/experimental_weapon/populate_contents()
-		if(prob(10))
+	if(prob(10))
 		new /obj/item/clothing/mask/facehugger(src) //Suprise! Storing facehuggers improperly is what lead to this mess.
 		return
 	var/spawn_type = pick(/obj/item/gun/energy/kinetic_accelerator/experimental, /obj/item/surveillance_upgrade, /obj/item/mod/module/stealth/ninja)
@@ -220,6 +220,5 @@
 			/obj/item/organ/internal/cyberimp/arm/toolset_abductor,
 			/obj/item/organ/internal/cyberimp/arm/esword,
 			/obj/item/organ/internal/heart/demon/pulse,
-			/obj/item/organ/internal/eyes/cybernetic/eyesofgod
-		)
+			/obj/item/organ/internal/eyes/cybernetic/eyesofgod)
 	new spawn_type(src)

--- a/code/game/objects/items/weapons/storage/lockbox.dm
+++ b/code/game/objects/items/weapons/storage/lockbox.dm
@@ -220,5 +220,6 @@
 			/obj/item/organ/internal/cyberimp/arm/toolset_abductor,
 			/obj/item/organ/internal/cyberimp/arm/esword,
 			/obj/item/organ/internal/heart/demon/pulse,
-			/obj/item/organ/internal/eyes/cybernetic/eyesofgod)
+			/obj/item/organ/internal/eyes/cybernetic/eyesofgod
+		)
 	new spawn_type(src)

--- a/code/game/objects/items/weapons/storage/lockbox.dm
+++ b/code/game/objects/items/weapons/storage/lockbox.dm
@@ -221,7 +221,7 @@
 			/obj/item/organ/internal/cyberimp/arm/esword,
 			/obj/item/organ/internal/heart/demon/pulse,
 			/obj/item/organ/internal/eyes/cybernetic/eyesofgod
-			)
+		)
 
 		spawn_type = pick(organ_loot)
 	new spawn_type(src)

--- a/code/game/objects/items/weapons/storage/lockbox.dm
+++ b/code/game/objects/items/weapons/storage/lockbox.dm
@@ -205,29 +205,21 @@
 	req_access = list(ACCESS_SEC_DOORS) //officers, heads
 
 /obj/item/storage/lockbox/experimental_weapon/populate_contents()
-	if(prob(90))
-		switch(rand(1, 4))
-			if(1)
-				new /obj/item/gun/energy/kinetic_accelerator/experimental(src)
-			if(2)
-				new /obj/item/surveillance_upgrade(src)
-			if(3)
-				new /obj/item/mod/module/stealth/ninja(src)
-			if(4)	//organ time. I want this to be more balanced in distribution, so organs are under a prob 25
-				switch(rand(5, 10))
-					if(5)
-						new /obj/item/organ/internal/cyberimp/arm/katana(src)
-					if(6)
-						new /obj/item/organ/internal/cyberimp/arm/toolset_abductor(src)
-					if(7)
-						new /obj/item/organ/internal/cyberimp/arm/esword(src)
-					if(8)
-						new /obj/item/organ/internal/heart/demon/pulse(src)
-					if(9)
-						new /obj/item/organ/internal/eyes/cybernetic/eyesofgod(src)
-					if(10) //Disected drone before the place got wiped. No hivenode.
-						new /obj/item/organ/internal/alien/plasmavessel/drone(src)
-						new /obj/item/organ/internal/alien/acidgland(src)
-						new /obj/item/organ/internal/alien/resinspinner(src)
+		if(prob(10))
+		new /obj/item/clothing/mask/facehugger(src) //Suprise! Storing facehuggers improperly is what lead to this mess.
 		return
-	new /obj/item/clothing/mask/facehugger(src) //Suprise! Storing facehuggers improperly is what lead to this mess.
+	var/spawn_type = pick(/obj/item/gun/energy/kinetic_accelerator/experimental, /obj/item/surveillance_upgrade, /obj/item/mod/module/stealth/ninja)
+	if(prob(25))
+		if(rand(1, 6) == 1) //organ time. I want this to be more balanced in distribution, so organs are under a prob 25
+			new /obj/item/organ/internal/alien/plasmavessel/drone(src)  //Disected drone before the place got wiped. No hivenode.
+			new /obj/item/organ/internal/alien/acidgland(src)
+			new /obj/item/organ/internal/alien/resinspinner(src)
+			return
+		spawn_type = pick(
+			/obj/item/organ/internal/cyberimp/arm/katana,
+			/obj/item/organ/internal/cyberimp/arm/toolset_abductor,
+			/obj/item/organ/internal/cyberimp/arm/esword,
+			/obj/item/organ/internal/heart/demon/pulse,
+			/obj/item/organ/internal/eyes/cybernetic/eyesofgod
+		)
+	new spawn_type(src)

--- a/code/game/objects/items/weapons/storage/lockbox.dm
+++ b/code/game/objects/items/weapons/storage/lockbox.dm
@@ -215,11 +215,13 @@
 			new /obj/item/organ/internal/alien/acidgland(src)
 			new /obj/item/organ/internal/alien/resinspinner(src)
 			return
-		spawn_type = pick(
+		var/list/organ_loot = list(
 			/obj/item/organ/internal/cyberimp/arm/katana,
 			/obj/item/organ/internal/cyberimp/arm/toolset_abductor,
 			/obj/item/organ/internal/cyberimp/arm/esword,
 			/obj/item/organ/internal/heart/demon/pulse,
 			/obj/item/organ/internal/eyes/cybernetic/eyesofgod
-		)
+			)
+
+		spawn_type = pick(organ_loot)
 	new spawn_type(src)

--- a/code/game/objects/items/weapons/storage/lockbox.dm
+++ b/code/game/objects/items/weapons/storage/lockbox.dm
@@ -200,7 +200,7 @@
 		origin_tech = null //wipe out any origin tech if it's unlocked in any way so you can't double-dip tech levels at R&D.
 
 /obj/item/storage/lockbox/experimental_weapon
-	name = "class A-113 classified lockbox"
+	name = "A-113 classified lockbox"
 	desc = "Contains a classifed item for experimental purposes. Looks like some acid was spilt on it."
 	req_access = list(ACCESS_SEC_DOORS) //officers, heads
 

--- a/code/game/objects/items/weapons/storage/lockbox.dm
+++ b/code/game/objects/items/weapons/storage/lockbox.dm
@@ -198,3 +198,36 @@
 		locked = FALSE
 		icon_state = icon_broken
 		origin_tech = null //wipe out any origin tech if it's unlocked in any way so you can't double-dip tech levels at R&D.
+
+/obj/item/storage/lockbox/experimental_weapon
+	name = "class A-113 classified lockbox"
+	desc = "Contains a classifed item for experimental purposes. Looks like some acid was spilt on it."
+	req_access = list(ACCESS_SEC_DOORS) //officers, heads
+
+/obj/item/storage/lockbox/experimental_weapon/populate_contents()
+	if(prob(90))
+		switch(rand(1, 4))
+			if(1)
+				new /obj/item/gun/energy/kinetic_accelerator/experimental(src)
+			if(2)
+				new /obj/item/surveillance_upgrade(src)
+			if(3)
+				new /obj/item/mod/module/stealth/ninja(src)
+			if(4)	//organ time. I want this to be more balanced in distribution, so organs are under a prob 25
+				switch(rand(5, 10))
+					if(5)
+						new /obj/item/organ/internal/cyberimp/arm/katana(src)
+					if(6)
+						new /obj/item/organ/internal/cyberimp/arm/toolset_abductor(src)
+					if(7)
+						new /obj/item/organ/internal/cyberimp/arm/esword(src)
+					if(8)
+						new /obj/item/organ/internal/heart/demon/pulse(src)
+					if(9)
+						new /obj/item/organ/internal/eyes/cybernetic/eyesofgod(src)
+					if(10) //Disected drone before the place got wiped. No hivenode.
+						new /obj/item/organ/internal/alien/plasmavessel/drone(src)
+						new /obj/item/organ/internal/alien/acidgland(src)
+						new /obj/item/organ/internal/alien/resinspinner(src)
+		return
+	new /obj/item/clothing/mask/facehugger(src) //Suprise! Storing facehuggers improperly is what lead to this mess.


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Removes the fluff item from moonbase.
Moves the anomaly core into the safe, as that is more valuable than the research paper.
Paper moved outside the vault.
Added the experimental item lockbox to the safe. This one requires head or sec door access, so an explorer will have to bribe a head or officer to keep the contents.

Note: The ruin has no way to open a safe. You need to bring a stethoscope from somewhere else.

Contents 10% of the time are a facehugger, which will leap out and infect the person without a proper helmet.
This is unlikely to cause a breakout, as the person will need to not be taken to medbay during this time, and not have a mask on. Combined with sec access or head access needed, rare. As you can not look inside, not going to exactly be easy to prepare a monkey as bait either.

If not the hugger, we move onto other loot. 25% of the time an experimental KA. 25% of the time AI camera upgrade. 25% of the time ninja stealth.
The remaining 25% of the time grants some various organs. This will require medical or robotics helping you, and some of them are going to raise eyebrows if the officer or head looks in the box first.
One of these is picked. Drone organs are all together
Dark shard katana, same as mining.
Toolset abductor, good tools or rnd.
Esword arm. Better than straight up giving them an esword as they have to get it implanted, and the officer / heads are going to shut you down.
Pulse heart, bio or charging. 
Eyes of the gods, harder to use xray than the bio 8 implant.
Xeno drone organs WITHOUT hivenode. Could have fun with them, but no stunning neurotoxin, and no hearing xenos spawn.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Fluff items in space ruins are bad.

Moving the stronger loot into the safe is good.

Making a lootbox which many crewmembers could use that requires the explorer to work with a head or officer (or bribe them), with a small chance to go wrong is interesting!

## Testing
<!-- How did you test the PR, if at all? -->

Confirm map changed correctly

Confirmed lockbox worked correctly.

## Changelog
:cl:
del: Remove fluff item from moon outpost 19
tweak: Moved anomaly core inside moon outpost 19 safe.
tweak: A lockbox with many experimental items can be found inside the outpost 19 safe.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
