### PR TITLE
refactor: make build compatible with 514 compiler again

### DIFF
--- a/code/modules/lavaland/lavaland_theme.dm
+++ b/code/modules/lavaland/lavaland_theme.dm
@@ -10,7 +10,7 @@
 	if(!primary_turf_type)
 		stack_trace("Turf type is `null` in `[type]` lavaland theme")
 	else if(!ispath(primary_turf_type))
-		stack_trace("Wrong turf type `[initial(primary_turf_type.type)]` in `[type]` lavaland theme")
+		stack_trace("Wrong turf type `[primary_turf_type.type]` in `[type]` lavaland theme")
 
 /**
  * This proc should do all theme specific thing.


### PR DESCRIPTION
## What Does This PR Do
Make build compatible with 514 compiler again

## Why It's Good For The Game
Easier usage of debugger on 514. And for 514 users anyway.

## Testing
Compiles with 514