### PR TITLE
Allow MODsuit storage Bag (ShiftB) keybinding

### DIFF
--- a/code/modules/mob/living/carbon/human/human_inventory.dm
+++ b/code/modules/mob/living/carbon/human/human_inventory.dm
@@ -447,7 +447,7 @@
 	if(ismodcontrol(equipped_item)) // Check if the item is a MODsuit
 		if(thing && equipped_item.can_be_inserted(thing)) // Check if the item can be inserted into the MODsuit
 			equipped_item.handle_item_insertion(thing) // Insert the item into the MODsuit
-			playsound(loc, "rustle", 50, 1, -5)
+			playsound(loc, "rustle", 50, TRUE, -5)
 			return
 	if(!istype(equipped_item)) // We also let you equip things like this
 		equip_to_slot_if_possible(thing, slot_item)

--- a/code/modules/mob/living/carbon/human/human_inventory.dm
+++ b/code/modules/mob/living/carbon/human/human_inventory.dm
@@ -445,8 +445,8 @@
 	if(ismecha(loc) || HAS_TRAIT(src, TRAIT_HANDS_BLOCKED))
 		return
 	if(ismodcontrol(equipped_item)) // Check if the item is a MODsuit
-		if(thing && equipped_item.can_be_inserted(thing, 1)) // Check if the item can be inserted into the MODsuit
-			equipped_item.handle_item_insertion(thing, TRUE) // Insert the item into the MODsuit
+		if(thing && equipped_item.can_be_inserted(thing)) // Check if the item can be inserted into the MODsuit
+			equipped_item.handle_item_insertion(thing) // Insert the item into the MODsuit
 			playsound(loc, "rustle", 50, 1, -5)
 			return
 	if(!istype(equipped_item)) // We also let you equip things like this

--- a/code/modules/mob/living/carbon/human/human_inventory.dm
+++ b/code/modules/mob/living/carbon/human/human_inventory.dm
@@ -444,6 +444,11 @@
 	var/obj/item/storage/equipped_item = get_item_by_slot(slot_item)
 	if(ismecha(loc) || HAS_TRAIT(src, TRAIT_HANDS_BLOCKED))
 		return
+	if(ismodcontrol(equipped_item)) // Check if the item is a MODsuit
+		if(thing && equipped_item.can_be_inserted(thing, 1)) // Check if the item can be inserted into the MODsuit
+			equipped_item.handle_item_insertion(thing, TRUE) // Insert the item into the MODsuit
+			playsound(loc, "rustle", 50, 1, -5)
+			return
 	if(!istype(equipped_item)) // We also let you equip things like this
 		equip_to_slot_if_possible(thing, slot_item)
 		return


### PR DESCRIPTION
## What Does This PR Do
Add modsuit storage keybinding (through shift+b) to works.
Updated the quick_equip_item method to handle MODsuits and allow items to be inserted into MODsuit storage using key bindings. Therefore Fixes #23152.

## Why It's Good For The Game
Oversight fix gud 

## Images of changes
![Capture d'écran 2023-12-22 170847](https://github.com/ParadiseSS13/Paradise/assets/44984704/22b53e64-2491-4157-a207-71d4f083ae0a)
![image](https://github.com/ParadiseSS13/Paradise/assets/44984704/edc2078d-e099-499f-90ba-662cef89bfd3)

## Testing
Spawned with a modsuit with storage item, could put item on item with shift+b. Joy.

## Changelog
:cl:
add:  Allow MODsuit storage Bag (ShiftB) keybinding
/:cl: