### PR TITLE
Makes some alterations to the APC CI

### DIFF
--- a/code/modules/unit_tests/areas_apcs.dm
+++ b/code/modules/unit_tests/areas_apcs.dm
@@ -8,5 +8,10 @@
 			continue
 		if(is_type_in_list(A, optional_areas))
 			continue
-		if(!(length(A.apc) == 1))
-			Fail("Area [A] has [length(A.apc)] apcs, instead of 1.")
+		if(length(A.apc) == 0)
+			Fail("Area [A.type] has [length(A.apc)] apcs, instead of 1.")
+		else if (length(A.apc) > 1)
+			var/list/locations = list()
+			for(var/atom/probably_an_apc as anything in A.apc)
+				locations += "([probably_an_apc.x], [probably_an_apc.y], [probably_an_apc.z])"
+			Fail("Area [A.type] has [length(A.apc)] apcs, instead of 1. APCs are located at [english_list(locations)]")

--- a/code/modules/unit_tests/areas_apcs.dm
+++ b/code/modules/unit_tests/areas_apcs.dm
@@ -10,7 +10,7 @@
 			continue
 		if(length(A.apc) == 0)
 			Fail("Area [A.type] has [length(A.apc)] apcs, instead of 1.")
-		else if (length(A.apc) > 1)
+		else if(length(A.apc) > 1)
 			var/list/locations = list()
 			for(var/atom/probably_an_apc as anything in A.apc)
 				locations += "([probably_an_apc.x], [probably_an_apc.y], [probably_an_apc.z])"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->CI now shows the type of the area instead of the name. If the area has multiple APCs, it now lists the locations of the APCs.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Makes it easier for people to fix their CI.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![image](https://github.com/ParadiseSS13/Paradise/assets/91113370/58ba9e12-4881-46e9-a81b-01c9d78afe11)

## Testing
<!-- How did you test the PR, if at all? -->
Yeah, it runs

## Changelog
NPFC

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
