### PR TITLE
Fixes mutable_appearance where it causes UI bugs

### DIFF
--- a/code/_onclick/hud/radial.dm
+++ b/code/_onclick/hud/radial.dm
@@ -329,7 +329,7 @@ GLOBAL_LIST_EMPTY(radial_menus)
 		if(!istype(possible_atom))
 			stack_trace("radial_menu_helper was passed a non-atom (\"[possible_atom]\", [possible_atom.type]) as a choice")
 			continue
-		var/mutable_appearance/atom_appearance = new(possible_atom.appearance)
+		var/mutable_appearance/atom_appearance = mutable_appearance(possible_atom.icon, possible_atom.icon_state, possible_atom.layer)
 
 		var/hover_outline_index = possible_atom.get_filter("hover_outline")
 		if(!isnull(hover_outline_index))

--- a/code/_onclick/hud/radial.dm
+++ b/code/_onclick/hud/radial.dm
@@ -329,7 +329,7 @@ GLOBAL_LIST_EMPTY(radial_menus)
 		if(!istype(possible_atom))
 			stack_trace("radial_menu_helper was passed a non-atom (\"[possible_atom]\", [possible_atom.type]) as a choice")
 			continue
-		var/mutable_appearance/atom_appearance = mutable_appearance(possible_atom.icon, possible_atom.icon_state, possible_atom.layer)
+		var/mutable_appearance/atom_appearance = mutable_appearance(possible_atom.icon, possible_atom.icon_state, possible_atom.layer, filters = possible_atom.filters)
 
 		var/hover_outline_index = possible_atom.get_filter("hover_outline")
 		if(!isnull(hover_outline_index))

--- a/code/datums/mutable_appearance.dm
+++ b/code/datums/mutable_appearance.dm
@@ -10,7 +10,7 @@
 						// And yes this does have to be in the constructor, BYOND ignores it if you set it as a normal var
 
 // Helper similar to image()
-/proc/mutable_appearance(icon, icon_state = "", layer = FLOAT_LAYER, plane = FLOAT_PLANE, alpha = 255, appearance_flags = NONE, color)
+/proc/mutable_appearance(icon, icon_state = "", layer = FLOAT_LAYER, plane = FLOAT_PLANE, alpha = 255, appearance_flags = NONE, color, filters)
 	var/mutable_appearance/MA = new()
 	MA.icon = icon
 	MA.icon_state = icon_state
@@ -20,6 +20,7 @@
 	MA.appearance_flags |= appearance_flags
 	if(color)
 		MA.color = color
+	MA.filters = filters
 	return MA
 
 /mutable_appearance/clean/New()

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1560,7 +1560,7 @@
 	for(var/obj/item/mecha_parts/mecha_equipment/MT in equipment)
 		if(!MT.selectable || selected == MT)
 			continue
-		var/mutable_appearance/clean/MA = mutable_appearance(MT.icon, MT.icon_state, MT.layer)
+		var/mutable_appearance/clean/MA = mutable_appearance(MT.icon, MT.icon_state, MT.layer, filters = MT.filters)
 		choices[MT.name] = MA
 		choices_to_refs[MT.name] = MT
 

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1560,7 +1560,7 @@
 	for(var/obj/item/mecha_parts/mecha_equipment/MT in equipment)
 		if(!MT.selectable || selected == MT)
 			continue
-		var/mutable_appearance/clean/MA = new(MT)
+		var/mutable_appearance/clean/MA = mutable_appearance(MT.icon, MT.icon_state, MT.layer)
 		choices[MT.name] = MA
 		choices_to_refs[MT.name] = MT
 


### PR DESCRIPTION
## What Does This PR Do
Changes mutable_appearance var in mecha.dm and radial.dm to use mutable_appearance() instead of new()

## Why It's Good For The Game
Now UI, hydroponics trays and beakers overlays will break less often

## Images of changes
Before (not your build, but your code anyway):
![изображение](https://github.com/ParadiseSS13/Paradise/assets/47046463/dafa1a8b-0500-43d3-89b0-687548690ec2)
![изображение](https://github.com/ParadiseSS13/Paradise/assets/47046463/36a801ca-5003-4821-91d8-9bb9a0cceb87)

## Testing
Localhosted the game

## Changelog
:cl: Romains
fix: UI, hydroponics trays and beakers overlays will break less often
/:cl: