### PR TITLE
Fixes a bug with Hemo Claws being spent on tile clicks

### DIFF
--- a/code/modules/antagonists/vampire/vampire_powers/hemomancer_powers.dm
+++ b/code/modules/antagonists/vampire/vampire_powers/hemomancer_powers.dm
@@ -92,12 +92,11 @@
 			attacker.adjustStaminaLoss(-20) // security is dead
 			attacker.heal_overall_damage(4, 4) // the station is full
 			attacker.AdjustKnockDown(-1 SECONDS) // blood is fuel
-
-	if(!V.get_ability(/datum/vampire_passive/blood_spill))
-		durability--
-		if(durability <= 0)
-			qdel(src)
-			to_chat(user, "<span class='warning'>Your claws shatter!</span>")
+		if(!V.get_ability(/datum/vampire_passive/blood_spill))
+			durability--
+			if(durability <= 0)
+				qdel(src)
+				to_chat(user, "<span class='warning'>Your claws shatter!</span>")
 
 /obj/item/vamp_claws/melee_attack_chain(mob/user, atom/target, params)
 	..()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes an oversight with hemo claws being used when clicking tiles, resulting is shorter and more awkward amounts of slices.

## Why It's Good For The Game
Clicking a tile shouldn't waste your important vampire ability. No more having paper blood daggers for hands that break after a single slap against someone. Also consistency is nice.


## Testing
yes

## Changelog
:cl: DGamerL Octus
fix: Fixed hemo claw charges being used from clicking tiles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
