### PR TITLE
fix: remove `owner` requiring dependencies from `/datum/antagonist` only if `owner` is present

### DIFF
--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -43,18 +43,29 @@ GLOBAL_LIST_EMPTY(antagonists)
 /datum/antagonist/Destroy(force, ...)
 	qdel(objective_holder)
 	GLOB.antagonists -= src
-	if(owner)
-		remove_owner_from_gamemode()
-		if(!silent)
-			farewell()
-		remove_innate_effects()
-		antag_memory = null
-		var/datum/team/team = get_team()
-		team?.remove_member(owner)
-		LAZYREMOVE(owner.antag_datums, src)
-		restore_last_hud_and_role()
-		owner = null
+	if(!QDELETED(owner))
+		detach_from_owner()
+
 	return ..()
+
+/**
+ * Removes owner's dependencies on this antag datum.
+ * For example: removal of antag datum from owner's `antag_datums`, antag datum related teams etc.
+ * If your `/datum/antagonist`  subtype adds more dependencies on `owner` - they should be cleared there.
+ */
+/datum/antagonist/proc/detach_from_owner()
+	SHOULD_CALL_PARENT(TRUE)
+
+	remove_owner_from_gamemode()
+	if(!silent)
+		farewell()
+	remove_innate_effects()
+	antag_memory = null
+	var/datum/team/team = get_team()
+	team?.remove_member(owner)
+	LAZYREMOVE(owner.antag_datums, src)
+	restore_last_hud_and_role()
+	owner = null
 
 /**
  * Adds the owner to their respective gamemode's list. For example `SSticker.mode.traitors |= owner`.

--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -42,18 +42,18 @@ GLOBAL_LIST_EMPTY(antagonists)
 
 /datum/antagonist/Destroy(force, ...)
 	qdel(objective_holder)
-	remove_owner_from_gamemode()
 	GLOB.antagonists -= src
-	if(!silent)
-		farewell()
-	remove_innate_effects()
-	antag_memory = null
-	var/datum/team/team = get_team()
-	team?.remove_member(owner)
 	if(owner)
+		remove_owner_from_gamemode()
+		if(!silent)
+			farewell()
+		remove_innate_effects()
+		antag_memory = null
+		var/datum/team/team = get_team()
+		team?.remove_member(owner)
 		LAZYREMOVE(owner.antag_datums, src)
-	restore_last_hud_and_role()
-	owner = null
+		restore_last_hud_and_role()
+		owner = null
 	return ..()
 
 /**


### PR DESCRIPTION
## What Does This PR Do
Owner is not mandatory in `/datum/antagonist`, but when it's destroyed - `owner` is not properly checked for nullability, where it is required

## Why It's Good For The Game
Less runtimes - better.

## Images of changes
Nothing to show.

## Testing
Compiled, added antag datums and removed antag datums.
