### PR TITLE
Fixes patches and pills not being grindable, and fixes a runtime with xenos

### DIFF
--- a/code/modules/mob/living/carbon/alien/alien_base.dm
+++ b/code/modules/mob/living/carbon/alien/alien_base.dm
@@ -290,3 +290,22 @@ and carry the owner just to make sure*/
 /mob/living/carbon/alien/on_lying_down(new_lying_angle)
 	. = ..()
 	ADD_TRAIT(src, TRAIT_IMMOBILIZED, LYING_DOWN_TRAIT) //Xenos can't crawl
+
+/mob/living/carbon/alien/consume_patch_or_pill(obj/item/reagent_containers/medicine, mob/user)
+	var/apply_method = "swallow"
+	var/efficiency = 1
+	var/reagent_application = REAGENT_INGEST
+	if(ispatch(medicine))
+		apply_method = "apply"
+		efficiency = 0.5
+		reagent_application = REAGENT_TOUCH
+
+	visible_message("<span class='warning'>[user] attempts to force [src] to [apply_method] [medicine].</span>")
+	if(!do_after(user, 5 SECONDS, TRUE, src)) // You try feeding a xenomorph a pill
+		return
+
+	visible_message("<span class='warning'>[user] forces [src] to [apply_method] [medicine].</span>")
+	var/fraction = min(1 / medicine.reagents.total_volume, 1)
+	medicine.reagents.reaction(src, reagent_application, fraction)
+	medicine.reagents.trans_to(src, medicine.reagents.total_volume * efficiency)
+	return TRUE

--- a/code/modules/mob/living/carbon/alien/alien_base.dm
+++ b/code/modules/mob/living/carbon/alien/alien_base.dm
@@ -293,11 +293,11 @@ and carry the owner just to make sure*/
 
 /mob/living/carbon/alien/consume_patch_or_pill(obj/item/reagent_containers/medicine, mob/user)
 	var/apply_method = "swallow"
-	var/efficiency = 1
+	var/how_many_reagents = medicine.reagents.total_volume
 	var/reagent_application = REAGENT_INGEST
 	if(ispatch(medicine))
 		apply_method = "apply"
-		efficiency = 0.5
+		how_many_reagents = clamp(medicine.reagents.total_volume, 0.1, 2)
 		reagent_application = REAGENT_TOUCH
 
 	visible_message("<span class='warning'>[user] attempts to force [src] to [apply_method] [medicine].</span>")
@@ -307,5 +307,5 @@ and carry the owner just to make sure*/
 	visible_message("<span class='warning'>[user] forces [src] to [apply_method] [medicine].</span>")
 	var/fraction = min(1 / medicine.reagents.total_volume, 1)
 	medicine.reagents.reaction(src, reagent_application, fraction)
-	medicine.reagents.trans_to(src, medicine.reagents.total_volume * efficiency)
+	medicine.reagents.trans_to(src, how_many_reagents)
 	return TRUE

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1216,9 +1216,8 @@ so that different stomachs can handle things in different ways VB*/
 	if(to_eat.reagents.total_volume)
 		taste(to_eat.reagents)
 		var/fraction = min(this_bite / to_eat.reagents.total_volume, 1)
-		if(fraction)
-			to_eat.reagents.reaction(src, REAGENT_INGEST, fraction)
-			to_eat.reagents.trans_to(src, this_bite)
+		to_eat.reagents.reaction(src, REAGENT_INGEST, fraction)
+		to_eat.reagents.trans_to(src, this_bite)
 
 /mob/living/carbon/proc/consume_patch_or_pill(obj/item/reagent_containers/medicine, mob/user) // medicine = patch or pill
 	// The reason why this is bundled up is to avoid 2 procs that will be practically identical
@@ -1233,13 +1232,13 @@ so that different stomachs can handle things in different ways VB*/
 	var/reagent_application = REAGENT_INGEST
 	var/requires_mouth = TRUE
 	var/instant = FALSE
-	var/efficiency = 1
+	var/how_many_reagents = medicine.reagents.total_volume
 
 	if(ispatch(medicine))
 		apply_method = "apply"
 		reagent_application = REAGENT_TOUCH
 		requires_mouth = FALSE
-		efficiency = 0.5 // Patches aren't that good at transporting reagents into the bloodstream
+		how_many_reagents = clamp(medicine.reagents.total_volume, 0.1, 2) // Patches aren't that good at transporting reagents into the bloodstream
 		var/obj/item/reagent_containers/patch/patch = medicine
 		if(patch.instant_application)
 			instant = TRUE
@@ -1258,7 +1257,7 @@ so that different stomachs can handle things in different ways VB*/
 
 	var/fraction = min(1 / medicine.reagents.total_volume, 1)
 	medicine.reagents.reaction(src, reagent_application, fraction)
-	medicine.reagents.trans_to(src, medicine.reagents.total_volume * efficiency)
+	medicine.reagents.trans_to(src, how_many_reagents)
 	return TRUE
 
 /mob/living/carbon/get_access()

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1220,7 +1220,7 @@ so that different stomachs can handle things in different ways VB*/
 			to_eat.reagents.reaction(src, REAGENT_INGEST, fraction)
 			to_eat.reagents.trans_to(src, this_bite)
 
-/mob/living/carbon/proc/consume_patch_or_pill(obj/item/reagent_containers/medicine, user) // medicine = patch or pill
+/mob/living/carbon/proc/consume_patch_or_pill(obj/item/reagent_containers/medicine, mob/user) // medicine = patch or pill
 	// The reason why this is bundled up is to avoid 2 procs that will be practically identical
 	if(!medicine.reagents.total_volume)
 		return TRUE // Doesn't have reagents, would be fine to use up

--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -53,7 +53,9 @@
 
 		//All types that you can put into the grinder to transfer the reagents to the beaker. !Put all recipes above this.!
 		/obj/item/slime_extract = list(),
-		/obj/item/reagent_containers/food = list()
+		/obj/item/reagent_containers/food = list(),
+		/obj/item/reagent_containers/pill = list(),
+		/obj/item/reagent_containers/patch = list()
 	)
 
 	var/list/juice_items = list (


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes patches and pills not being grindable
Fixes xenos not being able to have patches and pills forced on them - This takes 5 seconds instead of the 3 for humans
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
These are things that should absolutely work.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Grinded patches and pills, forced a xeno queen to get patched and eat pills
Didn't get the Perf OD from applying a 30u perf patch
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Fixed pills and patches not being grindable
fix: Xenos can now be forced patches again
fix: Fixes some issues with reagent amounts
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
