### PR TITLE
Fixes reverse lighting

### DIFF
--- a/code/modules/power/lights.dm
+++ b/code/modules/power/lights.dm
@@ -478,9 +478,13 @@
 		if(spraycan.capped)
 			to_chat(user, "<span class='notice'>You can't spraypaint [src] with the cap still on!</span>")
 			return
-		color = spraycan.colour
+		var/list/hsl = rgb2hsl(hex2num(copytext(spraycan.colour, 2, 4)), hex2num(copytext(spraycan.colour, 4, 6)), hex2num(copytext(spraycan.colour, 6, 8)))
+		hsl[3] = max(hsl[3], 0.4)
+		var/list/rgb = hsl2rgb(arglist(hsl))
+		var/new_color = "#[num2hex(rgb[1], 2)][num2hex(rgb[2], 2)][num2hex(rgb[3], 2)]"
+		color = new_color
 		to_chat(user, "<span class='notice'>You change [src]'s light bulb color.</span>")
-		brightness_color = spraycan.colour
+		brightness_color = new_color
 		update(TRUE, TRUE, FALSE)
 		return
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes people being able to create lights with negative light

## Why It's Good For The Game
Ideally the station shouldn't be this fucking dark
![we're 100% black](https://github.com/ParadiseSS13/Paradise/assets/96800819/26703b04-71ce-4b2a-b975-e0869c646e03)

## Testing
Sprayed the lights on the arrival shuttle

## Changelog
:cl:
fix: Fixed being able to give lights no luminosity 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
