### PR TITLE
IPCs once again get 65 damage from a heavy EMP, and 40 from a light.

### DIFF
--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -359,11 +359,11 @@
 	else if(emp_resistant) // IPC limbs
 		switch(severity)
 			if(1)
-				// 5.28 (9 * 0.66 burn_mod) burn damage, 65.34 damage with 11 limbs.
-				receive_damage(0, 9)
+				// 5.9 burn damage, 64.9 damage with 11 limbs.
+				receive_damage(0, 5.9)
 			if(2)
-				// 3.63 (5 * 0.66 burn_mod) burn damage, 39.93 damage with 11 limbs.
-				receive_damage(0, 5.5)
+				// 3.63ds burn damage, 39.93 damage with 11 limbs.
+				receive_damage(0, 3.63)
 	else // Basic prosthetic limbs
 		switch(severity)
 			if(1)

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -362,7 +362,7 @@
 				// 5.9 burn damage, 64.9 damage with 11 limbs.
 				receive_damage(0, 5.9)
 			if(2)
-				// 3.63ds burn damage, 39.93 damage with 11 limbs.
+				// 3.63 burn damage, 39.93 damage with 11 limbs.
 				receive_damage(0, 3.63)
 	else // Basic prosthetic limbs
 		switch(severity)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Fixes IPCS taking much more (60 from light, 99 from heavy) damage from emp when intended.
Brings them back to 40 and 65 as before

resolve #23862 

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

When https://github.com/ParadiseSS13/Paradise/pull/23178 was merged, it turns out that the limb damage mod (rather than the species damage mod) affected emp damage.
So when we removed the limb resist and extra damage from species, ipcs were taking extra damage from emp.
This brings them back to 40 and 65 as before

## Testing
<!-- How did you test the PR, if at all? -->
Light and heavy emp'd machines to confirm intended values.

## Changelog
:cl:
fix: IPCs once again get 65 damage from a heavy EMP, and 40 from a light.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
