### PR TITLE
Re-adds newscaster announcement logging + Makes Public Station Announcements news channel Public

### DIFF
--- a/code/controllers/subsystem/SSticker.dm
+++ b/code/controllers/subsystem/SSticker.dm
@@ -658,8 +658,7 @@ SUBSYSTEM_DEF(ticker)
 	newChannel.channel_name = "Public Station Announcements"
 	newChannel.author = "Automated Announcement Listing"
 	newChannel.icon = "bullhorn"
-	newChannel.frozen = TRUE
-	newChannel.admin_locked = TRUE
+	newChannel.is_public = FALSE
 	GLOB.news_network.channels += newChannel
 
 	newChannel = new /datum/feed_channel

--- a/code/controllers/subsystem/SSticker.dm
+++ b/code/controllers/subsystem/SSticker.dm
@@ -658,7 +658,7 @@ SUBSYSTEM_DEF(ticker)
 	newChannel.channel_name = "Public Station Announcements"
 	newChannel.author = "Automated Announcement Listing"
 	newChannel.icon = "bullhorn"
-	newChannel.is_public = FALSE
+	newChannel.is_public = TRUE
 	GLOB.news_network.channels += newChannel
 
 	newChannel = new /datum/feed_channel

--- a/code/controllers/subsystem/SSticker.dm
+++ b/code/controllers/subsystem/SSticker.dm
@@ -655,7 +655,7 @@ SUBSYSTEM_DEF(ticker)
 
 /datum/controller/subsystem/ticker/proc/setup_news_feeds()
 	var/datum/feed_channel/newChannel = new /datum/feed_channel
-	newChannel.channel_name = "Station Command Announcements"
+	newChannel.channel_name = "Station Announcements Log"
 	newChannel.author = "Automated Announcement Listing"
 	newChannel.icon = "bullhorn"
 	newChannel.frozen = TRUE

--- a/code/controllers/subsystem/SSticker.dm
+++ b/code/controllers/subsystem/SSticker.dm
@@ -655,9 +655,17 @@ SUBSYSTEM_DEF(ticker)
 
 /datum/controller/subsystem/ticker/proc/setup_news_feeds()
 	var/datum/feed_channel/newChannel = new /datum/feed_channel
-	newChannel.channel_name = "Public Station Announcements"
+	newChannel.channel_name = "Station Command Announcements"
 	newChannel.author = "Automated Announcement Listing"
 	newChannel.icon = "bullhorn"
+	newChannel.frozen = TRUE
+	newChannel.admin_locked = TRUE
+	GLOB.news_network.channels += newChannel
+
+	newChannel = new /datum/feed_channel
+	newChannel.channel_name = "Public Station Announcements"
+	newChannel.author = "Automated Announcement Listing"
+	newChannel.icon = "users"
 	newChannel.is_public = TRUE
 	GLOB.news_network.channels += newChannel
 

--- a/code/defines/procs/announcer_datum.dm
+++ b/code/defines/procs/announcer_datum.dm
@@ -60,11 +60,6 @@ GLOBAL_DATUM_INIT(major_announcement, /datum/announcer, new(config_type = /datum
 		message_language.scramble(subtitle)
 	)
 
-	formatted_message += "\n"
-	formatted_message += "message: [message]\n"
-	formatted_message += "title: [title]\n"
-	formatted_message += "subtitle: [subtitle]\n"
-
 	Message(formatted_message, garbled_formatted_message, receivers, garbled_receivers)
 
 	var/datum/feed_message/FM = new

--- a/code/defines/procs/announcer_datum.dm
+++ b/code/defines/procs/announcer_datum.dm
@@ -60,13 +60,18 @@ GLOBAL_DATUM_INIT(major_announcement, /datum/announcer, new(config_type = /datum
 		message_language.scramble(subtitle)
 	)
 
+	formatted_message += "\n"
+	formatted_message += "message: [message]\n"
+	formatted_message += "title: [title]\n"
+	formatted_message += "subtitle: [subtitle]\n"
+
 	Message(formatted_message, garbled_formatted_message, receivers, garbled_receivers)
 
 	var/datum/feed_message/FM = new
-	FM.author = author
-	FM.title = title + subtitle ? ": [subtitle]" : ""
+	FM.author = author ? author : "Automated Announcement System"
+	FM.title = subtitle ? "[title]: [subtitle]" : "[title]"
 	FM.body = message
-	GLOB.news_network.get_channel_by_name("Station Command Announcements")?.add_message(FM)
+	GLOB.news_network.get_channel_by_name("Station Announcements Log")?.add_message(FM)
 
 	Sound(message_sound, combined_receivers[1] + combined_receivers[2])
 	if(message_sound2)

--- a/code/defines/procs/announcer_datum.dm
+++ b/code/defines/procs/announcer_datum.dm
@@ -62,6 +62,12 @@ GLOBAL_DATUM_INIT(major_announcement, /datum/announcer, new(config_type = /datum
 
 	Message(formatted_message, garbled_formatted_message, receivers, garbled_receivers)
 
+	var/datum/feed_message/FM = new
+	FM.author = author
+	FM.title = title + subtitle ? ": [subtitle]" : ""
+	FM.body = message
+	GLOB.news_network.get_channel_by_name("Station Command Announcements")?.add_message(FM)
+
 	Sound(message_sound, combined_receivers[1] + combined_receivers[2])
 	if(message_sound2)
 		Sound(message_sound2, combined_receivers[1] + combined_receivers[2])


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes it so anyone can post news stories in Public Station Announcements channel using newscaster, Before only admins could use it.
Adds new Station Announcements Log channel that tried to implement how old Public Station Announcements worked, it silently publishes every announcement as a news story.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
I was told that Public Station Announcements was used to save command announcements in news form, but it was at some point broken or removed.
It is currently only usable by admins, and admins do not use it because they can make Central Command announcements.
I think having an auto-generated channel news channel may encourage crew to share one of their small stories without any complications of making another news channel.
I have been requested to re-add old feature of having announcements channel work as it used to, so I created a new channel that does that, it may help get people up to speed on late-join or simply see the announced message again without needing to scroll in chat,

## Testing
Tried to announce things in Public Station Announcements, it worked.
Announced a lot of thing using consoles and event manager, all of them logged in .
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
add: Newscaster now has Station Announcements Log that saves every announcement.
tweak: Public Station Announcements in newscaster is now public channel by default.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
