### PR TITLE
Adds a 10s Global Cooldown to Changeling Powers Post-Revival

### DIFF
--- a/code/modules/antagonists/changeling/changeling_power.dm
+++ b/code/modules/antagonists/changeling/changeling_power.dm
@@ -90,6 +90,9 @@
 	if(HAS_TRAIT(user, TRAIT_FAKEDEATH) && !bypass_fake_death)
 		to_chat(user, "<span class='warning'>We are incapacitated.</span>")
 		return FALSE
+	if(!cling.can_use_powers)
+		to_chat(owner, "<span class='warning'>Our cells are repairing themselves, we are unable to use our powers!</span>")
+		return FALSE
 	return TRUE
 
 // Transform the target to the chosen dna. Used in transform.dm and tiny_prick.dm (handy for changes since it's the same thing done twice)

--- a/code/modules/antagonists/changeling/datum_changeling.dm
+++ b/code/modules/antagonists/changeling/datum_changeling.dm
@@ -48,6 +48,8 @@
 	var/datum/action/changeling/sting/chosen_sting
 	/// If the changeling is in the process of regenerating from their fake death.
 	var/regenerating = FALSE
+	/// Can you use abilities due to a recent revival?
+	var/can_use_powers = TRUE
 
 
 /datum/antagonist/changeling/New()

--- a/code/modules/antagonists/changeling/powers/revive.dm
+++ b/code/modules/antagonists/changeling/powers/revive.dm
@@ -11,6 +11,10 @@
 	if(HAS_TRAIT(user, TRAIT_UNREVIVABLE))
 		to_chat(user, "<span class='notice'>Something is preventing us from regenerating, we will need to revive at another point.</span>")
 		return FALSE
+
+	cling.can_use_powers = FALSE
+	addtimer(VARSET_CALLBACK(cling, can_use_powers, TRUE), 10 SECONDS)
+
 	REMOVE_TRAIT(user, TRAIT_FAKEDEATH, CHANGELING_TRAIT)
 	for(var/obj/item/grab/G in user.grabbed_by)
 		var/mob/living/carbon/M = G.assailant


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds a `10 SECOND` global cooldown to all Changeling Powers after you use Revival.

## Why It's Good For The Game
So. Changelings. I absolutely love their design. They have a kit that allows for amazingly fun Stealth while also being able to scuffle with a silly amount of melee prowess if backed into a corner.

**HOWEVER.**

Currently, Changelings have a bit of an issues. You don't need to even touch any of their escape, evasion, or stealth powers. The Antagonist built around stealing skins and pretending to be others doesnt do so at all. It is actually IMMENSELY non-meta to do so. The current "most efficient" way to play Changeling is to take as many combat powers as you can and play "Can I Out Attrition All of Security's HP With My Own With Revives?" This leads to low-pop rounds being a Changeling's paradise, as you can practically avoid any and all death by simply destroying as many points of death on Station and then revival + speed-legs to get away from the 1-3 Officers in the round. And in high-pop, you either have to gamble that you slowed down the Security people enough that they wont be able to keep you down or you have to giga-game with weapons/armor/etc.

This change would force Changelings to go from "Oh time to ooga booga and just apply armblade x1479141" to "I am being hunted to death by the entirety of the Station's Security Force. I need to ambush, swap disguises, and plan my fights with some actual skill." You would need to actually ESCAPE and EVADE instead of just killing everyone, smacking Revival, and gambling that the injured assailants wont have time to take you somewhere to put you down for good.

This would, however, mean that Changelings are more susceptible to getting smacked into orbit, stripped, and meme-sprayed to the Burner. I would like, then, to suggest merging this along with #23992, as this gives an "oh fuck, a chance to escape" that isnt just "revive 20 times cause it rolled Farragus".

Every single other Antagonist's "loss scenario" is getting cuffed and captured (or shot to death) barring their own tools of escape. These tools put you in the "shoot to kill" zone just the same (freedoms/dark passage/etc) as Changeling's abilities do. Yet, Changelings get a reset button the second they go down. This "oh just ooga booga again" strategy is the whole entire reason that the current meta for Changelings is to take all the funny combat powers and go to town. This change should force them to actually use some knowledge, skill, and planning to complete their goals rather than just brute force.


## Testing
Ran around testing the Changeling powers after revival.

## Changelog
:cl:
tweak: Changeling Powers now have a 10 second global cooldown after Revival is used.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
