### PR TITLE
pulse demons can now ai click doors without runtiming

### DIFF
--- a/code/_onclick/ai_onclick.dm
+++ b/code/_onclick/ai_onclick.dm
@@ -179,7 +179,6 @@
 /obj/machinery/power/apc/AICtrlClick(mob/living/user) // turns off/on APCs.
 	if(stat & BROKEN)
 		return
-		
 	if(aidisabled)
 		to_chat(user, "<span class='warning'>Unable to interface: Connection refused.</span>")
 		return
@@ -212,7 +211,7 @@
 /obj/machinery/door/airlock/AICtrlClick(mob/living/silicon/user) // Bolts doors
 	if(!ai_control_check(user))
 		return
-	if(user.can_instant_lockdown() || do_after_once(user, 3 SECONDS, needhand = FALSE, target = src, allow_moving = TRUE, attempt_cancel_message = "Bolting [src] cancelled.", special_identifier = "Bolt"))
+	if(ispulsedemon(user) || user.can_instant_lockdown() || do_after_once(user, 3 SECONDS, needhand = FALSE, target = src, allow_moving = TRUE, attempt_cancel_message = "Bolting [src] cancelled.", special_identifier = "Bolt"))
 		toggle_bolt(user)
 
 
@@ -224,7 +223,7 @@
 	if(isElectrified())
 		electrify(0, user, TRUE) // un-shock
 	else
-		if(user.can_instant_lockdown() || do_after_once(user, 3 SECONDS, target = src, allow_moving = TRUE, attempt_cancel_message = "Shocking [src] cancelled.", special_identifier = "Shock"))
+		if(ispulsedemon(user) || user.can_instant_lockdown() || do_after_once(user, 3 SECONDS, target = src, allow_moving = TRUE, attempt_cancel_message = "Shocking [src] cancelled.", special_identifier = "Shock"))
 			electrify(-1, user, TRUE) // permanent shock + audio cue
 			playsound(loc, "sparks", 100, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
 

--- a/code/game/gamemodes/miniantags/pulsedemon/pulsedemon_interactions.dm
+++ b/code/game/gamemodes/miniantags/pulsedemon/pulsedemon_interactions.dm
@@ -82,6 +82,9 @@
 	if(get_area(A) == controlling_area)
 		A.AICtrlClick(src)
 
+/mob/living/simple_animal/demon/pulse_demon/proc/can_instant_lockdown()
+	return TRUE
+
 // for alt-click status tab
 /mob/living/simple_animal/demon/pulse_demon/TurfAdjacent(turf/T)
 	return get_area(T) == controlling_area || ..()

--- a/code/game/gamemodes/miniantags/pulsedemon/pulsedemon_interactions.dm
+++ b/code/game/gamemodes/miniantags/pulsedemon/pulsedemon_interactions.dm
@@ -82,9 +82,6 @@
 	if(get_area(A) == controlling_area)
 		A.AICtrlClick(src)
 
-/mob/living/simple_animal/demon/pulse_demon/proc/can_instant_lockdown()
-	return TRUE
-
 // for alt-click status tab
 /mob/living/simple_animal/demon/pulse_demon/TurfAdjacent(turf/T)
 	return get_area(T) == controlling_area || ..()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Makes pulse demons return true on instant bolting / shocking

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Runtimes bad, pulse should be able to bolt / shock instantly when in an apc they control

## Testing
<!-- How did you test the PR, if at all? -->

bolted / shocked / opened door as pulse

## Changelog
:cl:
fix: pulse demons can now ai click doors without runtiming
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
