### PR TITLE
Removes the IPC damage mod. For real this time.

### DIFF
--- a/code/modules/mob/living/carbon/human/species/machine.dm
+++ b/code/modules/mob/living/carbon/human/species/machine.dm
@@ -16,8 +16,6 @@
 	skinned_type = /obj/item/stack/sheet/metal // Let's grind up IPCs for station resources!
 
 	eyes = "blank_eyes"
-	brute_mod = 1 / 0.66 // 1 * 0.66 (robolimbs) * 1/0.66 = 1
-	burn_mod = 1 / 0.66 // so no damage mod overall.
 	tox_mod = 0
 	clone_mod = 0
 	death_message = "gives a short series of shrill beeps, their chassis shuddering before falling limp, nonfunctional."

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -205,7 +205,7 @@
 	if((brute <= 0) && (burn <= 0))
 		return 0
 
-	if(!ignore_resists)
+	if(!ignore_resists && !ismachineperson(owner)) //Machine people can't have augmented limbs, and this lets us give them no strange damage issues from countering the 33% resist
 		brute *= brute_mod
 		burn *= burn_mod
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Removes damage mod from ipcs.
Prevents IPCS from using limb damage mods. The only thing that uses this is robo limbs, which ipcs will never not have.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

IPCs still have a damage mod. For lasers / punches, it balances out.
Anything that does adjust brute loss or adjust burn loss however, does about 37% more damage than it should.
Chemicals, atmos, fire, magic, special attacks from mobs, a whole bunch of other mechanics do this
As such, we fix this by removing the damage mods ipcs have internally to counter their resist by robo limbs, and prevent them from getting the damage mod from robo limbs. We don't make limbs more protected, ipcs will never get less protected limbs (organic limbs), so we will not have to worry about it.
The only way this would be funny is if an admin var edited the limbs on an IPC to be tougher, rather than just adjusting psychology on an IPC, which is what would be done, as no one is going to edit each limb on a mob one by one.

## Testing
<!-- How did you test the PR, if at all? -->

Confirmed other species took damage as expected.
Confirmed ipcs took toolboxes as epected. 
Confirmed that adjusting brute via VV adjusts 5 brute into 5 brute, vs 6.98872 brute

## Changelog
:cl:
tweak: IPCS now don't have a damage mod for real. They no longer take extra damage from non projectile / melee attack sources.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
