### PR TITLE
add ci check for toplevel vardecls

### DIFF
--- a/tools/ci/check_grep2.py
+++ b/tools/ci/check_grep2.py
@@ -83,6 +83,13 @@ def check_global_vars(lines):
             return Failure(idx + 1, "Unmanaged global var use detected in code, please use the helpers.")
 
 
+TOPLEVEL_VARDECLS_RE = re.compile(r"^(/[^\*(\/\/)].*/var/(list/)?\w+)")
+def check_toplevel_vardecls(lines):
+    for idx, line in enumerate(lines):
+        if match := TOPLEVEL_VARDECLS_RE.match(line):
+            return Failure(idx + 1, f"Top-level var {match.group(0)} found, please move to type declaration.")
+
+
 PROC_ARGS_WITH_VAR_PREFIX_RE = re.compile(r"^/[\w/]\S+\(.*(var/|, ?var/.*).*\)")
 def check_proc_args_with_var_prefix(lines):
     for idx, line in enumerate(lines):
@@ -136,6 +143,7 @@ CODE_CHECKS = [
     check_mixed_indentation,
     check_trailing_newlines,
     check_global_vars,
+    check_toplevel_vardecls,
     check_proc_args_with_var_prefix,
     check_for_nanotrasen_camel_case,
     check_to_chats_have_a_user_arguement,


### PR DESCRIPTION
## What Does This PR Do
This PR adds a CI check for toplevel vardecls. This is only the check, it will fail CI until the burndown list is complete.
## Why It's Good For The Game
As GDN said, navigation to types is possible and simple, there's no reason to scatter these around their related functionality.
## Testing
Ran CI.
## Changelog
NPFC.