### PR TITLE
Makes goggles no longer take up multiple loadout points

### DIFF
--- a/code/modules/client/preference/loadout/loadout_general.dm
+++ b/code/modules/client/preference/loadout/loadout_general.dm
@@ -93,40 +93,6 @@
 	display_name = "Shark plushie"
 	path = /obj/item/toy/plushie/shark
 
-/datum/gear/goggles
-	display_name = "Goggles"
-	path = /obj/item/clothing/glasses/goggles
-
-/datum/gear/sechud
-	display_name = "Classic security HUD"
-	path = /obj/item/clothing/glasses/hud/security
-	allowed_roles = list("Head of Security", "Warden", "Security Officer", "Internal Affairs Agent","Magistrate")
-
-/datum/gear/sechudgoggles
-	display_name = "Security HUD goggles"
-	path = /obj/item/clothing/glasses/hud/security/goggles
-	allowed_roles = list("Head of Security", "Warden", "Security Officer", "Internal Affairs Agent", "Magistrate")
-
-/datum/gear/medhudgoggles
-	display_name = "Health HUD goggles"
-	path = /obj/item/clothing/glasses/hud/health/goggles
-	allowed_roles = list("Chief Medical Officer", "Medical Doctor", "Coroner", "Chemist", "Geneticist", "Virologist", "Psychiatrist", "Paramedic")
-
-/datum/gear/diaghudgoggles
-	display_name = "Diagnostic HUD goggles"
-	path = /obj/item/clothing/glasses/hud/diagnostic/goggles
-	allowed_roles = list("Research Director", "Scientist", "Roboticist")
-
-/datum/gear/hydrohudgoggles
-	display_name = "Hydroponic HUD goggles"
-	path = /obj/item/clothing/glasses/hud/hydroponic/goggles
-	allowed_roles = list("Botanist")
-
-/datum/gear/skillhudgoggles
-	display_name = "Skill HUD goggles"
-	path = /obj/item/clothing/glasses/hud/skills/goggles
-	allowed_roles = list("Psychiatrist", "Nanotrasen Representative", "Head of Personnel", "Captain")
-
 /datum/gear/cryaonbox
 	display_name = "Box of crayons"
 	path = /obj/item/storage/fancy/crayons

--- a/code/modules/client/preference/loadout/loadout_glasses.dm
+++ b/code/modules/client/preference/loadout/loadout_glasses.dm
@@ -35,3 +35,41 @@
 /datum/gear/glasses/prescription
 	display_name = "Prescription glasses"
 	path = /obj/item/clothing/glasses/regular
+
+/datum/gear/glasses/sechud
+	display_name = "Classic security HUD"
+	path = /obj/item/clothing/glasses/hud/security
+	allowed_roles = list("Head of Security", "Warden", "Security Officer", "Internal Affairs Agent","Magistrate")
+
+/datum/gear/glasses/goggles
+	display_name = "Goggles"
+	path = /obj/item/clothing/glasses/goggles
+
+/datum/gear/glasses/goggles_job
+	main_typepath = /datum/gear/glasses/goggles_job
+	subtype_selection_cost = FALSE
+
+/datum/gear/glasses/goggles_job/sechudgoggles
+	display_name = "Security HUD goggles"
+	path = /obj/item/clothing/glasses/hud/security/goggles
+	allowed_roles = list("Head of Security", "Warden", "Security Officer", "Internal Affairs Agent", "Magistrate")
+
+/datum/gear/glasses/goggles_job/medhudgoggles
+	display_name = "Health HUD goggles"
+	path = /obj/item/clothing/glasses/hud/health/goggles
+	allowed_roles = list("Chief Medical Officer", "Medical Doctor", "Coroner", "Chemist", "Geneticist", "Virologist", "Psychiatrist", "Paramedic")
+
+/datum/gear/glasses/goggles_job/diaghudgoggles
+	display_name = "Diagnostic HUD goggles"
+	path = /obj/item/clothing/glasses/hud/diagnostic/goggles
+	allowed_roles = list("Research Director", "Scientist", "Roboticist")
+
+/datum/gear/glasses/goggles_job/hydrohudgoggles
+	display_name = "Hydroponic HUD goggles"
+	path = /obj/item/clothing/glasses/hud/hydroponic/goggles
+	allowed_roles = list("Botanist")
+
+/datum/gear/glasses/goggles_job/skillhudgoggles
+	display_name = "Skill HUD goggles"
+	path = /obj/item/clothing/glasses/hud/skills/goggles
+	allowed_roles = list("Psychiatrist", "Nanotrasen Representative", "Head of Personnel", "Captain")


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes goggles not take up multiple loadout points like some other items already do https://github.com/ParadiseSS13/Paradise/pull/13827.
Moves goggles and Classic SecHUD to glasses section of loadout.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
it had been requested as a feature 
fixes https://github.com/ParadiseSS13/Paradise/issues/23201?
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://github.com/ParadiseSS13/Paradise/assets/20885860/b299dfa8-52ab-489c-9913-58579924fbb7)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Opened game, picked all goggles, join as Captain.
Only one loadout slot was taken, I spawned with only one goggles.
Questioned why roundstart HUDs weren't merged and why this is the first instance of roundstart HUDs.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Made job specific goggles not take up extra loadout points.
tweak: Moves goggles and classic SecHUD to glasses tab.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
