### PR TITLE
Refactors `mob_has_gravity` to use `TRAIT_MAGPULSE` instead of a noslip flag

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -524,9 +524,6 @@
 	icon_state = "[icon_state]_opentoe"
 	item_state = "[item_state]_opentoe"
 
-/obj/item/proc/negates_gravity()
-	return
-
 //Suit
 /obj/item/clothing/suit
 	name = "suit"

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -60,9 +60,6 @@
 	if(HAS_TRAIT(user, TRAIT_MAGPULSE)) // User has trait and the magboots were turned off, remove trait
 		REMOVE_TRAIT(user, TRAIT_MAGPULSE, "magboots")
 
-/obj/item/clothing/shoes/magboots/negates_gravity()
-	return flags & NOSLIP
-
 /obj/item/clothing/shoes/magboots/examine(mob/user)
 	. = ..()
 	. += "Its [magpulse_name] appears to be [magpulse ? "enabled" : "disabled"]."

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -33,7 +33,7 @@
 			. = 1
 
 /mob/living/carbon/human/mob_negates_gravity()
-	return shoes && shoes.negates_gravity()
+	return HAS_TRAIT(src, TRAIT_MAGPULSE)
 
 /mob/living/carbon/human/Move(NewLoc, direct)
 	. = ..()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Moves the `mob_has_gravity` check to check for the magpulse trait instead of checking if the shoes have the noslip flag.
This doesn't have any mechanical implementations.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
It cleans up the code and removes a proc that does nothing for 99% of all items.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Compiled, and chameleon shoes didn't protect me against the gravity being down.
<!-- How did you test the PR, if at all? -->

## Changelog
NPFC

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
