### PR TITLE
Fixes cleanables not garbage collecting properly

### DIFF
--- a/code/game/objects/effects/decals/cleanable.dm
+++ b/code/game/objects/effects/decals/cleanable.dm
@@ -13,13 +13,6 @@
 	var/gravity_check = TRUE
 	hud_possible = list(JANI_HUD)
 
-/obj/effect/decal/cleanable/Initialize(mapload)
-	. = ..()
-	var/datum/atom_hud/data/janitor/jani_hud = GLOB.huds[DATA_HUD_JANITOR]
-	prepare_huds()
-	jani_hud.add_to_hud(src)
-	jani_hud_set_sign()
-
 /obj/effect/decal/cleanable/proc/replace_decal(obj/effect/decal/cleanable/C) // Returns true if we should give up in favor of the pre-existing decal
 	if(mergeable_decal)
 		return TRUE
@@ -103,10 +96,16 @@
 		QUEUE_SMOOTH_NEIGHBORS(src)
 	if(iswallturf(loc) && plane == FLOOR_PLANE)
 		plane = GAME_PLANE // so they can be seen above walls
+	var/datum/atom_hud/data/janitor/jani_hud = GLOB.huds[DATA_HUD_JANITOR]
+	prepare_huds()
+	jani_hud.add_to_hud(src)
+	jani_hud_set_sign()
 
 /obj/effect/decal/cleanable/Destroy()
 	if(smoothing_flags)
 		QUEUE_SMOOTH_NEIGHBORS(src)
+	var/datum/atom_hud/data/janitor/jani_hud = GLOB.huds[DATA_HUD_JANITOR]
+	jani_hud.remove_from_hud(src)
 	return ..()
 
 /obj/effect/decal/cleanable/proc/try_merging_decal(turf/T)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
It now removes the jani HUD when the cleanable is destroyed.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
It lags the server if not GC properly.

## Testing
<!-- How did you test the PR, if at all? -->
- Spawned a cleanbot over a dirty maints and observed for any issues
## Changelog
:cl:
fix: Cleanable decals no longer lags the servers when destroyed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
