### PR TITLE
Updated makeCluwne method to instantly deactivate modsuit before appl…

### DIFF
--- a/code/datums/spells/cluwne.dm
+++ b/code/datums/spells/cluwne.dm
@@ -12,6 +12,11 @@
 	action_icon_state = "cluwne"
 
 /mob/living/carbon/human/proc/makeCluwne()
+	if(istype(back, /obj/item/mod/control)) // Check if the target is wearing a modsuit
+		var/obj/item/mod/control/modsuit_control = back
+		if(modsuit_control.active) // Check if the modsuit control unit is active
+			modsuit_control.active = FALSE // Instantly deactivate the modsuit
+			modsuit_control.quick_deploy(src) // Redeploy the modsuit
 	to_chat(src, "<span class='danger'>You feel funny.</span>")
 	if(!get_int_organ(/obj/item/organ/internal/brain/cluwne))
 		var/obj/item/organ/internal/brain/cluwne/idiot_brain = new


### PR DESCRIPTION
## What Does This PR Do
Updated the makeCluwne method to instantly deactivate the modsuit control unit before applying the Cluwne spell. This ensures that the target is immediately affected by the spell without them being forever locked in the modsuit. Therefore fixes #22502

## Why It's Good For The Game
Bug fix gud


## Testing
Spawned a NPC with a modsuit on, spawned as wizzie cluwned them, and their modsuit was desactivated, still on them in their backpack slot.

## Changelog
:cl:
tweak: Desactivate the modsuit before clowning the wizzard target.
fix: Cluwn spell target no longer get blocked and locked within their incomplete modsuit forever.
/:cl: