### PR TITLE
Fixes janihud highlight not being very visible sometimes

### DIFF
--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -503,7 +503,7 @@
 	holder.icon_state = "hudjani"
 	holder.alpha = 130
 	holder.plane = ABOVE_LIGHTING_PLANE
-	holder.appearance_flags = RESET_COLOR | RESET_ALPHA
+	holder.appearance_flags = RESET_COLOR | RESET_ALPHA | RESET_TRANSFORM
 
 /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	I'll just put this somewhere near the end...

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -503,6 +503,7 @@
 	holder.icon_state = "hudjani"
 	holder.alpha = 130
 	holder.plane = ABOVE_LIGHTING_PLANE
+	holder.appearance_flags = RESET_COLOR | RESET_ALPHA
 
 /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	I'll just put this somewhere near the end...


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
The janihud highlight low image alpha combined with the slime jelly, that too has a small alpha value, resulted in not so visible sprites.
This PR fixes this by making it reset the image alpha and its color too to prevent cleanables from changing its colors.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Fixes https://github.com/ParadiseSS13/Paradise/issues/23892
## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![lick](https://github.com/ParadiseSS13/Paradise/assets/77684085/25b01ebf-258f-4db5-a3e8-2566b184be59)

## Testing
<!-- How did you test the PR, if at all? -->
- Made both human and slime people to bleed
- Noticed that the slime jelly highlight has the same alpha as common blood
## Changelog
:cl:
fix: Janihud highlight is now more visible on certain kinds of bloods
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
