### PR TITLE
Adds Light Tube Coloring - Colored Lighting! No more light floors needed!

### DIFF
--- a/code/modules/power/lights.dm
+++ b/code/modules/power/lights.dm
@@ -478,10 +478,9 @@
 		if(spraycan.capped)
 			to_chat(user, "<span class='notice'>You can't spraypaint [src] with the cap still on!</span>")
 			return
-		var/new_color = spraycan.colour
-		color = new_color
+		color = spraycan.colour
 		to_chat(user, "<span class='notice'>You change [src]'s light bulb color.</span>")
-		brightness_color = new_color
+		brightness_color = spraycan.colour
 		update(TRUE, TRUE, FALSE)
 		return
 

--- a/code/modules/power/lights.dm
+++ b/code/modules/power/lights.dm
@@ -472,16 +472,14 @@
 
 	// ඞ Attack with Spray Can! Coloring time.
 	if(istype(W, /obj/item/toy/crayon/spraycan))
-		// Some ported code from Light_floor. I was going to write my own but this seems decently written, covers something I wouldn't be able to fix myself - noob
-		var/new_color = input(user, "Select a bulb color", "Select a bulb color", color) as color|null
-		if(!new_color)
+		var/obj/item/toy/crayon/spraycan/spraycan = W
+
+		// quick check to disable capped spraypainting, aesthetic reasons
+		if(spraycan.capped)
+			to_chat(user, "<span class='notice'>You can't spraypaint with the cap still on, silly.</span>")
 			return
-		if(!Adjacent(user, src))
-			return
-		var/list/hsl = rgb2hsl(hex2num(copytext(new_color, 2, 4)), hex2num(copytext(new_color, 4, 6)), hex2num(copytext(new_color, 6, 8)))
-		hsl[3] = max(hsl[3], 0.4)
-		var/list/rgb = hsl2rgb(arglist(hsl))
-		color = "#[num2hex(rgb[1], 2)][num2hex(rgb[2], 2)][num2hex(rgb[3], 2)]"
+		var/new_color = spraycan.colour
+		color = new_color
 		to_chat(user, "<span class='notice'>You change [src]'s light bulb color.</span>")
 		brightness_color = new_color
 		update(TRUE, TRUE, FALSE)

--- a/code/modules/power/lights.dm
+++ b/code/modules/power/lights.dm
@@ -476,7 +476,7 @@
 
 		// quick check to disable capped spraypainting, aesthetic reasons
 		if(spraycan.capped)
-			to_chat(user, "<span class='notice'>You can't spraypaint with the cap still on, silly.</span>")
+			to_chat(user, "<span class='notice'>You can't spraypaint [src] with the cap still on!</span>")
 			return
 		var/new_color = spraycan.colour
 		color = new_color

--- a/code/modules/power/lights.dm
+++ b/code/modules/power/lights.dm
@@ -470,7 +470,7 @@
 		LR.ReplaceLight(src, user)
 		return
 
-	// ඞ Attack with Spray Can! Coloring time.
+	// Attack with Spray Can! Coloring time.
 	if(istype(W, /obj/item/toy/crayon/spraycan))
 		var/obj/item/toy/crayon/spraycan/spraycan = W
 

--- a/code/modules/power/lights.dm
+++ b/code/modules/power/lights.dm
@@ -470,6 +470,23 @@
 		LR.ReplaceLight(src, user)
 		return
 
+	// ඞ Attack with Spray Can! Coloring time.
+	if(istype(W, /obj/item/toy/crayon/spraycan))
+		// Some ported code from Light_floor. I was going to write my own but this seems decently written, covers something I wouldn't be able to fix myself - noob
+		var/new_color = input(user, "Select a bulb color", "Select a bulb color", color) as color|null
+		if(!new_color)
+			return
+		if(!Adjacent(user, src))
+			return
+		var/list/hsl = rgb2hsl(hex2num(copytext(new_color, 2, 4)), hex2num(copytext(new_color, 4, 6)), hex2num(copytext(new_color, 6, 8)))
+		hsl[3] = max(hsl[3], 0.4)
+		var/list/rgb = hsl2rgb(arglist(hsl))
+		color = "#[num2hex(rgb[1], 2)][num2hex(rgb[2], 2)][num2hex(rgb[3], 2)]"
+		to_chat(user, "<span class='notice'>You change [src]'s light bulb color.</span>")
+		brightness_color = new_color
+		update(TRUE, TRUE, FALSE)
+		return
+
 	// attempt to insert light
 	if(istype(W, /obj/item/light))
 		if(status != LIGHT_EMPTY)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Allows players to use Spraycans to color lights, similar to the functionality of the Floor Lights.

## Why It's Good For The Game
Allows for nice, pretty colored lighting without the ugly as sin Light Floor sprites. Adds further functionality to Spray Cans that aren't just lol graffiti or antag item

## Images of changes

![image](https://github.com/ParadiseSS13/Paradise/assets/32783144/93c28728-2bbc-4e2b-80b0-32cb93ea9f7c)
![image](https://github.com/ParadiseSS13/Paradise/assets/32783144/7f84a73d-46d8-40e6-8b4b-515f549d0e63)
![image](https://github.com/ParadiseSS13/Paradise/assets/32783144/78eec49f-c5fc-4c59-9538-bd7535394fad)
![image](https://github.com/ParadiseSS13/Paradise/assets/32783144/39d977f3-e74c-485b-8fec-68d4887e86c2)
![image](https://github.com/ParadiseSS13/Paradise/assets/32783144/ab35f384-e30b-45b9-8e1f-c64678198ac6)


## Testing
Built, no errors. Loaded up in game. Took Spray can. Hit light tube. Changed color. Worked. Removed Light Tube. Put it back. Color came back. Good! Activated Fire Alarms, lights turned red, turned them off, lights went back to the colored states. Great. Tested crayon, didn't work, that is good.

## Changelog
:cl:
add: Added Light Coloring! Spray a light tube with a spraycan to use it!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
