### PR TITLE
Add Incision Management System upgrade for medical cyborgs

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -262,6 +262,16 @@
 	for(var/obj/item/reagent_containers/borghypo/F in R.module.modules)
 		F.emag_act()
 
+/obj/item/borg/upgrade/incision_management
+    name = "medical cyborg IMS upgrade"
+    desc = "An Incision Managment System replacment for the medical cyborg's standard scapel."
+    icon_state = "cyborg_upgrade3"
+    require_module = TRUE
+    module_type = /obj/item/robot_module/medical
+    items_to_replace = list(
+        /obj/item/scalpel = /obj/item/scalpel/laser/manager
+    )
+
 /obj/item/borg/upgrade/syndicate
 	name = "safety override module"
 	desc = "Unlocks the hidden, deadlier functions of a cyborg."
@@ -428,7 +438,7 @@
 	items_to_replace = list(
 		/obj/item/soap/nanotrasen = /obj/item/soap/syndie
 	)
-	
+
 /obj/item/borg/upgrade/bluespace_trash_bag
 	name = "janitor cyborg trash bag of holding upgrade"
 	desc = "An advanced trash bag upgrade board with bluespace properties that can be attached to janitorial cyborgs."

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -264,7 +264,7 @@
 
 /obj/item/borg/upgrade/incision_management
 	name = "medical cyborg IMS upgrade"
-	desc = "An Incision Managment System replacment for the medical cyborg's standard scapel."
+	desc = "An Incision Management System replacment for the medical cyborg's standard scapel."
 	icon_state = "cyborg_upgrade3"
 	require_module = TRUE
 	module_type = /obj/item/robot_module/medical

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -263,14 +263,14 @@
 		F.emag_act()
 
 /obj/item/borg/upgrade/incision_management
-    name = "medical cyborg IMS upgrade"
-    desc = "An Incision Managment System replacment for the medical cyborg's standard scapel."
-    icon_state = "cyborg_upgrade3"
-    require_module = TRUE
-    module_type = /obj/item/robot_module/medical
-    items_to_replace = list(
-        /obj/item/scalpel = /obj/item/scalpel/laser/manager
-    )
+	name = "medical cyborg IMS upgrade"
+	desc = "An Incision Managment System replacment for the medical cyborg's standard scapel."
+	icon_state = "cyborg_upgrade3"
+	require_module = TRUE
+	module_type = /obj/item/robot_module/medical
+	items_to_replace = list(
+		/obj/item/scalpel = /obj/item/scalpel/laser/manager
+	)
 
 /obj/item/borg/upgrade/syndicate
 	name = "safety override module"

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -1081,14 +1081,14 @@
 	category = list("Cyborg Upgrade Modules")
 
 /datum/design/borg_upgrade_incision_management
-    name = "Cyborg Upgrade (Incision Management System)"
-    id = "borg_upgrade_incision_management"
-    build_type = MECHFAB
-    build_path = /obj/item/borg/upgrade/incision_management
-    req_tech = list("engineering" = 6, "biotech" = 6)
-    materials = list(MAT_METAL = 10000, MAT_GLASS = 15000, MAT_SILVER = 5000, MAT_GOLD = 5000)
-    construction_time = 120
-    category = list("Cyborg Upgrade Modules")
+	name = "Cyborg Upgrade (Incision Management System)"
+	id = "borg_upgrade_incision_management"
+	build_type = MECHFAB
+	build_path = /obj/item/borg/upgrade/incision_management
+	req_tech = list("engineering" = 6, "biotech" = 6)
+	materials = list(MAT_METAL = 10000, MAT_GLASS = 15000, MAT_SILVER = 5000, MAT_GOLD = 5000)
+	construction_time = 120
+	category = list("Cyborg Upgrade Modules")
 
 /datum/design/borg_upgrade_lavaproof
 	name = "Cyborg Upgrade (Lavaproof Chassis)"

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -1080,6 +1080,16 @@
 	construction_time = 120
 	category = list("Cyborg Upgrade Modules")
 
+/datum/design/borg_upgrade_incision_management
+    name = "Cyborg Upgrade (Incision Management System)"
+    id = "borg_upgrade_incision_management"
+    build_type = MECHFAB
+    build_path = /obj/item/borg/upgrade/incision_management
+    req_tech = list("engineering" = 6, "biotech" = 6)
+    materials = list(MAT_METAL = 10000, MAT_GLASS = 15000, MAT_SILVER = 5000, MAT_GOLD = 5000)
+    construction_time = 120
+    category = list("Cyborg Upgrade Modules")
+
 /datum/design/borg_upgrade_lavaproof
 	name = "Cyborg Upgrade (Lavaproof Chassis)"
 	id = "borg_upgrade_lavaproof"
@@ -1138,7 +1148,7 @@
 	materials = list(MAT_GOLD = 1250, MAT_PLASMA = 2500, MAT_SILVER = 1250)
 	construction_time = 120
 	category = list("Cyborg Upgrade Modules")
-	
+
 /datum/design/borg_upgrade_rcd
 	name = "Cyborg Upgrade (Rapid Construction Device)"
 	id = "borg_upgrade_RCD"


### PR DESCRIPTION
## What Does This PR Do
Add Incision Management System upgrade for medical cyborgs, it'll replace the standard cyborg scapel.

## Why It's Good For The Game
As a doc i always get the IMS whenever available at RnD, as it make the surgeries way smoother.
The few times i play as a medical borg i end-up frustrated for one thing: not being able to have the upgrade even with high levels researched. 
It's still on the logic of adding a few more options to borgs, while not changing the balance of the game whatsover.

## Images of changes
![image](https://github.com/ParadiseSS13/Paradise/assets/44984704/25381ad1-d8d1-43bd-b111-baa0a1e4431e)


## Testing
Spawned as a medical cyborg and as roboticist, put the upgrade on it. Everything worked.

## Changelog
:cl:
add: Add Incision Management System upgrade for medical cyborgs
/:cl:
