### PR TITLE
Purges clown planet references from station traits

### DIFF
--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -2,7 +2,7 @@
 	name = "Bananium Shipment"
 	trait_type = STATION_TRAIT_NEUTRAL
 	weight = 5
-	report_message = "An unidentified benefactor has dispatched a mysterious shipment to your station. It was reported to smell faintly of bananas."
+	report_message = "An unidentified benefactor has dispatched a mysterious shipment to your station's clown. It was reported to smell faintly of bananas."
 	trait_to_give = STATION_TRAIT_BANANIUM_SHIPMENTS
 
 /datum/station_trait/bananium_shipment

--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -2,14 +2,14 @@
 	name = "Bananium Shipment"
 	trait_type = STATION_TRAIT_NEUTRAL
 	weight = 5
-	report_message = "Rumor has it that the clown planet has been sending support packages to clowns in this system."
+	report_message = "An unidentified benefactor has dispatched a mysterious shipment to your station. It was reported to smell faintly of bananas."
 	trait_to_give = STATION_TRAIT_BANANIUM_SHIPMENTS
 
 /datum/station_trait/bananium_shipment
 	name = "Tranquilite Shipment"
 	trait_type = STATION_TRAIT_NEUTRAL
 	weight = 5
-	report_message = "Rumor has it that the mime federation has been sending support packages to mimes in this system."
+	report_message = "Shipping records show an unmarked crate being delivered to your station's mime."
 	trait_to_give = STATION_TRAIT_TRANQUILITE_SHIPMENTS
 
 /datum/station_trait/unique_ai


### PR DESCRIPTION
## What Does This PR Do
See title.

Also edits the tranquilite crate trait to make it lore-compliant.

## Why It's Good For The Game
Lore team already agreed Clown Planet was to be deleted, so here we are again.

## Testing
N/A, just text changes

## Changelog
:cl:
tweak: Edited trait descriptions for Bananium and Tranquilite crate station traits.
/:cl: