### PR TITLE
fixes armory shuttle spacing itself every time we send it

### DIFF
--- a/_maps/map_files/shuttles/admin_armory.dmm
+++ b/_maps/map_files/shuttles/admin_armory.dmm
@@ -340,10 +340,6 @@
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/administration)
-"wQ" = (
-/obj/effect/spawner/window/shuttle,
-/turf/space,
-/area/shuttle/administration)
 "xm" = (
 /obj/structure/table/reinforced,
 /obj/item/rcd/preloaded,
@@ -960,7 +956,7 @@ vk
 NQ
 NQ
 NQ
-wQ
+NQ
 vk
 vk
 vk


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

removes a sneaky space tile under an armory shuttle window that spaces it

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

I like my shuttle being non spaced.

## Testing
<!-- How did you test the PR, if at all? -->
Loaded it through shuttle console.
Wasn't spaced

## Changelog
:cl:
fix: Admin shuttle no longer spaces itself.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
