### PR TITLE
Species with oldcrit no longer go unconcious at 0 HP

### DIFF
--- a/code/__DEFINES/combat_defines.dm
+++ b/code/__DEFINES/combat_defines.dm
@@ -53,6 +53,7 @@
 
 //Health Defines
 #define HEALTH_THRESHOLD_CRIT 0
+#define HEALTH_THRESHOLD_KNOCKOUT -50
 #define HEALTH_THRESHOLD_DEAD -100
 
 //Grab levels

--- a/code/modules/mob/living/carbon/carbon_life.dm
+++ b/code/modules/mob/living/carbon/carbon_life.dm
@@ -287,7 +287,7 @@
 	if(!client)
 		return
 	var/shock_reduction = shock_reduction()
-	if(stat == UNCONSCIOUS && health <= HEALTH_THRESHOLD_CRIT)
+	if(health <= HEALTH_THRESHOLD_CRIT)
 		if(check_death_method())
 			var/severity = 0
 			switch(health - shock_reduction)

--- a/code/modules/mob/living/carbon/carbon_update_status.dm
+++ b/code/modules/mob/living/carbon/carbon_update_status.dm
@@ -6,10 +6,12 @@
 			death()
 			create_debug_log("died of damage, trigger reason: [reason]")
 			return
-		if(HAS_TRAIT(src, TRAIT_KNOCKEDOUT) || (check_death_method() && getOxyLoss() > 50) || HAS_TRAIT(src, TRAIT_FAKEDEATH) || health <= HEALTH_THRESHOLD_CRIT && check_death_method())
+		if(HAS_TRAIT(src, TRAIT_KNOCKEDOUT) || (check_death_method() && getOxyLoss() > 50) || HAS_TRAIT(src, TRAIT_FAKEDEATH) || health < HEALTH_THRESHOLD_KNOCKOUT && check_death_method())
 			if(stat == CONSCIOUS)
 				KnockOut()
 				create_debug_log("fell unconscious, trigger reason: [reason]")
+		else if (health < HEALTH_THRESHOLD_CRIT && check_death_method())
+			KnockDown(3 SECONDS)
 		else
 			if(stat == UNCONSCIOUS)
 				WakeUp()

--- a/code/modules/mob/living/carbon/carbon_update_status.dm
+++ b/code/modules/mob/living/carbon/carbon_update_status.dm
@@ -10,7 +10,7 @@
 			if(stat == CONSCIOUS)
 				KnockOut()
 				create_debug_log("fell unconscious, trigger reason: [reason]")
-		else if (health < HEALTH_THRESHOLD_CRIT && check_death_method())
+		else if(health < HEALTH_THRESHOLD_CRIT && check_death_method())
 			KnockDown(3 SECONDS)
 		else
 			if(stat == UNCONSCIOUS)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
This PR adds an in-between phase for species that use oldcrit, where from 0 to -50 HP, they'll be in a forced knockdown state instead of immediately going unconscious. This affects IPCs, Abductors, Golems, Skeletons, and Shadows.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Oldcrit has not been touched since crawling was added, and I feel like it is a worthwhile change. The game is much more forgiving than it used to be, so I think this change lines up with these new game design decisions.

The major pushback that I can see is that that this is a major buff to IPCs and abductors. Abductors are currently getting nerfed, but they're still in a very strong position. IPCs are already quite weak, and they cannot repair themselves without nanopaste if they are floored. 

With these numbers, it would take a maximum of 102 seconds to go from 0 to -51, given that


## Testing
<!-- How did you test the PR, if at all? -->
Attacked myself and others into crit as IPCs, skeletons, and abductor. Also made sure I didn't somehow break normal crit too.
## Changelog
:cl:
tweak: Species that previously died at 0 HP now get knocked down until -51 HP, then they go unconscious.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
