### PR TITLE
Fix Windoor at NSS Cerebron Arrivals Security Checkpoint public access

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -64,12 +64,6 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/solar/auxport)
-"abN" = (
-/obj/effect/mapping_helpers/airlock/windoor/access/all/supply/general{
-	dir = 4
-	},
-/turf/space,
-/area/space)
 "abU" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -70488,19 +70482,19 @@
 	name = "Outer Window";
 	dir = 8
 	},
-/obj/machinery/door/window/reinforced/normal{
-	name = "Security Desk";
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/security/general{
-	dir = 4
-	},
 /obj/item/folder/red,
 /obj/item/pen{
 	pixel_x = -3;
 	pixel_y = 5
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/windoor/access/any/security/general{
+	dir = 4
+	},
+/obj/machinery/door/window/reinforced/normal{
+	name = "Security Desk";
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
 "ncG" = (
@@ -108722,7 +108716,7 @@ aaa
 aaa
 aaa
 aaa
-abN
+aaa
 aaa
 aaa
 aaa

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -64,6 +64,12 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/solar/auxport)
+"abN" = (
+/obj/effect/mapping_helpers/airlock/windoor/access/all/supply/general{
+	dir = 4
+	},
+/turf/space,
+/area/space)
 "abU" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -33569,6 +33575,16 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/command/office/hop)
+"cfk" = (
+/obj/machinery/door/window/classic/reversed{
+	name = "Deliveries";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/station/hallway/primary/fore)
 "cfm" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical,
@@ -57875,7 +57891,11 @@
 "hDY" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/delivery,
-/obj/effect/mapping_helpers/airlock/windoor/access/all/security/brig{
+/obj/machinery/door/window/reinforced/normal{
+	name = "Security Desk";
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/security/brig{
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
@@ -70470,7 +70490,7 @@
 	},
 /obj/machinery/door/window/reinforced/normal{
 	name = "Security Desk";
-	dir = 4
+	dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/windoor/access/any/security/general{
 	dir = 4
@@ -73590,10 +73610,6 @@
 "oDf" = (
 /obj/item/paper,
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/reinforced/normal{
-	name = "Arrivals Security Checkpoint";
-	pixel_y = -8
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
 	},
@@ -108706,7 +108722,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+abN
 aaa
 aaa
 aaa
@@ -122058,7 +122074,7 @@ acf
 fRT
 jIs
 epM
-aHM
+cfk
 aJk
 aNt
 aNt

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -33569,16 +33569,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/command/office/hop)
-"cfk" = (
-/obj/machinery/door/window/classic/reversed{
-	name = "Deliveries";
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "red"
-	},
-/area/station/hallway/primary/fore)
 "cfm" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical,
@@ -122068,7 +122058,7 @@ acf
 fRT
 jIs
 epM
-cfk
+aHM
 aJk
 aNt
 aNt


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. --> Fixes the access to the windoor so no Assistants don't got access to the checkpoint, 
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. --> fixes #22434

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. --> People shouldn't be able to easily break into sec like this

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

https://github.com/ParadiseSS13/Paradise/assets/98861947/94d5198c-9155-44c6-9fe4-bf93550663f9



## Testing
<!-- How did you test the PR, if at all? --> I spawned myself as a Assistant and checked if you they access and they don't, But security officers do

## Changelog
:cl:
fix: Fixed the door access in arrivals sec checkpoint on NSS Cerebron
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
