### PR TITLE
Swap's Suit Sensors Hotkey With Remove Accessories Hotkey

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -356,7 +356,7 @@
 			if(H.w_uniform == src)
 				H.update_suit_sensors()
 
-/obj/item/clothing/under/AltShiftClick(mob/user)
+/obj/item/clothing/under/AltClick(mob/user)
 	set_sensors(user)
 
 //Head
@@ -814,14 +814,14 @@
 			if(SUIT_SENSOR_TRACKING)
 				. += "Its vital tracker and tracking beacon appear to be enabled."
 		if(has_sensor == 1)
-			. += "<span class='info'>Alt-shift-click to toggle the sensors mode.</span>"
+			. += "<span class='info'>Alt-click to toggle the sensors mode.</span>"
 	else
 		. += "This suit does not have any sensors."
 
 	if(length(accessories))
 		for(var/obj/item/clothing/accessory/A in accessories)
 			. += "\A [A] is attached to it."
-	. += "<span class='info'>Alt-click to remove an accessory.</span>"
+	. += "<span class='info'>Alt-Shift-Click to remove an accessory.</span>"
 	. += "<span class='info'>Ctrl-Shift-Click to roll down this jumpsuit.</span>"
 
 
@@ -855,7 +855,7 @@
 		body_parts_covered &= ~LOWER_TORSO
 		body_parts_covered &= ~ARMS
 
-/obj/item/clothing/under/AltClick(mob/user)
+/obj/item/clothing/under/AltShiftClick(mob/user)
 	if(user.stat || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED) || !Adjacent(user))
 		return
 	if(!length(accessories))


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Suit sensor hotkey is now alt+click instead of the annoying alt+shift+click. Yes it will annoy some people who are used to it, but its up to you. This also changes the remove accessories hotkey to alt+shift+click, and i've changed the examine thingy to match the hotkeys. And yeah, that's all it does
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
it makes changing your suit sensors a lot easier especially for beginners
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
I've tested it by changing my suit sensors and it works flawlessly, there obviously wouldn't be any bugs since I'm only really changing the hotkey.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl: Vengie
tweak: Changed Suit Sensor Hotkey to Alt+Click. Remove Accessories is now Alt+Shift+Click
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
