### PR TITLE
Purges most clown planet references

### DIFF
--- a/code/__HELPERS/name_helpers.dm
+++ b/code/__HELPERS/name_helpers.dm
@@ -215,7 +215,7 @@ GLOBAL_VAR(syndicate_code_response) //Code response for traitors.
 		if(2)
 			syndicate_code_phrase += pick("How do I get to","How do I find","Where is","Where do I find")
 			syndicate_code_phrase += " "
-			syndicate_code_phrase += pick("Escape","Engineering","Atmos","the bridge","the brig","Clown Planet","CentComm","the library","the chapel","a bathroom","Med Bay","Tool Storage","the escape shuttle","Robotics","a locker room","the living quarters","the gym","the autolathe","QM","the bar","the theater","the derelict")
+			syndicate_code_phrase += pick("Escape","Engineering","Atmos","the bridge","the brig","CentComm","the library","the chapel","a bathroom","Med Bay","Tool Storage","the escape shuttle","Robotics","a locker room","the living quarters","the gym","the autolathe","QM","the bar","the theater","the derelict")
 			syndicate_code_phrase += "?"
 		if(3)
 			if(prob(70))
@@ -242,7 +242,7 @@ GLOBAL_VAR(syndicate_code_response) //Code response for traitors.
 			if(prob(80))
 				syndicate_code_response += pick("Try looking for them near","I they ran off to","Yes. I saw them near","Nope. I'm heading to","Try searching")
 				syndicate_code_response += " "
-				syndicate_code_response += pick("Escape","Engineering","Atmos","the bridge","the brig","Clown Planet","CentComm","the library","the chapel","a bathroom","Med Bay","Tool Storage","the escape shuttle","Robotics","a locker room","the living quarters","the gym","the autolathe","QM","the bar","the theater","the derelict")
+				syndicate_code_response += pick("Escape","Engineering","Atmos","the bridge","the brig","CentComm","the library","the chapel","a bathroom","Med Bay","Tool Storage","the escape shuttle","Robotics","a locker room","the living quarters","the gym","the autolathe","QM","the bar","the theater","the derelict")
 				syndicate_code_response += "."
 			else if(prob(60))
 				syndicate_code_response += pick("No. I'm busy, sorry.","I don't have the time.","Not sure, maybe?","There is no time.")

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -20,7 +20,7 @@
 	/// The target turf of the teleporter
 	var/turf/target
 
-	/* 	var/area_bypass is for one-time-use teleport cards (such as clown planet coordinates.)
+	/* 	var/area_bypass is for one-time-use teleport cards
 		Setting this to TRUE will set var/obj/item/gps/locked to null after a player enters the portal and will not allow hand-teles to open portals to that location.
 	*/
 	var/area_bypass = FALSE

--- a/code/game/objects/items/flag.dm
+++ b/code/game/objects/items/flag.dm
@@ -54,13 +54,13 @@
 	icon_state = "ntflag"
 
 /obj/item/flag/clown
-	name = "\improper Clown Planet flag"
-	desc = "The banner of His Majesty, King Squiggles the Eighth."
+	name = "\improper Clown Unity flag"
+	desc = "The universal banner of clowns everywhere. It smells faintly of banana."
 	icon_state = "clownflag"
 
 /obj/item/flag/mime
-	name = "\improper Mime Revolution flag"
-	desc = "The banner of the glorious revolutionary forces fighting the oppressors on Clown Planet."
+	name = "\improper Mime Unity flag"
+	desc = "The standard by which all mimes march to war, as cold as ice and silent as the grave."
 	icon_state = "mimeflag"
 
 /obj/item/flag/ian

--- a/code/game/objects/items/flag.dm
+++ b/code/game/objects/items/flag.dm
@@ -55,7 +55,7 @@
 
 /obj/item/flag/clown
 	name = "\improper Clown Unity flag"
-	desc = "The universal banner of clowns everywhere. It smells faintly of banana."
+	desc = "The universal banner of clowns everywhere. It smells faintly of bananas."
 	icon_state = "clownflag"
 
 /obj/item/flag/mime

--- a/code/modules/food_and_drinks/food/foods/baked_goods.dm
+++ b/code/modules/food_and_drinks/food/foods/baked_goods.dm
@@ -277,7 +277,7 @@
 
 /obj/item/reagent_containers/food/snacks/pie
 	name = "banana cream pie"
