### PR TITLE
[BORG UPDATE] drone holosign creator atmos

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -689,6 +689,7 @@
 		/obj/item/multitool/cyborg,
 		/obj/item/t_scanner,
 		/obj/item/analyzer,
+		/obj/item/holosign_creator/atmos,
 		/obj/item/gripper_engineering,
 		/obj/item/melee/energy/sword/cyborg,
 		/obj/item/card/emag,
@@ -789,7 +790,8 @@
 		/obj/item/stack/sheet/glass/cyborg,
 		/obj/item/stack/sheet/rglass/cyborg,
 		/obj/item/stack/sheet/wood/cyborg,
-		/obj/item/stack/tile/wood/cyborg
+		/obj/item/stack/tile/wood/cyborg,
+		/obj/item/holosign_creator/atmos,
 	)
 	special_rechargables = list(
 		/obj/item/reagent_containers/spray/cleaner/drone,


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Port of the refactor and new tools from "SS220 WyccStation".
We played with these changes for 2 years and don’t touch them anymore, since we fully tested them for balance, usability and user response. We hope you will like them too and improve the gameplay of robots.

- Drones, on the contrary, have received a limited compact atmos holobarrier and cannot close large holes, unlike their larger comrades.
- The saboteurs also received holosign_creator/atmos so as not to arouse suspicion during infiltration.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Drones can isolate small depressurization so that they do not interfere with the work of the crew and do not waste a valuable resource of the station - air.
Sabotaging cyborgs were able to covertly enter the station through the walls without causing atmospheric alarms.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
<!-- How did you test the PR, if at all? -->
Tested for 2 years on the SS220 WyccStation on live servers.

## Changelog
:cl:
add: Added drone holoatmos creator
add: Added cyborg saboteur holoatmos creator
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
