### PR TITLE
Fixes changeling with contort body being able to pass airlock while upright

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -766,6 +766,8 @@ GLOBAL_LIST_EMPTY(airlock_emissive_underlays)
 		if((istype(living_mover) && HAS_TRAIT(living_mover, TRAIT_CONTORTED_BODY) && IS_HORIZONTAL(living_mover))) // We really dont want people to get shocked on a door they're passing through
 			if(density && !do_mob(living_mover, living_mover, 2 SECONDS, requires_upright = FALSE))
 				return FALSE
+			if(!IS_HORIZONTAL(living_mover) || locked) // Checking if the user has gotten up or the airlock was bolted after we tried to crawl underneath
+				return FALSE
 			living_mover.forceMove(get_turf(src))
 			return TRUE
 	if(isElectrified() && density && isitem(mover) && !on_spark_cooldown)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes contort body check if the user has not stood up since lying down to crawl underneath an airlock. Also checks if the airlock hasn't been bolted since starting to crawl underneath.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Contort body is only supposed to allow you to crawl underneath airlocks while lying down and while the airlock is unbolted.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Be a skrell changeling, try to crawl underneath an airlock but stand up before crawling under, it fails.
Be a skrell changeling, try to crawl underneath an airlock but bolt it before crawling under, it fails.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Fixes changeling with contort body being able to pass airlock while upright
fix: Fixes changeling with contort body being able to pass through an airlock when it is bolted
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
