### PR TITLE
Purges improvised and overloaded improvised shotgun ammo

### DIFF
--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -421,29 +421,6 @@
 	category = CAT_WEAPONRY
 	subcategory = CAT_AMMO
 
-/datum/crafting_recipe/improvisedslug
-	name = "Improvised Shotgun Shell"
-	result = list(/obj/item/ammo_casing/shotgun/improvised)
-	reqs = list(/obj/item/grenade/chem_grenade = 1,
-				/obj/item/stack/sheet/metal = 1,
-				/obj/item/stack/cable_coil = 1,
-				/datum/reagent/fuel = 10)
-	tools = list(TOOL_SCREWDRIVER)
-	time = 5
-	category = CAT_WEAPONRY
-	subcategory = CAT_AMMO
-
-/datum/crafting_recipe/improvisedslugoverload
-	name = "Overload Improvised Shell"
-	result = list(/obj/item/ammo_casing/shotgun/improvised/overload)
-	reqs = list(/obj/item/ammo_casing/shotgun/improvised = 1,
-				/datum/reagent/blackpowder = 10,
-				/datum/reagent/plasma_dust = 20)
-	tools = list(TOOL_SCREWDRIVER)
-	time = 5
-	category = CAT_WEAPONRY
-	subcategory = CAT_AMMO
-
 /datum/crafting_recipe/lasershot
 	name = "Lasershot Shell"
 	result = list(/obj/item/ammo_casing/shotgun/lasershot)

--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -165,32 +165,6 @@
 	muzzle_flash_strength = MUZZLE_FLASH_STRENGTH_NORMAL
 	muzzle_flash_range = MUZZLE_FLASH_RANGE_NORMAL
 
-
-/obj/item/ammo_casing/shotgun/improvised
-	name = "improvised shell"
-	desc = "An extremely weak shotgun shell with multiple small pellets made out of metal shards."
-	icon_state = "improvshell"
-	projectile_type = /obj/item/projectile/bullet/pellet/weak
-	materials = list(MAT_METAL=250)
-	pellets = 10
-	variance = 35
-	muzzle_flash_strength = MUZZLE_FLASH_STRENGTH_NORMAL
-	muzzle_flash_range = MUZZLE_FLASH_RANGE_NORMAL
-
-
-/obj/item/ammo_casing/shotgun/improvised/overload
-	name = "overloaded improvised shell"
-	desc = "An extremely weak shotgun shell with multiple small pellets made out of metal shards. This one has been packed with even more \
-	propellant. It's like playing russian roulette, with a shotgun."
-	icon_state = "improvshell"
-	projectile_type = /obj/item/projectile/bullet/pellet/overload
-	materials = list(MAT_METAL=250)
-	pellets = 4
-	variance = 40
-	muzzle_flash_strength = MUZZLE_FLASH_STRENGTH_NORMAL
-	muzzle_flash_range = MUZZLE_FLASH_RANGE_STRONG
-
-
 /obj/item/ammo_casing/shotgun/stunslug
 	name = "taser slug"
 	desc = "A stunning taser slug."

--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -123,7 +123,7 @@
 
 /obj/item/ammo_box/magazine/internal/shot/improvised
 	name = "improvised shotgun internal magazine"
-	ammo_type = /obj/item/ammo_casing/shotgun/improvised
+	ammo_type = /obj/item/ammo_casing/shotgun/rubbershot
 	max_ammo = 1
 
 /obj/item/ammo_box/magazine/internal/shot/improvised/cane

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -101,13 +101,6 @@
 	if(H.getStaminaLoss() >= 60)
 		H.KnockDown(8 SECONDS)
 
-/obj/item/projectile/bullet/pellet/overload
-	damage = 3
-
-/obj/item/projectile/bullet/pellet/overload/New()
-	range = rand(1, 10)
-	..()
-
 /obj/item/projectile/bullet/pellet/assassination
 	damage = 12
 	tile_dropoff = 1	// slightly less damage and greater damage falloff compared to normal buckshot

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -101,18 +101,6 @@
 	if(H.getStaminaLoss() >= 60)
 		H.KnockDown(8 SECONDS)
 
-/obj/item/projectile/bullet/pellet/weak
-	tile_dropoff = 0.55		//Come on it does 6 damage don't be like that.
-	damage = 6
-
-/obj/item/projectile/bullet/pellet/weak/New()
-	range = rand(1, 8)
-	..()
-
-/obj/item/projectile/bullet/pellet/weak/on_range()
-	do_sparks(1, 1, src)
-	..()
-
 /obj/item/projectile/bullet/pellet/overload
 	damage = 3
 
@@ -128,15 +116,6 @@
 	if(..(target, blocked))
 		var/mob/living/M = target
 		M.AdjustSilence(4 SECONDS)	// HELP MIME KILLING ME IN MAINT
-
-/obj/item/projectile/bullet/pellet/overload/on_hit(atom/target, blocked = 0)
-	..()
-	explosion(target, 0, 0, 2)
-
-/obj/item/projectile/bullet/pellet/overload/on_range()
-	explosion(src, 0, 0, 2)
-	do_sparks(3, 3, src)
-	..()
 
 /obj/item/projectile/bullet/midbullet
 	damage = 20


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Purges improvised shotgun ammo and overloaded improvised shotgun ammo. The improvised shotgun remains.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

We moved past buckshot long ago for a reason. It's time to kill off improvised shotgun, which was nearly as strong point blank or a few tiles away. Lasershot gets to stay as it's damage is burn, and 20 less than buckshot. While not the most effective on armored targets, it's high base damage still made it pack a punch, especially vs terrors.

Improvised overloaded has been removed,  due to it being easier (arguably) to make than frag 12, and more destructive. Yes, it can back fire, but more often than not, the person you are trying to kill will go down with you. A lot of people would trade a kill on a vampire / nuclear operative / agent with their own life, and this ammo made it a bit too easy to do so.

This was also suggested by rurik in order to potentially allow combat shotguns to fit on armor vests.\

The lack of maintenance ammo for the shotgun is a shame, but I have been thinking of porting the laser musket / smoothbore. But that is for another time.

## Testing
<!-- How did you test the PR, if at all? -->

Compiled, was not in code, had no errors

## Changelog
:cl:
del: Improvised buckshot / overloaded improvised buckshot has been purged.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
