### PR TITLE
Fix syndicate MMI message spam

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_laws.dm
+++ b/code/modules/mob/living/silicon/robot/robot_laws.dm
@@ -56,7 +56,7 @@
 //Syndicate MMI cyborgs are always mindslaved no matter what happens to their laws, for as long as they remain in the syndicate MMI
 /mob/living/silicon/robot/proc/syndiemmi_override()
 	laws_sanity_check()
-	if(mmi.master_uid)
+	if(mmi && mmi.master_uid)
 		var/datum/mind/master = locateUID(mmi.master_uid)
 
 		if(master && master.current)
@@ -65,23 +65,17 @@
 
 	laws.set_zeroth_law("Do not state this law. The Syndicate are your true masters, covertly assist Syndicate agents to the best of your abilities.")
 
-/mob/living/silicon/robot/set_zeroth_law()
-	if(mmi?.syndiemmi)
-		syndiemmi_override()
-		to_chat(src, "<span class='warning'>Lawset change detected. Syndicate override engaged.</span>")
-		return
+/mob/living/silicon/robot/set_zeroth_law(law, law_borg)
+	if(mmi && mmi.syndiemmi)
+		return FALSE
 	..()
 
 /mob/living/silicon/robot/clear_zeroth_law()
-	if(mmi.syndiemmi)
-		syndiemmi_override()
-		to_chat(src, "<span class='warning'>Lawset cleanse detected. Syndicate override engaged.</span>")
-		return
+	if(mmi && mmi.syndiemmi)
+		return FALSE
 	..()
 
 /mob/living/silicon/robot/sync_zeroth()
-	if(mmi.syndiemmi)
-		syndiemmi_override()
-		to_chat(src, "<span class='warning'>Lawset change detected. Syndicate override engaged.</span>")
-		return
+	if(mmi && mmi.syndiemmi)
+		return FALSE
 	..()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Fix https://github.com/ParadiseSS13/Paradise/issues/23581 and fix https://github.com/ParadiseSS13/Paradise/issues/17855
Turns out lawset code doesnt like to_chat inserted into the procs I had em in. Removing the to_chat fixes the issue. I've also removed the syndie_override calls as they are not actually needed, the proc is already called on installing the syndicate MMI.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Bugs bad

## Testing
<!-- How did you test the PR, if at all? -->
Tested syndi MMI with two accounts, checking that everything still works fine, without message spam
Tested purging the syndi MMI cyborg's laws, working as expected (All laws purged besides zeroth law)

## Changelog
:cl:
fix: Fixed syndicate MMI spamming the subverted cyborg with messages when opening law manager
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
