### PR TITLE
Refactors custom_pain to work on organs instead of on mobs

### DIFF
--- a/code/modules/mob/living/carbon/human/human_mob.dm
+++ b/code/modules/mob/living/carbon/human/human_mob.dm
@@ -1197,7 +1197,7 @@
 		return 0
 
 	if(!L.is_bruised())
-		custom_pain("You feel a stabbing pain in your chest!")
+		L.custom_pain("You feel a stabbing pain in your chest!")
 		L.damage = L.min_bruised_damage
 
 /mob/living/carbon/human/cuff_resist(obj/item/I)

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -23,10 +23,10 @@
 		//Moving around with fractured ribs won't do you any good
 			if(E.is_broken() && E.internal_organs && E.internal_organs.len && prob(15))
 				var/obj/item/organ/internal/I = pick(E.internal_organs)
-				custom_pain("You feel broken bones moving in your [E.name]!")
+				E.custom_pain("You feel broken bones moving in your [E.name]!")
 				I.receive_damage(rand(3,5))
 			if((E.status & ORGAN_BURNT) && !(E.status & ORGAN_SALVED))
-				custom_pain("You feel the skin sloughing off the burn on your [E.name]!")
+				E.custom_pain("You feel the skin sloughing off the burn on your [E.name]!")
 				E.germ_level++
 
 

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -24,7 +24,7 @@
 			if(E.is_broken() && E.internal_organs && E.internal_organs.len && prob(15))
 				var/obj/item/organ/internal/I = pick(E.internal_organs)
 				E.custom_pain("You feel broken bones moving in your [E.name]!")
-				I.receive_damage(rand(3,5))
+				I.receive_damage(rand(3, 5))
 			if((E.status & ORGAN_BURNT) && !(E.status & ORGAN_SALVED))
 				E.custom_pain("You feel the skin sloughing off the burn on your [E.name]!")
 				E.germ_level++

--- a/code/modules/surgery/bones.dm
+++ b/code/modules/surgery/bones.dm
@@ -62,7 +62,7 @@
 		"[user] starts applying medication to the damaged bones in [target]'s [affected.name] with \the [tool].",
 		"You start applying medication to the damaged bones in [target]'s [affected.name] with \the [tool]."
 	)
-	target.custom_pain("Something in your [affected.name] is causing you a lot of pain!")
+	affected.custom_pain("Something in your [affected.name] is causing you a lot of pain!")
 	return ..()
 
 /datum/surgery_step/glue_bone/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -98,7 +98,7 @@
 		"[user] is beginning to set the bone in [target]'s [affected.name] in place with \the [tool].",
 		"You are beginning to set the bone in [target]'s [affected.name] in place with \the [tool]."
 	)
-	target.custom_pain("The pain in your [affected.name] is going to make you pass out!")
+	affected.custom_pain("The pain in your [affected.name] is going to make you pass out!")
 	return ..()
 
 /datum/surgery_step/set_bone/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)

--- a/code/modules/surgery/cavity_implant.dm
+++ b/code/modules/surgery/cavity_implant.dm
@@ -158,7 +158,7 @@
 		"[user] starts making some space inside [target]'s [get_cavity(affected)] cavity with \the [tool].",
 		"You start making some space inside [target]'s [get_cavity(affected)] cavity with \the [tool]."
 	)
-	target.custom_pain("The pain in your chest is living hell!")
+	affected.custom_pain("The pain in your chest is living hell!")
 	return ..()
 
 /datum/surgery_step/cavity/make_space/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery)
@@ -188,7 +188,7 @@
 		"[user] starts mending [target]'s [get_cavity(affected)] cavity wall with \the [tool].",
 		"You start mending [target]'s [get_cavity(affected)] cavity wall with \the [tool]."
 	)
-	target.custom_pain("The pain in your chest is living hell!")
+	affected.custom_pain("The pain in your chest is living hell!")
 	return ..()
 
 /datum/surgery_step/cavity/close_space/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery)
@@ -300,7 +300,7 @@
 		"[user] starts putting \the [tool] inside [target]'s [get_cavity(affected)] cavity.",
 		"You start putting \the [tool] inside [target]'s [get_cavity(affected)] cavity."
 	)
-	target.custom_pain("The pain in your [target_zone] is living hell!")
+	affected.custom_pain("The pain in your [target_zone] is living hell!")
 	return ..()
 
 /datum/surgery_step/cavity/place_item/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery)

--- a/code/modules/surgery/encased.dm
+++ b/code/modules/surgery/encased.dm
@@ -22,7 +22,7 @@
 		"[user] begins to cut through [target]'s [affected.encased] with \the [tool].",
 		"You begin to cut through [target]'s [affected.encased] with \the [tool]."
 	)
-	target.custom_pain("Something hurts horribly in your [affected.name]!")
+	affected.custom_pain("Something hurts horribly in your [affected.name]!")
 	return ..()
 
 /datum/surgery_step/open_encased/saw/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery)
@@ -67,7 +67,7 @@
 		"[user] starts to force open the [affected.encased] in [target]'s [affected.name] with \the [tool].",
 		"You start to force open the [affected.encased] in [target]'s [affected.name] with \the [tool]."
 	)
-	target.custom_pain("Something hurts horribly in your [affected.name]!")
+	affected.custom_pain("Something hurts horribly in your [affected.name]!")
 	return ..()
 
 /datum/surgery_step/open_encased/retract/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery)
@@ -113,7 +113,7 @@
 		"[user] starts bending [target]'s [affected.encased] back into place with \the [tool].",
 		"You start bending [target]'s [affected.encased] back into place with \the [tool]."
 	)
-	target.custom_pain("Something hurts horribly in your [affected.name]!")
+	affected.custom_pain("Something hurts horribly in your [affected.name]!")
 	return ..()
 
 /datum/surgery_step/open_encased/close/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery)
@@ -155,7 +155,7 @@
 		"[user] starts applying \the [tool] to [target]'s [affected.encased].",
 		"You start applying \the [tool] to [target]'s [affected.encased]."
 	)
-	target.custom_pain("Something hurts horribly in your [affected.name]!")
+	affected.custom_pain("Something hurts horribly in your [affected.name]!")
 	return ..()
 
 /datum/surgery_step/open_encased/mend/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery)

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -29,7 +29,7 @@
 		"[user] starts the incision on [target]'s [affected.name] with \the [tool].",
 		"You start the incision on [target]'s [affected.name] with \the [tool]."
 	)
-	target.custom_pain("You feel a horrible pain as if from a sharp knife in your [affected.name]!")
+	affected.custom_pain("You feel a horrible pain as if from a sharp knife in your [affected.name]!")
 	return ..()
 
 /datum/surgery_step/generic/cut_open/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery)
@@ -69,7 +69,7 @@
 		"[user] starts clamping bleeders in [target]'s [affected.name] with \the [tool].",
 		"You start clamping bleeders in [target]'s [affected.name] with \the [tool]."
 	)
-	target.custom_pain("The pain in your [affected.name] is maddening!")
+	affected.custom_pain("The pain in your [affected.name] is maddening!")
 	return ..()
 
 /datum/surgery_step/generic/clamp_bleeders/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery)
@@ -114,7 +114,7 @@
 		msg = "[user] starts to pry open the incision and rearrange the organs in [target]'s lower abdomen with \the [tool]."
 		self_msg = "You start to pry open the incision and rearrange the organs in [target]'s lower abdomen with \the [tool]."
 	user.visible_message(msg, self_msg)
-	target.custom_pain("It feels like the skin on your [affected.name] is on fire!")
+	affected.custom_pain("It feels like the skin on your [affected.name] is on fire!")
 	return ..()
 
 /datum/surgery_step/generic/retract_skin/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery)
@@ -165,7 +165,7 @@
 		"[user] is beginning to cauterize the incision on [target]'s [affected.name] with \the [tool].",
 		"You are beginning to cauterize the incision on [target]'s [affected.name] with \the [tool]."
 	)
-	target.custom_pain("Your [affected.name] is being burned!")
+	affected.custom_pain("Your [affected.name] is being burned!")
 	return ..()
 
 /datum/surgery_step/generic/cauterize/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery)
@@ -197,7 +197,7 @@
 		// give a little heads up to the surgeon that they're stopping the surgery prematurely in case that wasn't the intention.
 		"<span class='warning'>You are interrupting the current surgery</span>, beginning to cauterize the incision on [target]'s [affected.name] with \the [tool]."
 	)
-	target.custom_pain("Your [affected.name] is being burned!")
+	affected.custom_pain("Your [affected.name] is being burned!")
 	return ..()
 
 
@@ -252,7 +252,7 @@
 		"[user] is beginning to amputate [target]'s [affected.name] with \the [tool].",
 		"You are beginning to cut through [target]'s [affected.amputation_point] with \the [tool]."
 	)
-	target.custom_pain("Your [affected.amputation_point] is being ripped apart!")
+	affected.custom_pain("Your [affected.amputation_point] is being ripped apart!")
 	return ..()
 
 /datum/surgery_step/generic/amputate/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery)

--- a/code/modules/surgery/implant_removal.dm
+++ b/code/modules/surgery/implant_removal.dm
@@ -50,7 +50,7 @@
 		"[user] starts poking around inside [target]'s [affected.name] with \the [tool].",
 		"You start poking around inside [target]'s [affected.name] with \the [tool]."
 	)
