### PR TITLE
Adds airlock helpers to USSP station

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/ussp.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/ussp.dmm
@@ -3952,21 +3952,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/ruin/space/derelict/crew_quarters)
-"jK" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "rus2_door_int";
-	name = "External Airlock"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/ruin/space/derelict/crew_quarters)
 "jL" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -3974,23 +3959,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light/small,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	autolink_id = "rus2_vent";
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/ruin/space/derelict/crew_quarters)
-"jM" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/external{
-	id_tag = "rus2_door_ext";
-	locked = 1;
-	name = "External Airlock"
-	},
 /turf/simulated/floor/plating,
 /area/ruin/space/derelict/crew_quarters)
 "jN" = (
@@ -4490,11 +4458,6 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/machinery/access_button{
-	autolink_id = "rus2_btn_ext";
-	name = "exterior access button";
-	pixel_x = -25
-	},
 /turf/template_noop,
 /area/ruin/space/derelict/crew_quarters)
 "kJ" = (
@@ -4729,13 +4692,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external{
-	id_tag = "rus2_door_int";
-	name = "External Airlock"
-	},
 /turf/simulated/floor/plating,
 /area/ruin/space/derelict/crew_quarters)
 "lp" = (
@@ -4746,31 +4702,6 @@
 	},
 /obj/machinery/light/small{
 	dir = 1
-	},
-/obj/machinery/airlock_controller/air_cycler{
-	ext_door_link_id = "rus2_door_ext";
-	ext_button_link_id = "rus2_btn_ext";
-	int_door_link_id = "rus2_door_int";
-	int_button_link_id = "rus2_btn_int";
-	pixel_y = -25;
-	vent_link_id = "rus2_vent"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 8;
-	autolink_id = "rus2_vent"
-	},
-/turf/simulated/floor/plating,
-/area/ruin/space/derelict/crew_quarters)
-"lq" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "rus2_door_ext";
-	locked = 1;
-	name = "External Airlock"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/ruin/space/derelict/crew_quarters)
@@ -4909,11 +4840,6 @@
 "lG" = (
 /obj/machinery/light/spot{
 	dir = 4
-	},
-/obj/machinery/access_button{
-	autolink_id = "rus2_btn_int";
-	name = "interior access button";
-	pixel_x = 25
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -7372,11 +7298,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/machinery/access_button{
-	autolink_id = "rus1_btn_int";
-	name = "interior access button";
-	pixel_y = -25
-	},
 /obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
@@ -7464,32 +7385,6 @@
 /obj/structure/sign/vacuum,
 /turf/simulated/wall/mineral/titanium/nodecon/nodiagonal,
 /area/ruin/space/derelict/arrival)
-"sa" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "rus1_door_int";
-	name = "External Airlock"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/plating,
-/area/ruin/space/derelict/arrival)
-"sb" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/door/airlock/external{
-	id_tag = "rus1_door_int";
-	name = "External Airlock"
-	},
-/turf/simulated/floor/plating,
-/area/ruin/space/derelict/arrival)
 "sc" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -7498,18 +7393,6 @@
 	},
 /obj/machinery/light/small{
 	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 1;
-	autolink_id = "rus1_vent"
-	},
-/obj/machinery/airlock_controller/air_cycler{
-	pixel_x = -25;
-	ext_button_link_id = "rus1_btn_ext";
-	ext_door_link_id = "rus1_door_ext";
-	int_button_link_id = "rus1_btn_int";
-	int_door_link_id = "rus1_door_int";
-	vent_link_id = "rus1_vent"
 	},
 /turf/simulated/floor/plating,
 /area/ruin/space/derelict/arrival)
@@ -7522,31 +7405,9 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 1;
-	autolink_id = "rus1_vent"
-	},
 /turf/simulated/floor/plating,
 /area/ruin/space/derelict/arrival)
 "se" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/external{
-	id_tag = "rus1_door_ext";
-	locked = 1;
-	name = "External Airlock"
-	},
-/turf/simulated/floor/plating,
-/area/ruin/space/derelict/arrival)
-"sf" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "rus1_door_ext";
-	locked = 1;
-	name = "External Airlock"
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -7563,11 +7424,6 @@
 "sh" = (
 /obj/machinery/light/small{
 	dir = 1
-	},
-/obj/machinery/access_button{
-	autolink_id = "rus1_btn_ext";
-	name = "exterior access button";
-	pixel_y = 25
 	},
 /turf/template_noop,
 /area/ruin/space/derelict/arrival)
@@ -7725,8 +7581,26 @@
 	},
 /turf/simulated/wall/mineral/titanium/nodecon/nodiagonal,
 /area/ruin/space/derelict/arrival)
+"Nv" = (
+/obj/effect/spawner/airlock{
+	req_access_txt = 0
+	},
+/turf/simulated/wall/mineral/titanium/nodecon/nodiagonal,
+/area/ruin/space/derelict/arrival)
+"Oh" = (
+/obj/effect/spawner/airlock/w_to_e{
+	req_access_txt = 0
+	},
+/turf/simulated/wall/mineral/titanium/nodecon/nodiagonal,
+/area/ruin/space/derelict/crew_quarters)
 "QN" = (
 /turf/simulated/wall/mineral/titanium/nodecon/nosmooth,
+/area/ruin/space/derelict/arrival)
+"Ud" = (
+/obj/effect/spawner/airlock{
+	req_access_txt = 0
+	},
+/turf/simulated/wall/mineral/titanium/nodecon,
 /area/ruin/space/derelict/arrival)
 "Xn" = (
 /obj/structure/cable{
@@ -11128,9 +11002,9 @@ rq
 rq
 hY
 rO
-rZ
 bn
-aW
+bn
+Ud
 ac
 ac
 jO
@@ -11220,7 +11094,7 @@ rr
 ry
 rE
 rP
-sa
+se
 sc
 se
 jx
@@ -11314,7 +11188,7 @@ qu
 rQ
 bn
 bn
-bn
+Nv
 sh
 ac
 kJ
@@ -11404,9 +11278,9 @@ rt
 rA
 qu
 rR
-sb
+se
 sd
-sf
+se
 jx
 jx
 sk
@@ -14131,11 +14005,11 @@ aV
 bm
 dH
 dH
-bm
-jK
 kG
 lo
-bm
+Oh
+lo
+Oh
 dH
 dH
 bm
@@ -14316,9 +14190,9 @@ ac
 ac
 ac
 aV
-jM
+lo
 bm
-lq
+lo
 aV
 ag
 ag


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. --> pretty much what the title says
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. --> Makes it easy to access instead of being one way of accessing in and out

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. --> 
![Screenshot 2024-01-17 201022](https://github.com/ParadiseSS13/Paradise/assets/98861947/4dccc89d-8fa3-4410-9acf-5fb8d0290c13)
![Screenshot 2024-01-17 200551](https://github.com/ParadiseSS13/Paradise/assets/98861947/4e5a5db8-69aa-43c3-8f72-8edabda9f024)

## Testing
<!-- How did you test the PR, if at all? --> spawned as a USSP and checked if the airlocks worked

## Changelog
:cl:
Add: added airlock helpers since it was needed on USSP
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
