### PR TITLE
Thrown mobs cant move until the throw ends

### DIFF
--- a/code/controllers/subsystem/SSthrowing.dm
+++ b/code/controllers/subsystem/SSthrowing.dm
@@ -70,7 +70,7 @@ SUBSYSTEM_DEF(throwing)
 	var/last_move = 0
 	///When this variable is false, non dense mobs will be hit by a thrown item. useful for things that you dont want to be cheesed by crawling, EG. gravitational anomalies
 	var/dodgeable = TRUE
-	///Should thrownthing movement be blocked if its a mob?
+	/// Can a thrown mob move themselves to stop the throw?
 	var/block_movement = TRUE
 
 /datum/thrownthing/proc/tick()

--- a/code/controllers/subsystem/SSthrowing.dm
+++ b/code/controllers/subsystem/SSthrowing.dm
@@ -70,6 +70,8 @@ SUBSYSTEM_DEF(throwing)
 	var/last_move = 0
 	///When this variable is false, non dense mobs will be hit by a thrown item. useful for things that you dont want to be cheesed by crawling, EG. gravitational anomalies
 	var/dodgeable = TRUE
+	///Should thrownthing movement be blocked if its a mob?
+	var/block_movement = TRUE
 
 /datum/thrownthing/proc/tick()
 	var/atom/movable/AM = thrownthing

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -394,7 +394,7 @@
 		step(src, AM.dir)
 	..()
 
-/atom/movable/proc/throw_at(atom/target, range, speed, mob/thrower, spin = TRUE, diagonals_first = FALSE, datum/callback/callback, force = INFINITY, dodgeable = TRUE)
+/atom/movable/proc/throw_at(atom/target, range, speed, mob/thrower, spin = TRUE, diagonals_first = FALSE, datum/callback/callback, force = INFINITY, dodgeable = TRUE, block_movement = TRUE)
 	if(!target || (flags & NODROP) || speed <= 0)
 		return 0
 
@@ -435,6 +435,7 @@
 	TT.diagonals_first = diagonals_first
 	TT.callback = callback
 	TT.dodgeable = dodgeable
+	TT.block_movement = block_movement
 
 	var/dist_x = abs(target.x - src.x)
 	var/dist_y = abs(target.y - src.y)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1116,7 +1116,7 @@
 		if("lighting_alpha")
 			sync_lighting_plane_alpha()
 
-/mob/living/throw_at(atom/target, range, speed, mob/thrower, spin, diagonals_first, datum/callback/callback, force, dodgeable)
+/mob/living/throw_at(atom/target, range, speed, mob/thrower, spin, diagonals_first, datum/callback/callback, force, dodgeable, block_movement)
 	stop_pulling()
 	return ..()
 

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -68,7 +68,7 @@
 	if(mob.notransform)
 		return 0 //This is sota the goto stop mobs from moving var
 
-	if(mob.throwing)
+	if(mob.throwing && mob.throwing.block_movement)
 		return
 
 	if(mob.control_object)
@@ -185,6 +185,8 @@
 		mob.setDir(get_dir(mob, mob.pulling)) // Face welding tanks and stuff when pulling
 
 	moving = 0
+	if(mob && . && mob.throwing)
+		mob.throwing.finalize(FALSE)
 
 	for(var/obj/O in mob)
 		O.on_mob_move(direct, mob)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -68,6 +68,9 @@
 	if(mob.notransform)
 		return 0 //This is sota the goto stop mobs from moving var
 
+	if(mob.throwing)
+		return
+
 	if(mob.control_object)
 		return Move_object(direct)
 
@@ -182,9 +185,6 @@
 		mob.setDir(get_dir(mob, mob.pulling)) // Face welding tanks and stuff when pulling
 
 	moving = 0
-	if(mob && .)
-		if(mob.throwing)
-			mob.throwing.finalize(FALSE)
 
 	for(var/obj/O in mob)
 		O.on_mob_move(direct, mob)

--- a/code/modules/mod/modules/modules_engineering.dm
+++ b/code/modules/mod/modules/modules_engineering.dm
@@ -145,7 +145,7 @@
 	if(firer && isliving(firer))
 		var/mob/living/L = firer
 		L.apply_status_effect(STATUS_EFFECT_IMPACT_IMMUNE)
-		L.throw_at(target, 15, 1, L, FALSE, FALSE, callback = CALLBACK(L, TYPE_PROC_REF(/mob/living, remove_status_effect), STATUS_EFFECT_IMPACT_IMMUNE))
+		L.throw_at(target, 15, 1, L, FALSE, FALSE, callback = CALLBACK(L, TYPE_PROC_REF(/mob/living, remove_status_effect), STATUS_EFFECT_IMPACT_IMMUNE), block_movement = FALSE)
 
 /obj/item/projectile/tether/Destroy()
 	QDEL_NULL(chain)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
This PR blocks moving if you're currently being thrown. 

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
If you're being thrown, being able to stop throw by any movement button is... weird. 
Xeno hunter stopping jump in the middle of leap? Shadow demon being able to not move after using grapple hand on non living target? Gargantua failing charge spell because you pressed W in fight? not like this. 
Being thrown is not easy and being able to just press button to make it much lesser than it supposed to be  or to completely kill spell based on throwing is weird.

## Testing
<!-- How did you test the PR, if at all? -->
Compiled, tested various throwing

## Changelog
:cl:
tweak: You cant move while being thrown
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
