### PR TITLE
Buffs Machine Overload

### DIFF
--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -474,7 +474,7 @@
 
 /datum/action/innate/ai/ranged/overload_machine/proc/detonate_machine(obj/machinery/M)
 	if(M && !QDELETED(M))
-		explosion(get_turf(M), 0,1,1,0)
+		explosion(get_turf(M), 0,3,5,0)
 		if(M) //to check if the explosion killed it before we try to delete it
 			qdel(M)
 

--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -460,7 +460,7 @@
 /datum/AI_Module/overload_machine
 	module_name = "Machine Overload"
 	mod_pick_name = "overload"
-	description = "Overheats an electrical machine, causing a small explosion and destroying it. Two uses per purchase."
+	description = "Overheats an electrical machine, causing a small explosion and destroying it. Four uses per purchase."
 	cost = 20
 	power_type = /datum/action/innate/ai/ranged/overload_machine
 	unlock_text = "<span class='notice'>You enable the ability for the station's APCs to direct intense energy into machinery.</span>"
@@ -469,7 +469,7 @@
 	name = "Overload Machine"
 	desc = "Overheats a machine, causing a small explosion after a short time."
 	button_icon_state = "overload_machine"
-	uses = 2
+	uses = 4
 	linked_ability_type = /obj/effect/proc_holder/ranged_ai/overload_machine
 
 /datum/action/innate/ai/ranged/overload_machine/proc/detonate_machine(obj/machinery/M)

--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -474,7 +474,7 @@
 
 /datum/action/innate/ai/ranged/overload_machine/proc/detonate_machine(obj/machinery/M)
 	if(M && !QDELETED(M))
-		explosion(get_turf(M), 0,3,5,0)
+		explosion(get_turf(M), 0, 3, 5, 0)
 		if(M) //to check if the explosion killed it before we try to delete it
 			qdel(M)
 

--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -460,7 +460,7 @@
 /datum/AI_Module/overload_machine
 	module_name = "Machine Overload"
 	mod_pick_name = "overload"
-	description = "Overheats an electrical machine, causing a small explosion and destroying it. Four uses per purchase."
+	description = "Overheats an electrical machine, causing a moderately-sized explosion and destroying it. Four uses per purchase."
 	cost = 20
 	power_type = /datum/action/innate/ai/ranged/overload_machine
 	unlock_text = "<span class='notice'>You enable the ability for the station's APCs to direct intense energy into machinery.</span>"

--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -467,7 +467,7 @@
 
 /datum/action/innate/ai/ranged/overload_machine
 	name = "Overload Machine"
-	desc = "Overheats a machine, causing a small explosion after a short time."
+	desc = "Overheats a machine, causing a moderately-sized explosion after a short time."
 	button_icon_state = "overload_machine"
 	uses = 4
 	linked_ability_type = /obj/effect/proc_holder/ranged_ai/overload_machine


### PR DESCRIPTION
## What Does This PR Do
Adds two uses to the Machine Overload Malfunction ability, bringing the total to four, comparable with Machine Override.

Increases the explosion's size to roughly that of several frag grenades duct-taped together.

## Why It's Good For The Game
Apparently, Machine Override also has four uses, thus making it more economical to use despite being objectively better than Overload.

This should make the decision over which ability to use slightly more of a thinker. 

Additionally, the explosion size has been buffed per request from Qwerty.

## Testing
Became AI, violently exploded R&D, Cargo, Command, and several Vulps.

It works very well.

## Changelog
:cl:
tweak: Increased Machine Overload uses to four. Increases blast size.
/:cl: