### PR TITLE
Non-clonable species can no longer be cloned

### DIFF
--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -330,6 +330,10 @@
 			set_scan_temp("Subject species is not clonable.", "bad")
 			SStgui.update_uis(src)
 			return
+	if(NO_CLONESCAN in subject.dna.species.species_traits)
+		set_scan_temp("[subject.dna.species.name_plural] are not clonable. Alternative revival methods recommended.", "bad")
+		SStgui.update_uis(src)
+		return
 	if(subject.get_int_organ(/obj/item/organ/internal/brain))
 		var/obj/item/organ/internal/brain/Brn = subject.get_int_organ(/obj/item/organ/internal/brain)
 		if(istype(Brn))


### PR DESCRIPTION
## What Does This PR Do
Added a check for non-clonable species DNA (body) before checking for brain existence to prevent cloning of non-clonable species. Hence Fixes #22675

## Why It's Good For The Game
Another player ploy to get free KFV while harvesting innocents Vox and you thought I would not patch it? Foolish thought surely...
Also oversight fix gud

## Testing
Spawned as a doc, tried to clone a vox with human brain (forgive me), couldn't.

## Changelog
:cl:
fix: Non-clonable species can no longer be cloned
/:cl: