### PR TITLE
Fixes a few runtimes

### DIFF
--- a/code/datums/diseases/advance/symptoms/shivering.dm
+++ b/code/datums/diseases/advance/symptoms/shivering.dm
@@ -29,8 +29,6 @@ Bonus
 	..()
 	if(prob(SYMPTOM_ACTIVATION_PROB))
 		var/mob/living/carbon/M = A.affected_mob
-		if(!M) // Don't know how we got here, but we did
-			return
 		to_chat(M, "<span class='warning'>[pick("You feel cold.", "You start shivering.")]</span>")
 		if(M.bodytemperature > BODYTEMP_COLD_DAMAGE_LIMIT)
 			Chill(M, A)

--- a/code/datums/diseases/advance/symptoms/shivering.dm
+++ b/code/datums/diseases/advance/symptoms/shivering.dm
@@ -29,6 +29,8 @@ Bonus
 	..()
 	if(prob(SYMPTOM_ACTIVATION_PROB))
 		var/mob/living/carbon/M = A.affected_mob
+		if(!M) // Don't know how we got here, but we did
+			return
 		to_chat(M, "<span class='warning'>[pick("You feel cold.", "You start shivering.")]</span>")
 		if(M.bodytemperature > BODYTEMP_COLD_DAMAGE_LIMIT)
 			Chill(M, A)

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -267,7 +267,7 @@
 	data["chemicals"] = chemicals
 	return data
 
-/obj/machinery/sleeper/ui_act(action, params)
+/obj/machinery/sleeper/ui_act(action, params, datum/tgui/ui)
 	if(..())
 		return
 	if(!controls_inside && usr == occupant)
@@ -295,7 +295,7 @@
 			else
 				to_chat(usr, "<span class='danger'>This person is not in good enough condition for sleepers to be effective! Use another means of treatment, such as cryogenics!</span>")
 		if("removebeaker")
-			remove_beaker(usr)
+			remove_beaker(ui.user)
 		if("togglefilter")
 			toggle_filter()
 		if("ejectify")

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -295,7 +295,7 @@
 			else
 				to_chat(usr, "<span class='danger'>This person is not in good enough condition for sleepers to be effective! Use another means of treatment, such as cryogenics!</span>")
 		if("removebeaker")
-			remove_beaker()
+			remove_beaker(usr)
 		if("togglefilter")
 			toggle_filter()
 		if("ejectify")

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -231,7 +231,7 @@
 	if(Adjacent(user) && !opened)
 		if(HAS_TRAIT(user, TRAIT_HANDS_BLOCKED) || user.stat) // Don't use it if you're not able to! Checks for stuns, ghost and restrain
 			return
-		togglelock()
+		togglelock(user)
 		return
 
 	. = ..()

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -102,7 +102,6 @@
 		return ..()
 
 /obj/item/paper/proc/rename(mob/user)
-
 	if(HAS_TRAIT(user, TRAIT_CLUMSY) && prob(50))
 		to_chat(user, "<span class='warning'>You cut yourself on the paper.</span>")
 		return

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -102,7 +102,7 @@
 		return ..()
 
 /obj/item/paper/proc/rename(mob/user)
-	if(user && HAS_TRAIT(user, TRAIT_CLUMSY) && prob(50))
+	if(HAS_TRAIT(user, TRAIT_CLUMSY) && prob(50))
 		to_chat(user, "<span class='warning'>You cut yourself on the paper.</span>")
 		return
 	if(!user.is_literate())

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -820,7 +820,7 @@
 		"[user] is beginning to cauterize the incision on [target]'s [zone] with \the [tool].",
 		"You are beginning to cauterize the incision on [target]'s [zone] with \the [tool]."
 	)
-	to_chat(user, "<span class='userdanger'>Your carapace is being burned!</span>") // No custom pain because xenos are special
+	to_chat(user, "<span class='userdanger'>Your [zone] is being burned!</span>") // No custom pain because xenos are special
 	return ..()
 
 /datum/surgery_step/generic/seal_carapace/end_step(mob/living/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -820,8 +820,7 @@
 		"[user] is beginning to cauterize the incision on [target]'s [zone] with \the [tool].",
 		"You are beginning to cauterize the incision on [target]'s [zone] with \the [tool]."
 	)
-	var/obj/item/organ/affected = target.get_organ(target_zone)
-	affected.custom_pain("Your [zone] is being burned!")
+	to_chat(user, "<span class='userdanger'>Your carapace is being burned!</span>") // No custom pain because xenos are special
 	return ..()
 
 /datum/surgery_step/generic/seal_carapace/end_step(mob/living/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes some runtimes, most of which were caused by the verb PR
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
These shouldn't runtime and should actually work.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Could do all of the things without runtiming.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Fixed not being able to take beakers out of sleepers
fix: You can now unlock crates with altclick again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
