### PR TITLE
Fix snow machines

### DIFF
--- a/code/game/machinery/snow_machine.dm
+++ b/code/game/machinery/snow_machine.dm
@@ -56,9 +56,9 @@
 	. = TRUE
 	if(!default_unfasten_wrench(user, I, 0))
 		return
-	anchored = !anchored
 	to_chat(user, "<span class='notice'>You [anchored ? "tighten" : "loosen"] [src]'s wheels.</span>")
-	turn_on_or_off(FALSE)
+	if (!anchored)
+		turn_on_or_off(FALSE)
 
 /obj/machinery/snow_machine/process()
 	if(power_used_this_cycle)

--- a/code/game/machinery/snow_machine.dm
+++ b/code/game/machinery/snow_machine.dm
@@ -56,7 +56,7 @@
 	. = TRUE
 	if(!default_unfasten_wrench(user, I, 0))
 		return
-	if (!anchored)
+	if(!anchored)
 		turn_on_or_off(FALSE)
 
 /obj/machinery/snow_machine/process()

--- a/code/game/machinery/snow_machine.dm
+++ b/code/game/machinery/snow_machine.dm
@@ -56,7 +56,6 @@
 	. = TRUE
 	if(!default_unfasten_wrench(user, I, 0))
 		return
-	to_chat(user, "<span class='notice'>You [anchored ? "tighten" : "loosen"] [src]'s wheels.</span>")
 	if (!anchored)
 		turn_on_or_off(FALSE)
 


### PR DESCRIPTION
## What Does This PR Do
Fixes #23620 : snowmachine were let loose even if you tried to anchor them, while they can only be turned on when wrenched in the floor.

## Why It's Good For The Game
Bug fix gud

## Images of changes
![image](https://github.com/ParadiseSS13/Paradise/assets/44984704/7638b4a1-a33e-4664-a74f-7b558f83dc0f)


## Testing
Spawned as the CE, wrenched the snow machines. Turned the machine on. Steve got snow, Steve is happy.

## Changelog
:cl:
fix: Snow machines are no longer anchored and then set loose - allowing the player to use them
/:cl: