### PR TITLE
Reverts Stechkin Buff, No Extra Mags

### DIFF
--- a/code/datums/uplink_items/uplink_general.dm
+++ b/code/datums/uplink_items/uplink_general.dm
@@ -174,7 +174,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	name = "FK-69 Pistol Kit"
 	reference = "SPI"
 	desc = "A box containing a small, easily concealable handgun and two eight-round magazines chambered in 10mm auto rounds. Compatible with suppressors."
-	item = /obj/item/storage/box/syndie_kit/stechkin
+	item = /obj/item/gun/projectile/automatic/pistol
 	cost = 20
 
 /datum/uplink_item/dangerous/revolver

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -373,15 +373,6 @@
 	new /obj/item/gun/projectile/revolver(src)
 	new /obj/item/ammo_box/a357(src)
 
-/obj/item/storage/box/syndie_kit/stechkin
-	name = "\improper FK-69 Stechkin kit"
-	desc = "A box marked with Neo-Russkiyan characters. It appears to contain a 10mm pistol and two magazines."
-
-/obj/item/storage/box/syndie_kit/stechkin/populate_contents()
-	new /obj/item/gun/projectile/automatic/pistol(src)
-	new /obj/item/ammo_box/magazine/m10mm(src)
-	new /obj/item/ammo_box/magazine/m10mm(src)
-
 /obj/item/storage/box/syndie_kit/camera_bug
 	name = "\improper Camera Bug kit"
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Reverts
- https://github.com/ParadiseSS13/Paradise/pull/21300

Removes the two free spare mags from the Stechkin. Back to its old one gun, on clip purchase. Spoken with another member in the balance team.

## Why It's Good For The Game
Gonna be honest, I don't understand why the Stechkin needed 16 extra shots of magazines despite its previous position before the buff being in a well established place. The points I read were, it was outclassed, needed more chances to reload, and promote its viability. But all of these were never issues to begin with.

The Stechkin is a 20 TC weapon (out of 100), for that price you get a pretty strong firearm that deals 30 brute damage on unarmored targets, and can be silenced, concealed easily, and use specialized ammo. I don't understand how it feels outclassed to other weapons when the whole guns niche was cheapness and flexibility. Compared to other firearms like the 357 or Ebow, which are triple the price of the Stech and reduce build strategies. Is it strong enough to compete with both of these? No, not really, but that's because its the cheapest choice and its supposed to have more glaring weakness to be balanced.  If a 20 TC gun could stand its ground with triple price heavy hitters, and easily beat security it would be insanely unbalanced.

As for needing more chances to reload, the original stech made players either find spare magazines in maint loot to help them reduce cost, or buy a spare or specialized mag to quickly reload the gun. Giving it two free mags for a total of 24 shots wasn't necessary when you only need half of a magazine (4 shots) to put someone into crit. Also the price for the mags are not even expensive, their cheap at 3 TC, 26 TC is still a really good deal for an economical gun. Lastly take into account how frequently they spawn in maint tunnels for free, and its practically unnecessary to give them MORE magazines to stay "viable" it feels like blatant powercreep and makes players not have a reason to ever strategize if they need more magazines for safety. Why invest more into your firearm when it already comes loaded with package?

Lastly, the issue 'that people will now use the "standard syndicate firearm" a bit more' didn't make sense with me. As the Stech was always a common choice and praised. It was always a viable weapon, it just wasn't a weapon that could brute force everything and win fights. It however like I stated previously had its niches and reasons to exist, it was used as a relatively good sidearm when other options were too expensive and it could still hold its ground against small security or robust crew. I simply disagree with that point and think its a bit of a weak reasoning for additional mags when it was already popular and well established.

## Testing
works

## Changelog
:cl: OctusGit
tweak: The Stechkin no longer gains two free mags in its purchase
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