-	target.custom_pain("The pain in your [affected.name] is living hell!")
+	affected.custom_pain("The pain in your [affected.name] is living hell!")
 	return ..()
 
 /datum/surgery_step/extract_implant/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery)

--- a/code/modules/surgery/organs/organ.dm
+++ b/code/modules/surgery/organs/organ.dm
@@ -34,6 +34,10 @@
 	///Should this organ be destroyed on removal?
 	var/destroy_on_removal = FALSE
 
+	/// What was the last pain message that was sent?
+	var/last_pain_message
+	/// When can we get the next pain message?
+	var/next_pain_time
 
 /obj/item/organ/Destroy()
 	STOP_PROCESSING(SSobj, src)
@@ -219,7 +223,7 @@
 	if(owner && parent_organ && amount > 0)
 		var/obj/item/organ/external/parent = owner.get_organ(parent_organ)
 		if(parent && !silent)
-			owner.custom_pain("Something inside your [parent.name] hurts a lot.")
+			custom_pain("Something inside your [parent.name] hurts a lot.")
 
 		//check if we've hit max_damage
 	if(damage >= max_damage)
@@ -306,3 +310,16 @@ I use this so that this can be made better once the organ overhaul rolls out -- 
 			robotize()
 		status = data["status"]
 	..()
+
+// A proc to send a pain message to the owner.
+/obj/item/organ/proc/custom_pain(message)
+	if(!owner.can_feel_pain() || !message)
+		return
+
+	var/msg = "<span class='userdanger'>[message]</span>"
+
+	// Anti message spam checks
+	if(msg != last_pain_message || world.time >= next_pain_time)
+		last_pain_message = msg
+		to_chat(owner, msg)
+		next_pain_time = world.time + 10 SECONDS

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -716,7 +716,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	if(limb_flags & CANNOT_INT_BLEED)
 		return
 	status |= ORGAN_INT_BLEEDING
-	owner.custom_pain("You feel something rip in your [name]!")
+	custom_pain("You feel something rip in your [name]!")
 
 /obj/item/organ/external/proc/fix_internal_bleeding()
 	if(is_robotic())

--- a/code/modules/surgery/organs/pain.dm
+++ b/code/modules/surgery/organs/pain.dm
@@ -39,20 +39,6 @@
 		to_chat(src, msg)
 	next_pain_time = world.time + (100 - amount)
 
-
-// message is the custom message to be displayed
-/mob/living/carbon/proc/custom_pain(message)
-	if(!can_feel_pain())
-		return
-
-	var/msg = "<span class='userdanger'>[message]</span>"
-
-	// Anti message spam checks
-	if(msg && ((msg != last_pain_message) && (world.time >= next_pain_time)))
-		last_pain_message = msg
-		to_chat(src, msg)
-		next_pain_time = world.time + 10 SECONDS
-
 /mob/living/carbon/human/proc/handle_pain()
 	// not when sleeping
 
@@ -89,4 +75,4 @@
 					intensity = "a sharp"
 				else
 					intensity = "a stabbing"
-			custom_pain("You feel [intensity] pain in your [parent.limb_name]!")
+			I.custom_pain("You feel [intensity] pain in your [parent.limb_name]!")

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -225,8 +225,7 @@
 		return SURGERY_BEGINSTEP_SKIP
 
 	if(affected)
-		var/mob/living/carbon/C = target
-		C.custom_pain("The pain in your [affected.name] is living hell!")
+		affected.custom_pain("The pain in your [affected.name] is living hell!")
 
 	return ..()
 
@@ -320,7 +319,7 @@
 		var/mob/living/carbon/human/H = target
 		var/obj/item/organ/affected = H.get_organ(user.zone_selected)
 		if(H && affected)
-			H.custom_pain("The pain in your [affected.name] is living hell!")
+			affected.custom_pain("The pain in your [affected.name] is living hell!")
 	else
 		return SURGERY_BEGINSTEP_SKIP
 
@@ -414,8 +413,7 @@
 			"[user] starts transplanting [tool] into [target]'s [affected.name].",
 			"You start transplanting [tool] into [target]'s [affected.name]."
 		)
-		var/mob/living/carbon/human/H = target
-		H.custom_pain("Someone's rooting around in your [affected.name]!")
+		affected.custom_pain("Someone's rooting around in your [affected.name]!")
 	else
 		user.visible_message(
 			"[user] starts transplanting [tool] into [target]'s [parse_zone(target_zone)].",
@@ -495,7 +493,7 @@
 			msg = "[user] begins injecting [tool] into [target]'s [I.name]."
 			self_msg = "You begin injecting [tool] into [target]'s [I.name]."
 		user.visible_message(msg, self_msg)
-		target.custom_pain("Something burns horribly in your [parse_zone(target_zone)]!")
+		affected.custom_pain("Something burns horribly in your [parse_zone(target_zone)]!")
 
 	return ..()
 
@@ -633,7 +631,7 @@
 		user.visible_message(msg, self_msg)
 
 	if(H && affected)
-		H.custom_pain("Something hurts horribly in your [affected.name]!")
+		affected.custom_pain("Something hurts horribly in your [affected.name]!")
 
 	return ..()
 
@@ -822,7 +820,8 @@
 		"[user] is beginning to cauterize the incision on [target]'s [zone] with \the [tool].",
 		"You are beginning to cauterize the incision on [target]'s [zone] with \the [tool]."
 	)
-	target.custom_pain("Your [zone] is being burned!")
+	var/obj/item/organ/affected = target.get_organ(target_zone)
+	affected.custom_pain("Your [zone] is being burned!")
 	return ..()
 
 /datum/surgery_step/generic/seal_carapace/end_step(mob/living/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -92,7 +92,7 @@
 		"[user] starts patching the damaged vein in [target]'s [affected.name] with \the [tool].",
 		"You start patching the damaged vein in [target]'s [affected.name] with \the [tool]."
 	)
-	target.custom_pain("The pain in your [affected.name] is unbearable!")
+	affected.custom_pain("The pain in your [affected.name] is unbearable!")
 	return ..()
 
 
@@ -141,7 +141,7 @@
 		"[user] starts to treat the scorched tissue in [target]'s [affected.name] with [tool].",
 		"You start to treat the scorched tissue in [target]'s [affected.name] with [tool]."
 	)
-	target.custom_pain("Your [affected.name] flares with agony as its burn is touched!")
+	affected.custom_pain("Your [affected.name] flares with agony as its burn is touched!")
 
 	return ..()
 
@@ -192,7 +192,7 @@
 		"[user] starts cutting away necrotic tissue in [target]'s [affected.name] with \the [tool].",
 		"You start cutting away necrotic tissue in [target]'s [affected.name] with \the [tool]."
 	)
-	target.custom_pain("The pain in [affected.name] is unbearable!")
+	affected.custom_pain("The pain in [affected.name] is unbearable!")
 	return ..()
 
 /datum/surgery_step/fix_dead_tissue/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery)
@@ -254,7 +254,7 @@
 		"[user] starts applying medication to the affected tissue in [target]'s [affected.name] with \the [tool].",
 		"You start applying medication to the affected tissue in [target]'s [affected.name] with \the [tool]."
 	)
-	target.custom_pain("Something in your [affected.name] is causing you a lot of pain!")
+	affected.custom_pain("Something in your [affected.name] is causing you a lot of pain!")
 	return ..()
 
 /datum/surgery_step/treat_necrosis/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery)

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -363,7 +363,7 @@
 		to_chat(user, "There are no damaged components in [affected].")
 		return SURGERY_BEGINSTEP_SKIP
 
-	target.custom_pain("The pain in your [affected.name] is living hell!")
+	affected.custom_pain("The pain in your [affected.name] is living hell!")
 	return ..()
 
 
@@ -427,7 +427,7 @@
 		"You start reattaching [target]'s [tool]."
 	)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	target.custom_pain("Someone's rooting around in your [affected.name]!")
+	affected.custom_pain("Someone's rooting around in your [affected.name]!")
 	return ..()
 
 /datum/surgery_step/robotics/manipulate_robotic_organs/implant/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery)
@@ -482,7 +482,7 @@
 				"You start to decouple [target]'s [I] with \the [tool]."
 			)
 
-			target.custom_pain("The pain in your [affected.name] is living hell!")
+			affected.custom_pain("The pain in your [affected.name] is living hell!")
 		else
 			return SURGERY_BEGINSTEP_SKIP
 
@@ -603,7 +603,7 @@
 		"You start to decouple [target]'s [affected.name] with \the [tool]."
 	)
 
-	target.custom_pain("Your [affected.amputation_point] is being ripped apart!")
+	affected.custom_pain("Your [affected.amputation_point] is being ripped apart!")
 	return ..()
 
 /datum/surgery_step/robotics/external/amputate/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Rescopes `custom_pain` to be a proc on `/obj/item/organ` instead of mobs.
This will prevent custom pain messages to be clouded up if there are multiple burn wounds/broken bones/damaged organs on a person.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
- Won't only give chat messages for 2 of your total burn wounds/broken bones/damaged organs
- Still won't spam your chat as much as it used to
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Gave myself a burn wound, broken bone and a pierced lung. All messages showed up in my chat.
<!-- How did you test the PR, if at all? -->

## Changelog
NPFC

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
