### PR TITLE
fixes some strange behavior with righting tilted objects

### DIFF
--- a/code/datums/components/tilted.dm
+++ b/code/datums/components/tilted.dm
@@ -82,14 +82,14 @@
 
 	if(user)
 		user.visible_message(
-			"[user] begins to right [parent].",
-			"You begin to right [parent]."
+			"[user] begins to right [atom_parent].",
+			"You begin to right [atom_parent]."
 		)
-		if(!do_after(user, duration, TRUE, parent))
+		if(!do_after(user, duration, TRUE, parent) || QDELETED(src))
 			return
 		user.visible_message(
-			"<span class='notice'>[user] rights [parent].</span>",
-			"<span class='notice'>You right [parent].</span>",
+			"<span class='notice'>[user] rights [atom_parent].</span>",
+			"<span class='notice'>You right [atom_parent].</span>",
 			"<span class='notice'>You hear a loud clang.</span>"
 		)
 
@@ -98,7 +98,7 @@
 
 	atom_parent.unbuckle_all_mobs(TRUE)
 
-	SEND_SIGNAL(parent, COMSIG_MOVABLE_UNTILTED, user)
+	SEND_SIGNAL(atom_parent, COMSIG_MOVABLE_UNTILTED, user)
 
 	atom_parent.layer = initial(atom_parent.layer)
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
fixes some strange behavior with righting tilted objects, from runtimes to text messages saying `` rights .`` with nothing else

## Why It's Good For The Game
bugs bad

## Testing
slammed a skrell into a vendor and righted it

## Changelog
:cl:
fix: Righting a vendor multiple times no longer sends an odd message
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
