### PR TITLE
destination tagger UI improvements

### DIFF
--- a/code/modules/tgui/modules/destination_tagger.dm
+++ b/code/modules/tgui/modules/destination_tagger.dm
@@ -5,8 +5,9 @@
 /datum/ui_module/destination_tagger/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = TRUE, datum/tgui/master_ui = null, datum/ui_state/state = GLOB.default_state)
 	ui = SStgui.try_update_ui(user, src, ui_key, ui, force_open)
 	if(!ui)
-		ui = new(user, src, ui_key, "DestinationTagger", name, 395, 350, master_ui, state)
+		ui = new(user, src, ui_key, "DestinationTagger", name, 400, 350, master_ui, state)
 		ui.open()
+		ui.set_autoupdate(FALSE)
 
 /datum/ui_module/destination_tagger/ui_data(mob/user)
 	var/list/data = list()
@@ -35,7 +36,7 @@
 
 		my_tag = destination_id
 		playsound(host, 'sound/machines/terminal_select.ogg', 15, TRUE)
-
+		SStgui.update_uis(src)
 		// Handle setting tags (and flushing for drones)
 		if(istype(host, /obj/item/destTagger))
 			var/obj/item/destTagger/O = host


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Destination tagger no longer auto updates, updates only when needed and updates instantly (no awkward delay between the new tag updating)
Destination tagger now has a width of 400, so you can actually see all the options in one screen. it actually makes me angry that it was 395 before and it just prevented you from seeing all of it

## Why It's Good For The Game
Kinda just speaks for itself, makes it easier and cleaner to use. Also good for performance

## Testing
drone gaming

## Changelog
:cl:
tweak: Destination tagger UI now is slightly bigger to let you see all ui options on screen
tweak: Destination tagger ui no longer auto updates, updates when you change a tag
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
