### PR TITLE
meta: move table away from sci airlock

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -34011,18 +34011,6 @@
 	icon_state = "whitepurple"
 	},
 /area/station/science/research)
-"clc" = (
-/obj/structure/table/glass,
-/obj/item/paper_bin{
-	pixel_x = -2;
-	pixel_y = 6
-	},
-/obj/item/paicard,
-/turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "whitepurple"
-	},
-/area/station/science/research)
 "cle" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5
@@ -47166,6 +47154,17 @@
 	icon_state = "grimy"
 	},
 /area/station/security/detective)
+"dJC" = (
+/obj/structure/table/glass,
+/obj/item/paper_bin{
+	pixel_x = -2;
+	pixel_y = 6
+	},
+/obj/item/paicard,
+/turf/simulated/floor/plasteel{
+	icon_state = "whitepurple"
+	},
+/area/station/science/research)
 "dKd" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -123978,7 +123977,7 @@ cft
 cgF
 rFe
 cjN
-clb
+dJC
 cmz
 fwz
 daG
@@ -124492,7 +124491,7 @@ cfw
 cgu
 qnt
 qnt
-clc
+oic
 uxR
 cic
 bVj


### PR DESCRIPTION
## What Does This PR Do
This PR moves a glass table away from directly in front of the science lobby airlocks.
## Why It's Good For The Game
This is real dumb.
## Images of changes
### Before
![2024_01_30__01_23_30__paradise dme  MetaStation dmm  - StrongDMM](https://github.com/ParadiseSS13/Paradise/assets/59303604/48f02a31-7948-46ad-adda-1bd97fc21394)
### After
![2024_01_30__01_23_52__paradise dme  MetaStation dmm  - StrongDMM](https://github.com/ParadiseSS13/Paradise/assets/59303604/b0077870-c869-41d6-bbd9-43ca9cca80eb)
## Testing
I failed to.
## Changelog
:cl:
fix: Cerebron: a glass table was moved away from the front of the science lobby airlock.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
