### PR TITLE
Buffs drasks

### DIFF
--- a/code/modules/mob/living/carbon/human/species/drask.dm
+++ b/code/modules/mob/living/carbon/human/species/drask.dm
@@ -15,7 +15,6 @@
 	male_sneeze_sound = 'sound/voice/drasksneeze.ogg'
 	female_sneeze_sound = 'sound/voice/drasksneeze.ogg'
 
-	burn_mod = 1.5
 	//exotic_blood = "cryoxadone"
 	body_temperature = 273
 
@@ -46,7 +45,7 @@
 	heat_level_1 = 310 //Default 370 - Higher is better
 	heat_level_2 = 340 //Default 400
 	heat_level_3 = 400 //Default 460
-	heatmod = 2 // 3 * more damage from body temp
+	heatmod = 3 // 3 * more damage from body temp
 
 	flesh_color = "#a3d4eb"
 	reagent_tag = PROCESS_ORG


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Drasks no longer have a burn mod, but they keep the same relative 3x heat mod.

Old system:
human: takes 3 damage per max heat tick, 5 if on fire. Takes 20 laser damage.
drask: takes 9 damage per max heat tick, 15 if on fire. Takes 30 laser damage.

New system
human: takes 3 damage per max heat tick, 5 if on fire. Takes 20 laser damage.
drask: takes 9 damage per max heat tick, 15 if on fire. Takes 20 laser damage.


## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Drasks are in a very sorry state for anything antag-wise, they get absolutely brutalized by lasers, and essentially killed in 2 shots by immolators. I think moving away from burn-mod is a good thing.

## Testing
<!-- How did you test the PR, if at all? -->
Burned a couple a drasks.

## Changelog
:cl:
tweak: Drasks no longer take 1.5x fire damage
tweak: Drasks now have a 3x head modifier instead of 2x.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
