### PR TITLE
Runechats emotes with sound effects.

### DIFF
--- a/code/__DEFINES/emotes_defines.dm
+++ b/code/__DEFINES/emotes_defines.dm
@@ -10,12 +10,10 @@
 #define EMOTE_VISIBLE (1<<0)
 /// Emote is audible (in character).
 #define EMOTE_AUDIBLE (1<<1)
-/// Emote makes a sound. These emotes will specifically not be runechatted.
-#define EMOTE_SOUND (1<<2)
 /// Regardless of its existing flags, an emote with this flag will not be sent to runechat.
-#define EMOTE_FORCE_NO_RUNECHAT (1<<3)
+#define EMOTE_FORCE_NO_RUNECHAT (1<<2)
 /// This emote uses the mouth, and so should be blocked if the user is muzzled or can't breathe (for humans).
-#define EMOTE_MOUTH (1<<4)
+#define EMOTE_MOUTH (1<<3)
 
 // User audio cooldown system.
 // This is a value stored on the user and represents their current ability to perform audio emotes.

--- a/code/datums/emote.dm
+++ b/code/datums/emote.dm
@@ -182,7 +182,7 @@
 	var/suppressed = FALSE
 
 	// Keep em quiet if they can't speak
-	if(!can_vocalize_emotes(user) && (emote_type & (EMOTE_MOUTH | EMOTE_AUDIBLE) || emote_type & (EMOTE_MOUTH | EMOTE_SOUND)))
+	if(!can_vocalize_emotes(user) && (emote_type & (EMOTE_MOUTH | EMOTE_AUDIBLE)))
 		var/noise_emitted = pick(muzzled_noises)
 		suppressed = TRUE
 		msg = "makes \a [noise_emitted] noise."
@@ -215,12 +215,12 @@
 			for(var/mob/dead/observer/ghost in viewers(user))
 				ghost.show_message("<span class=deadsay>[displayed_msg]</span>", EMOTE_VISIBLE)
 
-		else if(emote_type & (EMOTE_AUDIBLE | EMOTE_SOUND) && !user.mind?.miming)
+		else if(emote_type & (EMOTE_AUDIBLE) && !user.mind?.miming)
 			user.audible_message(displayed_msg, deaf_message = "<span class='emote'>You see how <b>[user]</b> [msg]</span>")
 		else
 			user.visible_message(displayed_msg, blind_message = "<span class='emote'>You hear how someone [msg]</span>")
 
-		if(!(emote_type & (EMOTE_FORCE_NO_RUNECHAT | EMOTE_SOUND) || suppressed) && !isobserver(user))
+		if(!(emote_type & (EMOTE_FORCE_NO_RUNECHAT) || suppressed) && !isobserver(user))
 			runechat_emote(user, msg)
 
 	SEND_SIGNAL(user, COMSIG_MOB_EMOTED(key), src, key, emote_type, message, intentional)

--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid_emote.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid_emote.dm
@@ -9,7 +9,7 @@
 	key_third_person = "roars"
 	message = "roars!"
 	message_param = "roars at %t!"
-	emote_type = EMOTE_SOUND | EMOTE_MOUTH
+	emote_type = EMOTE_AUDIBLE | EMOTE_MOUTH
 	sound = "sound/voice/hiss5.ogg"
 	volume = 80
 
@@ -18,7 +18,7 @@
 	key_third_person = "hisses"
 	message = "hisses!"
 	message_param = "hisses at %t!"
-	emote_type = EMOTE_SOUND | EMOTE_MOUTH
+	emote_type = EMOTE_AUDIBLE | EMOTE_MOUTH
 	sound = "sound/voice/hiss1.ogg"
 	volume = 30
 
@@ -28,5 +28,5 @@
 	message = "gnarls and shows its teeth."
 	message_param = "gnarls and flashes its teeth at %t."
 	sound = "sound/voice/hiss4.ogg"
-	emote_type = EMOTE_SOUND | EMOTE_MOUTH
+	emote_type = EMOTE_AUDIBLE | EMOTE_MOUTH
 	volume = 30

--- a/code/modules/mob/living/carbon/carbon_emote.dm
+++ b/code/modules/mob/living/carbon/carbon_emote.dm
@@ -30,7 +30,7 @@
 	key_third_person = "coughs"
 	message = "coughs!"
 	message_mime = "appears to cough!"
-	emote_type = EMOTE_SOUND | EMOTE_MOUTH
+	emote_type = EMOTE_AUDIBLE | EMOTE_MOUTH
 	vary = TRUE
 	age_based = TRUE
 	volume = 120

--- a/code/modules/mob/living/carbon/human/human_emote.dm
+++ b/code/modules/mob/living/carbon/human/human_emote.dm
@@ -44,7 +44,7 @@
 	message = "claps."
 	message_mime = "claps silently."
 	message_param = "claps at %t."
-	emote_type = EMOTE_SOUND
+	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
 
 /datum/emote/living/carbon/human/clap/run_emote(mob/user, params, type_override, intentional)
@@ -79,7 +79,7 @@
 	key = "crack"
 	key_third_person = "cracks"
 	message = "cracks their knuckles."
-	emote_type = EMOTE_AUDIBLE | EMOTE_SOUND
+	emote_type = EMOTE_AUDIBLE | EMOTE_AUDIBLE
 	// knuckles.ogg by CGEffex. Shortened and cut.
 	// https://freesound.org/people/CGEffex/sounds/93981/
 	sound = "sound/effects/mob_effects/knuckles.ogg"
@@ -116,7 +116,7 @@
 	message = "facepalms."
 	hands_use_check = TRUE
 	sound = 'sound/weapons/slap.ogg'
-	emote_type = EMOTE_SOUND
+	emote_type = EMOTE_AUDIBLE
 	volume = 50
 
 /datum/emote/living/carbon/human/palm
@@ -161,7 +161,7 @@
 	message_mime = "acts out a scream!"
 	message_postfix = "at %t!"
 	muzzled_noises = list("very loud")
-	emote_type = EMOTE_SOUND | EMOTE_MOUTH
+	emote_type = EMOTE_AUDIBLE | EMOTE_MOUTH
 	only_forced_audio = FALSE
 	vary = TRUE
 	age_based = TRUE
@@ -195,7 +195,7 @@
 	key_third_person = "gasps"
 	message = "gasps!"
 	message_mime = "appears to be gasping!"
-	emote_type = EMOTE_SOUND  // Don't make this one a mouth emote since we don't want it to be caught by nobreath
+	emote_type = EMOTE_AUDIBLE  // Don't make this one a mouth emote since we don't want it to be caught by nobreath
 	age_based = TRUE
 	unintentional_stat_allowed = UNCONSCIOUS
 	volume = 100
@@ -333,7 +333,7 @@
 	key_third_person = "sneezes"
 	message = "sneezes."
 	muzzled_noises = list("strange", "sharp")
-	emote_type = EMOTE_SOUND | EMOTE_MOUTH
+	emote_type = EMOTE_AUDIBLE | EMOTE_MOUTH
 	volume = 70
 
 /datum/emote/living/carbon/human/sneeze/get_sound(mob/user)
@@ -407,7 +407,7 @@
 	message = "snaps their fingers."
 	message_param = "snaps their fingers at %t."
 	sound = "sound/effects/fingersnap.ogg"
-	emote_type = EMOTE_SOUND
+	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/carbon/human/snap/run_emote(mob/user, params, type_override, intentional)
 
@@ -589,7 +589,7 @@
 	key_third_person = "quills"
 	message = "rustles their quills."
 	message_param = "rustles their quills at %t."
-	emote_type = EMOTE_SOUND
+	emote_type = EMOTE_AUDIBLE
 	age_based = TRUE
 	// Credit to sound-ideas (freesfx.co.uk) for the sound.
 	sound = "sound/effects/voxrustle.ogg"
@@ -600,7 +600,7 @@
 	key_third_person = "warbles"
 	message = "warbles."
 	message_param = "warbles at %t."
-	emote_type = EMOTE_SOUND
+	emote_type = EMOTE_AUDIBLE
 	age_based = TRUE
 	// Copyright CC BY 3.0 alienistcog (freesound.org) for the sound.
 	sound = "sound/effects/warble.ogg"
@@ -612,7 +612,7 @@
 	message = "clacks their mandibles."
 	message_param = "clacks their mandibles at %t."
 	species_type_whitelist_typecache = list(/datum/species/kidan)
-	emote_type = EMOTE_SOUND
+	emote_type = EMOTE_AUDIBLE
 	audio_cooldown = 3 SECONDS
 	age_based = TRUE
 	// Credit to DrMinky (freesound.org) for the sound.
@@ -634,7 +634,7 @@
 
 /datum/emote/living/carbon/human/drask_talk
 	species_type_whitelist_typecache = list(/datum/species/drask)
-	emote_type = EMOTE_SOUND
+	emote_type = EMOTE_AUDIBLE
 	age_based = TRUE
 	sound = "sound/voice/drasktalk.ogg"
 
@@ -662,7 +662,7 @@
 	message = "hisses."
 	message_param = "hisses at %t."
 	species_type_whitelist_typecache = list(/datum/species/unathi)
-	emote_type = EMOTE_SOUND | EMOTE_MOUTH
+	emote_type = EMOTE_AUDIBLE | EMOTE_MOUTH
 	age_based = TRUE
 	// Credit to Jamius (freesound.org) for the sound.
 	sound = "sound/effects/unathihiss.ogg"
@@ -673,7 +673,7 @@
 	key_third_person = "creaks"
 	message = "creaks."
 	message_param = "creaks at %t."
-	emote_type = EMOTE_SOUND
+	emote_type = EMOTE_AUDIBLE
 	age_based = TRUE
 	species_type_whitelist_typecache = list(/datum/species/diona)
 	sound = "sound/voice/dionatalk1.ogg"
@@ -699,7 +699,7 @@
 	key_third_person = "squishes"
 	message = "squishes."
 	message_param = "squishes at %t."
-	emote_type = EMOTE_SOUND
+	emote_type = EMOTE_AUDIBLE
 	age_based = TRUE
 	// Credit to DrMinky (freesound.org) for the sound.
 	sound = "sound/effects/slime_squish.ogg"
@@ -709,7 +709,7 @@
 	key_third_person = "bubbles"
 	message = "bubbles."
 	message_param = "bubbles at %t."
-	emote_type = EMOTE_SOUND
+	emote_type = EMOTE_AUDIBLE
 	age_based = TRUE
 	// Sound is CC-4.0 by Audiolarx
 	// Effect is cut out of original clip
@@ -722,7 +722,7 @@
 	message = "makes a popping sound."
 	message_param = "makes a popping sound at %t."
 	message_mime = "makes a silent pop."
-	emote_type = EMOTE_SOUND
+	emote_type = EMOTE_AUDIBLE
 	age_based = TRUE
 	// CC0
 	// https://freesound.org/people/greenvwbeetle/sounds/244653/
@@ -736,7 +736,7 @@
 	message_mime = "acts out a howl."
 	message_param = "howls at %t."
 	species_type_whitelist_typecache = list(/datum/species/vulpkanin)
-	emote_type = EMOTE_SOUND | EMOTE_MOUTH
+	emote_type = EMOTE_AUDIBLE | EMOTE_MOUTH
 	age_based = TRUE
 	sound = "sound/goonstation/voice/howl.ogg"
 	muzzled_noises = list("very loud")
@@ -753,7 +753,7 @@
 	sound = "growls"  // what the fuck why is this just top level
 	volume = 80
 	muzzled_noises = list("annoyed")
-	emote_type = EMOTE_SOUND | EMOTE_MOUTH
+	emote_type = EMOTE_AUDIBLE | EMOTE_MOUTH
 
 /datum/emote/living/carbon/human/hiss/tajaran
 	message_mime = "hisses silently."

--- a/code/modules/mob/living/living_emote.dm
+++ b/code/modules/mob/living/living_emote.dm
@@ -224,7 +224,7 @@
 	message_mime = "acts out a scream!"
 	message_simple = "whimpers."
 	message_alien = "roars!"
-	emote_type = EMOTE_SOUND | EMOTE_MOUTH
+	emote_type = EMOTE_MOUTH | EMOTE_AUDIBLE
 	mob_type_blacklist_typecache = list(
 		// Humans and silicons get specialized scream.
 		/mob/living/carbon/human,

--- a/code/modules/mob/living/silicon/silicon_emote.dm
+++ b/code/modules/mob/living/silicon/silicon_emote.dm
@@ -20,7 +20,7 @@
 	key_third_person = "screams"
 	message = "screams!"
 	message_param = "screams at %t!"
-	emote_type = EMOTE_SOUND | EMOTE_AUDIBLE
+	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
 	sound = "sound/goonstation/voice/robot_scream.ogg"
 	volume = 80
@@ -30,7 +30,7 @@
 	key_third_person = "pings"
 	message = "pings."
 	message_param = "pings at %t."
-	emote_type = EMOTE_SOUND | EMOTE_AUDIBLE
+	emote_type = EMOTE_AUDIBLE
 	sound = "sound/machines/ping.ogg"
 
 /datum/emote/living/silicon/buzz
@@ -38,14 +38,14 @@
 	key_third_person = "buzzes"
 	message = "buzzes."
 	message_param = "buzzes at %t."
-	emote_type = EMOTE_SOUND | EMOTE_AUDIBLE
+	emote_type = EMOTE_AUDIBLE
 	sound = "sound/machines/buzz-sigh.ogg"
 
 /datum/emote/living/silicon/buzz2
 	key = "buzz2"
 	message = "emits an irritated buzzing sound."
 	message_param = "emits an irritated buzzing sound at %t."
-	emote_type = EMOTE_SOUND | EMOTE_AUDIBLE
+	emote_type = EMOTE_AUDIBLE
 	sound = "sound/machines/buzz-two.ogg"
 
 /datum/emote/living/silicon/beep
@@ -53,7 +53,7 @@
 	key_third_person = "beeps"
 	message = "beeps."
 	message_param = "beeps at %t."
-	emote_type = EMOTE_SOUND | EMOTE_AUDIBLE
+	emote_type = EMOTE_AUDIBLE
 	sound = "sound/machines/twobeep.ogg"
 
 /datum/emote/living/silicon/boop
@@ -61,28 +61,28 @@
 	key_third_person = "boops"
 	message = "boops."
 	message_param = "boops at %t."
-	emote_type = EMOTE_SOUND | EMOTE_AUDIBLE
+	emote_type = EMOTE_AUDIBLE
 	sound = "sound/machines/boop.ogg"
 
 /datum/emote/living/silicon/yes
 	key = "yes"
 	message = "emits an affirmative blip."
 	message_param = "emits an affirmative blip at %t."
-	emote_type = EMOTE_SOUND | EMOTE_AUDIBLE
+	emote_type = EMOTE_AUDIBLE
 	sound = "sound/machines/synth_yes.ogg"
 
 /datum/emote/living/silicon/no
 	key = "no"
 	message = "emits a negative blip."
 	message_param = "emits a negative blip at %t."
-	emote_type = EMOTE_SOUND | EMOTE_AUDIBLE
+	emote_type = EMOTE_AUDIBLE
 	sound = "sound/machines/synth_no.ogg"
 
 /datum/emote/living/silicon/law
 	key = "law"
 	message = "shows its legal authorization barcode."
 	message_param = "shows %t its legal authorization barcode."
-	emote_type = EMOTE_SOUND | EMOTE_AUDIBLE
+	emote_type = EMOTE_AUDIBLE
 	sound = "sound/voice/biamthelaw.ogg"
 
 /datum/emote/living/silicon/law/can_run_emote(mob/user, status_check, intentional)
@@ -95,7 +95,7 @@
 	key = "halt"
 	message = "screeches \"HALT! SECURITY!\" from its speakers."
 	message_param = "instructs %t to HALT."
-	emote_type = EMOTE_SOUND
+	emote_type = EMOTE_AUDIBLE
 	sound = "sound/voice/halt.ogg"
 
 /datum/emote/living/silicon/halt/can_run_emote(mob/user, status_check, intentional)

--- a/code/modules/mob/living/simple_animal/friendly/friendly_emote.dm
+++ b/code/modules/mob/living/simple_animal/friendly/friendly_emote.dm
@@ -6,7 +6,7 @@
 	key_third_person = "chirps"
 	message = "chirps!"
 	sound = "sound/creatures/nymphchirp.ogg"
-	emote_type = EMOTE_SOUND
+	emote_type = EMOTE_AUDIBLE
 	mob_type_allowed_typecache = list(/mob/living/simple_animal/diona)
 
 // Dog emotes
@@ -19,7 +19,7 @@
 	key_third_person = "barks"
 	message = "barks."
 	message_param = "barks at %t."
-	emote_type = EMOTE_SOUND
+	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/simple_animal/pet/dog/bark/get_sound(mob/living/user)
 	. = ..()
@@ -33,7 +33,7 @@
 	key_third_person = "yelps"
 	message = "yelps!"
 	message_param = "yelps at %t!"
-	emote_type = EMOTE_SOUND
+	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/simple_animal/pet/dog/yelp/get_sound(mob/living/user)
 	var/mob/living/simple_animal/pet/dog/D = user
@@ -44,7 +44,7 @@
 	key_third_person = "growls"
 	message = "growls!"
 	message_param = "growls at %t!"
-	emote_type = EMOTE_SOUND
+	emote_type = EMOTE_AUDIBLE
 	sound = "growl"
 
 // Mouse
@@ -57,7 +57,7 @@
 	key_third_person = "squeaks"
 	message = "squeaks!"
 	message_param = "squeaks at %t!"
-	emote_type = EMOTE_SOUND
+	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/simple_animal/mouse/squeak/get_sound(mob/living/user)
 	var/mob/living/simple_animal/mouse/M = user
@@ -74,7 +74,7 @@
 	message = "meows."
 	message_param = "meows at %t."
 	sound = "sound/creatures/cat_meow.ogg"
-	emote_type = EMOTE_SOUND
+	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/simple_animal/pet/cat/meow/run_emote(mob/user, params, type_override, intentional)
 	var/mob/living/simple_animal/pet/cat/C = user

--- a/code/modules/mob/living/simple_animal/hostile/gorilla/gorilla_emote.dm
+++ b/code/modules/mob/living/simple_animal/hostile/gorilla/gorilla_emote.dm
@@ -6,5 +6,5 @@
 	key_third_person = "oogas"
 	message = "oogas."
 	message_param = "oogas at %t."
-	emote_type = EMOTE_SOUND
+	emote_type = EMOTE_AUDIBLE
 	sound = 'sound/creatures/gorilla.ogg'


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Removes the `EMOTE_SOUND` flag from a bunch of emotes, which now allows them to go to runechat. This means that any sound-emitting emote that was previously filtered from runechat should now be visible.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
We've had some (relatively) recent runechat improvements, even showing it to ghosts. Along with the maptick improvements, I think we can afford a few extra runechats during rounds. This also makes it clear who is emoting, which might not be especially obvious in a crowded situation by sound (and chatbar) alone.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://github.com/ParadiseSS13/Paradise/assets/89928798/e53c446f-4e03-49c8-aa3b-0caf72c9da1b)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
![image](https://github.com/ParadiseSS13/Paradise/assets/89928798/718ea2c2-d79a-454c-af94-018e63a6248c)

<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Emotes that make sounds are now runechatted.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
