### PR TITLE
Tone down upgraded cybernetic heart EMP necrosis

### DIFF
--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -310,12 +310,6 @@
 		emagged = FALSE
 
 
-/obj/item/organ/internal/heart/cybernetic/upgraded/emp_act(severity)
-	..()
-	if(emp_proof)
-		return
-	necrotize()
-
 /obj/item/organ/internal/heart/cybernetic/upgraded/proc/shock_heart(mob/living/carbon/human/source, intensity)
 	SIGNAL_HANDLER_DOES_SLEEP
 


### PR DESCRIPTION
## What Does This PR Do
Removes the `emp_act()` override of upgraded cybernetic hearts. Instead of going _necrotic_ on an EMP, being a basically unavoidable death, it now simply stops beating just like the regular cybernetic heart (which still very likely means death).

## Why It's Good For The Game
The upgraded variant already has an additional malus from taking electric shocks, ranging from brute/burn damage, instant Cardiac Failure, to stopping or even rarely necrotizing. Even besides that, the self-restarting quirk of the organ only lets you survive 10% of EMPs, which can simply be chained if something wants to mathematically guarantee your demise. In other words, necrotizing on EMPs as a downside on top of everything else is severely overkill.

The more notable effect of this buff and frankly the ignition point of this change is that abductor EMP glands no longer mass-necrotize all nearby cybernetic hearts during surgery just because Robotics wanted to be helpful and printed the upgraded variants.

## Testing
Spawned in an autosurgeon and an upgraded cyberheart, shot self with a reflected ion rifle bolt, enjoyed the 90% chance of a sweet embrace of death.
Placed several upgraded cyberhearts near an EMP gland victim, rejoiced when they survived the EMP blast without requiring nanopaste to make them useful again.

## Changelog
:cl:
tweak: Upgraded cybernetic hearts now simply stop beating instead of necrotizing on EMP.
/:cl: