### PR TITLE
Player-controlled simplemobs can now open lockers and morgue trays

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -279,14 +279,14 @@
 	toggle(user)
 
 /obj/structure/closet/attack_animal(mob/living/user)
-    if(user.a_intent == INTENT_HARM || welded || locked)
-        return ..()
-    if(!user.mind) // Stops mindless mobs from opening lockers + endlessly opening/closing crates instead of attacking
-        return ..()
-    if(user.mob_size < MOB_SIZE_HUMAN)
-        return ..()
-    add_fingerprint(user)
-    toggle(user)
+	if(user.a_intent == INTENT_HARM || welded || locked)
+	return ..()
+	if(!user.mind) // Stops mindless mobs from opening lockers + endlessly opening/closing crates instead of attacking
+		return ..()
+	if(user.mob_size < MOB_SIZE_HUMAN)
+		return ..()
+	add_fingerprint(user)
+	toggle(user)
 
 
 /obj/structure/closet/attack_alien(mob/user)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -278,6 +278,24 @@
 	add_fingerprint(user)
 	toggle(user)
 
+/obj/structure/closet/attack_animal(mob/living/user)
+	if(user.a_intent == INTENT_HARM || welded || locked)
+		return ..()
+	if(user.mob_size < MOB_SIZE_LARGE)
+		return ..()
+	if(!user.mind) //Stops mindless mobs from opening lockers + endlessly opening/closing crates instead of attacking
+		return ..()
+	add_fingerprint(user)
+	toggle(user)
+
+/obj/structure/closet/attack_alien(mob/user)
+	if(user.a_intent == INTENT_HARM || welded || locked)
+		return ..()
+	if(!user.mind)
+		return ..()
+	add_fingerprint(user)
+	toggle(user)
+
 /obj/structure/closet/attack_ghost(mob/user)
 	if(user.can_advanced_admin_interact())
 		toggle(user)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -288,7 +288,6 @@
 	add_fingerprint(user)
 	toggle(user)
 
-
 /obj/structure/closet/attack_alien(mob/user)
 	if(user.a_intent == INTENT_HARM || welded || locked)
 		return ..()

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -280,7 +280,7 @@
 
 /obj/structure/closet/attack_animal(mob/living/user)
 	if(user.a_intent == INTENT_HARM || welded || locked)
-	return ..()
+		return ..()
 	if(!user.mind) // Stops mindless mobs from opening lockers + endlessly opening/closing crates instead of attacking
 		return ..()
 	if(user.mob_size < MOB_SIZE_HUMAN)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -279,14 +279,15 @@
 	toggle(user)
 
 /obj/structure/closet/attack_animal(mob/living/user)
-	if(user.a_intent == INTENT_HARM || welded || locked)
-		return ..()
-	if(user.mob_size < MOB_SIZE_LARGE)
-		return ..()
-	if(!user.mind) //Stops mindless mobs from opening lockers + endlessly opening/closing crates instead of attacking
-		return ..()
-	add_fingerprint(user)
-	toggle(user)
+    if(user.a_intent == INTENT_HARM || welded || locked)
+        return ..()
+    if(!user.mind) // Stops mindless mobs from opening lockers + endlessly opening/closing crates instead of attacking
+        return ..()
+    if(user.mob_size < MOB_SIZE_HUMAN)
+        return ..()
+    add_fingerprint(user)
+    toggle(user)
+
 
 /obj/structure/closet/attack_alien(mob/user)
 	if(user.a_intent == INTENT_HARM || welded || locked)

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -155,7 +155,7 @@
 /obj/structure/morgue/attack_animal(mob/living/user)
 	if(user.a_intent == INTENT_HARM)
 		return ..()
-	if(user.mob_size < MOB_SIZE_LARGE)
+	if(user.mob_size < MOB_SIZE_HUMAN)
 		return ..()
 	if(!user.mind) //Stops mindless mobs from doing weird stuff with them
 		return ..()
@@ -269,7 +269,7 @@
 /obj/structure/m_tray/attack_animal(mob/living/user)
 	if(user.a_intent == INTENT_HARM)
 		return ..()
-	if(user.mob_size < MOB_SIZE_LARGE)
+	if(user.mob_size < MOB_SIZE_HUMAN)
 		return ..()
 	if(!user.mind) //Stops mindless mobs from doing weird stuff with them
 		return ..()

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -152,6 +152,22 @@
 	update_state()
 	return
 
+/obj/structure/morgue/attack_animal(mob/living/user)
+	if(user.a_intent == INTENT_HARM)
+		return ..()
+	if(user.mob_size < MOB_SIZE_LARGE)
+		return ..()
+	if(!user.mind) //Stops mindless mobs from doing weird stuff with them
+		return ..()
+	attack_hand(user)
+
+/obj/structure/morgue/attack_alien(mob/user)
+	if(user.a_intent == INTENT_HARM)
+		return ..()
+	if(!user.mind)
+		return ..()
+	attack_hand(user)
+
 /obj/structure/morgue/attackby(P as obj, mob/user as mob, params)
 	if(is_pen(P))
 		var/t = rename_interactive(user, P)
@@ -249,6 +265,22 @@
 		add_fingerprint(user)
 		qdel(src)
 		return
+
+/obj/structure/m_tray/attack_animal(mob/living/user)
+	if(user.a_intent == INTENT_HARM)
+		return ..()
+	if(user.mob_size < MOB_SIZE_LARGE)
+		return ..()
+	if(!user.mind) //Stops mindless mobs from doing weird stuff with them
+		return ..()
+	attack_hand(user)
+
+/obj/structure/m_tray/attack_alien(mob/user)
+	if(user.a_intent == INTENT_HARM)
+		return ..()
+	if(!user.mind)
+		return ..()
+	attack_hand(user)
 
 /obj/structure/m_tray/MouseDrop_T(atom/movable/O, mob/living/user)
 	if((!(istype(O, /atom/movable)) || O.anchored || get_dist(user, src) > 1 || get_dist(user, O) > 1 || user.contents.Find(src) || user.contents.Find(O)))


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Player-controlled simplemobs (and xenos) can now open lockers and morgue trays. They need to be human size or bigger to do this, and will still slash at lockers/morgues if they're on harm intent or if the locker is locked/welded.

Note that this does not change behavior for non-intelligent simplemobs - they'll still chew away at lockers as before.
You also need to be human sized or bigger to open stuff - no mice slamming lockers closed.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Interacting with lockers has always been really awkward as an intelligent simplemob. Lockers being something humans can pass trough and flick closed with ease whilst the xeno (with perfectly functional hand-like appendages) right behind them needs to spend 5 seconds slashing at it in order to get it open is a bit silly.
Also fixes annoying scenarios like being a green terror spider in a morgue filled with bodies, unable to get to any of them, as well as crew members using lockers and bodybags to make bodies significantly harder to access for midround antags.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Tried opening stuff as a few different mob types
Slashed at a few locked lockers
Failed to open lockers as a mouse
Baited dumb simplemobs into attacking a bunch of lockers
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
add: Player-controlled simplemobs can now open lockers and morgue trays
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
