### PR TITLE
Add Cranial Hypertrichosis (Hair Grow Symptom)

### DIFF
--- a/code/datums/diseases/advance/symptoms/hair.dm
+++ b/code/datums/diseases/advance/symptoms/hair.dm
@@ -29,7 +29,7 @@ BONUS
 		if(!ishuman(A.affected_mob))
 			return
 		var/mob/living/carbon/human/H = A.affected_mob
-		if (H.dna.species.bodyflags & BALD)
+		if(H.dna.species.bodyflags & BALD)
 			return
 		var/obj/item/organ/external/head/head_organ = H.get_organ("head")
 		if(!istype(head_organ))

--- a/code/datums/diseases/advance/symptoms/hair.dm
+++ b/code/datums/diseases/advance/symptoms/hair.dm
@@ -46,4 +46,4 @@ BONUS
 					head_organ.h_style = "Very Long Hair"
 				else //Otherwise, give them a random hair style.
 					head_organ.h_style = random_hair_style(H.gender, head_organ.dna.species.name)
-			H.update_hair()
+		H.update_hair()

--- a/code/datums/diseases/advance/symptoms/hair.dm
+++ b/code/datums/diseases/advance/symptoms/hair.dm
@@ -33,7 +33,7 @@ BONUS
 		if(!istype(head_organ))
 			return
 		switch(A.stage)
-			if(1, 3)
+			if(1, 2, 3)
 				to_chat(H, "<span class='warning'>Your scalp itches.</span>")
 				head_organ.h_style = random_hair_style(H.gender, head_organ.dna.species.name)
 			else

--- a/code/datums/diseases/advance/symptoms/hair.dm
+++ b/code/datums/diseases/advance/symptoms/hair.dm
@@ -2,7 +2,7 @@
 //////////////////////////////////////
 Cranial Hypertrichosis
 
-	Very very Noticable.
+	Very very Noticeable.
 	Decreases resistance slightly.
 	Decreases stage speed.
 	Reduced transmittability
@@ -26,10 +26,9 @@ BONUS
 /datum/symptom/hair/Activate(datum/disease/advance/A)
 	..()
 	if(prob(SYMPTOM_ACTIVATION_PROB))
-		var/mob/living/M = A.affected_mob
-		if(!ishuman(M))
+		if(!ishuman(A.affected_mob))
 			return
-		var/mob/living/carbon/human/H = M
+		var/mob/living/carbon/human/H = A.affected_mob
 		var/obj/item/organ/external/head/head_organ = H.get_organ("head")
 		if(!istype(head_organ))
 			return
@@ -37,7 +36,6 @@ BONUS
 			if(1, 3)
 				to_chat(H, "<span class='warning'>Your scalp itches.</span>")
 				head_organ.h_style = random_hair_style(H.gender, head_organ.dna.species.name)
-				H.update_hair()
 			else
 				to_chat(H, "<span class='warning'>Hair bursts forth from your scalp!</span>")
 				var/datum/sprite_accessory/tmp_hair_style = GLOB.hair_styles_full_list["Very Long Hair"]
@@ -46,4 +44,4 @@ BONUS
 					head_organ.h_style = "Very Long Hair"
 				else //Otherwise, give them a random hair style.
 					head_organ.h_style = random_hair_style(H.gender, head_organ.dna.species.name)
-				H.update_hair()
+		H.update_hair()

--- a/code/datums/diseases/advance/symptoms/hair.dm
+++ b/code/datums/diseases/advance/symptoms/hair.dm
@@ -1,0 +1,50 @@
+/*
+//////////////////////////////////////
+Cranial Hypertrichosis
+
+	Very very Noticable.
+	Decreases resistance slightly.
+	Decreases stage speed.
+	Reduced transmittability
+	Intense Level.
+
+BONUS
+	Makes the mob grow massive hair, regardless of gender.
+
+//////////////////////////////////////
+*/
+
+/datum/symptom/hair
+
+	name = "Cranial Hypertrichosis"
+	stealth = -3
+	resistance = -1
+	stage_speed = -3
+	transmittable = -1
+	level = 4
+	severity = 1
+
+/datum/symptom/hair/Activate(datum/disease/advance/A)
+	..()
+	if(prob(SYMPTOM_ACTIVATION_PROB))
+		var/mob/living/M = A.affected_mob
+		if(ishuman(M))
+			var/mob/living/carbon/human/H = M
+			var/obj/item/organ/external/head/head_organ = H.get_organ("head")
+			if(!istype(head_organ))
+				return
+			switch(A.stage)
+				if(1, 3)
+					to_chat(H, "<span class='warning'>Your scalp itches.</span>")
+					head_organ.h_style = random_hair_style(H.gender, head_organ.dna.species.name)
+					H.update_hair()
+				else
+					to_chat(H, "<span class='warning'>Hair bursts forth from your scalp!</span>")
+					var/datum/sprite_accessory/tmp_hair_style = GLOB.hair_styles_full_list["Very Long Hair"]
+
+					if(head_organ.dna.species.name in tmp_hair_style.species_allowed) //If 'Very Long Hair' is a style the person's species can have, give it to them.
+						head_organ.h_style = "Very Long Hair"
+					else //Otherwise, give them a random hair style.
+						head_organ.h_style = random_hair_style(H.gender, head_organ.dna.species.name)
+					H.update_hair()
+	return

--- a/code/datums/diseases/advance/symptoms/hair.dm
+++ b/code/datums/diseases/advance/symptoms/hair.dm
@@ -15,7 +15,6 @@ BONUS
 */
 
 /datum/symptom/hair
-
 	name = "Cranial Hypertrichosis"
 	stealth = -3
 	resistance = -1
@@ -47,4 +46,3 @@ BONUS
 					else //Otherwise, give them a random hair style.
 						head_organ.h_style = random_hair_style(H.gender, head_organ.dna.species.name)
 					H.update_hair()
-	return

--- a/code/datums/diseases/advance/symptoms/hair.dm
+++ b/code/datums/diseases/advance/symptoms/hair.dm
@@ -27,22 +27,23 @@ BONUS
 	..()
 	if(prob(SYMPTOM_ACTIVATION_PROB))
 		var/mob/living/M = A.affected_mob
-		if(ishuman(M))
-			var/mob/living/carbon/human/H = M
-			var/obj/item/organ/external/head/head_organ = H.get_organ("head")
-			if(!istype(head_organ))
-				return
-			switch(A.stage)
-				if(1, 3)
-					to_chat(H, "<span class='warning'>Your scalp itches.</span>")
-					head_organ.h_style = random_hair_style(H.gender, head_organ.dna.species.name)
-					H.update_hair()
-				else
-					to_chat(H, "<span class='warning'>Hair bursts forth from your scalp!</span>")
-					var/datum/sprite_accessory/tmp_hair_style = GLOB.hair_styles_full_list["Very Long Hair"]
+		if(!ishuman(M))
+			return
+		var/mob/living/carbon/human/H = M
+		var/obj/item/organ/external/head/head_organ = H.get_organ("head")
+		if(!istype(head_organ))
+			return
+		switch(A.stage)
+			if(1, 3)
+				to_chat(H, "<span class='warning'>Your scalp itches.</span>")
+				head_organ.h_style = random_hair_style(H.gender, head_organ.dna.species.name)
+				H.update_hair()
+			else
+				to_chat(H, "<span class='warning'>Hair bursts forth from your scalp!</span>")
+				var/datum/sprite_accessory/tmp_hair_style = GLOB.hair_styles_full_list["Very Long Hair"]
 
-					if(head_organ.dna.species.name in tmp_hair_style.species_allowed) //If 'Very Long Hair' is a style the person's species can have, give it to them.
-						head_organ.h_style = "Very Long Hair"
-					else //Otherwise, give them a random hair style.
-						head_organ.h_style = random_hair_style(H.gender, head_organ.dna.species.name)
-					H.update_hair()
+				if(head_organ.dna.species.name in tmp_hair_style.species_allowed) //If 'Very Long Hair' is a style the person's species can have, give it to them.
+					head_organ.h_style = "Very Long Hair"
+				else //Otherwise, give them a random hair style.
+					head_organ.h_style = random_hair_style(H.gender, head_organ.dna.species.name)
+				H.update_hair()

--- a/code/datums/diseases/advance/symptoms/hair.dm
+++ b/code/datums/diseases/advance/symptoms/hair.dm
@@ -44,4 +44,4 @@ BONUS
 					head_organ.h_style = "Very Long Hair"
 				else //Otherwise, give them a random hair style.
 					head_organ.h_style = random_hair_style(H.gender, head_organ.dna.species.name)
-		H.update_hair()
+			H.update_hair()

--- a/code/datums/diseases/advance/symptoms/hair.dm
+++ b/code/datums/diseases/advance/symptoms/hair.dm
@@ -29,6 +29,8 @@ BONUS
 		if(!ishuman(A.affected_mob))
 			return
 		var/mob/living/carbon/human/H = A.affected_mob
+		if (H.dna.species.bodyflags & BALD)
+			return
 		var/obj/item/organ/external/head/head_organ = H.get_organ("head")
 		if(!istype(head_organ))
 			return

--- a/paradise.dme
+++ b/paradise.dme
@@ -443,6 +443,7 @@
 #include "code\datums\diseases\advance\symptoms\fever.dm"
 #include "code\datums\diseases\advance\symptoms\fire.dm"
 #include "code\datums\diseases\advance\symptoms\flesh_eating.dm"
+#include "code\datums\diseases\advance\symptoms\hair.dm"
 #include "code\datums\diseases\advance\symptoms\hallucigen.dm"
 #include "code\datums\diseases\advance\symptoms\headache.dm"
 #include "code\datums\diseases\advance\symptoms\heal.dm"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds a "Cranial Hypertrichosis" symptom which behaves like hairgrownium in stage 1-3, and like super hairgrownium in stage 4-5. This symptom complements the symptom "Facial Hypertrichosis"
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Completes the hair symptom trio: Alopecia, Facial Hypertrichosis, and Cranial Hypertrichosis.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Infected the player with a virus containing Cranial Hypertrichosis and checked that the behavior is consistent with Hairgrownium
<!-- How did you test the PR, if at all? -->

## Changelog
:cl: cdui
add: Cranial Hypertrichosis symptom for advanced microbes which behaves similarly to Hairgrownium
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
