### PR TITLE
fix Tranquilite Shipment station trait typepath

### DIFF
--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -5,7 +5,7 @@
 	report_message = "An unidentified benefactor has dispatched a mysterious shipment to your station's clown. It was reported to smell faintly of bananas."
 	trait_to_give = STATION_TRAIT_BANANIUM_SHIPMENTS
 
-/datum/station_trait/bananium_shipment
+/datum/station_trait/tranquilite_shipment
 	name = "Tranquilite Shipment"
 	trait_type = STATION_TRAIT_NEUTRAL
 	weight = 5


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
The typepath of the station trait `Tranquilite Shipment` will be changed because it was the same as that of the `Bananium Shipment`.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Because of this, there was no bananium trait. I don't think it was done on purpose. I would like to become a clown with bananium.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


## Testing
I started local server. Both traits were on the `Modify station traits`
![image](https://github.com/ParadiseSS13/Paradise/assets/120549107/f3385b7b-bd0b-4e54-8f48-cf9674fe0b8d)

<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Bananium Shipment trait available now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
