### PR TITLE
Reduces Dehydrated Carp's price to 4tc

### DIFF
--- a/code/datums/uplink_items/uplink_general.dm
+++ b/code/datums/uplink_items/uplink_general.dm
@@ -365,7 +365,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "Just add water to make your very own hostile to everything space carp. It looks just like a plushie. The first person to squeeze it will be registered as its owner, who it will not attack. If no owner is registered, it'll just attack everyone."
 	reference = "DSC"
 	item = /obj/item/toy/plushie/carpplushie/dehy_carp
-	cost = 5
+	cost = 4
 
 
 // GRENADES AND EXPLOSIVES


### PR DESCRIPTION
## What Does This PR Do
See title.

## Why It's Good For The Game
feesh. 

Dehydrated carp isn't a very often picked item, and while this probably isn't going to turn it into a must-pick, it will hopefully see some more use. 

Additionally, if you're going for a full carp build you can now buy 25 carp instead of 20. That's five more than twenty.

## Testing
- Loaded in
- Became tot
- Purchased 25 dried instant carp

## Changelog
:cl:
tweak: Syndiefeesh now cost 4tc
/:cl: