### PR TITLE
Fix duplicate tracking beacon issue

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -747,12 +747,12 @@
 				to_chat(user, "<span class='warning'>This exosuit already has a [current_tracker].</span>")
 				user.put_in_hands(new_tracker)
 				return
-			else
-				trackers -= current_tracker
-				to_chat(user, "<span class='notice'>You remove [current_tracker].</span>")
-				var/obj/item/mecha_parts/mecha_tracking/duplicate_tracker = new current_tracker.type
-				user.put_in_hands(duplicate_tracker)
-				qdel(current_tracker)
+
+			trackers -= current_tracker
+			to_chat(user, "<span class='notice'>You remove [current_tracker].</span>")
+			var/obj/item/mecha_parts/mecha_tracking/duplicate_tracker = new current_tracker.type
+			user.put_in_hands(duplicate_tracker)
+			qdel(current_tracker)
 		new_tracker.forceMove(src)
 		trackers += W
 		user.visible_message("[user] attaches [new_tracker] to [src].", "<span class='notice'>You attach [new_tracker] to [src].</span>")

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -743,11 +743,16 @@
 		// Check if a tracker exists
 		var/obj/item/mecha_parts/mecha_tracking/new_tracker = W
 		for(var/obj/item/mecha_parts/mecha_tracking/current_tracker in trackers)
-			if(new_tracker.ai_beacon == current_tracker.ai_beacon)
-				to_chat(user, "<span class='warning'>This exosuit already has \a [new_tracker.ai_beacon ? "AI" : "tracking"] beacon.</span>")
+			if(new_tracker.type == current_tracker.type)
+				to_chat(user, "<span class='warning'>This exosuit already has a [current_tracker].</span>")
 				user.put_in_hands(new_tracker)
 				return
-
+			else
+				trackers -= current_tracker
+				to_chat(user, "<span class='notice'>You remove [current_tracker].</span>")
+				var/obj/item/mecha_parts/mecha_tracking/duplicate_tracker = new current_tracker.type
+				user.put_in_hands(duplicate_tracker)
+				qdel(current_tracker)
 		new_tracker.forceMove(src)
 		trackers += W
 		user.visible_message("[user] attaches [new_tracker] to [src].", "<span class='notice'>You attach [new_tracker] to [src].</span>")


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
It prevent the player from putting two trackers (ai beacon+ the standard one) within a mech.
It return the old tracker on the player hand when you put a new one in the mech.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Before it was possible to put both an ai beacon and a tracker one within a mech, making the same mech appear twice in the robotic control console.
This isn't the end of the world type of "issues" as i was even unable to find any players reporting it on the github, but it's good to have it fixed.
There was also another (rare) issue that came with it:
From my own experiences, since it was also impossible to remove an ai beacon when it was put on a mech by a mistake, the RD usually order the mech to be destroyed to not tempt luck in the worst case scenario of a malf AI.

## Testing
I made a mech and the trackers spawns to test it out.

## Changelog
:cl:
fix: Can no longer put both an ai beacon and a tracker on a mech.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
