### PR TITLE
allow quick spawn with doubleclick

### DIFF
--- a/html/create_object.html
+++ b/html/create_object.html
@@ -65,4 +65,10 @@
 
 			populateList(filtered);
 		}
+
+		function quickSpawn() {
+			document.spawner.submit();
+		}
+
+		document.getElementById('object_list').ondblclick = quickSpawn;
 	</script>


### PR DESCRIPTION
## What Does This PR Do
This PR adds a handler to the Admin spawn windows to allow for doubleclicking on the desired items to spawn them. It works as expected for multiple selections as well.
## Why It's Good For The Game
I've lost years of my life moving my mouse cursor to the Spawn button.
## Images of changes
https://github.com/ParadiseSS13/Paradise/assets/59303604/5e370541-c16f-4508-ab5f-eff0edf3f9d4
## Testing
See above. Since the create object page is reused for all types, this works for e.g. the Spawn Mob page as well.
## Changelog
NPFC