### PR TITLE
Fixes pills and patches displaying a fake transfer rate

### DIFF
--- a/code/modules/reagents/reagent_containers/patch.dm
+++ b/code/modules/reagents/reagent_containers/patch.dm
@@ -6,8 +6,6 @@
 	item_state = "bandaid"
 	possible_transfer_amounts = null
 	volume = 30
-	temperature_min = 270
-	temperature_max = 350
 	var/instant_application = FALSE
 	var/needs_to_apply_reagents = TRUE
 

--- a/code/modules/reagents/reagent_containers/patch.dm
+++ b/code/modules/reagents/reagent_containers/patch.dm
@@ -5,6 +5,7 @@
 	icon_state = "bandaid"
 	item_state = "bandaid"
 	possible_transfer_amounts = null
+	visible_transfer_rate = FALSE
 	volume = 30
 	var/instant_application = FALSE
 	var/needs_to_apply_reagents = TRUE

--- a/code/modules/reagents/reagent_containers/patch.dm
+++ b/code/modules/reagents/reagent_containers/patch.dm
@@ -7,6 +7,8 @@
 	possible_transfer_amounts = null
 	visible_transfer_rate = FALSE
 	volume = 30
+	temperature_min = 270
+	temperature_max = 350
 	var/instant_application = FALSE
 	var/needs_to_apply_reagents = TRUE
 

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -9,10 +9,8 @@
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = null
 	item_state = "pill"
-	container_type = NONE
 	possible_transfer_amounts = null
 	volume = 100
-	has_lid = FALSE
 
 /obj/item/reagent_containers/pill/Initialize(mapload)
 	. = ..()

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -10,6 +10,7 @@
 	icon_state = null
 	item_state = "pill"
 	possible_transfer_amounts = null
+	visible_transfer_rate = FALSE
 	volume = 100
 
 /obj/item/reagent_containers/pill/Initialize(mapload)


### PR DESCRIPTION
## What Does This PR Do
Fixes pills and patches displaying their nonexistent transfer rate in examine text;
Also cleans up a couple redundant, same-as-parent property reassignments from pills.

## Why It's Good For The Game
Oversights bad, pills/patches shouldn't have a visible transfer rate

## Testing
Made some pills and patches, examined them

## Changelog
:cl:
spellcheck: Fixed pills/patches advertising a nonexistent transfer rate in their examine text
/:cl:
