### PR TITLE
tweak: randomly choose special kit receiver

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -631,7 +631,7 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 			if(kit_receiver_mind == objective_owner || !objective_owner.current)
 				continue
 
-			to_chat(objective_owner.current, "<br><br>[kit_receiver] has received box containing <b>items and instructions</b> to help you with your steal objective.</span><br>")
+			to_chat(objective_owner.current, "<br><br>[kit_receiver] has received a box containing <b>items and instructions</b> to help you with your steal objective.</span><br>")
 
 		return
 

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -565,26 +565,25 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 	explanation_text = "Free Objective."
 
 /datum/objective/steal/proc/select_target()
-	var/list/possible_items_all = GLOB.potential_theft_objectives+"custom"
+	var/list/possible_items_all = GLOB.potential_theft_objectives + "custom"
 	var/new_target = input("Select target:", "Objective target", null) as null|anything in possible_items_all
 	if(!new_target)
 		return
 
 	if(new_target == "custom")
-		var/datum/theft_objective/O=new
-		O.typepath = input("Select type:","Type") as null|anything in typesof(/obj/item)
-		if(!O.typepath)
+		var/obj/item/steal_target_path = input("Select type:","Type") as null|anything in typesof(/obj/item)
+		if(!steal_target_path)
 			return
 
-		var/tmp_obj = new O.typepath
-		var/custom_name = tmp_obj:name
-		qdel(tmp_obj)
-		O.name = sanitize(copytext(input("Enter target name:", "Objective target", custom_name) as text|null,1,MAX_NAME_LEN))
-		if(!O.name)
+		var/theft_objective_name = sanitize(copytext(input("Enter target name:", "Objective target", initial(steal_target_path.name)) as text|null, 1, MAX_NAME_LEN))
+		if(!theft_objective_name)
 			return
 
-		steal_target = O
-		explanation_text = "Steal [O.name]."
+		var/datum/theft_objective/target_theft_objective = new
+		target_theft_objective.typepath = steal_target_path
+		target_theft_objective.name = theft_objective_name
+		steal_target = target_theft_objective
+		explanation_text = "Steal [theft_objective_name]."
 	else
 		steal_target = new new_target
 		explanation_text = "Steal [steal_target.name]."

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -623,14 +623,27 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 			continue
 
 		var/where = kit_receiver.equip_in_one_of_slots(item_to_give, slots)
-		if(where)
-			to_chat(kit_receiver, "<br><br><span class='info'>In your [where] is a box containing <b>items and instructions</b> to help you with your steal objective.</span><br>")
-			return
+		if(!where)
+			continue
 
-		to_chat(kit_receiver, "<span class='userdanger'>Unfortunately, you weren't able to get a stealing kit. This is very bad and you should adminhelp immediately (press F1).</span>")
-		message_admins("[ADMIN_LOOKUPFLW(kit_receiver)] Failed to spawn with their [item_path] theft kit.")
+		to_chat(kit_receiver, "<br><br><span class='info'>In your [where] is a box containing <b>items and instructions</b> to help you with your steal objective.</span><br>")
+		for(var/datum/mind/objective_owner as anything in objective_owners)
+			if(kit_receiver_mind == objective_owner || !objective_owner.current)
+				continue
+
+			to_chat(objective_owner.current, "<br><br>[kit_receiver] has received box containing <b>items and instructions</b> to help you with your steal objective.</span><br>")
+
+		return
 
 	qdel(item_to_give)
+
+	for(var/datum/mind/objective_owner as anything in objective_owners)
+		var/mob/living/carbon/human/failed_receiver = objective_owner.current
+		if(!failed_receiver)
+			continue
+
+		to_chat(failed_receiver, "<span class='userdanger'>Unfortunately, you weren't able to get a stealing kit. This is very bad and you should adminhelp immediately (press F1).</span>")
+		message_admins("[ADMIN_LOOKUPFLW(failed_receiver)] Failed to spawn with their [item_path] theft kit.")
 
 
 /datum/objective/absorb


### PR DESCRIPTION
## What Does This PR Do
Steal object special kits are now given to random objective owner (multiple owners possible when objective is assigned to team). 
Previously the SAME item was given to each one in team, which effectively resulted in item being given to the last owner.

## Why It's Good For The Game
More predictable special equipment giving strategy.

## Images of changes
All in code.

## Testing
Spawned, given objective.

## Changelog
:cl:
tweak: Steal object special kits are now given to random objective owner. Previously the SAME item was given to each one in team, which effectively resulted in item being given to the last owner.
/:cl:
