### PR TITLE
fixes water backpacks not being able to have their miser be toggled by clicking on it while it's on your back

### DIFF
--- a/code/game/objects/items/weapons/tanks/watertank.dm
+++ b/code/game/objects/items/weapons/tanks/watertank.dm
@@ -75,9 +75,9 @@
 		QDEL_NULL(noz)
 	return ..()
 
-/obj/item/watertank/attack_hand(mob/user as mob)
-	if(src.loc == user)
-		ui_action_click()
+/obj/item/watertank/attack_hand(mob/user)
+	if(loc == user)
+		toggle_mister(user)
 		return
 	..()
 


### PR DESCRIPTION

<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
fixes water backpacks not being able to have their miser be toggled by clicking on it while it's on your back

## Why It's Good For The Game
bugs are bad, manually calling ui-interact is stupid

## Testing
clicked on it

## Changelog
:cl:
fix: fixes water backpacks not being able to have their miser be toggled by clicking on it while it's on your back
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
