### PR TITLE
using the storage implant's action button while it's activated now closes the implant's storage

### DIFF
--- a/code/game/objects/items/weapons/implants/implant_storage.dm
+++ b/code/game/objects/items/weapons/implants/implant_storage.dm
@@ -28,7 +28,11 @@
 	storage.emp_act(severity)
 
 /obj/item/implant/storage/activate()
-	storage.MouseDrop(imp_in)
+	if(!length(storage.mobs_viewing))
+		storage.MouseDrop(imp_in)
+	else
+		for(var/mob/to_close in storage.mobs_viewing)
+			storage.close(to_close)
 
 /obj/item/implant/storage/removed(source)
 	if(..())


### PR DESCRIPTION

<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
using the storage implant's action button while it's activated now closes the implant's storage

## Why It's Good For The Game
actual qol pr from gdn wowwie
matt gave me these brainworms and I hate them

## Testing
clicked it a bunch

## Changelog
:cl:
tweak: using the storage implant's action button while it's activated now closes the implant's storage
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
