### PR TITLE
Makes pens sharp and annoying to poke people with

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -998,7 +998,7 @@
 /mob/living/proc/attempt_harvest(obj/item/I, mob/user)
 	if(user.a_intent == INTENT_HARM && stat == DEAD && butcher_results) //can we butcher it?
 		var/sharpness = is_sharp(I)
-		if(sharpness)
+		if(sharpness && I.force >= 5)
 			to_chat(user, "<span class='notice'>You begin to butcher [src]...</span>")
 			playsound(loc, 'sound/weapons/slice.ogg', 50, 1, -1)
 			if(do_mob(user, src, 80 / sharpness) && Adjacent(I))

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -33,9 +33,8 @@
 	if(force)
 		return ..()
 
-	to_chat(user, "<span class='warning'>You poke [M] with the [src].</span>")
+	to_chat(user, "<span class='warning'>You poke [M] with [src].</span>")
 	to_chat(M, "<span class='notice'>You feel a tiny prick!</span>")
-	add_attack_logs(user, M, "stabbed with [src]")
 	return TRUE
 
 /obj/item/pen/blue

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -20,6 +20,7 @@
 	w_class = WEIGHT_CLASS_TINY
 	throw_speed = 3
 	throw_range = 7
+	sharp = TRUE
 	materials = list(MAT_METAL=10)
 	var/colour = "black"	//what colour the ink is!
 	pressure_resistance = 2
@@ -27,6 +28,15 @@
 /obj/item/pen/suicide_act(mob/user)
 	to_chat(viewers(user), "<span class='suicide'>[user] starts scribbling numbers over [user.p_themselves()] with [src]! It looks like [user.p_theyre()] trying to commit sudoku.</span>")
 	return BRUTELOSS
+
+/obj/item/pen/attack(mob/living/carbon/human/M, mob/user)
+	if(force)
+		return ..()
+
+	to_chat(user, "<span class='warning'>You poke [M] with the [src].</span>")
+	to_chat(M, "<span class='notice'>You feel a tiny prick!</span>")
+	add_attack_logs(user, M, "stabbed with [src]")
+	return TRUE
 
 /obj/item/pen/blue
 	name = "blue-ink pen"
@@ -222,7 +232,6 @@
 		playsound(user, 'sound/weapons/saberon.ogg', 2, 1)
 		to_chat(user, "<span class='warning'>[src] is now active.</span>")
 		set_light(brightness_on, 1)
-	set_sharpness(on)
 	update_icon()
 
 /obj/item/pen/edagger/update_icon_state()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Makes pens sharp (but does not give them force) and lets you poke people with them. Replicates pen behavior as seen on TGcode. 

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Small QOL that's intended to give another tool for cutting things that don't require damage, like bedsheets. I also think poking somebody with a pen is funny. 
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Had runtime issue with edaggers and set_sharpness(on). Removing set_sharpness resolved runtime & restored functionality, but I don't know how to stress test it.

Spawned & tested all subtypes of pens (sleepy, poison, edagger, multicolor, gilded) to ensure that their functionality wasn't overridden. 
<!-- How did you test the PR, if at all? -->

## Changelog
:cl: Chuga
tweak: Pens can now cut things and poke people. 
tweak: Butchering corpses now requires at least 5 damage.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
