### PR TITLE
"You'll find all my treasure in one place..." -- Adds optional last words whispered when succumbing

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -295,7 +295,7 @@
 /mob/living/verb/succumb()
 	set hidden = TRUE
 	if(!can_succumb())
-		to_chat("<span class='warning'>You are unable to succumb to death! This life continues!</span>")
+		to_chat(src, "<span class='warning'>You are unable to succumb to death! This life continues!</span>")
 		return
 
 	var/last_words = input(src, "Do you have any last words?", "Goodnight, Sweet Prince") as text|null

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -289,7 +289,7 @@
 	return TRUE
 
 /mob/living/proc/can_succumb()
-	return health < HEALTH_THRESHOLD_CRIT
+	return health < HEALTH_THRESHOLD_CRIT && stat == UNCONSCIOUS
 
 
 /mob/living/verb/succumb()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -310,7 +310,7 @@
 	adjustOxyLoss(max(health - HEALTH_THRESHOLD_DEAD, 0))
 	// super check for weird mobs, including ones that adjust hp
 	// we don't want to go overboard and gib them, though
-	for(var/i = 1 to 5)
+	for(var/i in 1 to 5)
 		if(health < HEALTH_THRESHOLD_DEAD)
 			break
 		take_overall_damage(max(5, health - HEALTH_THRESHOLD_DEAD), 0)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -296,6 +296,10 @@
 
 	var/last_words = input(src, "Do you have any last words?", "Goodnight, Sweet Prince") as text|null
 
+	if(stat == DEAD)
+		// cancel em out if they died while they had the message box up
+		last_words = null
+
 	if(!isnull(last_words))
 		create_log(MISC_LOG, "gave their final words, [last_words]")
 		whisper(last_words)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -288,13 +288,9 @@
 	visible_message("<b>[src]</b> points to [pointed_object]")
 	return TRUE
 
-/mob/living/proc/can_succumb()
-	return health < HEALTH_THRESHOLD_CRIT && stat == UNCONSCIOUS
-
-
 /mob/living/verb/succumb()
 	set hidden = TRUE
-	if(!can_succumb())
+	if(health >= HEALTH_THRESHOLD_CRIT || stat != UNCONSCIOUS)
 		to_chat(src, "<span class='warning'>You are unable to succumb to death! This life continues!</span>")
 		return
 
@@ -307,14 +303,17 @@
 	add_attack_logs(src, src, "[src] has [!isnull(last_words) ? "whispered [p_their()] final words" : "succumbed to death"] with [round(health, 0.1)] points of health!")
 
 	create_log(MISC_LOG, "has succumbed to death with [round(health, 0.1)] points of health")
-	adjustOxyLoss(health - HEALTH_THRESHOLD_DEAD)
+	adjustOxyLoss(max(health - HEALTH_THRESHOLD_DEAD, 0))
 	// super check for weird mobs, including ones that adjust hp
 	// we don't want to go overboard and gib them, though
 	for(var/i = 1 to 5)
 		if(health < HEALTH_THRESHOLD_DEAD)
 			break
 		take_overall_damage(max(5, health - HEALTH_THRESHOLD_DEAD), 0)
-	death()
+	if(!isnull(last_words))
+		addtimer(CALLBACK(src, PROC_REF(death)), 1 SECONDS)
+	else
+		death()
 	to_chat(src, "<span class='notice'>You have given up life and succumbed to death.</span>")
 
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -298,13 +298,13 @@
 		to_chat("<span class='warning'>You are unable to succumb to death! This life continues!</span>")
 		return
 
-	var/last_words = input(src, "Do you have any last words?", "Goodnight, Sweet Prince")
+	var/last_words = input(src, "Do you have any last words?", "Goodnight, Sweet Prince") as text|null
 
 	if(!isnull(last_words))
 		create_log(MISC_LOG, "gave their final words, [last_words]")
 		whisper(last_words)
 
-	create_attack_log("[src] has [!isnull(last_words) ? "whispered [p_their()] final words" : "succumbed to death"] with [round(health, 0.1)] points of health!")
+	add_attack_logs(src, src, "[src] has [!isnull(last_words) ? "whispered [p_their()] final words" : "succumbed to death"] with [round(health, 0.1)] points of health!")
 
 	create_log(MISC_LOG, "has succumbed to death with [round(health, 0.1)] points of health")
 	adjustOxyLoss(health - HEALTH_THRESHOLD_DEAD)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -288,20 +288,34 @@
 	visible_message("<b>[src]</b> points to [pointed_object]")
 	return TRUE
 
+/mob/living/proc/can_succumb()
+	return health < HEALTH_THRESHOLD_CRIT
+
+
 /mob/living/verb/succumb()
-	set hidden = 1
-	if(InCritical())
-		create_attack_log("[src] has ["succumbed to death"] with [round(health, 0.1)] points of health!")
-		create_log(MISC_LOG, "has succumbed to death with [round(health, 0.1)] points of health")
-		adjustOxyLoss(health - HEALTH_THRESHOLD_DEAD)
-		// super check for weird mobs, including ones that adjust hp
-		// we don't want to go overboard and gib them, though
-		for(var/i = 1 to 5)
-			if(health < HEALTH_THRESHOLD_DEAD)
-				break
-			take_overall_damage(max(5, health - HEALTH_THRESHOLD_DEAD), 0)
-		death()
-		to_chat(src, "<span class='notice'>You have given up life and succumbed to death.</span>")
+	set hidden = TRUE
+	if(!can_succumb())
+		to_chat("<span class='warning'>You are unable to succumb to death! This life continues!</span>")
+		return
+
+	var/last_words = input(src, "Do you have any last words?", "Goodnight, Sweet Prince")
+
+	if(!isnull(last_words))
+		create_log(MISC_LOG, "gave their final words, [last_words]")
+		whisper(last_words)
+
+	create_attack_log("[src] has [!isnull(last_words) ? "whispered [p_their()] final words" : "succumbed to death"] with [round(health, 0.1)] points of health!")
+
+	create_log(MISC_LOG, "has succumbed to death with [round(health, 0.1)] points of health")
+	adjustOxyLoss(health - HEALTH_THRESHOLD_DEAD)
+	// super check for weird mobs, including ones that adjust hp
+	// we don't want to go overboard and gib them, though
+	for(var/i = 1 to 5)
+		if(health < HEALTH_THRESHOLD_DEAD)
+			break
+		take_overall_damage(max(5, health - HEALTH_THRESHOLD_DEAD), 0)
+	death()
+	to_chat(src, "<span class='notice'>You have given up life and succumbed to death.</span>")
 
 
 /mob/living/proc/InCritical()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds a dialog for trying to say your last words when you succumb from crit. 
Also allows you to succumb when you're below -100 HP, which might not have actually been possible before?

If you're in losebreath, this won't do much for you, so I'm hoping that https://github.com/ParadiseSS13/Paradise/pull/23425 goes in before this one.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
It adds a bit of fun flavor to death, and lets you choose how you'd like to go out. You can summon just enough energy to break out of unconsciousness for one last phrase...and then you're done.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

https://github.com/ParadiseSS13/Paradise/assets/89928798/18c8631d-88ae-477a-9922-f41b231d4be8
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing

Punched myself to death, then tried the succumb verb.

<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
add: You can now utter some last words when you succumb to death from crit.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
