### PR TITLE
Fixes some chat messages with the arcade prize machine

### DIFF
--- a/code/modules/arcade/prize_datums.dm
+++ b/code/modules/arcade/prize_datums.dm
@@ -20,10 +20,10 @@ GLOBAL_DATUM_INIT(global_prizes, /datum/prizes, new())
 		new item.typepath(prize_counter.loc)
 		prize_counter.tickets -= item.cost
 		to_chat(usr, "<span class='notice'>Enjoy your prize!</span>")
-		return 1
+		return TRUE
 	else
 		to_chat(usr, "<span class='warning'>Not enough tickets!</span>")
-		return 0
+		return FALSE
 
 //////////////////////////////////////
 //			prize_item datum		//

--- a/code/modules/arcade/prize_datums.dm
+++ b/code/modules/arcade/prize_datums.dm
@@ -22,7 +22,7 @@ GLOBAL_DATUM_INIT(global_prizes, /datum/prizes, new())
 		to_chat(usr, "<span class='notice'>Enjoy your prize!</span>")
 		return 1
 	else
-		to_chat(usr,"<span class='warning'>Not enough tickets!</span>")
+		to_chat(usr, "<span class='warning'>Not enough tickets!</span>")
 		return 0
 
 //////////////////////////////////////

--- a/code/modules/arcade/prize_datums.dm
+++ b/code/modules/arcade/prize_datums.dm
@@ -19,10 +19,10 @@ GLOBAL_DATUM_INIT(global_prizes, /datum/prizes, new())
 	if(prize_counter.tickets >= item.cost)
 		new item.typepath(prize_counter.loc)
 		prize_counter.tickets -= item.cost
-		prize_counter.visible_message("<span class='notice'>Enjoy your prize!</span>")
+		to_chat(usr, "<span class='notice'>Enjoy your prize!</span>")
 		return 1
 	else
-		prize_counter.visible_message("<span class='warning'>Not enough tickets!</span>")
+		to_chat(usr,"<span class='warning'>Not enough tickets!</span>")
 		return 0
 
 //////////////////////////////////////


### PR DESCRIPTION
## What Does This PR Do
Fixes chat messages meant just for the user going to everyone within view.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Generally makes more sense, not everyone needs to see that you're too arcade poor to afford the water balloon

## Testing
Fired up the server with 2 clients, made sure only the machine user could see it when the purchase went through and when it didn't
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Arcade reward machine no longer broadcasts your lack of tickets to the world
/:cl: