### PR TITLE
fixes moon base 19 powering all other ruins, makes it it's own ruin area

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/moonoutpost19.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/moonoutpost19.dmm
@@ -7,7 +7,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ac" = (
 /obj/structure/sign/directions/medical{
 	pixel_x = -32;
@@ -18,10 +18,10 @@
 	icon_state = "caution";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ad" = (
 /turf/simulated/floor/plating/asteroid/airless,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ae" = (
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 4
@@ -32,14 +32,14 @@
 /turf/simulated/floor/plating/asteroid/airless{
 	icon_state = "asteroidplating"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "af" = (
 /obj/effect/spawner/random_spawners/wall_rusted_always,
 /turf/simulated/wall/r_wall,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ag" = (
 /turf/simulated/wall/r_wall,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ah" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -50,24 +50,24 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ai" = (
 /obj/structure/railing/corner,
 /turf/simulated/floor/plasteel{
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "aj" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/alien,
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ak" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "al" = (
 /obj/structure/railing/cap{
 	dir = 10
@@ -75,7 +75,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "green"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "am" = (
 /obj/structure/window/reinforced,
 /obj/structure/chair{
@@ -86,14 +86,14 @@
 	dir = 1;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ao" = (
 /obj/structure/closet/crate,
 /obj/item/flashlight/flare,
 /obj/item/flashlight/flare,
 /obj/item/flashlight/flare,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ap" = (
 /obj/machinery/shower{
 	dir = 8
@@ -101,7 +101,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/noslip,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "aq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery/partial{
@@ -111,7 +111,7 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "as" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/reinforced/normal,
@@ -119,7 +119,7 @@
 	dir = 8;
 	icon_state = "dark"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "at" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/tracks{
@@ -131,7 +131,7 @@
 	pixel_y = 8
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "au" = (
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 1
@@ -141,12 +141,12 @@
 	},
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/plating/asteroid/airless,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "av" = (
 /turf/simulated/floor/plating/asteroid/airless{
 	icon_state = "asteroid2"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "aw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -161,7 +161,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ax" = (
 /obj/machinery/computer/arcade/recruiter{
 	dir = 1
@@ -170,7 +170,7 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ay" = (
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 1
@@ -181,10 +181,10 @@
 /turf/simulated/floor/plating/asteroid/airless{
 	icon_state = "asteroid10"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "aA" = (
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "aB" = (
 /obj/structure/railing,
 /obj/item/storage/toolbox/mechanical{
@@ -195,7 +195,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "aC" = (
 /obj/structure/table/glass,
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -204,7 +204,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "whitehall"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "aD" = (
 /obj/structure/toilet{
 	pixel_y = 8
@@ -214,14 +214,14 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "aE" = (
 /obj/structure/railing{
 	dir = 1
 	},
 /obj/structure/chair/sofa/bench/right,
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "aF" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -232,7 +232,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "aG" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/reinforced/normal{
@@ -250,14 +250,14 @@
 	dir = 8;
 	icon_state = "dark"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "aH" = (
 /obj/structure/railing/cap{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "aI" = (
 /obj/structure/railing{
 	dir = 4
@@ -272,7 +272,7 @@
 	pixel_x = -2
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "aJ" = (
 /obj/structure/railing,
 /obj/effect/turf_decal/stripes/asteroid/line,
@@ -282,34 +282,34 @@
 /turf/simulated/floor/plating/asteroid/airless{
 	icon_state = "asteroid12"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "aK" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "aL" = (
 /turf/simulated/wall,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "aM" = (
 /obj/effect/spawner/random_spawners/wall_rusted_always,
 /turf/simulated/wall,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "aN" = (
 /obj/machinery/door/airlock/medical/glass{
 	req_access_txt = "271";
 	name = "Storage Room"
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "aO" = (
 /obj/structure/table/glass/reinforced/titanium,
 /turf/simulated/floor/plasteel{
 	icon_state = "black"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "aP" = (
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 1
@@ -318,7 +318,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating/asteroid/airless,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "aQ" = (
 /obj/structure/disposaloutlet{
 	dir = 8
@@ -332,7 +332,7 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "aR" = (
 /obj/structure/railing/cap{
 	dir = 1
@@ -345,7 +345,7 @@
 	icon_state = "whitehall";
 	dir = 6
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "aS" = (
 /obj/structure/railing,
 /obj/effect/turf_decal/stripes/asteroid/line,
@@ -355,7 +355,7 @@
 /turf/simulated/floor/plating/asteroid/airless{
 	icon_state = "asteroid8"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "aU" = (
 /turf/simulated/floor/mineral/titanium,
 /area/ruin/space/powered)
@@ -363,7 +363,7 @@
 /obj/effect/decal/remains/human,
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/plating/asteroid/airless,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "aW" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -376,7 +376,7 @@
 	dir = 9;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "aX" = (
 /obj/structure/railing{
 	dir = 8
@@ -387,7 +387,7 @@
 	icon_state = "black";
 	dir = 10
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "aY" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -395,7 +395,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "black"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "aZ" = (
 /obj/machinery/door/poddoor/impassable{
 	id_tag = "awaymlock"
@@ -405,7 +405,7 @@
 	name = "Medical Ward"
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ba" = (
 /obj/machinery/door/airlock/multi_tile/glass{
 	req_access_txt = "271"
@@ -413,14 +413,14 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "bb" = (
 /obj/machinery/door/airlock/multi_tile/glass,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "bd" = (
 /obj/structure/sign/nosmoking_1{
 	pixel_x = 32
@@ -430,7 +430,7 @@
 	icon_state = "caution";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "be" = (
 /obj/structure/chair/sofa/bench/left{
 	dir = 4
@@ -439,7 +439,7 @@
 	icon_state = "caution";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "bf" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -449,7 +449,7 @@
 	dir = 5;
 	icon_state = "black"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "bh" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -457,39 +457,39 @@
 	icon_state = "caution";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "bi" = (
 /obj/structure/railing{
 	dir = 1
 	},
 /obj/structure/chair/sofa/bench/left,
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "bj" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/structure/barricade/wooden/crude{
 	layer = 4
 	},
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "bk" = (
 /obj/machinery/economy/vending/snack,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "bl" = (
 /obj/structure/chair/office{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "bm" = (
 /obj/structure/closet,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "bp" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
@@ -503,7 +503,7 @@
 	dir = 8;
 	icon_state = "dark"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "bq" = (
 /obj/structure/table/reinforced,
 /obj/item/book/manual/wiki/security_space_law,
@@ -512,14 +512,14 @@
 	dir = 8;
 	icon_state = "dark"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "bs" = (
 /obj/structure/table/glass,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitehall";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "bt" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
@@ -531,7 +531,7 @@
 	icon_state = "whitecorner";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "bu" = (
 /obj/structure/railing{
 	dir = 4
@@ -539,11 +539,11 @@
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "bv" = (
 /obj/structure/ore_box,
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "bw" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -552,7 +552,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "bx" = (
 /obj/machinery/door/airlock/external/glass,
 /turf/simulated/floor/mineral/titanium,
@@ -560,7 +560,7 @@
 "bz" = (
 /obj/structure/girder,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "bB" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -573,7 +573,7 @@
 	dir = 4;
 	icon_state = "black"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "bC" = (
 /obj/machinery/atmospherics/unary/cryo_cell,
 /obj/structure/window/reinforced{
@@ -584,7 +584,7 @@
 	},
 /obj/effect/turf_decal/delivery/white/hollow,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "bD" = (
 /obj/structure/railing{
 	dir = 1
@@ -594,7 +594,7 @@
 	dir = 8;
 	icon_state = "dark"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "bE" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/structure/sign/vacuum{
@@ -609,7 +609,7 @@
 	icon_state = "caution";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "bF" = (
 /obj/structure/railing,
 /obj/effect/turf_decal/stripes/asteroid/end{
@@ -620,7 +620,7 @@
 	},
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/plating/asteroid/airless,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "bG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb,
@@ -630,7 +630,7 @@
 	dir = 9;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "bH" = (
 /obj/structure/sign/restroom{
 	pixel_y = -32
@@ -638,7 +638,7 @@
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "bJ" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/reinforced/normal{
@@ -648,14 +648,14 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "bK" = (
 /obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "dark"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "bN" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -668,15 +668,15 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "bO" = (
 /obj/item/cigbutt,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "bP" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "bS" = (
 /obj/effect/turf_decal/loading_area/white{
 	dir = 1
@@ -685,7 +685,7 @@
 	icon_state = "caution";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "bU" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -693,7 +693,7 @@
 	dir = 8;
 	icon_state = "dark"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "bW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -702,11 +702,11 @@
 	color = "red"
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "bY" = (
 /obj/structure/railing,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "bZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -715,7 +715,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ca" = (
 /obj/structure/railing/cap{
 	dir = 8
@@ -723,30 +723,30 @@
 /turf/simulated/floor/plasteel/stairs{
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "cb" = (
 /obj/structure/railing/corner,
 /turf/simulated/floor/plasteel/stairs{
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "cc" = (
 /obj/structure/flora/tree/jungle/small,
 /obj/structure/flora/rock/pile/largejungle,
 /turf/simulated/floor/grass,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "cd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ce" = (
 /obj/structure/window/reinforced,
 /obj/machinery/light/small,
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "cf" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	color = "red";
@@ -761,13 +761,13 @@
 	icon_state = "whitehall";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ch" = (
 /obj/structure/chair/office{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ci" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -778,22 +778,22 @@
 /turf/simulated/floor/plasteel/stairs{
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "cj" = (
 /obj/structure/chair/office/dark{
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "cm" = (
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "cn" = (
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 8
 	},
 /turf/simulated/floor/plating/asteroid/airless,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "co" = (
 /obj/structure/railing/cap{
 	dir = 1
@@ -805,11 +805,11 @@
 	icon_state = "yellowsiding";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "cp" = (
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "cq" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -817,17 +817,17 @@
 /turf/simulated/floor/plasteel/stairs{
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "cr" = (
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating/airless,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "cs" = (
 /obj/structure/flora/ausbushes/sunnybush,
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/window/full/basic,
 /turf/simulated/floor/grass,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ct" = (
 /obj/structure/railing,
 /obj/machinery/optable,
@@ -836,7 +836,7 @@
 	icon_state = "darkblue";
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "cv" = (
 /obj/structure/table/glass/reinforced/titanium,
 /obj/machinery/door_control{
@@ -852,7 +852,7 @@
 	id = "awaycargogate"
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "cw" = (
 /obj/machinery/sleeper,
 /obj/effect/turf_decal/delivery/white/hollow,
@@ -860,7 +860,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "whitehall"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "cx" = (
 /obj/machinery/door/airlock/security/glass{
 	req_access_txt = "271"
@@ -872,14 +872,14 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "cy" = (
 /obj/structure/closet,
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "cA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -888,7 +888,7 @@
 	icon_state = "caution";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "cB" = (
 /obj/structure/railing{
 	dir = 4
@@ -898,7 +898,7 @@
 	icon_state = "caution";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "cC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -906,7 +906,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "blackcorner"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "cD" = (
 /obj/structure/railing/cap{
 	dir = 5
@@ -919,7 +919,7 @@
 	},
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "cF" = (
 /obj/structure/barricade/wooden/crude{
 	layer = 4
@@ -929,7 +929,7 @@
 	req_access_txt = "271"
 	},
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "cI" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 32
@@ -940,7 +940,7 @@
 	dir = 5;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "cJ" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -948,7 +948,7 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "cK" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -957,13 +957,13 @@
 	dir = 8;
 	icon_state = "dark"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "cL" = (
 /obj/effect/decal/cleanable/blood/splatter{
 	color = "red"
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "cM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -972,7 +972,7 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "cN" = (
 /obj/machinery/bodyscanner{
 	dir = 4
@@ -984,7 +984,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "whitehall"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "cR" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -997,7 +997,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "cS" = (
 /obj/effect/decal/cleanable/cobweb2,
 /obj/structure/largecrate,
@@ -1008,7 +1008,7 @@
 	dir = 1;
 	icon_state = "black"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "cY" = (
 /obj/structure/railing{
 	dir = 8
@@ -1021,7 +1021,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "da" = (
 /obj/structure/chair{
 	dir = 8
@@ -1030,18 +1030,18 @@
 	icon_state = "black";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "db" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/plating/asteroid/ancient,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "dc" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "black";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "dd" = (
 /obj/structure/table/glass,
 /obj/machinery/light/small{
@@ -1055,7 +1055,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkblue"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "df" = (
 /obj/structure/railing{
 	dir = 1
@@ -1063,7 +1063,7 @@
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "dg" = (
 /obj/structure/shuttle/engine/propulsion/burst{
 	dir = 4
@@ -1080,7 +1080,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "dj" = (
 /obj/structure/closet/crate,
 /turf/simulated/floor/mineral/titanium,
@@ -1088,26 +1088,26 @@
 "dk" = (
 /obj/structure/window/reinforced,
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "dm" = (
 /obj/effect/turf_decal/stripes/asteroid/line,
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/railing/corner,
 /turf/simulated/floor/plating/asteroid/ancient,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "dn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "do" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/plating/asteroid/airless{
 	icon_state = "asteroid12"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "dp" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -1120,7 +1120,7 @@
 	icon_state = "white";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ds" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -1132,7 +1132,7 @@
 	icon_state = "cautioncorner";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "dt" = (
 /obj/effect/turf_decal/stripes/asteroid/corner{
 	dir = 8
@@ -1165,30 +1165,30 @@
 	dir = 8;
 	icon_state = "dark"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "dw" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "whitehall"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "dx" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /turf/simulated/floor/plasteel{
 	icon_state = "black";
 	dir = 6
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "dz" = (
 /obj/structure/flora/ausbushes/fernybush,
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/window/full/basic,
 /turf/simulated/floor/grass,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "dA" = (
 /turf/simulated/floor/plating/asteroid/airless{
 	icon_state = "asteroid1"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "dB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -1200,20 +1200,20 @@
 	dir = 9;
 	icon_state = "whitecorner"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "dD" = (
 /obj/structure/closet/walllocker/emerglocker{
 	pixel_y = 32
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "dE" = (
 /obj/effect/turf_decal/loading_area/white,
 /turf/simulated/floor/plasteel{
 	icon_state = "caution";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "dG" = (
 /obj/machinery/door/poddoor/impassable{
 	id_tag = "awaycontlockdown"
@@ -1223,7 +1223,7 @@
 	name = "Specimen Containtment Zone"
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "dH" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -1235,7 +1235,7 @@
 	icon_state = "white";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "dK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb2,
@@ -1245,18 +1245,18 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "dL" = (
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "dM" = (
 /turf/simulated/floor/plasteel/stairs{
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "dN" = (
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 1
@@ -1266,7 +1266,7 @@
 	},
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/plating/asteroid/airless,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "dO" = (
 /obj/structure/table/glass/reinforced/plastitanium,
 /obj/item/clipboard,
@@ -1278,7 +1278,7 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "dQ" = (
 /obj/structure/table/glass,
 /obj/structure/railing{
@@ -1291,7 +1291,7 @@
 	icon_state = "whitecorner";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "dR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/splatter{
@@ -1302,20 +1302,20 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "dS" = (
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "dT" = (
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/carpet/royalblue,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "dU" = (
 /obj/machinery/computer/arcade/orion_trail{
 	dir = 1
@@ -1324,18 +1324,18 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "dV" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "dW" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "dX" = (
 /obj/structure/sign/security{
 	pixel_y = 32
@@ -1344,13 +1344,13 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "dY" = (
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "eb" = (
 /obj/structure/closet/crate/can,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -1358,7 +1358,7 @@
 	icon_state = "showroomfloor";
 	temperature = 273.15
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ed" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -1373,14 +1373,14 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ee" = (
 /obj/structure/table/glass/reinforced/titanium,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "eg" = (
 /turf/simulated/floor/grass,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "eh" = (
 /obj/effect/turf_decal/caution{
 	dir = 4
@@ -1393,7 +1393,7 @@
 	icon_state = "caution";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ek" = (
 /obj/effect/turf_decal/stripes/asteroid/line,
 /obj/effect/decal/cleanable/dirt,
@@ -1401,19 +1401,19 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/asteroid/ancient,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "el" = (
 /obj/machinery/door/airlock,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "em" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "blackcorner"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "eo" = (
 /obj/machinery/door/poddoor/impassable{
 	id_tag = "awaymlock"
@@ -1423,7 +1423,7 @@
 	name = "Medical Ward"
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ep" = (
 /obj/effect/decal/cleanable/blood/splatter{
 	color = "red"
@@ -1431,14 +1431,14 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "eq" = (
 /obj/effect/turf_decal/loading_area/white{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "er" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -1451,11 +1451,11 @@
 	icon_state = "black";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "es" = (
 /obj/structure/flora/ausbushes/fernybush,
 /turf/simulated/floor/grass,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ev" = (
 /obj/structure/chair{
 	dir = 8
@@ -1464,7 +1464,7 @@
 	icon_state = "whitehall";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ew" = (
 /obj/machinery/computer/security{
 	desc = "Used to access the various cameras on the outpost.";
@@ -1475,7 +1475,7 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ey" = (
 /obj/item/kirbyplants,
 /obj/machinery/light/small{
@@ -1485,7 +1485,7 @@
 	dir = 1;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ez" = (
 /obj/structure/chair{
 	dir = 8
@@ -1500,16 +1500,16 @@
 	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "eA" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "eC" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/plating/asteroid/ancient,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "eE" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -1527,11 +1527,11 @@
 	icon_state = "caution";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "eJ" = (
 /obj/structure/flora/junglebush/large,
 /turf/simulated/floor/grass,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "eK" = (
 /obj/item/kirbyplants,
 /obj/effect/decal/cleanable/dirt,
@@ -1544,7 +1544,7 @@
 	icon_state = "caution";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "eL" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -32
@@ -1557,13 +1557,13 @@
 	dir = 8;
 	icon_state = "black"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "eM" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "eO" = (
 /obj/structure/mirror{
 	pixel_x = -28
@@ -1577,7 +1577,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "eR" = (
 /obj/structure/railing{
 	dir = 8
@@ -1586,13 +1586,13 @@
 	dir = 8;
 	icon_state = "black"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "eU" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "black"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "eW" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -1600,7 +1600,7 @@
 /turf/simulated/floor/plasteel/stairs{
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "eX" = (
 /obj/structure/barricade/wooden/crude{
 	layer = 4
@@ -1609,7 +1609,7 @@
 	req_access_txt = "271"
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "eZ" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -1621,7 +1621,7 @@
 /obj/effect/turf_decal/box,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "fc" = (
 /obj/structure/railing{
 	dir = 4
@@ -1643,7 +1643,7 @@
 	icon_state = "yellowcornersiding";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "fd" = (
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 8
@@ -1651,14 +1651,14 @@
 /turf/simulated/floor/plating/asteroid/airless{
 	icon_state = "asteroid6"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "fe" = (
 /obj/structure/railing{
 	dir = 8
 	},
 /obj/structure/closet/crate,
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ff" = (
 /obj/structure/chair/stool{
 	dir = 4
@@ -1679,7 +1679,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/engine,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "fi" = (
 /obj/structure/chair/wheelchair,
 /obj/effect/turf_decal/delivery/white,
@@ -1687,11 +1687,11 @@
 	icon_state = "white";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "fl" = (
 /obj/structure/closet/crate,
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "fm" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/item/clothing/suit/storage/labcoat,
@@ -1705,43 +1705,43 @@
 	icon_state = "whitecorner";
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "fn" = (
 /obj/machinery/door/airlock/centcom{
 	req_access_txt = "271"
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "fp" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "fq" = (
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "fr" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "fs" = (
 /obj/structure/chair/sofa/bench,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "fv" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/plating/asteroid/airless,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "fw" = (
 /obj/structure/flora/ash/rock/style_random,
 /turf/simulated/floor/plating/asteroid/airless,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "fx" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/effect/turf_decal/stripes/corner{
@@ -1754,18 +1754,18 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "fy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "fA" = (
 /obj/structure/mopbucket,
 /obj/item/mop,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "fB" = (
 /obj/structure/railing{
 	dir = 1
@@ -1777,32 +1777,32 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/asteroid/airless,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "fC" = (
 /obj/item/kirbyplants,
 /turf/simulated/floor/plasteel{
 	icon_state = "black";
 	dir = 10
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "fD" = (
 /obj/structure/chair,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "fF" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "black";
 	dir = 6
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "fG" = (
 /obj/structure/fans/tiny,
 /obj/machinery/door/poddoor{
 	id_tag = "awaycargogate1"
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "fI" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/machinery/atmospherics/meter,
@@ -1810,7 +1810,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "fJ" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/reinforced/normal{
@@ -1830,26 +1830,26 @@
 	dir = 8;
 	icon_state = "dark"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "fK" = (
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "black"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "fM" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "caution";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "fP" = (
 /obj/structure/railing{
 	dir = 4
 	},
 /obj/structure/closet/l3closet/general,
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "fQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -1859,7 +1859,7 @@
 	name = "Cafeteria"
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "fR" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -1869,24 +1869,24 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "fV" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/plating/asteroid/airless,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "fX" = (
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/glass,
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating/airless,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "fY" = (
 /obj/item/stack/sheet/mineral/titanium,
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/cleanable/molten_object/large,
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating/airless,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "gb" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -1897,7 +1897,7 @@
 /turf/simulated/floor/plasteel/stairs{
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "gc" = (
 /obj/structure/chair/sofa/bench/right{
 	dir = 4
@@ -1909,7 +1909,7 @@
 	icon_state = "caution";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "gd" = (
 /obj/structure/sign/directions/science{
 	dir = 1;
@@ -1918,34 +1918,34 @@
 /obj/structure/chair,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ge" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/asteroid/ancient,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "gf" = (
 /obj/structure/railing{
 	dir = 4
 	},
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "gg" = (
 /obj/structure/flora/ausbushes/grassybush,
 /obj/machinery/light/small,
 /turf/simulated/floor/grass,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "gh" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/alien,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "gi" = (
 /turf/simulated/floor/plating/asteroid/airless{
 	icon_state = "asteroid4"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "gj" = (
 /obj/structure/railing,
 /obj/structure/railing/cap{
@@ -1954,14 +1954,14 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "gk" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 1
 	},
 /obj/machinery/atmospherics/portable/canister/oxygen,
 /turf/simulated/floor/plating/asteroid/ancient,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "gl" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -1972,7 +1972,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "gm" = (
 /obj/effect/turf_decal/delivery/partial{
 	dir = 1
@@ -1985,7 +1985,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "gn" = (
 /obj/machinery/economy/vending/coffee,
 /obj/effect/decal/cleanable/cobweb,
@@ -1993,7 +1993,7 @@
 	dir = 9;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "go" = (
 /obj/structure/railing,
 /obj/structure/largecrate,
@@ -2001,7 +2001,7 @@
 	icon_state = "caution";
 	dir = 6
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "gq" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -2017,7 +2017,7 @@
 	pixel_x = 2
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "gr" = (
 /obj/effect/turf_decal/delivery/red/partial{
 	dir = 1
@@ -2026,22 +2026,22 @@
 	icon_state = "whitehall";
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "gs" = (
 /obj/machinery/economy/vending/snack,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "gt" = (
 /obj/machinery/economy/vending/cola,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "gv" = (
 /obj/item/kirbyplants,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "gw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/splatter{
@@ -2051,7 +2051,7 @@
 	icon_state = "yellowcornersiding";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "gx" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
 /obj/effect/decal/cleanable/dirt,
@@ -2059,7 +2059,7 @@
 	icon_state = "showroomfloor";
 	temperature = 273.15
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "gy" = (
 /obj/item/reagent_containers/food/snacks/xenomeatbreadslice{
 	pixel_y = 5
@@ -2073,7 +2073,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "gz" = (
 /obj/machinery/light{
 	active_power_consumption = 0;
@@ -2084,21 +2084,21 @@
 	color = "red"
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "gA" = (
 /obj/structure/flora/ausbushes/grassybush,
 /obj/structure/flora/ausbushes,
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/window/full/basic,
 /turf/simulated/floor/grass,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "gB" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "cautioncorner";
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "gC" = (
 /obj/effect/decal/cleanable/greenglow,
 /obj/effect/landmark/damageturf,
@@ -2108,11 +2108,11 @@
 	stat = 2
 	},
 /turf/simulated/floor/plating/airless,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "gD" = (
 /obj/structure/girder,
 /turf/simulated/floor/plating/airless,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "gE" = (
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 1
@@ -2123,19 +2123,19 @@
 /turf/simulated/floor/plating/asteroid/airless{
 	icon_state = "asteroid5"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "gH" = (
 /obj/structure/fans/tiny,
 /obj/machinery/door/airlock/external,
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "gJ" = (
 /obj/effect/turf_decal/stripes/asteroid/line,
 /obj/structure/railing,
 /turf/simulated/floor/plating/asteroid/airless{
 	icon_state = "asteroidplating"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "gL" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -2147,7 +2147,7 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "gM" = (
 /obj/machinery/shower{
 	dir = 4
@@ -2156,12 +2156,12 @@
 	dir = 8
 	},
 /turf/simulated/floor/noslip,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "gN" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "gO" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
@@ -2175,28 +2175,28 @@
 	dir = 9;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "gS" = (
 /obj/structure/chair{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "gT" = (
 /obj/structure/flora/rock/pile,
 /turf/simulated/floor/grass,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "gU" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitehall"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "gV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "gW" = (
 /obj/effect/landmark/damageturf,
 /obj/machinery/door/airlock/titanium{
@@ -2204,7 +2204,7 @@
 	name = "Escape Pod Hatch"
 	},
 /turf/simulated/floor/mineral/titanium/airless,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "gX" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/cobweb2,
@@ -2213,7 +2213,7 @@
 	dir = 5;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "gZ" = (
 /obj/structure/railing{
 	dir = 1
@@ -2227,7 +2227,7 @@
 	pixel_y = 8
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "hc" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/alien,
@@ -2235,7 +2235,7 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "he" = (
 /obj/effect/turf_decal/stripes/asteroid/corner{
 	dir = 8
@@ -2246,23 +2246,23 @@
 /turf/simulated/floor/plating/asteroid/airless{
 	icon_state = "asteroidplating"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "hf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "hg" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowsiding";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "hh" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "whitehall";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "hi" = (
 /obj/structure/falsewall/rock_ancient,
 /obj/effect/decal/cleanable/blood/tracks{
@@ -2274,7 +2274,7 @@
 	pixel_y = 9
 	},
 /turf/simulated/floor/plating/asteroid/ancient,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "hj" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -2286,7 +2286,7 @@
 	icon_state = "caution";
 	dir = 6
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "hk" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
@@ -2302,7 +2302,7 @@
 	dir = 8;
 	icon_state = "dark"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "hl" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -2314,12 +2314,12 @@
 	dir = 8;
 	icon_state = "dark"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "hm" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/suit/navy,
 /turf/simulated/floor/carpet,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "hn" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -2328,14 +2328,14 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ho" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkbluefull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "hp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/xeno{
@@ -2345,7 +2345,7 @@
 	icon_state = "white";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "hq" = (
 /obj/item/storage/toolbox/mechanical{
 	pixel_x = 2;
@@ -2356,7 +2356,7 @@
 	icon_state = "caution";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "hr" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -2366,14 +2366,14 @@
 	icon_state = "white";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "hs" = (
 /obj/item/kirbyplants,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "dark"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "hu" = (
 /turf/simulated/wall/mineral/titanium,
 /area/ruin/space/powered)
@@ -2387,7 +2387,7 @@
 /turf/simulated/floor/plating/asteroid/airless{
 	icon_state = "asteroidplating"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "hw" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -2402,7 +2402,7 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "hx" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -2418,7 +2418,7 @@
 	icon_state = "caution";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "hy" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -2431,11 +2431,11 @@
 	icon_state = "caution";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "hz" = (
 /obj/structure/flora/junglebush,
 /turf/simulated/floor/grass,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "hA" = (
 /obj/structure/chair/sofa/bench{
 	dir = 4
@@ -2444,7 +2444,7 @@
 	icon_state = "caution";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "hC" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -2453,7 +2453,7 @@
 	dir = 8;
 	icon_state = "dark"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "hD" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -2463,10 +2463,10 @@
 	dir = 8;
 	icon_state = "dark"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "hE" = (
 /turf/simulated/floor/carpet,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "hF" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
@@ -2477,33 +2477,33 @@
 	dir = 8;
 	icon_state = "dark"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "hG" = (
 /turf/simulated/floor/plating/asteroid/airless{
 	icon_state = "asteroid10"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "hH" = (
 /obj/effect/decal/remains/xeno,
 /turf/simulated/floor/plating/asteroid/airless{
 	icon_state = "asteroid8"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "hI" = (
 /turf/simulated/floor/plating/asteroid/airless{
 	icon_state = "asteroid5"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "hK" = (
 /obj/machinery/door/airlock/external/glass,
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "hL" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor";
 	temperature = 273.15
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "hN" = (
 /obj/structure/railing,
 /obj/structure/railing{
@@ -2512,7 +2512,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "hO" = (
 /obj/effect/spawner/window/shuttle,
 /turf/simulated/floor/plating,
@@ -2522,7 +2522,7 @@
 	color = "red"
 	},
 /turf/simulated/floor/plating/asteroid/ancient,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "hQ" = (
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 5
@@ -2533,7 +2533,7 @@
 /turf/simulated/floor/plating/asteroid/airless{
 	icon_state = "asteroidplating"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "hR" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -2542,21 +2542,21 @@
 	dir = 4
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "hS" = (
 /obj/structure/railing{
 	dir = 1
 	},
 /obj/structure/closet,
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "hT" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "hU" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/reinforced/normal{
@@ -2571,7 +2571,7 @@
 	dir = 8;
 	icon_state = "dark"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "hV" = (
 /obj/structure/railing,
 /obj/structure/closet/secure_closet,
@@ -2587,12 +2587,12 @@
 	dir = 8;
 	icon_state = "dark"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "hW" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
 /turf/simulated/floor/carpet,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "hX" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/reinforced/normal{
@@ -2603,30 +2603,30 @@
 	dir = 8;
 	icon_state = "dark"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "hY" = (
 /obj/effect/decal/cleanable/blood/oil{
 	color = "black"
 	},
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "hZ" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/plating/asteroid/airless{
 	icon_state = "asteroid8"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ia" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ib" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ic" = (
 /obj/structure/railing{
 	dir = 4
@@ -2639,11 +2639,11 @@
 	dir = 1
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "id" = (
 /obj/structure/largecrate,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ie" = (
 /obj/effect/decal/cleanable/blood/splatter{
 	color = "red"
@@ -2651,7 +2651,7 @@
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "if" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
@@ -2659,14 +2659,14 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "whitehall"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ig" = (
 /obj/machinery/door/poddoor/impassable{
 	id_tag = "awaymlock"
 	},
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ii" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -2679,14 +2679,14 @@
 	dir = 1;
 	icon_state = "escape"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ij" = (
 /obj/structure/fans/tiny,
 /obj/machinery/door/poddoor/multi_tile/impassable/four_tile_ver{
 	id_tag = "awaycargogate"
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "il" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2696,7 +2696,7 @@
 	icon_state = "white";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "im" = (
 /obj/effect/turf_decal/stripes/asteroid/corner{
 	dir = 4
@@ -2707,14 +2707,14 @@
 /turf/simulated/floor/plating/asteroid/airless{
 	icon_state = "asteroidplating"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "in" = (
 /obj/structure/largecrate,
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "io" = (
 /obj/item/kirbyplants,
 /obj/structure/sign/directions/engineering{
@@ -2728,7 +2728,7 @@
 	icon_state = "caution";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "iq" = (
 /obj/structure/railing{
 	dir = 1
@@ -2738,7 +2738,7 @@
 	},
 /obj/effect/turf_decal/stripes/asteroid/line,
 /turf/simulated/floor/plating/asteroid/airless,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ir" = (
 /obj/structure/railing{
 	dir = 1
@@ -2750,7 +2750,7 @@
 /turf/simulated/floor/plating/asteroid/airless{
 	icon_state = "asteroid8"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "is" = (
 /obj/structure/railing/cap{
 	dir = 5
@@ -2759,7 +2759,7 @@
 	dir = 1;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "it" = (
 /obj/structure/railing/cap{
 	dir = 1
@@ -2768,20 +2768,20 @@
 	dir = 1;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "iu" = (
 /obj/structure/railing{
 	dir = 1
 	},
 /obj/structure/table,
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "iv" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "iw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -2794,13 +2794,13 @@
 	dir = 1;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ix" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "white";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "iy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/tracks{
@@ -2812,13 +2812,13 @@
 	pixel_y = -1
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "iz" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/window/full/basic,
 /turf/simulated/floor/grass,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "iA" = (
 /obj/effect/decal/cleanable/blood/splatter{
 	color = "red"
@@ -2828,7 +2828,7 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "iB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -2836,7 +2836,7 @@
 	icon_state = "black";
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "iC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -2844,7 +2844,7 @@
 	dir = 8;
 	icon_state = "green"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "iD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -2858,14 +2858,14 @@
 	dir = 1;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "iE" = (
 /obj/effect/decal/cleanable/blood/splatter{
 	color = "red"
 	},
 /obj/effect/decal/remains/human,
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "iF" = (
 /obj/machinery/door/window/reinforced/normal{
 	dir = 8
@@ -2873,13 +2873,13 @@
 /turf/simulated/floor/plasteel/stairs{
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "iG" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "black";
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "iI" = (
 /obj/machinery/door/window/reinforced/normal{
 	dir = 4
@@ -2887,21 +2887,21 @@
 /turf/simulated/floor/plasteel/stairs{
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "iJ" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "iL" = (
 /turf/simulated/floor/plating/asteroid/airless{
 	icon_state = "asteroid6"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "iM" = (
 /turf/simulated/floor/plating/asteroid/airless{
 	icon_state = "asteroid12"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "iN" = (
 /obj/effect/turf_decal/caution{
 	dir = 4
@@ -2913,21 +2913,21 @@
 	icon_state = "caution";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "iO" = (
 /obj/effect/turf_decal/delivery/white/partial,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitehall"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "iP" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "iQ" = (
 /obj/structure/kitchenspike,
 /obj/effect/decal/cleanable/cobweb,
@@ -2935,7 +2935,7 @@
 	icon_state = "showroomfloor";
 	temperature = 273.15
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "iR" = (
 /obj/structure/railing{
 	dir = 1
@@ -2947,7 +2947,7 @@
 /turf/simulated/floor/plating/asteroid/airless{
 	icon_state = "asteroid12"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "iS" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
@@ -2964,11 +2964,11 @@
 	dir = 8;
 	icon_state = "dark"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "iT" = (
 /obj/structure/fans/tiny,
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "iW" = (
 /obj/structure/chair{
 	dir = 4
@@ -2977,19 +2977,19 @@
 	icon_state = "black";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "iX" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/carpet,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "iY" = (
 /obj/structure/flora/junglebush,
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/window/full/basic,
 /turf/simulated/floor/grass,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "iZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -3002,24 +3002,24 @@
 	name = "Workshop"
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ja" = (
 /obj/machinery/economy/arcade/claw,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "jb" = (
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "jc" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "black"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "jf" = (
 /obj/machinery/atmospherics/unary/cryo_cell,
 /obj/structure/window/reinforced{
@@ -3030,7 +3030,7 @@
 	},
 /obj/effect/turf_decal/delivery/white/hollow,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "jg" = (
 /obj/structure/railing{
 	dir = 9
@@ -3038,14 +3038,14 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "whitecorner"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "jh" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ji" = (
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 8
@@ -3056,19 +3056,19 @@
 /turf/simulated/floor/plating/asteroid/airless{
 	icon_state = "asteroidplating"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "jj" = (
 /obj/item/kirbyplants,
 /turf/simulated/floor/plasteel{
 	icon_state = "caution";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "jk" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/ash/rock/style_random,
 /turf/simulated/floor/grass,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "jl" = (
 /obj/structure/table/reinforced,
 /obj/structure/railing/cap{
@@ -3083,7 +3083,7 @@
 	dir = 8;
 	icon_state = "dark"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "jm" = (
 /obj/structure/railing{
 	dir = 1
@@ -3093,19 +3093,19 @@
 	dir = 8;
 	icon_state = "dark"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "jn" = (
 /obj/machinery/door/airlock/centcom,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "jo" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/misc/assistantformal,
 /turf/simulated/floor/carpet,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "jp" = (
 /obj/structure/railing,
 /obj/item/kirbyplants,
@@ -3113,24 +3113,24 @@
 	dir = 8;
 	icon_state = "dark"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "jq" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "jr" = (
 /obj/item/kirbyplants,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "jt" = (
 /obj/structure/railing/cap,
 /obj/structure/railing/cap{
 	dir = 5
 	},
 /turf/simulated/floor/plating/asteroid/airless,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "jw" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/reinforced/normal{
@@ -3141,19 +3141,19 @@
 	dir = 8;
 	icon_state = "dark"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "jx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille/broken,
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "jy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/candy,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "jz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -3165,7 +3165,7 @@
 	dir = 8;
 	icon_state = "dark"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "jB" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -3177,22 +3177,22 @@
 	dir = 8;
 	icon_state = "dark"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "jC" = (
 /obj/effect/landmark/damageturf,
 /mob/living/simple_animal/hostile/alien,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "jD" = (
 /obj/structure/closet/crate,
 /turf/simulated/floor/plasteel/stairs{
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "jE" = (
 /obj/structure/grille,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "jF" = (
 /obj/structure/railing,
 /obj/effect/turf_decal/stripes/asteroid/end{
@@ -3202,13 +3202,13 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/asteroid/airless,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "jH" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "cautioncorner";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "jI" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -3221,7 +3221,7 @@
 	dir = 5;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "jJ" = (
 /obj/structure/window/reinforced,
 /obj/machinery/computer/security{
@@ -3233,7 +3233,7 @@
 	dir = 8;
 	icon_state = "dark"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "jK" = (
 /obj/structure/railing{
 	dir = 4
@@ -3242,17 +3242,17 @@
 	icon_state = "caution";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "jL" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "jM" = (
 /obj/structure/chair/office/dark{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "jP" = (
 /obj/structure/railing,
 /obj/effect/turf_decal/stripes/asteroid/line,
@@ -3260,7 +3260,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating/asteroid/airless,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "jQ" = (
 /obj/machinery/door/poddoor/shutters{
 	dir = 2
@@ -3272,24 +3272,24 @@
 	dir = 4;
 	icon_state = "blackcorner"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "jS" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "cautioncorner";
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "jU" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/window/full/basic,
 /turf/simulated/floor/grass,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "jW" = (
 /turf/simulated/floor/plating/asteroid/airless{
 	icon_state = "asteroid8"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "jY" = (
 /obj/structure/chair{
 	dir = 4
@@ -3304,7 +3304,7 @@
 	icon_state = "caution";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "jZ" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -3320,7 +3320,7 @@
 	icon_state = "whitecorner";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ka" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -3329,12 +3329,12 @@
 	icon_state = "caution";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "kb" = (
 /obj/structure/closet,
 /obj/item/storage/box/lights/mixed,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "kc" = (
 /obj/structure/railing{
 	dir = 1
@@ -3353,7 +3353,7 @@
 /turf/simulated/floor/plating/asteroid/airless{
 	icon_state = "asteroid6"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "kd" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -3364,7 +3364,7 @@
 	dir = 1;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ke" = (
 /obj/structure/window/reinforced,
 /obj/structure/chair{
@@ -3378,7 +3378,7 @@
 	dir = 1;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "kf" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -3386,7 +3386,7 @@
 	dir = 1;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "kg" = (
 /obj/item/kirbyplants,
 /obj/effect/landmark/damageturf,
@@ -3394,7 +3394,7 @@
 	dir = 6;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "kh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/poddoor/impassable{
@@ -3405,11 +3405,11 @@
 	name = "Research Division"
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ki" = (
 /obj/machinery/door/airlock/external,
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "kj" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -3420,13 +3420,13 @@
 	},
 /obj/effect/turf_decal/box,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "kk" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "caution";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "km" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -3435,17 +3435,17 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ko" = (
 /obj/structure/railing,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "kp" = (
 /turf/simulated/floor/plating/asteroid/ancient,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "kr" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -3455,7 +3455,7 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ks" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -3474,7 +3474,7 @@
 	icon_state = "yellowsiding";
 	dir = 9
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ku" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/portable/scrubber,
@@ -3482,7 +3482,7 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "kw" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -3495,14 +3495,14 @@
 	icon_state = "black";
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "kx" = (
 /obj/structure/table/glass,
 /turf/simulated/floor/plasteel{
 	icon_state = "white";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ky" = (
 /obj/structure/railing/cap{
 	dir = 9
@@ -3510,7 +3510,7 @@
 /turf/simulated/floor/plasteel/stairs{
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "kz" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -3520,14 +3520,14 @@
 	id = "mo19rdoffice"
 	},
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "kB" = (
 /obj/item/kirbyplants,
 /obj/structure/railing{
 	dir = 10
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "kC" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -3542,7 +3542,7 @@
 	icon_state = "whitehall";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "kE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -3552,14 +3552,14 @@
 	dir = 8;
 	icon_state = "dark"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "kG" = (
 /obj/item/kirbyplants,
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitecorner"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "kJ" = (
 /obj/machinery/power/port_gen/pacman{
 	desc = "A portable generator for emergency backup power.";
@@ -3569,13 +3569,13 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "kM" = (
 /obj/structure/flora/ausbushes/sunnybush,
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/window/full/basic,
 /turf/simulated/floor/grass,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "kN" = (
 /obj/item/kirbyplants,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -3590,7 +3590,7 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "kO" = (
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for monitoring the research division and the labs within.";
@@ -3599,7 +3599,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/carpet/royalblue,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "kQ" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -3612,11 +3612,11 @@
 	icon_state = "black";
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "kR" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/engine,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "kW" = (
 /obj/machinery/door/airlock/centcom{
 	req_access_txt = "271"
@@ -3625,7 +3625,7 @@
 	dir = 1;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "kX" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced,
@@ -3637,18 +3637,18 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "kZ" = (
 /obj/structure/flora/rock/jungle,
 /turf/simulated/floor/grass,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "la" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /mob/living/simple_animal/hostile/alien,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "lc" = (
 /obj/machinery/shieldwallgen{
 	locked = 0;
@@ -3660,7 +3660,7 @@
 	},
 /obj/effect/turf_decal/box,
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "li" = (
 /obj/structure/railing{
 	dir = 1
@@ -3669,13 +3669,13 @@
 	dir = 8;
 	icon_state = "dark"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "lk" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel{
 	icon_state = "black"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "lm" = (
 /obj/effect/turf_decal/stripes/asteroid/line,
 /obj/effect/decal/cleanable/dirt,
@@ -3683,20 +3683,20 @@
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "lo" = (
 /obj/structure/barricade/wooden{
 	layer = 4
 	},
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "lp" = (
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "black"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "lq" = (
 /obj/machinery/door/airlock{
 	req_access_txt = "271"
@@ -3708,20 +3708,20 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "lv" = (
 /obj/structure/largecrate,
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "lz" = (
 /obj/machinery/photocopier,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "lC" = (
 /obj/item/reagent_containers/food/snacks/beans,
 /obj/item/reagent_containers/food/snacks/beans{
@@ -3741,7 +3741,7 @@
 	icon_state = "black";
 	dir = 9
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "lD" = (
 /obj/item/kirbyplants,
 /obj/machinery/light/small,
@@ -3749,7 +3749,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "lF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -3763,7 +3763,7 @@
 	icon_state = "caution";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "lH" = (
 /obj/machinery/power/port_gen/pacman{
 	desc = "A portable generator for emergency backup power.";
@@ -3778,7 +3778,7 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "lI" = (
 /obj/item/kirbyplants,
 /obj/effect/decal/cleanable/dirt,
@@ -3786,7 +3786,7 @@
 	icon_state = "caution";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "lL" = (
 /obj/structure/railing{
 	dir = 8
@@ -3797,39 +3797,39 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "lM" = (
 /obj/structure/closet/firecloset,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "lN" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "black";
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "lP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/carpet/royalblue,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "lQ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "dark"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "lS" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/plating/asteroid/airless{
 	icon_state = "asteroid4"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "lT" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -3839,23 +3839,23 @@
 	dir = 8;
 	icon_state = "dark"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "lX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "lY" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "mb" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/carpet,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "md" = (
 /obj/structure/chair/sofa/bench/left{
 	dir = 1
@@ -3864,7 +3864,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "mh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -3878,7 +3878,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "mj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line,
@@ -3886,7 +3886,7 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "mk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -3899,7 +3899,7 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "mm" = (
 /obj/machinery/conveyor/east{
 	id = "awayfusrodah"
@@ -3908,7 +3908,7 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "mn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -3920,14 +3920,14 @@
 	dir = 8;
 	icon_state = "cautioncorner"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "mq" = (
 /obj/machinery/atmospherics/unary/outlet_injector/on{
 	dir = 4;
 	volume_rate = 200
 	},
 /turf/simulated/floor/plating/asteroid/airless,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "mr" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -3937,7 +3937,7 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ms" = (
 /obj/machinery/door/window{
 	dir = 8
@@ -3948,7 +3948,7 @@
 /turf/simulated/floor/plasteel/stairs{
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "mt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -3960,7 +3960,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "cautioncorner"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "mu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery/partial{
@@ -3970,21 +3970,21 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "mv" = (
 /obj/item/kirbyplants,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "mw" = (
 /obj/structure/alien/resin/wall,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "mx" = (
 /obj/machinery/shieldwallgen{
 	locked = 0;
@@ -3993,7 +3993,7 @@
 /obj/structure/cable,
 /obj/effect/turf_decal/box,
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "my" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -4002,7 +4002,7 @@
 	dir = 8;
 	icon_state = "cautioncorner"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "mz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/splatter{
@@ -4011,7 +4011,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "whitehall"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "mB" = (
 /obj/machinery/economy/vending/cigarette,
 /obj/machinery/light/small{
@@ -4026,7 +4026,7 @@
 	dir = 8;
 	icon_state = "escape"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "mC" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	color = "red";
@@ -4038,7 +4038,7 @@
 	icon_state = "whitehall";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "mH" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -4053,26 +4053,26 @@
 	dir = 1;
 	icon_state = "escape"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "mJ" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "mK" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/alien/resin/wall,
 /obj/machinery/atmospherics/air_sensor,
 /turf/simulated/floor/engine,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "mM" = (
 /obj/machinery/floodlight,
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowsiding";
 	dir = 5
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "mS" = (
 /obj/machinery/conveyor/east{
 	id = "awayfusrodah"
@@ -4094,7 +4094,7 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "mT" = (
 /obj/item/kitchen/knife,
 /obj/item/kitchen/rollingpin,
@@ -4103,7 +4103,7 @@
 	icon_state = "showroomfloor";
 	temperature = 273.15
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "mU" = (
 /obj/machinery/shieldwallgen{
 	locked = 0;
@@ -4125,7 +4125,7 @@
 	},
 /obj/effect/turf_decal/box,
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "mV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -4137,7 +4137,7 @@
 	},
 /mob/living/simple_animal/hostile/alien/sentinel,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "mW" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/machinery/computer/security{
@@ -4147,7 +4147,7 @@
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "mX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -4156,7 +4156,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "na" = (
 /obj/structure/sign/nosmoking_1{
 	pixel_x = -32
@@ -4176,7 +4176,7 @@
 	icon_state = "tracks"
 	},
 /turf/simulated/floor/plasteel/stairs,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "nc" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/machinery/light/small{
@@ -4187,28 +4187,28 @@
 	dir = 9;
 	icon_state = "black"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "nf" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
 /obj/structure/alien/resin/wall,
 /turf/simulated/floor/engine,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ng" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkblue";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "nh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
 /turf/simulated/floor/carpet/royalblue,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "nk" = (
 /obj/structure/sign/electricshock{
 	pixel_y = 32
@@ -4218,7 +4218,7 @@
 	dir = 1;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "nl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -4235,23 +4235,23 @@
 	},
 /obj/effect/spawner/window/reinforced/tinted/grilled,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "nm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "nn" = (
 /obj/effect/spawner/window/reinforced/tinted/grilled,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "nt" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "black"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "nu" = (
 /obj/structure/lattice,
 /obj/item/stack/sheet/plasteel,
@@ -4261,14 +4261,14 @@
 /obj/machinery/door/airlock,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "nx" = (
 /obj/machinery/door/airlock/centcom{
 	req_access_txt = "271";
 	name = "Engineering Division"
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ny" = (
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating/airless,
@@ -4280,7 +4280,7 @@
 	dir = 8;
 	icon_state = "dark"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "nA" = (
 /obj/structure/rack,
 /obj/item/flashlight/flare,
@@ -4291,7 +4291,7 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "nC" = (
 /obj/structure/closet/secure_closet,
 /obj/machinery/camera{
@@ -4304,7 +4304,7 @@
 	icon_state = "black";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "nE" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -4317,7 +4317,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/engine,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "nG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/splatter{
@@ -4327,14 +4327,14 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "nI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "nJ" = (
 /obj/structure/railing/cap{
 	dir = 10
@@ -4349,7 +4349,7 @@
 	dir = 4;
 	icon_state = "green"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "nK" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -4360,7 +4360,7 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "nO" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/machinery/light/small{
@@ -4371,14 +4371,14 @@
 	icon_state = "black";
 	dir = 9
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "nQ" = (
 /obj/structure/railing,
 /obj/structure/closet/cardboard,
 /turf/simulated/floor/plasteel{
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "nV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -4387,7 +4387,7 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "nW" = (
 /obj/structure/railing{
 	dir = 10
@@ -4396,7 +4396,7 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "nX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -4406,14 +4406,14 @@
 	},
 /mob/living/simple_animal/hostile/alien,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "nZ" = (
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "oc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -4428,13 +4428,13 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "od" = (
 /obj/structure/chair/office/dark,
 /turf/simulated/floor/plasteel{
 	icon_state = "black"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "oh" = (
 /obj/structure/sign/poster/contraband/lusty_xenomorph{
 	pixel_y = 32
@@ -4445,7 +4445,7 @@
 	dir = 5;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "oi" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -4460,7 +4460,7 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ok" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -4471,13 +4471,13 @@
 	},
 /mob/living/simple_animal/hostile/alien,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "on" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "oo" = (
 /obj/structure/chair/office/dark,
 /obj/effect/decal/cleanable/dirt,
@@ -4485,14 +4485,14 @@
 	icon_state = "white";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "op" = (
 /mob/living/simple_animal/hostile/alien/sentinel,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "or" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -4501,13 +4501,13 @@
 /obj/structure/window/basic,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ot" = (
 /obj/structure/railing{
 	dir = 8
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ov" = (
 /obj/effect/turf_decal/caution/stand_clear/white{
 	dir = 4
@@ -4516,14 +4516,14 @@
 	icon_state = "caution";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ow" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "oA" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	color = "red";
@@ -4536,7 +4536,7 @@
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "oD" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -4544,7 +4544,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "escape"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "oF" = (
 /obj/structure/chair/sofa/bench/left,
 /obj/machinery/camera{
@@ -4556,7 +4556,7 @@
 	icon_state = "whitecorner";
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "oH" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable{
@@ -4573,7 +4573,7 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "oJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/tracks{
@@ -4585,7 +4585,7 @@
 	pixel_y = 9
 	},
 /turf/simulated/floor/plating/asteroid/ancient,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "oL" = (
 /obj/structure/rack,
 /obj/structure/window/reinforced{
@@ -4593,7 +4593,7 @@
 	},
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "oM" = (
 /obj/structure/chair{
 	dir = 1
@@ -4602,7 +4602,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "oP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -4615,12 +4615,12 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "oR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille/broken,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "oS" = (
 /obj/structure/railing{
 	dir = 8
@@ -4629,7 +4629,7 @@
 /turf/simulated/floor/plasteel/stairs{
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "oT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -4637,14 +4637,14 @@
 	dir = 4;
 	icon_state = "green"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "oU" = (
 /obj/item/kirbyplants,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "oX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -4652,7 +4652,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "greencorner"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "oZ" = (
 /obj/effect/decal/cleanable/blood/splatter{
 	color = "red"
@@ -4667,14 +4667,14 @@
 	pixel_x = 10
 	},
 /turf/simulated/floor/plating/asteroid/ancient,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "pa" = (
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "pe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -4691,13 +4691,13 @@
 	},
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ph" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/plating/asteroid/airless{
 	icon_state = "asteroid4"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "pi" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 4
@@ -4709,20 +4709,20 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "escape"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "pm" = (
 /obj/structure/largecrate,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "pn" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/plating/asteroid/airless{
 	icon_state = "asteroid3"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "pp" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -4737,7 +4737,7 @@
 /obj/item/clothing/gloves/color/yellow,
 /obj/structure/table/reinforced,
 /turf/simulated/floor/engine,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "pq" = (
 /obj/structure/railing/cap{
 	dir = 5
@@ -4747,7 +4747,7 @@
 	dir = 4;
 	icon_state = "blackcorner"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "pr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -4758,7 +4758,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ps" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -4768,7 +4768,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "pt" = (
 /obj/structure/railing{
 	dir = 1
@@ -4776,7 +4776,7 @@
 /obj/structure/rack,
 /obj/item/flashlight/flare/glowstick,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "pu" = (
 /obj/effect/decal/cleanable/greenglow,
 /obj/structure/railing/cap{
@@ -4786,19 +4786,19 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "pz" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "pB" = (
 /obj/structure/rack,
 /obj/item/paicard{
 	pixel_x = -4
 	},
 /turf/simulated/floor/carpet/royalblue,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "pD" = (
 /obj/structure/chair/sofa/bench/right{
 	dir = 4
@@ -4807,12 +4807,12 @@
 	icon_state = "caution";
 	dir = 10
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "pE" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowsiding"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "pF" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/effect/decal/cleanable/dirt,
@@ -4820,7 +4820,7 @@
 	icon_state = "escape";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "pI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -4829,17 +4829,17 @@
 	icon_state = "blackcorner";
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "pK" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/asteroid/ancient,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "pL" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/cobweb2,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "pN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/xeno{
@@ -4850,7 +4850,7 @@
 	desc = "They look like the remains of something... alien. The front of skull appears to have been completely obliterated."
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "pP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -4860,7 +4860,7 @@
 	icon_state = "white";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "pQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -4878,11 +4878,11 @@
 	dir = 8;
 	icon_state = "cautioncorner"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "pR" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "pS" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -4892,7 +4892,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "pV" = (
 /obj/machinery/door/poddoor/impassable{
 	id_tag = "awayscilock"
@@ -4902,7 +4902,7 @@
 	name = "Research Division"
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "pW" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable{
@@ -4914,12 +4914,12 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "pZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/reagent_containers/food/snacks/badrecipe,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "qa" = (
 /obj/structure/chair/sofa/bench{
 	dir = 8
@@ -4934,7 +4934,7 @@
 	icon_state = "caution";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "qb" = (
 /obj/structure/railing/cap{
 	dir = 10
@@ -4946,7 +4946,7 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "qc" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/alien/sentinel,
@@ -4954,7 +4954,7 @@
 	icon_state = "caution";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "qj" = (
 /obj/structure/railing/cap{
 	dir = 9
@@ -4962,7 +4962,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "qm" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -4977,7 +4977,7 @@
 	id = "mo19rdoffice"
 	},
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "qo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -4988,7 +4988,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "qp" = (
 /obj/structure/railing{
 	dir = 8
@@ -4997,7 +4997,7 @@
 	icon_state = "yellowsiding";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "qq" = (
 /obj/structure/table/reinforced,
 /obj/item/clipboard{
@@ -5012,7 +5012,7 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "qr" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -5021,7 +5021,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "qt" = (
 /obj/machinery/power/smes{
 	input_level = 10000;
@@ -5031,14 +5031,14 @@
 	},
 /obj/structure/cable,
 /turf/simulated/floor/engine,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "qu" = (
 /obj/item/kirbyplants,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "escape"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "qv" = (
 /obj/structure/disposalpipe/segment{
 	desc = "An underfloor disposal pipe. This one has been applied with an acid-proof coating.";
@@ -5050,14 +5050,14 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "qx" = (
 /obj/machinery/door/airlock/centcom{
 	req_access_txt = "271";
 	name = "Cafeteria"
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "qA" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	color = "red";
@@ -5070,7 +5070,7 @@
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "qB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -5083,7 +5083,7 @@
 	dir = 6;
 	icon_state = "escape"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "qC" = (
 /obj/structure/chair/sofa/bench/left{
 	dir = 8
@@ -5097,7 +5097,7 @@
 	icon_state = "caution";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "qD" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -5106,14 +5106,14 @@
 	icon_state = "white";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "qF" = (
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "qI" = (
 /obj/structure/railing{
 	dir = 1
@@ -5122,7 +5122,7 @@
 	dir = 1;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "qM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -5134,7 +5134,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "qQ" = (
 /obj/machinery/kitchen_machine/grill,
 /obj/machinery/light/small{
@@ -5145,7 +5145,7 @@
 	icon_state = "showroomfloor";
 	temperature = 273.15
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "qS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb2,
@@ -5155,14 +5155,14 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "qY" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "black"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "re" = (
 /obj/structure/railing/cap{
 	dir = 8
@@ -5174,14 +5174,14 @@
 	icon_state = "darkblue";
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "rf" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
 /obj/effect/decal/cleanable/cobweb2,
 /obj/item/toy/plushie/lizardplushie,
 /turf/simulated/floor/carpet,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ri" = (
 /obj/item/radio/off{
 	pixel_x = -8
@@ -5201,7 +5201,7 @@
 /obj/item/coin/antagtoken/syndicate,
 /obj/structure/table,
 /turf/simulated/floor/plating/asteroid/ancient,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "rk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/damageturf,
@@ -5212,7 +5212,7 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "rl" = (
 /obj/structure/sink{
 	dir = 8;
@@ -5223,7 +5223,7 @@
 	icon_state = "darkblue";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "rm" = (
 /obj/structure/railing/cap,
 /obj/structure/railing/cap{
@@ -5236,7 +5236,7 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ro" = (
 /obj/structure/railing/cap,
 /obj/structure/alien/resin/wall,
@@ -5244,7 +5244,7 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "rp" = (
 /obj/effect/decal/cleanable/blood/xeno{
 	color = "green"
@@ -5253,7 +5253,7 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "rq" = (
 /obj/structure/railing/cap{
 	dir = 6
@@ -5261,7 +5261,7 @@
 /turf/simulated/floor/plasteel/stairs{
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "rs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
@@ -5277,27 +5277,27 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ru" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "green"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "rv" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "whitehall";
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "rx" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ry" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/glasses/meson,
@@ -5308,7 +5308,7 @@
 	},
 /obj/item/paper/fluff/ruins/moonoutpost19/engineering,
 /turf/simulated/floor/engine,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "rB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -5318,7 +5318,7 @@
 	dir = 8;
 	icon_state = "escape"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "rC" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -5326,7 +5326,7 @@
 /turf/simulated/floor/plating/asteroid/airless{
 	icon_state = "asteroid5"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "rD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -5336,7 +5336,7 @@
 	dir = 1;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "rE" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	color = "red";
@@ -5346,26 +5346,26 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "rG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/plating/asteroid/ancient,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "rH" = (
 /obj/item/kirbyplants,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "escape"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "rJ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "black"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "rK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -5385,14 +5385,14 @@
 	icon_state = "whitecorner";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "rL" = (
 /obj/structure/chair/sofa/bench/left,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "rN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -5401,11 +5401,11 @@
 	icon_state = "white";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "rP" = (
 /obj/structure/flora/ash/rock/style_random,
 /turf/simulated/floor/plating/asteroid/ancient,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "rQ" = (
 /obj/structure/railing/cap,
 /obj/effect/decal/cleanable/blood/splatter{
@@ -5415,7 +5415,7 @@
 	icon_state = "yellowsiding";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "rS" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -5434,7 +5434,7 @@
 	stat = 2
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "rT" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -5447,7 +5447,7 @@
 	icon_state = "black";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "rV" = (
 /obj/machinery/door/airlock{
 	req_access_txt = "271";
@@ -5457,13 +5457,13 @@
 	dir = 8;
 	icon_state = "green"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "rW" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "escapecorner";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "rY" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -5472,13 +5472,13 @@
 	icon_state = "caution";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "rZ" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_access_txt = "271"
 	},
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "sa" = (
 /obj/structure/sign/radiation/rad_area{
 	pixel_y = 32
@@ -5489,14 +5489,14 @@
 /turf/simulated/floor/plasteel/stairs{
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "sc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/splatter{
 	color = "red"
 	},
 /turf/simulated/floor/carpet,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "se" = (
 /obj/effect/turf_decal/stripes/asteroid/corner{
 	dir = 8
@@ -5504,7 +5504,7 @@
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "sg" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/railing,
@@ -5512,7 +5512,7 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "sh" = (
 /obj/machinery/recharger{
 	pixel_y = 4
@@ -5524,7 +5524,7 @@
 	},
 /obj/structure/table/reinforced,
 /turf/simulated/floor/engine,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "si" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -5532,7 +5532,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "sj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -5540,7 +5540,7 @@
 	icon_state = "black";
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "sk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -5557,7 +5557,7 @@
 	icon_state = "cautioncorner";
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "sl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -5569,11 +5569,11 @@
 	},
 /obj/structure/alien/resin/wall,
 /turf/simulated/floor/engine,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "sm" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "sn" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -5586,7 +5586,7 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "so" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -5594,7 +5594,7 @@
 /turf/simulated/floor/plating/asteroid/airless{
 	icon_state = "asteroid6"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "sp" = (
 /obj/item/kirbyplants,
 /obj/structure/railing,
@@ -5607,7 +5607,7 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "sq" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -5617,7 +5617,7 @@
 	dir = 8;
 	icon_state = "dark"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "sv" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -5627,15 +5627,15 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/engine,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "sy" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/wall/r_wall,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "sF" = (
 /obj/effect/spawner/random_spawners/wall_rusted_always,
 /turf/simulated/wall/indestructible/riveted,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "sK" = (
 /obj/structure/chair/sofa/bench/left{
 	dir = 8
@@ -5644,34 +5644,34 @@
 	icon_state = "escape";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "sL" = (
 /obj/machinery/door/airlock/external/glass,
 /turf/simulated/floor/plating/asteroid/ancient,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "sR" = (
 /obj/structure/chair/sofa/bench/left,
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "sV" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/grass,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "sY" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "sZ" = (
 /obj/structure/chair/office/dark,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "dark"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "tb" = (
 /obj/structure/sign/securearea{
 	pixel_x = -32
@@ -5683,14 +5683,14 @@
 	icon_state = "caution";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "tc" = (
 /obj/structure/railing{
 	dir = 4
 	},
 /obj/item/kirbyplants,
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "td" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -5698,7 +5698,7 @@
 	icon_state = "cautioncorner";
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "te" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -5708,7 +5708,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "tf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -5720,20 +5720,20 @@
 	},
 /obj/machinery/atmospherics/air_sensor,
 /turf/simulated/floor/engine,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "th" = (
 /obj/structure/chair/office/dark{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "tj" = (
 /obj/structure/railing/cap,
 /obj/structure/flora/ash/rock/style_random,
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/plating/asteroid/airless,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "tk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -5753,7 +5753,7 @@
 	pixel_x = 2
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "tl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/blood/tracks{
@@ -5765,21 +5765,21 @@
 	pixel_x = 2
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "tm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "to" = (
 /obj/structure/railing{
 	dir = 4
 	},
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/plating/asteroid/airless,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "tp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -5791,11 +5791,11 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "tv" = (
 /obj/structure/largecrate,
 /turf/simulated/floor/plating/asteroid/ancient,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "tw" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
@@ -5808,12 +5808,12 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "tx" = (
 /obj/structure/window/reinforced,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "tD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/noticeboard{
@@ -5822,12 +5822,12 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "tE" = (
 /obj/structure/closet/crate/secure/loot,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "tG" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -5841,7 +5841,7 @@
 	icon_state = "whitecorner";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "tI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/splatter{
@@ -5850,7 +5850,7 @@
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "tR" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
@@ -5863,7 +5863,7 @@
 	icon_state = "white";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "tV" = (
 /obj/effect/decal/cleanable/blood/splatter{
 	color = "red"
@@ -5872,21 +5872,21 @@
 	dir = 1;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "tW" = (
 /obj/structure/grille/broken,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "tX" = (
 /turf/simulated/wall/indestructible/rock,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "tY" = (
 /obj/machinery/economy/vending/dinnerware,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "tZ" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -5898,7 +5898,7 @@
 	stat = 2
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ub" = (
 /obj/structure/cable,
 /obj/machinery/power/smes{
@@ -5908,7 +5908,7 @@
 	outputting = 0
 	},
 /turf/simulated/floor/engine,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "uf" = (
 /obj/structure/window/reinforced,
 /mob/living/simple_animal/hostile/alien/drone,
@@ -5916,14 +5916,14 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ug" = (
 /obj/structure/railing{
 	dir = 6
 	},
 /obj/structure/chair,
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "uh" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -5938,12 +5938,12 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "uj" = (
 /obj/effect/decal/remains/human,
 /obj/item/reagent_containers/hypospray/autoinjector/survival,
 /turf/simulated/floor/plating/asteroid/airless,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "up" = (
 /obj/structure/chair/sofa/bench{
 	dir = 8
@@ -5952,7 +5952,7 @@
 	icon_state = "escape";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ur" = (
 /obj/machinery/light/small{
 	active_power_consumption = 0;
@@ -5965,7 +5965,7 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "uv" = (
 /obj/structure/railing/cap{
 	dir = 9
@@ -5973,7 +5973,7 @@
 /turf/simulated/floor/plating/asteroid/airless{
 	icon_state = "asteroid12"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "uw" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
@@ -5983,14 +5983,14 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "uA" = (
 /obj/structure/closet/crate,
 /turf/simulated/floor/plasteel{
 	icon_state = "white";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "uG" = (
 /obj/structure/railing{
 	dir = 4
@@ -5998,7 +5998,7 @@
 /turf/simulated/floor/plasteel/stairs{
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "uJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -6016,7 +6016,7 @@
 	},
 /obj/effect/spawner/window/reinforced/tinted/grilled,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "uM" = (
 /obj/machinery/light/small,
 /obj/structure/noticeboard{
@@ -6025,7 +6025,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "black"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "uO" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/fancy/vials,
@@ -6033,14 +6033,14 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "uP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
 /obj/structure/alien/resin/wall,
 /turf/simulated/floor/engine,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "uR" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	color = "red";
@@ -6050,7 +6050,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "uS" = (
 /obj/structure/railing{
 	dir = 8
@@ -6062,7 +6062,7 @@
 	icon_state = "black";
 	dir = 9
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "uT" = (
 /obj/structure/railing/cap{
 	dir = 10
@@ -6071,26 +6071,26 @@
 	icon_state = "yellowsiding";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "uV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "uX" = (
 /obj/structure/table/glass/reinforced/titanium,
 /obj/item/paper_bin,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "va" = (
 /obj/machinery/economy/vending/cola,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "vd" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -6103,14 +6103,14 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ve" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "vf" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -6120,7 +6120,7 @@
 	dir = 1;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "vh" = (
 /obj/structure/rack,
 /obj/item/mecha_parts/core,
@@ -6129,26 +6129,26 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "vm" = (
 /obj/machinery/atmospherics/portable/canister/air,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "vn" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "black"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "vq" = (
 /obj/structure/railing/cap{
 	dir = 1
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "vy" = (
 /obj/structure/railing/cap{
 	dir = 1
@@ -6159,14 +6159,14 @@
 /turf/simulated/floor/plasteel/stairs{
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "vz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitehall";
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "vA" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin{
@@ -6182,7 +6182,7 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "vB" = (
 /obj/item/kirbyplants,
 /obj/machinery/light/small{
@@ -6192,7 +6192,7 @@
 	icon_state = "escape";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "vC" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
@@ -6201,26 +6201,26 @@
 	icon_state = "whitehall";
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "vD" = (
 /obj/structure/railing{
 	dir = 1
 	},
 /turf/simulated/floor/plating/asteroid/airless,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "vF" = (
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitecorner";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "vH" = (
 /obj/structure/railing/cap{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "vL" = (
 /obj/structure/noticeboard{
 	pixel_y = 32
@@ -6229,14 +6229,14 @@
 	dir = 1
 	},
 /turf/simulated/floor/carpet/royalblue,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "vN" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor";
 	temperature = 273.15
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "vO" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -6247,14 +6247,14 @@
 	dir = 8;
 	icon_state = "dark"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "vS" = (
 /obj/structure/alien/resin/door,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "vT" = (
 /obj/structure/railing/cap{
 	dir = 6
@@ -6262,7 +6262,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "vV" = (
 /obj/structure/flora/ausbushes/pointybush,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -6270,7 +6270,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/grass,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "vY" = (
 /obj/structure/railing,
 /obj/structure/railing{
@@ -6283,7 +6283,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "wb" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	color = "red";
@@ -6295,7 +6295,7 @@
 	icon_state = "white";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "wc" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	color = "red";
@@ -6307,7 +6307,7 @@
 	icon_state = "darkbluecorners";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "wd" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
@@ -6320,7 +6320,7 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "we" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/structure/sign/poster/contraband/donut_corp{
@@ -6331,7 +6331,7 @@
 	dir = 8;
 	icon_state = "escape"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "wh" = (
 /obj/item/chair{
 	dir = 4;
@@ -6342,17 +6342,17 @@
 	icon_state = "black";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "wj" = (
 /obj/structure/railing/cap,
 /turf/simulated/floor/plasteel/stairs{
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "wk" = (
 /obj/machinery/computer,
 /turf/simulated/floor/plating/asteroid/ancient,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "wl" = (
 /obj/item/stack/ore/slag,
 /turf/simulated/floor/engine/vacuum,
@@ -6367,14 +6367,14 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "wp" = (
 /obj/item/kirbyplants,
 /turf/simulated/floor/plasteel{
 	icon_state = "caution";
 	dir = 5
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "wq" = (
 /obj/machinery/light/small,
 /obj/structure/closet/l3closet/general,
@@ -6382,26 +6382,26 @@
 	icon_state = "whitehall";
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "wt" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "wv" = (
 /obj/item/kirbyplants,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "wC" = (
 /obj/structure/closet/cabinet,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/under/syndicate,
 /turf/simulated/floor/carpet,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "wD" = (
 /obj/machinery/economy/vending/cola,
 /obj/effect/decal/cleanable/dirt,
@@ -6409,7 +6409,7 @@
 	icon_state = "escape";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "wF" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -6421,26 +6421,26 @@
 	dir = 8;
 	icon_state = "dark"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "wH" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "wL" = (
 /obj/item/reagent_containers/food/drinks/drinkingglass,
 /obj/structure/table,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "wP" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engine Room"
 	},
 /obj/machinery/door/firedoor/closed,
 /turf/simulated/floor/plating/airless,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "wQ" = (
 /obj/structure/railing{
 	dir = 4
@@ -6448,7 +6448,7 @@
 /obj/structure/rack,
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "wR" = (
 /obj/structure/sign/monkey_paint{
 	pixel_x = -28;
@@ -6461,7 +6461,7 @@
 	icon_state = "black";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "wS" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
@@ -6470,7 +6470,7 @@
 	},
 /obj/effect/decal/remains/human,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "wU" = (
 /obj/structure/chair/office/dark,
 /obj/effect/turf_decal/delivery/red/partial,
@@ -6479,7 +6479,7 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "xf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -6496,20 +6496,20 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "xh" = (
 /obj/structure/railing/cap,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "green"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "xi" = (
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plasteel/stairs{
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "xl" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -6523,7 +6523,7 @@
 	icon_state = "whitecorner";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "xm" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -6537,7 +6537,7 @@
 	dir = 4;
 	icon_state = "black"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "xn" = (
 /obj/structure/railing{
 	dir = 4
@@ -6545,13 +6545,13 @@
 /turf/simulated/floor/plating/asteroid/airless{
 	icon_state = "asteroid10"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "xo" = (
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "xs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -6570,7 +6570,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "xt" = (
 /obj/structure/railing{
 	dir = 8
@@ -6582,7 +6582,7 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "xu" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 1
@@ -6590,12 +6590,12 @@
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "xw" = (
 /obj/structure/closet/crate/can,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "xz" = (
 /obj/structure/sign/lifestar{
 	pixel_y = 32
@@ -6611,7 +6611,7 @@
 	dir = 1;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "xA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -6619,7 +6619,7 @@
 	icon_state = "caution";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "xC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -6631,7 +6631,7 @@
 	dir = 1;
 	icon_state = "escape"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "xE" = (
 /obj/structure/chair/sofa/bench/right{
 	dir = 1
@@ -6640,7 +6640,7 @@
 	dir = 6;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "xF" = (
 /obj/structure/chair/sofa/bench/right{
 	dir = 8
@@ -6649,15 +6649,15 @@
 	dir = 5;
 	icon_state = "escape"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "xG" = (
 /turf/simulated/floor/engine,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "xL" = (
 /turf/simulated/floor/plasteel/stairs{
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "xO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -6666,7 +6666,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "xS" = (
 /obj/structure/railing/cap{
 	dir = 10
@@ -6677,18 +6677,18 @@
 	icon_state = "yellowsiding";
 	dir = 5
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "xW" = (
 /obj/machinery/door/airlock,
 /turf/simulated/floor/carpet,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "xX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "xZ" = (
 /obj/machinery/disposal/deliveryChute{
 	dir = 8
@@ -6699,7 +6699,7 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ya" = (
 /obj/structure/chair/sofa/bench{
 	dir = 8
@@ -6711,13 +6711,13 @@
 	icon_state = "escape";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "yb" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/simulated/floor/carpet,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "yc" = (
 /obj/machinery/computer{
 	dir = 8
@@ -6726,13 +6726,13 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "yd" = (
 /obj/structure/railing,
 /turf/simulated/floor/plasteel/stairs{
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "yf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -6741,7 +6741,7 @@
 	icon_state = "white";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "yi" = (
 /obj/structure/rack,
 /obj/item/pickaxe,
@@ -6750,7 +6750,7 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "yj" = (
 /obj/item/storage/belt/utility,
 /obj/structure/table,
@@ -6758,7 +6758,7 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ym" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -6775,7 +6775,7 @@
 	icon_state = "white";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ys" = (
 /obj/structure/railing{
 	dir = 8
@@ -6783,7 +6783,7 @@
 /turf/simulated/floor/plasteel/stairs{
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "yu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -6796,7 +6796,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "yv" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -6819,7 +6819,7 @@
 	icon_state = "whitecorner";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "yx" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -6828,14 +6828,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "yy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/engine,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "yB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -6843,7 +6843,7 @@
 	icon_state = "whitecorner";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "yD" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/delivery,
@@ -6857,7 +6857,7 @@
 	icon_state = "yellowsiding";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "yE" = (
 /obj/item/stack/sheet/metal,
 /obj/effect/landmark/damageturf,
@@ -6868,12 +6868,12 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "yF" = (
 /obj/structure/table/wood,
 /obj/item/toy/plushie/nianplushie,
 /turf/simulated/floor/carpet,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "yG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -6882,7 +6882,7 @@
 	pixel_y = -3
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "yI" = (
 /obj/structure/railing/cap{
 	dir = 1
@@ -6891,7 +6891,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/plating/asteroid/airless,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "yM" = (
 /obj/structure/railing/cap{
 	dir = 4
@@ -6900,13 +6900,13 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "yO" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/plating/asteroid/airless{
 	icon_state = "asteroid8"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "yQ" = (
 /obj/structure/table/glass/reinforced/plastitanium,
 /obj/machinery/door_control{
@@ -6933,7 +6933,7 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "yR" = (
 /obj/item/reagent_containers/food/snacks/xenomeatbreadslice,
 /obj/item/reagent_containers/food/snacks/xenomeatbreadslice{
@@ -6952,12 +6952,12 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "yU" = (
 /obj/item/reagent_containers/food/snacks/candy,
 /obj/structure/table,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "yX" = (
 /obj/structure/railing/cap{
 	dir = 4
@@ -6970,20 +6970,20 @@
 /turf/simulated/floor/plasteel/stairs{
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "yZ" = (
 /obj/structure/closet/cabinet,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/carpet,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "zh" = (
 /obj/item/reagent_containers/food/snacks/badrecipe,
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor";
 	temperature = 273.15
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "zi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -7002,7 +7002,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "zj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -7013,33 +7013,33 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "zl" = (
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "zm" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "escapecorner";
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "zn" = (
 /obj/effect/spawner/random_spawners/wall_rusted_always,
 /obj/effect/spawner/random_spawners/wall_rusted_always,
 /turf/simulated/wall/r_wall,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "zr" = (
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "green"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "zu" = (
 /obj/structure/alien/resin/wall,
 /obj/structure/cable{
@@ -7048,7 +7048,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "zv" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/food/snacks/cornchips,
@@ -7056,14 +7056,14 @@
 	dir = 8;
 	icon_state = "escape"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "zw" = (
 /obj/machinery/computer/aifixer,
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/simulated/floor/carpet/royalblue,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "zy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -7083,7 +7083,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "zz" = (
 /obj/structure/window/reinforced,
 /obj/structure/chair/comfy/corp{
@@ -7092,11 +7092,11 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "black"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "zE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "zG" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -7107,13 +7107,13 @@
 	icon_state = "caution";
 	dir = 10
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "zI" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "escape"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "zK" = (
 /obj/item/kirbyplants,
 /obj/structure/sign/biohazard{
@@ -7131,7 +7131,7 @@
 	dir = 1;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "zL" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -7143,21 +7143,21 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "zM" = (
 /obj/machinery/cooker/deepfryer,
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor";
 	temperature = 273.15
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "zN" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "zP" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/effect/decal/cleanable/dirt,
@@ -7165,7 +7165,7 @@
 	icon_state = "showroomfloor";
 	temperature = 273.15
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "zQ" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 8
@@ -7180,12 +7180,12 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "zT" = (
 /turf/simulated/floor/plating/asteroid/airless{
 	icon_state = "asteroid3"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "zV" = (
 /obj/machinery/economy/vending/medical{
 	req_access_txt = "271"
@@ -7194,24 +7194,24 @@
 	icon_state = "whitecorner";
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "zW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Aa" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Ae" = (
 /obj/machinery/economy/vending/coffee,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Af" = (
 /obj/machinery/door/airlock/command/glass{
 	req_access_txt = "271";
@@ -7224,18 +7224,18 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Aj" = (
 /mob/living/simple_animal/hostile/alien/sentinel,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Ak" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "cautioncorner";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Al" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/corner{
@@ -7245,7 +7245,7 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Am" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
@@ -7253,7 +7253,7 @@
 /turf/simulated/floor/plasteel/stairs{
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "An" = (
 /obj/structure/punching_bag,
 /obj/effect/turf_decal/delivery/hollow,
@@ -7265,7 +7265,7 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Ao" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -7274,7 +7274,7 @@
 	color = "red"
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Ap" = (
 /obj/structure/chair{
 	dir = 1
@@ -7283,7 +7283,7 @@
 	icon_state = "whitehall";
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Ar" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/railing{
@@ -7293,7 +7293,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "escape"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "As" = (
 /obj/structure/closet/secure_closet,
 /obj/item/clothing/gloves/color/latex,
@@ -7306,7 +7306,7 @@
 /obj/item/laser_pointer,
 /obj/item/clothing/suit/storage/labcoat,
 /turf/simulated/floor/carpet/royalblue,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Av" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	color = "red";
@@ -7320,7 +7320,7 @@
 	icon_state = "whitehall";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Aw" = (
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -7333,37 +7333,37 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Ay" = (
 /obj/structure/railing{
 	dir = 5
 	},
 /obj/structure/closet/l3closet/general,
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Az" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "AA" = (
 /obj/structure/chair{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "AH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/chair{
 	pixel_y = -3
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "AI" = (
 /obj/structure/table,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "AJ" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	color = "red";
@@ -7373,13 +7373,13 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "AL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "AM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -7390,7 +7390,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "AN" = (
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/glass,
@@ -7399,7 +7399,7 @@
 	icon_state = "medium"
 	},
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "AO" = (
 /obj/structure/railing/cap{
 	dir = 5
@@ -7412,10 +7412,10 @@
 /turf/simulated/floor/plasteel/stairs{
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "AP" = (
 /turf/simulated/wall/indestructible/riveted,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "AQ" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -7431,14 +7431,14 @@
 	icon_state = "yellowsiding";
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "AR" = (
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowsiding";
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "AS" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -7448,7 +7448,7 @@
 	dir = 1;
 	icon_state = "black"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "AV" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/glass/beaker{
@@ -7467,7 +7467,7 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "AZ" = (
 /obj/machinery/atmospherics/unary/tank/air{
 	dir = 8
@@ -7478,7 +7478,7 @@
 	icon_state = "yellowsiding";
 	dir = 6
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Bd" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -7487,19 +7487,19 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Be" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Bg" = (
 /turf/simulated/floor/plasteel/stairs{
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Bj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -7512,14 +7512,14 @@
 	icon_state = "caution";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Bk" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Br" = (
 /obj/structure/railing{
 	dir = 4
@@ -7531,7 +7531,7 @@
 	icon_state = "black";
 	dir = 5
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Bt" = (
 /obj/structure/disposalpipe/segment{
 	desc = "An underfloor disposal pipe. This one has been applied with an acid-proof coating.";
@@ -7541,7 +7541,7 @@
 /obj/structure/alien/resin/wall,
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Bu" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	color = "red";
@@ -7553,7 +7553,7 @@
 	pixel_x = 2
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Bv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -7565,7 +7565,7 @@
 	dir = 6;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Bw" = (
 /obj/structure/railing/cap{
 	dir = 6
@@ -7577,7 +7577,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Bx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -7588,7 +7588,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/engine,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "BA" = (
 /obj/structure/railing{
 	dir = 4
@@ -7600,7 +7600,7 @@
 /turf/simulated/floor/plating/asteroid/airless{
 	icon_state = "asteroid12"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "BB" = (
 /obj/structure/railing{
 	dir = 8
@@ -7610,11 +7610,11 @@
 	icon_state = "yellowsiding";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "BC" = (
 /obj/machinery/economy/vending/boozeomat,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "BE" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/reinforced/normal{
@@ -7628,7 +7628,7 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "BF" = (
 /obj/item/chair{
 	pixel_y = -6;
@@ -7639,7 +7639,7 @@
 	icon_state = "yellowsiding";
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "BI" = (
 /obj/machinery/door/poddoor/impassable{
 	id_tag = "awayscilock"
@@ -7648,12 +7648,12 @@
 	req_access_txt = "271"
 	},
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "BK" = (
 /obj/structure/railing,
 /obj/structure/chair,
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "BO" = (
 /obj/machinery/door/airlock/engineering/glass{
 	req_access_txt = "271";
@@ -7671,13 +7671,13 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "BQ" = (
 /obj/structure/railing{
 	dir = 9
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "BY" = (
 /obj/structure/railing{
 	dir = 8
@@ -7687,7 +7687,7 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "BZ" = (
 /obj/effect/decal/cleanable/blood/splatter{
 	color = "red"
@@ -7696,20 +7696,20 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Cc" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/plating/asteroid/airless{
 	icon_state = "asteroid6"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Cd" = (
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Ci" = (
 /obj/structure/railing{
 	dir = 1
@@ -7718,7 +7718,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "whitehall"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Cm" = (
 /obj/structure/table/glass/reinforced/plastitanium,
 /obj/item/paper/fluff/ruins/moonoutpost19/boreraccountant,
@@ -7726,7 +7726,7 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Cr" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -7741,7 +7741,7 @@
 	name = "Specimen Containtment Zone"
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Cs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
@@ -7749,7 +7749,7 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Ct" = (
 /obj/machinery/door/airlock/highsecurity{
 	req_access_txt = "271"
@@ -7761,7 +7761,7 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Cv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -7780,7 +7780,7 @@
 	name = "Engineering Division"
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Cw" = (
 /obj/item/chair{
 	pixel_x = 4;
@@ -7790,7 +7790,7 @@
 	icon_state = "black";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Cy" = (
 /obj/structure/rack,
 /obj/item/mop,
@@ -7799,7 +7799,7 @@
 	dir = 9;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "CB" = (
 /obj/machinery/economy/vending/coffee,
 /obj/effect/decal/cleanable/dirt,
@@ -7807,7 +7807,7 @@
 	icon_state = "whitecorner";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "CC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -7817,25 +7817,25 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "CE" = (
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "CH" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/cobweb2,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating/asteroid/ancient,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "CI" = (
 /turf/simulated/floor/plating/asteroid/airless{
 	icon_state = "asteroidplating"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "CJ" = (
 /obj/structure/chair/stool/bar{
 	dir = 8
@@ -7850,14 +7850,14 @@
 	dir = 8;
 	icon_state = "escape"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "CL" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "black"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "CM" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -7868,7 +7868,7 @@
 	icon_state = "whitecorner";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "CR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -7881,18 +7881,18 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "CS" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "escape"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "CV" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/machinery/atmospherics/portable/scrubber,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "CW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -7906,11 +7906,11 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "CY" = (
 /obj/structure/rack,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "CZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -7920,10 +7920,10 @@
 	},
 /obj/effect/decal/remains/human,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Da" = (
 /turf/simulated/floor/plasteel/stairs,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Dc" = (
 /obj/structure/chair/sofa/bench/left{
 	dir = 1
@@ -7932,13 +7932,13 @@
 	dir = 10;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Dd" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/plating/asteroid/airless{
 	icon_state = "asteroid1"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "De" = (
 /obj/structure/closet/crate,
 /obj/item/reagent_containers/glass/beaker/waterbottle,
@@ -7948,14 +7948,14 @@
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Df" = (
 /obj/structure/chair{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Di" = (
 /obj/machinery/light{
 	dir = 8
@@ -7964,7 +7964,7 @@
 	icon_state = "caution";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Dk" = (
 /obj/effect/turf_decal/delivery/white/partial{
 	dir = 1
@@ -7974,12 +7974,12 @@
 	icon_state = "whitehall";
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Dl" = (
 /obj/structure/rack,
 /obj/item/tank/internals/emergency_oxygen,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Dn" = (
 /obj/structure/railing{
 	dir = 9
@@ -7989,14 +7989,14 @@
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Dp" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "black";
 	dir = 10
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Dr" = (
 /obj/effect/turf_decal/delivery/hollow,
 /obj/structure/railing{
@@ -8005,7 +8005,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "escape"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Ds" = (
 /obj/effect/turf_decal/caution/stand_clear{
 	dir = 8
@@ -8017,7 +8017,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "escape"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Dt" = (
 /obj/machinery/door/airlock/medical/glass{
 	req_access_txt = "271"
@@ -8032,14 +8032,14 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Dw" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Dy" = (
 /obj/item/kirbyplants,
 /obj/structure/sign/biohazard{
@@ -8052,7 +8052,7 @@
 	dir = 1;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "DA" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/cable{
@@ -8061,13 +8061,13 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "DB" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "cautioncorner"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "DG" = (
 /obj/structure/chair/sofa/bench/right{
 	dir = 8
@@ -8076,7 +8076,7 @@
 	icon_state = "caution";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "DJ" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -8089,7 +8089,7 @@
 	dir = 4;
 	icon_state = "black"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "DK" = (
 /obj/structure/railing/cap{
 	dir = 5
@@ -8098,7 +8098,7 @@
 	icon_state = "yellowsiding";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "DM" = (
 /obj/structure/rack,
 /obj/machinery/light/small{
@@ -8106,7 +8106,7 @@
 	},
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "DO" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -8119,12 +8119,12 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "DR" = (
 /obj/item/kitchen/utensil/spoon,
 /obj/structure/table,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "DU" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
@@ -8134,18 +8134,18 @@
 	dir = 10
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "DV" = (
 /obj/structure/closet/crate,
 /obj/item/reagent_containers/food/snacks/beans,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Ef" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "dark"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Eg" = (
 /obj/effect/decal/cleanable/blood/xeno{
 	color = "green"
@@ -8158,7 +8158,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "El" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -8178,7 +8178,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "whitehall"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Em" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/cobweb2,
@@ -8199,7 +8199,7 @@
 	icon_state = "whitecorner";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Eo" = (
 /obj/structure/filingcabinet,
 /obj/structure/sign/poster/official/fruit_bowl{
@@ -8207,7 +8207,7 @@
 	},
 /obj/item/paper/fluff/ruins/moonoutpost19/rdnote,
 /turf/simulated/floor/carpet/royalblue,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Ep" = (
 /obj/item/kirbyplants,
 /obj/effect/decal/cleanable/dirt,
@@ -8215,7 +8215,7 @@
 	icon_state = "escape";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Er" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -8229,7 +8229,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "black"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Es" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -8252,13 +8252,13 @@
 	icon_state = "whitecorner";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Et" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/plating/asteroid/airless{
 	icon_state = "asteroid1"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Ev" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -8266,7 +8266,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Ex" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/snacks/sliceable/xenomeatbread{
@@ -8277,14 +8277,14 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Ey" = (
 /obj/machinery/shower{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/noslip,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "EE" = (
 /obj/item/stack/ore/slag,
 /turf/simulated/floor/plating/airless,
@@ -8305,12 +8305,12 @@
 	icon_state = "whitecorner";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "EH" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/decal/cleanable/vomit/green,
 /turf/simulated/floor/engine,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "EL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -8320,7 +8320,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "EN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/greenglow,
@@ -8328,18 +8328,18 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "EP" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel{
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "EQ" = (
 /obj/structure/window/reinforced,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ER" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5
@@ -8350,7 +8350,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowsiding"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ET" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/table,
@@ -8358,7 +8358,7 @@
 	dir = 9;
 	icon_state = "escape"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "EV" = (
 /obj/structure/closet,
 /obj/item/soap,
@@ -8368,14 +8368,14 @@
 	dir = 6;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "EZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/xeno{
 	color = "green"
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Fa" = (
 /obj/effect/turf_decal/delivery/white/partial{
 	dir = 1
@@ -8387,13 +8387,13 @@
 	icon_state = "whitehall";
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Fb" = (
 /obj/structure/chair/office/dark{
 	dir = 4
 	},
 /turf/simulated/floor/plating/asteroid/ancient,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Fc" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -8404,7 +8404,7 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Fd" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -8412,7 +8412,7 @@
 	},
 /mob/living/simple_animal/hostile/alien/sentinel,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Fe" = (
 /obj/structure/table/reinforced,
 /obj/item/stock_parts/cell/high,
@@ -8422,7 +8422,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/engine,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Ff" = (
 /obj/machinery/computer{
 	dir = 1
@@ -8431,14 +8431,14 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Fk" = (
 /obj/item/kirbyplants,
 /turf/simulated/floor/plasteel{
 	icon_state = "caution";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Fm" = (
 /obj/structure/safe,
 /obj/machinery/light/small{
@@ -8451,7 +8451,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Fo" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -8461,7 +8461,7 @@
 	},
 /obj/machinery/atmospherics/air_sensor,
 /turf/simulated/floor/engine,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Fp" = (
 /obj/structure/sink{
 	dir = 4;
@@ -8471,12 +8471,12 @@
 	icon_state = "showroomfloor";
 	temperature = 273.15
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Fq" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/grass,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Fs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/greenglow,
@@ -8486,7 +8486,7 @@
 	stat = 2
 	},
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Ft" = (
 /obj/effect/turf_decal/stripes/corner,
 /mob/living/simple_animal/hostile/alien/sentinel,
@@ -8497,25 +8497,25 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Fw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Fz" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 8
 	},
 /turf/simulated/wall/r_wall,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "FB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "FC" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -8523,7 +8523,7 @@
 	icon_state = "caution";
 	dir = 10
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "FH" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -8532,7 +8532,7 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "FM" = (
 /obj/structure/railing{
 	dir = 8
@@ -8541,7 +8541,7 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "FN" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/decal/cleanable/cobweb2,
@@ -8549,7 +8549,7 @@
 	dir = 5;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "FO" = (
 /obj/item/kirbyplants,
 /obj/structure/railing{
@@ -8559,7 +8559,7 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "FP" = (
 /obj/structure/mopbucket,
 /obj/machinery/light/small{
@@ -8569,7 +8569,7 @@
 	dir = 1;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "FT" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -8577,7 +8577,7 @@
 	dir = 9;
 	icon_state = "whitecorner"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "FV" = (
 /obj/item/kirbyplants,
 /obj/effect/decal/cleanable/cobweb,
@@ -8585,7 +8585,7 @@
 	dir = 9;
 	icon_state = "escape"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "FW" = (
 /obj/structure/flora/ausbushes/grassybush,
 /obj/structure/flora/ausbushes/ywflowers,
@@ -8593,20 +8593,20 @@
 	dir = 8
 	},
 /turf/simulated/floor/grass,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "FX" = (
 /obj/structure/railing{
 	dir = 1
 	},
 /obj/structure/chair/sofa/bench,
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "FY" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "FZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -8617,7 +8617,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Gd" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -8627,14 +8627,14 @@
 	dir = 4
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Ge" = (
 /obj/structure/closet/crate/secure/loot,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Gg" = (
 /turf/simulated/mineral/ancient,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Gh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb2,
@@ -8642,7 +8642,7 @@
 	icon_state = "darkbluecorners";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Gk" = (
 /obj/machinery/door/airlock/medical/glass{
 	req_access_txt = "271";
@@ -8652,7 +8652,7 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Gl" = (
 /obj/structure/railing/cap{
 	dir = 9
@@ -8662,7 +8662,7 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Gp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/tracks{
@@ -8673,7 +8673,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Gq" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -8681,7 +8681,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Gs" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -8702,7 +8702,7 @@
 	icon_state = "tracks"
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Gw" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -8722,25 +8722,25 @@
 	dir = 1;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Gx" = (
 /obj/structure/closet/crate/freezer,
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor";
 	temperature = 273.15
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Gy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille/broken,
 /obj/item/stack/rods,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Gz" = (
 /obj/structure/table/wood,
 /obj/item/toy/plushie/slimeplushie,
 /turf/simulated/floor/carpet,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "GC" = (
 /obj/effect/turf_decal/caution/stand_clear/white{
 	dir = 8
@@ -8749,7 +8749,7 @@
 	icon_state = "caution";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "GD" = (
 /obj/structure/holosign/barrier/engineering,
 /obj/effect/landmark/damageturf,
@@ -8762,7 +8762,7 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "GH" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -8771,7 +8771,7 @@
 	icon_state = "caution";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "GJ" = (
 /obj/structure/railing{
 	dir = 1
@@ -8787,7 +8787,7 @@
 	dir = 8;
 	icon_state = "green"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "GL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/splatter{
@@ -8797,7 +8797,7 @@
 	icon_state = "yellowsiding";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "GP" = (
 /obj/machinery/computer,
 /obj/structure/window/reinforced{
@@ -8810,19 +8810,19 @@
 	dir = 1;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "GS" = (
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/glass,
 /obj/item/stack/rods,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "GT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
 /turf/simulated/floor/engine,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "GX" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/effect/decal/cleanable/dirt,
@@ -8830,7 +8830,7 @@
 	icon_state = "whitecorner";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Hb" = (
 /obj/structure/table/wood,
 /obj/item/toy/plushie/greyplushie{
@@ -8841,7 +8841,7 @@
 	pixel_y = 4
 	},
 /turf/simulated/floor/carpet,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Hd" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -8851,7 +8851,7 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Hg" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window{
@@ -8872,7 +8872,7 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Hh" = (
 /obj/structure/railing/cap{
 	dir = 10
@@ -8880,7 +8880,7 @@
 /turf/simulated/floor/plasteel/stairs{
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Hj" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -8889,7 +8889,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Hm" = (
 /obj/structure/railing,
 /obj/effect/decal/cleanable/blood/splatter{
@@ -8899,14 +8899,14 @@
 /turf/simulated/floor/plasteel/stairs{
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Hp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
 /obj/structure/table,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Hq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -8915,7 +8915,7 @@
 	icon_state = "whitehall";
 	dir = 10
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Hr" = (
 /obj/structure/railing{
 	dir = 8
@@ -8928,13 +8928,13 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Hu" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowsiding"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Hv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -8948,7 +8948,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Hx" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -8957,21 +8957,21 @@
 	dir = 4
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "HA" = (
 /obj/item/kirbyplants,
 /turf/simulated/floor/plasteel{
 	icon_state = "caution";
 	dir = 10
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "HE" = (
 /obj/structure/chair/sofa/bench/right,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "HL" = (
 /obj/machinery/light{
 	active_power_consumption = 0;
@@ -8985,7 +8985,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "HM" = (
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
@@ -9004,7 +9004,7 @@
 	pixel_x = 6
 	},
 /turf/simulated/floor/engine,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "HO" = (
 /obj/machinery/door/airlock/highsecurity{
 	req_access_txt = "271";
@@ -9015,13 +9015,13 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "HP" = (
 /obj/item/chair{
 	pixel_y = -3
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "HU" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/metal/fifty{
@@ -9035,7 +9035,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "HV" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -9044,14 +9044,14 @@
 	icon_state = "yellowsiding";
 	dir = 9
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "HW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/largecrate,
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "HY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -9063,12 +9063,12 @@
 	dir = 1;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Ib" = (
 /turf/simulated/floor/plating/asteroid/airless{
 	icon_state = "asteroid11"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Ic" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/railing{
@@ -9076,15 +9076,15 @@
 	},
 /obj/structure/table,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Ie" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "If" = (
 /turf/simulated/floor/bluegrid,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Ij" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -9097,13 +9097,13 @@
 	icon_state = "whitecorner";
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Io" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "darkbluecorners";
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Ip" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -9111,7 +9111,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/engine,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Iq" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -9119,7 +9119,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/alien/weeds/node,
 /turf/simulated/floor/engine,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Ix" = (
 /obj/effect/decal/cleanable/blood/splatter{
 	color = "red"
@@ -9128,11 +9128,11 @@
 	icon_state = "greencorner";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Iz" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "IB" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -9142,7 +9142,7 @@
 	icon_state = "caution";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "IC" = (
 /obj/structure/railing{
 	dir = 4
@@ -9151,7 +9151,7 @@
 /turf/simulated/floor/plating/asteroid/airless{
 	icon_state = "asteroid1"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ID" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
@@ -9160,7 +9160,7 @@
 	icon_state = "whitecorner";
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "IE" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -9169,7 +9169,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "IH" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/decal/cleanable/dirt,
@@ -9177,7 +9177,7 @@
 	dir = 1;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "IJ" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -9194,7 +9194,7 @@
 	icon_state = "black";
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "IM" = (
 /obj/structure/chair{
 	dir = 8
@@ -9207,12 +9207,12 @@
 	icon_state = "tracks"
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "IN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "IO" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/machinery/light/small{
@@ -9223,7 +9223,7 @@
 	icon_state = "white";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "IS" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/structure/filingcabinet/chestdrawer,
@@ -9235,7 +9235,7 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "IU" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/airlock/highsecurity{
@@ -9246,11 +9246,11 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "IV" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "IW" = (
 /turf/simulated/floor/engine/vacuum,
 /area/space/nearstation)
@@ -9271,27 +9271,27 @@
 	id_tag = "awayscilock1"
 	},
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Jc" = (
 /obj/structure/rack,
 /turf/simulated/floor/plasteel{
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Ji" = (
 /obj/structure/railing/cap,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitehall";
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Jl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /obj/structure/alien/resin/wall,
 /turf/simulated/floor/engine,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Jm" = (
 /obj/structure/punching_bag,
 /obj/effect/turf_decal/delivery/hollow,
@@ -9299,20 +9299,20 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Jo" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Jr" = (
 /obj/structure/alien/resin/wall,
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Ju" = (
 /obj/machinery/autolathe,
 /turf/simulated/floor/engine,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Jv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/chair{
@@ -9324,7 +9324,7 @@
 	icon_state = "black";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Jx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -9333,13 +9333,13 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "whitecorner"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Jy" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Jz" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
@@ -9347,14 +9347,14 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "JA" = (
 /obj/structure/table/glass,
 /obj/item/storage/backpack/duffel/medical,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkblue"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "JB" = (
 /obj/item/clothing/gloves/color/black,
 /obj/item/stack/tape_roll,
@@ -9363,18 +9363,18 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "JE" = (
 /obj/machinery/door/airlock/external{
 	req_access_txt = "271"
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "JG" = (
 /obj/structure/flora/ash/rock/style_random,
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/plating/asteroid/ancient,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "JI" = (
 /obj/structure/railing/cap{
 	dir = 10
@@ -9383,14 +9383,14 @@
 	icon_state = "whitehall";
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "JJ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "black";
 	dir = 5
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "JK" = (
 /obj/effect/turf_decal/delivery/partial,
 /obj/effect/turf_decal/caution{
@@ -9402,13 +9402,13 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "JL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
 /turf/simulated/floor/carpet/royalblue,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "JN" = (
 /obj/structure/chair{
 	dir = 1
@@ -9419,28 +9419,28 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "JP" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/newscaster{
 	pixel_y = 30
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "JQ" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "JR" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/sign/poster/official/nanotrasen_logo{
 	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "JS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/tracks{
@@ -9456,7 +9456,7 @@
 	icon_state = "whitecorner";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "JU" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/power/apc/off_station/empty_charge{
@@ -9483,21 +9483,21 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "JW" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "JZ" = (
 /obj/structure/table/wood,
 /obj/item/lighter/zippo,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/toy/plushie/tabby_cat,
 /turf/simulated/floor/carpet,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Ka" = (
 /obj/item/chair{
 	pixel_y = -3
@@ -9512,14 +9512,14 @@
 	pixel_x = 32
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Kb" = (
 /obj/structure/barricade/wooden/crude{
 	layer = 4
 	},
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Kc" = (
 /obj/structure/railing/cap,
 /obj/effect/decal/cleanable/dirt,
@@ -9527,14 +9527,14 @@
 	icon_state = "caution";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Kd" = (
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "whitecorner"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Ki" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -9543,7 +9543,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Km" = (
 /obj/structure/railing{
 	dir = 6
@@ -9552,13 +9552,13 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Kp" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Kr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -9573,7 +9573,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Kt" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -9583,34 +9583,34 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Ku" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "green"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Kv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Kx" = (
 /obj/structure/closet/toolcloset,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Kz" = (
 /obj/item/kirbyplants,
 /turf/simulated/floor/plasteel{
 	icon_state = "escape";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "KC" = (
 /obj/machinery/disposal/deliveryChute,
 /obj/structure/disposalpipe/trunk{
@@ -9627,7 +9627,7 @@
 	},
 /obj/machinery/door/window/reinforced/normal,
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "KE" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -9636,7 +9636,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "KG" = (
 /obj/structure/railing/cap{
 	dir = 9
@@ -9650,7 +9650,7 @@
 	pixel_y = -1
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "KI" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -9658,13 +9658,13 @@
 	},
 /obj/effect/turf_decal/box,
 /turf/simulated/floor/engine,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "KJ" = (
 /obj/structure/railing{
 	dir = 4
 	},
 /turf/simulated/floor/plating/asteroid/airless,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "KN" = (
 /obj/structure/railing{
 	dir = 4
@@ -9674,13 +9674,13 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "KO" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "cautioncorner"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "KP" = (
 /obj/machinery/light{
 	dir = 4
@@ -9703,7 +9703,7 @@
 	icon_state = "caution";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "KQ" = (
 /obj/effect/decal/cleanable/blood/splatter{
 	color = "red"
@@ -9712,14 +9712,14 @@
 	icon_state = "white";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "KR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/splatter{
 	color = "red"
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "KS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -9732,11 +9732,11 @@
 	icon_state = "escapecorner";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "KW" = (
 /obj/structure/chair/sofa/bench/right,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "KZ" = (
 /obj/machinery/door/poddoor/impassable{
 	id_tag = "awaycontlockdown"
@@ -9747,7 +9747,7 @@
 	},
 /obj/effect/spawner/window/reinforced/tinted/grilled,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "La" = (
 /obj/structure/closet/crate/freezer,
 /obj/item/clothing/mask/facehugger{
@@ -9758,12 +9758,12 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkbluecorners"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Lb" = (
 /obj/structure/rack,
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Ld" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/tracks{
@@ -9776,7 +9776,7 @@
 	pixel_x = 2
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Lf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -9787,7 +9787,7 @@
 	stat = 2
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Lj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/chair{
@@ -9799,7 +9799,7 @@
 	icon_state = "whitehall";
 	dir = 9
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Lk" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -9810,21 +9810,21 @@
 	dir = 1;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Ll" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "escape"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Ln" = (
 /obj/effect/decal/cleanable/blood/splatter{
 	color = "red"
 	},
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/plating/asteroid/ancient,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Lq" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -9833,7 +9833,7 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Lw" = (
 /obj/structure/railing{
 	dir = 4
@@ -9841,7 +9841,7 @@
 /turf/simulated/floor/plating/asteroid/airless{
 	icon_state = "asteroid4"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Lz" = (
 /obj/structure/railing{
 	dir = 4
@@ -9852,17 +9852,17 @@
 /turf/simulated/floor/plasteel/stairs{
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "LA" = (
 /obj/structure/shuttle/engine/propulsion/burst,
 /turf/simulated/wall/mineral/titanium,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "LC" = (
 /obj/structure/largecrate,
 /turf/simulated/floor/plating/asteroid/airless{
 	icon_state = "asteroid3"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "LD" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -9872,7 +9872,7 @@
 	icon_state = "whitecorner";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "LG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb2,
@@ -9881,7 +9881,7 @@
 	icon_state = "black";
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "LJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -9895,7 +9895,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "LK" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/effect/turf_decal/stripes/corner{
@@ -9907,7 +9907,7 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "LL" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin{
@@ -9919,7 +9919,7 @@
 	pixel_x = -7
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "LS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -9929,21 +9929,21 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "LY" = (
 /obj/structure/railing{
 	dir = 1
 	},
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/plating/asteroid/airless,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "LZ" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
 /obj/structure/disposaloutlet,
 /turf/simulated/floor/engine,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Me" = (
 /obj/effect/turf_decal/stripes/asteroid/line,
 /obj/structure/railing,
@@ -9953,7 +9953,7 @@
 /turf/simulated/floor/plating/asteroid/airless{
 	icon_state = "asteroidplating"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Mg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -9963,7 +9963,7 @@
 	icon_state = "whitecorner";
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Mk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -9973,20 +9973,20 @@
 	icon_state = "caution";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Ml" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/carpet,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Mn" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Mp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/railing/corner{
@@ -9996,7 +9996,7 @@
 /turf/simulated/floor/plasteel/stairs{
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Mq" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -10010,7 +10010,7 @@
 	dir = 4;
 	icon_state = "black"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Mt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -10019,7 +10019,7 @@
 	icon_state = "black";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Mv" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical{
@@ -10034,20 +10034,20 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Mx" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_access_txt = "271"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "My" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Mz" = (
 /obj/item/t_scanner,
 /obj/structure/table,
@@ -10055,7 +10055,7 @@
 	dir = 8;
 	icon_state = "cautioncorner"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "MF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/newscaster{
@@ -10070,7 +10070,7 @@
 	icon_state = "black";
 	dir = 6
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "MG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -10083,21 +10083,21 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "MH" = (
 /obj/structure/closet/emcloset,
 /obj/structure/window/basic{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "MI" = (
 /obj/structure/chair/sofa/bench,
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "MJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -10106,7 +10106,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "MK" = (
 /obj/machinery/door_control{
 	id = "awaykitchen";
@@ -10117,7 +10117,7 @@
 	icon_state = "black";
 	dir = 5
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "MN" = (
 /obj/effect/decal/cleanable/cobweb2,
 /obj/effect/turf_decal/stripes/corner{
@@ -10127,7 +10127,7 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "MS" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/light/small,
@@ -10144,7 +10144,7 @@
 	icon_state = "whitecorner";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "MT" = (
 /obj/structure/lattice,
 /turf/template_noop,
@@ -10154,7 +10154,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "MY" = (
 /obj/item/kirbyplants,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -10163,13 +10163,13 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "MZ" = (
 /obj/structure/railing/corner{
 	dir = 8
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Nb" = (
 /obj/structure/chair/sofa/bench{
 	dir = 1
@@ -10177,7 +10177,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Nc" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -10185,7 +10185,7 @@
 	},
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Nd" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/effect/decal/cleanable/dirt,
@@ -10193,7 +10193,7 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Ne" = (
 /obj/structure/table/reinforced,
 /obj/machinery/flasher_button{
@@ -10216,11 +10216,11 @@
 	icon_state = "black";
 	dir = 5
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Ni" = (
 /obj/structure/falsewall/rock_ancient,
 /turf/simulated/floor/plating/asteroid/ancient,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Nm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -10236,7 +10236,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "cautioncorner"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Nn" = (
 /obj/machinery/camera{
 	c_tag = "South Cafeteria";
@@ -10250,7 +10250,7 @@
 	dir = 8;
 	icon_state = "escape"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Np" = (
 /obj/structure/chair/sofa/bench{
 	dir = 4
@@ -10262,7 +10262,7 @@
 	icon_state = "caution";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Nu" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -10278,12 +10278,12 @@
 	dir = 5
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Nv" = (
 /obj/effect/decal/cleanable/cobweb2,
 /obj/structure/grille/broken,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Nx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -10294,7 +10294,7 @@
 	icon_state = "yellowsiding";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Ny" = (
 /obj/structure/alien/resin/wall,
 /obj/structure/cable{
@@ -10306,7 +10306,7 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "NC" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	color = "red";
@@ -10318,7 +10318,7 @@
 	pixel_x = 2
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "NE" = (
 /obj/machinery/light/small{
 	active_power_consumption = 0;
@@ -10329,7 +10329,7 @@
 /obj/effect/decal/cleanable/cobweb2,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "NF" = (
 /obj/structure/railing,
 /obj/effect/turf_decal/delivery/red/partial{
@@ -10339,14 +10339,14 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "black"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "NJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "NM" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -10361,14 +10361,14 @@
 	icon_state = "whitecorner";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "NS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "NT" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt,
@@ -10384,14 +10384,14 @@
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "NU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/oil{
 	color = "black"
 	},
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "NZ" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
@@ -10407,7 +10407,7 @@
 	dir = 8;
 	icon_state = "dark"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Oa" = (
 /obj/structure/chair/sofa/bench{
 	dir = 1
@@ -10416,13 +10416,13 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Ob" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/plating/asteroid/airless{
 	icon_state = "asteroid12"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Oc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/splatter{
@@ -10432,7 +10432,7 @@
 	icon_state = "white";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Od" = (
 /obj/item/kirbyplants,
 /obj/effect/decal/cleanable/cobweb,
@@ -10440,7 +10440,7 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Oe" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/reinforced/normal{
@@ -10450,18 +10450,18 @@
 	icon_state = "white";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Of" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Og" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "black";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Oi" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	color = "red";
@@ -10474,7 +10474,7 @@
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Oj" = (
 /obj/structure/table/glass,
 /obj/item/storage/fancy/donut_box,
@@ -10483,7 +10483,7 @@
 	icon_state = "black";
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Ol" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -10497,7 +10497,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Om" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -10507,7 +10507,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "cautioncorner"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "On" = (
 /obj/structure/safe/floor{
 	known_by = list("captain")
@@ -10519,7 +10519,7 @@
 /obj/item/coin/mythril,
 /obj/item/coin/adamantine,
 /turf/simulated/floor/carpet/royalblue,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Oo" = (
 /obj/item/kirbyplants,
 /obj/machinery/light/small{
@@ -10532,21 +10532,21 @@
 	icon_state = "whitecorner";
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Op" = (
 /obj/structure/window/reinforced,
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
 	icon_state = "black"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Oq" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowsiding";
 	dir = 6
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Os" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -10556,7 +10556,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Ot" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -10566,13 +10566,13 @@
 	},
 /obj/effect/decal/remains/human,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Ou" = (
 /obj/structure/rack,
 /turf/simulated/floor/plasteel{
 	icon_state = "escape"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Ox" = (
 /obj/machinery/light{
 	active_power_consumption = 0;
@@ -10580,7 +10580,7 @@
 	status = 2
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "OD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -10588,7 +10588,7 @@
 	icon_state = "black";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "OE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -10598,10 +10598,10 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "OG" = (
 /turf/simulated/wall/mineral/titanium,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "OL" = (
 /obj/structure/railing/cap{
 	dir = 1
@@ -10611,7 +10611,7 @@
 	dir = 1;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "OM" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/item/shard{
@@ -10621,7 +10621,7 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ON" = (
 /turf/template_noop,
 /area/space/nearstation)
@@ -10631,7 +10631,7 @@
 	icon_state = "black";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "OP" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -10642,7 +10642,7 @@
 	icon_state = "caution";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "OR" = (
 /obj/structure/railing{
 	dir = 10
@@ -10659,7 +10659,7 @@
 	icon_state = "darkblue";
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "OT" = (
 /obj/effect/turf_decal/delivery/partial{
 	dir = 4
@@ -10673,13 +10673,13 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "OW" = (
 /obj/structure/railing{
 	dir = 10
 	},
 /turf/simulated/floor/plating/asteroid/airless,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "OX" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -10691,7 +10691,7 @@
 	color = "green"
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "OZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -10700,7 +10700,7 @@
 	dir = 8;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Pa" = (
 /obj/structure/table/glass,
 /obj/machinery/light/small{
@@ -10710,7 +10710,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkblue"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Pd" = (
 /obj/machinery/light/small{
 	active_power_consumption = 0;
@@ -10719,21 +10719,21 @@
 	status = 2
 	},
 /turf/simulated/floor/carpet,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Pf" = (
 /obj/structure/railing/cap{
 	dir = 1
 	},
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/plating/asteroid/airless,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Ph" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "caution";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Pj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -10745,7 +10745,7 @@
 	dir = 1;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Po" = (
 /obj/structure/alien/resin/wall,
 /obj/effect/decal/cleanable/dirt,
@@ -10753,7 +10753,7 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Pq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -10761,10 +10761,10 @@
 /obj/structure/alien/resin/wall,
 /obj/machinery/atmospherics/air_sensor,
 /turf/simulated/floor/engine,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Pr" = (
 /turf/simulated/floor/carpet/royalblue,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Ps" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -10773,7 +10773,7 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Pt" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
@@ -10782,7 +10782,7 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Pv" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -10791,18 +10791,18 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "PA" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowsiding";
 	dir = 10
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "PB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "PE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/reagent_containers/food/snacks/badrecipe,
@@ -10810,7 +10810,7 @@
 	icon_state = "showroomfloor";
 	temperature = 273.15
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "PF" = (
 /obj/machinery/door/airlock/security{
 	req_access_txt = "271";
@@ -10820,25 +10820,25 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "PK" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "PL" = (
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "PM" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "PP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -10851,20 +10851,20 @@
 	icon_state = "tracks"
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "PQ" = (
 /obj/item/kirbyplants,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "PS" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/plating/asteroid/airless{
 	icon_state = "asteroid5"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "PT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -10876,7 +10876,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/engine,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "PU" = (
 /obj/effect/decal/cleanable/blood/splatter{
 	color = "red"
@@ -10885,7 +10885,7 @@
 	icon_state = "caution";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "PY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -10906,19 +10906,19 @@
 	id_tag = "awayscilock1"
 	},
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "PZ" = (
 /obj/structure/railing{
 	dir = 8
 	},
 /turf/simulated/floor/plating/asteroid/airless,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Qc" = (
 /obj/structure/railing/cap{
 	dir = 10
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Qe" = (
 /obj/structure/railing/cap{
 	dir = 1
@@ -10928,14 +10928,14 @@
 	dir = 1;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Qf" = (
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plasteel{
 	icon_state = "caution";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Qh" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -10943,7 +10943,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Qj" = (
 /obj/machinery/light/small{
 	active_power_consumption = 0;
@@ -10953,11 +10953,11 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Qk" = (
 /mob/living/simple_animal/hostile/alien,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Ql" = (
 /obj/structure/chair/sofa/bench/right{
 	dir = 1
@@ -10971,12 +10971,12 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Qm" = (
 /obj/structure/flora/junglebush,
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/grass,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Qn" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -10988,7 +10988,7 @@
 	icon_state = "whitecorner";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Qt" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -11001,7 +11001,7 @@
 	icon_state = "black";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Qu" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/mineral/plasma{
@@ -11014,7 +11014,7 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Qv" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 10
@@ -11022,7 +11022,7 @@
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Qx" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window{
@@ -11032,7 +11032,7 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Qy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -11042,7 +11042,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Qz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/tracks{
@@ -11052,7 +11052,7 @@
 	icon_state = "tracks"
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "QB" = (
 /obj/structure/sign/biohazard{
 	pixel_y = 32
@@ -11060,7 +11060,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "QD" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
@@ -11069,14 +11069,14 @@
 	dir = 10;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "QE" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "QF" = (
 /obj/structure/railing{
 	dir = 4
@@ -11087,7 +11087,7 @@
 	},
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "QG" = (
 /obj/structure/railing{
 	dir = 1
@@ -11096,7 +11096,7 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "QI" = (
 /obj/structure/railing/cap{
 	dir = 10
@@ -11105,11 +11105,11 @@
 	icon_state = "darkbluefull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "QK" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/carpet/royalblue,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "QL" = (
 /obj/effect/decal/cleanable/glass,
 /obj/item/shard{
@@ -11117,7 +11117,7 @@
 	},
 /obj/item/stack/rods,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "QM" = (
 /obj/structure/railing/cap{
 	dir = 1
@@ -11126,7 +11126,7 @@
 	dir = 1;
 	icon_state = "blackcorner"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "QO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -11139,45 +11139,45 @@
 	name = "Cafeteria"
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "QP" = (
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plasteel/stairs,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "QQ" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5
 	},
 /turf/simulated/floor/plating/asteroid/ancient,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "QS" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitecorner";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "QT" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "QW" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "white";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "QX" = (
 /obj/structure/alien/weeds/node,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "QZ" = (
 /obj/structure/alien/resin/wall,
 /obj/structure/cable{
@@ -11186,7 +11186,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel/stairs,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Rc" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -11210,7 +11210,7 @@
 	icon_state = "whitecorner";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Rf" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
@@ -11223,7 +11223,7 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Rg" = (
 /obj/machinery/door/airlock/freezer{
 	req_access_txt = "271"
@@ -11232,13 +11232,13 @@
 	icon_state = "showroomfloor";
 	temperature = 273.15
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Rh" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/plating/asteroid/airless{
 	icon_state = "asteroid10"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Ri" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/blood/splatter{
@@ -11246,7 +11246,7 @@
 	},
 /obj/effect/decal/remains/human,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Rl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -11254,7 +11254,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel/stairs,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Ro" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -11272,7 +11272,7 @@
 	icon_state = "cautioncorner";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Rr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -11281,7 +11281,7 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Ru" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -11290,14 +11290,14 @@
 	dir = 10
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Rv" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "RA" = (
 /obj/structure/flora/rock,
 /turf/simulated/floor/engine/vacuum,
@@ -11306,7 +11306,7 @@
 /obj/structure/table/reinforced,
 /obj/structure/alien/egg/burst,
 /turf/simulated/floor/engine,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "RD" = (
 /obj/machinery/door/airlock/multi_tile/glass{
 	req_access_txt = "271"
@@ -11317,20 +11317,20 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "RF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "RH" = (
 /obj/machinery/kitchen_machine/oven,
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor";
 	temperature = 273.15
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "RI" = (
 /obj/structure/railing/cap{
 	dir = 8
@@ -11339,7 +11339,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "RK" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -11348,7 +11348,7 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "RN" = (
 /obj/structure/sign/radiation/rad_area{
 	pixel_y = 32
@@ -11359,7 +11359,7 @@
 /turf/simulated/floor/plasteel/stairs{
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "RQ" = (
 /obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/porta_turret{
@@ -11368,35 +11368,35 @@
 	lethal = 1
 	},
 /turf/simulated/floor/bluegrid,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "RU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 8
 	},
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Sa" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "cautioncorner"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Sb" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "caution";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Sc" = (
 /obj/machinery/computer/monitor/secret{
 	dir = 4
 	},
 /obj/structure/cable,
 /turf/simulated/floor/engine,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Sd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -11410,7 +11410,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Sg" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
@@ -11423,7 +11423,7 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Si" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/xeno{
@@ -11433,7 +11433,7 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Sj" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -11442,28 +11442,28 @@
 	icon_state = "black";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Sk" = (
 /obj/structure/flora/ausbushes/fernybush,
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/grass,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Sm" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitehall";
 	dir = 10
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Sp" = (
 /mob/living/simple_animal/cockroach,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Sq" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "green"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "St" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window,
@@ -11475,24 +11475,24 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Su" = (
 /obj/structure/closet/crate,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Sv" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/plating/asteroid/airless{
 	icon_state = "asteroid10"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Sx" = (
 /obj/effect/decal/cleanable/greenglow,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Sz" = (
 /obj/effect/landmark/damageturf,
 /obj/structure/cable{
@@ -11504,7 +11504,7 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "SG" = (
 /obj/structure/railing{
 	dir = 4
@@ -11514,7 +11514,7 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "SI" = (
 /obj/structure/table/glass,
 /obj/effect/decal/cleanable/dirt,
@@ -11524,14 +11524,14 @@
 	icon_state = "whitehall";
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "SL" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
 /obj/structure/alien/resin/wall,
 /turf/simulated/floor/engine,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "SO" = (
 /obj/effect/turf_decal/stripes/asteroid/line,
 /obj/structure/railing,
@@ -11539,7 +11539,7 @@
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ST" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -11554,7 +11554,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "SV" = (
 /obj/structure/chair/stool/bar{
 	dir = 8
@@ -11563,7 +11563,7 @@
 	dir = 8;
 	icon_state = "escape"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Tc" = (
 /obj/machinery/computer{
 	dir = 4
@@ -11572,7 +11572,7 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Td" = (
 /obj/structure/weightmachine/stacklifter,
 /obj/effect/turf_decal/delivery/hollow,
@@ -11580,7 +11580,7 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Te" = (
 /obj/machinery/shieldwallgen{
 	locked = 0;
@@ -11600,7 +11600,7 @@
 	},
 /obj/effect/turf_decal/box,
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Tf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -11611,7 +11611,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "cautioncorner"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Ti" = (
 /obj/machinery/door/airlock/command/glass{
 	req_access_txt = "271";
@@ -11626,7 +11626,7 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Tm" = (
 /obj/structure/railing/cap{
 	dir = 9
@@ -11636,7 +11636,7 @@
 	icon_state = "whitehall";
 	dir = 6
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Tn" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -11651,7 +11651,7 @@
 	id = "mo19rdoffice"
 	},
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Tr" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/alien,
@@ -11659,7 +11659,7 @@
 	icon_state = "white";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Tu" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -11668,7 +11668,7 @@
 	dir = 8;
 	icon_state = "black"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Tv" = (
 /obj/structure/chair/sofa/bench/right{
 	dir = 1
@@ -11677,7 +11677,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Tw" = (
 /obj/machinery/light/small{
 	active_power_consumption = 0;
@@ -11687,7 +11687,7 @@
 	},
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/carpet,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Tx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -11696,14 +11696,14 @@
 	dir = 1;
 	icon_state = "escape"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Tz" = (
 /obj/structure/chair/office/dark,
 /turf/simulated/floor/plasteel{
 	icon_state = "white";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "TB" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
@@ -11719,14 +11719,14 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "TD" = (
 /obj/structure/chair/comfy/corp,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "TF" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -11736,7 +11736,7 @@
 /turf/simulated/floor/plasteel/stairs{
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "TI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -11753,14 +11753,14 @@
 	icon_state = "whitecorner";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "TK" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
 /obj/effect/decal/cleanable/cobweb,
 /obj/item/toy/plushie/voxplushie,
 /turf/simulated/floor/carpet,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "TO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -11770,7 +11770,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "TS" = (
 /obj/machinery/reagentgrinder,
 /obj/structure/table,
@@ -11778,7 +11778,7 @@
 	icon_state = "whitecorner";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "TW" = (
 /obj/structure/railing/cap{
 	dir = 1
@@ -11788,7 +11788,7 @@
 	icon_state = "yellowsiding";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "TY" = (
 /obj/structure/sign/biohazard{
 	pixel_y = -32
@@ -11806,7 +11806,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "TZ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -11815,7 +11815,7 @@
 	dir = 8;
 	icon_state = "cautioncorner"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Ua" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/office/dark{
@@ -11825,7 +11825,7 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Ub" = (
 /obj/structure/filingcabinet,
 /obj/structure/sign/poster/contraband/fun_police{
@@ -11835,7 +11835,7 @@
 	icon_state = "black";
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Ue" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -11847,7 +11847,7 @@
 	dir = 4;
 	icon_state = "green"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Ug" = (
 /obj/structure/chair,
 /obj/machinery/light/small{
@@ -11857,7 +11857,7 @@
 	icon_state = "yellowsiding";
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Ul" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -11873,7 +11873,7 @@
 	color = "red"
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Un" = (
 /obj/item/shard{
 	icon_state = "medium"
@@ -11883,14 +11883,14 @@
 	dir = 1;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Up" = (
 /obj/item/chair{
 	pixel_y = 1;
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Ur" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -11898,7 +11898,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Ut" = (
 /obj/item/chair{
 	dir = 4;
@@ -11909,7 +11909,7 @@
 	icon_state = "black";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Uu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -11922,7 +11922,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Uv" = (
 /obj/machinery/flasher{
 	pixel_x = 28
@@ -11937,7 +11937,7 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Uz" = (
 /obj/structure/barricade/wooden/crude{
 	layer = 4
@@ -11953,7 +11953,7 @@
 	req_access_txt = "271"
 	},
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "UA" = (
 /obj/structure/table/glass/reinforced/plastitanium,
 /obj/machinery/computer/id_upgrader,
@@ -11961,7 +11961,7 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "UB" = (
 /obj/structure/weightmachine/weightlifter,
 /obj/effect/turf_decal/delivery/hollow,
@@ -11974,30 +11974,30 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "UD" = (
 /mob/living/simple_animal/hostile/alien/drone,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "UF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "UG" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/cobweb2,
 /obj/item/stack/cable_coil,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "UH" = (
 /obj/structure/railing/cap{
 	dir = 6
 	},
 /turf/simulated/floor/plasteel/stairs,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "UI" = (
 /obj/structure/railing{
 	dir = 4
@@ -12013,7 +12013,7 @@
 	icon_state = "yellowsiding";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "UK" = (
 /obj/structure/railing{
 	dir = 10
@@ -12023,7 +12023,7 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "UO" = (
 /obj/structure/lattice,
 /obj/item/shard{
@@ -12036,7 +12036,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "UV" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -12046,12 +12046,12 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "UX" = (
 /obj/structure/alien/resin/wall,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "UZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -12060,11 +12060,11 @@
 	dir = 6
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Va" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Vf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -12073,7 +12073,7 @@
 	icon_state = "caution";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Vg" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -12082,7 +12082,7 @@
 	dir = 4;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Vh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -12091,7 +12091,7 @@
 	icon_state = "blackcorner";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Vi" = (
 /obj/effect/turf_decal/delivery/white/partial,
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -12106,18 +12106,18 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "whitecorner"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Vl" = (
 /obj/structure/railing,
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Vm" = (
 /obj/structure/railing/corner{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Vo" = (
 /obj/structure/closet/crate/can,
 /obj/effect/decal/cleanable/cobweb2,
@@ -12126,13 +12126,13 @@
 	dir = 5;
 	icon_state = "escape"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Vs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/kitchen/utensil/fork,
 /obj/structure/table,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Vv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -12144,7 +12144,7 @@
 	},
 /obj/structure/table,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Vx" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -12153,14 +12153,14 @@
 	dir = 1;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Vy" = (
 /obj/machinery/floodlight,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "VC" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -12173,14 +12173,14 @@
 	icon_state = "yellowsiding";
 	dir = 10
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "VG" = (
 /obj/item/kirbyplants,
 /turf/simulated/floor/plasteel{
 	icon_state = "caution";
 	dir = 9
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "VH" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -12188,7 +12188,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/engine,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "VK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -12201,7 +12201,7 @@
 	icon_state = "escape";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "VL" = (
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 1
@@ -12212,7 +12212,7 @@
 /turf/simulated/floor/plating/asteroid/airless{
 	icon_state = "asteroidplating"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "VM" = (
 /obj/structure/rack,
 /obj/item/flashlight/flare,
@@ -12222,18 +12222,18 @@
 	dir = 1;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "VN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
 /turf/simulated/wall/r_wall,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "VO" = (
 /obj/machinery/computer,
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "VR" = (
 /obj/structure/chair{
 	dir = 1
@@ -12242,7 +12242,7 @@
 	dir = 10;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "VS" = (
 /obj/structure/disposalpipe/segment{
 	desc = "An underfloor disposal pipe. This one has been applied with an acid-proof coating.";
@@ -12255,12 +12255,12 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "VT" = (
 /obj/structure/bed,
 /obj/structure/closet/crate/secure/loot,
 /turf/simulated/floor/carpet,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "VU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/xeno{
@@ -12270,7 +12270,7 @@
 	icon_state = "darkbluefull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "VV" = (
 /obj/structure/railing{
 	dir = 4
@@ -12283,7 +12283,7 @@
 	icon_state = "yellowsiding";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "VX" = (
 /obj/machinery/shower{
 	dir = 8
@@ -12294,17 +12294,17 @@
 	dir = 4
 	},
 /turf/simulated/floor/noslip,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Wb" = (
 /obj/effect/decal/cleanable/blood/xeno{
 	color = "green"
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Wd" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "We" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_access_txt = "271"
@@ -12314,12 +12314,12 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Wg" = (
 /obj/structure/lattice,
 /obj/machinery/door/firedoor/closed,
 /turf/template_noop,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Wi" = (
 /obj/effect/decal/cleanable/blood/splatter{
 	color = "red"
@@ -12328,20 +12328,20 @@
 	icon_state = "black";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Wl" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/plating/asteroid/airless{
 	icon_state = "asteroid6"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Wn" = (
 /obj/item/kirbyplants,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Wo" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -12354,24 +12354,24 @@
 	icon_state = "caution";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Wp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel/stairs,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Wq" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowsiding";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Ws" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "whitehall";
 	dir = 5
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Wv" = (
 /obj/structure/railing{
 	dir = 8
@@ -12381,7 +12381,7 @@
 	},
 /obj/structure/table,
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Wz" = (
 /obj/machinery/light/small,
 /obj/structure/table,
@@ -12389,7 +12389,7 @@
 	dir = 10;
 	icon_state = "escape"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "WE" = (
 /obj/structure/railing,
 /obj/item/cigbutt{
@@ -12404,7 +12404,7 @@
 	},
 /obj/item/reagent_containers/food/drinks/cans/beer,
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "WF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -12416,14 +12416,14 @@
 	icon_state = "caution";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "WG" = (
 /obj/machinery/door/airlock/vault{
 	locked = 1;
 	req_access_txt = "271"
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "WH" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/table,
@@ -12431,14 +12431,14 @@
 	icon_state = "whitecorner";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "WJ" = (
 /obj/item/kirbyplants,
 /obj/structure/railing{
 	dir = 9
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "WK" = (
 /obj/effect/turf_decal/stripes/asteroid/corner{
 	dir = 1
@@ -12456,18 +12456,18 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "WN" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "WS" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "escapecorner";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "WU" = (
 /obj/machinery/light{
 	active_power_consumption = 0;
@@ -12482,7 +12482,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "WW" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -12493,7 +12493,7 @@
 	icon_state = "black";
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "WX" = (
 /obj/item/stack/rods,
 /turf/template_noop,
@@ -12506,7 +12506,7 @@
 	color = "red"
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Xb" = (
 /obj/structure/disposalpipe/segment{
 	desc = "An underfloor disposal pipe. This one has been applied with an acid-proof coating.";
@@ -12517,14 +12517,14 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Xc" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "black";
 	dir = 6
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Xd" = (
 /obj/effect/turf_decal/delivery/white/partial{
 	dir = 1
@@ -12533,7 +12533,7 @@
 	icon_state = "whitehall";
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Xg" = (
 /obj/structure/railing{
 	dir = 4
@@ -12543,7 +12543,7 @@
 	icon_state = "yellowsiding";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Xi" = (
 /obj/machinery/computer,
 /obj/structure/window/reinforced{
@@ -12553,7 +12553,7 @@
 	dir = 1;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Xl" = (
 /obj/item/shard{
 	icon_state = "medium"
@@ -12574,7 +12574,7 @@
 	dir = 8;
 	icon_state = "green"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Xp" = (
 /obj/structure/chair{
 	dir = 8
@@ -12584,7 +12584,7 @@
 	dir = 6;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Xq" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -12595,7 +12595,7 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Xr" = (
 /obj/machinery/atmospherics/unary/thermomachine/freezer/on{
 	dir = 1
@@ -12603,7 +12603,7 @@
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Xs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -12615,7 +12615,7 @@
 	icon_state = "tracks"
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Xv" = (
 /obj/machinery/reagentgrinder,
 /obj/item/reagent_containers/food/drinks/shaker{
@@ -12624,7 +12624,7 @@
 	},
 /obj/structure/table,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Xw" = (
 /obj/machinery/processor{
 	dir = 4
@@ -12633,7 +12633,7 @@
 	icon_state = "showroomfloor";
 	temperature = 273.15
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Xz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -12644,13 +12644,13 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "XB" = (
 /obj/structure/railing{
 	dir = 10
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "XD" = (
 /obj/structure/chair/sofa/bench/right{
 	dir = 8
@@ -12659,13 +12659,13 @@
 	icon_state = "escape";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "XE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/carpet/royalblue,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "XF" = (
 /obj/structure/table/reinforced,
 /obj/item/taperecorder{
@@ -12675,7 +12675,7 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "XH" = (
 /obj/structure/railing{
 	dir = 1
@@ -12690,7 +12690,7 @@
 	dir = 4;
 	icon_state = "green"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "XK" = (
 /obj/machinery/camera{
 	c_tag = "Exterior Hangar";
@@ -12698,7 +12698,7 @@
 	network = list("MO19")
 	},
 /turf/simulated/floor/plating/asteroid/airless,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "XL" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -12708,7 +12708,7 @@
 	icon_state = "whitecorner";
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "XM" = (
 /obj/structure/filingcabinet,
 /obj/structure/sign/mech{
@@ -12719,7 +12719,7 @@
 	icon_state = "black";
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "XN" = (
 /obj/machinery/reagentgrinder,
 /obj/machinery/light/small{
@@ -12734,7 +12734,7 @@
 	icon_state = "showroomfloor";
 	temperature = 273.15
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "XO" = (
 /obj/structure/railing/cap{
 	dir = 4
@@ -12742,7 +12742,7 @@
 /turf/simulated/floor/plasteel/stairs{
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "XR" = (
 /obj/structure/chair{
 	dir = 1
@@ -12755,7 +12755,7 @@
 	icon_state = "whitecorner";
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "XU" = (
 /obj/item/airlock_electronics,
 /obj/item/stack/cable_coil,
@@ -12763,14 +12763,14 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "XW" = (
 /obj/structure/closet/l3closet/general,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitecorner";
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "XX" = (
 /obj/structure/closet/crate/can,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -12778,13 +12778,13 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "XY" = (
 /obj/item/kirbyplants,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitehall"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Yd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -12794,7 +12794,7 @@
 	icon_state = "blackcorner";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Ye" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -12805,11 +12805,11 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "black"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Yh" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Yi" = (
 /obj/structure/railing/cap,
 /obj/effect/turf_decal/stripes/corner{
@@ -12825,7 +12825,7 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Yj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/engineering/glass{
@@ -12833,7 +12833,7 @@
 	name = "Engineering Division"
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Yk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery/white/partial,
@@ -12841,7 +12841,7 @@
 	icon_state = "black";
 	dir = 1
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Yl" = (
 /obj/structure/mirror{
 	pixel_x = -28
@@ -12853,7 +12853,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Yt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -12866,7 +12866,7 @@
 	icon_state = "escapecorner";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Yu" = (
 /obj/structure/toilet{
 	pixel_y = 8
@@ -12876,7 +12876,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Yw" = (
 /obj/machinery/chem_master,
 /obj/effect/decal/cleanable/dirt,
@@ -12884,13 +12884,13 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Yy" = (
 /obj/structure/chair/office/dark{
 	dir = 1
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Yz" = (
 /obj/machinery/light/small{
 	active_power_consumption = 0;
@@ -12908,7 +12908,7 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "YB" = (
 /obj/machinery/door/poddoor/impassable{
 	id_tag = "awaymlock"
@@ -12919,7 +12919,7 @@
 	name = "Medical Ward"
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "YC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -12934,18 +12934,18 @@
 	pixel_x = 2
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "YJ" = (
 /obj/structure/table,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "YK" = (
 /obj/structure/railing{
 	dir = 8
 	},
 /mob/living/simple_animal/hostile/alien/sentinel,
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "YL" = (
 /obj/structure/railing{
 	dir = 4
@@ -12961,14 +12961,14 @@
 	icon_state = "yellowsiding";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "YM" = (
 /obj/machinery/door/airlock/engineering/glass{
 	req_access_txt = "271";
 	name = "Workshop"
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "YQ" = (
 /obj/structure/railing{
 	dir = 8
@@ -12981,7 +12981,7 @@
 	icon_state = "yellowsiding";
 	dir = 4
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "YS" = (
 /obj/structure/alien/resin/wall,
 /obj/structure/cable{
@@ -12990,7 +12990,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "YX" = (
 /obj/structure/railing,
 /obj/effect/turf_decal/delivery/red/partial{
@@ -13002,7 +13002,7 @@
 	icon_state = "black";
 	dir = 10
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "YY" = (
 /obj/structure/chair{
 	dir = 4
@@ -13017,18 +13017,18 @@
 	icon_state = "caution";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Za" = (
 /obj/structure/holosign/barrier/engineering,
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Zb" = (
 /obj/machinery/door/airlock/external/glass{
 	locked = 1
 	},
 /turf/simulated/floor/catwalk,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Zf" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/alien/queen/large{
@@ -13039,7 +13039,7 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Zg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -13054,7 +13054,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Zh" = (
 /obj/effect/decal/cleanable/molten_object/large,
 /obj/effect/decal/cleanable/glass,
@@ -13066,14 +13066,14 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Zi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Zj" = (
 /obj/effect/turf_decal/delivery/white/partial{
 	dir = 1
@@ -13081,7 +13081,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "black"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Zk" = (
 /obj/machinery/atmospherics/unary/tank/air{
 	dir = 8
@@ -13095,7 +13095,7 @@
 	icon_state = "yellowsiding";
 	dir = 5
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Zn" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -13103,7 +13103,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Zp" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/table,
@@ -13111,7 +13111,7 @@
 	dir = 10;
 	icon_state = "escape"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Zq" = (
 /obj/structure/rack,
 /obj/item/taperecorder{
@@ -13119,7 +13119,7 @@
 	},
 /obj/item/storage/secure/briefcase,
 /turf/simulated/floor/carpet/royalblue,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Zu" = (
 /obj/machinery/computer,
 /obj/structure/window/reinforced{
@@ -13132,7 +13132,7 @@
 	dir = 1;
 	icon_state = "caution"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Zw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -13143,14 +13143,14 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "Zz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ZA" = (
 /obj/structure/railing{
 	dir = 1
@@ -13164,7 +13164,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "whitecorner"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ZC" = (
 /obj/structure/railing,
 /obj/effect/turf_decal/stripes/asteroid/line,
@@ -13173,21 +13173,21 @@
 	},
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/plating/asteroid/airless,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ZE" = (
 /obj/machinery/door/airlock/external/glass,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ZI" = (
 /obj/effect/decal/cleanable/cobweb2,
 /obj/structure/table,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ZK" = (
 /obj/machinery/light/small,
 /mob/living/simple_animal/cockroach,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ZL" = (
 /obj/structure/alien/resin/wall,
 /obj/structure/cable{
@@ -13199,7 +13199,7 @@
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ZN" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -13209,7 +13209,7 @@
 	icon_state = "darkfull";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ZO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -13221,7 +13221,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/engine,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ZP" = (
 /obj/machinery/door/airlock/medical/glass{
 	req_access_txt = "271"
@@ -13233,7 +13233,7 @@
 	icon_state = "white";
 	dir = 8
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ZR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/space_heater,
@@ -13241,7 +13241,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ZU" = (
 /obj/machinery/kitchen_machine/microwave{
 	pixel_x = -3;
@@ -13249,13 +13249,13 @@
 	},
 /obj/structure/table,
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ZV" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/plating/asteroid/airless{
 	icon_state = "asteroid5"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 "ZX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -13266,7 +13266,7 @@
 	pixel_y = -4
 	},
 /turf/simulated/floor/plasteel,
-/area/ruin/space/unpowered)
+/area/ruin/space/moonbase19)
 
 (1,1,1) = {"
 aa

--- a/code/game/area/areas/ruins/space_areas.dm
+++ b/code/game/area/areas/ruins/space_areas.dm
@@ -171,3 +171,7 @@
 /area/ruin/space/abandoned_engi_sat
 	name = "Abandoned NT Engineering Satellite"
 	apc_starts_off = TRUE
+
+/area/ruin/space/moonbase19
+	name = "Moon Base 19"
+	apc_starts_off = TRUE


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->



## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

fixes moon base 19 powering all other ruins, makes it it's own ruin area

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Ruin being it's own area is good.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

![image](https://github.com/ParadiseSS13/Paradise/assets/52090703/0822ac32-fc35-45a0-b80b-2e0f9df804f9)

god this place is power hungry, 30 sheets doesn't last long, hope you brought plasma or better stock parts


## Testing
<!-- How did you test the PR, if at all? -->

see above

## Changelog
:cl:
fix: Fixed moonbase 19 using the base unpowered area, now uses it's own area.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
