### PR TITLE
Instant summons no longer works on the NAD.

### DIFF
--- a/code/datums/spells/summonitem.dm
+++ b/code/datums/spells/summonitem.dm
@@ -124,9 +124,11 @@
 			if(visible_item)
 				item_to_retrieve.loc.visible_message("<span class='warning'>[item_to_retrieve] suddenly disappears!</span>")
 			var/list/heres_disky = item_to_retrieve.search_contents_for(/obj/item/disk/nuclear)
+			heres_disky += item_to_retrieve.loc.search_contents_for(/obj/item/disk/nuclear) //So if you mark another item in a bag, we don't pull
 			for(var/obj/item/disk/nuclear/N in heres_disky)
 				N.forceMove(get_turf(item_to_retrieve))
-				N.visible_message("<span class='warning'>as [item_to_retrieve] vanishes, [N] remains behind!</span>")
+				N.visible_message("<span class='warning'>As [item_to_retrieve] vanishes, [N] remains behind!</span>")
+				break //If you have 2 nads, well, congrats? Keeps message from doubling up
 			if(target.hand) //left active hand
 				if(!target.equip_to_slot_if_possible(item_to_retrieve, SLOT_HUD_LEFT_HAND, FALSE, TRUE))
 					if(!target.equip_to_slot_if_possible(item_to_retrieve, SLOT_HUD_RIGHT_HAND, FALSE, TRUE))

--- a/code/datums/spells/summonitem.dm
+++ b/code/datums/spells/summonitem.dm
@@ -123,8 +123,10 @@
 				return
 			if(visible_item)
 				item_to_retrieve.loc.visible_message("<span class='warning'>[item_to_retrieve] suddenly disappears!</span>")
-
-
+			var/list/heres_disky = item_to_retrieve.search_contents_for(/obj/item/disk/nuclear)
+			for(var/obj/item/disk/nuclear/N in heres_disky)
+				N.forceMove(get_turf(item_to_retrieve))
+				N.visible_message("<span class='warning'>as [item_to_retrieve] vanishes, [N] remains behind!</span>")
 			if(target.hand) //left active hand
 				if(!target.equip_to_slot_if_possible(item_to_retrieve, SLOT_HUD_LEFT_HAND, FALSE, TRUE))
 					if(!target.equip_to_slot_if_possible(item_to_retrieve, SLOT_HUD_RIGHT_HAND, FALSE, TRUE))

--- a/code/datums/spells/summonitem.dm
+++ b/code/datums/spells/summonitem.dm
@@ -28,6 +28,9 @@
 			for(var/obj/item in hand_items)
 				if(istype(item, /obj/item/organ/internal/brain)) //Yeah, sadly this doesn't work due to the organ system.
 					break
+				if(istype(item, /obj/item/disk/nuclear)) //Let's not make nukies suffer with this bullshit.
+					to_chat(user, "<span class='notice'>[item] has some built in protections against such summoning magic.</span>")
+					break
 				if(ABSTRACT in item.flags)
 					continue
 				if(NODROP in item.flags)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Instant summons no longer works on the NAD, and gives a message.
Instant summons will eject nad from contents when summoning something with the NAD inside it

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Similar to implantation, certain NAD related things should be disabled, under the fact that "maybe this isn't fun for nukies when abused"

Instant summons plus NAD is a recipe for nukies having a horrible time, especially if used right. Let us give them some mercy.

## Testing
<!-- How did you test the PR, if at all? -->

Attempted to bind spell to NAD, failed.

## Changelog
:cl:
tweak: Instant summons no longer works on the NAD.
tweak: Instant summons will eject the nad from contents when recalling something.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
