### PR TITLE
Remove unused 'salvage captain' ID and related areas

### DIFF
--- a/code/__DEFINES/access_defines.dm
+++ b/code/__DEFINES/access_defines.dm
@@ -65,7 +65,6 @@
 #define ACCESS_XENOARCH 65
 #define ACCESS_PARAMEDIC 66
 #define ACCESS_BLUESHIELD 67
-// #define ACCESS_SALVAGE_CAPTAIN 69 // Salvage ship captain's quarters
 // #define ACCESS_MECHANIC 70 // AA07 2021-10-02 - Removed: Kept for history sake
 // #define ACCESS_PILOT 71 // AA07 2021-10-02 - Removed: Kept for history sake
 #define ACCESS_NTREP 73

--- a/code/__DEFINES/access_defines.dm
+++ b/code/__DEFINES/access_defines.dm
@@ -65,7 +65,7 @@
 #define ACCESS_XENOARCH 65
 #define ACCESS_PARAMEDIC 66
 #define ACCESS_BLUESHIELD 67
-#define ACCESS_SALVAGE_CAPTAIN 69 // Salvage ship captain's quarters
+// #define ACCESS_SALVAGE_CAPTAIN 69 // Salvage ship captain's quarters
 // #define ACCESS_MECHANIC 70 // AA07 2021-10-02 - Removed: Kept for history sake
 // #define ACCESS_PILOT 71 // AA07 2021-10-02 - Removed: Kept for history sake
 #define ACCESS_NTREP 73

--- a/code/game/area/shuttle_areas.dm
+++ b/code/game/area/shuttle_areas.dm
@@ -234,63 +234,6 @@
 /area/shuttle/research/outpost
 	icon_state = "shuttle"
 
-/area/shuttle/salvage
-	name = "\improper Salvage Ship"
-	icon_state = "yellow"
-
-/area/shuttle/salvage/start
-	name = "\improper Middle of Nowhere"
-	icon_state = "yellow"
-
-/area/shuttle/salvage/arrivals
-	name = "\improper Space Station Auxiliary Docking"
-	icon_state = "yellow"
-
-/area/shuttle/salvage/derelict
-	name = "\improper Derelict Station"
-	icon_state = "yellow"
-
-/area/shuttle/salvage/djstation
-	name = "\improper Ruskie DJ Station"
-	icon_state = "yellow"
-
-/area/shuttle/salvage/north
-	name = "\improper North of the Station"
-	icon_state = "yellow"
-
-/area/shuttle/salvage/east
-	name = "\improper East of the Station"
-	icon_state = "yellow"
-
-/area/shuttle/salvage/south
-	name = "\improper South of the Station"
-	icon_state = "yellow"
-
-/area/shuttle/salvage/commssat
-	name = "\improper The Communications Satellite"
-	icon_state = "yellow"
-
-/area/shuttle/salvage/mining
-	name = "\improper South-West of the Mining Asteroid"
-	icon_state = "yellow"
-
-/area/shuttle/salvage/abandoned_ship
-	name = "\improper Abandoned Ship"
-	icon_state = "yellow"
-	parallax_movedir = WEST
-
-/area/shuttle/salvage/clown_asteroid
-	name = "\improper Clown Asteroid"
-	icon_state = "yellow"
-
-/area/shuttle/salvage/trading_post
-	name = "\improper Trading Post"
-	icon_state = "yellow"
-
-/area/shuttle/salvage/transit
-	name = "\improper hyperspace"
-	icon_state = "shuttle"
-
 /area/shuttle/supply
 	name = "Supply Shuttle"
 	icon_state = "shuttle3"

--- a/code/game/jobs/access.dm
+++ b/code/game/jobs/access.dm
@@ -144,7 +144,7 @@
 	return list(ACCESS_SYNDICATE, ACCESS_SYNDICATE_LEADER, ACCESS_SYNDICATE_COMMAND)
 
 /proc/get_all_misc_access()
-	return list(ACCESS_SALVAGE_CAPTAIN, ACCESS_TRADE_SOL, ACCESS_CRATE_CASH, ACCESS_AWAY01)
+	return list(ACCESS_TRADE_SOL, ACCESS_CRATE_CASH, ACCESS_AWAY01)
 
 /proc/get_absolutely_all_accesses()
 	return (get_all_accesses() | get_all_centcom_access() | get_all_syndicate_access() | get_all_misc_access())

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -718,13 +718,6 @@
 	name = "Prisoner [random_number]"
 	registered_name = name
 
-/obj/item/card/id/salvage_captain
-	name = "Captain's ID"
-	registered_name = "Captain"
-	icon_state = "centcom"
-	desc = "Finders, keepers."
-	access = list(ACCESS_SALVAGE_CAPTAIN)
-
 /obj/item/card/id/medical
 	name = "Medical ID"
 	registered_name = "Medic"


### PR DESCRIPTION
## What Does This PR Do
This PR removes an unused ID card type, the "salvage captain". This was nominally meant to be used for some kind of ship that could access other space ruins: https://github.com/ParadiseSS13/Paradise/commit/544c39f7c2aeab497eaae61032cdf80c15b92e2e but I can't find any use of it in any map throughout git history. It also removes the unused `/area/shuttle/salvage/...` subtypes. While these have the same name as existing ruins, they are _not_ the areas for those ruins. Those are `/area/ruin/...`.

## Why It's Good For The Game
Dead code bad.

## Changelog
NPFC
