### PR TITLE
Engineer ERT buff, and a small gamma ert buff

### DIFF
--- a/code/modules/mod/mod_theme.dm
+++ b/code/modules/mod/mod_theme.dm
@@ -1064,6 +1064,7 @@
 	siemens_coefficient = 0
 	slowdown_inactive = 0.5
 	slowdown_active = 0
+	complexity_max = DEFAULT_MAX_COMPLEXITY + 5
 	allowed_suit_storage = list(
 		/obj/item/ammo_box,
 		/obj/item/ammo_casing,

--- a/code/modules/mod/mod_types.dm
+++ b/code/modules/mod/mod_types.dm
@@ -292,7 +292,7 @@
 
 /obj/item/mod/control/pre_equipped/responsory
 	theme = /datum/mod_theme/responsory
-	applied_cell = /obj/item/stock_parts/cell/hyper
+	applied_cell = /obj/item/stock_parts/cell/bluespace
 	req_access = list(ACCESS_CENT_GENERAL)
 	applied_modules = list(
 		/obj/item/mod/module/storage/syndicate, //Yes yes syndicate tech in ert but they need the storage
@@ -326,7 +326,7 @@
 
 /obj/item/mod/control/pre_equipped/responsory/engineer
 	insignia_type = /obj/item/mod/module/insignia/engineer
-	additional_module = /obj/item/mod/module/anomaly_locked/kinesis/prebuilt //This can only end well.
+	additional_module = list(/obj/item/mod/module/anomaly_locked/kinesis/prebuilt, /obj/item/mod/module/firefighting_tank) //This can only end well.
 
 /obj/item/mod/control/pre_equipped/responsory/medic
 	insignia_type = /obj/item/mod/module/insignia/medic

--- a/code/modules/response_team/ert_outfits.dm
+++ b/code/modules/response_team/ert_outfits.dm
@@ -223,7 +223,7 @@
 	name = "RT Engineer (Amber)"
 	shoes = /obj/item/clothing/shoes/magboots
 	suit = /obj/item/clothing/suit/space/hardsuit/ert/engineer
-	suit_store = /obj/item/tank/internals/emergency_oxygen/engi
+	suit_store = /obj/item/tank/internals/emergency_oxygen/double
 	glasses = /obj/item/clothing/glasses/meson/engine
 	mask = /obj/item/clothing/mask/gas
 	l_pocket = /obj/item/gun/energy/gun/mini
@@ -246,7 +246,7 @@
 	name = "RT Engineer (Red)"
 	shoes = /obj/item/clothing/shoes/magboots/advance
 	suit = /obj/item/clothing/suit/space/hardsuit/ert/engineer/gamma
-	suit_store = /obj/item/tank/internals/emergency_oxygen/engi
+	suit_store = /obj/item/tank/internals/emergency_oxygen/double
 	glasses = /obj/item/clothing/glasses/meson/engine
 	mask = /obj/item/clothing/mask/gas
 	l_pocket = /obj/item/t_scanner
@@ -256,7 +256,7 @@
 		/obj/item/rcd/preloaded = 1,
 		/obj/item/rcd_ammo = 3,
 		/obj/item/gun/energy/gun = 1,
-		/obj/item/rpd = 1
+		/obj/item/rpd/bluespace = 1
 	)
 
 	cybernetic_implants = list(
@@ -274,6 +274,7 @@
 	name = "RT Engineer (Gamma)"
 	shoes = /obj/item/clothing/shoes/magboots/elite
 	back = /obj/item/mod/control/pre_equipped/responsory/engineer
+	suit_store = /obj/item/tank/internals/emergency_oxygen/double
 	glasses = /obj/item/clothing/glasses/meson/night
 	mask = /obj/item/clothing/mask/gas/sechailer/swat
 	l_pocket = /obj/item/t_scanner
@@ -283,7 +284,7 @@
 		/obj/item/rcd/combat = 1,
 		/obj/item/rcd_ammo/large = 3,
 		/obj/item/gun/energy/gun/blueshield/pdw9 = 1,
-		/obj/item/rpd = 1
+		/obj/item/rpd/bluespace = 1
 	)
 
 	cybernetic_implants = list(


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Give all engineer erts double emergency tanks(should last roughly 30-45 minutes if my math is right), gives gamma and red ert bluespace pipe replacers, and gives gamma ert the fire fighter module on their modsuit.
All ert modsuits now have 20 max complexity, mainly for the engineer that was very strapped for space, all ert modsuits also have bluespace cells now.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
ERT engineers should be given some better gear since they're for emergencies and all, the bluespace pipe replacer, doesn't requite *too* high/hard to get of levels from rnd to be printed, needing toxins level 6, (the BSRPD doesn't decon into toxins levels), and the storage room on central command has a handful of them laying there.
As for the suit changes, the complexity is mainly due to the fact i wanted to give the engineer modsuit the firefighter module, so they can, fight fires, but they already had the kenesis module eating most of the complexity up, and its only five extra, on ert.
All ert getting double emergency tanks is pretty self explanatory, the like, ~15 minutes the extended emergency tank had isn't very much, when it comes to engineering. fixing major breaches takes quite the bit of time.
And the cell upgrade, was because they really should be getting the top of the line equipment for gamma, needing to charge your suit during a gamma worthy issue isn't overly ideal.
AAAND for the fire fighter module, its so the ert can assist in fighting fires.

## Testing
<!-- How did you test the PR, if at all? -->
Checked if changes changed. changes were changed. 
## Changelog
:cl:
tweak: All ert suits now have 5 extra complexity to work with, and have bluespace cells
tweak: Red and gamma ERT engineers get bluespace pipe replacers rather than the basic ones.
tweak: Gamma ERT now have a firefighting module
tweak: All engineering ERT now have double emergency air tanks. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
