### PR TITLE
Observer antaghud use is extended to 5 minutes after roundstart

### DIFF
--- a/code/controllers/configuration/sections/general_configuration.dm
+++ b/code/controllers/configuration/sections/general_configuration.dm
@@ -44,6 +44,8 @@
 	var/base_loadout_points = 5
 	/// Respawnability loss penalty for eary cryoing (minutes)
 	var/cryo_penalty_period = 30
+	/// Observers count as roundstart if they join from the main menu before this time (in minutes). Set to 0 to allow only-pregame start observers.
+	var/roundstart_observer_period = 5
 	/// Enable OOC emojis?
 	var/enable_ooc_emoji = TRUE
 	/// Auto start the game if on a local test server
@@ -118,6 +120,7 @@
 	CONFIG_LOAD_NUM(lobby_time, data["lobby_time"])
 	CONFIG_LOAD_NUM(base_loadout_points, data["base_loadout_points"])
 	CONFIG_LOAD_NUM(cryo_penalty_period, data["cryo_penalty_period"])
+	CONFIG_LOAD_NUM(roundstart_observer_period, data["roundstart_observer_period"])
 	CONFIG_LOAD_NUM(minimum_client_build, data["minimum_client_build"])
 	CONFIG_LOAD_NUM(byond_account_age_threshold, data["byond_account_age_threshold"])
 	CONFIG_LOAD_NUM(max_client_cid_history, data["max_client_cid_history"])

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -188,7 +188,10 @@
 			stop_sound_channel(CHANNEL_LOBBYMUSIC)
 			if(ROUND_TIME <= (GLOB.configuration.general.roundstart_observer_period MINUTES))
 				GLOB.roundstart_observer_keys |= ckey
-				to_chat(src, "<span class='notice'>As you observed within [GLOB.configuration.general.roundstart_observer_period] minutes, you can freely toggle antag-hud without losing respawnability.</span>")
+				var/period_human_readable = "within [GLOB.configuration.general.roundstart_observer_period] minutes"
+				if(GLOB.configuration.general.roundstart_observer_period == 0)
+					period_human_readable = "before the round started"
+				to_chat(src, "<span class='notice'>As you observed [period_human_readable], you can freely toggle antag-hud without losing respawnability.</span>")
 			observer.started_as_observer = 1
 			close_spawn_windows()
 			var/obj/O = locate("landmark*Observer-Start")

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -186,9 +186,9 @@
 			src << browse(null, "window=playersetup")
 			spawning = TRUE
 			stop_sound_channel(CHANNEL_LOBBYMUSIC)
-			if(SSticker.current_state < GAME_STATE_PLAYING)
+			if(ROUND_TIME <= (GLOB.configuration.general.roundstart_observer_period MINUTES))
 				GLOB.roundstart_observer_keys |= ckey
-				to_chat(src, "<span class='notice'>As you observed before the round started, you can freely toggle antag-hud without losing respawnability.</span>")
+				to_chat(src, "<span class='notice'>As you observed within [GLOB.configuration.general.roundstart_observer_period] minutes, you can freely toggle antag-hud without losing respawnability.</span>")
 			observer.started_as_observer = 1
 			close_spawn_windows()
 			var/obj/O = locate("landmark*Observer-Start")

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -188,7 +188,7 @@
 			stop_sound_channel(CHANNEL_LOBBYMUSIC)
 			if(ROUND_TIME <= (GLOB.configuration.general.roundstart_observer_period MINUTES))
 				GLOB.roundstart_observer_keys |= ckey
-				var/period_human_readable = "within [GLOB.configuration.general.roundstart_observer_period] minutes"
+				var/period_human_readable = "within [GLOB.configuration.general.roundstart_observer_period] minute\s"
 				if(GLOB.configuration.general.roundstart_observer_period == 0)
 					period_human_readable = "before the round started"
 				to_chat(src, "<span class='notice'>As you observed [period_human_readable], you can freely toggle antag-hud without losing respawnability.</span>")

--- a/config/example/config.toml
+++ b/config/example/config.toml
@@ -306,6 +306,8 @@ disable_cid_warning_popup = false
 base_loadout_points = 5
 # Respawnability loss penalty if you cryo below this threshold (Minutes)
 cryo_penalty_period = 30
+# Observers count as roundstart if they join from the main menu before this time (in minutes). Set to 0 to allow only-pregame start observers.
+roundstart_observer_period = 5
 # Enable twitter emojis in OOC?
 enable_ooc_emoji = true
 # Auto start the game if running a local test server


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->This extends the #23009 PR to allow people observing the game within 5 minutes of roundstart (not just before the game has actually started) to antaghud without losing respawnability. 

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Sometimes players leave their computers between rounds, and when they come back the round has already started. If they want to observe in this case, I think they should have a chance to have the same benefits as of just before the round.

## Testing
<!-- How did you test the PR, if at all? -->
Observed 2 minutes after the game started, was a roundstart observer
set the config to 0 minutes
observed 2 minutes after the game started, was not a roundstart observer
restarted, observed before the game started, was a roundstart observer

## Changelog
:cl:
tweak: Observing before 5 minutes into a round, lets you toggle AntagHUD without losing respawnability.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
