### PR TITLE
Adjusts checks on appearance changer, fixes CMA admin

### DIFF
--- a/code/modules/tgui/modules/appearance_changer.dm
+++ b/code/modules/tgui/modules/appearance_changer.dm
@@ -231,7 +231,7 @@
 		data["head_accessory_styles"] = head_accessory_styles
 		data["head_accessory_style"] = head_organ ? head_organ.ha_style : "None"
 
-	if(!(user.dna.species.bodyflags & BALD))
+	if(!(owner.dna.species.bodyflags & BALD))
 		data["change_hair"] = can_change(APPEARANCE_HAIR)
 		if(data["change_hair"])
 			var/list/hair_styles = list()
@@ -242,7 +242,7 @@
 		data["change_hair_color"] = can_change(APPEARANCE_HAIR_COLOR)
 		data["change_secondary_hair_color"] = can_change(APPEARANCE_SECONDARY_HAIR_COLOR)
 
-	if(!(user.dna.species.bodyflags & SHAVED))
+	if(!(owner.dna.species.bodyflags & SHAVED))
 		data["change_facial_hair"] = can_change(APPEARANCE_FACIAL_HAIR)
 		if(data["change_facial_hair"])
 			var/list/facial_hair_styles = list()
@@ -254,7 +254,7 @@
 		data["change_secondary_facial_hair_color"] = can_change(APPEARANCE_SECONDARY_FACIAL_HAIR_COLOR)
 		data["change_hair_gradient"] = can_change(APPEARANCE_HAIR) && length(valid_hairstyles)
 
-	if(!ismachineperson(user))
+	if(!ismachineperson(owner))
 		data["change_head_markings"] = can_change_markings("head")
 		if(data["change_head_markings"])
 			var/m_style = owner.m_styles["head"]


### PR DESCRIPTION
## What Does This PR Do
This adjusts checks on appearance changer options and fixes the CMA admin ability, that was preventing admins from properly changing appearance of players while ghosted.

## Why It's Good For The Game
Fixes an oversight with the original PR that hid appearance options from species that were not applicable. (PR #22359)
Fixes #23409 

## Testing
Spawned in mobs of varying species.
Used CMA admin to change appearance and species.
Checked for odd behavior and runtime issues. 

## Changelog
NPFC