### PR TITLE
Test further CI fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,8 +106,7 @@ jobs:
         run: |
           sudo dpkg --add-architecture i386
           sudo apt update || true
-          sudo apt install lib32z1 git pkg-config libssl-dev:i386 libssl-dev zlib1g-dev:i386 curl gcc libdbus-1-dev
-          sudo apt install gcc:i386
+          sudo apt install zlib1g-dev:i386
           tools/ci/install_rustg.sh
       - name: Compile & Run Unit Tests
         run: |


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
More CI fix testing, after a short period of it working it broke again due to package conflicts. This tests a fix by stripping back the required packages to what TG's rust-g repo recommends.
``` 
The following packages have unmet dependencies:
 binutils : Conflicts: binutils:i386 but 2.38-4ubuntu2.4 is to be installed
 binutils:i386 : Conflicts: binutils but 2.38-4ubuntu2.3 is to be installed
 binutils-common : Breaks: binutils-common:i386 (!= 2.38-4ubuntu2.3) but 2.38-4ubuntu2.4 is to be installed
 binutils-common:i386 : Breaks: binutils-common (!= 2.38-4ubuntu2.4) but 2.38-4ubuntu2.3 is to be installed
 libbinutils : Breaks: libbinutils:i386 (!= 2.38-4ubuntu2.3) but 2.38-4ubuntu2.4 is to be installed
 libbinutils:i386 : Breaks: libbinutils (!= 2.38-4ubuntu2.4) but 2.38-4ubuntu2.3 is to be installed
 libctf0 : Breaks: libctf0:i386 (!= 2.38-4ubuntu2.3) but 2.38-4ubuntu2.4 is to be installed
 libctf0:i386 : Breaks: libctf0 (!= 2.38-4ubuntu2.4) but 2.38-4ubuntu2.3 is to be installed
E: Error, pkgProblemResolver::Resolve generated breaks, this may be caused by held packages.
Error: Process completed with exit code 100.
```
