### PR TITLE
Fix ghost bar character selector breaking when multiple characters share the same name

### DIFF
--- a/code/modules/ruins/ghost_bar.dm
+++ b/code/modules/ruins/ghost_bar.dm
@@ -20,12 +20,12 @@
 			our_characters_names += "[saves.real_name] (Slot #[index])"
 			our_character_saves += list("[saves.real_name] (Slot #[index])" = saves)
 
-		var/character_index = tgui_input_list(user, "Select a character", "Character selection", our_characters_names)
-		if(!character_index)
+		var/character_name = tgui_input_list(user, "Select a character", "Character selection", our_characters_names)
+		if(!character_name)
 			return
 		if(QDELETED(user))
 			return
-		save_to_load = our_character_saves[character_index]
+		save_to_load = our_character_saves[character_name]
 	else
 		if(QDELETED(user))
 			return

--- a/code/modules/ruins/ghost_bar.dm
+++ b/code/modules/ruins/ghost_bar.dm
@@ -17,8 +17,8 @@
 		var/list/our_character_saves = list()
 		for(var/index in 1 to length(user.client.prefs.character_saves))
 			var/datum/character_save/saves = user.client.prefs.character_saves[index]
-			our_characters_names += saves.real_name
-			our_character_saves += list(index = saves)
+			our_characters_names += "[saves.real_name] (Slot #[index])"
+			our_character_saves += list("[saves.real_name] (Slot #[index])" = saves)
 
 		var/character_index = tgui_input_list(user, "Select a character", "Character selection", our_characters_names)
 		if(!character_index)

--- a/code/modules/ruins/ghost_bar.dm
+++ b/code/modules/ruins/ghost_bar.dm
@@ -15,16 +15,17 @@
 	if(alert(user, "Would you like to use one of your saved characters in your character creator?",, "Yes", "No") == "Yes")
 		var/list/our_characters_names = list()
 		var/list/our_character_saves = list()
-		for(var/datum/character_save/saves in user.client.prefs.character_saves)
+		for(var/index in 1 to length(user.client.prefs.character_saves))
+			var/datum/character_save/saves = user.client.prefs.character_saves[index]
 			our_characters_names += saves.real_name
-			our_character_saves += list(saves.real_name = saves)
+			our_character_saves += list(index = saves)
 
-		var/character_name = tgui_input_list(user, "Select a character", "Character selection", our_characters_names)
-		if(!character_name)
+		var/character_index = tgui_input_list(user, "Select a character", "Character selection", our_characters_names)
+		if(!character_index)
 			return
 		if(QDELETED(user))
 			return
-		save_to_load = our_character_saves[character_name]
+		save_to_load = our_character_saves[character_index]
 	else
 		if(QDELETED(user))
 			return


### PR DESCRIPTION
## What Does This PR Do
Make it so the character selector on ghost bar use index and you know which character slot you are picking.
Meaning, no more bug with same character names.

Gotta follow ACID properties and make sure unique ID (and not names) are used as identifiers.
Therefore Fixes #23608

## Why It's Good For The Game
Bug fix gud

## Testing
Spawned in ghost bar with two different characters having the same name, had no issues.

## Changelog
:cl:
fix: Fix ghost bar character selection - using ID now
/:cl:
