### PR TITLE
protect syndie depot interior from radstorms

### DIFF
--- a/code/datums/weather/weather_types/radiation_storm.dm
+++ b/code/datums/weather/weather_types/radiation_storm.dm
@@ -27,6 +27,7 @@
 		/area/station/security/brig,
 		/area/shuttle,
 		/area/survivalpod, //although survivalpods are off-station, creating one on station no longer protects pods on station from the rad storm
+		/area/syndicate_depot/core, // exterior of depot still dangerous, gotta be inside
 		/area/ruin, //Let us not completely kill space explorers.
 		/area/station/command/server
 	)


### PR DESCRIPTION
## What Does This PR Do
This PR adds the syndie depot interior to areas excluded from radstorms. Fixes #23895.
## Why It's Good For The Game
All other space ruins are protected from radstorms, this one should be too.
## Images of changes
![2024_01_26__00_12_01__Paradise Station 13](https://github.com/ParadiseSS13/Paradise/assets/59303604/c11ff824-7240-4cfe-89a2-36a7a25c695a)
## Testing
Spawned in, caused radstorm, checked inside and outside of depot.
## Changelog
:cl:
fix: The interior of the Syndicate depot is now protected from radstorms.
/:cl:
