### PR TITLE
Wizard crash shuttle walls are now not weldable, crate no longer destroys the loot.

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/wizardcrash.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/wizardcrash.dmm
@@ -18,7 +18,7 @@
 	},
 /area/ruin/space/unpowered)
 "ae" = (
-/turf/simulated/wall/mineral/titanium,
+/turf/simulated/wall/mineral/titanium/nodecon,
 /area/ruin/space/unpowered)
 "af" = (
 /obj/structure/computerframe,
@@ -429,7 +429,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/window/reinforced,
+/obj/structure/window/plasmareinforced,
 /turf/simulated/floor/mineral/plasma,
 /area/ruin/space/unpowered)
 "bC" = (
@@ -468,14 +468,14 @@
 /turf/simulated/floor/plating/airless,
 /area/ruin/space/unpowered)
 "bH" = (
-/turf/simulated/wall/mineral/titanium,
+/turf/simulated/wall/mineral/titanium/nodecon,
 /area/space/nearstation)
 "bI" = (
-/obj/structure/window/reinforced,
+/obj/structure/window/plasmareinforced,
 /turf/simulated/floor/mineral/plasma,
 /area/ruin/space/unpowered)
 "bJ" = (
-/obj/structure/window/reinforced{
+/obj/structure/window/plasmareinforced{
 	dir = 4
 	},
 /turf/simulated/floor/mineral/plasma,
@@ -485,15 +485,14 @@
 /turf/space,
 /area/ruin/space/unpowered)
 "bL" = (
-/obj/structure/window/reinforced{
+/obj/structure/window/plasmareinforced{
 	dir = 8
 	},
 /turf/simulated/floor/mineral/plasma,
 /area/ruin/space/unpowered)
 "bM" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
+/obj/structure/window/plasmareinforced{
+	dir = 1
 	},
 /turf/simulated/floor/mineral/plasma,
 /area/ruin/space/unpowered)


### PR DESCRIPTION


<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Walls of the shuttle are insulated against non magical fire, so crew can not welder a wall to pick up the loot avoiding the two monsters inside.

The windows inside the shuttle are now plasma reinforced however, so the crate doesn't instantly break the windows surrounding the singularities, destroying the loot before you pick it up if you don't cheese it.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Slightly more effort for your magic item.
Loot getting destroyed because you didn't cheese it is bad.

## Testing
<!-- How did you test the PR, if at all? -->

went to ruin, tried to weld it, had crate agro me and not instantly smash the windows

## Changelog
:cl:
tweak: Crashed wizard shuttle is no longer weldable.
tweak: Crashed wizard shuttle now has plasma reinforced windows surrounding the singularity.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
