### PR TITLE
Cyborgs and AIs now don't get a bank account assigned.

### DIFF
--- a/code/controllers/subsystem/SSjobs.dm
+++ b/code/controllers/subsystem/SSjobs.dm
@@ -594,7 +594,7 @@ SUBSYSTEM_DEF(jobs)
 
 //fuck
 /datum/controller/subsystem/jobs/proc/CreateMoneyAccount(mob/living/H, rank, datum/job/job)
-	if(istype(job, /datum/job/cyborg) || istype(job, /datum/job/ai)) // They don't need bank accounts, robots don't get paid.
+	if(!job.has_bank_account)
 		return
 	var/starting_balance = job?.department_account_access ? COMMAND_MEMBER_STARTING_BALANCE : CREW_MEMBER_STARTING_BALANCE
 	var/datum/money_account/account = GLOB.station_money_database.create_account(H.real_name, starting_balance, ACCOUNT_SECURITY_ID, "NAS Trurl Accounting", TRUE)

--- a/code/controllers/subsystem/SSjobs.dm
+++ b/code/controllers/subsystem/SSjobs.dm
@@ -594,6 +594,8 @@ SUBSYSTEM_DEF(jobs)
 
 //fuck
 /datum/controller/subsystem/jobs/proc/CreateMoneyAccount(mob/living/H, rank, datum/job/job)
+	if(istype(job, /datum/job/cyborg) || istype(job, /datum/job/ai)) // They don't need bank accounts, robots don't get paid.
+		return
 	var/starting_balance = job?.department_account_access ? COMMAND_MEMBER_STARTING_BALANCE : CREW_MEMBER_STARTING_BALANCE
 	var/datum/money_account/account = GLOB.station_money_database.create_account(H.real_name, starting_balance, ACCOUNT_SECURITY_ID, "NAS Trurl Accounting", TRUE)
 

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -17,6 +17,8 @@
 	var/job_departments = list()
 	///Can this role access its department money account?
 	var/department_account_access = FALSE
+	/// Does this job get a bank account?
+	var/has_bank_account = TRUE
 	//How many players can be this job
 	var/total_positions = 0
 

--- a/code/game/jobs/job/silicon_jobs.dm
+++ b/code/game/jobs/job/silicon_jobs.dm
@@ -10,6 +10,7 @@
 	req_admin_notify = 1
 	minimal_player_age = 30
 	exp_map = list(EXP_TYPE_SILICON = 300)
+	has_bank_account = FALSE
 
 /datum/job/ai/equip(mob/living/carbon/human/H)
 	if(!H)
@@ -31,6 +32,7 @@
 	minimal_player_age = 21
 	exp_map = list(EXP_TYPE_CREW = 300)
 	alt_titles = list("Robot")
+	has_bank_account = FALSE
 
 /datum/job/cyborg/equip(mob/living/carbon/human/H)
 	if(!H)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes sure that Cyborgs and AIs don't get a bank account assigned on roundstart.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Alright so, let's first take a look why this even happened.
First, everyone gets created as a human/whatever race, and then they get equipped for their job. The equip for Cyborgs is that they get Roboticized, meaning that the borg is created. The issue is that right before this, they get assigned a bank account which is thus linked to the human mob.

Then why is this good?
AIs and Cyborgs don't get paid by Nanotrasen. There is no reason for them to have a bank account that just siphons funds for no reason.
And for those arguing Corporate is a reason for this:
The **station** should be making money on this lawset. Revenue for Nanotrasen =/= revenue for the sillicons.

Resolves #22364
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Spawned in as a roundstart borg, couldn't see any accounts on the HOP Terminal
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Borgs and AIs now don't get a bank account assigned.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
