### PR TITLE
Fixed the paramedic not having access on NSS Kerberos Departures cycled airlock

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -71993,9 +71993,8 @@
 "dTh" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/camera{
-	c_tag = "Virology south";
-	dir = 4;
-	network = list("Medical","SS13")
+	c_tag = "Departure Lounge North";
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -73291,9 +73291,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/exit)
-"dXK" = (
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/exit)
 "dXQ" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/delivery,
@@ -138137,8 +138134,8 @@ dNa
 dKo
 dXJ
 uaj
-dXK
-dXK
+dKo
+dKo
 dUT
 dIH
 abj

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -71768,10 +71768,6 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint)
 "dSs" = (
-/obj/machinery/camera{
-	c_tag = "Departure Lounge North";
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
@@ -71779,7 +71775,7 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 10
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
@@ -71805,17 +71801,9 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/maintenance/apmaint)
 "dSB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/exit)
+/obj/effect/spawner/airlock,
+/turf/simulated/wall,
+/area/station/service/chapel/office)
 "dSD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -71997,8 +71985,10 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint)
 "dTh" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
 "dTi" = (
@@ -72589,14 +72579,12 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint)
 "dUT" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
 /obj/machinery/light_switch{
-	dir = 4;
-	name = "west bump";
-	pixel_x = -24
+	dir = 1;
+	name = "south bump";
+	pixel_y = -24
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
 "dUY" = (
@@ -73294,20 +73282,6 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/station/hallway/secondary/exit)
-"dXK" = (
-/obj/machinery/newscaster{
-	dir = 1;
-	name = "south bump";
-	pixel_y = -28
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/structure/sign/vacuum{
-	pixel_x = -32
-	},
-/turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
 "dXQ" = (
 /obj/machinery/light,
@@ -81079,20 +81053,10 @@
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/secondary)
 "jJq" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4;
-	autolink_id = "escape_vent"
-	},
-/obj/machinery/airlock_controller/air_cycler{
-	pixel_x = -26;
-	pixel_y = 6;
-	vent_link_id = "escape_vent";
-	ext_door_link_id = "escape_door_ext";
-	int_door_link_id = "escape_door_int";
-	ext_button_link_id = "escape_btn_ext";
-	int_button_link_id = "escape_btn_int"
-	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
 "jJI" = (
@@ -81625,19 +81589,6 @@
 	},
 /area/station/hallway/primary/fore)
 "kdg" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "escape_door_ext";
-	locked = 1;
-	name = "Escape External Access"
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/access_button{
-	autolink_id = "escape_btn_ext";
-	name = "exterior access button";
-	pixel_x = 26;
-	pixel_y = -6;
-	req_access_txt = "12;13"
-	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
 "kdm" = (
@@ -93659,9 +93610,15 @@
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
 "sYX" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 6
 	},
+/obj/machinery/camera{
+	c_tag = "Virology south";
+	dir = 4;
+	network = list("Medical","SS13")
+	},
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
 "sZp" = (
@@ -94651,12 +94608,11 @@
 /turf/simulated/floor/plating,
 /area/station/security/prison/cell_block)
 "tSp" = (
+/obj/structure/sign/vacuum{
+	pixel_x = -32
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
-	},
-/obj/item/radio/intercom{
-	name = "west bump";
-	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
@@ -95097,12 +95053,17 @@
 	},
 /area/station/security/processing)
 "uil" = (
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 8
+/obj/item/radio/intercom{
+	name = "west bump";
+	pixel_x = -28
 	},
-/obj/machinery/atmospherics/portable/canister/air,
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/newscaster{
+	dir = 1;
+	name = "south bump";
+	pixel_y = -28
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
@@ -96980,18 +96941,12 @@
 	},
 /area/station/public/fitness)
 "vJP" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "escape_door_int";
-	locked = 1;
-	name = "Escape External Access"
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/access_button{
-	autolink_id = "escape_btn_int";
-	name = "interior access button";
-	pixel_x = -26;
-	pixel_y = 26;
-	req_access_txt = "12;13"
+/obj/machinery/atmospherics/portable/canister/air,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
@@ -137157,7 +137112,7 @@ dIx
 dIx
 dIx
 dIx
-dIx
+dSB
 abj
 aaa
 aaa
@@ -137412,9 +137367,9 @@ dSo
 dKP
 dTh
 sYX
-vJP
+dVb
 jJq
-kdg
+dVb
 acF
 acF
 aaa
@@ -137667,10 +137622,10 @@ dPM
 dPM
 dkq
 dSs
+dSP
+vJP
 dIH
 dIH
-dIH
-uil
 dIH
 abj
 aaa
@@ -137923,11 +137878,11 @@ dKo
 dKo
 dKo
 dKo
-dSB
+dXJ
+dKo
+dUj
 tSp
-dXK
-dIH
-dIH
+uil
 dIH
 abj
 aaa
@@ -138182,8 +138137,8 @@ dNa
 dKo
 dXJ
 uaj
-dUj
-dSP
+kdg
+kdg
 dUT
 dIH
 abj

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -71801,9 +71801,15 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/maintenance/apmaint)
 "dSB" = (
-/obj/effect/spawner/airlock,
-/turf/simulated/wall,
-/area/station/service/chapel/office)
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 8
+	},
+/obj/machinery/atmospherics/portable/canister/air,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/exit)
 "dSD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -71985,10 +71991,12 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint)
 "dTh" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/camera{
+	c_tag = "Virology south";
+	dir = 4;
+	network = list("Medical","SS13")
+	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
 "dTi" = (
@@ -73282,6 +73290,9 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
+/area/station/hallway/secondary/exit)
+"dXK" = (
+/turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
 "dXQ" = (
 /obj/machinery/light,
@@ -81589,6 +81600,12 @@
 	},
 /area/station/hallway/primary/fore)
 "kdg" = (
+/obj/structure/sign/vacuum{
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
 "kdm" = (
@@ -93613,12 +93630,10 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 6
 	},
-/obj/machinery/camera{
-	c_tag = "Virology south";
-	dir = 4;
-	network = list("Medical","SS13")
-	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
 "sZp" = (
@@ -94608,11 +94623,17 @@
 /turf/simulated/floor/plating,
 /area/station/security/prison/cell_block)
 "tSp" = (
-/obj/structure/sign/vacuum{
-	pixel_x = -32
+/obj/item/radio/intercom{
+	name = "west bump";
+	pixel_x = -28
+	},
+/obj/machinery/newscaster{
+	dir = 1;
+	name = "south bump";
+	pixel_y = -28
 	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 8
+	dir = 10
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
@@ -95053,20 +95074,9 @@
 	},
 /area/station/security/processing)
 "uil" = (
-/obj/item/radio/intercom{
-	name = "west bump";
-	pixel_x = -28
-	},
-/obj/machinery/newscaster{
-	dir = 1;
-	name = "south bump";
-	pixel_y = -28
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/exit)
+/obj/effect/spawner/airlock,
+/turf/simulated/wall,
+/area/station/service/chapel/office)
 "uit" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4;
@@ -96940,16 +96950,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/public/fitness)
-"vJP" = (
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 8
-	},
-/obj/machinery/atmospherics/portable/canister/air,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/exit)
 "vKf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -137112,7 +137112,7 @@ dIx
 dIx
 dIx
 dIx
-dSB
+uil
 abj
 aaa
 aaa
@@ -137623,7 +137623,7 @@ dPM
 dkq
 dSs
 dSP
-vJP
+dSB
 dIH
 dIH
 dIH
@@ -137881,8 +137881,8 @@ dKo
 dXJ
 dKo
 dUj
+kdg
 tSp
-uil
 dIH
 abj
 aaa
@@ -138137,8 +138137,8 @@ dNa
 dKo
 dXJ
 uaj
-kdg
-kdg
+dXK
+dXK
 dUT
 dIH
 abj

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -72592,6 +72592,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/machinery/light_switch{
+	dir = 4;
+	name = "west bump";
+	pixel_x = -24
+	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
 "dUY" = (
@@ -73299,10 +73304,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/machinery/light_switch{
-	dir = 4;
-	name = "west bump";
-	pixel_x = -24
+/obj/structure/sign/vacuum{
+	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
@@ -81628,6 +81631,13 @@
 	name = "Escape External Access"
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/access_button{
+	autolink_id = "escape_btn_ext";
+	name = "exterior access button";
+	pixel_x = 26;
+	pixel_y = -6;
+	req_access_txt = "12;13"
+	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
 "kdm" = (
@@ -93652,16 +93662,6 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/access_button{
-	autolink_id = "escape_btn_int";
-	name = "interior access button";
-	pixel_x = -24;
-	pixel_y = -24;
-	req_access_txt = "10;13"
-	},
-/obj/structure/sign/vacuum{
-	pixel_x = -32
-	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
 "sZp" = (
@@ -96986,6 +96986,13 @@
 	name = "Escape External Access"
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/access_button{
+	autolink_id = "escape_btn_int";
+	name = "interior access button";
+	pixel_x = -26;
+	pixel_y = 26;
+	req_access_txt = "12;13"
+	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
 "vKf" = (
@@ -99799,17 +99806,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fore)
-"xRm" = (
-/obj/machinery/access_button{
-	autolink_id = "escape_btn_ext";
-	name = "exterior access button";
-	pixel_x = 24;
-	pixel_y = 24;
-	req_access_txt = "10;13"
-	},
-/obj/structure/lattice/catwalk,
-/turf/space,
-/area/space/nearstation)
 "xRD" = (
 /obj/effect/spawner/random_spawners/cobweb_right_frequent,
 /obj/structure/closet/firecloset,
@@ -137419,7 +137415,7 @@ sYX
 vJP
 jJq
 kdg
-xRm
+acF
 acF
 aaa
 aaa


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. --> Fixed the departures airlock access and moved a few things around
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. --> Fixes #22861 

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Makes the paramedic have faster response in Departures In case someone dies in spess

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. --> Before
![687474~1](https://github.com/ParadiseSS13/Paradise/assets/98861947/bc309944-dcbf-4d82-8b79-0afb043359db)
 After
![Screenshot 2023-12-21 212804](https://github.com/ParadiseSS13/Paradise/assets/98861947/a4938e10-399e-4e86-a482-014cf3e7945e)





## Testing
<!-- How did you test the PR, if at all? --> Spawned as a paramedic and tested that I got access and I did

## Changelog
:cl:
Add: added a airlock helper for the airlock
Tweak: made the room a bit bigger
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
