### PR TITLE
Gives flares the same attack sound and attack verbs as lighters.

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -203,7 +203,7 @@
 	force = initial(force)
 	damtype = initial(damtype)
 	hitsound = initial(hitsound)
-	attack_verb = list(null)
+	attack_verb = list()
 	update_brightness()
 
 /obj/item/flashlight/flare/attack_self(mob/user)

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -202,6 +202,8 @@
 	on = FALSE
 	force = initial(force)
 	damtype = initial(damtype)
+	hitsound = initial(hitsound)
+	attack_verb = list(null)
 	update_brightness()
 
 /obj/item/flashlight/flare/attack_self(mob/user)
@@ -220,6 +222,8 @@
 		if(produce_heat)
 			force = on_damage
 			damtype = "fire"
+			hitsound = 'sound/items/welder.ogg'
+			attack_verb = list("burnt", "singed")
 		START_PROCESSING(SSobj, src)
 
 /obj/item/flashlight/flare/decompile_act(obj/item/matter_decompiler/C, mob/user)

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -202,7 +202,7 @@
 	on = FALSE
 	force = initial(force)
 	damtype = initial(damtype)
-	hitsound = initial(hitsound)
+	hitsound = "swing_hit"
 	attack_verb = list()
 	update_brightness()
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Gives flares the same attack sound and attack verbs as lighters.

## Why It's Good For The Game
Currently flares use the generic hit sound and generic "attacked" verb in it's attack message. Flares only do damage when they're turned on and do burn damage, so it would make sense for them to use the same sound and verbs as lighters.

## Testing
Hit things with flares.

## Changelog
:cl:
tweak: Flares now use the same attack sound and attack verbs as lighters
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
