### PR TITLE
Reboots the CNS implant

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -525,7 +525,12 @@
 #define COMSIG_CARBON_UPDATE_HANDCUFFED "carbon_update_handcuff"
 /// From /mob/living/carbon/regenerate_icons()
 #define COMSIG_CARBON_REGENERATE_ICONS "carbon_regen_icons"
-
+/// From /mob/living/carbon/enter_stamcrit()
+#define COMSIG_CARBON_ENTER_STAMINACRIT "carbon_enter_staminacrit"
+/// From /mob/living/carbon/update_stamina()
+#define COMSIG_CARBON_EXIT_STAMINACRIT "carbon_exit_staminacrit"
+/// From /mob/living/carbon/handle_status_effects()
+#define COMSIG_CARBON_STAMINA_REGENERATED "carbon_stamina_regenerated"
 
 // /mob/living/simple_animal/hostile signals
 #define COMSIG_HOSTILE_ATTACKINGTARGET "hostile_attackingtarget"

--- a/code/modules/mob/living/carbon/carbon_life.dm
+++ b/code/modules/mob/living/carbon/carbon_life.dm
@@ -251,6 +251,7 @@
 			update_stamina()
 		if(staminaloss)
 			setStaminaLoss(0, FALSE)
+			SEND_SIGNAL(src, COMSIG_CARBON_STAMINA_REGENERATED)
 			update_health_hud()
 
 	// Keep SSD people asleep

--- a/code/modules/mob/living/carbon/carbon_status_procs.dm
+++ b/code/modules/mob/living/carbon/carbon_status_procs.dm
@@ -9,7 +9,7 @@
 	if(!IsWeakened())
 		to_chat(src, "<span class='notice'>You're too exhausted to keep going...</span>")
 	SEND_SIGNAL(src, COMSIG_CARBON_ENTER_STAMINACRIT)
-	stam_regen_start_time = world.time + STAMINA_REGEN_BLOCK_TIME * stamina_regen_block_modifier
+	stam_regen_start_time = world.time + (STAMINA_REGEN_BLOCK_TIME * stamina_regen_block_modifier)
 	var/prev = stam_paralyzed
 	stam_paralyzed = TRUE
 	ADD_TRAIT(src, TRAIT_IMMOBILIZED, "stam_crit") // make defines later

--- a/code/modules/mob/living/carbon/carbon_status_procs.dm
+++ b/code/modules/mob/living/carbon/carbon_status_procs.dm
@@ -8,6 +8,8 @@
 		return
 	if(!IsWeakened())
 		to_chat(src, "<span class='notice'>You're too exhausted to keep going...</span>")
+	SEND_SIGNAL(src, COMSIG_CARBON_ENTER_STAMINACRIT)
+	stam_regen_start_time = world.time + STAMINA_REGEN_BLOCK_TIME * stamina_regen_block_modifier
 	var/prev = stam_paralyzed
 	stam_paralyzed = TRUE
 	ADD_TRAIT(src, TRAIT_IMMOBILIZED, "stam_crit") // make defines later

--- a/code/modules/mob/living/carbon/carbon_update_status.dm
+++ b/code/modules/mob/living/carbon/carbon_update_status.dm
@@ -24,6 +24,7 @@
 	if(stam > DAMAGE_PRECISION && (maxHealth - stam) <= HEALTH_THRESHOLD_CRIT && !stat)
 		enter_stamcrit()
 	else if(stam_paralyzed)
+		SEND_SIGNAL(src, COMSIG_CARBON_EXIT_STAMINACRIT)
 		stam_paralyzed = FALSE
 		REMOVE_TRAIT(src, TRAIT_IMMOBILIZED, "stam_crit") // make defines later
 		REMOVE_TRAIT(src, TRAIT_FLOORED, "stam_crit")

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -284,7 +284,7 @@
 	else
 		. = STATUS_UPDATE_STAMINA
 	if(amount > 0)
-		stam_regen_start_time = world.time + STAMINA_REGEN_BLOCK_TIME
+		stam_regen_start_time = world.time + STAMINA_REGEN_BLOCK_TIME * stamina_regen_block_modifier
 	if(updating)
 		update_health_hud()
 		update_stamina()
@@ -300,7 +300,7 @@
 	else
 		. = STATUS_UPDATE_STAMINA
 	if(amount > 0)
-		stam_regen_start_time = world.time + STAMINA_REGEN_BLOCK_TIME
+		stam_regen_start_time = world.time + STAMINA_REGEN_BLOCK_TIME * stamina_regen_block_modifier
 	if(updating)
 		update_health_hud()
 		update_stamina()

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -284,7 +284,7 @@
 	else
 		. = STATUS_UPDATE_STAMINA
 	if(amount > 0)
-		stam_regen_start_time = world.time + STAMINA_REGEN_BLOCK_TIME * stamina_regen_block_modifier
+		stam_regen_start_time = world.time + (STAMINA_REGEN_BLOCK_TIME * stamina_regen_block_modifier)
 	if(updating)
 		update_health_hud()
 		update_stamina()
@@ -300,7 +300,7 @@
 	else
 		. = STATUS_UPDATE_STAMINA
 	if(amount > 0)
-		stam_regen_start_time = world.time + STAMINA_REGEN_BLOCK_TIME * stamina_regen_block_modifier
+		stam_regen_start_time = world.time + (STAMINA_REGEN_BLOCK_TIME * stamina_regen_block_modifier)
 	if(updating)
 		update_health_hud()
 		update_stamina()

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -71,6 +71,8 @@
 
 	var/stun_absorption = null //converted to a list of stun absorption sources this mob has when one is added
 	var/stam_regen_start_time = 0 //used to halt stamina regen temporarily
+	/// A multiplier for the ammount of time it takes for someone to regenerate stamina damage.
+	var/stamina_regen_block_modifier = 1
 	var/stam_paralyzed = FALSE //knocks you down
 
 	/// Number of degrees of rotation of a mob. 0 means no rotation, up-side facing NORTH. 90 means up-side rotated to face EAST, and so on.

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -132,27 +132,46 @@
 	implant_color = "#FFFF00"
 	slot = "brain_antistun"
 	origin_tech = "materials=5;programming=4;biotech=5"
-	var/last_stamina_damage = 0
-	var/max_stamina_increment = 40
+	/// How much we multiply the owners stamina regen block modifier by.
+	var/stamina_crit_time_multiplier = 0.4
+	/// Are we currently modifying somoeones stamina regen block modifier? If so, we will want to undo it on removal.
+	var/currently_modifying_stamina = FALSE
+	COOLDOWN_DECLARE(implant_cooldown)
 
-/obj/item/organ/internal/cyberimp/brain/anti_stam/on_life()
+/obj/item/organ/internal/cyberimp/brain/anti_stam/insert(mob/living/carbon/M, special = FALSE)
 	..()
-	if(crit_fail)
-		return
-	if(last_stamina_damage + max_stamina_increment < owner.getStaminaLoss())
-		owner.setStaminaLoss(last_stamina_damage + max_stamina_increment)
-	last_stamina_damage = owner.getStaminaLoss()
+	RegisterSignal(M, COMSIG_CARBON_ENTER_STAMINACRIT, PROC_REF(on_enter))
+	RegisterSignal(M, COMSIG_CARBON_EXIT_STAMINACRIT, PROC_REF(on_exit))
+	RegisterSignal(M, COMSIG_CARBON_STAMINA_REGENERATED, PROC_REF(on_regen))
 
+/obj/item/organ/internal/cyberimp/brain/anti_stam/remove(mob/living/carbon/M, special = FALSE)
+	UnregisterSignal(M, COMSIG_CARBON_ENTER_STAMINACRIT)
+	UnregisterSignal(M, COMSIG_CARBON_EXIT_STAMINACRIT)
+	RegisterSignal(M, COMSIG_CARBON_STAMINA_REGENERATED)
+	on_exit()
+	return ..()
+
+/obj/item/organ/internal/cyberimp/brain/anti_stam/proc/on_enter()
+	SIGNAL_HANDLER
+	if(currently_modifying_stamina || !COOLDOWN_FINISHED(src, implant_cooldown))
+		return
+	owner.stamina_regen_block_modifier *= stamina_crit_time_multiplier
+	currently_modifying_stamina = TRUE
+
+/obj/item/organ/internal/cyberimp/brain/anti_stam/proc/on_exit()
+	SIGNAL_HANDLER
+	if(!currently_modifying_stamina)
+		return
+	owner.stamina_regen_block_modifier /= stamina_crit_time_multiplier
+	currently_modifying_stamina = FALSE
+
+/obj/item/organ/internal/cyberimp/brain/anti_stam/proc/on_regen()
+	SIGNAL_HANDLER
+	owner.update_stamina() //This is here so they actually get unstaminacrit when it triggers, vs 2-4 seconds later
 
 /obj/item/organ/internal/cyberimp/brain/anti_stam/emp_act(severity)
 	..()
-	if(crit_fail || emp_proof)
-		return
-	crit_fail = TRUE
-	addtimer(CALLBACK(src, PROC_REF(reboot)), 90 / severity)
-
-/obj/item/organ/internal/cyberimp/brain/anti_stam/proc/reboot()
-	crit_fail = FALSE
+	COOLDOWN_START(src, implant_cooldown, 1 MINUTES / severity)
 
 /obj/item/organ/internal/cyberimp/brain/anti_stam/hardened
 	name = "Hardened CNS Rebooter implant"

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -150,21 +150,21 @@
 	return ..()
 
 /obj/item/organ/internal/cyberimp/brain/anti_stam/proc/on_enter()
-	SIGNAL_HANDLER
+	SIGNAL_HANDLER // COMSIG_CARBON_ENTER_STAMINACRIT
 	if(currently_modifying_stamina || !COOLDOWN_FINISHED(src, implant_cooldown))
 		return
 	owner.stamina_regen_block_modifier *= stamina_crit_time_multiplier
 	currently_modifying_stamina = TRUE
 
 /obj/item/organ/internal/cyberimp/brain/anti_stam/proc/on_exit()
-	SIGNAL_HANDLER
+	SIGNAL_HANDLER // COMSIG_CARBON_EXIT_STAMINACRIT
 	if(!currently_modifying_stamina)
 		return
 	owner.stamina_regen_block_modifier /= stamina_crit_time_multiplier
 	currently_modifying_stamina = FALSE
 
 /obj/item/organ/internal/cyberimp/brain/anti_stam/proc/on_regen()
-	SIGNAL_HANDLER
+	SIGNAL_HANDLER // COMSIG_CARBON_STAMINA_REGENERATED
 	owner.update_stamina() //This is here so they actually get unstaminacrit when it triggers, vs 2-4 seconds later
 
 /obj/item/organ/internal/cyberimp/brain/anti_stam/emp_act(severity)

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -145,7 +145,7 @@
 	RegisterSignal(M, COMSIG_CARBON_STAMINA_REGENERATED, PROC_REF(on_regen))
 
 /obj/item/organ/internal/cyberimp/brain/anti_stam/remove(mob/living/carbon/M, special = FALSE)
-	UnregisterSignal(M, list(COMSIG_CARBON_ENTER_STAMINACRIT, COMSIG_CARBON_EXIT_STAMINACRIT, COMSIG_CARBON_STAMINA_REGENERATED)
+	UnregisterSignal(M, list(COMSIG_CARBON_ENTER_STAMINACRIT, COMSIG_CARBON_EXIT_STAMINACRIT, COMSIG_CARBON_STAMINA_REGENERATED))
 	on_exit()
 	return ..()
 

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -145,9 +145,7 @@
 	RegisterSignal(M, COMSIG_CARBON_STAMINA_REGENERATED, PROC_REF(on_regen))
 
 /obj/item/organ/internal/cyberimp/brain/anti_stam/remove(mob/living/carbon/M, special = FALSE)
-	UnregisterSignal(M, COMSIG_CARBON_ENTER_STAMINACRIT)
-	UnregisterSignal(M, COMSIG_CARBON_EXIT_STAMINACRIT)
-	RegisterSignal(M, COMSIG_CARBON_STAMINA_REGENERATED)
+	UnregisterSignal(M, list(COMSIG_CARBON_ENTER_STAMINACRIT, COMSIG_CARBON_EXIT_STAMINACRIT, COMSIG_CARBON_STAMINA_REGENERATED)
 	on_exit()
 	return ..()
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
The CNS rebooter no longer runs a life based reduction of stamina every 2 seconds.
Instead, when a person enters stamina crit with the CNS rebooter, it will lower their stamina regen time to 4 seconds. 
This does **not** impact stamina regeneration out of stamina crit. If you take 90 stamina damage, you will take 10 seconds to regenerate your stamina.

EMPing the implant stuns as before. However, it will be disabled for 30 seconds or a minute, depending on EMP severity.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Current CNS rebooter is... niche. It can save your ass. It will take 3 batons to down you, over 2. If you eat a bunch of buckshot rapidly, it can recover a bunch of stamina.

If you are disabled however, it probably won't help you much.

The issue is the implant checks every 2 seconds off life. As such, depending on on when you are hit, it can have a massive impact.
If you are hit slowly by disablers, it will not help you.
An upgraded cybernetic heart will help much better (for more significant risk)

This PR makes the implant work more like old CNS.
It will not help you before stamina crit, but it will help you outside of stamina crit. A person will need to consistently apply stamina to you, or cuff you *right* after stamina critting you, or you will get back up fast. Of course, someone harmbatoning you to death will kill you, but that would kill you with cybernetic heart and old cns with old baton.

This implant will be good for a surprise vs officers, or officers in a group,
For advantages to the heart, while the heart provides constant stamina healing, the CNS implant will fully recover stamina after a stamina crit. People will have to use their resources on you much more often to keep you stamina crit, be it more disablers, or more baton charge.

## Testing
<!-- How did you test the PR, if at all? -->
Batoned and disabled my self a bunch, along with other skrells.
Worked as expected.

## Changelog
:cl:
tweak: CNS no longer removes stamina potentially after every 2 seconds. Instead, will shorten stamina crit time to 4 seconds
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
