### PR TITLE
Dead cultists no longer count towards the amount of cultists & cult-size is checked on stat change

### DIFF
--- a/code/game/gamemodes/cult/cult_mode.dm
+++ b/code/game/gamemodes/cult/cult_mode.dm
@@ -248,16 +248,16 @@ GLOBAL_LIST_EMPTY(all_cults)
 /datum/game_mode/proc/get_cultists(separate = FALSE)
 	var/cultists = 0
 	var/constructs = 0
-	for(var/I in cult)
-		var/datum/mind/M = I
+	for(var/datum/mind/M as anything in cult)
+		if(M.current.stat == DEAD)
+			continue
 		if(ishuman(M.current) && !M.current.has_status_effect(STATUS_EFFECT_SUMMONEDGHOST))
 			cultists++
 		else if(isconstruct(M.current))
 			constructs++
 	if(separate)
 		return list(cultists, constructs)
-	else
-		return cultists + constructs
+	return cultists + constructs
 
 /datum/game_mode/proc/check_cult_size()
 	var/cult_players = get_cultists()

--- a/code/game/gamemodes/cult/cult_mode.dm
+++ b/code/game/gamemodes/cult/cult_mode.dm
@@ -206,7 +206,7 @@ GLOBAL_LIST_EMPTY(all_cults)
 	if(show_message)
 		cultist.visible_message("<span class='cult'>[cultist] looks like [cultist.p_they()] just reverted to [cultist.p_their()] old faith!</span>",
 		"<span class='userdanger'>An unfamiliar white light flashes through your mind, cleansing the taint of [SSticker.cultdat ? SSticker.cultdat.entity_title1 : "Nar'Sie"] and the memories of your time as their servant with it.</span>")
-	UnregisterSignal(cult_mind.current, COMSIG_MOB_DEATH)
+	UnregisterSignal(cult_mind.current, COMSIG_MOB_STATCHANGE)
 
 /datum/game_mode/proc/add_cult_immunity(mob/living/target)
 	ADD_TRAIT(target, TRAIT_CULT_IMMUNITY, CULT_TRAIT)
@@ -262,6 +262,7 @@ GLOBAL_LIST_EMPTY(all_cults)
 	return cultists + constructs
 
 /datum/game_mode/proc/check_cult_size()
+	SIGNAL_HANDLER // COMSIG_MOB_STATCHANGE from cultists
 	var/cult_players = get_cultists()
 
 	if(cult_ascendant)

--- a/code/game/gamemodes/cult/cult_mode.dm
+++ b/code/game/gamemodes/cult/cult_mode.dm
@@ -166,7 +166,7 @@ GLOBAL_LIST_EMPTY(all_cults)
 		check_cult_size()
 		cult_objs.study(cult_mind.current)
 		to_chat(cult_mind.current, "<span class='motd'>For more information, check the wiki page: ([GLOB.configuration.url.wiki_url]/index.php/Cultist)</span>")
-		RegisterSignal(cult_mind.current, COMSIG_MOB_STATCHANGE, PROC_REF(check_cult_size))
+		RegisterSignal(cult_mind.current, COMSIG_MOB_STATCHANGE, PROC_REF(cultist_stat_change))
 		return TRUE
 
 /datum/game_mode/proc/remove_cultist(datum/mind/cult_mind, show_message = TRUE, remove_gear = FALSE, mob/target_mob)
@@ -261,8 +261,16 @@ GLOBAL_LIST_EMPTY(all_cults)
 		return list(cultists, constructs)
 	return cultists + constructs
 
-/datum/game_mode/proc/check_cult_size()
+/datum/game_mode/proc/cultist_stat_change(mob/target_cultist, new_stat, old_stat)
 	SIGNAL_HANDLER // COMSIG_MOB_STATCHANGE from cultists
+	if(new_stat == old_stat) // huh, how? whatever, we ignore it
+		return
+	if(new_stat != DEAD && old_stat != DEAD)
+		return // switching between alive and unconcious
+	// switching between dead and alive/unconcious
+	check_cult_size()
+
+/datum/game_mode/proc/check_cult_size()
 	var/cult_players = get_cultists()
 
 	if(cult_ascendant)

--- a/code/game/gamemodes/cult/cult_mode.dm
+++ b/code/game/gamemodes/cult/cult_mode.dm
@@ -166,6 +166,7 @@ GLOBAL_LIST_EMPTY(all_cults)
 		check_cult_size()
 		cult_objs.study(cult_mind.current)
 		to_chat(cult_mind.current, "<span class='motd'>For more information, check the wiki page: ([GLOB.configuration.url.wiki_url]/index.php/Cultist)</span>")
+		RegisterSignal(cult_mind.current, COMSIG_MOB_STATCHANGE, PROC_REF(check_cult_size))
 		return TRUE
 
 /datum/game_mode/proc/remove_cultist(datum/mind/cult_mind, show_message = TRUE, remove_gear = FALSE, mob/target_mob)
@@ -205,6 +206,7 @@ GLOBAL_LIST_EMPTY(all_cults)
 	if(show_message)
 		cultist.visible_message("<span class='cult'>[cultist] looks like [cultist.p_they()] just reverted to [cultist.p_their()] old faith!</span>",
 		"<span class='userdanger'>An unfamiliar white light flashes through your mind, cleansing the taint of [SSticker.cultdat ? SSticker.cultdat.entity_title1 : "Nar'Sie"] and the memories of your time as their servant with it.</span>")
+	UnregisterSignal(cult_mind.current, COMSIG_MOB_DEATH)
 
 /datum/game_mode/proc/add_cult_immunity(mob/living/target)
 	ADD_TRAIT(target, TRAIT_CULT_IMMUNITY, CULT_TRAIT)
@@ -249,7 +251,7 @@ GLOBAL_LIST_EMPTY(all_cults)
 	var/cultists = 0
 	var/constructs = 0
 	for(var/datum/mind/M as anything in cult)
-		if(M.current.stat == DEAD)
+		if(QDELETED(M) || M.current?.stat == DEAD)
 			continue
 		if(ishuman(M.current) && !M.current.has_status_effect(STATUS_EFFECT_SUMMONEDGHOST))
 			cultists++
@@ -264,7 +266,7 @@ GLOBAL_LIST_EMPTY(all_cults)
 
 	if(cult_ascendant)
 		// The cult only falls if below 1/2 of the rising, usually pretty low. e.g. 5% on highpop, 10% on lowpop
-		if(cult_players < rise_number / 2)
+		if(cult_players < (rise_number / 2))
 			cult_fall()
 		return
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->With the addition of #21429, the amount of cultists actually alive matters a lot more. This PR makes it so dead cultists no longer count towards the rise/ascend/fall of cults, and fixes the amount of cultists on the study screen to not include the dead ones.

This PR makes it so that this count is also checked whenever a cultist's stat is changed, this includes both death and revival.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Security can kill all the cult they please, and then not deconvert any of them, so that the 2 remaining cultists will still have their halos. Having the cult count be more accurate is a good thing.

## Testing
<!-- How did you test the PR, if at all? -->
Spawned in a bunch of skrells, made them into cultists, killed em with a pulse rifle and revived them.

## Changelog
:cl:
fix: dead cultists no longer count towards the rise/fall number
fix: cultist's study objectives should now be more accurate with the amount of cultists and constructs
tweak: cult-size count now updates when a cultist is revived or dies
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
