### PR TITLE
Contractor item changes

### DIFF
--- a/code/modules/antagonists/traitor/contractor/items/contractor_kit.dm
+++ b/code/modules/antagonists/traitor/contractor/items/contractor_kit.dm
@@ -17,6 +17,7 @@
 		/obj/item/storage/box/syndie_kit/dart_gun,
 		/obj/item/gun/syringe/rapidsyringe,
 		// Mixed
+		/obj/item/storage/box/syndie_kit/c4,
 		/obj/item/storage/box/syndie_kit/emp,
 		/obj/item/flashlight/emp,
 		// Support

--- a/code/modules/antagonists/traitor/contractor/items/contractor_kit.dm
+++ b/code/modules/antagonists/traitor/contractor/items/contractor_kit.dm
@@ -13,6 +13,7 @@
 		/obj/item/gun/projectile/automatic/c20r/toy,
 		/obj/item/storage/box/syndie_kit/throwing_weapons,
 		/obj/item/gun/projectile/automatic/toy/pistol/riot,
+		/obj/item/soap/syndie,
 		/obj/item/storage/box/syndie_kit/dart_gun,
 		/obj/item/gun/syringe/rapidsyringe,
 		// Mixed
@@ -20,7 +21,6 @@
 		/obj/item/flashlight/emp,
 		// Support
 		/obj/item/storage/box/syndidonkpockets,
-		/obj/item/door_remote/omni/access_tuner,
 		/obj/item/storage/belt/military/traitor,
 		/obj/item/clothing/shoes/chameleon/noslip,
 		/obj/item/storage/toolbox/syndicate,

--- a/code/modules/antagonists/traitor/contractor/items/contractor_kit.dm
+++ b/code/modules/antagonists/traitor/contractor/items/contractor_kit.dm
@@ -12,23 +12,21 @@
 		// Offensive
 		/obj/item/gun/projectile/automatic/c20r/toy,
 		/obj/item/storage/box/syndie_kit/throwing_weapons,
-		/obj/item/pen/edagger,
 		/obj/item/gun/projectile/automatic/toy/pistol/riot,
-		/obj/item/soap/syndie,
 		/obj/item/storage/box/syndie_kit/dart_gun,
 		/obj/item/gun/syringe/rapidsyringe,
-		/obj/item/storage/backpack/duffel/syndie/x4,
 		// Mixed
 		/obj/item/storage/box/syndie_kit/emp,
 		/obj/item/flashlight/emp,
 		// Support
 		/obj/item/storage/box/syndidonkpockets,
+		/obj/item/door_remote/omni/access_tuner,
 		/obj/item/storage/belt/military/traitor,
 		/obj/item/clothing/shoes/chameleon/noslip,
 		/obj/item/storage/toolbox/syndicate,
 		/obj/item/storage/backpack/duffel/syndie/med/surgery,
 		/obj/item/multitool/ai_detect,
-		/obj/item/encryptionkey/binary,
+		/obj/item/encryptionkey/syndicate,
 		/obj/item/jammer,
 		/obj/item/clothing/under/syndicate/silicon_cham,
 		/obj/item/implanter/freedom,
@@ -53,6 +51,8 @@
 	new /obj/item/clothing/suit/space/syndicate/contractor(src)
 	new /obj/item/melee/classic_baton/telescopic/contractor(src)
 	new /obj/item/clothing/under/chameleon(src)
+	new /obj/item/clothing/suit/chameleon(src)
+	new /obj/item/clothing/head/chameleon(src)
 	new /obj/item/clothing/mask/chameleon(src)
 	new /obj/item/card/id/syndicate(src)
 	new /obj/item/storage/fancy/cigarettes/cigpack_syndicate(src)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
**Chameleon kit changes**:
The chameleon suit has long not been enough to hide your disguise as a contractor, which is why they will get a suit and helmet to change their disguise while on the run.

Removes: 
**Energy dagger:** Contractors are not supposed to have lethal gear as their package. You can buy it from the uplink instead.
**X4 charges:** This is a highly lethal weapon that can gib people outside of the door. Potentially round-ending the person on the other side. Not to mention that the noise is heard throughout the entire station. The direct opposite of a stealth weapon.
**Binary translator key:** Useless AI comms that do nothing for the contractor. It's generally only used to add laws and talk with the AI privately.

Adds: 
**A box of 5 C4 charges:** Swapped with the X4 charges, they do the same without all the damage to the station.
**Syndicate encryption key:** Swapped with the Binary translator key as a more useful item that still costs less TC.

This PR was made after a talk with two balance devs.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
The items generally did not fit the theme of a non-lethal kidnapper, which is why they were replaced or removed.
## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![image](https://github.com/ParadiseSS13/Paradise/assets/154929127/e1b809f6-3fd8-4e36-83ee-ebb68fb97b60)
![image](https://github.com/ParadiseSS13/Paradise/assets/154929127/5f3326b0-9aa9-417e-970f-7737d2e7fad5)


## Testing
<!-- How did you test the PR, if at all? -->
100 boxes of contractor goods were spawned in, and the items were rummaged through for loot
A lot of toolboxes were found, and all the items spawned as it should
## Changelog
:cl:
add: A Syndicate encryption key and a box of 5 C4 charges were added to the contractor item pool
tweak: The contractor chameleon kit has a hat and suit added to the standard kit
del: The Energy dagger, X4 charges, and Binary Translator Key were removed from the contractor item pool
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
