### PR TITLE
Removes Syndicate MEGA Surplus Crate

### DIFF
--- a/code/datums/uplink_items/uplink_traitor.dm
+++ b/code/datums/uplink_items/uplink_traitor.dm
@@ -573,13 +573,6 @@
 	var/crate_value = 250
 	uses_special_spawn = TRUE
 
-/datum/uplink_item/bundles_TC/surplus_crate/super
-	name = "Syndicate Super Surplus Crate"
-	desc = "A crate containing 625 telecrystals worth of random syndicate leftovers."
-	reference = "SYSS"
-	cost = 200
-	crate_value = 625
-
 /datum/uplink_item/bundles_TC/surplus_crate/spawn_item(turf/loc, obj/item/uplink/U)
 	if(..() != UPLINK_SPECIAL_SPAWNING)
 		return FALSE


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Removes Syndicate Super Surplus (200 TC) from the uplink. This does **NOT** remove the normal 100 TC surplus. 

## Why It's Good For The Game
Just gonna repost what I said in discord, to here, quote

"Mega surplus is a pretty obvious choice with zero risk aside from the gambling part. 

People will blurt out code words and do surplus because it always results in something either party can use, or an extremely broken combo that has been gained by breaking the job restrictions. 

Given that 95% of the time antags don't actually backstab each other when doing it means there isn't any sort of risk, so it's not something that is ever taken into account when making the choice.

The main issue is it complete breaks the TC economy for a round. 100 tc per antag is stable, and there are two exclusions, the first being contractor, which has its own challenges and requires snowballing with risky play to slowly build items.

The second is surplus, which has no challenges and is all just luck. But the gambling part is always rigged to win because your gaining 625 tc worth of shit from a 200 tc investment everytime. Adding over triple the original amount of items into the round always causes escelation or powergaming issues, and the regular surplus does a better job because its a single party, and it only doubles, not over triples it.

The tldr, very safe, very beneficial choice with no risk or downsides. You win the gambling every time and there is no loss. Completely fucks the tc economy in a round and leads to escalations problems."

## Testing
Compiles, and not buyable anymore

## Changelog
:cl:
del: Removed the Syndicate Super Surplus Crate from uplink
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
