### PR TITLE
Fixes IPC drinking jestosterone

### DIFF
--- a/code/modules/reagents/chemistry/reagents/misc_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/misc_reagents.dm
@@ -506,7 +506,7 @@
 
 /datum/reagent/jestosterone/on_mob_delete(mob/living/M)
 	..()
-	if(M.mind && M.mind.assigned_role != "Clown")
+	if(M?.mind.assigned_role != "Clown")
 		REMOVE_TRAIT(M, TRAIT_COMIC_SANS, id)
 		M.RemoveElement(/datum/element/waddling)
 	qdel(M.GetComponent(/datum/component/squeak))

--- a/code/modules/reagents/chemistry/reagents/misc_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/misc_reagents.dm
@@ -506,7 +506,7 @@
 
 /datum/reagent/jestosterone/on_mob_delete(mob/living/M)
 	..()
-	if(M.mind && M.mind.assigned_role != "Clown")
+	if(M.mind?.assigned_role != "Clown")
 		REMOVE_TRAIT(M, TRAIT_COMIC_SANS, id)
 		M.RemoveElement(/datum/element/waddling)
 	qdel(M.GetComponent(/datum/component/squeak))

--- a/code/modules/reagents/chemistry/reagents/misc_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/misc_reagents.dm
@@ -506,7 +506,7 @@
 
 /datum/reagent/jestosterone/on_mob_delete(mob/living/M)
 	..()
-	if(M?.mind.assigned_role != "Clown")
+	if(M.mind && M.mind.assigned_role != "Clown")
 		REMOVE_TRAIT(M, TRAIT_COMIC_SANS, id)
 		M.RemoveElement(/datum/element/waddling)
 	qdel(M.GetComponent(/datum/component/squeak))

--- a/code/modules/reagents/chemistry/reagents/misc_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/misc_reagents.dm
@@ -465,12 +465,13 @@
 		else if(C.mind.assigned_role == "Mime")
 			to_chat(C, "<span class='warning'>You feel nauseous.</span>")
 			C.AdjustDizzy(volume STATUS_EFFECT_CONSTANT)
+			ADD_TRAIT(C, TRAIT_COMIC_SANS, id)
+			C.AddElement(/datum/element/waddling)
 		else
 			to_chat(C, "<span class='warning'>Something doesn't feel right...</span>")
 			C.AdjustDizzy(volume STATUS_EFFECT_CONSTANT)
-	if(C.mind.assigned_role != "Clown")
-		ADD_TRAIT(C, TRAIT_COMIC_SANS, id)
-		C.AddElement(/datum/element/waddling)
+			ADD_TRAIT(C, TRAIT_COMIC_SANS, id)
+			C.AddElement(/datum/element/waddling)
 	C.AddComponent(/datum/component/squeak, null, null, null, null, null, TRUE, falloff_exponent = 20)
 
 /datum/reagent/jestosterone/on_mob_life(mob/living/carbon/M)
@@ -505,7 +506,7 @@
 
 /datum/reagent/jestosterone/on_mob_delete(mob/living/M)
 	..()
-	if(M.mind.assigned_role != "Clown")
+	if(M.mind && M.mind.assigned_role != "Clown")
 		REMOVE_TRAIT(M, TRAIT_COMIC_SANS, id)
 		M.RemoveElement(/datum/element/waddling)
 	qdel(M.GetComponent(/datum/component/squeak))

--- a/code/modules/reagents/chemistry/reagents_holder.dm
+++ b/code/modules/reagents/chemistry/reagents_holder.dm
@@ -716,8 +716,12 @@
 		cached_reagents += R
 		R.holder = src
 		R.volume = amount
-		if(ishuman(my_atom) && can_metabolize(my_atom, R))
+		if(ishuman(my_atom))
+			if(can_metabolize(my_atom, R))
+				R.on_new(data)
+		else
 			R.on_new(data)
+
 		if(data)
 			R.data = data
 

--- a/code/modules/reagents/chemistry/reagents_holder.dm
+++ b/code/modules/reagents/chemistry/reagents_holder.dm
@@ -716,7 +716,7 @@
 		cached_reagents += R
 		R.holder = src
 		R.volume = amount
-		if(can_metabolize(my_atom, R))
+		if(ishuman(my_atom) && can_metabolize(my_atom, R))
 			R.on_new(data)
 		if(data)
 			R.data = data

--- a/code/modules/reagents/chemistry/reagents_holder.dm
+++ b/code/modules/reagents/chemistry/reagents_holder.dm
@@ -716,7 +716,8 @@
 		cached_reagents += R
 		R.holder = src
 		R.volume = amount
-		R.on_new(data)
+		if(can_metabolize(my_atom, R))
+			R.on_new(data)
 		if(data)
 			R.data = data
 


### PR DESCRIPTION
## What Does This PR Do

Fixes IPC not losing component "squeak", waddling and comic sans trait when drinking jestosterone
Fixes runtime error when applying jestosterone to mob without a player

## Why It's Good For The Game
Right now IPC receives all effects from on_new() proc of reagent disregarding ability to metabolize it. Fixes this bug.

## Testing
Locally

## Changelog
:cl:
fix: Fixes IPC not losing squeakyness, waddling and comic sans trait when drinking jestosterone
/:cl:
