### PR TITLE
Makes Endoskeleton Bulky

### DIFF
--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -87,6 +87,7 @@
 	name = "endoskeleton"
 	desc = "A complex metal backbone with standard limb sockets and pseudomuscle anchors."
 	icon_state = "robo_suit"
+	w_class = WEIGHT_CLASS_BULKY
 	model_info = null
 	var/obj/item/robot_parts/l_arm/l_arm = null
 	var/obj/item/robot_parts/r_arm/r_arm = null


### PR DESCRIPTION
## What Does This PR Do
Makes it harder to assemble borgs on the fly by plopping down a finished borg shell with an active brain. An arguably rare occurrence, but even still. Main point of this is it makes no sense for an endoskeleton as big as a person to be able to fit into your backpack. 

## Why It's Good For The Game
It just doesn't make sense to me and does fix an, albeit rare, balance concern I have about being able to carry completed borg shells and plop down armies/multiple borgs on the fly for crew and antag alike.

## Testing
1. Spawned endoskeleton.
2. Attempted to bag it.
3. Could not bag it.

## Changelog
:cl:
tweak: Endoskeletons are bulky and no longer fit in backpacks.
/:cl:
