### PR TITLE
Add immunity to ash storm for possessed objects and swords

### DIFF
--- a/code/datums/weather/weather_types/ash_storm.dm
+++ b/code/datums/weather/weather_types/ash_storm.dm
@@ -115,7 +115,7 @@
 			var/thermal_protection = H.get_thermal_protection()
 			if(thermal_protection >= FIRE_IMMUNITY_MAX_TEMP_PROTECT)
 				return TRUE
-		if(istype(L, /mob/living/simple_animal/possessed_object)) //Possessed Sword are immune
+		if(istype(L, /mob/living/simple_animal/shade/sword)) //Possessed Sword are immune
 			return TRUE
 		L = L.loc //Matryoshka check
 	return FALSE //RIP you

--- a/code/datums/weather/weather_types/ash_storm.dm
+++ b/code/datums/weather/weather_types/ash_storm.dm
@@ -115,8 +115,6 @@
 			var/thermal_protection = H.get_thermal_protection()
 			if(thermal_protection >= FIRE_IMMUNITY_MAX_TEMP_PROTECT)
 				return TRUE
-		if(istype(L, /mob/living/simple_animal/shade/sword)) //Possessed Sword are immune
-			return TRUE
 		L = L.loc //Matryoshka check
 	return FALSE //RIP you
 

--- a/code/datums/weather/weather_types/ash_storm.dm
+++ b/code/datums/weather/weather_types/ash_storm.dm
@@ -115,6 +115,8 @@
 			var/thermal_protection = H.get_thermal_protection()
 			if(thermal_protection >= FIRE_IMMUNITY_MAX_TEMP_PROTECT)
 				return TRUE
+		if(istype(L, /mob/living/simple_animal/possessed_object)) //Possessed Sword are immune
+			return TRUE
 		L = L.loc //Matryoshka check
 	return FALSE //RIP you
 

--- a/code/modules/mob/living/simple_animal/posessed_object.dm
+++ b/code/modules/mob/living/simple_animal/posessed_object.dm
@@ -16,6 +16,7 @@
 
 	no_spin_thrown = TRUE
 	del_on_death = TRUE
+	weather_immunities = list("ash")
 
 	/// The probability % of us escaping if stuffed into a bag/toolbox/etc
 	var/escape_chance = 10

--- a/code/modules/mob/living/simple_animal/shade.dm
+++ b/code/modules/mob/living/simple_animal/shade.dm
@@ -32,6 +32,7 @@
 	loot = list(/obj/item/reagent_containers/food/snacks/ectoplasm)
 	del_on_death = TRUE
 	deathmessage = "lets out a contented sigh as their form unwinds."
+	weather_immunities = list("ash")
 	var/holy = FALSE
 
 /mob/living/simple_animal/shade/cult/Initialize(mapload)

--- a/code/modules/mob/living/simple_animal/shade.dm
+++ b/code/modules/mob/living/simple_animal/shade.dm
@@ -62,7 +62,7 @@
 	can_change_intents = FALSE // same here
 	health = 100
 	maxHealth = 100
-	weather_immunities = list("ash"
+	weather_immunities = list("ash")
 
 /mob/living/simple_animal/shade/sword/Initialize(mapload)
 	.=..()

--- a/code/modules/mob/living/simple_animal/shade.dm
+++ b/code/modules/mob/living/simple_animal/shade.dm
@@ -32,7 +32,6 @@
 	loot = list(/obj/item/reagent_containers/food/snacks/ectoplasm)
 	del_on_death = TRUE
 	deathmessage = "lets out a contented sigh as their form unwinds."
-	weather_immunities = list("ash")
 	var/holy = FALSE
 
 /mob/living/simple_animal/shade/cult/Initialize(mapload)
@@ -63,6 +62,7 @@
 	can_change_intents = FALSE // same here
 	health = 100
 	maxHealth = 100
+	weather_immunities = list("ash"
 
 /mob/living/simple_animal/shade/sword/Initialize(mapload)
 	.=..()


### PR DESCRIPTION
## What Does This PR Do
Fixes #23110 by adding immunity to ash storm for both possessed objects (admin ghost controlled object) and possessed sword (miner loot), addressing the oversight.

## Why It's Good For The Game
Oversight fix gud.

## Testing
Spawned as a possessed sword during an ashtorm took no damages.

## Changelog
:cl:
tweak: Add immunity to ash storm for possessed objects
/:cl:
