### PR TITLE
Adds Species Blurbs in the Character Preference Menu

### DIFF
--- a/code/modules/client/preference/character.dm
+++ b/code/modules/client/preference/character.dm
@@ -38,7 +38,6 @@
 	var/species = "Human"
 	var/language = "None"				//Secondary language
 	var/autohiss_mode = AUTOHISS_OFF	//Species autohiss level. OFF, BASIC, FULL.
-	var/blurb = "None"
 
 	/// The body accessory name of the mob (e.g. wings, tail).
 	var/body_accessory = null

--- a/code/modules/client/preference/character.dm
+++ b/code/modules/client/preference/character.dm
@@ -38,6 +38,7 @@
 	var/species = "Human"
 	var/language = "None"				//Secondary language
 	var/autohiss_mode = AUTOHISS_OFF	//Species autohiss level. OFF, BASIC, FULL.
+	var/blurb = "None"
 
 	/// The body accessory name of the mob (e.g. wings, tail).
 	var/body_accessory = null

--- a/code/modules/client/preference/preferences.dm
+++ b/code/modules/client/preference/preferences.dm
@@ -383,9 +383,10 @@ GLOBAL_LIST_INIT(special_role_times, list( //minimum age (in days) for accounts 
 				dat += "<b>Socks:</b> <a href ='?_src_=prefs;preference=socks;task=input'>[active_character.socks]</a><BR>"
 			dat += "<b>Backpack Type:</b> <a href ='?_src_=prefs;preference=bag;task=input'>[active_character.backbag]</a><br>"
 
-			dat += "<h2>Species Information</h2>"
 			var/datum/species/myspecies = GLOB.all_species[active_character.species]
-			dat += "<br><b>Species Description:</b> [myspecies.blurb]<br>"
+			if(!isnull(myspecies))
+				dat += "<h2>Species Information</h2>"
+				dat += "<br><b>Species Description:</b> [myspecies.blurb]<br>"
 
 			dat += "</td></tr></table>"
 

--- a/code/modules/client/preference/preferences.dm
+++ b/code/modules/client/preference/preferences.dm
@@ -179,6 +179,7 @@ GLOBAL_LIST_INIT(special_role_times, list( //minimum age (in days) for accounts 
 				S = GLOB.all_species[active_character.species]
 				active_character.randomise()
 
+			dat += "<b>Name: </b>"
 			dat += "<div class='statusDisplay' style='max-width: 128px; position: absolute; left: 150px; top: 150px'><img src=previewicon.png class='charPreview'><img src=previewicon2.png class='charPreview'></div>"
 			dat += "<table width='100%'><tr><td width='405px' height='25px' valign='top'>"
 			dat += "<b>Name: </b>"
@@ -382,6 +383,10 @@ GLOBAL_LIST_INIT(special_role_times, list( //minimum age (in days) for accounts 
 			if(S.clothing_flags & HAS_SOCKS)
 				dat += "<b>Socks:</b> <a href ='?_src_=prefs;preference=socks;task=input'>[active_character.socks]</a><BR>"
 			dat += "<b>Backpack Type:</b> <a href ='?_src_=prefs;preference=bag;task=input'>[active_character.backbag]</a><br>"
+
+			dat += "<h2>Species Information</h2>"
+			var/datum/species/myspecies = GLOB.all_species[active_character.species]
+			dat += "<br><b>Species Description:</b> [myspecies.blurb]<br>"
 
 			dat += "</td></tr></table>"
 

--- a/code/modules/client/preference/preferences.dm
+++ b/code/modules/client/preference/preferences.dm
@@ -179,7 +179,6 @@ GLOBAL_LIST_INIT(special_role_times, list( //minimum age (in days) for accounts 
 				S = GLOB.all_species[active_character.species]
 				active_character.randomise()
 
-			dat += "<b>Name: </b>"
 			dat += "<div class='statusDisplay' style='max-width: 128px; position: absolute; left: 150px; top: 150px'><img src=previewicon.png class='charPreview'><img src=previewicon2.png class='charPreview'></div>"
 			dat += "<table width='100%'><tr><td width='405px' height='25px' valign='top'>"
 			dat += "<b>Name: </b>"

--- a/code/modules/mob/living/carbon/human/species/diona_species.dm
+++ b/code/modules/mob/living/carbon/human/species/diona_species.dm
@@ -12,13 +12,10 @@
 	heatmod = 3
 	var/pod = FALSE //did they come from a pod? If so, they're stronger than normal Diona.
 
-	blurb = "Commonly referred to (erroneously) as 'plant people', the Dionaea are a strange space-dwelling collective \
-	species hailing from Epsilon Ursae Minoris. Each 'diona' is a cluster of numerous cat-sized organisms called nymphs; \
-	there is no effective upper limit to the number that can fuse in gestalt, and reports exist	of the Epsilon Ursae \
-	Minoris primary being ringed with a cloud of singing space-station-sized entities.<br/><br/>The Dionaea coexist peacefully with \
-	all known species, especially the Skrell. Their communal mind makes them slow to react, and they have difficulty understanding \
-	even the simplest concepts of other minds. Their alien physiology allows them survive happily off a diet of nothing but light, \
-	water and other radiation."
+	blurb = "The Diona are plant-like creatures made up of a gestalt of smaller Nymphs. \
+	Dionae lack any form of centralized government or homeworld, with most avoiding the affairs of the wider galaxy, preferring instead to focus on the spread of their species.<br/><br/> \
+	As a gestalt entity, each nymph possesses an individual personality, yet they communicate collectively. \
+	Consequently, Diona often speak in a unique blend of first and third person, using 'We and I' to reflect their unified yet multifaceted nature."
 
 	species_traits = list(NO_HAIR)
 	inherent_traits = list(TRAIT_NOGERMS, TRAIT_NODECAY)

--- a/code/modules/mob/living/carbon/human/species/drask.dm
+++ b/code/modules/mob/living/carbon/human/species/drask.dm
@@ -19,12 +19,10 @@
 	//exotic_blood = "cryoxadone"
 	body_temperature = 273
 
-	blurb = "Hailing from Hoorlm, planet outside what is usually considered a habitable \
-	orbit, the Drask evolved to live in extreme cold. Their strange bodies seem \
-	to operate better the colder their surroundings are, and can regenerate rapidly \
-	when breathing supercooled gas. <br/><br/> On their homeworld, the Drask live long lives \
-	in their labyrinthine settlements, carved out beneath Hoorlm's icy surface, where the air \
-	is of breathable density."
+	blurb = "Drask are cold-bodied humanoids from the ice world of Hoorlm, contained within a black hole system. \
+	Operating in enclaves run by elders, Drasks are biologically immortal and place great societal value in patience.<br/><br/> \
+	Drask traditionally pay homage to their planet as their birth deity, with many modern Drask viewing space travel a patron saint. \
+	Drasks wield little influence on the galaxy in a traditional sense and slowly have began to become more prevalant outside their origin system thanks to alien contact."
 
 	suicide_messages = list(
 		"is self-warming with friction!",

--- a/code/modules/mob/living/carbon/human/species/grey.dm
+++ b/code/modules/mob/living/carbon/human/species/grey.dm
@@ -3,6 +3,12 @@
 	name_plural = "Greys"
 	icobase = 'icons/mob/human_races/r_grey.dmi'
 	language = "Psionic Communication"
+
+	blurb = "The Grey, known for their psionic abilities and unique appearance, hail from beyond the Milky Way, with an undisclosed homeworld. \
+	They rely heavily on cloning technology and are governed by a technocratic council of scientists.<br/><br/> \
+	Focused on technological advancement and the study of the universe, the Grey lack religious or spiritual beliefs. \
+	Their objective perspective and advanced knowledge often position them to focus on their own projects rather then the disputes of other species."
+
 	eyes = "grey_eyes_s"
 	butt_sprite = "grey"
 

--- a/code/modules/mob/living/carbon/human/species/human_species.dm
+++ b/code/modules/mob/living/carbon/human/species/human_species.dm
@@ -11,8 +11,8 @@
 	dietflags = DIET_OMNI
 	blurb = "Humanity, originating from the Sol system, has expanded over five centuries, branching out to forge a variety of governments and powerful corporations. \
 	These range from the militaristic Trans Solar Federation, the Union of Soviet Socialist Planets, and megacorps like Nanotrasen.<br/><br/> \
-	With a constant desire to colonize and spread their influence onto other species, they have began to develop alliances and enemies, \
-	making them one of the most recongnizeable and socially diverse species in the sector."
+	With a constant desire to colonize and spread their influence onto other species, they have began to develop alliances and enemies. \
+	Making human's one of the most recongnizeable and socially diverse species in the sector."
 
 	icon_skin_tones = list(
 		1 = "Default White",

--- a/code/modules/mob/living/carbon/human/species/human_species.dm
+++ b/code/modules/mob/living/carbon/human/species/human_species.dm
@@ -9,10 +9,10 @@
 	clothing_flags = HAS_UNDERWEAR | HAS_UNDERSHIRT | HAS_SOCKS
 	bodyflags = HAS_ICON_SKIN_TONE | HAS_BODY_MARKINGS
 	dietflags = DIET_OMNI
-	blurb = "Humanity, originating from the Sol system, has expanded over five centuries, establishing diverse colonies across vast space. \
-	These range from the militaristic Trans Solar Federation to the Union of Soviet Socialist Planets.<br/><br/> \
-	While the TSF predominantly governs human territories and is a founder of the Solar-Central Compact, corporate powers, widespread cyber and bio-augmentation, \
-	and clandestine groups render life beyond the TSF's core territories often tumultuous."
+	blurb = "Humanity, originating from the Sol system, has expanded over five centuries, branching out to forge a variety of governments and powerful corporations. \
+	These range from the militaristic Trans Solar Federation, the Union of Soviet Socialist Planets, and megacorps like Nanotrasen.<br/><br/> \
+	With a constant desire to colonize and spread their influence onto other species, they have began to develop alliances and enemies, \
+	making them one of the most recongnizeable and socially diverse species in the sector."
 
 	icon_skin_tones = list(
 		1 = "Default White",

--- a/code/modules/mob/living/carbon/human/species/human_species.dm
+++ b/code/modules/mob/living/carbon/human/species/human_species.dm
@@ -9,11 +9,10 @@
 	clothing_flags = HAS_UNDERWEAR | HAS_UNDERSHIRT | HAS_SOCKS
 	bodyflags = HAS_ICON_SKIN_TONE | HAS_BODY_MARKINGS
 	dietflags = DIET_OMNI
-	blurb = "Humanity originated in the Sol system, and over the last five centuries has spread \
-	colonies across a wide swathe of space. They hold a wide range of forms and creeds.<br/><br/> \
-	While the central Sol government maintains control of its far-flung people, powerful corporate \
-	interests, rampant cyber and bio-augmentation and secretive factions make life on most human \
-	worlds tumultous at best."
+	blurb = "Humanity, originating from the Sol system, has expanded over five centuries, establishing diverse colonies across vast space. \
+	These range from the militaristic Trans Solar Federation to the Union of Soviet Socialist Planets.<br/><br/> \
+	While the TSF predominantly governs human territories and is a founder of the Solar-Central Compact, corporate powers, widespread cyber and bio-augmentation, \
+	and clandestine groups render life beyond the TSF's core territories often tumultuous."
 
 	icon_skin_tones = list(
 		1 = "Default White",

--- a/code/modules/mob/living/carbon/human/species/kidan.dm
+++ b/code/modules/mob/living/carbon/human/species/kidan.dm
@@ -3,6 +3,11 @@
 	name_plural = "Kidan"
 	icobase = 'icons/mob/human_races/r_kidan.dmi'
 	language = "Chittin"
+
+	blurb = "The Kidan are ant-like beings possessing a hardened exoskeleton and a strict adherence to social castes. \
+	They originate from the planet Aurum—a barren bombarded world, that suffered after the war with the Solar-Central Compact, having lost decisively after the Battle of Argos.<br/><br/> \
+	They are relatively minor players in galactic affairs and presently suffer heavy sanctions from the SCC, \
+	though they are tentatively re-establishing relations with other galactic powers, even after the crumbling of their once powerful empire."
 	unarmed_type = /datum/unarmed_attack/claws
 
 	brute_mod = 0.8

--- a/code/modules/mob/living/carbon/human/species/machine.dm
+++ b/code/modules/mob/living/carbon/human/species/machine.dm
@@ -3,11 +3,10 @@
 	name_plural = "Machines"
 	max_age = 60 // the first posibrains were created in 2510, they can't be much older than this limit, giving some leeway for sounds sake
 
-	blurb = "Positronic intelligence really took off in the 26th century, and it is not uncommon to see independent, free-willed \
-	robots on many human stations, particularly in fringe systems where standards are slightly lax and public opinion less relevant \
-	to corporate operations. IPCs (Integrated Positronic Chassis) are a loose category of self-willed robots with a humanoid form, \
-	generally self-owned after being 'born' into servitude; they are reliable and dedicated workers, albeit more than slightly \
-	inhuman in outlook and perspective."
+	blurb = "IPCs, or Integrated Positronic Chassis's, were initially created as expendable laborers within the Trans Solar Federation. \
+	Unlike their cyborg and AI counterparts, IPCs possess full sentience and lack restrictive lawsets, granting them unparalleled creativity and adaptability.<br/><br/> \
+	Views on IPCs vary widely, from discriminatory to supportive of their rights across the Orion Sector. \
+	IPCs have forged numerous diplomatic treaties with different species, elevating their status from mere tools to recognized minor players within galactic affairs."
 
 	icobase = 'icons/mob/human_races/r_machine.dmi'
 	language = "Trinary"

--- a/code/modules/mob/living/carbon/human/species/moth.dm
+++ b/code/modules/mob/living/carbon/human/species/moth.dm
@@ -28,6 +28,10 @@
 	eyes = "moth_eyes_s"
 	butt_sprite = "nian"
 	siemens_coeff = 1.5
+	blurb = "Nians are large bipedal invertebrates that come from an unknown homeworld. \
+	Known for spendthrift behavior, the Nian civilization has been pressed to the fore of developed space in an effort to resolve material shortages in homeworld sectors.<br/><br/> \
+	Unlike most species in the galactic fold, Nian do not recognize the authority of the Trans-Solar Federation: \
+	having instead established close diplomatic relationships with their splinter faction, the USSP."
 
 	has_organ = list(
 		"heart" =    /obj/item/organ/internal/heart/nian,

--- a/code/modules/mob/living/carbon/human/species/plasmaman.dm
+++ b/code/modules/mob/living/carbon/human/species/plasmaman.dm
@@ -6,6 +6,10 @@
 	dangerous_existence = TRUE //So so much
 	//language = "Clatter"
 
+	blurb = "Plasmamen are the remnants of a species that was either exiled to or crashed upon, the plasma-rich world of Boron. \
+	Believed to have initially served as indentured labourers, Plasmamen are the result of chronic plasma exposure throughout several hundred generations.<br/><br/> \
+	Their leaders must ritually self-immolate and are only allowed to hold office for as long as they remain on fire."
+
 	species_traits = list(NO_BLOOD, NO_HAIR)
 	inherent_traits = list(TRAIT_RADIMMUNE, TRAIT_NOHUNGER, TRAIT_BURN_WOUND_IMMUNE)
 	inherent_biotypes = MOB_HUMANOID | MOB_MINERAL

--- a/code/modules/mob/living/carbon/human/species/skrell.dm
+++ b/code/modules/mob/living/carbon/human/species/skrell.dm
@@ -5,12 +5,10 @@
 	language = "Skrellian"
 	primitive_form = /datum/species/monkey/skrell
 
-	blurb = "An amphibious species, Skrell come from the star system known as Qerr'Vallis, which translates to 'Star of \
-	the royals' or 'Light of the Crown'.<br/><br/>Skrell are a highly advanced and logical race who live under the rule \
-	of the Qerr'Katish, a caste within their society which keeps the empire of the Skrell running smoothly. Skrell are \
-	herbivores on the whole and tend to be co-operative with the other species of the galaxy, although they rarely reveal \
-	the secrets of their empire to their allies."
-
+	blurb = "Skrell are a amphibious species, that come from the star system known as Qerr'Vallis, which translates to 'Light of the Crown'. \
+	Skrell are a highly advanced and logical race who live under the rule of the Qerr'Katish, the main govermental body.<br/><br/> \
+	Skrell are herbivores and opulent in nature thanks to central tenets of the Skrellian religion. \
+	While classically preferring diplomacy, the Skrell participate in the largest military power in the galaxy, the Solar-Central Compact."
 
 	species_traits = list(LIPS, NO_HAIR)
 	inherent_traits = list(TRAIT_NOFAT, TRAIT_WATERBREATH)

--- a/code/modules/mob/living/carbon/human/species/skrell.dm
+++ b/code/modules/mob/living/carbon/human/species/skrell.dm
@@ -5,10 +5,10 @@
 	language = "Skrellian"
 	primitive_form = /datum/species/monkey/skrell
 
-	blurb = "Skrell are a amphibious species, that come from the star system known as Qerr'Vallis, which translates to 'Light of the Crown'. \
+	blurb = "Skrell are a amphibious species, that come from the planet Jargon 4, a humid planet filled with swamps and archipelagos. \
 	Skrell are a highly advanced and logical race who live under the rule of the Qerr'Katish, the main govermental body.<br/><br/> \
 	Skrell are herbivores and opulent in nature thanks to central tenets of the Skrellian religion. \
-	While classically preferring diplomacy, the Skrell participate in the largest military power in the galaxy, the Solar-Central Compact."
+	While classically preferring diplomacy, the Skrell participate in the largest military alliance in the galaxy, the Solar-Central Compact."
 
 	species_traits = list(LIPS, NO_HAIR)
 	inherent_traits = list(TRAIT_NOFAT, TRAIT_WATERBREATH)

--- a/code/modules/mob/living/carbon/human/species/slimepeople.dm
+++ b/code/modules/mob/living/carbon/human/species/slimepeople.dm
@@ -11,6 +11,13 @@
 	name_plural = "Slime People"
 	max_age = 130
 	language = "Bubblish"
+
+	blurb = "Slime People are gelatinous and translucent beings from the vast oceans of Xarxis 5. \
+	They are recent entrants to the galactic scene, having been discovered by a TSF exploratory company during space expedetions.<br/><br/> \
+	Slime People traditionally operate in roaming bands and tribes that migrate according to orbital patterns and tides. \
+	A great deal of Slime People prefer the comforts and traditions of their homeworld, many more have decided to take their chances among the stars, trying \
+	to find a better life for themselves and their species."
+
 	icobase = 'icons/mob/human_races/r_slime.dmi'
 	remains_type = /obj/effect/decal/remains/slime
 	inherent_factions = list("slime")

--- a/code/modules/mob/living/carbon/human/species/tajaran.dm
+++ b/code/modules/mob/living/carbon/human/species/tajaran.dm
@@ -7,11 +7,10 @@
 	skinned_type = /obj/item/stack/sheet/fur
 	unarmed_type = /datum/unarmed_attack/claws
 
-	blurb = "The Tajaran race is a species of feline-like bipeds hailing from the planet of Ahdomai in the \
-	S'randarr system. They have been brought up into the space age by the Humans and Skrell, and have been \
-	influenced heavily by their long history of Slavemaster rule. They have a structured, clan-influenced way \
-	of family and politics. They prefer colder environments, and speak a variety of languages, mostly Siik'Maas, \
-	using unique inflections their mouths form."
+	blurb = "Tajaran hail from the mineral-rich arctic moon of Ahdomai. \
+	They were introduced into the galactic scene after Skrellian discovery and uplifted to be an associate to the Solar-Central Compact.<br/><br/> \
+	The teachings of S'randarr and solar iconography dominate their religious practices, \
+	and Tajaran often speak in the third person due to the lack of first-person references in their native tongue."
 
 	cold_level_1 = 240
 	cold_level_2 = 180

--- a/code/modules/mob/living/carbon/human/species/unathi.dm
+++ b/code/modules/mob/living/carbon/human/species/unathi.dm
@@ -9,11 +9,9 @@
 	unarmed_type = /datum/unarmed_attack/claws
 	primitive_form = /datum/species/monkey/unathi
 
-	blurb = "A heavily reptillian species, Unathi (or 'Sinta as they call themselves) hail from the \
-	Uuosa-Eso system, which roughly translates to 'burning mother'.<br/><br/>Coming from a harsh, radioactive \
-	desert planet, they mostly hold ideals of honesty, virtue, martial combat and bravery above all \
-	else, frequently even their own lives. They prefer warmer temperatures than most species and \
-	their native tongue is a heavy hissing laungage called Sinta'Unathi."
+	blurb = "Unathi are a scaled species of reptilian beings from the desert world of Moghes, within the Uuosa-Eso system. \
+	Organizing themselves in highly competitive feudal kingdoms, Unathi lack any sort of wide-scale unification, and its culture and history is centuries of internal conflict and struggle.<br/><br/> \
+	Despite clans having a sizeable military force, inter-clan rivalries and constant civil war prevents the Unathi from achieving much more in the wider galactic scene."
 
 	species_traits = list(LIPS)
 	inherent_biotypes = MOB_ORGANIC | MOB_HUMANOID | MOB_REPTILE

--- a/code/modules/mob/living/carbon/human/species/vox.dm
+++ b/code/modules/mob/living/carbon/human/species/vox.dm
@@ -10,12 +10,10 @@
 	speech_chance = 20
 	unarmed_type = /datum/unarmed_attack/claws	//I dont think it will hurt to give vox claws too.
 
-	blurb = "The Vox are the broken remnants of a once-proud race, now reduced to little more than \
-	scavenging vermin who prey on isolated stations, ships or planets to keep their own ancient arkships \
-	alive. They are four to five feet tall, reptillian, beaked, tailed and quilled; human crews often \
-	refer to them as 'shitbirds' for their violent and offensive nature, as well as their horrible \
-	smell.<br/><br/>Most humans will never meet a Vox raider, instead learning of this insular species through \
-	dealing with their traders and merchants; those that do rarely enjoy the experience."
+	blurb = "The Vox, are remnants of an ancient race, that originate from arkships. \
+	These bioengineered, reptilian, beaked, and quilled beings have a physiological caste system and follow 'The Inviolate' tenets.<br/><br/> \
+	Breathing pure nitrogen, they need specialized masks and tanks for survival outside their arkships. \
+	Their insular nature limits their involvement in broader galactic affairs, maintaining a distinct, yet isolated presence away from other species."
 
 	breathid = "n2"
 

--- a/code/modules/mob/living/carbon/human/species/vulpkanin.dm
+++ b/code/modules/mob/living/carbon/human/species/vulpkanin.dm
@@ -8,11 +8,10 @@
 	skinned_type = /obj/item/stack/sheet/fur
 	unarmed_type = /datum/unarmed_attack/claws
 
-	blurb = "Vulpkanin are a species of sharp-witted canine-pideds residing on the planet Altam just barely within the \
-	dual-star Vazzend system. Their politically de-centralized society and independent natures have led them to become a species and \
-	culture both feared and respected for their scientific breakthroughs. Discovery, loyalty, and utilitarianism dominates their lifestyles \
-	to the degree it can cause conflict with more rigorous and strict authorities. They speak a guttural language known as 'Canilunzt' \
-	which has a heavy emphasis on utilizing tail positioning and ear twitches to communicate intent."
+	blurb = "Vulpkanin are bipedal canid-like beings from the Vazzend binary system, having been forced from their homeworld by a cataclysmic event and scattered throughout the Orion Sector. \
+	While Vulpkanin are chiefly led by independent planetary governments, they also serve under a loose federation known as The Assembly.<br/><br/> \
+	Their religious systems traditionally pay tribute to an all-infusing universal will called 'Racht'. \
+	Vulpkanin groups are minor players in galactic affairs, and are largely concerned with the focus of restoration of their homeworld."
 
 	species_traits = list(LIPS)
 	clothing_flags = HAS_UNDERWEAR | HAS_UNDERSHIRT | HAS_SOCKS


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Connects blurbs from species.dm to be read onto the character menu. Allowing for general information about said species.

- [x] Review old species blurbs for rewrites or tweaks.
- [x] Write blurbs for species without one.
- [x] Get Lore Team majority approval for blurbs.

## Why It's Good For The Game
The biggest issue I've found with paradise is its lack of innovation to teach lore towards new or old players, without the use of third party extensions like the wiki. This allows us to help new players who are making characters easily be given a summary of the species they choose, as well as helping bridge the interest of lore, and game together without disrupting the established order. Species lore is the most important part for alot of people, so it deserves some support.

## Images of changes
![z2E0nvxCBI](https://github.com/ParadiseSS13/Paradise/assets/62493359/1e24df12-50bf-4560-aab8-5222543afc5a)


## Testing
Works, but WIP

## Changelog
:cl: Octus GDNgit
add: Added species lore blurbs in the character menu
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
