### PR TITLE
fixes xeno headslugging not working

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/headslug.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headslug.dm
@@ -117,7 +117,6 @@
 	var/obj/item/organ/external/chest = owner.get_organ(BODY_ZONE_CHEST)
 	chest.fracture()
 	chest.disembowel()
-		
 
 #undef EGG_INCUBATION_DEAD_TIME
 #undef EGG_INCUBATION_LIVING_TIME

--- a/code/modules/mob/living/simple_animal/hostile/headslug.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headslug.dm
@@ -108,11 +108,14 @@
 		M.key = origin.key
 		M.revive() // better make sure some weird shit doesn't happen, because it has in the pas
 		M.forceMove(get_turf(owner)) // So that they are not stuck inside
-	owner.apply_damage(300, BRUTE, BODY_ZONE_CHEST)
-	owner.bleed(BLOOD_VOLUME_NORMAL)
-	var/obj/item/organ/external/chest = owner.get_organ(BODY_ZONE_CHEST)
-	chest.fracture()
-	chest.disembowel()
+	if(ishuman(owner))
+		owner.apply_damage(300, BRUTE, BODY_ZONE_CHEST)
+		owner.bleed(BLOOD_VOLUME_NORMAL)
+		var/obj/item/organ/external/chest = owner.get_organ(BODY_ZONE_CHEST)
+		chest.fracture()
+		chest.disembowel()
+	else
+		owner.gib()
 
 #undef EGG_INCUBATION_DEAD_TIME
 #undef EGG_INCUBATION_LIVING_TIME

--- a/code/modules/mob/living/simple_animal/hostile/headslug.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headslug.dm
@@ -108,14 +108,16 @@
 		M.key = origin.key
 		M.revive() // better make sure some weird shit doesn't happen, because it has in the pas
 		M.forceMove(get_turf(owner)) // So that they are not stuck inside
-	if(ishuman(owner))
-		owner.apply_damage(300, BRUTE, BODY_ZONE_CHEST)
-		owner.bleed(BLOOD_VOLUME_NORMAL)
-		var/obj/item/organ/external/chest = owner.get_organ(BODY_ZONE_CHEST)
-		chest.fracture()
-		chest.disembowel()
-	else
+	if(!ishuman(owner))
 		owner.gib()
+		return
+		
+	owner.apply_damage(300, BRUTE, BODY_ZONE_CHEST)
+	owner.bleed(BLOOD_VOLUME_NORMAL)
+	var/obj/item/organ/external/chest = owner.get_organ(BODY_ZONE_CHEST)
+	chest.fracture()
+	chest.disembowel()
+		
 
 #undef EGG_INCUBATION_DEAD_TIME
 #undef EGG_INCUBATION_LIVING_TIME

--- a/code/modules/surgery/organs/organ.dm
+++ b/code/modules/surgery/organs/organ.dm
@@ -50,21 +50,18 @@
 /obj/item/organ/proc/update_health()
 	return
 
-/obj/item/organ/New(mob/living/carbon/holder, datum/species/species_override = null)
+/obj/item/organ/New(mob/living/carbon/human/holder, datum/species/species_override = null)
 	..(holder)
 	if(!max_damage)
 		max_damage = min_broken_damage * 2
 	if(istype(holder))
 		if(holder.dna)
 			dna = holder.dna.Clone()
+			if(!blood_DNA)
+				blood_DNA = list()
+			blood_DNA[dna.unique_enzymes] = dna.blood_type
 		else
 			stack_trace("[holder] spawned without a proper DNA.")
-		var/mob/living/carbon/human/H = holder
-		if(istype(H))
-			if(dna)
-				if(!blood_DNA)
-					blood_DNA = list()
-				blood_DNA[dna.unique_enzymes] = dna.blood_type
 	else
 		dna = new /datum/dna(null)
 		if(species_override)

--- a/code/modules/surgery/organs/organ.dm
+++ b/code/modules/surgery/organs/organ.dm
@@ -50,11 +50,11 @@
 /obj/item/organ/proc/update_health()
 	return
 
-/obj/item/organ/New(mob/living/carbon/human/holder, datum/species/species_override = null)
+/obj/item/organ/New(mob/living/carbon/holder, datum/species/species_override = null)
 	..(holder)
 	if(!max_damage)
 		max_damage = min_broken_damage * 2
-	if(istype(holder))
+	if(ishuman(holder))
 		if(holder.dna)
 			dna = holder.dna.Clone()
 			if(!blood_DNA)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
fixes #23316 

## Why It's Good For The Game
Intended behavior is good, runtimes are bad

## Testing
Egged a skrell and an xeno

## Changelog
:cl:
fix: xenos can be properly headslug'd again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
