### PR TITLE
Allow cmag consoles

### DIFF
--- a/code/game/mecha/mecha_control_console.dm
+++ b/code/game/mecha/mecha_control_console.dm
@@ -72,6 +72,14 @@
 			stored_data = list()
 			return TRUE
 
+/obj/machinery/computer/mecha/cmag_act(mob/user)
+    if(emagged)
+        to_chat(user, "<span class='warning'>The console has already been tampered with!</span>")
+        return
+    emagged = TRUE
+    req_access = list() // Remove access restrictions
+    to_chat(user, "<span class='notice'>You short out the console's access restrictions.</span>")
+
 /obj/item/mecha_parts/mecha_tracking
 	name = "exosuit tracking beacon"
 	desc = "Device used to transmit exosuit data."

--- a/code/game/mecha/mecha_control_console.dm
+++ b/code/game/mecha/mecha_control_console.dm
@@ -73,12 +73,12 @@
 			return TRUE
 
 /obj/machinery/computer/mecha/cmag_act(mob/user)
-    if(emagged)
-        to_chat(user, "<span class='warning'>The console has already been tampered with!</span>")
-        return
-    emagged = TRUE
-    req_access = list() // Remove access restrictions
-    to_chat(user, "<span class='notice'>You short out the console's access restrictions.</span>")
+	if(emagged)
+		to_chat(user, "<span class='warning'>The console has already been tampered with!</span>")
+		return
+	emagged = TRUE
+	req_access = list() // Remove access restrictions
+	to_chat(user, "<span class='notice'>You short out the console's access restrictions.</span>")
 
 /obj/item/mecha_parts/mecha_tracking
 	name = "exosuit tracking beacon"

--- a/code/modules/mob/living/carbon/human/human_inventory.dm
+++ b/code/modules/mob/living/carbon/human/human_inventory.dm
@@ -445,8 +445,8 @@
 	if(ismecha(loc) || HAS_TRAIT(src, TRAIT_HANDS_BLOCKED))
 		return
 	if(ismodcontrol(equipped_item)) // Check if the item is a MODsuit
-		if(thing && equipped_item.can_be_inserted(thing, 1)) // Check if the item can be inserted into the MODsuit
-			equipped_item.handle_item_insertion(thing, TRUE) // Insert the item into the MODsuit
+		if(thing && equipped_item.can_be_inserted(thing)) // Check if the item can be inserted into the MODsuit
+			equipped_item.handle_item_insertion(thing) // Insert the item into the MODsuit
 			playsound(loc, "rustle", 50, 1, -5)
 			return
 	if(!istype(equipped_item)) // We also let you equip things like this

--- a/code/modules/mob/living/carbon/human/human_inventory.dm
+++ b/code/modules/mob/living/carbon/human/human_inventory.dm
@@ -445,8 +445,8 @@
 	if(ismecha(loc) || HAS_TRAIT(src, TRAIT_HANDS_BLOCKED))
 		return
 	if(ismodcontrol(equipped_item)) // Check if the item is a MODsuit
-		if(thing && equipped_item.can_be_inserted(thing)) // Check if the item can be inserted into the MODsuit
-			equipped_item.handle_item_insertion(thing) // Insert the item into the MODsuit
+		if(thing && equipped_item.can_be_inserted(thing, 1)) // Check if the item can be inserted into the MODsuit
+			equipped_item.handle_item_insertion(thing, TRUE) // Insert the item into the MODsuit
 			playsound(loc, "rustle", 50, 1, -5)
 			return
 	if(!istype(equipped_item)) // We also let you equip things like this

--- a/code/modules/mob/living/carbon/human/human_inventory.dm
+++ b/code/modules/mob/living/carbon/human/human_inventory.dm
@@ -444,6 +444,11 @@
 	var/obj/item/storage/equipped_item = get_item_by_slot(slot_item)
 	if(ismecha(loc) || HAS_TRAIT(src, TRAIT_HANDS_BLOCKED))
 		return
+	if(ismodcontrol(equipped_item)) // Check if the item is a MODsuit
+		if(thing && equipped_item.can_be_inserted(thing, 1)) // Check if the item can be inserted into the MODsuit
+			equipped_item.handle_item_insertion(thing, TRUE) // Insert the item into the MODsuit
+			playsound(loc, "rustle", 50, 1, -5)
+			return
 	if(!istype(equipped_item)) // We also let you equip things like this
 		equip_to_slot_if_possible(thing, slot_item)
 		return

