### PR TITLE
Adds Two Soap Crates

### DIFF
--- a/code/modules/supply/supply_packs/pack_miscellaneous.dm
+++ b/code/modules/supply/supply_packs/pack_miscellaneous.dm
@@ -211,9 +211,9 @@
 	name = "Suspicious Soap Crate"
 	contains = list(/obj/item/soap/syndie,
 					/obj/item/soap/syndie)
-	cost = 750
+	cost = 250
 	containername = "suspicious soap crate"
-	contraband = TRUE
+	hidden = TRUE
 
 ///////////// Costumes
 

--- a/code/modules/supply/supply_packs/pack_miscellaneous.dm
+++ b/code/modules/supply/supply_packs/pack_miscellaneous.dm
@@ -198,6 +198,23 @@
 	cost = 200
 	containername = "high-traction floor tiles"
 
+/datum/supply_packs/misc/soap
+	name = "Assorted Soap Crate"
+	contains = list(/obj/item/soap,
+					/obj/item/soap,
+					/obj/item/soap,
+					/obj/item/soap/nanotrasen)
+	cost = 250
+	containername = "soap crate"
+
+/datum/supply_packs/misc/sus_soap
+	name = "Suspicious Soap Crate"
+	contains = list(/obj/item/soap/syndie,
+					/obj/item/soap/syndie)
+	cost = 750
+	containername = "suspicious soap crate"
+	contraband = TRUE
+
 ///////////// Costumes
 
 /datum/supply_packs/misc/servicecostume


### PR DESCRIPTION
## What Does This PR Do

Adds two new soap crates:

Assorted Soap Crate: 3 regular soap, one NT soap. 250 credits

Suspicious Soap Crate: 2 Syndiesoaps. Requires emagged supply console. 250 credits.

## Why It's Good For The Game

Soap is surprisingly difficult to get. You either grab the few in the station's bathrooms, are lucky enough to get one from the janitor, or you bribe mining.

With the mixed reactions to the semi-recent space cleaner nerf, I figured it should be a bit easier for people to help clean the station, without needing to buy an entire crate of janitorial equipment. 

## Testing
- Loaded in
- Bought soap
- Soap was delivered
- Hacked supply console
- Bought sus soap
- Soap was delivered

## Changelog
:cl:
add: Added two new soap crates
/:cl: