### PR TITLE
customised_abstract_text - removed useless check, changed var

### DIFF
--- a/code/game/gamemodes/cult/blood_magic.dm
+++ b/code/game/gamemodes/cult/blood_magic.dm
@@ -402,7 +402,7 @@
 	return ..()
 
 /obj/item/melee/blood_magic/customised_abstract_text()
-	var/mob/living/carbon/human/owner = loc
+	var/mob/living/carbon/owner = loc
 	return "<span class='warning'>[owner.p_their(TRUE)] [owner.l_hand == src ? "left hand" : "right hand"] is burning in blood-red fire.</span>"
 
 /obj/item/melee/blood_magic/attack_self(mob/living/user)

--- a/code/game/gamemodes/cult/blood_magic.dm
+++ b/code/game/gamemodes/cult/blood_magic.dm
@@ -401,7 +401,7 @@
 			source.UpdateButtonIcon()
 	return ..()
 
-/obj/item/melee/blood_magic/customized_abstract_text()
+/obj/item/melee/blood_magic/customised_abstract_text()
 	var/mob/living/carbon/human/owner = loc
 	return "<span class='warning'>[owner.p_their(TRUE)] [owner.l_hand == src ? "left hand" : "right hand"] is burning in blood-red fire.</span>"
 

--- a/code/game/gamemodes/cult/blood_magic.dm
+++ b/code/game/gamemodes/cult/blood_magic.dm
@@ -401,8 +401,7 @@
 			source.UpdateButtonIcon()
 	return ..()
 
-/obj/item/melee/blood_magic/customised_abstract_text()
-	var/mob/living/carbon/owner = loc
+/obj/item/melee/blood_magic/customised_abstract_text(mob/living/carbon/owner)
 	return "<span class='warning'>[owner.p_their(TRUE)] [owner.l_hand == src ? "left hand" : "right hand"] is burning in blood-red fire.</span>"
 
 /obj/item/melee/blood_magic/attack_self(mob/living/user)

--- a/code/game/gamemodes/cult/blood_magic.dm
+++ b/code/game/gamemodes/cult/blood_magic.dm
@@ -401,9 +401,7 @@
 			source.UpdateButtonIcon()
 	return ..()
 
-/obj/item/melee/blood_magic/customised_abstract_text()
-	if(!ishuman(loc))
-		return
+/obj/item/melee/blood_magic/customized_abstract_text()
 	var/mob/living/carbon/human/owner = loc
 	return "<span class='warning'>[owner.p_their(TRUE)] [owner.l_hand == src ? "left hand" : "right hand"] is burning in blood-red fire.</span>"
 

--- a/code/game/gamemodes/wizard/godhand.dm
+++ b/code/game/gamemodes/wizard/godhand.dm
@@ -23,8 +23,7 @@
 		attached_spell.UnregisterSignal(attached_spell.action.owner, COMSIG_MOB_WILLINGLY_DROP)
 	return ..()
 
-/obj/item/melee/touch_attack/customised_abstract_text()
-	var/mob/living/carbon/owner = loc
+/obj/item/melee/touch_attack/customised_abstract_text(mob/living/carbon/owner)
 	return "<span class='warning'>[owner.p_their(TRUE)] [owner.l_hand == src ? "left hand" : "right hand"] is burning in magic fire.</span>"
 
 /obj/item/melee/touch_attack/attack(mob/target, mob/living/carbon/user)

--- a/code/game/gamemodes/wizard/godhand.dm
+++ b/code/game/gamemodes/wizard/godhand.dm
@@ -24,7 +24,7 @@
 	return ..()
 
 /obj/item/melee/touch_attack/customised_abstract_text()
-	var/mob/living/carbon/human/owner = loc
+	var/mob/living/carbon/owner = loc
 	return "<span class='warning'>[owner.p_their(TRUE)] [owner.l_hand == src ? "left hand" : "right hand"] is burning in magic fire.</span>"
 
 /obj/item/melee/touch_attack/attack(mob/target, mob/living/carbon/user)

--- a/code/game/gamemodes/wizard/godhand.dm
+++ b/code/game/gamemodes/wizard/godhand.dm
@@ -23,9 +23,7 @@
 		attached_spell.UnregisterSignal(attached_spell.action.owner, COMSIG_MOB_WILLINGLY_DROP)
 	return ..()
 
-/obj/item/melee/touch_attack/customised_abstract_text()
-	if(!ishuman(loc))
-		return
+/obj/item/melee/touch_attack/customized_abstract_text()
 	var/mob/living/carbon/human/owner = loc
 	return "<span class='warning'>[owner.p_their(TRUE)] [owner.l_hand == src ? "left hand" : "right hand"] is burning in magic fire.</span>"
 

--- a/code/game/gamemodes/wizard/godhand.dm
+++ b/code/game/gamemodes/wizard/godhand.dm
@@ -23,7 +23,7 @@
 		attached_spell.UnregisterSignal(attached_spell.action.owner, COMSIG_MOB_WILLINGLY_DROP)
 	return ..()
 
-/obj/item/melee/touch_attack/customized_abstract_text()
+/obj/item/melee/touch_attack/customised_abstract_text()
 	var/mob/living/carbon/human/owner = loc
 	return "<span class='warning'>[owner.p_their(TRUE)] [owner.l_hand == src ? "left hand" : "right hand"] is burning in magic fire.</span>"
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -154,7 +154,7 @@ GLOBAL_DATUM_INIT(welding_sparks, /mutable_appearance, mutable_appearance('icons
 		in_storage = TRUE
 
 // this proc is used to add text for items with ABSTRACT flag after default examine text
-/obj/item/proc/customised_abstract_text()
+/obj/item/proc/customised_abstract_text(mob/living/carbon/owner)
 	return
 
 /obj/item/proc/determine_move_resist()

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -154,7 +154,7 @@ GLOBAL_DATUM_INIT(welding_sparks, /mutable_appearance, mutable_appearance('icons
 		in_storage = TRUE
 
 // this proc is used to add text for items with ABSTRACT flag after default examine text
-/obj/item/proc/customized_abstract_text()
+/obj/item/proc/customised_abstract_text()
 	return
 
 /obj/item/proc/determine_move_resist()

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -154,7 +154,7 @@ GLOBAL_DATUM_INIT(welding_sparks, /mutable_appearance, mutable_appearance('icons
 		in_storage = TRUE
 
 // this proc is used to add text for items with ABSTRACT flag after default examine text
-/obj/item/proc/customised_abstract_text()
+/obj/item/proc/customized_abstract_text()
 	return
 
 /obj/item/proc/determine_move_resist()

--- a/code/game/objects/items/weapons/holy_weapons.dm
+++ b/code/game/objects/items/weapons/holy_weapons.dm
@@ -123,7 +123,7 @@
 	attack_verb = list("punched", "cross countered", "pummeled")
 
 /obj/item/nullrod/godhand/customised_abstract_text()
-	var/mob/living/carbon/human/owner = loc
+	var/mob/living/carbon/owner = loc
 	return "<span class='warning'>[owner.p_their(TRUE)] [owner.l_hand == src ? "left hand" : "right hand"] is burning in holy fire.</span>"
 
 /obj/item/nullrod/staff
@@ -436,7 +436,7 @@
 	sharp = TRUE
 
 /obj/item/nullrod/armblade/customised_abstract_text()
-	var/mob/living/carbon/human/owner = loc
+	var/mob/living/carbon/owner = loc
 	return "<span class='warning'>[owner.p_their(TRUE)] [owner.l_hand == src ? "left arm" : "right arm"] has been turned into a grotesque meat-blade.</span>"
 
 /obj/item/nullrod/armblade/mining

--- a/code/game/objects/items/weapons/holy_weapons.dm
+++ b/code/game/objects/items/weapons/holy_weapons.dm
@@ -122,8 +122,7 @@
 	damtype = BURN
 	attack_verb = list("punched", "cross countered", "pummeled")
 
-/obj/item/nullrod/godhand/customised_abstract_text()
-	var/mob/living/carbon/owner = loc
+/obj/item/nullrod/godhand/customised_abstract_text(mob/living/carbon/owner)
 	return "<span class='warning'>[owner.p_their(TRUE)] [owner.l_hand == src ? "left hand" : "right hand"] is burning in holy fire.</span>"
 
 /obj/item/nullrod/staff
@@ -435,8 +434,7 @@
 	w_class = WEIGHT_CLASS_HUGE
 	sharp = TRUE
 
-/obj/item/nullrod/armblade/customised_abstract_text()
-	var/mob/living/carbon/owner = loc
+/obj/item/nullrod/armblade/customised_abstract_text(mob/living/carbon/owner)
 	return "<span class='warning'>[owner.p_their(TRUE)] [owner.l_hand == src ? "left arm" : "right arm"] has been turned into a grotesque meat-blade.</span>"
 
 /obj/item/nullrod/armblade/mining

--- a/code/game/objects/items/weapons/holy_weapons.dm
+++ b/code/game/objects/items/weapons/holy_weapons.dm
@@ -122,9 +122,7 @@
 	damtype = BURN
 	attack_verb = list("punched", "cross countered", "pummeled")
 
-/obj/item/nullrod/godhand/customised_abstract_text()
-	if(!ishuman(loc))
-		return
+/obj/item/nullrod/godhand/customized_abstract_text()
 	var/mob/living/carbon/human/owner = loc
 	return "<span class='warning'>[owner.p_their(TRUE)] [owner.l_hand == src ? "left hand" : "right hand"] is burning in holy fire.</span>"
 
@@ -437,9 +435,7 @@
 	w_class = WEIGHT_CLASS_HUGE
 	sharp = TRUE
 
-/obj/item/nullrod/armblade/customised_abstract_text()
-	if(!ishuman(loc))
-		return
+/obj/item/nullrod/armblade/customized_abstract_text()
 	var/mob/living/carbon/human/owner = loc
 	return "<span class='warning'>[owner.p_their(TRUE)] [owner.l_hand == src ? "left arm" : "right arm"] has been turned into a grotesque meat-blade.</span>"
 

--- a/code/game/objects/items/weapons/holy_weapons.dm
+++ b/code/game/objects/items/weapons/holy_weapons.dm
@@ -122,7 +122,7 @@
 	damtype = BURN
 	attack_verb = list("punched", "cross countered", "pummeled")
 
-/obj/item/nullrod/godhand/customized_abstract_text()
+/obj/item/nullrod/godhand/customised_abstract_text()
 	var/mob/living/carbon/human/owner = loc
 	return "<span class='warning'>[owner.p_their(TRUE)] [owner.l_hand == src ? "left hand" : "right hand"] is burning in holy fire.</span>"
 
@@ -435,7 +435,7 @@
 	w_class = WEIGHT_CLASS_HUGE
 	sharp = TRUE
 
-/obj/item/nullrod/armblade/customized_abstract_text()
+/obj/item/nullrod/armblade/customised_abstract_text()
 	var/mob/living/carbon/human/owner = loc
 	return "<span class='warning'>[owner.p_their(TRUE)] [owner.l_hand == src ? "left arm" : "right arm"] has been turned into a grotesque meat-blade.</span>"
 

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -749,9 +749,7 @@
 	STOP_PROCESSING(SSobj, src)
 	return ..()
 
-/obj/item/pyro_claws/customised_abstract_text()
-	if(!ishuman(loc))
-		return
+/obj/item/pyro_claws/customized_abstract_text()
 	var/mob/living/carbon/human/owner = loc
 	return "<span class='warning'>[owner.p_they(TRUE)] [owner.p_have(FALSE)] energy claws extending [owner.p_their(FALSE)] wrists.</span>"
 

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -749,7 +749,7 @@
 	STOP_PROCESSING(SSobj, src)
 	return ..()
 
-/obj/item/pyro_claws/customized_abstract_text()
+/obj/item/pyro_claws/customised_abstract_text()
 	var/mob/living/carbon/human/owner = loc
 	return "<span class='warning'>[owner.p_they(TRUE)] [owner.p_have(FALSE)] energy claws extending [owner.p_their(FALSE)] wrists.</span>"
 

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -749,8 +749,7 @@
 	STOP_PROCESSING(SSobj, src)
 	return ..()
 
-/obj/item/pyro_claws/customised_abstract_text()
-	var/mob/living/carbon/owner = loc
+/obj/item/pyro_claws/customised_abstract_text(mob/living/carbon/owner)
 	return "<span class='warning'>[owner.p_they(TRUE)] [owner.p_have(FALSE)] energy claws extending [owner.p_their(FALSE)] wrists.</span>"
 
 /obj/item/pyro_claws/process()

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -750,7 +750,7 @@
 	return ..()
 
 /obj/item/pyro_claws/customised_abstract_text()
-	var/mob/living/carbon/human/owner = loc
+	var/mob/living/carbon/owner = loc
 	return "<span class='warning'>[owner.p_they(TRUE)] [owner.p_have(FALSE)] energy claws extending [owner.p_their(FALSE)] wrists.</span>"
 
 /obj/item/pyro_claws/process()

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -161,9 +161,7 @@
 		var/obj/machinery/computer/C = target
 		C.attack_alien(user) //muh copypasta
 
-/obj/item/melee/arm_blade/customised_abstract_text()
-	if(!ishuman(loc))
-		return
+/obj/item/melee/arm_blade/customized_abstract_text()
 	var/mob/living/carbon/human/owner = loc
 	return "<span class='warning'>[owner.p_their(TRUE)] [owner.l_hand == src ? "left arm" : "right arm"] has been turned into a grotesque meat-blade.</span>"
 
@@ -209,9 +207,7 @@
 	throw_speed = 0
 	var/datum/action/changeling/weapon/parent_action
 
-/obj/item/gun/magic/tentacle/customised_abstract_text()
-	if(!ishuman(loc))
-		return
+/obj/item/gun/magic/tentacle/customized_abstract_text()
 	var/mob/living/carbon/human/owner = loc
 	return "<span class='warning'>[owner.p_their(TRUE)] [owner.l_hand == src ? "left arm" : "right arm"] has been turned into a grotesque tentacle.</span>"
 

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -162,7 +162,7 @@
 		C.attack_alien(user) //muh copypasta
 
 /obj/item/melee/arm_blade/customised_abstract_text()
-	var/mob/living/carbon/human/owner = loc
+	var/mob/living/carbon/owner = loc
 	return "<span class='warning'>[owner.p_their(TRUE)] [owner.l_hand == src ? "left arm" : "right arm"] has been turned into a grotesque meat-blade.</span>"
 
 /***************************************\
@@ -208,7 +208,7 @@
 	var/datum/action/changeling/weapon/parent_action
 
 /obj/item/gun/magic/tentacle/customised_abstract_text()
-	var/mob/living/carbon/human/owner = loc
+	var/mob/living/carbon/owner = loc
 	return "<span class='warning'>[owner.p_their(TRUE)] [owner.l_hand == src ? "left arm" : "right arm"] has been turned into a grotesque tentacle.</span>"
 
 /obj/item/gun/magic/tentacle/Initialize(mapload, silent, new_parent_action)

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -161,8 +161,7 @@
 		var/obj/machinery/computer/C = target
 		C.attack_alien(user) //muh copypasta
 
-/obj/item/melee/arm_blade/customised_abstract_text()
-	var/mob/living/carbon/owner = loc
+/obj/item/melee/arm_blade/customised_abstract_text(mob/living/carbon/owner)
 	return "<span class='warning'>[owner.p_their(TRUE)] [owner.l_hand == src ? "left arm" : "right arm"] has been turned into a grotesque meat-blade.</span>"
 
 /***************************************\
@@ -207,8 +206,7 @@
 	throw_speed = 0
 	var/datum/action/changeling/weapon/parent_action
 
-/obj/item/gun/magic/tentacle/customised_abstract_text()
-	var/mob/living/carbon/owner = loc
+/obj/item/gun/magic/tentacle/customised_abstract_text(mob/living/carbon/owner)
 	return "<span class='warning'>[owner.p_their(TRUE)] [owner.l_hand == src ? "left arm" : "right arm"] has been turned into a grotesque tentacle.</span>"
 
 /obj/item/gun/magic/tentacle/Initialize(mapload, silent, new_parent_action)

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -161,7 +161,7 @@
 		var/obj/machinery/computer/C = target
 		C.attack_alien(user) //muh copypasta
 
-/obj/item/melee/arm_blade/customized_abstract_text()
+/obj/item/melee/arm_blade/customised_abstract_text()
 	var/mob/living/carbon/human/owner = loc
 	return "<span class='warning'>[owner.p_their(TRUE)] [owner.l_hand == src ? "left arm" : "right arm"] has been turned into a grotesque meat-blade.</span>"
 
@@ -207,7 +207,7 @@
 	throw_speed = 0
 	var/datum/action/changeling/weapon/parent_action
 
-/obj/item/gun/magic/tentacle/customized_abstract_text()
+/obj/item/gun/magic/tentacle/customised_abstract_text()
 	var/mob/living/carbon/human/owner = loc
 	return "<span class='warning'>[owner.p_their(TRUE)] [owner.l_hand == src ? "left arm" : "right arm"] has been turned into a grotesque tentacle.</span>"
 

--- a/code/modules/antagonists/vampire/vampire_powers/hemomancer_powers.dm
+++ b/code/modules/antagonists/vampire/vampire_powers/hemomancer_powers.dm
@@ -68,9 +68,7 @@
 		parent_spell = null
 	return ..()
 
-/obj/item/vamp_claws/customised_abstract_text()
-	if(!ishuman(loc))
-		return
+/obj/item/vamp_claws/customized_abstract_text()
 	var/mob/living/carbon/human/owner = loc
 	return "<span class='warning'>[owner.p_they(TRUE)] [owner.p_have(FALSE)] bloodied claws extending from [owner.p_their(FALSE)] wrists.</span>"
 

--- a/code/modules/antagonists/vampire/vampire_powers/hemomancer_powers.dm
+++ b/code/modules/antagonists/vampire/vampire_powers/hemomancer_powers.dm
@@ -68,7 +68,7 @@
 		parent_spell = null
 	return ..()
 
-/obj/item/vamp_claws/customized_abstract_text()
+/obj/item/vamp_claws/customised_abstract_text()
 	var/mob/living/carbon/human/owner = loc
 	return "<span class='warning'>[owner.p_they(TRUE)] [owner.p_have(FALSE)] bloodied claws extending from [owner.p_their(FALSE)] wrists.</span>"
 

--- a/code/modules/antagonists/vampire/vampire_powers/hemomancer_powers.dm
+++ b/code/modules/antagonists/vampire/vampire_powers/hemomancer_powers.dm
@@ -68,8 +68,7 @@
 		parent_spell = null
 	return ..()
 
-/obj/item/vamp_claws/customised_abstract_text()
-	var/mob/living/carbon/owner = loc
+/obj/item/vamp_claws/customised_abstract_text(mob/living/carbon/owner)
 	return "<span class='warning'>[owner.p_they(TRUE)] [owner.p_have(FALSE)] bloodied claws extending from [owner.p_their(FALSE)] wrists.</span>"
 
 /obj/item/vamp_claws/afterattack(atom/target, mob/user, proximity)

--- a/code/modules/antagonists/vampire/vampire_powers/hemomancer_powers.dm
+++ b/code/modules/antagonists/vampire/vampire_powers/hemomancer_powers.dm
@@ -69,7 +69,7 @@
 	return ..()
 
 /obj/item/vamp_claws/customised_abstract_text()
-	var/mob/living/carbon/human/owner = loc
+	var/mob/living/carbon/owner = loc
 	return "<span class='warning'>[owner.p_they(TRUE)] [owner.p_have(FALSE)] bloodied claws extending from [owner.p_their(FALSE)] wrists.</span>"
 
 /obj/item/vamp_claws/afterattack(atom/target, mob/user, proximity)

--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -176,7 +176,7 @@
 			msg += "<span class='warning'>[p_they(TRUE)] [p_are()] [bicon(legcuffed)] legcuffed!</span>\n"
 
 	for(var/obj/item/abstract_item in abstract_items)
-		var/text = abstract_item.customised_abstract_text()
+		var/text = abstract_item.customized_abstract_text()
 		if(!text)
 			continue
 		msg += "[text]\n"

--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -176,7 +176,7 @@
 			msg += "<span class='warning'>[p_they(TRUE)] [p_are()] [bicon(legcuffed)] legcuffed!</span>\n"
 
 	for(var/obj/item/abstract_item in abstract_items)
-		var/text = abstract_item.customized_abstract_text()
+		var/text = abstract_item.customised_abstract_text()
 		if(!text)
 			continue
 		msg += "[text]\n"

--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -176,7 +176,7 @@
 			msg += "<span class='warning'>[p_they(TRUE)] [p_are()] [bicon(legcuffed)] legcuffed!</span>\n"
 
 	for(var/obj/item/abstract_item in abstract_items)
-		var/text = abstract_item.customised_abstract_text()
+		var/text = abstract_item.customised_abstract_text(src)
 		if(!text)
 			continue
 		msg += "[text]\n"

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -498,7 +498,7 @@
 	var/force_when_disabled = 5 //still basically a metal pipe, just hard to move
 
 /obj/item/shield/v1_arm/customised_abstract_text()
-	var/mob/living/carbon/human/owner = loc
+	var/mob/living/carbon/owner = loc
 	return "<span class='warning'>[owner.p_their(TRUE)] [owner.l_hand == src ? "left arm" : "right arm"] is covered in metal.</span>"
 
 /obj/item/shield/v1_arm/emp_act(severity)

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -497,9 +497,7 @@
 	var/disabled = FALSE
 	var/force_when_disabled = 5 //still basically a metal pipe, just hard to move
 
-/obj/item/shield/v1_arm/customised_abstract_text()
-	if(!ishuman(loc))
-		return
+/obj/item/shield/v1_arm/customized_abstract_text()
 	var/mob/living/carbon/human/owner = loc
 	return "<span class='warning'>[owner.p_their(TRUE)] [owner.l_hand == src ? "left arm" : "right arm"] is covered in metal.</span>"
 

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -497,8 +497,7 @@
 	var/disabled = FALSE
 	var/force_when_disabled = 5 //still basically a metal pipe, just hard to move
 
-/obj/item/shield/v1_arm/customised_abstract_text()
-	var/mob/living/carbon/owner = loc
+/obj/item/shield/v1_arm/customised_abstract_text(mob/living/carbon/owner)
 	return "<span class='warning'>[owner.p_their(TRUE)] [owner.l_hand == src ? "left arm" : "right arm"] is covered in metal.</span>"
 
 /obj/item/shield/v1_arm/emp_act(severity)

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -497,7 +497,7 @@
 	var/disabled = FALSE
 	var/force_when_disabled = 5 //still basically a metal pipe, just hard to move
 
-/obj/item/shield/v1_arm/customized_abstract_text()
+/obj/item/shield/v1_arm/customised_abstract_text()
 	var/mob/living/carbon/human/owner = loc
 	return "<span class='warning'>[owner.p_their(TRUE)] [owner.l_hand == src ? "left arm" : "right arm"] is covered in metal.</span>"
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Cleaning code, nothing else

removed all 
```
if(!ishuman(loc))
	return
```
in procs `customised_abstract_text()` 
It is not needed because this proc is only called when we examine `/mob/living/carbon`, there is no chance it is called in other conditions

moved all 
`var/mob/living/carbon/human/owner = loc` into proc argument

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
less checks faster game

## Testing
<!-- How did you test the PR, if at all? -->
compiled, run

## Changelog
NPFC

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
