### PR TITLE
Changes the gamma alert announcement wording

### DIFF
--- a/code/modules/security_levels/security_level_datums.dm
+++ b/code/modules/security_levels/security_level_datums.dm
@@ -101,8 +101,8 @@
 	status_display_mode = STATUS_DISPLAY_ALERT
 	status_display_data = "gammaalert"
 	lowering_to_announcement_title = "Attention! Gamma security level activated!"
-	lowering_to_announcement_text = "Central Command has ordered the Gamma security level on the station. Security is to have weapons equipped at all times, and all civilians are advised to arm up and fight the threat."
-	elevating_to_announcement_text = "Central Command has ordered the Gamma security level on the station. Security is to have weapons equipped at all times, and all civilians are advised to arm up and fight the threat."
+	lowering_to_announcement_text = "Central Command has ordered the Gamma security level on the station. Security is to have weapons equipped at all times, and all civilians are to immediately seek out command staff for instructions."
+	elevating_to_announcement_text = "Central Command has ordered the Gamma security level on the station. Security is to have weapons equipped at all times, and all civilians are to immediately seek out command staff for instructions."
 	elevating_to_announcement_title = "Attention! Gamma security level activated!"
 
 /**

--- a/code/modules/security_levels/security_level_datums.dm
+++ b/code/modules/security_levels/security_level_datums.dm
@@ -101,8 +101,8 @@
 	status_display_mode = STATUS_DISPLAY_ALERT
 	status_display_data = "gammaalert"
 	lowering_to_announcement_title = "Attention! Gamma security level activated!"
-	lowering_to_announcement_text = "Central Command has ordered the Gamma security level on the station. Security is to have weapons equipped at all times, and all civilians are to immediately seek their nearest head for transportation to a secure location."
-	elevating_to_announcement_text = "Central Command has ordered the Gamma security level on the station. Security is to have weapons equipped at all times, and all civilians are to immediately seek their nearest head for transportation to a secure location."
+	lowering_to_announcement_text = "Central Command has ordered the Gamma security level on the station. Security is to have weapons equipped at all times, and all civilians are advised to arm up and fight the threat."
+	elevating_to_announcement_text = "Central Command has ordered the Gamma security level on the station. Security is to have weapons equipped at all times, and all civilians are advised to arm up and fight the threat."
 	elevating_to_announcement_title = "Attention! Gamma security level activated!"
 
 /**


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Changes the gamma alert announcement from 
`Central Command has ordered the Gamma security level on the station. Security is to have weapons equipped at all times, and all civilians are to immediately seek their nearest head for transportation to a secure location.`
to
`Central Command has ordered the Gamma security level on the station. Security is to have weapons equipped at all times, and all civilians are to immediately seek out command staff for instructions.`
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
About half the time, the instructions it gives to civilians are contrary to what command would want them to do (nukies/blob). Nobody follows it anyways during these cases, but it would be nice for the announcement to line up with reality to avoid confusion for newer players.

Since this also involves slight SOP changes, I also got approval from Qwerty for this.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Raised to gamma alert.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Changed the gamma alert announcement to be more in line with the station's interests. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
