### PR TITLE
[s] Fix a Syndicate Bundle oversight

### DIFF
--- a/code/game/objects/items/devices/radio/beacon.dm
+++ b/code/game/objects/items/devices/radio/beacon.dm
@@ -96,7 +96,7 @@
 		bundle_name = pick(unselected)
 	var/bundle = bundles[bundle_name]
 	bundle = new bundle(user.loc)
-	to_chat(user, "<span class='notice'>Welcome to [station_name()], [bundle_name]</span>")
+	to_chat(user, "<span class='notice'>Welcome to [station_name()], [bundle_name]!</span>")
 	user.drop_item()
 	qdel(src)
 	user.put_in_hands(bundle)

--- a/code/game/objects/items/devices/radio/beacon.dm
+++ b/code/game/objects/items/devices/radio/beacon.dm
@@ -87,7 +87,7 @@
 			selected += pick_n_take(unselected)
 		selected += "Random"
 	var/bundle_name  = tgui_input_list(user, "Available Bundles", "Bundle Selection", selected)
-	if(!bundle_name)
+	if(!bundle_name || QDELETED(src))
 		return
 	if(bundle_name == "Random")
 		bundle_name = pick(unselected)

--- a/code/game/objects/items/devices/radio/beacon.dm
+++ b/code/game/objects/items/devices/radio/beacon.dm
@@ -81,14 +81,17 @@
 /obj/item/radio/beacon/syndicate/bundle/attack_self(mob/user)
 	if(!user)
 		return
+
 	if(!length(selected))
 		unselected = bundles.Copy()
 		for(var/i in 1 to 3)
 			selected += pick_n_take(unselected)
 		selected += "Random"
-	var/bundle_name  = tgui_input_list(user, "Available Bundles", "Bundle Selection", selected)
+
+	var/bundle_name = tgui_input_list(user, "Available Bundles", "Bundle Selection", selected)
 	if(!bundle_name || QDELETED(src))
 		return
+
 	if(bundle_name == "Random")
 		bundle_name = pick(unselected)
 	var/bundle = bundles[bundle_name]


### PR DESCRIPTION
## What Does This PR Do
Fixes a small whoopsie oversight in tot bundle code that allowed the input to stay valid for too long

## Why It's Good For The Game
You only get one.

## Testing
Made myself a tot, logged into the uplink, bought a bundle, used it in hand several times.

## Changelog
:cl:
fix: Syndicate Bundle beacon's UI no longer allows you to get multiple bundles.
/:cl: