### PR TITLE
Runtime and GC fixes related to orbit UI bluescreens

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -49,6 +49,7 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 	owner = null
 	target = null
 	team = null
+	holder = null
 	return ..()
 
 /datum/objective/proc/check_completion()

--- a/code/game/gamemodes/objective_holder.dm
+++ b/code/game/gamemodes/objective_holder.dm
@@ -20,6 +20,9 @@
 
 /datum/objective_holder/Destroy(force, ...)
 	clear()
+	objective_owner = null
+	QDEL_NULL(on_add_callback)
+	QDEL_NULL(on_remove_callback)
 	return ..()
 
 /**

--- a/code/modules/antagonists/traitor/datum_mindslave.dm
+++ b/code/modules/antagonists/traitor/datum_mindslave.dm
@@ -27,8 +27,11 @@
 	if(owner.som)
 		owner.som.serv -= owner
 		owner.som.leave_serv_hud(owner)
-	// Remove the reference but turn this into a string so it can still be used in /datum/antagonist/mindslave/farewell().
-	master = "[master.current.real_name]"
+	// Remove the master reference but turn this into a string so it can still be used in /datum/antagonist/mindslave/farewell().
+	if(master.current)
+		master = "[master.current.real_name]"
+	else
+		master = "[master]"
 	return ..()
 
 /datum/antagonist/mindslave/on_gain()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
* Fixes GC issues with `datum/objective_holder` Which was causing mindslaves and thralls to fail GC and have their owners to have a null entry in their `mind.antag_datums` list.

![dreamseeker_0YvUJQOlcj](https://github.com/ParadiseSS13/Paradise/assets/42044220/298f736e-eccb-4a4c-a4ec-8b438ed32aeb)

This was leading to runtimes in the orbit menu:
```dm
[2023-12-09T05:04:10] Runtime in code/modules/mob/dead/observer/orbit.dm,102: Cannot read null.name
   proc name: ui static data (/datum/orbit_menu/ui_static_data)
   usr: Kar-Ski (ckey) (/mob/dead/observer)
   usr.loc: The catwalk (107,144,2) (/turf/simulated/floor/catwalk)
   src: /datum/orbit_menu (/datum/orbit_menu)
   call stack:
   /datum/orbit_menu (/datum/orbit_menu): ui_static_data
   /datum/tgui (/datum/tgui): open
   /datum/orbit_menu (/datum/orbit_menu): ui_interact
   Kar-Ski (/mob/dead/observer): Orbit
   Orbit (/obj/screen/ghost/orbit): Click
```

* Also fixes a runtime where in `/datum/antagonist/mindslave/Destroy` where `master.current` could be null, for example if their master was dusted.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Testing
1. Got 2 clients/characters
2. Had one be a vampire, then thralled the other.
3. Dusted the vampire, then de-thralled the thrall with holy water
4. Observed GC and runtime logs
<!-- How did you test the PR, if at all? -->

## Changelog
Nothing, just GC and runtime fixes.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
