### PR TITLE
Removes the e20 from surplus crates (for real this time)

### DIFF
--- a/code/datums/uplink_items/uplink_traitor.dm
+++ b/code/datums/uplink_items/uplink_traitor.dm
@@ -244,6 +244,7 @@
 	item = /obj/item/dice/d20/e20
 	cost = 15
 	job = list("Librarian")
+	surplus = 0
 
 //Botanist
 /datum/uplink_item/jobspecific/ambrosiacruciatus


### PR DESCRIPTION
## What Does This PR Do
Actually removes e20s from surplus crates like intended in https://github.com/ParadiseSS13/Paradise/pull/22772

## Why It's Good For The Game
My reasons have been pointed out in https://github.com/ParadiseSS13/Paradise/pull/22772. This item should not be able to be rolled in surplus crates as per the PR approving them no longer being rolled in surplus crates.

## Testing
e20 does not roll in surplus crates. How the fuck did I miss this?

## Changelog
:cl:
tweak: E20s can no longer be rolled in surplus crates.
/:cl: