### PR TITLE
[s] The PR I just made about fixing an IPC revival exploit but this time I'm on the right branch

### DIFF
--- a/code/modules/mob/living/carbon/human/human_update_status.dm
+++ b/code/modules/mob/living/carbon/human/human_update_status.dm
@@ -6,7 +6,7 @@
 		if(dna.species && dna.species.can_revive_by_healing)
 			var/obj/item/organ/internal/brain/B = get_int_organ(/obj/item/organ/internal/brain)
 			if(B)
-				if((health >= (HEALTH_THRESHOLD_DEAD + HEALTH_THRESHOLD_CRIT) * 0.5) && getBrainLoss() < 120 && !suiciding)
+				if((health >= (HEALTH_THRESHOLD_DEAD + HEALTH_THRESHOLD_CRIT) * 0.5) && check_vital_organs() && !suiciding)
 					update_revive()
 					create_debug_log("revived from healing, trigger reason: [reason]")
 

--- a/code/modules/surgery/organs/organ_helpers.dm
+++ b/code/modules/surgery/organs/organ_helpers.dm
@@ -107,4 +107,9 @@
 			.++
 		if(affecting.body_part == LEG_LEFT)
 			.++
-
+///Returns true if all the mob's vital organs are functional, otherwise returns false
+/mob/living/carbon/human/proc/check_vital_organs()
+	for(var/obj/item/organ/internal/organ in internal_organs)
+		if(organ.vital && (organ.damage == organ.max_damage))
+			return FALSE
+	return TRUE

--- a/code/modules/surgery/organs/organ_helpers.dm
+++ b/code/modules/surgery/organs/organ_helpers.dm
@@ -110,6 +110,6 @@
 ///Returns true if all the mob's vital organs are functional, otherwise returns false
 /mob/living/carbon/human/proc/check_vital_organs()
 	for(var/obj/item/organ/internal/organ in internal_organs)
-		if(organ.vital && (organ.damage == organ.max_damage))
+		if(organ.vital && (organ.damage >= organ.max_damage))
 			return FALSE
 	return TRUE


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Currently, if an IPC dies from a damaged microbattery and they attempt to re-enter their corpse they'll pop right back up until the heart takes damage again and realizes it's not supposed to work. This fixes that by adding a proc for checking if all vital organs are working.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
People should die when they are killed
## Testing
<!-- How did you test the PR, if at all? -->
Starved to death then tried to re-enter corpse, also made sure the check for brain damage didn't break either
## Changelog
:cl:
fix: IPCs that die from a damaged battery have to get it repaired before living
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
