### PR TITLE
Removes the random chance that a detomatix cartridge will backfire

### DIFF
--- a/code/datums/uplink_items/uplink_traitor.dm
+++ b/code/datums/uplink_items/uplink_traitor.dm
@@ -673,7 +673,7 @@
 
 /datum/uplink_item/explosives/detomatix
 	name = "Detomatix PDA Cartridge"
-	desc = "When inserted into a personal digital assistant, this cartridge gives you five opportunities to detonate PDAs of crewmembers who have their message feature enabled. The concussive effect from the explosion will knock the recipient out for a short period, and deafen them for longer. It has a chance to detonate your PDA."
+	desc = "When inserted into a personal digital assistant, this cartridge gives you five opportunities to detonate PDAs of crewmembers who have their message feature enabled. The concussive effect from the explosion will knock the recipient out for a short period, and deafen them for longer."
 	reference = "DEPC"
 	item = /obj/item/cartridge/syndicate
 	cost = 30

--- a/code/modules/pda/messenger_plugins.dm
+++ b/code/modules/pda/messenger_plugins.dm
@@ -42,7 +42,7 @@
 	name = "*Detonate*"
 	icon = "exclamation-circle"
 
-/datum/data/pda/messenger_plugin/virus/detonate/user_act(mob/user as mob, obj/item/pda/P)
+/datum/data/pda/messenger_plugin/virus/detonate/user_act(mob/user, obj/item/pda/P)
 	. = ..(user, P)
 	if(.)
 		if(!P.detonate || P.hidden_uplink)

--- a/code/modules/pda/messenger_plugins.dm
+++ b/code/modules/pda/messenger_plugins.dm
@@ -45,28 +45,13 @@
 /datum/data/pda/messenger_plugin/virus/detonate/user_act(mob/user as mob, obj/item/pda/P)
 	. = ..(user, P)
 	if(.)
-		var/difficulty = 0
-
-		if(pda.cartridge)
-			difficulty += pda.cartridge.programs.len / 2
-		else
-			difficulty += 2
-
 		if(!P.detonate || P.hidden_uplink)
 			user.show_message("<span class='warning'>The target PDA does not seem to respond to the detonation command.</span>", 1)
 			pda.cartridge.charges++
-		else if(prob(difficulty * 12))
-			user.show_message("<span class='warning'>An error flashes on your [pda].</span>", 1)
-		else if(prob(difficulty * 3))
-			user.show_message("<span class='danger'>Energy feeds back into your [pda]!</span>", 1)
-			pda.close(user)
-			pda.explode()
-			log_admin("[key_name(user)] just attempted to blow up [P] with the Detomatix cartridge but failed, blowing themselves up")
-			message_admins("[key_name_admin(user)] just attempted to blow up [P] with the Detomatix cartridge but failed, blowing themselves up", 1)
 		else
 			user.show_message("<span class='notice'>Success!</span>", 1)
-			log_admin("[key_name(user)] just attempted to blow up [P] with the Detomatix cartridge and succeeded")
-			message_admins("[key_name_admin(user)] just attempted to blow up [P] with the Detomatix cartridge and succeeded", 1)
+			log_admin("[key_name(user)] just blew up [P] with the Detomatix cartridge")
+			message_admins("[key_name_admin(user)] just blew up [P] with the Detomatix cartridge", 1)
 			P.explode()
 
 /datum/data/pda/messenger_plugin/virus/frame

--- a/code/modules/pda/messenger_plugins.dm
+++ b/code/modules/pda/messenger_plugins.dm
@@ -42,17 +42,17 @@
 	name = "*Detonate*"
 	icon = "exclamation-circle"
 
-/datum/data/pda/messenger_plugin/virus/detonate/user_act(mob/user, obj/item/pda/P)
-	. = ..(user, P)
+/datum/data/pda/messenger_plugin/virus/detonate/user_act(mob/user, obj/item/pda/pda_to_detonate)
+	. = ..()
 	if(.)
-		if(!P.detonate || P.hidden_uplink)
+		if(!pda_to_detonate.detonate || pda_to_detonate.hidden_uplink)
 			user.show_message("<span class='warning'>The target PDA does not seem to respond to the detonation command.</span>", 1)
 			pda.cartridge.charges++
 		else
 			user.show_message("<span class='notice'>Success!</span>", 1)
-			log_admin("[key_name(user)] just blew up [P] with the Detomatix cartridge")
-			message_admins("[key_name_admin(user)] just blew up [P] with the Detomatix cartridge", 1)
-			P.explode()
+			log_admin("[key_name(user)] just blew up [pda_to_detonate] with the Detomatix cartridge")
+			message_admins("[key_name_admin(user)] just blew up [pda_to_detonate] with the Detomatix cartridge", 1)
+			pda_to_detonate.explode()
 
 /datum/data/pda/messenger_plugin/virus/frame
 	icon = "exclamation-circle"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Removes the random chance that a PDA bomb will backfire on you.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
The original idea I assume is to make it slightly harder to bomb the heads of staff, but considering that you pay **30 TC** for the cartridge (On par with a MODsuit, the contortionist jumpsuit and pickpocket gloves for example), it doesn't seem like something you'd restrict, especially as it removes your PDA and uplink, costing you up to 100 TC in total.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
It compiled, I'm in the process of blowing many skrell up
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: The PDA bomb cartridge can now no longer backfire
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
