### PR TITLE
Lowers cost of the bike from the arcade.

### DIFF
--- a/code/modules/arcade/prize_datums.dm
+++ b/code/modules/arcade/prize_datums.dm
@@ -399,4 +399,4 @@ GLOBAL_DATUM_INIT(global_prizes, /datum/prizes, new())
 	name = "Awesome Bike!"
 	desc = "WOAH."
 	typepath = /obj/vehicle/bike
-	cost = 10000	//max stack + 1 tickets.
+	cost = 7000


### PR DESCRIPTION
## What Does This PR Do
Lowers the cost of the bike from the arcade to 7000 tickets, making it actually possible to get within a round. Cost is still up for negotiation, of course.

## Why It's Good For The Game
After a few arcade tweaks it's now incredibly difficult to get the bike; say the average arcade go-er gets 60 tickets a minute on average while trying to go fast, it would take them 167 minutes (2h 47min) to get the bike. Considering that rounds never take this long, lowering it to 7000 will make it a tad more achievable. It would now take said player around 117 minutes (just under 2 hours), which while still very difficult isn't impossible.

## Testing
Opened the game, checked the price was lower.

## Changelog
:cl:
tweak: Changed the price of the bike in the arcade to 7000 tickets.
/:cl: