### PR TITLE
Changelings can no longer roll absorb objective / makes DNA sting purchasable / changeling greeting cleanup.

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -632,7 +632,7 @@
 
 		var/new_obj_type = input("Select objective type:", "Objective type", def_value) as null|anything in	list(
 			"assassinate", "assassinateonce", "blood", "debrain", "protect", "prevent", "hijack", "escape", "survive", "steal", "download",
-			"nuclear", "capture", "absorb", "destroy", "maroon", "identity theft", "custom")
+			"nuclear", "capture", "destroy", "maroon", "identity theft", "custom")
 		if(!new_obj_type)
 			return
 
@@ -722,7 +722,7 @@
 				if(!steal.select_target())
 					return
 
-			if("download","capture","absorb", "blood")
+			if("download","capture", "blood")
 				var/def_num
 				if(objective&&objective.type==text2path("/datum/objective/[new_obj_type]"))
 					def_num = objective.target_amount
@@ -732,9 +732,6 @@
 					return
 
 				switch(new_obj_type)
-					if("absorb")
-						new_objective = new /datum/objective/absorb
-						new_objective.explanation_text = "Absorb [target_number] compatible genomes."
 					if("blood")
 						new_objective = new /datum/objective/blood
 						new_objective.explanation_text = "Accumulate at least [target_number] total units of blood."

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -984,7 +984,7 @@
 			if("changeling")
 				if(!ischangeling(current))
 					add_antag_datum(/datum/antagonist/changeling)
-					to_chat(current, "<span class='danger'>With a flash of light, your gestation is complete. You are a changeling!</span>")
+					to_chat(current, "<span class='danger'>With a flash of light, our gestation is complete. We are a changeling!</span>")
 					log_admin("[key_name(usr)] has changelinged [key_name(current)]")
 					message_admins("[key_name_admin(usr)] has changelinged [key_name_admin(current)]")
 

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -984,7 +984,7 @@
 			if("changeling")
 				if(!ischangeling(current))
 					add_antag_datum(/datum/antagonist/changeling)
-					to_chat(current, "<span class='biggerdanger'>Your powers have awoken. A flash of memory returns to us... we are a changeling!</span>")
+					to_chat(current, "<span class='danger'>With a flash of light, your gestation is complete. You are a changeling!</span>")
 					log_admin("[key_name(usr)] has changelinged [key_name(current)]")
 					message_admins("[key_name_admin(usr)] has changelinged [key_name_admin(current)]")
 

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -617,43 +617,6 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 			message_admins("[ADMIN_LOOKUPFLW(H)] Failed to spawn with their [item_path] theft kit.")
 			qdel(I)
 
-
-/datum/objective/absorb
-	name = "Absorb DNA"
-	needs_target = FALSE
-
-/datum/objective/absorb/New(text, datum/team/team_to_join)
-	. = ..()
-	gen_amount_goal()
-
-/datum/objective/absorb/proc/gen_amount_goal(lowbound = 6, highbound = 8)
-	target_amount = rand (lowbound,highbound)
-	if(SSticker)
-		var/n_p = 1 //autowin
-		if(SSticker.current_state == GAME_STATE_SETTING_UP)
-			for(var/mob/new_player/P in GLOB.player_list)
-				if(P.client && P.ready && !(P.mind in get_owners()))
-					if(P.client.prefs && (P.client.prefs.active_character.species == "Machine")) // Special check for species that can't be absorbed. No better solution.
-						continue
-					n_p++
-		else if(SSticker.current_state == GAME_STATE_PLAYING)
-			for(var/mob/living/carbon/human/P in GLOB.player_list)
-				if(HAS_TRAIT(P, TRAIT_GENELESS))
-					continue
-				if(P.client && !(P.mind in SSticker.mode.changelings) && !(P.mind in get_owners()))
-					n_p++
-		target_amount = min(target_amount, n_p)
-
-	explanation_text = "Acquire [target_amount] compatible genomes. The 'Extract DNA Sting' can be used to stealthily get genomes without killing somebody."
-	return target_amount
-
-/datum/objective/absorb/check_completion()
-	for(var/datum/mind/M in get_owners())
-		var/datum/antagonist/changeling/cling = M?.has_antag_datum(/datum/antagonist/changeling)
-		if(cling?.absorbed_dna && (cling.absorbed_count >= target_amount))
-			return TRUE
-	return FALSE
-
 /datum/objective/destroy
 	name = "Destroy AI"
 	martyr_compatible = 1

--- a/code/modules/antagonists/changeling/datum_changeling.dm
+++ b/code/modules/antagonists/changeling/datum_changeling.dm
@@ -86,10 +86,10 @@
 /datum/antagonist/changeling/greet()
 	. = ..()
 	SEND_SOUND(owner.current, sound('sound/ambience/antag/ling_alert.ogg'))
-	return . += "<span class='danger'>Remember: you get all of their absorbed DNA if you absorb a fellow changeling.</span>"
+	return . += "<span class='danger'>If your true identity is revealed, Nanotrasen will not take you alive.</span>"
 
 /datum/antagonist/changeling/farewell()
-	to_chat(owner.current, "<span class='biggerdanger'><B>You grow weak and lose your powers! You are no longer a changeling and are stuck in your current form!</span>")
+	to_chat(owner.current, "<span class='danger'><B>You grow weak and lose your powers! You are no longer a changeling and are stuck in your current form!</span>")
 
 /datum/antagonist/changeling/apply_innate_effects(mob/living/mob_override)
 	var/mob/living/L = ..()
@@ -149,7 +149,6 @@
  * If they have two objectives as well as absorb, they must survive rather than escape.
  */
 /datum/antagonist/changeling/give_objectives()
-	add_antag_objective(/datum/objective/absorb)
 
 	if(prob(60))
 		add_antag_objective(/datum/objective/steal)

--- a/code/modules/antagonists/changeling/datum_changeling.dm
+++ b/code/modules/antagonists/changeling/datum_changeling.dm
@@ -89,7 +89,7 @@
 	return . += "<span class='danger'>If your true identity is revealed, Nanotrasen will not take you alive.</span>"
 
 /datum/antagonist/changeling/farewell()
-	to_chat(owner.current, "<span class='danger'><B>You grow weak and lose your powers! You are no longer a changeling and are stuck in your current form!</span>")
+	to_chat(owner.current, "<span class='danger'><b>You grow weak and lose your powers! You are no longer a changeling and are stuck in your current form!</b></span>")
 
 /datum/antagonist/changeling/apply_innate_effects(mob/living/mob_override)
 	var/mob/living/L = ..()

--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -81,7 +81,7 @@
 	chemical_cost = 25
 	dna_cost = 1
 	power_type = CHANGELING_PURCHASABLE_POWER
-	menu_location = CLING_MENU_UTILITY
+	menu_location = CLING_MENU_STINGS
 
 /datum/action/changeling/sting/extract_dna/can_sting(mob/user, mob/target)
 	if(..())

--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -79,7 +79,9 @@
 	button_icon_state = "sting_extract"
 	sting_icon = "sting_extract"
 	chemical_cost = 25
-	power_type = CHANGELING_INNATE_POWER
+	dna_cost = 1
+	power_type = CHANGELING_PURCHASABLE_POWER
+	menu_location = CLING_MENU_UTILITY
 
 /datum/action/changeling/sting/extract_dna/can_sting(mob/user, mob/target)
 	if(..())


### PR DESCRIPTION
## What Does This PR Do

- Removes the ability for changelings to naturally roll the absorb objective (although keeps it for adminbus related objective purposes)

- Changes DNA sting from being innate to being a purchasable 1 DNA ability under the utility tab.

- The greeting has been cleaned up with a smaller font, alongside different messages- removing the reminder that encouraged changelings to permakill eachother for DNA? Of all things.

## Why It's Good For The Game
Right this is probably going to be one of my more controversial ones. The objective is boring, most people don't bother with it and its often the reason a lot of new changelings get caught and die, stinging random people, transforming (because that's what the objective wants them to do right? and inevitably getting account number tested. 

You can argue its a trial by fire if you want, but it makes for a pretty rough time, that I think is partly responsible for why people don't like changeling.

As for the changes to the greeting, the changeling greeting as it currently is encourages you to attack and permakill other changelings... Why? I don't know.  I assume its a leftover from hivemind to spark up paranoia between the changelings among us.

Finally, HUD bloat. Oh my GOD, changelings get so many HUD icons. If the objective is no longer there, DNA sting no longer needs to remain a base ability as a crutch to stop people getting annoyed about being husked roundstart.

## Images of changes
![image](https://github.com/ParadiseSS13/Paradise/assets/85680653/1214ba8a-b024-43f7-85d9-c6c7ea7f2f4f)
![image](https://github.com/ParadiseSS13/Paradise/assets/85680653/6e2278d1-e5c1-468f-8ec4-cdae34f00f9b)
![image](https://github.com/ParadiseSS13/Paradise/assets/85680653/c116913a-d17b-4ffc-8044-08161471fe61)


## Testing
see above. Mercy, please, the testing mines hurt.

## Changelog
:cl:
tweak: Absorb objective can no longer be rolled by changelings.
tweak: DNA sting is no longer a base changeling ability, instead purchasable under utility for 1 DNA.
tweak: Changeling greeting has been cleaned up to fit the new formatting, informing new changelings of their kos status.
/:cl: