### PR TITLE
Temporarily disables redis in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,10 +108,6 @@ jobs:
           sudo apt update || true
           sudo apt install libssl1.1:i386
           ldd librust_g.so
-      - name: Start Redis
-        uses: supercharge/redis-github-action@1.7.0
-        with:
-          redis-version: 6
       - name: Compile & Run Unit Tests
         run: |
           tools/ci/install_byond.sh '${{ matrix.byondtype }}'

--- a/code/controllers/configuration/sections/redis_configuration.dm
+++ b/code/controllers/configuration/sections/redis_configuration.dm
@@ -10,7 +10,7 @@
 	// UNIT TESTS ARE DEFINED - USE CUSTOM CI VALUES
 	#ifdef UNIT_TESTS
 
-	enabled = TRUE
+	// enabled = TRUE
 
 	#else
 	// Load the normal config. Were not in CI mode

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -294,7 +294,10 @@ GLOBAL_LIST_EMPTY(world_topic_handlers)
 /world/Del()
 	rustg_close_async_http_client() // Close the HTTP client. If you dont do this, youll get phantom threads which can crash DD from memory access violations
 	disable_auxtools_debugger() // Disables the debugger if running. See above comment
-	rustg_redis_disconnect() // Disconnects the redis connection. See above.
+
+	if(SSredis.connected)
+		rustg_redis_disconnect() // Disconnects the redis connection. See above.
+
 	#ifdef ENABLE_BYOND_TRACY
 	CALL_EXT("prof.dll", "destroy")() // Setup Tracy integration
 	#endif


### PR DESCRIPTION
## What Does This PR Do
Disables redis in CI

## Why It's Good For The Game
CI is spuriously failing because of issues with new BYOND and redis. I'll fix it at some point.

## Changelog
NPFC