### PR TITLE
fix lightswitch emissives

### DIFF
--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -25,7 +25,7 @@
 			pixel_x = -25
 			dir = WEST
 
-	update_icon(UPDATE_ICON_STATE)
+	update_icon(UPDATE_ICON_STATE|UPDATE_OVERLAYS)
 
 /obj/machinery/light_switch/update_icon_state()
 	if(stat & NOPOWER)
@@ -40,6 +40,7 @@
 	if(stat & NOPOWER)
 		return
 
+	. += "light[get_area(src).lightswitch]"
 	underlays += emissive_appearance(icon, "light_lightmask")
 
 /obj/machinery/light_switch/examine(mob/user)
@@ -52,7 +53,7 @@
 
 /obj/machinery/light_switch/attack_hand(mob/user)
 	playsound(src, 'sound/machines/lightswitch.ogg', 10, TRUE)
-	update_icon(UPDATE_ICON_STATE)
+	update_icon(UPDATE_ICON_STATE|UPDATE_OVERLAYS)
 
 	var/area/A = get_area(src)
 
@@ -60,7 +61,7 @@
 	A.update_icon(UPDATE_ICON_STATE)
 
 	for(var/obj/machinery/light_switch/L in A)
-		L.update_icon(UPDATE_ICON_STATE)
+		L.update_icon(UPDATE_ICON_STATE|UPDATE_OVERLAYS)
 
 	machine_powernet.power_change()
 
@@ -70,7 +71,7 @@
 	if(stat & NOPOWER)
 		set_light(0)
 	else
-		set_light(1, LIGHTING_MINIMUM_POWER)
+		set_light(1, 0.5)
 
 	update_icon(UPDATE_ICON_STATE|UPDATE_OVERLAYS)
 


### PR DESCRIPTION
## What Does This PR Do
This PR fixes emissive underlays for light switches. Also increases the light power amount to make them stand out a bit more.
## Why It's Good For The Game
These should have been showing up, more glowing things are better.
## Images of changes
### Before
![2024_01_25__21_44_24__Paradise Station 13](https://github.com/ParadiseSS13/Paradise/assets/59303604/4a4082ab-d7b8-4542-bce8-5ddbe0dbc97b)
![2024_01_25__21_44_30__Paradise Station 13](https://github.com/ParadiseSS13/Paradise/assets/59303604/fe585d5d-5910-4d1b-9a7b-4b80c71b1d69)

### After
![2024_01_25__21_41_17__Paradise Station 13](https://github.com/ParadiseSS13/Paradise/assets/59303604/1fea4303-bf2b-49f9-bb32-9bc5e61040aa)
![2024_01_25__21_41_22__Paradise Station 13](https://github.com/ParadiseSS13/Paradise/assets/59303604/9aa1407c-45df-42b9-a785-5986ea062766)

## Testing
Spawned in, toggled light switch, turned off power at APC to make sure it didn't show up with no power.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Light switches now properly glow.
/:cl:
