### PR TITLE
prevents forcemove from sending someone to a null location

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -282,6 +282,8 @@
 		A.Bumped(src)
 
 /atom/movable/proc/forceMove(atom/destination)
+	if(!destination)
+		CRASH("Forcemove attempted to move [src] to a null location")
 	var/turf/old_loc = loc
 	loc = destination
 	moving_diagonally = 0
@@ -329,7 +331,6 @@
 		if(hud_used && length(client.parallax_layers))
 			hud_used.update_parallax()
 	update_runechat_msg_location()
-
 
 //Called whenever an object moves and by mobs when they attempt to move themselves through space
 //And when an object or action applies a force on src, see newtonian_move() below

--- a/code/game/objects/items/weapons/storage/briefcase.dm
+++ b/code/game/objects/items/weapons/storage/briefcase.dm
@@ -61,7 +61,7 @@
 
 		stored_item = I
 		max_w_class = WEIGHT_CLASS_NORMAL - stored_item.w_class
-		I.forceMove(null) //null space here we go - to stop it showing up in the briefcase
+		I.loc = null // Nulls out the location to prevent it showing up in the contents of the briefcase, this won't have it zero ref delete
 		to_chat(user, "<span class='notice'>You place [I] into the false bottom of the briefcase.</span>")
 	else
 		return ..()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
prevents forcemove from sending someone to a null location

## Why It's Good For The Game
forcemove shouldn't be doing this, if you set a location to null and manage it directly setting loc will do this anyways

## Testing
Forcemoved a couple of things

## Changelog
this is largely not playerfacing

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
