### PR TITLE
Ipc translator implant

### DIFF
--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -540,6 +540,17 @@
 	build_path = /obj/item/organ/internal/cyberimp/brain/wire_interface
 	category = list("Medical")
 
+/datum/design/cyberimp_multilang_ipc
+	name = "Multilanguage Translator Implant"
+	desc = "An advanced implant that allows IPCs to understand and speak multiple languages."
+	id = "cyberimp_multilang_ipc"
+	req_tech = list("materials" = 6, "biotech" = 6)
+	build_type = PROTOLATHE | MECHFAB
+	materials = list(MAT_METAL = 1000, MAT_GLASS = 1000, MAT_SILVER = 500, MAT_GOLD = 500) // Adjust materials as needed
+	build_path = /obj/item/organ/internal/cyberimp/brain/multilang_ipc
+	category = list("Medical Designs")
+	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
+
 /datum/design/raiden_implant
 	name = "Reactive Repair Implant"
 	desc = "This implant reworks the IPC frame, in order to incorporate materials that return to their original shape after being damaged. Requires power to function."

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -546,10 +546,10 @@
 	id = "cyberimp_multilang_ipc"
 	req_tech = list("materials" = 6, "biotech" = 6)
 	build_type = PROTOLATHE | MECHFAB
-	materials = list(MAT_METAL = 1000, MAT_GLASS = 1000, MAT_SILVER = 500, MAT_GOLD = 500) // Adjust materials as needed
+	construction_time = 60
+	materials = list(MAT_METAL = 1000, MAT_GLASS = 1000, MAT_SILVER = 500, MAT_GOLD = 500)
 	build_path = /obj/item/organ/internal/cyberimp/brain/multilang_ipc
-	category = list("Medical Designs")
-	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
+	category = list("Medical")
 
 /datum/design/raiden_implant
 	name = "Reactive Repair Implant"

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -375,26 +375,29 @@
 /obj/item/organ/internal/cyberimp/brain/multilang_ipc
 	name = "Multilanguage Translator Implant"
 	desc = "An advanced implant that allows IPCs to understand and speak multiple languages."
-	implant_color = "#808080" // You can change this to any color you prefer
 	slot = "brain_multilang"
 	origin_tech = "materials=6;biotech=6"
-
-	var/list/languages = list(/datum/language/human, /datum/language/diona, /datum/language/chittin, /datum/language/skrell, /datum/language/slime, /datum/language/tajaran, /datum/language/unathi, /datum/language/vox, /datum/language/vulpkanin, /datum/language/drask, /datum/language/nian)
+	requires_machine_person = TRUE
+	var/ipc_default_languages = list()
 
 /obj/item/organ/internal/cyberimp/brain/multilang_ipc/insert(mob/living/carbon/M, special = FALSE)
 	. = ..()
+	var/mob/living/carbon/human/H = M
 	if(istype(M, /mob/living/carbon/human))
-		var/mob/living/carbon/human/H = M
-		if(H.species.name == "IPC")
-			for(var/lang in languages)
-				H.add_language(lang)
+		ipc_default_languages[H] = H.languages.Copy() // Store the default languages
+		for(var/la in GLOB.all_languages)
+			var/datum/language/new_language = GLOB.all_languages[la]
+			if(new_language.flags & (HIVEMIND|NOLIBRARIAN))
+				continue
+			H.add_language(la)
 
 /obj/item/organ/internal/cyberimp/brain/multilang_ipc/remove(mob/living/carbon/M, special = FALSE)
-	if(istype(M, /mob/living/carbon/human))
-		var/mob/living/carbon/human/H = M
-		if(H.species.name == "IPC")
-			for(var/lang in languages)
-				H.remove_language(lang)
+	var/mob/living/carbon/human/H = M
+	if(!istype(H))
+		return
+	H.languages = list() // Remove all languages
+	H.languages = ipc_default_languages[H] // Restore the default languages
+	ipc_default_languages -= H // Clear the stored default languages
 	. = ..()
 
 /obj/item/organ/internal/cyberimp/chest/nutriment/hardened

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -371,6 +371,32 @@
 	poison_amount = 10
 	origin_tech = "materials=4;powerstorage=3;biotech=3"
 
+
+/obj/item/organ/internal/cyberimp/brain/multilang_ipc
+	name = "Multilanguage Translator Implant"
+	desc = "An advanced implant that allows IPCs to understand and speak multiple languages."
+	implant_color = "#808080" // You can change this to any color you prefer
+	slot = "brain_multilang"
+	origin_tech = "materials=6;biotech=6"
+
+	var/list/languages = list(/datum/language/human, /datum/language/diona, /datum/language/chittin, /datum/language/skrell, /datum/language/slime, /datum/language/tajaran, /datum/language/unathi, /datum/language/vox, /datum/language/vulpkanin, /datum/language/drask, /datum/language/nian)
+
+/obj/item/organ/internal/cyberimp/brain/multilang_ipc/insert(mob/living/carbon/M, special = FALSE)
+	. = ..()
+	if(istype(M, /mob/living/carbon/human))
+		var/mob/living/carbon/human/H = M
+		if(H.species.name == "IPC")
+			for(var/lang in languages)
+				H.add_language(lang)
+
+/obj/item/organ/internal/cyberimp/brain/multilang_ipc/remove(mob/living/carbon/M, special = FALSE)
+	if(istype(M, /mob/living/carbon/human))
+		var/mob/living/carbon/human/H = M
+		if(H.species.name == "IPC")
+			for(var/lang in languages)
+				H.remove_language(lang)
+	. = ..()
+
 /obj/item/organ/internal/cyberimp/chest/nutriment/hardened
 	name = "hardened nutriment pump implant"
 	emp_proof = TRUE


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
It add a new implant for IPC only giving the same languages as the librarian job. It require high levels however.
This implant can be printed by the protolathe and exosuit on the medical section.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Honestly I always felt like having others "bonus" from high tech levels to be a good as it isn't game breaking.
Now that the librarian can speak and understand many languages i feel like this is due.
As for the reason i made it IPC only, well i can imagine some futurist implant allowing a machine to speak and understand every languages. But I don't think it'll work on a "biological" body. Even if (somehow) we could understood some aliens languages, we will be quite unable to speak them in the first place.


## Testing
I put the implant upon an IPC i inhabited to check the languages. Both after having the implant and it being removed. (To confirm that the languages were also removed)

## Changelog
:cl:
add: Added a new implant allowing IPC to speak and understand languages like a borg/librarian.
/:cl:

