### PR TITLE
Terminating/Demoting IDs now clear jobs slots

### DIFF
--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -564,7 +564,8 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 			SSjobs.log_job_transfer(modify.registered_name, jobnamedata, "Terminated", scan.registered_name, reason)
 			modify.lastlog = "[station_time_timestamp()]: TERMINATED by \"[scan.registered_name]\" ([scan.assignment]) from \"[jobnamedata]\" for: \"[reason]\"."
 			SSjobs.notify_dept_head(modify.rank, "[scan.registered_name] ([scan.assignment]) has terminated the employment of \"[modify.registered_name]\" the \"[jobnamedata]\" for \"[reason]\".")
-			if(modify.assignment != "Demoted" && !(SSjobs.GetJob(modify.rank).title in GLOB.command_positions))
+			var/datum/job/job = SSjobs.GetJob(modify.rank)
+			if(modify.assignment != "Demoted" && !(job.title in GLOB.command_positions))
 				SSjobs.GetJob(modify.rank).current_positions--
 			modify.assignment = "Terminated"
 			modify.access = list()

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -565,9 +565,8 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 			modify.lastlog = "[station_time_timestamp()]: TERMINATED by \"[scan.registered_name]\" ([scan.assignment]) from \"[jobnamedata]\" for: \"[reason]\"."
 			SSjobs.notify_dept_head(modify.rank, "[scan.registered_name] ([scan.assignment]) has terminated the employment of \"[modify.registered_name]\" the \"[jobnamedata]\" for \"[reason]\".")
 			var/datum/job/job = SSjobs.GetJob(modify.rank)
-			if(job)
-				if(modify.assignment != "Demoted" && !(job.title in GLOB.command_positions))
-					SSjobs.GetJob(modify.rank).current_positions--
+			if(modify.assignment != "Demoted" && !(job.title in GLOB.command_positions))
+				job.current_positions-
 			modify.assignment = "Terminated"
 			modify.access = list()
 			regenerate_id_name()

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -564,9 +564,8 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 			SSjobs.log_job_transfer(modify.registered_name, jobnamedata, "Terminated", scan.registered_name, reason)
 			modify.lastlog = "[station_time_timestamp()]: TERMINATED by \"[scan.registered_name]\" ([scan.assignment]) from \"[jobnamedata]\" for: \"[reason]\"."
 			SSjobs.notify_dept_head(modify.rank, "[scan.registered_name] ([scan.assignment]) has terminated the employment of \"[modify.registered_name]\" the \"[jobnamedata]\" for \"[reason]\".")
-			var/datum/job/j = SSjobs.GetJob(modify.rank)
-			if(j && modify.assignment != "Demoted")
-				j.current_positions--
+			if(modify.assignment != "Demoted" && !(SSjobs.GetJob(modify.rank).title in GLOB.command_positions))
+				SSjobs.GetJob(modify.rank).current_positions--
 			modify.assignment = "Terminated"
 			modify.access = list()
 			regenerate_id_name()

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -566,7 +566,7 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 			SSjobs.notify_dept_head(modify.rank, "[scan.registered_name] ([scan.assignment]) has terminated the employment of \"[modify.registered_name]\" the \"[jobnamedata]\" for \"[reason]\".")
 			var/datum/job/job = SSjobs.GetJob(modify.rank)
 			if(modify.assignment != "Demoted" && !(job.title in GLOB.command_positions))
-				job.current_positions-
+				job.current_positions--
 			modify.assignment = "Terminated"
 			modify.access = list()
 			regenerate_id_name()

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -565,8 +565,9 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 			modify.lastlog = "[station_time_timestamp()]: TERMINATED by \"[scan.registered_name]\" ([scan.assignment]) from \"[jobnamedata]\" for: \"[reason]\"."
 			SSjobs.notify_dept_head(modify.rank, "[scan.registered_name] ([scan.assignment]) has terminated the employment of \"[modify.registered_name]\" the \"[jobnamedata]\" for \"[reason]\".")
 			var/datum/job/job = SSjobs.GetJob(modify.rank)
-			if(modify.assignment != "Demoted" && !(job.title in GLOB.command_positions))
-				SSjobs.GetJob(modify.rank).current_positions--
+			if(job)
+				if(modify.assignment != "Demoted" && !(job.title in GLOB.command_positions))
+					SSjobs.GetJob(modify.rank).current_positions--
 			modify.assignment = "Terminated"
 			modify.access = list()
 			regenerate_id_name()

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -541,8 +541,8 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 			SSjobs.log_job_transfer(modify.registered_name, jobnamedata, "Demoted", scan.registered_name, reason)
 			modify.lastlog = "[station_time_timestamp()]: DEMOTED by \"[scan.registered_name]\" ([scan.assignment]) from \"[jobnamedata]\" for: \"[reason]\"."
 			SSjobs.notify_dept_head(modify.rank, "[scan.registered_name] ([scan.assignment]) has demoted \"[modify.registered_name]\" ([jobnamedata]) for \"[reason]\".")
+			SSjobs.slot_job_transfer(modify.rank, "Assistant")
 			modify.access = access
-			modify.rank = "Assistant"
 			modify.assignment = "Demoted"
 			modify.icon_state = "id"
 			regenerate_id_name()
@@ -564,6 +564,9 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 			SSjobs.log_job_transfer(modify.registered_name, jobnamedata, "Terminated", scan.registered_name, reason)
 			modify.lastlog = "[station_time_timestamp()]: TERMINATED by \"[scan.registered_name]\" ([scan.assignment]) from \"[jobnamedata]\" for: \"[reason]\"."
 			SSjobs.notify_dept_head(modify.rank, "[scan.registered_name] ([scan.assignment]) has terminated the employment of \"[modify.registered_name]\" the \"[jobnamedata]\" for \"[reason]\".")
+			var/datum/job/j = SSjobs.GetJob(modify.rank)
+			if(j && modify.assignment != "Demoted")
+				j.current_positions--
 			modify.assignment = "Terminated"
 			modify.access = list()
 			regenerate_id_name()


### PR DESCRIPTION
## What Does This PR Do
Demotion/Termination - with the exception of a command role - will clear their job slot.
Hence Fixes #22731.

## Why It's Good For The Game
Bug fix gud

## Testing
Tested both demotion and termination on detective and command members. Worked as excepted.
Even upon entering cryo no new job slot was created.

## Changelog
:cl:
tweak: Demotion/Termination - with the exception of a command role - will clear their job slot.
/:cl: