### PR TITLE
Adds colored shoes to loadout, makes satchels craftable

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -282,6 +282,7 @@ GLOBAL_LIST_INIT(cloth_recipes, list (
 	null,
 	new /datum/stack_recipe_list("cloth bags", list(
 		new /datum/stack_recipe("backpack", /obj/item/storage/backpack, 4),
+		new /datum/stack_recipe("satchel", /obj/item/storage/backpack/satchel_norm, 4),
 		new /datum/stack_recipe("dufflebag", /obj/item/storage/backpack/duffel, 6),
 		null,
 		new /datum/stack_recipe("plant bag", /obj/item/storage/bag/plants, 4),

--- a/code/modules/client/preference/loadout/loadout_shoes.dm
+++ b/code/modules/client/preference/loadout/loadout_shoes.dm
@@ -75,3 +75,31 @@
 /datum/gear/shoes/whiteshoes
 	display_name = "White shoes"
 	path = /obj/item/clothing/shoes/white
+
+/datum/gear/shoes/leathershoes
+	display_name = "Leather shoes"
+	path = /obj/item/clothing/shoes/leather
+
+/datum/gear/shoes/redshoes
+	display_name = "Red shoes"
+	path = /obj/item/clothing/shoes/red
+
+/datum/gear/shoes/orangeshoes
+	display_name = "Orange shoes"
+	path = /obj/item/clothing/shoes/orange
+
+/datum/gear/shoes/yellowshoes
+	display_name = "Yellow shoes"
+	path = /obj/item/clothing/shoes/yellow
+
+/datum/gear/shoes/greenshoes
+	display_name = "Green shoes"
+	path = /obj/item/clothing/shoes/green
+
+/datum/gear/shoes/blueshoes
+	display_name = "Blue shoes"
+	path = /obj/item/clothing/shoes/blue
+
+/datum/gear/shoes/purpleshoes
+	display_name = "Purple shoes"
+	path = /obj/item/clothing/shoes/purple


### PR DESCRIPTION
## What Does This PR Do
Title self-explanatory

## Why It's Good For The Game
I see no particular reason not to add all the colors of shoes to the loadout, especially considering our current options are somewhat limited color-wise; let people express themselves better!
Satchels are practically just a reskin of backpacks, so if backpacks can be crafted with cloth, I imagine satchels also should be.

## Images of changes / Testing
Loaded in with some snazzy sneakers and spawned a bit of cloth to craft meself a satchel
![2023-11-17 16_15_51](https://github.com/ParadiseSS13/Paradise/assets/100448493/7e09ae88-ef57-430f-9b04-98502857d5cf)

## Changelog
:cl:
add: Colored shoes are now available as Loadout options
add: You can now craft satchels using cloth
/:cl: