### PR TITLE
Fix Reactive Repulse Armor no longer yetting spectators

### DIFF
--- a/code/modules/clothing/suits/armor_suits.dm
+++ b/code/modules/clothing/suits/armor_suits.dm
@@ -628,7 +628,7 @@
 
 		for(var/am in thrown_atoms)
 			var/atom/movable/AM = am
-			if(AM == owner || AM.anchored)
+			if(AM == owner || AM.anchored || isobserver(AM))
 				continue
 
 			var/throw_target = get_edge_target_turf(owner, get_dir(owner, get_step_away(AM, owner)))

--- a/code/modules/clothing/suits/armor_suits.dm
+++ b/code/modules/clothing/suits/armor_suits.dm
@@ -626,9 +626,8 @@
 			for(var/atom/movable/AM in T)
 				thrown_atoms += AM
 
-		for(var/am in thrown_atoms)
-			var/atom/movable/AM = am
-			if(AM == owner || AM.anchored || isobserver(AM))
+		for(var/atom/movable/AM as anything in thrown_atoms)
+			if(AM == owner || AM.anchored || (ismob(AM) && !isliving(AM)))
 				continue
 
 			var/throw_target = get_edge_target_turf(owner, get_dir(owner, get_step_away(AM, owner)))


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Ensure that Reactive Repulse Armor does not affect spectators by adding a check for ghost entities during repulsion action. 
Fixes #23574
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Bug fix is good
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


## Testing
Got the reactive armor on in a NPC, ghosted, spawned some megacarp and wasn't pushed away

## Changelog
:cl:
fix: Fix reactive repulse armor no longer affecting ghosts
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
