### PR TITLE
Add a prompt for cyborg created with Roborgers/Nanomachines

### DIFF
--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -70,6 +70,8 @@
 			new_mob.a_intent = "harm"
 			if(affected_mob.mind)
 				affected_mob.mind.transfer_to(new_mob)
+			if(istype(new_mob, /mob/living/silicon/robot))
+				new_mob.rename_self("Cyborg", TRUE, TRUE)
 			else
 				new_mob.key = affected_mob.key
 		qdel(affected_mob)

--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -70,7 +70,7 @@
 			new_mob.a_intent = "harm"
 			if(affected_mob.mind)
 				affected_mob.mind.transfer_to(new_mob)
-			if(istype(new_mob, /mob/living/silicon/robot))
+			if(isrobot(new_mob))
 				new_mob.rename_self("Cyborg", TRUE, TRUE)
 			else
 				new_mob.key = affected_mob.key


### PR DESCRIPTION
## What Does This PR Do
Fixes #23616 : Oversight where cyborgs created with Roborgers/Nanomachines were not prompted to change their name.

## Why It's Good For The Game
**If** it is an oversight then it is good to have it fixed.

## Images of changes
![image](https://github.com/ParadiseSS13/Paradise/assets/44984704/cbb98b25-0809-454d-9687-fd892aec6ce7)

## Testing
Spawned as an assistant got some tasty hamborger, was proposed to change my name.

## Changelog
:cl:
tweak: Add a prompt for cyborg created with Roborgers/Nanomachines
/:cl: