### PR TITLE
Removes Xenomorphs from midround rotation

### DIFF
--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -203,7 +203,7 @@ GLOBAL_LIST_EMPTY(event_last_fired)
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Blob",				/datum/event/blob, 				20,		list(ASSIGNMENT_ENGINEER =  4), TRUE),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Meteor Wave",			/datum/event/meteor_wave,		0,		list(ASSIGNMENT_ENGINEER =  10),	TRUE),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Abductor Visit",		/datum/event/abductor, 		    20, 	list(ASSIGNMENT_SECURITY =  3), TRUE),
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Alien Infestation",	/datum/event/alien_infestation, 15,		list(ASSIGNMENT_SECURITY = 3), TRUE),
+		//new /datum/event_meta(EVENT_LEVEL_MAJOR, "Alien Infestation",	/datum/event/alien_infestation, 15,		list(ASSIGNMENT_SECURITY = 3), TRUE),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Traders",				/datum/event/traders,			85, 	is_one_shot = TRUE),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Terror Spiders",		/datum/event/spider_terror, 	15,		list(ASSIGNMENT_SECURITY = 3), TRUE),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Slaughter Demon",		/datum/event/spawn_slaughter,	20,  	is_one_shot = TRUE),


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Removes Xenomorphs as a potential automatic midround roll.  The event can still be spawned by admins manually.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Improve don't remove has been suggested time and time again for this biohazard.  It was even removed previously and brought back after balance changes.  I really do not feel like this has been enough.  

Xenos are more or less a 50/50 coin flip every single time whether it'll be a catastrophic loss for the xenos (and thus, the entire midround is basically wasted), or, in the more likely scenario, they snowball out of proportion and end in the station getting nuked.  The simple fact that multiple death squads, the literal signal of the end of the round, have been entirely wiped by xenos reflects just how horribly balanced this midround is.  Terrors are great, blob is good, and both offer a good push and pull balance that makes for an interesting midround.  Xenomorphs, on the other hand, are very much not this.  The simple fact that any xeno can quite literally click on you once and have you be unarmed, and only 1-2 more times to completely stun you and end your game, regardless who you are (organic or silicon) or how powerful your weapon is, is honestly not fun for anyone but the xeno.  With that being said, changing their speed and health to try to balance them would essentially make them terror spiders but worse.  There *is* no good solution to balancing them, because their entire gameplay loop is essentially who clicks first and changing that effectively makes them a poor imitation of an actually decently balanced midround.  This is why I recommend removal and keeping it as an admin spawned event.  I am tired of them, and I know many, many other players are also tired of them.  

## Testing
<!-- How did you test the PR, if at all? -->
N/A, unsure how to reliably test this change.

## Changelog
:cl:
del: Removed xenos as a possible major midround roll.  The event still exists and can be manually triggered, but will not occur naturally during a normal shift.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
