### PR TITLE
Removes Apple mutation from Olives

### DIFF
--- a/code/modules/hydroponics/grown/olive.dm
+++ b/code/modules/hydroponics/grown/olive.dm
@@ -12,7 +12,7 @@
 	growthstages = 6
 	growing_icon = 'icons/obj/hydroponics/growing_fruits.dmi'
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
-	mutatelist = list(/obj/item/seeds/apple)
+	mutatelist = list()
 	reagents_add = list("vitamin" = 0.02, "plantmatter" = 0.2, "sodiumchloride" = 0.2)
 
 /obj/item/reagent_containers/food/snacks/grown/olive


### PR DESCRIPTION
## What Does This PR Do
Makes Olives no longer mutate into anything, especially apples. My fault for copy pasting code and not noticing at all. Fixes #23665 

## Why It's Good For The Game
Olives shouldn't magically break biological and botanical barriers.

## Testing
1. Olive no mutate.

## Changelog
:cl:
fix: Olives no longer mutate into apples.
/:cl:
