### PR TITLE
Request Console Unread Messages Reminder

### DIFF
--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -243,7 +243,7 @@ GLOBAL_LIST_EMPTY(allRequestConsoles)
 				else if(recipient in SUPPLY_ROLES)
 					radiochannel = "Supply"
 				message_log.Add(list(list("Message sent to [recipient] at [station_time_timestamp()]", "[message]")))
-				Radio.autosay("Alert; a new requests console message received for [recipient] from [department]", null, "[radiochannel]")
+				Radio.autosay("Alert; a new message has been received from [department]", "[recipient] Requests Console", "[radiochannel]")
 			else
 				atom_say("No server detected!")
 

--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -260,7 +260,7 @@ GLOBAL_LIST_EMPTY(allRequestConsoles)
 						Console.newmessagepriority = RQ_NONEW_MESSAGES
 						Console.update_icon(UPDATE_OVERLAYS)
 						Console.set_light(1)
-						if (reminder_timer_id != TIMER_ID_NULL)
+						if(reminder_timer_id != TIMER_ID_NULL)
 							deltimer(reminder_timer_id)
 							reminder_timer_id = TIMER_ID_NULL
 			if(tempScreen == RCS_MAINMENU)
@@ -363,7 +363,7 @@ GLOBAL_LIST_EMPTY(allRequestConsoles)
 	set_light(2)
 
 /obj/machinery/requests_console/proc/remind_unread_messages()
-	if (newmessagepriority == RQ_NONEW_MESSAGES)
+	if(newmessagepriority == RQ_NONEW_MESSAGES)
 		deltimer(reminder_timer_id)
 		reminder_timer_id = TIMER_ID_NULL
 		return

--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -352,7 +352,7 @@ GLOBAL_LIST_EMPTY(allRequestConsoles)
 	if(!silent)
 		playsound(loc, 'sound/machines/twobeep.ogg', 50, TRUE)
 		atom_say(title)
-		if (reminder_timer_id == TIMER_ID_NULL)
+		if(reminder_timer_id == TIMER_ID_NULL)
 			reminder_timer_id = addtimer(CALLBACK(src, PROC_REF(remind_unread_messages)), 5 MINUTES, TIMER_STOPPABLE | TIMER_LOOP)
 
 	switch(priority)

--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -332,15 +332,16 @@ GLOBAL_LIST_EMPTY(allRequestConsoles)
 	if(mainmenu)
 		screen = RCS_MAINMENU
 
-/obj/machinery/requests_console/proc/createMessage(source, title, message, priority)
+/obj/machinery/requests_console/proc/createMessage(source, title, message, priority, forced = FALSE)
 	var/linkedSender
+	if(inoperable() && !forced)
+		message_log.Add(list(list("Message lost due to console failure. Please contact [station_name()]'s system administrator or AI for technical assistance.")))
+		return
 	if(istype(source, /obj/machinery/requests_console))
 		var/obj/machinery/requests_console/sender = source
 		linkedSender = sender.department
 	else
-		capitalize(source)
 		linkedSender = source
-	capitalize(title)
 	if(newmessagepriority < priority)
 		newmessagepriority = priority
 		update_icon(UPDATE_ICON_STATE | UPDATE_OVERLAYS)
@@ -350,9 +351,9 @@ GLOBAL_LIST_EMPTY(allRequestConsoles)
 
 	switch(priority)
 		if(RQ_HIGHPRIORITY) // High
-			message_log.Add(list(list("High Priority - From: [linkedSender]") + message)) // List in a list for passing into TGUI
+			message_log.Add(list(list("High Priority - From: [linkedSender]", message))) // List in a list for passing into TGUI
 		else // Normal
-			message_log.Add(list(list("From: [linkedSender]") + message)) // List in a list for passing into TGUI
+			message_log.Add(list(list("From: [linkedSender]", message))) // List in a list for passing into TGUI
 	set_light(2)
 
 /obj/machinery/requests_console/proc/print_label(tag_name, tag_index)

--- a/code/modules/research/message_server.dm
+++ b/code/modules/research/message_server.dm
@@ -92,24 +92,13 @@ GLOBAL_LIST_EMPTY(message_servers)
 	for(var/C in GLOB.allRequestConsoles)
 		var/obj/machinery/requests_console/RC = C
 		if(ckey(RC.department) == ckey(recipient))
-			if(RC.inoperable())
-				RC.message_log.Add(list(list("Message lost due to console failure. Please contact [station_name()]'s system administrator or AI for technical assistance.")))
-				continue
-			if(RC.newmessagepriority < priority)
-				RC.newmessagepriority = priority
-				RC.update_icon(UPDATE_OVERLAYS)
+			var/title
 			switch(priority)
 				if(2)
-					if(!RC.silent)
-						playsound(RC.loc, 'sound/machines/twobeep.ogg', 50, 1)
-						RC.atom_say("PRIORITY Alert in [sender]")
-					RC.message_log.Add(list(list("High Priority message from [sender]:", "[authmsg]")))
+					title = "PRIORITY Alert in [sender]"
 				else
-					if(!RC.silent)
-						playsound(RC.loc, 'sound/machines/twobeep.ogg', 50, 1)
-						RC.atom_say("Message from [sender]")
-					RC.message_log.Add(list(list("Message [sender]:", "[authmsg]")))
-			RC.set_light(2)
+					title = "Message from [sender]"
+			RC.createMessage(sender, title, authmsg, priority)
 
 /obj/machinery/message_server/attack_hand(user as mob)
 	to_chat(user, "You toggle PDA message passing from [active ? "On" : "Off"] to [active ? "Off" : "On"]")


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
- Added a sender(instead of leaving it blank) to the radio notification for a new message
- Changed the radio notification for a new message to better align with above changes
- Merges the code for sending messages to requests consoles present in messaging server into request consoles' `createMessage` proc
- Added a reminder for unread messages which triggers every 5 minutes
- Changes request consoles so that they no longer process messages(unless forced) when they are inoperable. Affected machinery include but are not limited to, ore redemption machines, mail crate shuttles, and MULE bots

Note: I am aware that ORMs send messages which may not necessarily be considered important enough to have a reminder. I've decided to keep that out for now and fix it in a separate PR because adding a new "low" priority requires changing defines and adding a new sprite
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
- Request consoles' radio notifications should be consistent with other machines, such as cloning pods, which broadcast information over radio
- Having reminders makes request console messages less likely to be ignored or forgotten
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
| | Image |
|-|-|
| Current | ![Sender empty](https://github.com/ParadiseSS13/Paradise/assets/41360489/d91e3981-9e69-4a64-b94d-dd2b39782028) |
| New | ![Sender is not empty](https://github.com/ParadiseSS13/Paradise/assets/41360489/dc7409ac-d384-4696-8a87-b7490fe7f079) |

---

Note: the reminder interval is 15 seconds in the video for demonstration purposes

https://github.com/ParadiseSS13/Paradise/assets/41360489/3af36a96-06a0-4e4a-9c8c-310ead1c693f
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Sent a message through a request console and checked that:
- the radio message has a sender
- a reminder for unread messages triggers
<!-- How did you test the PR, if at all? -->

## Changelog
:cl: cdui
add: request consoles reminder(runetext and proximity) for unread messages
tweak: request consoles' radio notifications are now sent by "<Origin> Request Console" instead of blank
tweak: request consoles no longer receive messages from ore redemption machines or crate delivery shuttles when they are inoperable
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
