### PR TITLE
Fixes welders costing welding fuel for empty clicks

### DIFF
--- a/code/game/objects/items/tools/welder.dm
+++ b/code/game/objects/items/tools/welder.dm
@@ -142,6 +142,8 @@
 	. = ..()
 	if(!tool_enabled)
 		return
+	if((get_dist(target, user) > 1) || isturf(target)) // We don't want to take away fuel when we hit something far away
+		return
 	remove_fuel(0.5)
 
 /obj/item/weldingtool/use_tool(atom/target, user, delay, amount, volume, datum/callback/extra_checks)

--- a/code/game/objects/items/tools/welder.dm
+++ b/code/game/objects/items/tools/welder.dm
@@ -142,7 +142,7 @@
 	. = ..()
 	if(!tool_enabled)
 		return
-	if((get_dist(target, user) > 1) || isturf(target)) // We don't want to take away fuel when we hit something far away
+	if(!proximity || isturf(target)) // We don't want to take away fuel when we hit something far away
 		return
 	remove_fuel(0.5)
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes welders not consume fuel when the target is either too far away, or a turf.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Oversight, you can rapidly lose fuel this way by simply being inaccurate
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Tried to melee a skrell from range, didn't cost me fuel.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Fixed welders consuming fuel for empty clicks
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
