### PR TITLE
allow mountable machines on asteroid walls

### DIFF
--- a/code/game/objects/items/mountable_frames/mountables.dm
+++ b/code/game/objects/items/mountable_frames/mountables.dm
@@ -1,5 +1,8 @@
 /obj/item/mounted
-	var/list/buildon_types = list(/turf/simulated/wall)
+	var/list/buildon_types = list(
+		/turf/simulated/mineral/ancient,
+		/turf/simulated/wall
+	)
 
 
 /obj/item/mounted/afterattack(atom/A, mob/user, proximity_flag)


### PR DESCRIPTION
## What Does This PR Do
This PR allows mountable items like light frames, light switches, and APCs to be built on asteroid walls such as the ones on Cerestation.
## Why It's Good For The Game
Cere has a lot of rock walls. It'd be nice to be able to build on them without replacing them with walls.
## Images of changes
![2024_01_28__00_01_58__Paradise Station 13](https://github.com/ParadiseSS13/Paradise/assets/59303604/3782f98d-43c3-4c94-a6b7-d33069132e4b)

## Testing
Spawned on Cere, added a bunch of stuff to the wall.
## Changelog
:cl:
add: Wall-mounted items like light frames can now be installed on asteroid walls.
/:cl:
