### PR TITLE
Adds wingding speech translators to the wizard's den.

### DIFF
--- a/_maps/map_files/generic/centcomm.dmm
+++ b/_maps/map_files/generic/centcomm.dmm
@@ -1068,9 +1068,8 @@
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/administration)
 "ej" = (
-/obj/structure/chair/comfy/purp{
-	dir = 8
-	},
+/obj/structure/rack,
+/obj/item/autosurgeon/organ/translator,
 /turf/simulated/floor/carpet/black,
 /area/wizard_station)
 "ek" = (
@@ -13455,6 +13454,12 @@
 	icon_state = "brown"
 	},
 /area/shuttle/escape)
+"VW" = (
+/obj/structure/chair/comfy/purp{
+	name = "wizard council throne"
+	},
+/turf/simulated/floor/carpet/black,
+/area/wizard_station)
 "VX" = (
 /obj/item/bikehorn/rubberducky,
 /obj/structure/window/basic{
@@ -62575,7 +62580,7 @@ so
 Ln
 Ln
 Ln
-pH
+ej
 OL
 xH
 CY
@@ -62831,8 +62836,8 @@ xH
 cH
 Ln
 Ln
-Ln
-ej
+VW
+pH
 VX
 xH
 xH

--- a/code/game/machinery/vendors/generic_vendors.dm
+++ b/code/game/machinery/vendors/generic_vendors.dm
@@ -577,6 +577,7 @@
 					/obj/item/clothing/mask/gas/clownwiz = 1,
 					/obj/item/clothing/shoes/clown_shoes/magical = 1,
 					/obj/item/dnainjector/comic = 1,
+					/obj/item/autosurgeon/organ/comic_translator = 1,
 					/obj/item/implanter/sad_trombone = 1,
 					/obj/item/clothing/suit/wizrobe/mime = 1,
 					/obj/item/clothing/head/wizard/mime = 1,

--- a/code/modules/surgery/organs/autosurgeon.dm
+++ b/code/modules/surgery/organs/autosurgeon.dm
@@ -105,4 +105,13 @@
 /obj/item/autosurgeon/organ/syndicate/reviver
 	starting_organ = /obj/item/organ/internal/cyberimp/chest/reviver/hardened
 
+/obj/item/autosurgeon/organ/translator
+	starting_organ = /obj/item/organ/internal/cyberimp/brain/speech_translator
+	uses = 1
+
+/obj/item/autosurgeon/organ/comic_translator
+	name = "comical translator autosurgeon"
+	starting_organ = /obj/item/organ/internal/cyberimp/brain/speech_translator/clown
+	uses = 1
+
 #undef INFINITE


### PR DESCRIPTION
## What Does This PR Do
Adds both a comic and normal speech translator implant to the wizard den, one in the open and one with the other clown gear in the magivend.

## Why It's Good For The Game
It'd be nice for greys to be able to speak at all if they roll wizard, currently if they have wingdings enabled the only way they can speak coherently would be admin intervention, changing species doesn't work to fix it. 

## Images of changes
<img width="841" alt="Untitled" src="https://github.com/ParadiseSS13/Paradise/assets/106778834/2d581ad5-2baa-479b-b3c6-8d7253cc81f8">



## Testing
Became a wizard with wingdings, used the autosurgeon. Put in the other implant, all worked. Made sure they were both one-use, looked at it in the vendor to make sure it displayed fine.

## Changelog
:cl:
add: There are now speech translators in the wizard den for grey wizards.
/:cl: