### PR TITLE
Make CereStation eligible for random map selection on 60+ players only

### DIFF
--- a/code/controllers/subsystem/SSticker.dm
+++ b/code/controllers/subsystem/SSticker.dm
@@ -142,7 +142,7 @@ SUBSYSTEM_DEF(ticker)
 				var/list/pickable_types = list()
 				for(var/x in subtypesof(/datum/map))
 					var/datum/map/M = x
-					if(initial(M.voteable))
+					if(initial(M.voteable) && length(GLOB.clients) >= initial(M.min_players_random))
 						pickable_types += M
 
 				var/datum/map/target_map = pick(pickable_types)

--- a/code/modules/mapping/base_map_datum.dm
+++ b/code/modules/mapping/base_map_datum.dm
@@ -16,3 +16,5 @@
 	var/webmap_url
 	/// Is this map voteable?
 	var/voteable = TRUE
+	/// Minimum amount of players required for this map to be eligible in random map picks.
+	var/min_players_random = 0

--- a/code/modules/mapping/cerestation.dm
+++ b/code/modules/mapping/cerestation.dm
@@ -3,3 +3,4 @@
 	technical_name = "CereStation"
 	map_path = "_maps/map_files/cerestation/cerestation.dmm"
 	webmap_url = "https://affectedarc07.github.io/SS13WebMap/Paradise/CereStation/"
+	min_players_random = 60


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
- Adds `min_players_random` variable (default `0`) to `/datum/map`. Used to filter out potential map picks during random map selection (that is, random map day) if the player count at the time of selection does not exceed it
- Sets the above variable to `60` for CereStation. I picked that number kind of randomly, so I'm open to adjusting it

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
On random map days, any map can currently be picked which is fine for normal pop. The problem is when CereStation (a large map) is picked during off hours where departments are rarely filled. At the time of writing, I just saw it get picked and the round started with 12 players in-game. That's a ridiculously low number

This doesn't solve the voting issue, but it should alleviate some of the frustration of having to deal with that map with hardly anyone online

## Testing
<!-- How did you test the PR, if at all? -->
Outputted the list of possible map picks at `60` then `0`

## Changelog
:cl:
tweak: CereStation may only be randomly picked if there are 60 players online or more on round end
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
