### PR TITLE
fix: replace `menu_location` with `category` in `/datum/action/changeling/apex_predator`. Rename 1 char vars

### DIFF
--- a/code/modules/antagonists/changeling/powers/apex_predator.dm
+++ b/code/modules/antagonists/changeling/powers/apex_predator.dm
@@ -5,18 +5,19 @@
 	button_icon_state = "predator"
 	dna_cost = 1
 	power_type = CHANGELING_PURCHASABLE_POWER
-	menu_location = CLING_MENU_UTILITY
+	category = /datum/changeling_power_category/utility
 
 /datum/action/changeling/apex_predator/sting_action(mob/user)
-	var/target_by_name = list()
-	for(var/mob/living/carbon/human/H in GLOB.human_list)
-		if((H.z != user.z) || !H.mind)
+	var/list/target_by_name = list()
+	for(var/mob/living/carbon/human/possible_target as anything in GLOB.human_list)
+		if((!possible_target.mind || possible_target.z != user.z))
 			continue
-		target_by_name[H.real_name] = H
+		target_by_name[possible_target.real_name] = possible_target
 
 	var/target_name = tgui_input_list(user, "Person to Locate", "Prey", target_by_name)
 	if(!target_name)
 		return
+
 	var/mob/living/carbon/human/target = target_by_name[target_name]
 	var/message = "[target_name] is in [get_area(target)], [dir2text(get_dir(user, target))] of us."
 	if(target.get_damage_amount() >= 40 || target.bleed_rate)


### PR DESCRIPTION
## What Does This PR Do
Fix error in code. Replaces `menu_location` to `category` for changeling ability. Also, rename some 1 char vars

## Why It's Good For The Game
The game will compile, it's good.

## Images of changes
All in code

## Testing
Compiled

Not player facing (actually is, but not really)