### PR TITLE
Adds genderless as a gender option for all races

### DIFF
--- a/code/modules/client/preference/link_processing.dm
+++ b/code/modules/client/preference/link_processing.dm
@@ -894,20 +894,12 @@
 						toggles ^= PREFTOGGLE_DONATOR_PUBLIC
 
 				if("gender")
-					if(!S.has_gender)
-						var/newgender = input(user, "Choose Gender:") as null|anything in list("Male", "Female", "Genderless")
-						switch(newgender)
-							if("Male")
-								active_character.gender = MALE
-							if("Female")
-								active_character.gender = FEMALE
-							if("Genderless")
-								active_character.gender = PLURAL
-					else
-						if(active_character.gender == MALE)
-							active_character.gender = FEMALE
-						else
-							active_character.gender = MALE
+					if(active_character.gender == MALE)
+						active_character.gender = FEMALE
+					else if(active_character.gender == FEMALE)
+						active_character.gender = PLURAL
+					else if(active_character.gender == PLURAL)
+						active_character.gender = MALE
 					active_character.underwear = random_underwear(active_character.gender)
 
 				if("hear_adminhelps")

--- a/code/modules/mob/living/carbon/human/appearance.dm
+++ b/code/modules/mob/living/carbon/human/appearance.dm
@@ -5,7 +5,7 @@
 
 /mob/living/carbon/human/proc/change_gender(new_gender, update_dna = TRUE)
 	var/obj/item/organ/external/head/H = bodyparts_by_name["head"]
-	if(gender == new_gender || (gender == PLURAL && !dna.species.has_gender))
+	if(gender == new_gender)
 		return
 
 	gender = new_gender

--- a/code/modules/mob/living/carbon/human/human_mob.dm
+++ b/code/modules/mob/living/carbon/human/human_mob.dm
@@ -1282,9 +1282,6 @@
 		if(oldspecies.default_language)
 			remove_language(oldspecies.default_language)
 
-		if(gender == PLURAL && oldspecies.has_gender)
-			change_gender(pick(MALE, FEMALE))
-
 		oldspecies.handle_dna(src, TRUE) // Remove any mutations that belong to the old species
 
 		oldspecies.on_species_loss(src)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds genderless as a gender option for all races, and removes some checks that forced most species to be male/female only
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
This was requested in [on the forums](url), as well as by a friend of mine. Allowing non-binary people to more freely express themselves in game seems good.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
https://github.com/ParadiseSS13/Paradise/assets/18598676/4f6a181c-fb31-46e7-897c-34918e39e49c

## Testing
Spawned in as genderless.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: All races can be genderless now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
