### PR TITLE
The great SSU securing of 2024.

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -60779,7 +60779,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/port2)
 "dvc" = (
-/obj/machinery/suit_storage_unit/rd/secure,
+/obj/machinery/suit_storage_unit/rd,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitepurplecorner"
@@ -75404,7 +75404,7 @@
 	},
 /area/station/medical/virology)
 "jin" = (
-/obj/machinery/suit_storage_unit/cmo/secure/sec_storage,
+/obj/machinery/suit_storage_unit/cmo/sec_storage,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkblue"
@@ -75416,7 +75416,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/machinery/suit_storage_unit/qm/secure,
+/obj/machinery/suit_storage_unit/qm,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -89421,7 +89421,7 @@
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
 "rYe" = (
-/obj/machinery/suit_storage_unit/cmo/secure/sec_storage,
+/obj/machinery/suit_storage_unit/cmo/sec_storage,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkbluecorners"

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -8178,7 +8178,7 @@
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/machinery/suit_storage_unit/qm/secure,
+/obj/machinery/suit_storage_unit/qm,
 /turf/simulated/floor/plasteel{
 	icon_state = "brown"
 	},
@@ -36157,7 +36157,7 @@
 	},
 /area/station/medical/cryo)
 "ctI" = (
-/obj/machinery/suit_storage_unit/cmo/secure/sec_storage,
+/obj/machinery/suit_storage_unit/cmo/sec_storage,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkblue"

--- a/_maps/map_files/cerestation/cerestation.dmm
+++ b/_maps/map_files/cerestation/cerestation.dmm
@@ -24815,7 +24815,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore2)
 "cDS" = (
-/obj/machinery/suit_storage_unit/qm/secure,
+/obj/machinery/suit_storage_unit/qm,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "brown"
@@ -56779,7 +56779,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
 "lfX" = (
-/obj/machinery/suit_storage_unit/cmo/secure/sec_storage,
+/obj/machinery/suit_storage_unit/cmo/sec_storage,
 /obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -72953,7 +72953,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/suit_storage_unit/cmo/secure/sec_storage,
+/obj/machinery/suit_storage_unit/cmo/sec_storage,
 /obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkbluefull"
@@ -80648,7 +80648,7 @@
 	},
 /area/station/legal/lawoffice)
 "sVv" = (
-/obj/machinery/suit_storage_unit/cmo/secure/sec_storage,
+/obj/machinery/suit_storage_unit/cmo/sec_storage,
 /obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -95108,7 +95108,7 @@
 /turf/simulated/floor/wood,
 /area/station/service/bar)
 "xyF" = (
-/obj/machinery/suit_storage_unit/cmo/secure/sec_storage,
+/obj/machinery/suit_storage_unit/cmo/sec_storage,
 /obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 4;

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -35323,7 +35323,7 @@
 	},
 /area/station/command/office/rd)
 "chP" = (
-/obj/machinery/suit_storage_unit/rd/secure,
+/obj/machinery/suit_storage_unit/rd,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "whitepurple"
@@ -36526,7 +36526,7 @@
 	},
 /area/station/medical/medbay3)
 "cmo" = (
-/obj/machinery/suit_storage_unit/cmo/secure/sec_storage,
+/obj/machinery/suit_storage_unit/cmo/sec_storage,
 /obj/machinery/camera{
 	c_tag = "Medbay Secure Storage";
 	dir = 4
@@ -36874,7 +36874,7 @@
 	},
 /area/station/medical/medbay3)
 "cnJ" = (
-/obj/machinery/suit_storage_unit/cmo/secure/sec_storage,
+/obj/machinery/suit_storage_unit/cmo/sec_storage,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkredfull"
 	},
@@ -90112,7 +90112,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/suit_storage_unit/qm/secure,
+/obj/machinery/suit_storage_unit/qm,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "brown"

--- a/_maps/map_files/generic/centcomm.dmm
+++ b/_maps/map_files/generic/centcomm.dmm
@@ -2550,7 +2550,7 @@
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/transport)
 "iX" = (
-/obj/machinery/suit_storage_unit/syndicate/secure,
+/obj/machinery/suit_storage_unit/syndicate,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/syndicate)
 "iY" = (
@@ -5312,7 +5312,7 @@
 /obj/machinery/light/spot{
 	dir = 8
 	},
-/obj/machinery/suit_storage_unit/syndicate/secure,
+/obj/machinery/suit_storage_unit/syndicate,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/syndicate)
 "rO" = (

--- a/_maps/map_files/shuttles/admin_armory.dmm
+++ b/_maps/map_files/shuttles/admin_armory.dmm
@@ -47,7 +47,7 @@
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/administration)
 "de" = (
-/obj/machinery/suit_storage_unit/security/secure,
+/obj/machinery/suit_storage_unit/security,
 /obj/machinery/light/spot,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/administration)
@@ -171,7 +171,7 @@
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/administration)
 "jU" = (
-/obj/machinery/suit_storage_unit/security/secure,
+/obj/machinery/suit_storage_unit/security,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/administration)
 "kf" = (

--- a/_maps/map_files/shuttles/admin_hospital.dmm
+++ b/_maps/map_files/shuttles/admin_hospital.dmm
@@ -538,12 +538,12 @@
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/administration)
 "cp" = (
-/obj/machinery/suit_storage_unit/cmo/secure/sec_storage,
+/obj/machinery/suit_storage_unit/cmo/sec_storage,
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/administration)
 "cq" = (
 /obj/machinery/light,
-/obj/machinery/suit_storage_unit/cmo/secure/sec_storage,
+/obj/machinery/suit_storage_unit/cmo/sec_storage,
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/administration)
 "cr" = (

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -293,10 +293,13 @@
 		return
 	if(panel_open)
 		if(istype(I, /obj/item/crowbar))
+			if(occupant || helmet || suit || storage || boots)
+				to_chat(user, "<span class='warning'>There are contents that prevent you form deconstructing [src]!</span>")
+				return
 			if(locked)
 				to_chat(user, "<span class='warning'>The security system prevents you from deconstructing [src]!</span>")
 				return
-			dump_contents()
+			dump_contents() // probably still a good idea for just incase?
 			default_deconstruction_crowbar(user, I)
 			return
 		wires.Interact(user)

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -57,36 +57,36 @@
 	board_type = /obj/item/circuitboard/suit_storage_unit/industrial
 
 /obj/machinery/suit_storage_unit/standard_unit
-	suit_type	= /obj/item/clothing/suit/space/eva
+	suit_type = /obj/item/clothing/suit/space/eva
 	helmet_type	= /obj/item/clothing/head/helmet/space/eva
-	mask_type	= /obj/item/clothing/mask/breath
+	mask_type = /obj/item/clothing/mask/breath
 
 /obj/machinery/suit_storage_unit/captain
 	name = "captain's suit storage unit"
 	desc = "An U-Stor-It Storage unit designed to accommodate all kinds of space suits. Its on-board equipment also allows the user to decontaminate the contents through a UV-ray purging cycle. There's a warning label dangling from the control pad, reading \"STRICTLY NO BIOLOGICALS IN THE CONFINES OF THE UNIT\". This one looks kind of fancy."
 	helmet_type	= /obj/item/clothing/head/helmet/space/capspace //Looks like they couldn't handle the Neutron Style
-	mask_type	= /obj/item/clothing/mask/gas
+	mask_type = /obj/item/clothing/mask/gas
 	suit_type = /obj/item/mod/control/pre_equipped/magnate
-	req_access	= list(ACCESS_CAPTAIN)
+	req_access = list(ACCESS_CAPTAIN)
 
 /obj/machinery/suit_storage_unit/engine
 	name = "engineering suit storage unit"
 	icon_state = "industrial"
 	base_icon_state = "industrial"
-	mask_type	= /obj/item/clothing/mask/breath
+	mask_type = /obj/item/clothing/mask/breath
 	boots_type = /obj/item/clothing/shoes/magboots
 	suit_type = /obj/item/mod/control/pre_equipped/engineering
-	req_access	= list(ACCESS_ENGINE_EQUIP)
+	req_access = list(ACCESS_ENGINE_EQUIP)
 	board_type = /obj/item/circuitboard/suit_storage_unit/industrial
 
 /obj/machinery/suit_storage_unit/ce
 	name = "chief engineer's suit storage unit"
 	icon_state = "industrial"
 	base_icon_state = "industrial"
-	mask_type	= /obj/item/clothing/mask/gas
+	mask_type = /obj/item/clothing/mask/gas
 	boots_type = /obj/item/clothing/shoes/magboots/advance
 	suit_type = /obj/item/mod/control/pre_equipped/advanced
-	req_access	= list(ACCESS_CE)
+	req_access = list(ACCESS_CE)
 	board_type = /obj/item/circuitboard/suit_storage_unit/industrial
 
 /obj/machinery/suit_storage_unit/ce/secure
@@ -95,8 +95,8 @@
 /obj/machinery/suit_storage_unit/rd
 	name = "research director's suit storage unit"
 	suit_type = /obj/item/mod/control/pre_equipped/research
-	mask_type	= /obj/item/clothing/mask/gas
-	req_access	= list(ACCESS_RD)
+	mask_type = /obj/item/clothing/mask/gas
+	req_access = list(ACCESS_RD)
 
 /obj/machinery/suit_storage_unit/qm
 	name = "quartermaster's suit storage unit"
@@ -106,9 +106,9 @@
 
 /obj/machinery/suit_storage_unit/security
 	name = "security suit storage unit"
-	mask_type	= /obj/item/clothing/mask/gas/sechailer
+	mask_type = /obj/item/clothing/mask/gas/sechailer
 	suit_type = /obj/item/mod/control/pre_equipped/security
-	req_access	= list(ACCESS_SECURITY)
+	req_access = list(ACCESS_SECURITY)
 
 /obj/machinery/suit_storage_unit/security/hos
 	name = "Head of Security's suit storage unit"
@@ -124,16 +124,16 @@
 
 /obj/machinery/suit_storage_unit/atmos
 	name = "atmospherics suit storage unit"
-	mask_type	= /obj/item/clothing/mask/gas
+	mask_type = /obj/item/clothing/mask/gas
 	boots_type = /obj/item/clothing/shoes/magboots/atmos
 	suit_type = /obj/item/mod/control/pre_equipped/atmospheric
-	req_access	= list(ACCESS_ATMOSPHERICS)
+	req_access = list(ACCESS_ATMOSPHERICS)
 
 /obj/machinery/suit_storage_unit/mining
 	name = "mining suit storage unit"
-	mask_type	= /obj/item/clothing/mask/breath
+	mask_type = /obj/item/clothing/mask/breath
 	suit_type = /obj/item/mod/control/pre_equipped/mining/asteroid
-	req_access	= list(ACCESS_MINING_STATION)
+	req_access = list(ACCESS_MINING_STATION)
 
 /obj/machinery/suit_storage_unit/lavaland
 	name = "mining suit storage unit"
@@ -143,9 +143,9 @@
 	req_access = list(ACCESS_MINING_STATION)
 
 /obj/machinery/suit_storage_unit/cmo
-	mask_type	= /obj/item/clothing/mask/breath
+	mask_type = /obj/item/clothing/mask/breath
 	suit_type = /obj/item/mod/control/pre_equipped/medical
-	req_access	= list(ACCESS_CMO)
+	req_access = list(ACCESS_CMO)
 
 //version of the SSU for medbay secondary storage. Includes magboots. //no it doesn't, it aint have shit for magboots
 /obj/machinery/suit_storage_unit/cmo/sec_storage
@@ -156,32 +156,32 @@
 /obj/machinery/suit_storage_unit/clown
 	name = "clown suit storage unit"
 	suit_type = /obj/item/clothing/suit/space/eva/clown
-	helmet_type  = /obj/item/clothing/head/helmet/space/eva/clown
+	helmet_type = /obj/item/clothing/head/helmet/space/eva/clown
 	req_access = list(ACCESS_CLOWN)
 
 /obj/machinery/suit_storage_unit/mime
 	name = "mime suit storage unit"
 	suit_type = /obj/item/clothing/suit/space/eva/mime
-	helmet_type  = /obj/item/clothing/head/helmet/space/eva/mime
+	helmet_type = /obj/item/clothing/head/helmet/space/eva/mime
 	req_access = list(ACCESS_MIME)
 
 /obj/machinery/suit_storage_unit/syndicate
 	name = "syndicate suit storage unit"
-	mask_type		= /obj/item/clothing/mask/gas/syndicate
-	storage_type	= /obj/item/mod/control/pre_equipped/nuclear
+	mask_type = /obj/item/clothing/mask/gas/syndicate
+	suit_type = /obj/item/mod/control/pre_equipped/nuclear
 	req_access = list(ACCESS_SYNDICATE)
 	safeties = FALSE	//in a syndicate base, everything can be used as a murder weapon at a moment's notice.
 
 //telecoms NASA SSU. Suits themselves are assigned in Initialize
 /obj/machinery/suit_storage_unit/telecoms
-	mask_type	= /obj/item/clothing/mask/breath
+	mask_type = /obj/item/clothing/mask/breath
 	storage_type = /obj/item/tank/jetpack/void
-	req_access	= list(ACCESS_TCOMSAT)
+	req_access = list(ACCESS_TCOMSAT)
 
 /obj/machinery/suit_storage_unit/radsuit
 	name = "radiation suit storage unit"
-	suit_type	= /obj/item/clothing/suit/radiation
-	helmet_type	= /obj/item/clothing/head/radiation
+	suit_type = /obj/item/clothing/suit/radiation
+	helmet_type = /obj/item/clothing/head/radiation
 	storage_type = /obj/item/geiger_counter
 
 //copied from /obj/effect/nasavoidsuitspawner

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -27,7 +27,7 @@
 	var/broken = FALSE
 
 	/// enables ID locking when set to true
-	var/secure = FALSE
+	var/secure = TRUE
 	/// Shocks anyone that touches it
 	var/shocked = FALSE
 	/// Access needed to control it, checked only if ID lock is enabled
@@ -61,9 +61,6 @@
 	helmet_type	= /obj/item/clothing/head/helmet/space/eva
 	mask_type	= /obj/item/clothing/mask/breath
 
-/obj/machinery/suit_storage_unit/standard_unit/secure
-	secure = TRUE	//start with ID lock enabled
-
 /obj/machinery/suit_storage_unit/captain
 	name = "captain's suit storage unit"
 	desc = "An U-Stor-It Storage unit designed to accommodate all kinds of space suits. Its on-board equipment also allows the user to decontaminate the contents through a UV-ray purging cycle. There's a warning label dangling from the control pad, reading \"STRICTLY NO BIOLOGICALS IN THE CONFINES OF THE UNIT\". This one looks kind of fancy."
@@ -71,9 +68,6 @@
 	mask_type	= /obj/item/clothing/mask/gas
 	suit_type = /obj/item/mod/control/pre_equipped/magnate
 	req_access	= list(ACCESS_CAPTAIN)
-
-/obj/machinery/suit_storage_unit/captain/secure
-	secure = TRUE
 
 /obj/machinery/suit_storage_unit/engine
 	name = "engineering suit storage unit"
@@ -84,9 +78,6 @@
 	suit_type = /obj/item/mod/control/pre_equipped/engineering
 	req_access	= list(ACCESS_ENGINE_EQUIP)
 	board_type = /obj/item/circuitboard/suit_storage_unit/industrial
-
-/obj/machinery/suit_storage_unit/engine/secure
-	secure = TRUE
 
 /obj/machinery/suit_storage_unit/ce
 	name = "chief engineer's suit storage unit"
@@ -107,17 +98,11 @@
 	mask_type	= /obj/item/clothing/mask/gas
 	req_access	= list(ACCESS_RD)
 
-/obj/machinery/suit_storage_unit/rd/secure
-	secure = TRUE
-
 /obj/machinery/suit_storage_unit/qm
 	name = "quartermaster's suit storage unit"
 	suit_type = /obj/item/mod/control/pre_equipped/loader
 	mask_type = /obj/item/clothing/mask/breath
 	req_access = list(ACCESS_QM)
-
-/obj/machinery/suit_storage_unit/qm/secure
-	secure = TRUE
 
 /obj/machinery/suit_storage_unit/security
 	name = "security suit storage unit"
@@ -125,26 +110,17 @@
 	suit_type = /obj/item/mod/control/pre_equipped/security
 	req_access	= list(ACCESS_SECURITY)
 
-/obj/machinery/suit_storage_unit/security/secure
-	secure = TRUE
-
 /obj/machinery/suit_storage_unit/security/hos
 	name = "Head of Security's suit storage unit"
 	mask_type = /obj/item/clothing/mask/gas/sechailer/hos
 	suit_type = /obj/item/mod/control/pre_equipped/safeguard
 	req_access = list(ACCESS_HOS)
 
-/obj/machinery/suit_storage_unit/security/hos/secure
-	secure = TRUE
-
 /obj/machinery/suit_storage_unit/gamma
 	name = "gamma shielded suit storage unit"
 	suit_type = /obj/item/clothing/suit/space/hardsuit/shielded/gamma
 	mask_type = /obj/item/clothing/mask/gas/sechailer/swat
 	req_access = list(ACCESS_SECURITY)
-
-/obj/machinery/suit_storage_unit/gamma/secure
-	secure = TRUE
 
 /obj/machinery/suit_storage_unit/atmos
 	name = "atmospherics suit storage unit"
@@ -153,17 +129,11 @@
 	suit_type = /obj/item/mod/control/pre_equipped/atmospheric
 	req_access	= list(ACCESS_ATMOSPHERICS)
 
-/obj/machinery/suit_storage_unit/atmos/secure
-	secure = TRUE
-
 /obj/machinery/suit_storage_unit/mining
 	name = "mining suit storage unit"
 	mask_type	= /obj/item/clothing/mask/breath
 	suit_type = /obj/item/mod/control/pre_equipped/mining/asteroid
 	req_access	= list(ACCESS_MINING_STATION)
-
-/obj/machinery/suit_storage_unit/mining/secure
-	secure = TRUE
 
 /obj/machinery/suit_storage_unit/lavaland
 	name = "mining suit storage unit"
@@ -177,13 +147,11 @@
 	suit_type = /obj/item/mod/control/pre_equipped/medical
 	req_access	= list(ACCESS_CMO)
 
-/obj/machinery/suit_storage_unit/cmo/secure
-	secure = TRUE
-
 //version of the SSU for medbay secondary storage. Includes magboots. //no it doesn't, it aint have shit for magboots
-/obj/machinery/suit_storage_unit/cmo/secure/sec_storage
+/obj/machinery/suit_storage_unit/cmo/sec_storage
 	name = "medical suit storage unit"
 	mask_type = /obj/item/clothing/mask/gas
+	req_access = list(ACCESS_MEDICAL)
 
 /obj/machinery/suit_storage_unit/clown
 	name = "clown suit storage unit"
@@ -191,17 +159,11 @@
 	helmet_type  = /obj/item/clothing/head/helmet/space/eva/clown
 	req_access = list(ACCESS_CLOWN)
 
-/obj/machinery/suit_storage_unit/clown/secure
-	secure = TRUE
-
 /obj/machinery/suit_storage_unit/mime
 	name = "mime suit storage unit"
 	suit_type = /obj/item/clothing/suit/space/eva/mime
 	helmet_type  = /obj/item/clothing/head/helmet/space/eva/mime
 	req_access = list(ACCESS_MIME)
-
-/obj/machinery/suit_storage_unit/mime/secure
-	secure = TRUE
 
 /obj/machinery/suit_storage_unit/syndicate
 	name = "syndicate suit storage unit"
@@ -210,17 +172,11 @@
 	req_access = list(ACCESS_SYNDICATE)
 	safeties = FALSE	//in a syndicate base, everything can be used as a murder weapon at a moment's notice.
 
-/obj/machinery/suit_storage_unit/syndicate/secure
-	secure = TRUE
-
 //telecoms NASA SSU. Suits themselves are assigned in Initialize
 /obj/machinery/suit_storage_unit/telecoms
 	mask_type	= /obj/item/clothing/mask/breath
 	storage_type = /obj/item/tank/jetpack/void
 	req_access	= list(ACCESS_TCOMSAT)
-
-/obj/machinery/suit_storage_unit/telecoms/secure
-	secure = TRUE
 
 /obj/machinery/suit_storage_unit/radsuit
 	name = "radiation suit storage unit"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Long story short, removes the `/secure` subtype. as it was used exactly five times, and the secure var is.. well a var, so if wanted/needed, admins/mappers can edit the var to not need a id.
You can no longer deconstruct SSU's if they have stuff inside them.
As well as fixes the syndicate modsuits being in the storage slot on the nukie ship
And cleans up some of the code, for whatever reason some of the spaces were indents.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Some of the notable secured SSU's were 
The RD's one, only on box and delta though.
The QM's one on all of the maps
The security one on a admin shuttle.
The secondary storage medical suits, ironically not the CMOs, on all the maps.
And the syndicate ones on the nukie shuttle.

Notice the complete lack of ID requirements on the two SSU's that house high value items? weird right? 
Being able to slip into someones office, and open whats meant to be a secure suit storage unit with no struggle at all is very dumb, the fact there WERE some maps that did use secure versions but others that didn't, was extra dumb.
So now you need proper ID access for SSU's. 
You ARE able to hack the SSU to remove the ID requirement, so you still have the ability to open them without the correct ID, however it requires you to actually hack it, rather than click two buttons. 

The mods being in the wrong spot was a bug.
The code stuff just looked cursed as hell.
And the deconstruction part was to prevent cheese, just hack the darned thing, come on!
## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
Map edits aren't visual.
## Testing
<!-- How did you test the PR, if at all? -->
Tested all the SSU's i could think of with the correct access and without on cyberiad, and the admin shuttles.
The other three maps had identical changes, so they should be the same. :clueless: 
## Changelog
:cl:
del: Removed the /secure SSU subtype from the code
tweak: All SSU's require the correct id access to open/(un)lock
tweak: You can no longer deconstruct SSU's with items inside them.
fix: Fixed the syndicate modsuits being in the wrong slot on the nukie ship.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
