### PR TITLE
Fix lavaland necropolis walls.

### DIFF
--- a/_maps/map_files/generic/Lavaland.dmm
+++ b/_maps/map_files/generic/Lavaland.dmm
@@ -1,6 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aa" = (
-/turf/simulated/wall/boss,
+/turf/simulated/wall/indestructible/boss,
 /area/lavaland/surface/outdoors)
 "ab" = (
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
@@ -5819,7 +5819,7 @@
 "ya" = (
 /obj/effect/mapping_helpers/no_lava,
 /obj/effect/mapping_helpers/no_lava,
-/turf/simulated/wall/boss,
+/turf/simulated/wall/indestructible/boss,
 /area/lavaland/surface/outdoors)
 "yb" = (
 /obj/structure/table/glass,
@@ -6139,6 +6139,10 @@
 	icon_state = "darkred"
 	},
 /area/mine/laborcamp/security)
+"Ad" = (
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/wall/indestructible/boss,
+/area/lavaland/surface/outdoors)
 "Ai" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -7273,6 +7277,10 @@
 	icon_state = "darkfull"
 	},
 /area/mine/outpost/storage)
+"If" = (
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/wall/indestructible/boss,
+/area/lavaland/surface/outdoors/unexplored/danger)
 "Il" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -7953,6 +7961,9 @@
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"NJ" = (
+/turf/simulated/wall/indestructible/boss,
+/area/lavaland/surface/outdoors/unexplored/danger)
 "NK" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/spawner/random_spawners/dirt_maybe,
@@ -35436,7 +35447,7 @@ BX
 BX
 BX
 BX
-BX
+If
 BX
 ZY
 ZY
@@ -41293,7 +41304,7 @@ aa
 aa
 aa
 aa
-Rl
+Ad
 gG
 pP
 kg
@@ -41331,7 +41342,7 @@ mN
 Gb
 QO
 ys
-ys
+NJ
 BX
 GC
 GC
@@ -41557,8 +41568,8 @@ pH
 Ol
 ag
 le
-Rl
-Rl
+Ad
+Ad
 ls
 Aw
 Aw
@@ -41570,8 +41581,8 @@ Aw
 Aw
 Aw
 lI
-Rl
-Rl
+Ad
+Ad
 wr
 Ly
 Ly
@@ -41828,7 +41839,7 @@ XU
 KO
 KO
 Eq
-Rl
+Ad
 hF
 Ly
 Ly
@@ -42342,7 +42353,7 @@ pS
 bc
 Qr
 bc
-Rl
+Ad
 IZ
 Ly
 Ly
@@ -42585,8 +42596,8 @@ Pl
 hk
 gr
 hH
-Rl
-Rl
+Ad
+Ad
 lw
 Aw
 Aw
@@ -42598,8 +42609,8 @@ Aw
 Aw
 lw
 Aw
-Rl
-Rl
+Ad
+Ad
 Vq
 Ly
 Ly
@@ -42835,7 +42846,7 @@ aa
 aa
 aa
 aa
-Rl
+Ad
 gr
 pP
 kl

--- a/_maps/map_files/generic/Lavaland.dmm
+++ b/_maps/map_files/generic/Lavaland.dmm
@@ -7277,10 +7277,6 @@
 	icon_state = "darkfull"
 	},
 /area/mine/outpost/storage)
-"If" = (
-/obj/effect/mapping_helpers/no_lava,
-/turf/simulated/wall/indestructible/boss,
-/area/lavaland/surface/outdoors/unexplored/danger)
 "Il" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -7961,9 +7957,6 @@
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"NJ" = (
-/turf/simulated/wall/indestructible/boss,
-/area/lavaland/surface/outdoors/unexplored/danger)
 "NK" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/spawner/random_spawners/dirt_maybe,
@@ -35447,7 +35440,7 @@ BX
 BX
 BX
 BX
-If
+BX
 BX
 ZY
 ZY
@@ -41342,7 +41335,7 @@ mN
 Gb
 QO
 ys
-NJ
+ys
 BX
 GC
 GC


### PR DESCRIPTION
## What Does This PR Do
Change necropolis walls back to be undestructable.

## Why It's Good For The Game
Fix issue where legion would break its own walls.

## Images of changes
![StrongDMM-2024-01-17 10 29 05](https://github.com/ParadiseSS13/Paradise/assets/89580971/6bf9c239-e443-41c6-94b4-e24fec1046b1)

## Testing
Run VSC, no errors occured.

## Changelog
:cl:
fix: changed destructable necropolis wall, back to undestructable.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
