### PR TITLE
shock biochip nerfs

### DIFF
--- a/code/_onclick/click_override.dm
+++ b/code/_onclick/click_override.dm
@@ -71,7 +71,7 @@
 	var/atom/beam_from = user
 	var/atom/target_atom = A
 
-	for(var/i in 0 to 3)
+	for(var/i in 0 to 2)
 		beam_from.Beam(target_atom, icon_state = "lightning[rand(1, 12)]", icon = 'icons/effects/effects.dmi', time = 6)
 		if(isliving(target_atom))
 			var/mob/living/L = target_atom
@@ -81,7 +81,12 @@
 				L.adjustStaminaLoss(60)
 				L.Jitter(10 SECONDS)
 				var/atom/throw_target = get_edge_target_turf(user, get_dir(user, get_step_away(L, user)))
-				L.throw_at(throw_target, powergrid / 100000, powergrid / 100000) //100 kW in grid throws 1 tile, 200 throws 2, etc.
+				if(ishuman(L))
+					var/mob/living/carbon/human/H = L
+					if(H.gloves && H.gloves.siemens_coefficient == 0) //No throwing with insulated gloves (you still get stamina however)
+						break
+				L.throw_at(throw_target, powergrid / 150000, powergrid / 300000) //150 kW in grid throws 1 tile, 300 throws 2, etc.
+
 			else
 				add_attack_logs(user, L, "electrocuted with[P.unlimited_power ? " unlimited" : null] power bio-chip")
 				if(P.unlimited_power)
@@ -90,13 +95,13 @@
 					electrocute_mob(L, C.powernet, P)
 			break
 		var/list/next_shocked = list()
-		for(var/mob/M in range(3, target_atom)) //Try to jump to a mob first
+		for(var/mob/M in range(1, target_atom)) //Try to jump to a mob first
 			if(M == user || isobserver(M))
 				continue
 			next_shocked.Add(M)
 			break //Break this so it gets the closest, thank you
 		if(!length(next_shocked)) //No mob? Random bullshit go, try to get closer to a mob with luck
-			for(var/atom/movable/AM in orange(3, target_atom))
+			for(var/atom/movable/AM in orange(1, target_atom))
 				if(AM == user || iseffect(AM) || isobserver(AM))
 					continue
 				next_shocked.Add(AM)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Shock biochip autodetection heavily tuned down
Now: 100% chance to hit if you click on their tile, or a tile adjacent, 33% chance from 2 tiles away, 0% otherwise.
Insulated gloves block the throw (not the stamina damage) of disarm intent.
Disarm intent scaling of throw distance and speed increased from 100kw per tile 100kw per speed, to 150kw and 300kw.


## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Autotarget was far too reliable, and needed a tune down
Lets security counter the throw slam into walls of the shock  chip better, as well as making it less brutal overall.

## Testing
<!-- How did you test the PR, if at all? -->
Shocked a bunch of skrell, with / without gloves

## Changelog
:cl:
tweak: Shock implants autotargeting tuned down heavily.
tweak: Shock implants disarm throw speed tuned down.
tweak: Insulated gloves block the throw of disarm intent from shock implants, but not the stamina now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
