### PR TITLE
Removes Vulp/Taj Chocolate Debuff

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drinks_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks_reagents.dm
@@ -271,10 +271,6 @@
 /datum/reagent/consumable/drink/hot_coco/on_mob_life(mob/living/M)
 	if(M.bodytemperature < 310) // 310 is the normal bodytemp. 310.055
 		M.bodytemperature = min(310, M.bodytemperature + (5 * TEMPERATURE_DAMAGE_COEFFICIENT))
-	var/update_flags = STATUS_UPDATE_NONE
-	if(isvulpkanin(M) || istajaran(M) || isfarwa(M) || iswolpin(M))
-		update_flags |= M.adjustToxLoss(2, FALSE)
-	return ..() | update_flags
 
 /datum/reagent/consumable/drink/coffee
 	name = "Coffee"

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -343,12 +343,6 @@
 	color = "#5F3A13"
 	taste_description = "bitter cocoa"
 
-/datum/reagent/consumable/cocoa/on_mob_life(mob/living/M)
-	var/update_flags = STATUS_UPDATE_NONE
-	if(isvulpkanin(M) || istajaran(M) || isfarwa(M) || iswolpin(M))
-		update_flags |= M.adjustToxLoss(2, FALSE)
-	return ..() | update_flags
-
 /datum/reagent/consumable/vanilla
 	name = "Vanilla"
 	id = "vanilla"
@@ -603,10 +597,6 @@
 
 /datum/reagent/consumable/chocolate/on_mob_life(mob/living/M)
 	M.reagents.add_reagent("sugar", 0.8)
-	var/update_flags = STATUS_UPDATE_NONE
-	if(isvulpkanin(M) || istajaran(M) || isfarwa(M) || iswolpin(M)) // chocolate is bad for dogs and cats, ya know
-		update_flags |= M.adjustToxLoss(2, FALSE)
-	return ..() | update_flags
 
 /datum/reagent/consumable/chocolate/reaction_turf(turf/T, volume)
 	if(volume >= 5 && !isspaceturf(T))
@@ -618,7 +608,7 @@
 	description = "A rather bitter herb once thought to hold magical protective properties."
 	reagent_state = LIQUID
 	color = "#21170E"
-	process_flags = ORGANIC | SYNTHETIC	
+	process_flags = ORGANIC | SYNTHETIC
 	taste_description = "tea"
 	harmless = TRUE
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Removes the negative effects of Vulp chocolate digestion.

## Why It's Good For The Game
If you need to add a niche weakness that pretty much is never recognized to balance things out, then it probably isn't worth making said consequence to begin with. Also we should avoid making our species be animals on legs, and more alien in nature, bit on the nose to have something like this. Lastly, this is technically a buff, so yeah, Vulp buff hooray woohoo.

editors note: I forgot Taj existed, this affects them, same argument applies lmao


## Testing
compiles

## Changelog
:cl: Octus
tweak: Removed Vulp weakness to chocolate
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
