### PR TITLE
refactor: purge `teams` from `mind`. Don't add antag datum to member on it's removal

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -56,8 +56,6 @@
 	var/miming = 0 // Mime's vow of silence
 	/// A list of all the antagonist datums that the player is (does not include undatumized antags)
 	var/list/antag_datums
-	/// A lazy list of all teams the player is part of but doesnt have an antag role for, (i.e. a custom admin team)
-	var/list/teams
 
 	var/antag_hud_icon_state = null //this mind's ANTAG_HUD should have this icon_state
 	var/datum/atom_hud/antag/antag_hud = null //this mind's antag HUD
@@ -226,11 +224,7 @@
 	for(var/datum/antagonist/A as anything in antag_datums)
 		if(A.has_antag_objectives(include_team)) // this checks teams also
 			return TRUE
-	// For custom non-antag role teams
-	if(include_team && LAZYLEN(teams))
-		for(var/datum/team/team as anything in teams)
-			if(team.objective_holder.has_objectives())
-				return TRUE
+
 	return FALSE
 
 /**
@@ -243,15 +237,12 @@
 
 	for(var/datum/antagonist/A as anything in antag_datums)
 		all_objectives += A.objective_holder.get_objectives() // Add all antag datum objectives.
-		if(include_team)
-			var/datum/team/team = A.get_team()
-			if(team) // have to make asure a team exists here, team?. does not work below because it will add the null to the list
-				all_objectives += team.objective_holder.get_objectives() // Get all of their teams' objectives
+		if(!include_team)
+			continue
 
-	// For custom non-antag role teams
-	if(include_team && LAZYLEN(teams))
-		for(var/datum/team/team as anything in teams)
-			all_objectives += team.objective_holder.get_objectives()
+		var/datum/team/team = A.get_team()
+		if(team) // have to make asure a team exists here, team?. does not work below because it will add the null to the list
+			all_objectives += team.objective_holder.get_objectives() // Get all of their teams' objectives
 
 	return all_objectives
 

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -235,14 +235,13 @@
 
 	all_objectives += objective_holder.get_objectives() // Get their personal objectives
 
-	for(var/datum/antagonist/A as anything in antag_datums)
-		all_objectives += A.objective_holder.get_objectives() // Add all antag datum objectives.
-		if(!include_team)
-			continue
+	for(var/datum/antagonist/antag_datum as anything in antag_datums)
+		all_objectives += antag_datum.objective_holder.get_objectives() // Add all antag datum objectives.
 
-		var/datum/team/team = A.get_team()
-		if(team) // have to make asure a team exists here, team?. does not work below because it will add the null to the list
-			all_objectives += team.objective_holder.get_objectives() // Get all of their teams' objectives
+		if(include_team)
+			var/datum/team/team = antag_datum.get_team()
+			if(team) // have to make asure a team exists here, team?. does not work below because it will add the null to the list
+				all_objectives += team.objective_holder.get_objectives() // Get all of their teams' objectives
 
 	return all_objectives
 

--- a/code/modules/antagonists/_common/antag_team.dm
+++ b/code/modules/antagonists/_common/antag_team.dm
@@ -57,9 +57,10 @@ GLOBAL_LIST_EMPTY(antagonist_teams)
 	SHOULD_CALL_PARENT(TRUE)
 	members |= new_member
 
-	// If no matching antag datum was found, give them one.
 	if(add_antag_datum && antag_datum_type)
 		var/datum/antagonist/antag = get_antag_datum_from_member(new_member) // make sure they have the antag datum
+
+		// If no matching antag datum was found, give them one.
 		if(!antag)
 			new_member.add_antag_datum(antag_datum_type, src)
 

--- a/code/modules/antagonists/_common/antag_team.dm
+++ b/code/modules/antagonists/_common/antag_team.dm
@@ -46,8 +46,10 @@ GLOBAL_LIST_EMPTY(antagonist_teams)
 	SHOULD_CALL_PARENT(TRUE)
 	var/datum/antagonist/antag = get_antag_datum_from_member(new_member) // make sure they have the antag datum
 	members |= new_member
-	if(!antag) // this team has no antag role, we'll add it directly to their mind team
-		LAZYDISTINCTADD(new_member.teams, src)
+
+	// If no matching antag datum was found, give them one.
+	if(!antag && antag_datum_type)
+		new_member.add_antag_datum(antag_datum_type, src)
 
 /**
  * Removes `member` from this team.
@@ -55,7 +57,6 @@ GLOBAL_LIST_EMPTY(antagonist_teams)
 /datum/team/proc/remove_member(datum/mind/member)
 	SHOULD_CALL_PARENT(TRUE)
 	members -= member
-	LAZYREMOVE(member.teams, src)
 	var/datum/antagonist/antag = get_antag_datum_from_member(member)
 	if(!QDELETED(antag))
 		qdel(antag)
@@ -103,9 +104,6 @@ GLOBAL_LIST_EMPTY(antagonist_teams)
 		if(A.get_team() != src)
 			continue
 		return A
-	// If no matching antag datum was found, give them one.
-	if(antag_datum_type)
-		return member.add_antag_datum(antag_datum_type, src)
 
 /**
  * Special overrides for teams for target exclusion from objectives.

--- a/code/modules/antagonists/_common/antag_team.dm
+++ b/code/modules/antagonists/_common/antag_team.dm
@@ -55,12 +55,13 @@ GLOBAL_LIST_EMPTY(antagonist_teams)
  */
 /datum/team/proc/add_member(datum/mind/new_member, add_antag_datum = TRUE)
 	SHOULD_CALL_PARENT(TRUE)
-	var/datum/antagonist/antag = get_antag_datum_from_member(new_member) // make sure they have the antag datum
 	members |= new_member
 
 	// If no matching antag datum was found, give them one.
-	if(add_antag_datum && !antag && antag_datum_type)
-		new_member.add_antag_datum(antag_datum_type, src)
+	if(add_antag_datum && antag_datum_type)
+		var/datum/antagonist/antag = get_antag_datum_from_member(new_member) // make sure they have the antag datum
+		if(!antag)
+			new_member.add_antag_datum(antag_datum_type, src)
 
 /**
  * Removes `member` from this team.

--- a/code/modules/antagonists/_common/antag_team.dm
+++ b/code/modules/antagonists/_common/antag_team.dm
@@ -40,7 +40,7 @@ GLOBAL_LIST_EMPTY(antagonist_teams)
 /**
  * Adds `new_member` to this team.
  *
- * Generally this should ONLY be called by `add_antag_datum()` to ensure proper order of operations.
+ * If team has `antag_datum_type` specified and `new_member` has not antag datum - than it will be added to it.
  */
 /datum/team/proc/add_member(datum/mind/new_member)
 	SHOULD_CALL_PARENT(TRUE)


### PR DESCRIPTION
## What Does This PR Do
Remove `teams` variable from `mind`, which is currently unused, and cause issues, like displaying duplicate objectives, when `antag datum` with team without `antag_datum_type` is added to team member.

## Why It's Good For The Game
Nothing player facing. Just more flexability in team creation.

## Images of changes
Nothing to show - all in code.

## Testing
Code compiled, teams properly created.
