### PR TITLE
LOOC no longer showed on runechat if muted in preferences

### DIFF
--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -212,7 +212,7 @@ GLOBAL_VAR_INIT(admin_ooc_colour, "#b82e00")
 	if(isliving(mob))
 		for(var/mob/M in viewers(7, mob))
 			if(M.client?.prefs.toggles & PREFTOGGLE_CHAT_LOOC) // Check if LOOC is enabled in game preferences
-				if((M.client?.prefs.toggles2 & (PREFTOGGLE_2_RUNECHAT|PREFTOGGLE_CHAT_LOOC) == (PREFTOGGLE_2_RUNECHAT|PREFTOGGLE_CHAT_LOOC)) // Check if Runechat and LOOC is enabled
+				if((M.client?.prefs.toggles2 & (PREFTOGGLE_2_RUNECHAT|PREFTOGGLE_CHAT_LOOC)) == (PREFTOGGLE_2_RUNECHAT|PREFTOGGLE_CHAT_LOOC)) // Check if Runechat and LOOC is enabled // Check if Runechat and LOOC is enabled
 					M.create_chat_message(mob, msg, FALSE, symbol = RUNECHAT_SYMBOL_LOOC)
 	var/mob/source = mob.get_looc_source()
 	var/list/heard = get_mobs_in_view(7, source)

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -211,8 +211,9 @@ GLOBAL_VAR_INIT(admin_ooc_colour, "#b82e00")
 	mob.create_log(LOOC_LOG, msg)
 	if(isliving(mob))
 		for(var/mob/M in viewers(7, mob))
-			if(M.client?.prefs.toggles2 & PREFTOGGLE_2_RUNECHAT)
-				M.create_chat_message(mob, msg, FALSE, symbol = RUNECHAT_SYMBOL_LOOC)
+			if(M.client?.prefs.toggles & PREFTOGGLE_CHAT_LOOC) // Check if LOOC is enabled in game preferences
+				if(M.client?.prefs.toggles2 & PREFTOGGLE_2_RUNECHAT) // Check if Runechat is enabled
+					M.create_chat_message(mob, msg, FALSE, symbol = RUNECHAT_SYMBOL_LOOC)
 	var/mob/source = mob.get_looc_source()
 	var/list/heard = get_mobs_in_view(7, source)
 

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -212,7 +212,7 @@ GLOBAL_VAR_INIT(admin_ooc_colour, "#b82e00")
 	if(isliving(mob))
 		for(var/mob/M in viewers(7, mob))
 			if(M.client?.prefs.toggles & PREFTOGGLE_CHAT_LOOC) // Check if LOOC is enabled in game preferences
-				if(M.client?.prefs.toggles2 & PREFTOGGLE_2_RUNECHAT) // Check if Runechat is enabled
+				if((M.client?.prefs.toggles2 & (PREFTOGGLE_2_RUNECHAT|PREFTOGGLE_CHAT_LOOC) == (PREFTOGGLE_2_RUNECHAT|PREFTOGGLE_CHAT_LOOC)) // Check if Runechat and LOOC is enabled
 					M.create_chat_message(mob, msg, FALSE, symbol = RUNECHAT_SYMBOL_LOOC)
 	var/mob/source = mob.get_looc_source()
 	var/list/heard = get_mobs_in_view(7, source)


### PR DESCRIPTION
## What Does This PR Do
LOOC no longer showed on runechat if muted in preferences. Fixes #23639
Add a smoll check to do so

## Why It's Good For The Game
Oversight fix is always good.

## Changelog
:cl:
fix: LOOC runechat no longer displayed when muted in preferences
/:cl: