### PR TITLE
Welding tools can be used to light other people's cigarettes

### DIFF
--- a/code/game/objects/items/tools/welder.dm
+++ b/code/game/objects/items/tools/welder.dm
@@ -146,8 +146,8 @@
 		return
 	remove_fuel(0.5)
 
-/obj/item/weldingtool/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
-	if(istype(M.wear_mask, /obj/item/clothing/mask/cigarette) && user.zone_selected == "mouth" && tool_enabled) // For lighting other people's cigarettes.
+/obj/item/weldingtool/attack(mob/living/carbon/M, mob/living/carbon/user)
+	if(istype(M) && istype(M.wear_mask, /obj/item/clothing/mask/cigarette) && user.zone_selected == "mouth" && tool_enabled) // For lighting other people's cigarettes.
 		var/obj/item/clothing/mask/cigarette/cig = M.wear_mask
 		if(M == user)
 			cig.attackby(src, user)

--- a/code/game/objects/items/tools/welder.dm
+++ b/code/game/objects/items/tools/welder.dm
@@ -147,16 +147,19 @@
 	remove_fuel(0.5)
 
 /obj/item/weldingtool/attack(mob/living/carbon/M, mob/living/carbon/user)
-	if(istype(M) && istype(M.wear_mask, /obj/item/clothing/mask/cigarette) && user.zone_selected == "mouth" && tool_enabled) // For lighting other people's cigarettes.
-		var/obj/item/clothing/mask/cigarette/cig = M.wear_mask
-		if(M == user)
-			cig.attackby(src, user)
-		else
-			cig.light("<span class='notice'>[user] holds out [src] out for [M], and casually lights [cig]. What a badass.</span>")
-			playsound(src, 'sound/items/lighter/light.ogg', 25, TRUE)
-			M.update_inv_wear_mask()
-	else
-		..()
+	// For lighting other people's cigarettes.
+	var/obj/item/clothing/mask/cigarette/cig = M?.wear_mask
+	if(!istype(cig) || user.zone_selected =! "mouth" || !tool_enabled) 
+		return ..()
+
+	if(M == user)
+		cig.attackby(src, user)
+		return
+
+	cig.light("<span class='notice'>[user] holds out [src] out for [M], and casually lights [cig]. What a badass.</span>")
+	playsound(src, 'sound/items/lighter/light.ogg', 25, TRUE)
+	M.update_inv_wear_mask()
+
 
 /obj/item/weldingtool/use_tool(atom/target, user, delay, amount, volume, datum/callback/extra_checks)
 	target.add_overlay(GLOB.welding_sparks)

--- a/code/game/objects/items/tools/welder.dm
+++ b/code/game/objects/items/tools/welder.dm
@@ -149,7 +149,7 @@
 /obj/item/weldingtool/attack(mob/living/carbon/M, mob/living/carbon/user)
 	// For lighting other people's cigarettes.
 	var/obj/item/clothing/mask/cigarette/cig = M?.wear_mask
-	if(!istype(cig) || user.zone_selected =! "mouth" || !tool_enabled) 
+	if(!istype(cig) || user.zone_selected != "mouth" || !tool_enabled) 
 		return ..()
 
 	if(M == user)

--- a/code/game/objects/items/tools/welder.dm
+++ b/code/game/objects/items/tools/welder.dm
@@ -160,7 +160,6 @@
 	playsound(src, 'sound/items/lighter/light.ogg', 25, TRUE)
 	M.update_inv_wear_mask()
 
-
 /obj/item/weldingtool/use_tool(atom/target, user, delay, amount, volume, datum/callback/extra_checks)
 	target.add_overlay(GLOB.welding_sparks)
 	var/did_thing = ..()

--- a/code/game/objects/items/tools/welder.dm
+++ b/code/game/objects/items/tools/welder.dm
@@ -146,6 +146,18 @@
 		return
 	remove_fuel(0.5)
 
+/obj/item/weldingtool/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
+	if(istype(M.wear_mask, /obj/item/clothing/mask/cigarette) && user.zone_selected == "mouth" && tool_enabled) // For lighting other people's cigarettes.
+		var/obj/item/clothing/mask/cigarette/cig = M.wear_mask
+		if(M == user)
+			cig.attackby(src, user)
+		else
+			cig.light("<span class='notice'>[user] holds out [src] out for [M], and casually lights [cig]. What a badass.</span>")
+			playsound(src, 'sound/items/lighter/light.ogg', 25, TRUE)
+			M.update_inv_wear_mask()
+	else
+		..()
+
 /obj/item/weldingtool/use_tool(atom/target, user, delay, amount, volume, datum/callback/extra_checks)
 	target.add_overlay(GLOB.welding_sparks)
 	var/did_thing = ..()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Allows welding tools to light another person's cigarette by targeting the mouth whilst there is an unlit cigarette perched between their lips.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
When someone asks you if you have a light, you can nod with confidence as you pull out your trusty welder like a true badass.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
A number of skrell were given cigarettes. They then lit each other's cigarettes with a welding tool that was also provided.

No skrell were harmed in the making of this PR.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
add: Unlit cigarettes in the mouth slot can be lit by another person using a lit welder when targeting the mouth.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
