### PR TITLE
RnD Nerf, Purges most NVG variants from the lathe

### DIFF
--- a/code/modules/research/designs/equipment_designs.dm
+++ b/code/modules/research/designs/equipment_designs.dm
@@ -21,16 +21,6 @@
 	build_path = /obj/item/clothing/glasses/hud/health
 	category = list("Equipment")
 
-/datum/design/health_hud_night
-	name = "Night Vision Health Scanner HUD"
-	desc = "An advanced medical head-up display that allows doctors to find patients in complete darkness."
-	id = "health_hud_night"
-	req_tech = list("biotech" = 4, "magnets" = 5, "plasmatech" = 4, "engineering" = 6)
-	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 600, MAT_GLASS = 600, MAT_URANIUM = 1000, MAT_SILVER = 350)
-	build_path = /obj/item/clothing/glasses/hud/health/night
-	category = list("Equipment")
-
 /datum/design/magboots
 	name = "Magnetic Boots"
 	desc = "Magnetic boots, often used during extravehicular activity to ensure the user remains safely attached to the vehicle."
@@ -61,16 +51,6 @@
 	build_path = /obj/item/clothing/glasses/hud/security
 	category = list("Equipment")
 
-/datum/design/security_hud_night
-	name = "Night Vision Security HUD"
-	desc = "A heads-up display which provides id data and vision in complete darkness."
-	id = "security_hud_night"
-	req_tech = list("combat" = 4, "magnets" = 5, "plasmatech" = 4, "engineering" = 6)
-	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 600, MAT_GLASS = 600, MAT_URANIUM = 1000, MAT_GOLD = 350)
-	build_path = /obj/item/clothing/glasses/hud/security/night
-	category = list("Equipment")
-
 /datum/design/skills_hud
 	name = "Skills HUD"
 	desc = "A heads-up display that scans the humans in view and shows a summary of their NT employment history."
@@ -89,16 +69,6 @@
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 500, MAT_GLASS = 500)
 	build_path = /obj/item/clothing/glasses/hud/janitor
-	category = list("Equipment", "Janitorial")
-
-/datum/design/jani_night_vision_goggles
-	name = "Night Vision Janitor HUD"
-	desc = "A janitorial filth scanner fitted with a light amplifier."
-	id = "night_vision_jani"
-	req_tech = list("biotech" = 4, "magnets" = 5, "plasmatech" = 4, "engineering" = 6)
-	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 600, MAT_GLASS = 600, MAT_PLASMA = 350, MAT_URANIUM = 1000)
-	build_path = /obj/item/clothing/glasses/hud/janitor/night
 	category = list("Equipment", "Janitorial")
 
 /datum/design/mesons
@@ -192,16 +162,6 @@
 	build_path = /obj/item/clothing/glasses/science
 	category = list("Equipment")
 
-/datum/design/nv_sci_goggles
-	name = "Night Vision Science Goggles"
-	desc = "Like Science Goggles, but works in darkness."
-	id = "nvscigoggles"
-	req_tech = list("magnets" = 5, "plasmatech" = 4, "engineering" = 6)
-	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 250, MAT_GLASS = 300, MAT_PLASMA = 250, MAT_URANIUM = 1000)
-	build_path = /obj/item/clothing/glasses/science/night
-	category = list("Equipment")
-
 /datum/design/diagnostic_hud
 	name = "Diagnostic HUD"
 	desc = "A HUD used to analyze and determine faults within robotic machinery."
@@ -212,16 +172,6 @@
 	build_path = /obj/item/clothing/glasses/hud/diagnostic
 	category = list("Equipment")
 
-/datum/design/diagnostic_hud_night
-	name = "Night Vision Diagnostic HUD"
-	desc = "Upgraded version of the diagnostic HUD designed to function during a power failure."
-	id = "dianostic_hud_night"
-	req_tech = list("magnets" = 5, "plasmatech" = 4, "engineering" = 6, "powerstorage" = 4)
-	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 600, MAT_GLASS = 600, MAT_URANIUM = 1000, MAT_PLASMA = 300)
-	build_path = /obj/item/clothing/glasses/hud/diagnostic/night
-	category = list("Equipment")
-
 /datum/design/hydroponic_hud
 	name = "Hydroponic HUD"
 	desc = "A HUD used to analyze the health and status of plants growing in hydro trays and soil."
@@ -230,16 +180,6 @@
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 500, MAT_GLASS = 500)
 	build_path = /obj/item/clothing/glasses/hud/hydroponic
-	category = list("Equipment")
-
-/datum/design/hydroponic_hud_night
-	name = "Night Vision Hydroponic HUD"
-	desc = "A HUD used to analyze the health and status of plants growing in low-light environments."
-	id = "hydroponic_hud_night"
-	req_tech = list("biotech" = 4, "magnets" = 5, "plasmatech" = 4, "engineering" = 6)
-	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 600, MAT_GLASS = 600, MAT_URANIUM = 1000, MAT_PLASMA = 200)
-	build_path = /obj/item/clothing/glasses/hud/hydroponic/night
 	category = list("Equipment")
 
 /datum/design/handdrill


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR removes several NVG's from the RnD console. The normal NVG and NVG Mesons are still available. Removed NVG's can still be spawned via admin. These include;

- NVG Sec Hud
- NVG Med Hud
- NVG Jani Hud
- NVG Sci Hud
- NVG Diagnostic Hud
- NVG Hydroponics Hud

## Why It's Good For The Game
So big issue with night vision is the powercreep state its in. There are several variants of NVG Huds that have made the item bloated as a blob, and its made the glasses a somewhat no brainer for all players to grab. With an NVG variant in almost all departments, its common to see people grabbing them to replace previous eyewear. Resulting in a majority of the station wearing NVG's because sci hands them out with no issue.

This also leads to another issue, and that is *fog of war*. Essentially, darkness is a common veil of antaggery that most antags utilize to survive and thrive within. Having a variant of every department NVG causes the choice of taking a utility tool, or safe vision in dark places obsolete as you can have both, which means that NVG's become the meta choice for station work, biohazards, and most antags. This devalues the role of darkness as an unknown, and makes flashlights and light sources irrelevant to use.

This change is designed to force people to choose. Take a HUD with a light source, or have Night Vision. Either option is both useful for specific station work, and encourages people to think more about what they prefer. These NVG's don't really need to exist every round, and some are downright meta for biohazard threats. I'm looking at you NVG MedHud.

Editors note: Genetics exist with NVG mutation, but that's a bit more complicated to get and isn't as common as the easily structed RnD shopping list meta.

## Testing
rnd console doesnt show em

## Changelog
:cl: Octus
tweak: Removes several night vision variants from RnD
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
