### PR TITLE
Fix runtime

### DIFF
--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -363,7 +363,7 @@ GLOBAL_LIST_EMPTY(allRequestConsoles)
 	set_light(2)
 
 /obj/machinery/requests_console/proc/remind_unread_messages()
-	if(newmessagepriority == RQ_NONEW_MESSAGES)
+	if(newmessagepriority == RQ_NONEW_MESSAGES && reminder_timer_id != TIMER_ID_NULL)
 		deltimer(reminder_timer_id)
 		reminder_timer_id = TIMER_ID_NULL
 		return

--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -363,7 +363,10 @@ GLOBAL_LIST_EMPTY(allRequestConsoles)
 	set_light(2)
 
 /obj/machinery/requests_console/proc/remind_unread_messages()
-	if(newmessagepriority == RQ_NONEW_MESSAGES && reminder_timer_id != TIMER_ID_NULL)
+	if(reminder_timer_id == TIMER_ID_NULL)
+		return
+
+	if(newmessagepriority == RQ_NONEW_MESSAGES)
 		deltimer(reminder_timer_id)
 		reminder_timer_id = TIMER_ID_NULL
 		return


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes runtime introduced by #23897
```
[2024-01-29T01:52:10] Runtime in code/controllers/subsystem/SStimer.dm,701: Tried to delete a null timerid. Use TIMER_STOPPABLE flag
   proc name: deltimer (/proc/deltimer)
   src: null
   call stack:
   deltimer(-1)
   Cargo Bay Requests Console (/obj/machinery/requests_console): remind_unread_messages
   /datum/callback (/datum/callback): InvokeAsync
   Timer (/datum/controller/subsystem/timer): fire
   Timer (/datum/controller/subsystem/timer): ignite
   Master (/datum/controller/master): RunQueue
   Master (/datum/controller/master): Loop
   Master (/datum/controller/master): StartProcessing
```
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Less runtimes
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Messaged several departments from Captain's Desk then went to each department to mark messages as read. Monitored the logs to make sure there's no runtimes
<!-- How did you test the PR, if at all? -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
