### PR TITLE
fixes admin given assassinateonce objective.

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -684,8 +684,8 @@
 				else
 					new_objective = new objective_path
 					new_objective:target = new_target:mind
-					//Will display as special role if assigned mode is equal to special role.. Ninjas/commandos/nuke ops.
 					new_objective.explanation_text = "[objective_type] [new_target:real_name], the [new_target:mind:assigned_role == new_target:mind:special_role ? (new_target:mind:special_role) : (new_target:mind:assigned_role)]."
+					new_objective.establish_signals()
 
 			if("destroy")
 				var/list/possible_targets = active_ais(1)

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -684,6 +684,7 @@
 				else
 					new_objective = new objective_path
 					new_objective:target = new_target:mind
+					//Will display as special role if assigned mode is equal to special role.. Ninjas/commandos/nuke ops.
 					new_objective.explanation_text = "[objective_type] [new_target:real_name], the [new_target:mind:assigned_role == new_target:mind:special_role ? (new_target:mind:special_role) : (new_target:mind:assigned_role)]."
 					new_objective.establish_signals()
 

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -57,6 +57,11 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 /datum/objective/proc/found_target()
 	return target
 
+/datum/objective/proc/establish_signals()
+	/**
+	 * This is for objectives that need to register signals, so place them in here. Makes it easier for add_objective to call it.
+	 */
+
 /**
  * Get all owners of the objective, including ones from the objective's team, if it has one.
  *
@@ -174,10 +179,13 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 	..()
 	if(target?.current)
 		explanation_text = "Teach [target.current.real_name], the [target.assigned_role], a lesson they will not forget. The target only needs to die once for success."
-		RegisterSignal(target.current, list(COMSIG_MOB_DEATH, COMSIG_PARENT_QDELETING), PROC_REF(check_midround_completion))
+		establish_signals()
 	else
 		explanation_text = "Free Objective"
 	return target
+
+/datum/objective/assassinateonce/establish_signals()
+	RegisterSignal(target.current, list(COMSIG_MOB_DEATH, COMSIG_PARENT_QDELETING), PROC_REF(check_midround_completion))
 
 /datum/objective/assassinateonce/check_completion()
 	return won || completed || !target?.current?.ckey
@@ -670,7 +678,7 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 
 /datum/objective/destroy/post_target_cryo(list/owners)
 	holder.replace_objective(src, /datum/objective/assassinate)
-	
+
 /datum/objective/steal_five_of_type
 	name = "Steal Five Items"
 	explanation_text = "Steal at least five items!"

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -57,10 +57,11 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 /datum/objective/proc/found_target()
 	return target
 
+/**
+ * This is for objectives that need to register signals, so place them in here. Makes it easier for add_objective to call it.
+ */
 /datum/objective/proc/establish_signals()
-	/**
-	 * This is for objectives that need to register signals, so place them in here. Makes it easier for add_objective to call it.
-	 */
+	return
 
 /**
  * Get all owners of the objective, including ones from the objective's team, if it has one.


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Fixes https://github.com/ParadiseSS13/Paradise/issues/23174#issue-1978366201

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
the objective properly functions when it's given to player via admin.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
<!-- How did you test the PR, if at all? -->
spawned two mobs and gave them minds, gave one traitor and a assassinateonce objective, killed the second mob, revived them, added a second assassinate once for comparison and ended the round.

## Changelog
:cl:
fix: Admin given "assassinateonce" works properly now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
