### PR TITLE
Added the Janicart to the available list of supply pack

### DIFF
--- a/code/modules/supply/supply_packs/pack_miscellaneous.dm
+++ b/code/modules/supply/supply_packs/pack_miscellaneous.dm
@@ -192,6 +192,15 @@
 	cost = 100
 	containername = "replacement lights crate"
 
+/datum/supply_packs/misc/janicart
+	name = "Janicart Crate"
+	contains = list(/obj/vehicle/janicart,
+					/obj/item/key/janitor)
+	cost = 500
+	containertype = /obj/structure/largecrate
+	containername = "Janicart. Caution while driving is advised."
+	department_restrictions = list(DEPARTMENT_SERVICE)
+
 /datum/supply_packs/misc/noslipfloor
 	name = "High-traction Floor Tiles"
 	contains = list(/obj/item/stack/tile/noslip/loaded)


### PR DESCRIPTION
## What Does This PR Do
Add the janicart (and its key) as a misc supply.

## Why It's Good For The Game
Sometimes the HoP hires multiple janitors - and only one of us can get the janicart, it fix this situation and allow multiple player to have the janicart...in exchange for the hefty sum of 500 credits each, which i think is only fair.


## Testing
Just compiled and ran the game to be sure that i could actually purcharse it. 

## Changelog
:cl:
add: Janicart and Janikey added as purchasable miscellanous supply.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
