### PR TITLE
[TM prolly] Some init optimisationss

### DIFF
--- a/code/controllers/subsystem/SSair.dm
+++ b/code/controllers/subsystem/SSair.dm
@@ -361,6 +361,7 @@ SUBSYSTEM_DEF(air)
 	for(var/obj/machinery/atmospherics/A in machines_to_init)
 		A.atmos_init()
 		count++
+		CHECK_TICK
 	return count
 
 //this can't be done with setup_atmos_machinery() because

--- a/code/controllers/subsystem/non_firing/SSmapping.dm
+++ b/code/controllers/subsystem/non_firing/SSmapping.dm
@@ -129,6 +129,8 @@ SUBSYSTEM_DEF(mapping)
 	var/num_extra_space = rand(GLOB.configuration.ruins.extra_levels_min, GLOB.configuration.ruins.extra_levels_max)
 	for(var/i in 1 to num_extra_space)
 		GLOB.space_manager.add_new_zlevel("Ruin Area #[i]", linkage = CROSSLINKED, traits = list(REACHABLE_BY_CREW, SPAWN_RUINS, REACHABLE_SPACE_ONLY))
+		CHECK_TICK
+
 	log_startup_progress("Loaded random space levels in [stop_watch(load_zlevels_timer)]s.")
 
 	// Now spawn ruins, random budget between 20 and 30 for all zlevels combined.

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -166,9 +166,17 @@ GLOBAL_VAR_INIT(record_id_num, 1001)
 		G.fields["m_stat"]		= "Stable"
 		G.fields["sex"]			= capitalize(H.gender)
 		G.fields["species"]		= H.dna.species.name
-		G.fields["photo"]		= get_id_photo(H)
-		G.fields["photo-south"] = "data:image/png;base64,[icon2base64(icon(G.fields["photo"], dir = SOUTH))]"
-		G.fields["photo-west"] = "data:image/png;base64,[icon2base64(icon(G.fields["photo"], dir = WEST))]"
+		// Do some ID card checking stuff here to save on resources
+		var/card_photo
+		if(istype(H.wear_id, /obj/item/card/id))
+			var/obj/item/card/id/IDC = H.wear_id
+			card_photo = IDC.photo
+		else
+			card_photo = get_id_photo(H)
+
+		G.fields["photo"] = card_photo
+		G.fields["photo-south"] = "data:image/png;base64,[icon2base64(icon(card_photo, dir = SOUTH))]"
+		G.fields["photo-west"] = "data:image/png;base64,[icon2base64(icon(card_photo, dir = WEST))]"
 		if(H.gen_record && !jobban_isbanned(H, ROLEBAN_RECORDS))
 			G.fields["notes"] = H.gen_record
 		else

--- a/code/game/dna/dna2.dm
+++ b/code/game/dna/dna2.dm
@@ -370,17 +370,21 @@ GLOBAL_LIST_EMPTY(bad_blocks)
 	return num2hex(value, 3)
 
 /datum/dna/proc/UpdateUI()
+	var/list/ui_text_list = list()
 	uni_identity = ""
 	for(var/block in UI)
-		uni_identity += EncodeDNABlock(block)
+		ui_text_list += EncodeDNABlock(block)
+	uni_identity = ui_text_list.Join("")
 	//testing("New UI: [uni_identity]")
 	dirtyUI = 0
 
 /datum/dna/proc/UpdateSE()
 	//var/oldse=struc_enzymes
+	var/list/se_text_list = list()
 	struc_enzymes = ""
 	for(var/block in SE)
-		struc_enzymes += EncodeDNABlock(block)
+		se_text_list += EncodeDNABlock(block)
+	struc_enzymes = se_text_list.Join("")
 	//testing("Old SE: [oldse]")
 	//testing("New SE: [struc_enzymes]")
 	dirtySE = 0

--- a/code/game/jobs/job_exp.dm
+++ b/code/game/jobs/job_exp.dm
@@ -51,7 +51,8 @@ GLOBAL_LIST_INIT(role_playtime_requirements, list(
 	set name = "Check Player Playtime"
 	if(!check_rights(R_ADMIN|R_MOD|R_MENTOR))
 		return
-	var/msg = "<html><head><title>Playtime Report</title></head><body>"
+	var/list/msg = list()
+	msg  += "<html><head><title>Playtime Report</title></head><body>"
 	var/datum/job/theirjob
 	var/jtext
 	msg += "<TABLE border ='1'><TR><TH>Player</TH><TH>Job</TH><TH>Crew</TH>"
@@ -80,7 +81,7 @@ GLOBAL_LIST_INIT(role_playtime_requirements, list(
 		msg += "</TR>"
 
 	msg += "</TABLE></BODY></HTML>"
-	src << browse(msg, "window=Player_playtime_check")
+	src << browse(msg.Join(""), "window=Player_playtime_check")
 
 
 /datum/admins/proc/cmd_mentor_show_exp_panel(client/C)

--- a/code/game/objects/items/devices/painter/floor_painter.dm
+++ b/code/game/objects/items/devices/painter/floor_painter.dm
@@ -21,6 +21,23 @@
 		"darkred", "darkredcorners", "darkredfull", "darkblue", "darkbluecorners", "darkbluefull", "darkgreen", "darkgreencorners",
 		"darkgreenfull", "darkyellow", "darkyellowcorners", "darkyellowfull", "darkbrown", "darkbrowncorners", "darkbrownfull")
 
+	// This is a double-list. First entry is the type key, second is the direction, with the final value being the b64 of the icon
+	var/static/list/lookup_cache = list()
+
+/datum/painter/floor/New(obj/item/painter/parent_painter)
+	. = ..()
+	if(!length(lookup_cache))
+		for(var/style in allowed_states)
+			if(!(style in lookup_cache))
+				lookup_cache += style
+				lookup_cache[style] = list()
+
+			for(var/dir in GLOB.alldirs)
+				var/icon/floor_icon = icon('icons/turf/floors.dmi', style, dir)
+				// These indexes have to be strings otherwise it treats it as a list index not a map lookup index
+				lookup_cache[style] += "[dir]"
+				lookup_cache[style]["[dir]"] = icon2base64(floor_icon)
+
 /datum/painter/floor/paint_atom(atom/target, mob/user)
 	if(!istype(target, /turf/simulated/floor/plasteel))
 		to_chat(user, "<span class='warning'>[holder] can only be used on station flooring.</span>")
@@ -59,8 +76,7 @@
 
 	data["directionsPreview"] = list()
 	for(var/dir in GLOB.alldirs)
-		var/icon/floor_icon = icon('icons/turf/floors.dmi', floor_state, dir)
-		data["directionsPreview"][dir2text(dir)] = icon2base64(floor_icon)
+		data["directionsPreview"][dir2text(dir)] = lookup_cache[floor_state]["[dir]"]
 
 	return data
 
@@ -69,8 +85,7 @@
 	var/list/data = list()
 	data["allStylesPreview"] = list()
 	for(var/style in allowed_states)
-		var/icon/floor_icon = icon('icons/turf/floors.dmi', style, SOUTH)
-		data["allStylesPreview"][style] = icon2base64(floor_icon)
+		data["allStylesPreview"][style] = lookup_cache[style]["[SOUTH]"]
 
 	return data
 
@@ -97,4 +112,4 @@
 		if(dir != 0)
 			floor_dir = dir
 
-	SStgui.update_uis(src)
+	return TRUE

--- a/code/modules/client/preference/character.dm
+++ b/code/modules/client/preference/character.dm
@@ -1784,7 +1784,7 @@
 
 /datum/character_save/proc/copy_to(mob/living/carbon/human/character)
 	var/datum/species/S = GLOB.all_species[species]
-	character.set_species(S.type) // Yell at me if this causes everything to melt
+	character.set_species(S.type, delay_icon_update = TRUE) // Yell at me if this causes everything to melt
 	if(be_random_name)
 		real_name = random_name(gender, species)
 
@@ -1885,7 +1885,7 @@
 			message_admins("[key_name_admin(character)] has spawned with their gender as plural or neuter. Please notify coders.")
 			character.change_gender(MALE)
 
-	character.change_eye_color(e_colour)
+	character.change_eye_color(e_colour, skip_icons = TRUE)
 	character.original_eye_color = e_colour
 
 	if(disabilities & DISABILITY_FLAG_FAT)
@@ -1945,12 +1945,11 @@
 
 	character.dna.ready_dna(character, flatten_SE = FALSE)
 	character.sync_organ_dna(assimilate = TRUE)
-	character.UpdateAppearance()
 
 	// Do the initial caching of the player's body icons.
 	character.force_update_limbs()
 	character.update_eyes()
-	character.regenerate_icons()
+	character.UpdateAppearance()
 
 //Check if the user has ANY job selected.
 /datum/character_save/proc/check_any_job()

--- a/code/modules/mob/living/carbon/human/appearance.dm
+++ b/code/modules/mob/living/carbon/human/appearance.dm
@@ -214,7 +214,7 @@
 		H.ha_style = "None"
 	update_head_accessory()
 
-/mob/living/carbon/human/proc/change_eye_color(colour = "#000000", update_dna = TRUE)
+/mob/living/carbon/human/proc/change_eye_color(colour = "#000000", update_dna = TRUE, skip_icons = FALSE)
 	// Update the main DNA datum, then sync the change across the organs
 	var/obj/item/organ/internal/eyes/eyes_organ = get_int_organ(/obj/item/organ/internal/eyes)
 	if(eyes_organ)
@@ -227,9 +227,11 @@
 
 	if(update_dna)
 		update_dna()
+
 	sync_organ_dna(assimilate = FALSE)
-	update_eyes()
-	update_body()
+	if(!skip_icons)
+		update_eyes()
+		update_body()
 	return TRUE
 
 /mob/living/carbon/human/proc/get_eye_color()

--- a/code/modules/mob/living/carbon/human/human_mob.dm
+++ b/code/modules/mob/living/carbon/human/human_mob.dm
@@ -1454,10 +1454,9 @@
 
 	if(!delay_icon_update)
 		UpdateAppearance()
-
-	overlays.Cut()
-	update_mutantrace()
-	regenerate_icons()
+		overlays.Cut()
+		update_mutantrace()
+		regenerate_icons()
 
 	if(dna.species)
 		return TRUE


### PR DESCRIPTION
## What Does This PR Do
Optimises some init things, specifically:
- Makes SSair sleep between initialising atmos machines (splits 300ms over multiple ticks)
- Makes ruin spawning check tick (each zlevel takes 330ms to add, and cant be slept, but for multiple Zs we can sleep between)
- Optimises creating DNA strings (moves it to a list that joins instead of += on a string 52 times for SE, and 48 for UI)
- Makes mobs not update icons constantly on ticker init (saves a ton of icon blend calls)
- Makes datacore use the existing ID photo if possible instead of regenerating each time (saves 50ms **per player**)

Also optimises some runtime things:
- EXP verb
- The floor painter UI

## Why It's Good For The Game
Performance good

## Testing
Spawned in - my character was still correct

## Changelog
:cl: AffectedArc07
add: Added performance
/:cl:
