### PR TITLE
add condiments to reagent updatepaths script

### DIFF
--- a/tools/UpdatePaths/Scripts/23379_food_containers.txt
+++ b/tools/UpdatePaths/Scripts/23379_food_containers.txt
@@ -1,2 +1,3 @@
+/obj/item/reagent_containers/food/condiment/@SUBTYPES : /obj/item/reagent_containers/condiment/@SUBTYPES{@OLD}
 /obj/item/reagent_containers/food/drinks/@SUBTYPES : /obj/item/reagent_containers/drinks/@SUBTYPES{@OLD}
 /obj/item/reagent_containers/food/@SUBTYPES : /obj/item/food/@SUBTYPES{@OLD}


### PR DESCRIPTION
## What Does This PR Do
This PR adds an extra modifier to the reagent UpdatePaths script to mutate condiment paths separately.
## Why It's Good For The Game
Without this, map-related PRs might break unexpectedly when merging to master.
## Testing
Checkout out master so I had the migrated paths from #23379, checked out all the maps to the PR immediately before #23379, ran the new UpdatePaths script and compiled.
## Changelog
NPFC