--- a/code/modules/mob/living/carbon/human/human_inventory.dm
+++ b/code/modules/mob/living/carbon/human/human_inventory.dm
@@ -444,11 +444,6 @@
 	var/obj/item/storage/equipped_item = get_item_by_slot(slot_item)
 	if(ismecha(loc) || HAS_TRAIT(src, TRAIT_HANDS_BLOCKED))
 		return
-	if(ismodcontrol(equipped_item)) // Check if the item is a MODsuit
-		if(thing && equipped_item.can_be_inserted(thing, 1)) // Check if the item can be inserted into the MODsuit
-			equipped_item.handle_item_insertion(thing, TRUE) // Insert the item into the MODsuit
-			playsound(loc, "rustle", 50, 1, -5)
-			return
 	if(!istype(equipped_item)) // We also let you equip things like this
 		equip_to_slot_if_possible(thing, slot_item)
 		return

--- a/code/modules/mob/living/silicon/robot/drone/drone_console.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_console.dm
@@ -137,9 +137,9 @@
 		to_chat(user, "<span class='warning'>Unable to locate drone fabricator.</span>")
 
 /obj/machinery/computer/drone_control/cmag_act(mob/user)
-    if(emagged)
-        to_chat(user, "<span class='warning'>The console has already been tampered with!</span>")
-        return
-    emagged = TRUE
-    req_access = list() // Remove access restrictions
-    to_chat(user, "<span class='notice'>You short out the console's access restrictions.</span>")
+	if(emagged)
+		to_chat(user, "<span class='warning'>The console has already been tampered with!</span>")
+		return
+	emagged = TRUE
+	req_access = list() // Remove access restrictions
+	to_chat(user, "<span class='notice'>You short out the console's access restrictions.</span>")

--- a/code/modules/mob/living/silicon/robot/drone/drone_console.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_console.dm
@@ -135,3 +135,11 @@
 
 	if(user)
 		to_chat(user, "<span class='warning'>Unable to locate drone fabricator.</span>")
+
+/obj/machinery/computer/drone_control/cmag_act(mob/user)
+    if(emagged)
+        to_chat(user, "<span class='warning'>The console has already been tampered with!</span>")
+        return
+    emagged = TRUE
+    req_access = list() // Remove access restrictions
+    to_chat(user, "<span class='notice'>You short out the console's access restrictions.</span>")

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -963,12 +963,12 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 	circuit = /obj/item/circuitboard/rdconsole/public
 
 /obj/machinery/computer/rdconsole/cmag_act(mob/user)
-    if(emagged)
-        to_chat(user, "<span class='warning'>The console has already been tampered with!</span>")
-        return
-    emagged = TRUE
-    req_access = list() // Remove access restrictions
-    to_chat(user, "<span class='notice'>You short out the console's access restrictions.</span>")
+	if(emagged)
+		to_chat(user, "<span class='warning'>The console has already been tampered with!</span>")
+		return
+	emagged = TRUE
+	req_access = list() // Remove access restrictions
+	to_chat(user, "<span class='notice'>You short out the console's access restrictions.</span>")
 
 #undef TECH_UPDATE_DELAY
 #undef DESIGN_UPDATE_DELAY

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -962,6 +962,14 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 	req_access = list()
 	circuit = /obj/item/circuitboard/rdconsole/public
 
+/obj/machinery/computer/rdconsole/cmag_act(mob/user)
+    if(emagged)
+        to_chat(user, "<span class='warning'>The console has already been tampered with!</span>")
+        return
+    emagged = TRUE
+    req_access = list() // Remove access restrictions
+    to_chat(user, "<span class='notice'>You short out the console's access restrictions.</span>")
+
 #undef TECH_UPDATE_DELAY
 #undef DESIGN_UPDATE_DELAY
 #undef PROTOLATHE_CONSTRUCT_DELAY


### PR DESCRIPTION
## What Does This PR Do
- Science control
- Mecha
- Drone
Consoles can now be cmag and remove restrictions access to them.

## Why It's Good For The Game
On this part i am not convinced myself: Hence why it is a draft, not an actual PR even though the code does works properly.
It could be argued that having access to a science console for an antag would allow more weapons to be crafted however.

## Testing
Spawned a cmag, had access to the consoles.

## Changelog
:cl:
add: Emag to some consoles
/:cl:
