### PR TITLE
BALANCE: Buff generator for mecha

### DIFF
--- a/code/game/mecha/equipment/tools/other_tools.dm
+++ b/code/game/mecha/equipment/tools/other_tools.dm
@@ -227,7 +227,7 @@
 
 /obj/item/mecha_parts/mecha_equipment/tesla_energy_relay
 	name = "exosuit energy relay"
-	desc = "An exosuit module that wirelessly drains energy from any available power channel in area. The performance index is quite low."
+	desc = "An exosuit module that wirelessly drains energy from any available power channel in area. The performance index barely compensate move cost."
 	icon_state = "tesla"
 	origin_tech = "magnets=4;powerstorage=4;engineering=4"
 	energy_drain = 0
@@ -299,7 +299,7 @@
 					pow_chan = c
 					break
 			if(pow_chan)
-				var/delta = min(20, chassis.cell.maxcharge-cur_charge)
+				var/delta = min(60, chassis.cell.maxcharge-cur_charge)
 				chassis.give_power(delta)
 				A.powernet.use_active_power(pow_chan, delta * coeff)
 
@@ -311,14 +311,15 @@
 	icon_state = "tesla"
 	origin_tech = "plasmatech=2;powerstorage=2;engineering=2"
 	range = MECHA_MELEE
+	energy_drain = 0 //for allow load fuel without energy
 	var/coeff = 100
 	var/fuel_type = MAT_PLASMA
-	var/max_fuel = 150000
+	var/max_fuel = 150000 // 45k energy for 75 plasma/ 375 cr.
 	var/fuel_name = "plasma" // Our fuel name as a string
 	var/fuel_amount = 0
 	var/fuel_per_cycle_idle = 10
-	var/fuel_per_cycle_active = 100
-	var/power_per_cycle = 30
+	var/fuel_per_cycle_active = 500
+	var/power_per_cycle = 150
 
 
 /obj/item/mecha_parts/mecha_equipment/generator/Destroy()
@@ -424,10 +425,10 @@
 	origin_tech = "powerstorage=4;engineering=4"
 	fuel_name = "uranium" // Our fuel name as a string
 	fuel_type = MAT_URANIUM
-	max_fuel = 50000
+	max_fuel = 50000 // around 83k energy for 25 uranium/ 0 cr.
 	fuel_per_cycle_idle = 10
-	fuel_per_cycle_active = 30
-	power_per_cycle = 50
+	fuel_per_cycle_active = 150
+	power_per_cycle = 250
 	var/rad_per_cycle = 30
 
 /obj/item/mecha_parts/mecha_equipment/generator/nuclear/process()

--- a/code/game/mecha/equipment/tools/other_tools.dm
+++ b/code/game/mecha/equipment/tools/other_tools.dm
@@ -227,7 +227,7 @@
 
 /obj/item/mecha_parts/mecha_equipment/tesla_energy_relay
 	name = "exosuit energy relay"
-	desc = "An exosuit module that wirelessly drains energy from any available power channel in area. The performance index barely compensate move cost."
+	desc = "An exosuit module that wirelessly drains energy from any available power channel in an area. The performance index barely compensates for movement costs."
 	icon_state = "tesla"
 	origin_tech = "magnets=4;powerstorage=4;engineering=4"
 	energy_drain = 0

--- a/code/game/mecha/equipment/tools/other_tools.dm
+++ b/code/game/mecha/equipment/tools/other_tools.dm
@@ -299,7 +299,7 @@
 					pow_chan = c
 					break
 			if(pow_chan)
-				var/delta = min(60, chassis.cell.maxcharge-cur_charge)
+				var/delta = min(60, chassis.cell.maxcharge - cur_charge)
 				chassis.give_power(delta)
 				A.powernet.use_active_power(pow_chan, delta * coeff)
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Part of topic https://discord.com/channels/145533722026967040/1188998198635806750/1188998198635806750
Buffs resource generators by a factor of 5, and tesla generator by a factor of three. This will allow generators to compete with the slime battery and say "I'm not taking up a slot in the mech for nothing!". Consumption, as well as generation of energy is increased by 5 times, without changing the coefficient of total energy, only speeds up the "metabolism".

The Tesla generator, on the other hand, has a different problem. It is so weak that it does not even cover the cost of walking. Increasing the delta by three times will increase the load on the APC, but will at least allow you to walk without discharging the battery. Regen will still be critically lacking for high-end weapons like rockets and flashbangs, as well as super intense shooting with regular weapons and Gigax's leg mode 

## Why It's Good For The Game
A generator of any type in current situation is completely, utterly useless and a mistake the very thought of even testing it. Needless to say, how the cockpit burned when it turned out that generators not only discharge the battery while working, just by walking, but also cannot be loaded with fuel if the mech is discharged? This change doesn't change the fuel consumption per unit of energy at all, but gives enough exhaust for intensive work on the mine or front, making all 3 modules worthy of their application in different fields.

## Images of changes


## Testing
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Increase Plasma and Uranium generators consumption and generation by 5, tesla`s delta have x3 buff
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
