### PR TITLE
Recorder no longer says "Skipping Silence"

### DIFF
--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -210,13 +210,10 @@
 			atom_say("End of recording.")
 			break
 		atom_say("[mytape.storedinfo[i]]")
-		if(length(mytape.storedinfo) < i + 1)
+		if(length(mytape.storedinfo) < i + 1 | playsleepseconds > 1.4 SECONDS)
 			playsleepseconds = 1 SECONDS
 		else
 			playsleepseconds = (mytape.timestamp[i + 1] - mytape.timestamp[i]) SECONDS
-		if(playsleepseconds > 1.4 SECONDS)
-			sleep(10)
-			playsleepseconds = 1 SECONDS
 		i++
 
 	stop(TRUE)

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -216,7 +216,6 @@
 			playsleepseconds = (mytape.timestamp[i + 1] - mytape.timestamp[i]) SECONDS
 		if(playsleepseconds > 1.4 SECONDS)
 			sleep(10)
-			atom_say("Skipping [playsleepseconds / 10] seconds of silence.")
 			playsleepseconds = 1 SECONDS
 		i++
 

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -210,7 +210,7 @@
 			atom_say("End of recording.")
 			break
 		atom_say("[mytape.storedinfo[i]]")
-		if(length(mytape.storedinfo) < i + 1 | playsleepseconds > 1.4 SECONDS)
+		if(length(mytape.storedinfo) < i + 1 || playsleepseconds > 1.4 SECONDS)
 			playsleepseconds = 1 SECONDS
 		else
 			playsleepseconds = (mytape.timestamp[i + 1] - mytape.timestamp[i]) SECONDS


### PR DESCRIPTION
## What Does This PR Do
Recorders no longer say `"Skipping X seconds of silence."` when playing them back.

## Why It's Good For The Game
Recorders already come with built-in time stamps for when something was said, having it announce that it `Skipped 2 seconds of silence` mostly clutters up chat with information you can already see right next to messages.
It makes people not want to use payback feature because printing transcript is usually easier.

## Testing
Said stuff to recorder with different delays in-between, played recordings back.

## Changelog
:cl:
tweak: Universal Recorder no longer announces the fact it skipped silence.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
