### PR TITLE
Moves Some Uplink Items from Job Specific to Standard Uplink

### DIFF
--- a/code/datums/uplink_items/uplink_general.dm
+++ b/code/datums/uplink_items/uplink_general.dm
@@ -367,6 +367,15 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/toy/plushie/carpplushie/dehy_carp
 	cost = 5
 
+/datum/uplink_item/stealthy_weapons/powergloves
+	name = "Power Gloves"
+	desc = "Insulated gloves that can utilize the power of the station to deliver a short arc of electricity at a target. \
+			Must be standing on a powered cable to use. \
+			Activated by alt-clicking, or pressing the middle mouse button. Disarm intent will deal stamina damage and cause jittering, while harm intent will deal damage based on the power of the cable you're standing on."
+	reference = "PG"
+	item = /obj/item/clothing/gloves/color/yellow/power
+	cost = 50
+
 
 // GRENADES AND EXPLOSIVES
 
@@ -544,6 +553,13 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/handheld_mirror
 	cost = 5
 
+/datum/uplink_item/stealthy_tools/pickpocketgloves
+	name = "Pickpocket's Gloves"
+	desc = "A pair of sleek gloves to aid in pickpocketing. While wearing these, you can loot your target without them knowing. Pickpocketing puts the item directly into your hand."
+	reference = "PPG"
+	item = /obj/item/clothing/gloves/color/black/thief
+	cost = 30
+
 // DEVICE AND TOOLS
 
 /datum/uplink_item/device_tools
@@ -596,6 +612,12 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/storage/box/syndie_kit/teleporter
 	cost = 40
 
+/datum/uplink_item/jdevice_tools/syndidonk
+	name = "Syndicate Donk Pockets"
+	desc = "A box of highly specialized Donk pockets with a number of regenerative and stimulating chemicals inside of them; the box comes equipped with a self-heating mechanism."
+	reference = "SDP"
+	item = /obj/item/storage/box/syndidonkpockets
+	cost = 10
 
 
 //Space Suits and Hardsuits

--- a/code/datums/uplink_items/uplink_traitor.dm
+++ b/code/datums/uplink_items/uplink_traitor.dm
@@ -104,14 +104,6 @@
 	cost = 40
 	job = list("Chef")
 
-/datum/uplink_item/jobspecific/syndidonk
-	name = "Syndicate Donk Pockets"
-	desc = "A box of highly specialized Donk pockets with a number of regenerative and stimulating chemicals inside of them; the box comes equipped with a self-heating mechanism."
-	reference = "SDP"
-	item = /obj/item/storage/box/syndidonkpockets
-	cost = 10
-	job = list("Chef")
-
 //Chaplain
 
 /datum/uplink_item/jobspecific/missionary_kit
@@ -174,16 +166,6 @@
 	cost = 10
 	job = list("Psychiatrist")//why? Becuase its funny that a person in charge of your mental wellbeing has a cat granade..
 
-//Assistant
-
-/datum/uplink_item/jobspecific/pickpocketgloves
-	name = "Pickpocket's Gloves"
-	desc = "A pair of sleek gloves to aid in pickpocketing. While wearing these, you can loot your target without them knowing. Pickpocketing puts the item directly into your hand."
-	reference = "PPG"
-	item = /obj/item/clothing/gloves/color/black/thief
-	cost = 30
-	job = list("Assistant")
-
 //Bartender
 
 /datum/uplink_item/jobspecific/drunkbullets
@@ -213,18 +195,6 @@
 	item = /obj/item/bee_briefcase
 	cost = 50
 	job = list("Botanist")
-
-//Engineer
-
-/datum/uplink_item/jobspecific/powergloves
-	name = "Power Gloves"
-	desc = "Insulated gloves that can utilize the power of the station to deliver a short arc of electricity at a target. \
-			Must be standing on a powered cable to use. \
-			Activated by alt-clicking, or pressing the middle mouse button. Disarm intent will deal stamina damage and cause jittering, while harm intent will deal damage based on the power of the cable you're standing on."
-	reference = "PG"
-	item = /obj/item/clothing/gloves/color/yellow/power
-	cost = 50
-	job = list("Station Engineer", "Chief Engineer")
 
 //RD
 
