### PR TITLE
Improvised Garrote nerf, tweaks to grab resisting.

### DIFF
--- a/code/game/objects/items/weapons/garrote.dm
+++ b/code/game/objects/items/weapons/garrote.dm
@@ -88,8 +88,9 @@
 	U.swap_hand()
 
 	if(G && istype(G))
-		if(improvised) // Improvised garrotes start you off with a passive grab, but keep you stunned like an agressive grab.
-			M.Stun(2 SECONDS)
+		if(improvised) // Improvised garrotes start you off with a passive grab, but will lock you in place. A quick stun to drop items but not to make it unescapable
+			M.Stun(1 SECONDS)
+			M.Immobilize(2 SECONDS)
 		else
 			G.state = GRAB_NECK
 			G.hud.icon_state = "kill"
@@ -153,7 +154,7 @@
 		return
 
 	if(G.state < GRAB_NECK) // Only possible with improvised garrotes, essentially this will stun people as if they were aggressively grabbed. Allows for resisting out if you're quick, but not running away.
-		strangling.Stun(6 SECONDS)
+		strangling.Immobilize(3 SECONDS)
 
 	if(improvised)
 		strangling.Stuttering(6 SECONDS)

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -642,7 +642,7 @@
 			target.Stun(0.5 SECONDS)
 	else
 		var/obj/item/active_hand = target.get_active_hand()
-		if(target.IsSlowed() && active_hand && !IS_HORIZONTAL(user) && !HAS_TRAIT(active_hand, TRAIT_WIELDED))
+		if(target.IsSlowed() && active_hand && !IS_HORIZONTAL(user) && !HAS_TRAIT(active_hand, TRAIT_WIELDED) && !istype(active_hand, /obj/item/grab))
 			target.drop_item()
 			add_attack_logs(user, target, "Disarmed object out of hand", ATKLOG_ALL)
 		else

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -778,6 +778,8 @@
 */////////////////////
 /mob/living/proc/resist_grab()
 	var/resisting = 0
+	if(HAS_TRAIT(src, TRAIT_IMMOBILIZED))
+		return TRUE //You can't move, so you can't resist
 	for(var/X in grabbed_by)
 		var/obj/item/grab/G = X
 		resisting++

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -206,6 +206,8 @@
 	if(mob.grabbed_by.len)
 		if(mob.incapacitated(FALSE, TRUE)) // Can't break out of grabs if you're incapacitated
 			return TRUE
+		if(HAS_TRAIT(mob, TRAIT_IMMOBILIZED))
+			return TRUE //You can't move, so you can't break it by trying to move.
 		var/list/grabbing = list()
 
 		if(istype(mob.l_hand, /obj/item/grab))


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Improvised Garrote is no longer unescapable.
Instead, it stuns for 1 second, then constantly grants them 3 seconds of immobilization. As such, their method of escape must be slaming them into something via disarm, batoning them, shooting them, ETC, but not just holding move or space.
You can no longer resist grabs when immobilized.
Grabs can no longer be dropped by disarm, so it isn't 2 disarms by people being grabbed to break it. Enviroment will matter. Disarming the person being grabbed still breaks it.

**Fiber wire is unchanged**

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Improvised Garrote can not be escaped right now. Considering it is an instant craftable hard stun, this is not great.
This means that while still very good, and still *hard to escape from*, it is not impossible unless you do not have the weapons to fight back, or if the user is silly and has their back to a wall / person / vendor.

Immobilize blocking movement resist makes sense, as for resist verb, that is just rng that is better off blocked out when immobilized to actually make the garotte work.

## Testing
<!-- How did you test the PR, if at all? -->

grabbed a lot of skrells with garrote, disarmed / batoned while grabbed with garrote

## Changelog
:cl:
tweak: Improvised Garrote is no longer inescapable. It now immobilizes the user (after a short stun) and must be broken out of by shoving them into something, knocking them down, or stunning them through other means.
tweak: You can no longer break out of grabs when immobilized.
tweak: Grabs can no longer be dropped by disarm. Shoving them into something, or disarming the victim, still works.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
