### PR TITLE
FIX: correct custom rank manifest modify

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -117,13 +117,20 @@ GLOBAL_LIST_EMPTY(PDA_Manifest)
 				break
 
 	var/list/all_jobs = get_job_datums()
+	var/is_custom_job = TRUE
 
 	for(var/datum/job/J in all_jobs)
 		var/list/alttitles = get_alternate_titles(J.title)
+		if(J.title == real_title)
+			is_custom_job = FALSE
 		if(!J)	continue
 		if(assignment in alttitles)
 			real_title = J.title
+			is_custom_job = FALSE
 			break
+
+	if(is_custom_job)
+		real_title = foundrecord.fields["real_rank"]
 
 	if(foundrecord)
 		foundrecord.fields["rank"] = assignment

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -121,7 +121,6 @@ GLOBAL_LIST_EMPTY(PDA_Manifest)
 
 	for(var/datum/job/J in all_jobs)
 		var/list/alttitles = get_alternate_titles(J.title)
-		if(!J)	continue
 		if(J.title == real_title)
 			is_custom_job = FALSE
 		if(assignment in alttitles)

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -123,7 +123,6 @@ GLOBAL_LIST_EMPTY(PDA_Manifest)
 		var/list/alttitles = get_alternate_titles(J.title)
 		if(J.title == real_title)
 			is_custom_job = FALSE
-		if(!J)	continue
 		if(assignment in alttitles)
 			real_title = J.title
 			is_custom_job = FALSE

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -121,6 +121,7 @@ GLOBAL_LIST_EMPTY(PDA_Manifest)
 
 	for(var/datum/job/J in all_jobs)
 		var/list/alttitles = get_alternate_titles(J.title)
+		if(!J)	continue
 		if(J.title == real_title)
 			is_custom_job = FALSE
 		if(assignment in alttitles)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
For custom work, we remember the last position so that we know where to display the role in the manifest.
This is only used in manifest_modify and in the role manager console.

## Why It's Good For The Game
This will help against custom roles issued by HOP. Now if you want to write "Temporary Deputy Captain", it will appear where it should be.

This problem has been annoying the HOS and everyone who looks at the manifest for several years now, especially with the influx of players and the actively working HOP, who likes to assign interesting roles to assistants.

## Images of changes

![image](https://github.com/ParadiseSS13/Paradise/assets/41479614/2c7aee18-9fd9-4719-a9eb-3c49cedc1221)


## Testing
Screenshot above. It's worked.

## Changelog
:cl:
fix: correct custom rank manifest modify
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