@@ -282,16 +252,6 @@
 	item = /obj/item/fireaxe/energized
 	cost = 40
 	job = list("Life Support Specialist")
-
-//Stimulants
-
-/datum/uplink_item/jobspecific/stims
-	name = "Stimulants"
-	desc = "A highly illegal compound contained within a compact auto-injector; when injected it makes the user extremely resistant to incapacitation and greatly enhances the body's ability to repair itself."
-	reference = "ST"
-	item = /obj/item/reagent_containers/hypospray/autoinjector/stimulants
-	cost = 40
-	job = list("Scientist", "Research Director", "Geneticist", "Chief Medical Officer", "Medical Doctor", "Psychiatrist", "Chemist", "Paramedic", "Coroner", "Virologist")
 
 // Genetics
 
@@ -596,6 +556,14 @@
 		return FALSE
 
 	new /obj/structure/closet/crate/surplus(loc, U, crate_value, cost)
+
+/datum/uplink_item/device_tools/stims
+	name = "Stimulants"
+	desc = "A highly illegal compound contained within a compact auto-injector; when injected it makes the user extremely resistant to incapacitation and greatly enhances the body's ability to repair itself."
+	reference = "ST"
+	item = /obj/item/reagent_containers/hypospray/autoinjector/stimulants
+	cost = 40
+	excludefrom = list(UPLINK_TYPE_NUCLEAR, UPLINK_TYPE_SST)
 
 // -----------------------------------
 // PRICES OVERRIDEN FOR NUCLEAR AGENTS

--- a/code/datums/uplink_items/uplink_traitor.dm
+++ b/code/datums/uplink_items/uplink_traitor.dm
@@ -264,17 +264,6 @@
 	cost = 25
 	job = list("Research Director", "Geneticist")
 
-// Paper contact poison pen
-
-/datum/uplink_item/jobspecific/poison_pen
-	name = "Poison Pen"
-	desc = "Cutting edge of deadly writing implements technology, this gadget will infuse any piece of paper with various delayed poisons based on the selected color. Black ink is normal ink, red ink is a highly lethal poison, green ink causes radiation, blue ink will periodically shock the victim, and yellow ink will paralyze. The included gloves will protect you from your own poisons."
-	reference = "PP"
-	item = /obj/item/storage/box/syndie_kit/poisoner
-	cost = 10
-	excludefrom = list(UPLINK_TYPE_NUCLEAR, UPLINK_TYPE_SST)
-	job = list("Head of Personnel", "Quartermaster", "Cargo Technician", "Librarian", "Coroner", "Psychiatrist", "Virologist")
-
 
 //--------------------------//
 // Species Restricted Gear //
@@ -563,6 +552,14 @@
 	reference = "ST"
 	item = /obj/item/reagent_containers/hypospray/autoinjector/stimulants
 	cost = 40
+	excludefrom = list(UPLINK_TYPE_NUCLEAR, UPLINK_TYPE_SST)
+
+/datum/uplink_item/stealthy_weapons/poison_pen
+	name = "Poison Pen"
+	desc = "Cutting edge of deadly writing implements technology, this gadget will infuse any piece of paper with various delayed poisons based on the selected color. Black ink is normal ink, red ink is a highly lethal poison, green ink causes radiation, blue ink will periodically shock the victim, and yellow ink will paralyze. The included gloves will protect you from your own poisons."
+	reference = "PP"
+	item = /obj/item/storage/box/syndie_kit/poisoner
+	cost = 10
 	excludefrom = list(UPLINK_TYPE_NUCLEAR, UPLINK_TYPE_SST)
 
 // -----------------------------------


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Moves a few items from Job Specific to Standard Uplink.
- Stimulants (not purchasable by Nuclear Operatives)
- Pickpocket Gloves
- SyndieDonks
- Power Gloves
- Poison Pen

## Why It's Good For The Game
This should open up some more kits for people - I'm open to ideas for other items to move over.

## Testing
Looked into a few different uplinks.

## Changelog
:cl:
tweak: moved a few traitor items from Job Specific to Standard Uplink items.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
