### PR TITLE
Remove names from monkey brains and heads (#23942)

### DIFF
--- a/code/modules/surgery/organs/brain.dm
+++ b/code/modules/surgery/organs/brain.dm
@@ -73,6 +73,9 @@
 		name = "[dna.real_name]'s [initial(name)]"
 
 	if(!owner) return ..() // Probably a redundant removal; just bail
+	
+	if(is_species(owner, /datum/species/monkey))
+		name = "[owner.name]'s [initial(name)]"
 
 	var/obj/item/organ/internal/brain/B = src
 	if(!special)

--- a/code/modules/surgery/organs/subtypes/standard_organs.dm
+++ b/code/modules/surgery/organs/subtypes/standard_organs.dm
@@ -264,6 +264,8 @@
 		if(!istype(dna))
 			dna = owner.dna.Clone()
 		name = "[dna.real_name]'s head"
+		if(is_species(owner, /datum/species/monkey))
+			name = "[owner.name]'s head"
 		if(owner.glasses)
 			owner.unEquip(owner.glasses, force = TRUE)
 		if(owner.head)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Fixes #23942. Previously, butchering or gibbing a monkey would yield a head and brain with a random human name, determined from its DNA. This change makes all monkeys drop heads and brains with their displayed name instead - that is, "monkey (488)" will, upon gibbing, yield "monkey (488)'s head".

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
As noted in #23942, it's confusing and not immersive to see a random human's name labeled on a brain when butchering a monkey.

## Testing
<!-- How did you test the PR, if at all? -->
1. Loaded local copy of the server, joined as Captain.
2. Gave myself a monkey cube, a kitchen sink, and a kitchen knife using the `spawn` verb.
3. Wet the cube
4. Killed and butchered the monkey
5. Observed that among the exploded parts were "monkey (716)'s head" and "monkey (716)'s brain"
6. `spawn`ed a wolpin
7. Killed and butchered the wolpin
8. Observed that among the exploded parts were "wolpin (889)'s brain" and "wolpin (889)'s head"

## Changelog
:cl: Ascio
fix: Remove names from monkey brains and heads
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
