### PR TITLE
delta: fix filters not using filter constants

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -5879,7 +5879,7 @@
 "axV" = (
 /obj/machinery/atmospherics/trinary/filter{
 	dir = 4;
-	filter_type = "o2";
+	filter_type = 3;
 	on = 1
 	},
 /turf/simulated/floor/plasteel{
@@ -8207,7 +8207,7 @@
 "aEd" = (
 /obj/machinery/atmospherics/trinary/filter{
 	dir = 1;
-	filter_type = "n2";
+	filter_type = 2;
 	name = "nitrogen filter";
 	on = 1
 	},
@@ -8593,7 +8593,7 @@
 "aFf" = (
 /obj/machinery/atmospherics/trinary/filter{
 	dir = 8;
-	filter_type = "n2"
+	filter_type = 2
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -17912,7 +17912,7 @@
 "bbQ" = (
 /obj/machinery/atmospherics/trinary/filter{
 	dir = 1;
-	filter_type = ""
+	filter_type = -1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"


### PR DESCRIPTION
## What Does This PR Do
This PR fixes several instances on Delta where filter types were set to strings instead of their proper filter value.
## Why It's Good For The Game
Since the strings are not valid filter types, these filters were instead filtering nothing. Also allows #23747 to get in to ensure this never happens again.
## Images of changes
Since varedits won't show up on MDB, I've highlighted the affected filters here with red circles:
![2024_01_20__15_45_08__paradise dme  delta dmm  - StrongDMM](https://github.com/ParadiseSS13/Paradise/assets/59303604/87a6175e-ab2e-4ab0-a1c7-0b6cf5470591)

<details><summary>Before</summary>
Note that the UI doesn't even have "Nothing" selected.

![2024_01_20__15_55_04__Paradise Station 13](https://github.com/ParadiseSS13/Paradise/assets/59303604/4e7e6568-39b7-4da1-8278-0c869d1afd51)

![2024_01_20__15_55_15__Paradise Station 13](https://github.com/ParadiseSS13/Paradise/assets/59303604/c5cffddd-ab2d-4c19-96e6-cbd9bbf70a7c)

![2024_01_20__15_55_26__Paradise Station 13](https://github.com/ParadiseSS13/Paradise/assets/59303604/21ae0003-7b68-47bb-8b3a-ef1e2fc25e46)

![2024_01_20__15_55_40__Paradise Station 13](https://github.com/ParadiseSS13/Paradise/assets/59303604/59cf30d4-da60-48aa-a3e3-4f492442ae75)
</details>

<details><summary>After</summary>

![2024_01_20__15_52_16__Paradise Station 13](https://github.com/ParadiseSS13/Paradise/assets/59303604/f90f39b1-6e43-4dc0-8adf-a0ce83465fa5)

![2024_01_20__15_52_27__Paradise Station 13](https://github.com/ParadiseSS13/Paradise/assets/59303604/5dcd2b22-13b8-4efa-ba38-ba1fb65290ee)

![2024_01_20__15_52_36__Paradise Station 13](https://github.com/ParadiseSS13/Paradise/assets/59303604/e7c6e74b-4fe6-4a88-bcdd-20595933d399)

![2024_01_20__15_52_54__Paradise Station 13](https://github.com/ParadiseSS13/Paradise/assets/59303604/bccc71f8-ac64-4635-b497-93ca1a9f1004)
</details>

## Testing
I wouldn't even know where to begin testing atmos-related changes, but I did check to ensure the filter UI was set to the right gas.

## Changelog
:cl:
fix: Kerberos: several gas filters in Atmos and SM now filter their intended gasses at round-start.
/:cl:
