### PR TITLE
Added protection from contact diseases for Medical Hardsuit

### DIFF
--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -554,6 +554,7 @@
 	item_state = "medical_hardsuit"
 	allowed = list(/obj/item/flashlight,/obj/item/tank/internals,/obj/item/storage/firstaid,/obj/item/healthanalyzer,/obj/item/stack/medical)
 	armor = list(MELEE = 20, BULLET = 5, LASER = 5, ENERGY = 5, BOMB = 5, RAD = 75, FIRE = 75, ACID = 150)
+	permeability_coefficient = 0
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/medical
 	slowdown = 0.5
 


### PR DESCRIPTION
## What Does This PR Do
Fixes issue #22650 - Medical Hardsuit now provides protection from contact diseases. Updated the armor properties to include contact disease resistance.

## Why It's Good For The Game
Oversight fix gud

## Testing
Spawned as a CMO with the hardsuit on, had a lot of crews NPC with a lot of different virus, had nothing.

## Changelog
:cl:
tweak:  Medical Hardsuit now provides protection from contact diseases. Updated the armor properties to include contact disease resistance.
/:cl: