### PR TITLE
Chitinous armor headgear cover both mouth and eyes

### DIFF
--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -580,3 +580,4 @@
 	flags = BLOCKHAIR | NODROP | DROPDEL
 	armor = list(MELEE = 40, BULLET = 40, LASER = 40, ENERGY = 20, BOMB = 10, RAD = 0, FIRE = 90, ACID = 90)
 	flags_inv = HIDEEARS
+	flags_cover = MASKCOVERSEYES | MASKCOVERSMOUTH


### PR DESCRIPTION
## What Does This PR Do
Chitinous armor headgear cover both mouth and eyes. Therefore protect from pepper spray. Fixes #23500

## Why It's Good For The Game
Misdesign requested fix gud.

## Testing
Spawned as a ling, pepper spray did nothing.

## Changelog
:cl:
tweak: Chitinous armor headgear cover both mouth and eyes
/:cl: