### PR TITLE
makes 2 wizard weapons less of a pain to use.

### DIFF
--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -257,7 +257,9 @@
 
 /datum/status_effect/force_shield
 	id = "forceshield"
-	duration = 4 SECONDS
+	alert_type = null
+	status_type = STATUS_EFFECT_REFRESH
+	duration = 5 SECONDS
 	tick_interval = 0
 	var/mutable_appearance/shield
 

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -574,7 +574,7 @@
 	icon_state = "singulohammer0"
 
 /obj/item/singularityhammer/proc/vortex(turf/pull, mob/wielder)
-	for(var/atom/movable/X in orange(5, pull))
+	for(var/atom/movable/X in range(5, pull))
 		if(X.move_resist == INFINITY)
 			continue
 		if(X == wielder)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Spellblade now has it's buff last one more second on protection mode and be refreshable. This means the weapon no longer has a period of downside when you are actively attacking someone. This makes it more viable (read: not great) for a wizard  to run spellblade without instant summons or mutate for stun immunity / recovery, which is the point of shielded spellblade (It's still finicky as hell. If balance wants I can make it refresh the status effect on each hit vs every 4 seconds.)

Fixes the shielded spellblade having an alert that shows nothing.

The singularity hammer now does it's vortex in range vs oragne from the person that you hit. This means you are no longer punished for... hitting a person with your melee weapon and it not stunning them. It's not exactly intuitive that every 4 seconds you need to click something other than the person you are attacking otherwise they get unstunned, and that every 4 seconds hit does extra damage, so it's counter intutive that you must constantly waste it on the floor.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

See above. Makes the spellblade more useful for what it is intended for. Makes singulo hammer not work strangely for you without code diving / asking someone else how to use it.

## Testing
<!-- How did you test the PR, if at all? -->

Confirmed refresh worked, confirmed stun worked.

## Changelog
:cl:
tweak: Shielded spellblades buff lasts 1 second more and can be refreshed.
tweak: Singularity hammer now can hit the mob you are attacking with a stun, rather than everyone but the tile you are attacking being stunned
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
