### PR TITLE
fixes extra lag from the RND console

### DIFF
--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -107,9 +107,8 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			return_name = "Bluespace Mesh"
 		else
 			var/datum/reagent/our_reagent = GLOB.chemical_reagents_list[return_name]
-			if(our_reagent)
-				if(initial(our_reagent.id) == return_name)
-					return_name = initial(our_reagent.name)
+			if(our_reagent && initial(our_reagent.id) == return_name)
+				return_name = initial(our_reagent.name)
 	return capitalize(return_name)
 
 /obj/machinery/computer/rdconsole/proc/SyncRDevices() //Makes sure it is properly sync'ed up with the devices attached to it (if any).

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -95,8 +95,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 		if(initial(tt.id) == ID)
 			return initial(tt.name)
 
-/proc/CallMaterialName(ID)
-	var/return_name = ID
+/proc/CallMaterialName(return_name)
 	switch(return_name)
 		if("plasma")
 			return_name = "Solid Plasma"
@@ -107,10 +106,10 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 		if("bluespace")
 			return_name = "Bluespace Mesh"
 		else
-			for(var/R in subtypesof(/datum/reagent))
-				var/datum/reagent/rt = R
-				if(initial(rt.id) == ID)
-					return_name = initial(rt.name)
+			var/datum/reagent/our_reagent = GLOB.chemical_reagents_list[return_name]
+			if(our_reagent)
+				if(initial(our_reagent.id) == return_name)
+					return_name = initial(our_reagent.name)
 	return capitalize(return_name)
 
 /obj/machinery/computer/rdconsole/proc/SyncRDevices() //Makes sure it is properly sync'ed up with the devices attached to it (if any).


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Optimizes CallMaterialName which is called a lot
BEFORE:
0.00007270315 per call (Roughly 0.21 cycles of overtime when trigger too, that's bad!)
AFTER:
0.00000403225 (No overtime)
18 times more efficient!

## Why It's Good For The Game
lag stupid and bad

## Testing
I profiled it so that should be enough. Just went in game and after putting mats and chems in the machine I viewed the machine after 
## Changelog
NPFC