### PR TITLE
Adds allowed items to HoP coat

### DIFF
--- a/code/modules/clothing/suits/job_suits.dm
+++ b/code/modules/clothing/suits/job_suits.dm
@@ -271,6 +271,7 @@
 	desc = "A big coat for the Head of Personnel who wants to make a fashion statement. Has armour woven within the fabric."
 	icon_state = "hopcoat"
 	item_state = "hopcoat"
+	allowed = list(/obj/item/gun/energy, /obj/item/reagent_containers/spray/pepper, /obj/item/gun/projectile, /obj/item/ammo_box, /obj/item/ammo_casing, /obj/item/melee/baton, /obj/item/restraints/handcuffs, /obj/item/flashlight/seclite, /obj/item/melee/classic_baton/telescopic, /obj/item/kitchen/knife/combat)
 	armor = list(MELEE = 15, BULLET = 10, LASER = 15, ENERGY = 5, BOMB = 15, RAD = 0, FIRE = 50, ACID = 50)
 	sprite_sheets = list(
 		"Vox" = 'icons/mob/clothing/species/vox/suit.dmi',


### PR DESCRIPTION
## What Does This PR Do
Adds allowed items to HoP coat - Currently uses the same list as the HoS mantle (HoP mantle inherits this, so it's consistent with other HoP items)

## Why It's Good For The Game
Drip should not come at the cost of specific item storage

## Testing
![image](https://github.com/ParadiseSS13/Paradise/assets/25437893/8d602e65-4749-4fd0-a2c3-f4978b52dc10)

It works :)

## Changelog
:cl:
tweak: The HoP coat can now hold items such as batons and guns
/:cl:
