### PR TITLE
Fixes railings mentioning tables on inspect.

### DIFF
--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -155,7 +155,7 @@
 	return TRUE
 
 /obj/structure/proc/get_climb_text()
-	return "<span class='info'>You can <b>Click-Drag</b> someone to [src] to put them on [src.p_them()] after a short delay.</span>"
+	return "<span class='info'>You can <b>Click-Drag</b> yourself to [src] to climb on top of [src.p_them()] after a short delay.</span>"
 
 /obj/structure/examine(mob/user)
 	. = ..()

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -155,7 +155,7 @@
 	return TRUE
 
 /obj/structure/proc/get_climb_text()
-	return "<span class='info'>You can <b>Click-Drag</b> yourself to [src] to climb on top of [src.p_them()] after a short delay.</span>"
+	return "<span class='info'>You can <b>Click-Drag</b> yourself to [src] to climb on top of it after a short delay.</span>"
 
 /obj/structure/examine(mob/user)
 	. = ..()

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -165,7 +165,7 @@
 		if(examine_status)
 			. += examine_status
 	if(climbable)
-		. += "<span class='info'>You can <b>Click-Drag</b> someone to [src] to put them on [src] after a short delay.</span>"
+		. += "<span class='info'>You can <b>Click-Drag</b> someone to [src] to put them on [src.p_them()] after a short delay.</span>"
 
 /obj/structure/proc/examine_status(mob/user) //An overridable proc, mostly for falsewalls.
 	var/healthpercent = (obj_integrity/max_integrity) * 100

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -165,7 +165,7 @@
 		if(examine_status)
 			. += examine_status
 	if(climbable)
-		. += "<span class='info'>You can <b>Click-Drag</b> someone to [src] to put them on the table after a short delay.</span>"
+		. += "<span class='info'>You can <b>Click-Drag</b> someone to [src] to put them on [src] after a short delay.</span>"
 
 /obj/structure/proc/examine_status(mob/user) //An overridable proc, mostly for falsewalls.
 	var/healthpercent = (obj_integrity/max_integrity) * 100

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -154,6 +154,9 @@
 		return FALSE
 	return TRUE
 
+/obj/structure/proc/get_climb_text()
+	return "<span class='info'>You can <b>Click-Drag</b> someone to [src] to put them on [src.p_them()] after a short delay.</span>"
+
 /obj/structure/examine(mob/user)
 	. = ..()
 	if(!(resistance_flags & INDESTRUCTIBLE))
@@ -165,7 +168,7 @@
 		if(examine_status)
 			. += examine_status
 	if(climbable)
-		. += "<span class='info'>You can <b>Click-Drag</b> someone to [src] to put them on [src.p_them()] after a short delay.</span>"
+		. += get_climb_text()
 
 /obj/structure/proc/examine_status(mob/user) //An overridable proc, mostly for falsewalls.
 	var/healthpercent = (obj_integrity/max_integrity) * 100

--- a/code/game/objects/structures/railings.dm
+++ b/code/game/objects/structures/railings.dm
@@ -13,7 +13,7 @@
 	var/mover_dir = null
 
 /obj/structure/railing/get_climb_text()
-	return "<span class='info'>You can <b>Click-Drag</b> yourself to [src] to climb over [src.p_them()] after a short delay.</span>"
+	return "<span class='info'>You can <b>Click-Drag</b> yourself to [src] to climb over it after a short delay.</span>"
 
 /obj/structure/railing/corner //aesthetic corner sharp edges hurt oof ouch
 	icon_state = "railing_corner"

--- a/code/game/objects/structures/railings.dm
+++ b/code/game/objects/structures/railings.dm
@@ -13,7 +13,7 @@
 	var/mover_dir = null
 
 /obj/structure/railing/get_climb_text()
-	return "<span class='info'>You can <b>Click-Drag</b> someone to [src] to put them over [src.p_them()] after a short delay.</span>"
+	return "<span class='info'>You can <b>Click-Drag</b> yourself to [src] to climb over [src.p_them()] after a short delay.</span>"
 
 /obj/structure/railing/corner //aesthetic corner sharp edges hurt oof ouch
 	icon_state = "railing_corner"

--- a/code/game/objects/structures/railings.dm
+++ b/code/game/objects/structures/railings.dm
@@ -12,6 +12,9 @@
 	var/currently_climbed = FALSE
 	var/mover_dir = null
 
+/obj/structure/railing/get_climb_text()
+	return "<span class='info'>You can <b>Click-Drag</b> someone to [src] to put them over [src.p_them()] after a short delay.</span>"
+
 /obj/structure/railing/corner //aesthetic corner sharp edges hurt oof ouch
 	icon_state = "railing_corner"
 	density = FALSE


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
![image](https://github.com/ParadiseSS13/Paradise/assets/96908085/c9cfcd93-825e-4dd8-9ed6-b080ad0edf64)

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
![image](https://github.com/ParadiseSS13/Paradise/assets/96908085/2fa4ba33-a1c1-473f-8085-36750594cd56)

## Testing
<!-- How did you test the PR, if at all? -->
Checked if it worked
## Changelog
:cl:
fix: Fixed railings mentioning tables in the tip of click-dragging
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
