### PR TITLE
Makes corazone unable to be spawned in strange seeds

### DIFF
--- a/code/_globalvars/lists/reagents_lists.dm
+++ b/code/_globalvars/lists/reagents_lists.dm
@@ -47,5 +47,5 @@ GLOBAL_LIST_INIT(blocked_chems, list("polonium", "initropidril", "concentrated_i
 							"fungalspores", "jagged_crystals", "salmonella",
 							"lavaland_extract", "stable_mutagen", "beer2",
 							"curare", "gluttonytoxin", "smoke_powder", "stimulative_cling",
-							"teslium_paste"
+							"teslium_paste", "corazone"
 							))


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Puts corazone in the `blocked_chem` list
This makes it unable to be extracted with sleepers, unable to be synthesized with Odyssei and bees, and unable to spawn in strange seeds.
As the source of Corazone is already infinite (Abductor surgery tables), this change only applies to the strange seeds.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
The OP makes-you-immune-for-heart-attacks chemical shouldn't be obtainable by a simple botany gacha.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Filled monkey with Corazone, got saturated active charcoal when I tried to dialysis it out with a sleeper.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Corazone now can't spawn in strange seeds anymore
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
