### PR TITLE
Add detectives revolver as theft objective

### DIFF
--- a/code/game/gamemodes/steal_items.dm
+++ b/code/game/gamemodes/steal_items.dm
@@ -143,6 +143,12 @@
 	protected_jobs = list("Head Of Security", "Warden")
 	location_override = "the Warden's Office"
 
+/datum/theft_objective/dl88
+	name = "the DL-88 energy revolver"
+	typepath = /obj/item/gun/energy/detective
+	protected_jobs = list("Detective")
+	location_override = "the Detective's Office"
+
 /datum/theft_objective/supermatter_sliver
 	name = "a supermatter sliver"
 	typepath = /obj/item/nuke_core/supermatter_sliver

--- a/code/game/gamemodes/steal_items.dm
+++ b/code/game/gamemodes/steal_items.dm
@@ -144,7 +144,7 @@
 	location_override = "the Warden's Office"
 
 /datum/theft_objective/dl88
-	name = "the DL-88 energy revolver"
+	name = "the detective's DL-88 energy revolver"
 	typepath = /obj/item/gun/energy/detective
 	protected_jobs = list("Detective")
 	location_override = "the Detective's Office"

--- a/code/modules/projectiles/guns/energy/special_eguns.dm
+++ b/code/modules/projectiles/guns/energy/special_eguns.dm
@@ -716,6 +716,7 @@
 	options["The Original"] = "handgun"
 	options["Golden Mamba"] = "handgun_golden-mamba"
 	options["NT's Finest"] = "handgun_nt-finest"
+	RegisterSignal(src, COMSIG_PARENT_QDELETING, PROC_REF(alert_admins_on_destroy))
 
 /obj/item/gun/energy/detective/Destroy()
 	QDEL_NULL(Announcer)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
This adds the detectives revolver, the DL-88 energy revolver as a theft objective, on account of it being both unique and special

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Adding more theft objectives is just good, and the detectives feels awfully safe regarding their revolver, and it would be a shame if something happened to it.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![image](https://github.com/ParadiseSS13/Paradise/assets/21987702/7b07b68b-7dc6-4ece-93a5-a11ab5879251)

## Testing
<!-- How did you test the PR, if at all? -->
![image](https://github.com/ParadiseSS13/Paradise/assets/21987702/1bb38c56-ced0-4e05-9e82-75b9b1970313)

## Changelog
:cl: ppi
add: Certain antagonist may get steal the detectives revolver as an objective.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
