### PR TITLE
Removing sleepers chemicals type limit on injured occupants

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -15,7 +15,6 @@
 	dir = WEST
 	var/mob/living/carbon/human/occupant = null
 	var/possible_chems = list("ephedrine", "salglu_solution", "salbutamol", "charcoal")
-	var/emergency_chems = list("ephedrine") // Desnowflaking
 	var/amounts = list(5, 10)
 	/// Beaker loaded into the sleeper. Used for dialysis.
 	var/obj/item/reagent_containers/glass/beaker = null
@@ -23,7 +22,6 @@
 	var/filtering = FALSE
 	var/max_chem
 	var/initial_bin_rating = 1
-	var/min_health = -25
 	var/controls_inside = FALSE
 	var/auto_eject_dead = FALSE
 	idle_power_consumption = 1250
@@ -86,7 +84,6 @@
 		E += B.rating
 
 	max_chem = E * 20
-	min_health = -E * 25
 
 /obj/machinery/sleeper/Destroy()
 	for(var/mob/M in contents)
@@ -171,7 +168,6 @@
 	data["amounts"] = amounts
 	data["hasOccupant"] = occupant ? 1 : 0
 	var/occupantData[0]
-	var/crisis = 0
 	if(occupant)
 		occupantData["name"] = occupant.name
 		occupantData["stat"] = occupant.stat
@@ -215,7 +211,6 @@
 		occupantData["btFaren"] = ((occupant.bodytemperature - T0C) * (9.0/5.0))+ 32
 
 
-		crisis = (occupant.health < min_health)
 		// I'm not sure WHY you'd want to put a simple_animal in a sleeper, but precedent is precedent
 		// Runtime is aptly named, isn't she?
 		if(ishuman(occupant) && !(NO_BLOOD in occupant.dna.species.species_traits))
@@ -227,7 +222,6 @@
 
 	data["occupant"] = occupantData
 	data["maxchem"] = max_chem
-	data["minhealth"] = min_health
 	data["dialysis"] = filtering
 	data["auto_eject_dead"] = auto_eject_dead
 	if(beaker)
@@ -250,8 +244,6 @@
 			var/injectable = occupant ? 1 : 0
 			var/overdosing = 0
 			var/caution = 0 // To make things clear that you're coming close to an overdose
-			if(crisis && !(temp.id in emergency_chems))
-				injectable = 0
 
 			if(occupant && occupant.reagents)
 				reagent_amount = occupant.reagents.get_reagent_amount(temp.id)
@@ -290,10 +282,7 @@
 			var/amount = text2num(params["amount"])
 			if(!length(chemical) || amount <= 0)
 				return
-			if(occupant.health > min_health || (chemical in emergency_chems))
-				inject_chemical(usr, chemical, amount)
-			else
-				to_chat(usr, "<span class='danger'>This person is not in good enough condition for sleepers to be effective! Use another means of treatment, such as cryogenics!</span>")
+			inject_chemical(usr, chemical, amount)
 		if("removebeaker")
 			remove_beaker(ui.user)
 		if("togglefilter")
@@ -553,7 +542,6 @@
 	icon_state = "sleeper_s-open"
 	base_icon = "sleeper_s"
 	possible_chems = list("epinephrine", "ether", "salbutamol", "styptic_powder", "silver_sulfadiazine")
-	emergency_chems = list("epinephrine")
 	controls_inside = TRUE
 
 	light_color = LIGHT_COLOR_DARKRED


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
This PR removes "crisis" var from sleeper code and removes health checks for chemicals so you can inject any available chemicals on any health if person is not dead.
Removes variable related to it and actual emergency_chems list

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
This part of sleeper logic was incomprehensible and not needed at all. Sometimes when you use sleeper its buttons becomes grey and you cant inject any chemicals but one(ephedrine or epinephrine). Even with syndicate sleeper. You wonder why? Because it had list of "emergency" chemicals and if occupant's health becomes less than -25(upgradable), sleeper wont allow you to inject "non emergency" chemicals. Without saying it. There is a message in code but with current TGUI it will never be displayed.
So lets say you have a person with 130 toxin damage, you will be unable to inject charcoal because its not emergency. This is stupid. So in this PR i remove this check at all and the only check exists here is occupants state, if they are dead you cant inject chemicals.

#RemoveDontImprove

## Testing
<!-- How did you test the PR, if at all? -->
Compiled, tested sleepers on critical targets.

## Changelog
:cl:
tweak: Sleepers no longer block you from using chemicals if occupant health is low.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
