### PR TITLE
Fixes IPC ghetto surgery tools not being able to actually initiate the surgery

### DIFF
--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -121,6 +121,10 @@
 	righthand_file = 'icons/mob/inhands/weapons_righthand.dmi'
 	var/bayonet = FALSE	//Can this be attached to a gun?
 
+/obj/item/kitchen/knife/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/surgery_initiator/robo)
+
 /obj/item/kitchen/knife/suicide_act(mob/user)
 	user.visible_message(pick("<span class='suicide'>[user] is slitting [user.p_their()] wrists with [src]! It looks like [user.p_theyre()] trying to commit suicide.</span>", \
 						"<span class='suicide'>[user] is slitting [user.p_their()] throat with [src]! It looks like [user.p_theyre()] trying to commit suicide.</span>", \

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -354,6 +354,10 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 	if(cmineral && name_by_cmineral)
 		name = "[cmineral] coin"
 
+/obj/item/coin/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/surgery_initiator/robo)
+
 /obj/item/coin/gold
 	cmineral = "gold"
 	icon_state = "coin_gold_heads"


### PR DESCRIPTION
## What Does This PR Do
Fixes ghetto surgery tools for the first step of IPC surgeries not being able to actually initiate the surgery

## Why It's Good For The Game
On other species you can initiate surgeries with ghetto tools used in the first step of those surgeries, so consistency in that is good and plus IC wise it doesnt make sense to be able to physically make the first step of a surgery but not being able to think about starting the surgery, initiating a surgery being hovering a scalpel over the limb and such

## Testing
Initiated a surgery on a IPC with a knife and a coin and then completed the surgery to make sure everything worked (the knife and coin being ghetto surgery tools for the first step of IPC surgeries)

## Changelog
:cl:
fix: Fixed not being able to start IPC surgeries with ghetto surgery tools
/:cl:
