### PR TITLE
makes make everyone random not the worst button of all time

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -548,11 +548,11 @@
 	if(SSticker.random_players)
 		var/mob/living/carbon/human/H = new_character
 		scramble(1, H, 100)
-		H.real_name = random_name(H.gender, H.dna.species.name) //Give them a name that makes sense for their species.
+		H.real_name = random_name(H.gender, H.dna.species.name)
 		H.sync_organ_dna(assimilate = 1)
 		H.update_body()
-		H.reset_hair() //No more winding up with hairstyles you're not supposed to have, and blowing your cover.
-		H.reset_markings() //...Or markings.
+		H.reset_hair()
+		H.reset_markings()
 		H.dna.ResetUIFrom(H)
 		H.flavor_text = ""
 	stop_sound_channel(CHANNEL_LOBBYMUSIC)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -544,12 +544,17 @@
 	check_prefs_are_sane()
 	var/mob/living/carbon/human/new_character = new(loc)
 	new_character.lastarea = get_area(loc)
-
-	if(SSticker.random_players)
-		client.prefs.active_character.randomise()
-		client.prefs.active_character.real_name = random_name(client.prefs.active_character.gender)
 	client.prefs.active_character.copy_to(new_character)
-
+	if(SSticker.random_players)
+		var/mob/living/carbon/human/H = new_character
+		scramble(1, H, 100)
+		H.real_name = random_name(H.gender, H.dna.species.name) //Give them a name that makes sense for their species.
+		H.sync_organ_dna(assimilate = 1)
+		H.update_body()
+		H.reset_hair() //No more winding up with hairstyles you're not supposed to have, and blowing your cover.
+		H.reset_markings() //...Or markings.
+		H.dna.ResetUIFrom(H)
+		H.flavor_text = ""
 	stop_sound_channel(CHANNEL_LOBBYMUSIC)
 
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Make everyone random now works without randomizing the players *currently saved character in preferences that will fuck them if they save it*

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

the button being usable is good

fix #20168

## Testing
<!-- How did you test the PR, if at all? -->

confirmed it scrambled, and that the save was not changed

## Changelog
:cl:
fix: make everyone random will no longer fuck up peoples saved characters so it can be used.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
