### PR TITLE
Engineering borg nerf (just their decompiler ;p)

### DIFF
--- a/code/game/objects/effects/decals/remains.dm
+++ b/code/game/objects/effects/decals/remains.dm
@@ -26,10 +26,12 @@
 	icon_state = "remainsrobot"
 
 /obj/effect/decal/remains/robot/decompile_act(obj/item/matter_decompiler/C, mob/user)
-	C.stored_comms["glass"] += 2
-	C.stored_comms["metal"] += 3
-	qdel(src)
-	return TRUE
+	if(isdrone(user))
+		C.stored_comms["glass"] += 2
+		C.stored_comms["metal"] += 3
+		qdel(src)
+		return TRUE
+	return ..()
 
 /obj/effect/decal/remains/slime
 	name = "You shouldn't see this"

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -219,8 +219,8 @@
 	if(!isdrone(user))
 		user.visible_message("<span class='notice'>[user] sucks [src] into its decompiler. There's a horrible crunching noise.</span>", \
 		"<span class='warning'>It's a bit of a struggle, but you manage to suck [user] into your decompiler. It makes a series of visceral crunching noises.</span>")
-		C.stored_comms["wood"] += 2
-		C.stored_comms["glass"] += 2
+		C.stored_comms["metal"] += 2
+		C.stored_comms["glass"] += 1
 		qdel(src)
 		return TRUE
 	return ..()

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -216,11 +216,13 @@
 		START_PROCESSING(SSobj, src)
 
 /obj/item/flashlight/flare/decompile_act(obj/item/matter_decompiler/C, mob/user)
-	if(!fuel)
-		C.stored_comms["metal"] += 1
-		C.stored_comms["glass"] += 1
-		qdel(src)
-		return TRUE
+	if(isdrone(user))
+		if(!fuel)
+			C.stored_comms["metal"] += 1
+			C.stored_comms["glass"] += 1
+			qdel(src)
+			return TRUE
+		return
 	return ..()
 
 // GLOWSTICKS

--- a/code/game/objects/items/trash.dm
+++ b/code/game/objects/items/trash.dm
@@ -9,11 +9,13 @@
 	resistance_flags = FLAMMABLE
 
 /obj/item/trash/decompile_act(obj/item/matter_decompiler/C, mob/user)
-	C.stored_comms["metal"] += 2
-	C.stored_comms["wood"] += 1
-	C.stored_comms["glass"] += 1
-	qdel(src)
-	return TRUE
+	if(isdrone(user))
+		C.stored_comms["metal"] += 2
+		C.stored_comms["wood"] += 1
+		C.stored_comms["glass"] += 1
+		qdel(src)
+		return TRUE
+	return ..()
 
 /obj/item/trash/raisins
 	name = "4no raisins"

--- a/code/game/objects/items/weapons/cigs.dm
+++ b/code/game/objects/items/weapons/cigs.dm
@@ -54,9 +54,11 @@ LIGHTERS ARE IN LIGHTERS.DM
 	return ..()
 
 /obj/item/clothing/mask/cigarette/decompile_act(obj/item/matter_decompiler/C, mob/user)
-	C.stored_comms["wood"] += 1
-	qdel(src)
-	return TRUE
+	if(isdrone(user))
+		C.stored_comms["wood"] += 1
+		qdel(src)
+		return TRUE
+	return ..()
 
 /obj/item/clothing/mask/cigarette/attack(mob/living/M, mob/living/user, def_zone)
 	if(istype(M) && M.on_fire)
@@ -348,9 +350,11 @@ LIGHTERS ARE IN LIGHTERS.DM
 	transform = turn(transform,rand(0,360))
 
 /obj/item/cigbutt/decompile_act(obj/item/matter_decompiler/C, mob/user)
-	C.stored_comms["wood"] += 1
-	qdel(src)
-	return TRUE
+	if(isdrone(user))
+		C.stored_comms["wood"] += 1
+		qdel(src)
+		return TRUE
+	return ..()
 
 /obj/item/cigbutt/cigarbutt
 	name = "cigar butt"

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -209,9 +209,11 @@
 	icon_state = "cablecuff_used"
 
 /obj/item/restraints/handcuffs/cable/zipties/used/decompile_act(obj/item/matter_decompiler/C, mob/user)
-	C.stored_comms["glass"] += 1
-	qdel(src)
-	return TRUE
+	if(isdrone(user))
+		C.stored_comms["glass"] += 1
+		qdel(src)
+		return TRUE
+	return ..()
 
 /obj/item/restraints/handcuffs/cable/zipties/used/attack()
 	return

--- a/code/game/objects/items/weapons/lighters.dm
+++ b/code/game/objects/items/weapons/lighters.dm
@@ -293,10 +293,12 @@
 		..()
 
 /obj/item/match/decompile_act(obj/item/matter_decompiler/C, mob/user)
-	if(burnt)
-		C.stored_comms["wood"] += 1
-		qdel(src)
-		return TRUE
+	if(isdrone(user))
+		if(burnt)
+			C.stored_comms["wood"] += 1
+			qdel(src)
+			return TRUE
+		return
 	return ..()
 
 /obj/item/proc/help_light_cig(mob/living/M)

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -66,10 +66,12 @@
 	return
 
 /obj/item/storage/fancy/donut_box/decompile_act(obj/item/matter_decompiler/C, mob/user)
-	if(!length(contents))
-		C.stored_comms["wood"] += 1
-		qdel(src)
-		return TRUE
+	if(isdrone(user))
+		if(!length(contents))
+			C.stored_comms["wood"] += 1
+			qdel(src)
+			return TRUE
+		return
 	return ..()
 
 /*
@@ -229,10 +231,12 @@
 	. = ..()
 
 /obj/item/storage/fancy/cigarettes/decompile_act(obj/item/matter_decompiler/C, mob/user)
-	if(!length(contents))
-		C.stored_comms["wood"] += 1
-		qdel(src)
-		return TRUE
+	if(isdrone(user))
+		if(!length(contents))
+			C.stored_comms["wood"] += 1
+			qdel(src)
+			return TRUE
+		return
 	return ..()
 
 /obj/item/storage/fancy/cigarettes/dromedaryco

--- a/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -131,10 +131,12 @@
 	smash(target, thrower, ranged = TRUE)
 
 /obj/item/reagent_containers/food/drinks/bottle/decompile_act(obj/item/matter_decompiler/C, mob/user)
-	if(!reagents.total_volume)
-		C.stored_comms["glass"] += 3
-		qdel(src)
-		return TRUE
+	if(isdrone(user))
+		if(!reagents.total_volume)
+			C.stored_comms["glass"] += 3
+			qdel(src)
+			return TRUE
+		return
 	return ..()
 
 //Keeping this here for now, I'll ask if I should keep it here.
@@ -155,9 +157,11 @@
 	sharp = TRUE
 
 /obj/item/broken_bottle/decompile_act(obj/item/matter_decompiler/C, mob/user)
-	C.stored_comms["glass"] += 3
-	qdel(src)
-	return TRUE
+	if(isdrone(user))
+		C.stored_comms["glass"] += 3
+		qdel(src)
+		return TRUE
+	return ..()
 
 /obj/item/reagent_containers/food/drinks/bottle/gin
 	name = "Griffeater Gin"

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -173,9 +173,11 @@
 	return ..()
 
 /obj/item/reagent_containers/food/snacks/grown/decompile_act(obj/item/matter_decompiler/C, mob/user)
-	C.stored_comms["wood"] += 4
-	qdel(src)
-	return TRUE
+	if(isdrone(user))
+		C.stored_comms["wood"] += 4
+		qdel(src)
+		return TRUE
+	return ..()
 
 // For item-containing growns such as eggy or gatfruit
 /obj/item/reagent_containers/food/snacks/grown/shell/attack_self(mob/user)

--- a/code/modules/hydroponics/grown/banana.dm
+++ b/code/modules/hydroponics/grown/banana.dm
@@ -58,9 +58,11 @@
 	icon_state = "[icon_state]_[rand(1, 3)]"
 
 /obj/item/grown/bananapeel/decompile_act(obj/item/matter_decompiler/C, mob/user)
-	C.stored_comms["wood"] += 1
-	qdel(src)
-	return TRUE
+	if(isdrone(user))
+		C.stored_comms["wood"] += 1
+		qdel(src)
+		return TRUE
+	return ..()
 
 /obj/item/grown/bananapeel/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is deliberately slipping on [src]! It looks like [user.p_theyre()] trying to commit suicide.</span>")

--- a/code/modules/mob/living/simple_animal/friendly/lizard.dm
+++ b/code/modules/mob/living/simple_animal/friendly/lizard.dm
@@ -83,8 +83,8 @@
 		user.visible_message("<span class='notice'>[user] sucks [src] into its decompiler. There's a horrible crunching noise.</span>", \
 		"<span class='warning'>It's a bit of a struggle, but you manage to suck [src] into your decompiler. It makes a series of visceral crunching noises.</span>")
 		new/obj/effect/decal/cleanable/blood/splatter(get_turf(src))
-		C.stored_comms["wood"] += 2 //TODO make this stuff not wood because borgs don't have a wood module, only drones, and this doesn't work with drones - GDN
-		C.stored_comms["glass"] += 2
+		C.stored_comms["metal"] += 2 /// having more metal than glass because blood has iron in it
+		C.stored_comms["glass"] += 1
 		qdel(src)
 		return TRUE
 	return ..()

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -212,8 +212,8 @@
 		user.visible_message("<span class='notice'>[user] sucks [src] into its decompiler. There's a horrible crunching noise.</span>", \
 		"<span class='warning'>It's a bit of a struggle, but you manage to suck [src] into your decompiler. It makes a series of visceral crunching noises.</span>")
 		new/obj/effect/decal/cleanable/blood/splatter(get_turf(src))
-		C.stored_comms["wood"] += 2
-		C.stored_comms["glass"] += 2
+		C.stored_comms["metal"] += 2
+		C.stored_comms["glass"] += 1
 		qdel(src)
 		return TRUE
 	return ..()

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -553,9 +553,11 @@
 		icon_state = "scrap_words"
 
 /obj/item/paper/crumpled/decompile_act(obj/item/matter_decompiler/C, mob/user)
-	C.stored_comms["wood"] += 1
-	qdel(src)
-	return TRUE
+	if(isdrone(user))
+		C.stored_comms["wood"] += 1
+		qdel(src)
+		return TRUE
+	return ..()
 
 /obj/item/paper/crumpled/bloody
 	icon_state = "scrap_bloodied"

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -100,10 +100,12 @@
 
 
 /obj/item/ammo_casing/decompile_act(obj/item/matter_decompiler/C, mob/user)
-	if(!BB)
-		C.stored_comms["metal"] += 1
-		qdel(src)
-		return TRUE
+	if(isdrone(user))
+		if(!BB)
+			C.stored_comms["metal"] += 1
+			qdel(src)
+			return TRUE
+		return
 	return ..()
 
 /obj/item/ammo_casing/emp_act(severity)

--- a/code/modules/reagents/reagent_containers/chemical_bottle.dm
+++ b/code/modules/reagents/reagent_containers/chemical_bottle.dm
@@ -41,10 +41,12 @@
 		. += "lid_[icon_state]"
 
 /obj/item/reagent_containers/glass/bottle/decompile_act(obj/item/matter_decompiler/C, mob/user)
-	if(!reagents.total_volume)
-		C.stored_comms["glass"] += 3
-		qdel(src)
-		return TRUE
+	if(isdrone(user))
+		if(!reagents.total_volume)
+			C.stored_comms["glass"] += 3
+			qdel(src)
+			return TRUE
+		return
 	return ..()
 
 /obj/item/reagent_containers/glass/bottle/toxin


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Makes it so engineering borgs cant decompile a lot of the things drones can, as well as replaces the *wood* spiderlings/mice/lizards give, to metal, since... iron in their blood?
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Engineering borg really shouldn't be a replacement janitor borg, there's little to zero reason the engineering borg needs to be decompiling trash, while for drones it does make sense, since their task is to maintain the station. 

As for the pest change, there was a TODO comment, so i quelled that while i was touching the code, and metal makes *slightly* more sense than wood, since the iron in the blood..

## Testing
<!-- How did you test the PR, if at all? -->

Spawned and checked every item i changed.

## Changelog
:cl:
tweak: Engineering borgs can no longer decompile most of the things maints drones can.
tweak: Lizard/mice/spiderlings now give metal over wood.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
