### PR TITLE
Fixes PDAs not dropping when being stripped

### DIFF
--- a/code/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/code/modules/mob/living/carbon/human/human_update_icons.dm
@@ -628,7 +628,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 			uniform_slots += wear_id
 			uniform_slots += wear_pda
 			uniform_slots += belt
-		if(belt.flags_2 & ALLOW_BELT_NO_JUMPSUIT_2)
+		if(belt && (belt.flags_2 & ALLOW_BELT_NO_JUMPSUIT_2))
 			uniform_slots -= belt
 
 		// Automatically drop anything in store / id / belt if you're not wearing a uniform.	//CHECK IF NECESARRY

--- a/code/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/code/modules/mob/living/carbon/human/human_update_icons.dm
@@ -628,6 +628,8 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 			uniform_slots += wear_id
 			uniform_slots += wear_pda
 			uniform_slots += belt
+		if(belt.flags_2 & ALLOW_BELT_NO_JUMPSUIT_2)
+			uniform_slots -= belt
 
 		// Automatically drop anything in store / id / belt if you're not wearing a uniform.	//CHECK IF NECESARRY
 		for(var/obj/item/thing in uniform_slots)												// whoever made this

--- a/code/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/code/modules/mob/living/carbon/human/human_update_icons.dm
@@ -614,8 +614,8 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 		standing.alpha = w_uniform.alpha
 		standing.color = w_uniform.color
 		overlays_standing[UNIFORM_LAYER] = standing
-	//If anyone asks, /mob/living/carbon/human/unEquip in human_inventory.dm already handles unequip code
-	/* else if(!dna.species.nojumpsuit)
+
+	else if(!dna.species.nojumpsuit)
 		var/list/uniform_slots = list()
 		var/obj/item/organ/external/L = get_organ(BODY_ZONE_L_LEG)
 		if(!(L?.status & ORGAN_ROBOT))
@@ -640,7 +640,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 					thing.forceMove(drop_location())											//
 					thing.dropped(src)															//
 					thing.layer = initial(thing.layer)
-					thing.plane = initial(thing.plane) */
+					thing.plane = initial(thing.plane)
 	apply_overlay(UNIFORM_LAYER)
 	update_hands_layer()
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes PDAs and such not being dropped when being stripped of your jumpsuit.
Fixes #23244
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Nobody except IPCs for some reason should get a free PDA slot that's unstrippable.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Stripped someone of their jumpsuit, PDA dropped.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Fixed PDAs not dropping when being stripped
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
