### PR TITLE
[s] Fixes an issue with nuke cores and AIs 

### DIFF
--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -342,6 +342,8 @@ GLOBAL_VAR(bomb_set)
 /obj/machinery/nuclearbomb/attack_hand(mob/user as mob)
 	if(!panel_open)
 		return ui_interact(user)
+	if(!Adjacent(user))
+		return
 	if(removal_stage != NUKE_CORE_FULLY_EXPOSED || !core)
 		return wires.Interact(user)
 	if(timing) //removing the core is less risk then cutting wires, and doesnt take long, so we should not let crew do it while the nuke is armed. You can however get to it, without the special screwdriver, if you put the NAD in.


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->Makes sure that the user is adjacent to it, because for some reason AI calls attack_hand on nuclear bombs. Its not really that game breaking, just funny.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Fixes an oversight

## Testing
<!-- How did you test the PR, if at all? -->
I could no longer use my remote-AI hands to touch the nuclear bomb

## Changelog
:cl:
fix: AIs can no longer remove the nuclear core from the nuclear bomb
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