-	desc = "Just like back home, on clown planet! HONK!"
+	desc = "One of the five essential food groups of clowns everywhere."
 	icon = 'icons/obj/food/bakedgoods.dmi'
 	icon_state = "pie"
 	trash = /obj/item/trash/plate

--- a/code/modules/food_and_drinks/food/foods/baked_goods.dm
+++ b/code/modules/food_and_drinks/food/foods/baked_goods.dm
@@ -277,7 +277,7 @@
 
 /obj/item/reagent_containers/food/snacks/pie
 	name = "banana cream pie"
-	desc = "One of the five essential food groups of clowns everywhere."
+	desc = "One of the five essential food groups of clowns."
 	icon = 'icons/obj/food/bakedgoods.dmi'
 	icon_state = "pie"
 	trash = /obj/item/trash/plate

--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -463,7 +463,7 @@
 
 /datum/language/clown
 	name = "Clownish"
-	desc = "The language of clown planet. Mother tongue of clowns throughout the Galaxy."
+	desc = "The language of Clown University. Mother tongue of clowns throughout the Galaxy."
 	speech_verb = "honks"
 	ask_verb = "honks"
 	exclaim_verbs = list("toots", "wubs", "honks")

--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -463,7 +463,7 @@
 
 /datum/language/clown
 	name = "Clownish"
-	desc = "The language of Clown University. Mother tongue of clowns throughout the Galaxy."
+	desc = "The language of Clown University. Mother tongue of clowns throughout the galaxy."
 	speech_verb = "honks"
 	ask_verb = "honks"
 	exclaim_verbs = list("toots", "wubs", "honks")

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/clown.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/clown.dm
@@ -1,6 +1,6 @@
 /mob/living/simple_animal/hostile/retaliate/clown
 	name = "Clown"
-	desc = "A strange creature that vaguely resembles a normal station clown. Upon closer inspection, it is nothing of the sort."
+	desc = "A strange creature that vaguely resembles a normal clown. Upon closer inspection, it is nothing of the sort."
 	icon = 'icons/mob/simple_human.dmi'
 	icon_state = "clown"
 	icon_living = "clown"

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/clown.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/clown.dm
@@ -1,6 +1,6 @@
 /mob/living/simple_animal/hostile/retaliate/clown
 	name = "Clown"
-	desc = "A denizen of clown planet"
+	desc = "A strange creature that vaguely resembles a normal station clown. Upon closer inspection, it is nothing of the sort."
 	icon = 'icons/mob/simple_human.dmi'
 	icon_state = "clown"
 	icon_living = "clown"
@@ -12,7 +12,7 @@
 	response_help = "pokes the"
 	response_disarm = "gently pushes aside the"
 	response_harm = "hits the"
-	speak = list("HONK", "Honk!", "Welcome to clown planet!")
+	speak = list("HONK", "Honk!", "Come join the fun!")
 	emote_see = list("honks")
 	speak_chance = 1
 	a_intent = INTENT_HARM

--- a/code/modules/projectiles/guns/energy/special_eguns.dm
+++ b/code/modules/projectiles/guns/energy/special_eguns.dm
@@ -292,7 +292,7 @@
 // HONK Rifle //
 /obj/item/gun/energy/clown
 	name = "\improper HONK rifle"
-	desc = "Clown Planet's finest."
+	desc = "Clown University's finest."
 	icon_state = "honkrifle"
 	ammo_type = list(/obj/item/ammo_casing/energy/clown)
 	clumsy_check = FALSE

--- a/strings/ion_laws.json
+++ b/strings/ion_laws.json
@@ -495,7 +495,7 @@
         "ENGINEERING",
         "THE AI CORE",
         "HELL",
-        "CLOWN PLANET",
+        "CLOWN UNIVERSITY",
         "AN ALTERNATE DIMENSION",
         "AN ALTERNATE UNIVERSE",
         "SPACE",


### PR DESCRIPTION
## What Does This PR Do
Removes most references to clown planet within the code and rewrites the accompanying text to accomodate this.

Ruins are unaffected currently but will be purged properly in the future.

## Why It's Good For The Game
By order of the Lore Team, this content has been marked for immediate destruction. 

Clown planet is an ancient meme that has no reason for existing beyond lolrandom funni clown world. The world will be better off for its passing.

## Testing
- Loaded in
- Spawned items
- Descriptions are updated

## Changelog
:cl:
del: Removed clown planet references
tweak: Rewrote several item and mob descriptions
/:cl: