### PR TITLE
Defibs now shock people giving CPR

### DIFF
--- a/code/datums/components/defibrillator.dm
+++ b/code/datums/components/defibrillator.dm
@@ -304,6 +304,10 @@
 		for(var/obj/item/grab/G in target.grabbed_by)
 			if(ishuman(G.assailant))
 				excess_shock(user, target, G.assailant, defib_ref)
+		if(target.receiving_cpr_from)
+			var/mob/living/L = locateUID(target.receiving_cpr_from)
+			if(istype(L))
+				excess_shock(user, target, L, defib_ref)
 
 		target.med_hud_set_health()
 		target.med_hud_set_status()

--- a/code/datums/components/defibrillator.dm
+++ b/code/datums/components/defibrillator.dm
@@ -305,9 +305,9 @@
 			if(ishuman(G.assailant))
 				excess_shock(user, target, G.assailant, defib_ref)
 		if(target.receiving_cpr_from)
-			var/mob/living/L = locateUID(target.receiving_cpr_from)
-			if(istype(L))
-				excess_shock(user, target, L, defib_ref)
+			var/mob/living/carbon/human/H = locateUID(target.receiving_cpr_from)
+			if(istype(H))
+				excess_shock(user, target, H, defib_ref)
 
 		target.med_hud_set_health()
 		target.med_hud_set_status()

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -67,7 +67,9 @@
 	var/check_mutations=0 // Check mutations on next life tick
 
 	var/heartbeat = 0
-	var/receiving_cpr = FALSE
+
+	/// UID of the person who is giving this mob CPR.
+	var/receiving_cpr_from
 
 	var/fire_dmi = 'icons/mob/OnFire.dmi'
 	var/fire_sprite = "Standing"

--- a/code/modules/mob/living/carbon/human/human_mob.dm
+++ b/code/modules/mob/living/carbon/human/human_mob.dm
@@ -1660,7 +1660,7 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 	if(H == src)
 		to_chat(src, "<span class='warning'>You cannot perform CPR on yourself!</span>")
 		return
-	if(H.receiving_cpr_from) // To prevent spam stacking
+	if(!isnull(H.receiving_cpr_from)) // To prevent spam stacking
 		to_chat(src, "<span class='warning'>They are already receiving CPR!</span>")
 		return
 	if(!can_use_hands() || !has_both_hands())

--- a/code/modules/mob/living/carbon/human/human_mob.dm
+++ b/code/modules/mob/living/carbon/human/human_mob.dm
@@ -1660,7 +1660,7 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 	if(H == src)
 		to_chat(src, "<span class='warning'>You cannot perform CPR on yourself!</span>")
 		return
-	if(H.receiving_cpr) // To prevent spam stacking
+	if(H.receiving_cpr_from) // To prevent spam stacking
 		to_chat(src, "<span class='warning'>They are already receiving CPR!</span>")
 		return
 	if(!can_use_hands() || !has_both_hands())
@@ -1670,7 +1670,7 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 		to_chat(src, "<span class='warning'>You can't perform effective CPR with your hands full!</span>")
 		return
 
-	H.receiving_cpr = TRUE
+	H.receiving_cpr_from = UID()
 	var/cpr_modifier = get_cpr_mod(H)
 	if(H.stat == DEAD || HAS_TRAIT(H, TRAIT_FAKEDEATH))
 		if(ismachineperson(H) && do_mob(src, H, 4 SECONDS))  // hehe
@@ -1680,12 +1680,12 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 				)
 			playsound(H, 'sound/weapons/ringslam.ogg', 50, TRUE)
 			adjustBruteLossByPart(2, "head")
-			H.receiving_cpr = FALSE
+			H.receiving_cpr_from = null
 			return
 
 		if(!H.is_revivable())
 			to_chat(src, "<span class='warning'>[H] is already too far gone for CPR...</span>")
-			H.receiving_cpr = FALSE
+			H.receiving_cpr_from = null
 			return
 
 		visible_message("<span class='danger'>[src] is trying to perform CPR on [H]'s lifeless body!</span>", "<span class='danger'>You start trying to perform CPR on [H]'s lifeless body!</span>")
@@ -1722,7 +1722,7 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 		else
 			visible_message("<span class='notice'>[src] stops giving [H] CPR.</span>", "<span class='notice'>You stop giving [H] CPR.</span>")
 
-		H.receiving_cpr = FALSE
+		H.receiving_cpr_from = null
 		return
 
 	visible_message("<span class='danger'>[src] is trying to perform CPR on [H.name]!</span>", "<span class='danger'>You try to perform CPR on [H.name]!</span>")
@@ -1741,7 +1741,7 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 			to_chat(H, "<span class='notice'>You feel a breath of fresh air enter your lungs. It feels good.</span>")
 		add_attack_logs(src, H, "CPRed", ATKLOG_ALL)
 
-	H.receiving_cpr = FALSE
+	H.receiving_cpr_from = null
 	visible_message("<span class='notice'>[src] stops performing CPR on [H].</span>", "<span class='notice'>You stop performing CPR on [H].</span>")
 	to_chat(src, "<span class='danger'>You need to stay still while performing CPR!</span>")
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Title. If you're giving CPR to someone who gets shocked by a defibrillator, you'll get a pretty nasty zap!
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
It's a fun little detail and encourages people in medbay to call out "CLEAR!"
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

https://github.com/ParadiseSS13/Paradise/assets/89928798/6e3220df-232b-447e-abd3-19e07065245f


<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
See video. Shocked someone receiving CPR, watched as they twitched.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Giving CPR to someone who's actively being defibrillated might leave you with a nasty shock! Careful!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
