### PR TITLE
remove unused language defines

### DIFF
--- a/code/__DEFINES/language_defines.dm
+++ b/code/__DEFINES/language_defines.dm
@@ -1,13 +1,3 @@
-//Languages!
-#define LANGUAGE_HUMAN		1
-#define LANGUAGE_ALIEN		2
-#define LANGUAGE_DOG		4
-#define LANGUAGE_CAT		8
-#define LANGUAGE_BINARY		16
-#define LANGUAGE_OTHER		32768
-
-#define LANGUAGE_UNIVERSAL	65535
-
 //Language flags.
 #define WHITELISTED 1  		// Language is available if the speaker is whitelisted.
 #define RESTRICTED 2   		// Language can only be accquired by spawning or an admin.


### PR DESCRIPTION
## What Does This PR Do
This PR removes several unused `#defines` used in earlier versions of language code.
## Why It's Good For The Game
Deadcode bad.
## Testing
Searched the codebase, prayed for successful CI.
## Changelog
NPFC