### PR TITLE
Fixes machine using power from the area it was created in, rather than using the area it is in

### DIFF
--- a/code/game/machinery/cell_charger.dm
+++ b/code/game/machinery/cell_charger.dm
@@ -101,13 +101,7 @@
 	if(charging)
 		to_chat(user, "<span class='warning'>Remove the cell first!</span>")
 		return
-	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
-		return
-	anchored = !anchored
-	if(anchored)
-		WRENCH_ANCHOR_MESSAGE
-	else
-		WRENCH_UNANCHOR_MESSAGE
+	default_unfasten_wrench(user, I, 0)
 
 /obj/machinery/cell_charger/proc/removecell()
 	charging.update_icon()

--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -205,8 +205,6 @@
 
 /obj/structure/AIcore/wrench_act(mob/living/user, obj/item/I)
 	. = TRUE
-	if(!I.tool_use_check(user, 0))
-		return
 	default_unfasten_wrench(user, I, 20)
 
 /obj/structure/AIcore/update_icon_state()

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -632,15 +632,7 @@
 
 /obj/structure/computerframe/wrench_act(mob/living/user, obj/item/I)
 	. = TRUE
-	if(!I.use_tool(src, user, 2 SECONDS, volume = I.tool_volume))
-		return
-
-	if(anchored)
-		to_chat(user, "<span class='notice'>You unfasten the frame.</span>")
-		anchored = FALSE
-	else
-		to_chat(user, "<span class='notice'>You wrench the frame into place.</span>")
-		anchored = TRUE
+	default_unfasten_wrench(user, I, 2 SECONDS)
 
 /obj/structure/computerframe/crowbar_act(mob/living/user, obj/item/I)
 	. = TRUE

--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -47,15 +47,8 @@ GLOBAL_LIST_EMPTY(doppler_arrays)
 
 /obj/machinery/doppler_array/wrench_act(mob/user, obj/item/I)
 	. = TRUE
-	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+	if(!default_unfasten_wrench(user, I, 0))
 		return
-	if(!anchored && !isinspace())
-		anchored = TRUE
-		WRENCH_ANCHOR_MESSAGE
-	else if(anchored)
-		anchored = FALSE
-		WRENCH_UNANCHOR_MESSAGE
-	power_change()
 	update_icon(UPDATE_ICON_STATE)
 
 /obj/machinery/doppler_array/attack_hand(mob/user)

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -125,17 +125,19 @@
 */
 /obj/machinery/proc/power_change()
 	var/old_stat = stat
-	if(machine_powernet.powernet_area != get_area(src))
-		var/area/machine_area = get_area(src)
-		if(machine_area)
-			machine_powernet?.unregister_machine(src)
-			machine_powernet = machine_area.powernet
-			machine_powernet.register_machine(src)
 	if(has_power(power_channel) || !requires_power) //if we don't require power, we don't give a shit about the power channel!
 		stat &= ~NOPOWER
 	else
 		stat |= NOPOWER
 	return old_stat != stat //performance saving for machines that use power_change() to update icons!
+
+/obj/machinery/proc/reregister_machine()
+	if(machine_powernet?.powernet_area != get_area(src))
+		var/area/machine_area = get_area(src)
+		if(machine_area)
+			machine_powernet?.unregister_machine(src)
+			machine_powernet = machine_area.powernet
+			machine_powernet.register_machine(src)
 
 /// Helper proc to change the machines power usage mode, automatically adjusts static power usage to maintain perfect parity
 /obj/machinery/proc/change_power_mode(use_type = IDLE_POWER_USE)
@@ -326,6 +328,7 @@
 /obj/machinery/default_unfasten_wrench(mob/user, obj/item/I, time)
 	. = ..()
 	if(.)
+		reregister_machine()
 		power_change()
 
 /obj/machinery/attackby(obj/item/O, mob/user, params)

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -128,7 +128,7 @@
 	if(machine_powernet.powernet_area != get_area(src))
 		var/area/machine_area = get_area(src)
 		if(machine_area)
-			machine_powernet.unregister_machine(src)
+			machine_powernet?.unregister_machine(src)
 			machine_powernet = machine_area.powernet
 			machine_powernet.register_machine(src)
 	if(has_power(power_channel) || !requires_power) //if we don't require power, we don't give a shit about the power channel!

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -125,6 +125,12 @@
 */
 /obj/machinery/proc/power_change()
 	var/old_stat = stat
+	if(machine_powernet.powernet_area != get_area(src))
+		var/area/machine_area = get_area(src)
+		if(machine_area)
+			machine_powernet.unregister_machine(src)
+			machine_powernet = machine_area.powernet
+			machine_powernet.register_machine(src)
 	if(has_power(power_channel) || !requires_power) //if we don't require power, we don't give a shit about the power channel!
 		stat &= ~NOPOWER
 	else

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -97,13 +97,7 @@
 	if(charging)
 		to_chat(user, "<span class='warning'>Remove the charging item first!</span>")
 		return
-	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
-		return
-	anchored = !anchored
-	if(anchored)
-		WRENCH_ANCHOR_MESSAGE
-	else
-		WRENCH_UNANCHOR_MESSAGE
+	default_unfasten_wrench(user, I, 0)
 
 /obj/machinery/recharger/attack_hand(mob/user)
 	if(issilicon(user))

--- a/code/game/machinery/snow_machine.dm
+++ b/code/game/machinery/snow_machine.dm
@@ -54,7 +54,7 @@
 
 /obj/machinery/snow_machine/wrench_act(mob/user, obj/item/I)
 	. = TRUE
-	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+	if(!default_unfasten_wrench(user, I, 0))
 		return
 	anchored = !anchored
 	to_chat(user, "<span class='notice'>You [anchored ? "tighten" : "loosen"] [src]'s wheels.</span>")

--- a/code/modules/atmospherics/machinery/datum_pipeline.dm
+++ b/code/modules/atmospherics/machinery/datum_pipeline.dm
@@ -113,51 +113,6 @@ GLOBAL_VAR_INIT(pipenetwarnings, 10)
 	E.other_atmosmch.Cut()
 	qdel(E)
 
-/*
-/datum/pipeline/proc/split(obj/machinery/atmospherics/A)
-
-	var/datum/pipeline/new_pipeline = new()
-	/*
-	var/list/uncheckednodes = nodes
-	var/list/new_networks
-	for(node in uncheckednodes)
-		var/list/possible_expansions = list(node)
-		var/list/next_pipes
-		for(var/obj/machinery/atmospherics/borderline in possible_expansions)
-			var/list/result = borderline.pipeline_expansion(src)
-			if(result.len>0)
-				for(n in result)
-					if(n in uncheckednodes)
-						uncheckednodes -= n
-						next_piptes += n
-
-		new_networks += next_pipes
-		//KEEP TRACK OF THE NETWORK SIZE, LARGEST NETWORK BECOMES BASE NETWORK,
-		OTHER NETWORKS GET SPLIT OFF
-	main_network = largest(new_networks)
-	new_networks -= main_network
-	for(network in new_networks)
-		new_network = new /datum/pipeline(network[1])
-		new_network.build_pipeline(network[1])
-		main_network.subtract(new_network)
-	*/
-
-	/*
-	air.volume += E.air.volume
-	members.Add(E.members)
-	for(var/obj/machinery/atmospherics/pipe/S in E.members)
-		S.parent = src
-	air.merge(E.air)
-	for(var/obj/machinery/atmospherics/A in E.other_atmosmch)
-		A.replacePipenet(E, src)
-	other_atmosmch.Add(E.other_atmosmch)
-	other_airs.Add(E.other_airs)
-	E.members.Cut()
-	E.other_atmosmch.Cut()
-	qdel(E)
-	*/
-*/
-
 /obj/machinery/atmospherics/proc/addMember(obj/machinery/atmospherics/A)
 	var/datum/pipeline/P = returnPipenet(A)
 	P.addMember(A, src)

--- a/code/modules/atmospherics/machinery/datum_pipeline.dm
+++ b/code/modules/atmospherics/machinery/datum_pipeline.dm
@@ -113,6 +113,51 @@ GLOBAL_VAR_INIT(pipenetwarnings, 10)
 	E.other_atmosmch.Cut()
 	qdel(E)
 
+/*
+/datum/pipeline/proc/split(obj/machinery/atmospherics/A)
+
+	var/datum/pipeline/new_pipeline = new()
+	/*
+	var/list/uncheckednodes = nodes
+	var/list/new_networks
+	for(node in uncheckednodes)
+		var/list/possible_expansions = list(node)
+		var/list/next_pipes
+		for(var/obj/machinery/atmospherics/borderline in possible_expansions)
+			var/list/result = borderline.pipeline_expansion(src)
+			if(result.len>0)
+				for(n in result)
+					if(n in uncheckednodes)
+						uncheckednodes -= n
+						next_piptes += n
+
+		new_networks += next_pipes
+		//KEEP TRACK OF THE NETWORK SIZE, LARGEST NETWORK BECOMES BASE NETWORK,
+		OTHER NETWORKS GET SPLIT OFF
+	main_network = largest(new_networks)
+	new_networks -= main_network
+	for(network in new_networks)
+		new_network = new /datum/pipeline(network[1])
+		new_network.build_pipeline(network[1])
+		main_network.subtract(new_network)
+	*/
+
+	/*
+	air.volume += E.air.volume
+	members.Add(E.members)
+	for(var/obj/machinery/atmospherics/pipe/S in E.members)
+		S.parent = src
+	air.merge(E.air)
+	for(var/obj/machinery/atmospherics/A in E.other_atmosmch)
+		A.replacePipenet(E, src)
+	other_atmosmch.Add(E.other_atmosmch)
+	other_airs.Add(E.other_airs)
+	E.members.Cut()
+	E.other_atmosmch.Cut()
+	qdel(E)
+	*/
+*/
+
 /obj/machinery/atmospherics/proc/addMember(obj/machinery/atmospherics/A)
 	var/datum/pipeline/P = returnPipenet(A)
 	P.addMember(A, src)

--- a/code/modules/atmospherics/machinery/portable/scrubber.dm
+++ b/code/modules/atmospherics/machinery/portable/scrubber.dm
@@ -202,10 +202,7 @@
 	if(on)
 		to_chat(user, "<span class='warning'>Turn it off first!</span>")
 		return
-	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
-		return
-	anchored = !anchored
-	to_chat(user, "<span class='notice'>You [anchored ? "wrench" : "unwrench"] [src].</span>")
+	default_unfasten_wrench(user, I, 4 SECONDS)
 
 /obj/machinery/atmospherics/portable/scrubber/huge/stationary
 	name = "Stationary Air Scrubber"

--- a/code/modules/food_and_drinks/drinks/bottler/bottler.dm
+++ b/code/modules/food_and_drinks/drinks/bottler/bottler.dm
@@ -86,13 +86,7 @@
 
 /obj/machinery/bottler/wrench_act(mob/user, obj/item/I)
 	. = TRUE
-	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
-		return
-	anchored = !anchored
-	if(anchored)
-		WRENCH_ANCHOR_MESSAGE
-	else
-		WRENCH_UNANCHOR_MESSAGE
+	default_unfasten_wrench(user, I, 0)
 
 /obj/machinery/bottler/proc/insert_item(obj/item/O, mob/user)
 	if(!O || !user)

--- a/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
@@ -203,6 +203,4 @@
 
 /obj/machinery/cooker/deepfryer/wrench_act(mob/user, obj/item/I)
 	. = TRUE
-	if(!I.tool_use_check(user, 0))
-		return
 	default_unfasten_wrench(user, I, 30)

--- a/code/modules/food_and_drinks/kitchen_machinery/icecream_vat.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/icecream_vat.dm
@@ -263,7 +263,5 @@
 
 /obj/machinery/icemachine/wrench_act(mob/user, obj/item/I)
 	. = TRUE
-	if(!I.tool_use_check(user, 0))
-		return
 	default_unfasten_wrench(user, I, 30)
 

--- a/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
@@ -129,12 +129,7 @@
 	if(operating)
 		return
 
-	I.play_tool_sound(src)
-	if(anchored)
-		to_chat(user, "<span class='alert'>[src] can now be moved.</span>")
-	else
-		to_chat(user, "<span class='alert'>[src] is now secured.</span>")
-	anchored = !anchored
+	default_unfasten_wrench(user, I, 0)
 	return TRUE
 
 /obj/machinery/kitchen_machine/proc/add_item(obj/item/I, mob/user)

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -158,8 +158,6 @@
 
 /obj/machinery/smartfridge/wrench_act(mob/living/user, obj/item/I)
 	. = default_unfasten_wrench(user, I, time = 4 SECONDS)
-	if(.)
-		power_change()
 
 /obj/machinery/smartfridge/crowbar_act(mob/living/user, obj/item/I)
 	. = default_deconstruction_crowbar(user, I)

--- a/code/modules/hydroponics/hydroponics_tray.dm
+++ b/code/modules/hydroponics/hydroponics_tray.dm
@@ -901,24 +901,7 @@
 		if(using_irrigation)
 			to_chat(user, "<span class='warning'>Disconnect the hoses first!</span>")
 			return
-
-		if(!anchored && !isinspace())
-			user.visible_message("[user] begins to wrench [src] into place.", "<span class='notice'>You begin to wrench [src] in place...</span>")
-			if(I.use_tool(src, user, 20, volume = I.tool_volume))
-				if(anchored)
-					return
-				anchored = TRUE
-				user.visible_message("[user] wrenches [src] into place.", \
-									"<span class='notice'>You wrench [src] in place.</span>")
-		else if(anchored)
-			user.visible_message("[user] begins to unwrench [src].", \
-								"<span class='notice'>You begin to unwrench [src]...</span>")
-			if(I.use_tool(src, user, 20, volume = I.tool_volume))
-				if(!anchored)
-					return
-				anchored = FALSE
-				user.visible_message("[user] unwrenches [src].", \
-									"<span class='notice'>You unwrench [src].</span>")
+		default_unfasten_wrench(user, I)
 
 /obj/machinery/hydroponics/attack_hand(mob/user)
 	if(issilicon(user)) //How does AI know what plant is?

--- a/code/modules/power/generators/thermo_electric_generator.dm
+++ b/code/modules/power/generators/thermo_electric_generator.dm
@@ -191,7 +191,7 @@
 
 /obj/machinery/power/teg/wrench_act(mob/user, obj/item/I)
 	. = TRUE
-	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+	if(!default_unfasten_wrench(user, I, 0))
 		return
 	anchored = !anchored
 	if(!anchored)

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -294,14 +294,7 @@
 
 /obj/machinery/chem_dispenser/wrench_act(mob/user, obj/item/I)
 	. = TRUE
-	if(!I.use_tool(src, user, 4 SECONDS, volume = I.tool_volume))
-		return
-	if(anchored)
-		anchored = FALSE
-		WRENCH_UNANCHOR_MESSAGE
-	else if(!anchored)
-		anchored = TRUE
-		WRENCH_ANCHOR_MESSAGE
+	default_unfasten_wrench(user, I, 4 SECONDS)
 
 /obj/machinery/chem_dispenser/attack_ai(mob/user)
 	return attack_hand(user)

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -148,9 +148,7 @@
 /obj/machinery/chem_master/wrench_act(mob/user, obj/item/I)
 	if(panel_open)
 		return
-	if(default_unfasten_wrench(user, I, time = 4 SECONDS))
-		power_change()
-		return TRUE
+	default_unfasten_wrench(user, I, 4 SECONDS)
 
 /obj/machinery/chem_master/ui_act(action, params, datum/tgui/ui, datum/ui_state/state)
 	if(..())


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Updates the machine powernet to the powernet of the area it is in when it is unwrenched/wrenched, meaning that machines that have been moved use the power of the area they are currently in, rather than the powernet of the area they came from.

Note that this means that machines that can be used while unwrenched will still use the powernet of the area they were originally built in until they are wrenched down again. This will still need fixing in the future.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Having machines draw power from an area they aren't even in is weird and potentially exploitable, and having machines randomly stop working because an area on the other side of the station has become unpowered is annoying.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Be in scichem, use the chem dispenser, it works.
Depower scichem, use the chem dispenser, doesn't work.
Move the chem dispenser out of scichem, depower scichem, chem dispenser still works
Depower the area the chem dispenser is in, chem dispenser no longer works.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Fixed machines using power from the area they were created in, rather than using the area they are in.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
