### PR TITLE
TGUI Input List Toggle

### DIFF
--- a/code/__DEFINES/preferences_defines.dm
+++ b/code/__DEFINES/preferences_defines.dm
@@ -63,8 +63,9 @@
 #define PREFTOGGLE_2_DANCE_DISCO			(1<<16) // 65536
 #define PREFTOGGLE_2_MOD_ACTIVATION_METHOD	(1<<17) // 131072
 #define PREFTOGGLE_2_PARALLAX_IN_DARKNESS	(1<<18) // 262144
+#define PREFTOGGLE_2_INPUT_LIST_CHOICE		(1<<19) // 524288
 
-#define TOGGLES_2_TOTAL 			524287 // If you add or remove a preference toggle above, make sure you update this define with the total value of the toggles combined.
+#define TOGGLES_2_TOTAL 					1048576 // If you add or remove a preference toggle above, make sure you update this define with the total value of the toggles combined.
 
 #define TOGGLES_2_DEFAULT (PREFTOGGLE_2_FANCYUI|PREFTOGGLE_2_ITEMATTACK|PREFTOGGLE_2_WINDOWFLASHING|PREFTOGGLE_2_RUNECHAT|PREFTOGGLE_2_DEATHMESSAGE|PREFTOGGLE_2_EMOTE_BUBBLE|PREFTOGGLE_2_SEE_ITEM_OUTLINES|PREFTOGGLE_2_THOUGHT_BUBBLE|PREFTOGGLE_2_DANCE_DISCO|PREFTOGGLE_2_MOD_ACTIVATION_METHOD)
 

--- a/code/__DEFINES/preferences_defines.dm
+++ b/code/__DEFINES/preferences_defines.dm
@@ -63,7 +63,7 @@
 #define PREFTOGGLE_2_DANCE_DISCO			(1<<16) // 65536
 #define PREFTOGGLE_2_MOD_ACTIVATION_METHOD	(1<<17) // 131072
 #define PREFTOGGLE_2_PARALLAX_IN_DARKNESS	(1<<18) // 262144
-#define PREFTOGGLE_2_TGUI_INPUT_LIST		(1<<19) // 524288
+#define PREFTOGGLE_2_DISABLE_TGUI_LISTS		(1<<19) // 524288
 
 #define TOGGLES_2_TOTAL 					1048575 // If you add or remove a preference toggle above, make sure you update this define with the total value of the toggles combined.
 

--- a/code/__DEFINES/preferences_defines.dm
+++ b/code/__DEFINES/preferences_defines.dm
@@ -65,7 +65,7 @@
 #define PREFTOGGLE_2_PARALLAX_IN_DARKNESS	(1<<18) // 262144
 #define PREFTOGGLE_2_INPUT_LIST_CHOICE		(1<<19) // 524288
 
-#define TOGGLES_2_TOTAL 					1048576 // If you add or remove a preference toggle above, make sure you update this define with the total value of the toggles combined.
+#define TOGGLES_2_TOTAL 					1048575 // If you add or remove a preference toggle above, make sure you update this define with the total value of the toggles combined.
 
 #define TOGGLES_2_DEFAULT (PREFTOGGLE_2_FANCYUI|PREFTOGGLE_2_ITEMATTACK|PREFTOGGLE_2_WINDOWFLASHING|PREFTOGGLE_2_RUNECHAT|PREFTOGGLE_2_DEATHMESSAGE|PREFTOGGLE_2_EMOTE_BUBBLE|PREFTOGGLE_2_SEE_ITEM_OUTLINES|PREFTOGGLE_2_THOUGHT_BUBBLE|PREFTOGGLE_2_DANCE_DISCO|PREFTOGGLE_2_MOD_ACTIVATION_METHOD)
 

--- a/code/__DEFINES/preferences_defines.dm
+++ b/code/__DEFINES/preferences_defines.dm
@@ -63,7 +63,7 @@
 #define PREFTOGGLE_2_DANCE_DISCO			(1<<16) // 65536
 #define PREFTOGGLE_2_MOD_ACTIVATION_METHOD	(1<<17) // 131072
 #define PREFTOGGLE_2_PARALLAX_IN_DARKNESS	(1<<18) // 262144
-#define PREFTOGGLE_2_INPUT_LIST_CHOICE		(1<<19) // 524288
+#define PREFTOGGLE_2_TGUI_INPUT_LIST		(1<<19) // 524288
 
 #define TOGGLES_2_TOTAL 					1048575 // If you add or remove a preference toggle above, make sure you update this define with the total value of the toggles combined.
 

--- a/code/modules/client/preference/link_processing.dm
+++ b/code/modules/client/preference/link_processing.dm
@@ -942,7 +942,7 @@
 					toggles2 ^= PREFTOGGLE_2_FANCYUI
 
 				if("input_lists")
-					toggles2 ^= PREFTOGGLE_2_TGUI_INPUT_LIST
+					toggles2 ^= PREFTOGGLE_2_DISABLE_TGUI_LISTS
 
 				if("ghost_att_anim")
 					toggles2 ^= PREFTOGGLE_2_ITEMATTACK

--- a/code/modules/client/preference/link_processing.dm
+++ b/code/modules/client/preference/link_processing.dm
@@ -941,6 +941,9 @@
 				if("tgui")
 					toggles2 ^= PREFTOGGLE_2_FANCYUI
 
+				if("input_lists")
+					toggles2 ^= PREFTOGGLE_2_INPUT_LIST_CHOICE
+
 				if("ghost_att_anim")
 					toggles2 ^= PREFTOGGLE_2_ITEMATTACK
 

--- a/code/modules/client/preference/link_processing.dm
+++ b/code/modules/client/preference/link_processing.dm
@@ -942,7 +942,7 @@
 					toggles2 ^= PREFTOGGLE_2_FANCYUI
 
 				if("input_lists")
-					toggles2 ^= PREFTOGGLE_2_INPUT_LIST_CHOICE
+					toggles2 ^= PREFTOGGLE_2_TGUI_INPUT_LIST
 
 				if("ghost_att_anim")
 					toggles2 ^= PREFTOGGLE_2_ITEMATTACK

--- a/code/modules/client/preference/preferences.dm
+++ b/code/modules/client/preference/preferences.dm
@@ -408,7 +408,7 @@ GLOBAL_LIST_INIT(special_role_times, list( //minimum age (in days) for accounts 
 			if(user.client.donator_level > 0)
 				dat += "<b>Donator Publicity:</b> <a href='?_src_=prefs;preference=donor_public'><b>[(toggles & PREFTOGGLE_DONATOR_PUBLIC) ? "Public" : "Hidden"]</b></a><br>"
 			dat += "<b>Fancy TGUI:</b> <a href='?_src_=prefs;preference=tgui'>[(toggles2 & PREFTOGGLE_2_FANCYUI) ? "Yes" : "No"]</a><br>"
-			dat += "<b>Input Lists:</b> <a href='?_src_=prefs;preference=input_lists'>[(toggles2 & PREFTOGGLE_2_INPUT_LIST_CHOICE) ? "Default" : "TGUI"]</a><br>"
+			dat += "<b>Input Lists:</b> <a href='?_src_=prefs;preference=input_lists'>[(toggles2 & PREFTOGGLE_2_TGUI_INPUT_LIST) ? "Default" : "TGUI"]</a><br>"
 			dat += "<b>FPS:</b>	 <a href='?_src_=prefs;preference=clientfps;task=input'>[clientfps]</a><br>"
 			dat += "<b>Ghost Ears:</b> <a href='?_src_=prefs;preference=ghost_ears'><b>[(toggles & PREFTOGGLE_CHAT_GHOSTEARS) ? "All Speech" : "Nearest Creatures"]</b></a><br>"
 			dat += "<b>Ghost Radio:</b> <a href='?_src_=prefs;preference=ghost_radio'><b>[(toggles & PREFTOGGLE_CHAT_GHOSTRADIO) ? "All Chatter" : "Nearest Speakers"]</b></a><br>"

--- a/code/modules/client/preference/preferences.dm
+++ b/code/modules/client/preference/preferences.dm
@@ -408,7 +408,7 @@ GLOBAL_LIST_INIT(special_role_times, list( //minimum age (in days) for accounts 
 			if(user.client.donator_level > 0)
 				dat += "<b>Donator Publicity:</b> <a href='?_src_=prefs;preference=donor_public'><b>[(toggles & PREFTOGGLE_DONATOR_PUBLIC) ? "Public" : "Hidden"]</b></a><br>"
 			dat += "<b>Fancy TGUI:</b> <a href='?_src_=prefs;preference=tgui'>[(toggles2 & PREFTOGGLE_2_FANCYUI) ? "Yes" : "No"]</a><br>"
-			dat += "<b>Input Lists:</b> <a href='?_src_=prefs;preference=input_lists'>[(toggles2 & PREFTOGGLE_2_TGUI_INPUT_LIST) ? "Default" : "TGUI"]</a><br>"
+			dat += "<b>Input Lists:</b> <a href='?_src_=prefs;preference=input_lists'>[(toggles2 & PREFTOGGLE_2_DISABLE_TGUI_LISTS) ? "Default" : "TGUI"]</a><br>"
 			dat += "<b>FPS:</b>	 <a href='?_src_=prefs;preference=clientfps;task=input'>[clientfps]</a><br>"
 			dat += "<b>Ghost Ears:</b> <a href='?_src_=prefs;preference=ghost_ears'><b>[(toggles & PREFTOGGLE_CHAT_GHOSTEARS) ? "All Speech" : "Nearest Creatures"]</b></a><br>"
 			dat += "<b>Ghost Radio:</b> <a href='?_src_=prefs;preference=ghost_radio'><b>[(toggles & PREFTOGGLE_CHAT_GHOSTRADIO) ? "All Chatter" : "Nearest Speakers"]</b></a><br>"

--- a/code/modules/client/preference/preferences.dm
+++ b/code/modules/client/preference/preferences.dm
@@ -408,6 +408,7 @@ GLOBAL_LIST_INIT(special_role_times, list( //minimum age (in days) for accounts 
 			if(user.client.donator_level > 0)
 				dat += "<b>Donator Publicity:</b> <a href='?_src_=prefs;preference=donor_public'><b>[(toggles & PREFTOGGLE_DONATOR_PUBLIC) ? "Public" : "Hidden"]</b></a><br>"
 			dat += "<b>Fancy TGUI:</b> <a href='?_src_=prefs;preference=tgui'>[(toggles2 & PREFTOGGLE_2_FANCYUI) ? "Yes" : "No"]</a><br>"
+			dat += "<b>Input Lists:</b> <a href='?_src_=prefs;preference=input_lists'>[(toggles2 & PREFTOGGLE_2_INPUT_LIST_CHOICE) ? "Default" : "TGUI"]</a><br>"
 			dat += "<b>FPS:</b>	 <a href='?_src_=prefs;preference=clientfps;task=input'>[clientfps]</a><br>"
 			dat += "<b>Ghost Ears:</b> <a href='?_src_=prefs;preference=ghost_ears'><b>[(toggles & PREFTOGGLE_CHAT_GHOSTEARS) ? "All Speech" : "Nearest Creatures"]</b></a><br>"
 			dat += "<b>Ghost Radio:</b> <a href='?_src_=prefs;preference=ghost_radio'><b>[(toggles & PREFTOGGLE_CHAT_GHOSTRADIO) ? "All Chatter" : "Nearest Speakers"]</b></a><br>"

--- a/code/modules/client/preference/preferences_toggles.dm
+++ b/code/modules/client/preference/preferences_toggles.dm
@@ -230,9 +230,9 @@
 	set name = "Toggle TGUI Input Lists"
 	set category = "Preferences"
 	set desc = "Switches input lists between the TGUI and the standard one"
-	prefs.toggles2 ^= PREFTOGGLE_2_TGUI_INPUT_LIST
+	prefs.toggles2 ^= PREFTOGGLE_2_DISABLE_TGUI_LISTS
 	prefs.save_preferences(src)
-	to_chat(src, "You will [(prefs.toggles2 & PREFTOGGLE_2_TGUI_INPUT_LIST) ? "no longer" : "now"] use TGUI Input Lists.")
+	to_chat(src, "You will [(prefs.toggles2 & PREFTOGGLE_2_DISABLE_TGUI_LISTS) ? "no longer" : "now"] use TGUI Input Lists.")
 
 /client/verb/Toggle_disco() //to toggle off the disco machine locally, in case it gets too annoying
 	set name = "Hear/Silence Dance Machine"

--- a/code/modules/client/preference/preferences_toggles.dm
+++ b/code/modules/client/preference/preferences_toggles.dm
@@ -230,9 +230,9 @@
 	set name = "Toggle TGUI Input Lists"
 	set category = "Preferences"
 	set desc = "Switches input lists between the TGUI and the standard one"
-	prefs.toggles2 ^= PREFTOGGLE_2_INPUT_LIST_CHOICE
+	prefs.toggles2 ^= PREFTOGGLE_2_TGUI_INPUT_LIST
 	prefs.save_preferences(src)
-	to_chat(src, "You will [(prefs.toggles2 & PREFTOGGLE_2_INPUT_LIST_CHOICE) ? "no longer" : "now"] use TGUI Input Lists.")
+	to_chat(src, "You will [(prefs.toggles2 & PREFTOGGLE_2_TGUI_INPUT_LIST) ? "no longer" : "now"] use TGUI Input Lists.")
 
 /client/verb/Toggle_disco() //to toggle off the disco machine locally, in case it gets too annoying
 	set name = "Hear/Silence Dance Machine"

--- a/code/modules/client/preference/preferences_toggles.dm
+++ b/code/modules/client/preference/preferences_toggles.dm
@@ -226,6 +226,14 @@
 		to_chat(src, "You will no longer hear musical instruments.")
 	SSblackbox.record_feedback("tally", "toggle_verbs", 1, "Toggle Instruments") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
+/client/verb/toggle_input()
+	set name = "Toggle TGUI Input Lists"
+	set category = "Preferences"
+	set desc = "Switches input lists between the TGUI and the standard one"
+	prefs.toggles2 ^= PREFTOGGLE_2_INPUT_LIST_CHOICE
+	prefs.save_preferences(src)
+	to_chat(src, "You will [(prefs.toggles2 & PREFTOGGLE_2_INPUT_LIST_CHOICE) ? "no longer" : "now"] use TGUI Input Lists.")
+
 /client/verb/Toggle_disco() //to toggle off the disco machine locally, in case it gets too annoying
 	set name = "Hear/Silence Dance Machine"
 	set category = "Preferences"

--- a/code/modules/tgui/modules/tgui_input_list.dm
+++ b/code/modules/tgui/modules/tgui_input_list.dm
@@ -21,7 +21,7 @@
 		user = client.mob
 
 	/// Client does NOT have tgui_input on: Returns regular input
-	if(user.client.prefs.toggles2 & PREFTOGGLE_2_INPUT_LIST_CHOICE)
+	if(user.client?.prefs?.toggles2 & PREFTOGGLE_2_INPUT_LIST_CHOICE)
 		return input(user, message, title) as null|anything in buttons
 
 	var/datum/tgui_list_input/input = new(user, message, title, buttons, timeout)

--- a/code/modules/tgui/modules/tgui_input_list.dm
+++ b/code/modules/tgui/modules/tgui_input_list.dm
@@ -21,7 +21,7 @@
 		user = client.mob
 
 	/// Client does NOT have tgui_input on: Returns regular input
-	if(user.client?.prefs?.toggles2 & PREFTOGGLE_2_TGUI_INPUT_LIST)
+	if(user.client?.prefs?.toggles2 & PREFTOGGLE_2_DISABLE_TGUI_LISTS)
 		return input(user, message, title) as null|anything in buttons
 
 	var/datum/tgui_list_input/input = new(user, message, title, buttons, timeout)

--- a/code/modules/tgui/modules/tgui_input_list.dm
+++ b/code/modules/tgui/modules/tgui_input_list.dm
@@ -21,7 +21,7 @@
 		user = client.mob
 
 	/// Client does NOT have tgui_input on: Returns regular input
-	if(user.client?.prefs?.toggles2 & PREFTOGGLE_2_INPUT_LIST_CHOICE)
+	if(user.client?.prefs?.toggles2 & PREFTOGGLE_2_TGUI_INPUT_LIST)
 		return input(user, message, title) as null|anything in buttons
 
 	var/datum/tgui_list_input/input = new(user, message, title, buttons, timeout)

--- a/code/modules/tgui/modules/tgui_input_list.dm
+++ b/code/modules/tgui/modules/tgui_input_list.dm
@@ -19,6 +19,11 @@
 			return
 		var/client/client = user
 		user = client.mob
+
+	/// Client does NOT have tgui_input on: Returns regular input
+	if(user.client.prefs.toggles2 & PREFTOGGLE_2_INPUT_LIST_CHOICE)
+		return input(user, message, title) as null|anything in buttons
+
 	var/datum/tgui_list_input/input = new(user, message, title, buttons, timeout)
 	input.ui_interact(user)
 	input.wait()


### PR DESCRIPTION
## What Does This PR Do
Allows you to switch off TGUI Input Lists if you don't like them for any reason
The setting is available both in Game Preferences (Input Lists) and in the Preferences tab (Toggle TGUI Input Lists)

## Why It's Good For The Game
Choice is always a good thing

## Images of changes
https://github.com/ParadiseSS13/Paradise/assets/69762909/5f9c2489-bc42-4a94-9184-9c0b884f5dc0

## Testing
Yep

## Changelog
:cl:
tweak: You can turn-off TGUI Input Lists if you don't like it, in Game Preferences (Input Lists) and in the Preferences tab (Toggle TGUI Input Lists)
/:cl:
