### PR TITLE
Modsuit no longer deleted by the Wizarditis virus

### DIFF
--- a/code/datums/diseases/wizarditis.dm
+++ b/code/datums/diseases/wizarditis.dm
@@ -54,7 +54,6 @@ STI KALY - blind
 	return
 
 
-
 /datum/disease/wizarditis/proc/spawn_wizard_clothes(chance = 0)
 	if(ishuman(affected_mob))
 		var/mob/living/carbon/human/H = affected_mob
@@ -62,18 +61,21 @@ STI KALY - blind
 			if(!istype(H.head, /obj/item/clothing/head/wizard))
 				if(!H.unEquip(H.head))
 					qdel(H.head)
+				handle_modsuit(H, H.wear_suit)
 				H.equip_to_slot_or_del(new /obj/item/clothing/head/wizard(H), SLOT_HUD_HEAD)
 			return
 		if(prob(chance))
 			if(!istype(H.wear_suit, /obj/item/clothing/suit/wizrobe))
 				if(!H.unEquip(H.wear_suit))
 					qdel(H.wear_suit)
+				handle_modsuit(H, H.wear_suit)
 				H.equip_to_slot_or_del(new /obj/item/clothing/suit/wizrobe(H), SLOT_HUD_OUTER_SUIT)
 			return
 		if(prob(chance))
 			if(!istype(H.shoes, /obj/item/clothing/shoes/sandal))
 				if(!H.unEquip(H.shoes))
 					qdel(H.shoes)
+			handle_modsuit(H, H.wear_suit)
 			H.equip_to_slot_or_del(new /obj/item/clothing/shoes/sandal(H), SLOT_HUD_SHOES)
 			return
 	else
@@ -119,3 +121,10 @@ STI KALY - blind
 	affected_mob.say("SCYAR NILA [uppertext(chosen_area.name)]!")
 	affected_mob.forceMove(pick(teleport_turfs))
 
+// Helper function to handle modsuit deactivation
+/proc/handle_modsuit(mob/living/carbon/human/H, item_slot)
+	if(istype(item_slot, /obj/item/mod/control))
+		var/obj/item/mod/control/modsuit = item_slot
+		if(istype(modsuit, /obj/item/clothing/suit/mod)) // Check if the modsuit is deployed
+			modsuit.active = FALSE // Instantly deactivate the modsuit - if it was activated
+			modsuit.quick_deploy(src) // The modsuit is no longer deployed

--- a/code/datums/diseases/wizarditis.dm
+++ b/code/datums/diseases/wizarditis.dm
@@ -60,19 +60,28 @@ STI KALY - blind
 		if(prob(chance) && !isplasmaman(H))
 			if(!istype(H.head, /obj/item/clothing/head/wizard))
 				if(!H.unEquip(H.head))
-					handle_modsuit(H)
+					if(istype(H.head, /obj/item/clothing/head/mod))
+						handle_modsuit(H)
+					else
+						qdel(H.head)
 				H.equip_to_slot_or_del(new /obj/item/clothing/head/wizard(H), SLOT_HUD_HEAD)
 			return
 		if(prob(chance))
 			if(!istype(H.wear_suit, /obj/item/clothing/suit/wizrobe))
 				if(!H.unEquip(H.wear_suit))
-					handle_modsuit(H)
+					if(istype(H.wear_suit, /obj/item/clothing/suit/mod))
+						handle_modsuit(H)
+					else
+						qdel(H.wear_suit)
 				H.equip_to_slot_or_del(new /obj/item/clothing/suit/wizrobe(H), SLOT_HUD_OUTER_SUIT)
 			return
 		if(prob(chance))
 			if(!istype(H.shoes, /obj/item/clothing/shoes/sandal))
 				if(!H.unEquip(H.shoes))
-					handle_modsuit(H)
+					if(istype(H.shoes, /obj/item/clothing/shoes/mod))
+						handle_modsuit(H)
+					else
+						qdel(H.shoes)
 				H.equip_to_slot_or_del(new /obj/item/clothing/shoes/sandal(H), SLOT_HUD_SHOES)
 			return
 	else

--- a/code/datums/diseases/wizarditis.dm
+++ b/code/datums/diseases/wizarditis.dm
@@ -60,23 +60,20 @@ STI KALY - blind
 		if(prob(chance) && !isplasmaman(H))
 			if(!istype(H.head, /obj/item/clothing/head/wizard))
 				if(!H.unEquip(H.head))
-					qdel(H.head)
-				handle_modsuit(H, H.wear_suit)
+					handle_modsuit(H)
 				H.equip_to_slot_or_del(new /obj/item/clothing/head/wizard(H), SLOT_HUD_HEAD)
 			return
 		if(prob(chance))
 			if(!istype(H.wear_suit, /obj/item/clothing/suit/wizrobe))
 				if(!H.unEquip(H.wear_suit))
-					qdel(H.wear_suit)
-				handle_modsuit(H, H.wear_suit)
+					handle_modsuit(H)
 				H.equip_to_slot_or_del(new /obj/item/clothing/suit/wizrobe(H), SLOT_HUD_OUTER_SUIT)
 			return
 		if(prob(chance))
 			if(!istype(H.shoes, /obj/item/clothing/shoes/sandal))
 				if(!H.unEquip(H.shoes))
-					qdel(H.shoes)
-			handle_modsuit(H, H.wear_suit)
-			H.equip_to_slot_or_del(new /obj/item/clothing/shoes/sandal(H), SLOT_HUD_SHOES)
+					handle_modsuit(H)
+				H.equip_to_slot_or_del(new /obj/item/clothing/shoes/sandal(H), SLOT_HUD_SHOES)
 			return
 	else
 		var/mob/living/carbon/H = affected_mob
@@ -122,9 +119,9 @@ STI KALY - blind
 	affected_mob.forceMove(pick(teleport_turfs))
 
 // Helper function to handle modsuit deactivation
-/proc/handle_modsuit(mob/living/carbon/human/H, item_slot)
-	if(istype(item_slot, /obj/item/mod/control))
-		var/obj/item/mod/control/modsuit = item_slot
-		if(istype(modsuit, /obj/item/clothing/suit/mod)) // Check if the modsuit is deployed
-			modsuit.active = FALSE // Instantly deactivate the modsuit - if it was activated
-			modsuit.quick_deploy(src) // The modsuit is no longer deployed
+/proc/handle_modsuit(var/mob/living/carbon/human/H)
+	if(istype(H.back, /obj/item/mod/control))
+		var/obj/item/mod/control/modsuit_control = H.back
+		if(istype(H.wear_suit, /obj/item/clothing/suit/mod)) // Check if the modsuit is deployed
+			modsuit_control.active = FALSE // Instantly deactivate the modsuit - if it was activated
+			modsuit_control.quick_deploy(src) // The modsuit is no longer deployed


### PR DESCRIPTION
## What Does This PR Do
Resolved the issue (Fixes #23497) where wizarditis would delete the modsuit while spawning a wizard costume. Now the modsuit is undeployed and desactivated rather than outright removed.
Take note that in case the virus is unable to unequip a clothing part - and this clothing part isn't a modsuit it still would be removed. As it was in the code before my fix.

## Why It's Good For The Game
Bug fix gud

## Testing
Spawned as a npc with a modsuit, got the virus, waited. The modsuit wasn't deleted.

## Changelog
:cl:
fix: Modsuit no longer deleted by the Wizarditis virus
/:cl: