### PR TITLE
Clap emote hand check

### DIFF
--- a/code/modules/mob/living/carbon/human/human_emote.dm
+++ b/code/modules/mob/living/carbon/human/human_emote.dm
@@ -52,10 +52,10 @@
 		return
 
 	var/mob/living/carbon/human/H = user
-+	if(H.get_active_hand() || H.get_inactive_hand())
-+		to_chat(user, "<span class='warning'>You need both hands free to clap.</span>")
-+		return TRUE
-	if(!H.bodyparts_by_name[BODY_ZONE_L_ARM] || !H.bodyparts_by_name[BODY_ZONE_R_ARM])
+	if(H.get_active_hand() || H.get_inactive_hand())
+		to_chat(user, "<span class='warning'>You need both hands free to clap.</span>")
+		return TRUE
+	else if(!H.bodyparts_by_name[BODY_ZONE_L_ARM] || !H.bodyparts_by_name[BODY_ZONE_R_ARM])
 		if(!H.bodyparts_by_name[BODY_ZONE_L_ARM] && !H.bodyparts_by_name[BODY_ZONE_R_ARM])
 			// no arms...
 			to_chat(user, "<span class='warning'>You need arms to be able to clap.</span>")

--- a/code/modules/mob/living/carbon/human/human_emote.dm
+++ b/code/modules/mob/living/carbon/human/human_emote.dm
@@ -52,6 +52,9 @@
 		return
 
 	var/mob/living/carbon/human/H = user
++	if(H.get_active_hand() || H.get_inactive_hand())
++		to_chat(user, "<span class='warning'>You need both hands free to clap.</span>")
++		return TRUE
 	if(!H.bodyparts_by_name[BODY_ZONE_L_ARM] || !H.bodyparts_by_name[BODY_ZONE_R_ARM])
 		if(!H.bodyparts_by_name[BODY_ZONE_L_ARM] && !H.bodyparts_by_name[BODY_ZONE_R_ARM])
 			// no arms...
@@ -62,6 +65,7 @@
 		return TRUE
 
 	return ..()
+
 
 /datum/emote/living/carbon/human/clap/get_sound(mob/living/user)
 	if(!ishuman(user))

--- a/code/modules/mob/living/carbon/human/human_emote.dm
+++ b/code/modules/mob/living/carbon/human/human_emote.dm
@@ -52,8 +52,8 @@
 		return
 
 	var/mob/living/carbon/human/H = user
-	if(H.get_active_hand() || H.get_inactive_hand())
-		to_chat(user, "<span class='warning'>You need both hands free to clap.</span>")
+	if(H.get_active_hand() && H.get_inactive_hand())
+		to_chat(user, "<span class='warning'>You need at least one hand free to clap.</span>")
 		return TRUE
 	else if(!H.bodyparts_by_name[BODY_ZONE_L_ARM] || !H.bodyparts_by_name[BODY_ZONE_R_ARM])
 		if(!H.bodyparts_by_name[BODY_ZONE_L_ARM] && !H.bodyparts_by_name[BODY_ZONE_R_ARM])
@@ -62,8 +62,10 @@
 		else
 			// well, we've got at least one
 			user.visible_message("[user] makes the sound of one hand clapping.")
+			return TRUE
+	else
+		user.visible_message("[user] makes the sound of two hands clapping.")
 		return TRUE
-
 	return ..()
 
 

--- a/code/modules/mob/living/carbon/human/human_emote.dm
+++ b/code/modules/mob/living/carbon/human/human_emote.dm
@@ -53,8 +53,8 @@
 
 	var/mob/living/carbon/human/H = user
 	if(H.get_active_hand() && H.get_inactive_hand())
-		to_chat(user, "<span class='warning'>You need at least one hand free to clap.</span>")
-		return TRUE
+		H.drop_item() // Drop item from active hand
+		to_chat(user, "<span class='warning'>You drop what you're holding to clap. Hopefully you had nothing important!</span>")
 	else if(!H.bodyparts_by_name[BODY_ZONE_L_ARM] || !H.bodyparts_by_name[BODY_ZONE_R_ARM])
 		if(!H.bodyparts_by_name[BODY_ZONE_L_ARM] && !H.bodyparts_by_name[BODY_ZONE_R_ARM])
 			// no arms...
@@ -63,9 +63,6 @@
 			// well, we've got at least one
 			user.visible_message("[user] makes the sound of one hand clapping.")
 			return TRUE
-	else
-		user.visible_message("[user] makes the sound of two hands clapping.")
-		return TRUE
 	return ..()
 
 


### PR DESCRIPTION
## What Does This PR Do
It make the player drop an item on the floor if they have both hands busy while trying to clap

## Why It's Good For The Game
I noticed in the game that we could still clap with our hands full of items, at first i just wanted to add a little check and block it (like we do with arms missing) until at least one hand was freed.
But i thought against in the end since i am a little prankster: After all if the player want to clap with both hands busy, who am i to stop them?

## Testing
I just clapped myself on localhost, truly a lonely experience.

## Changelog
:cl:
tweak: If you clap with both hands full of items, you'll drop one, your lose!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
