### PR TITLE
ensure no sunburn for vamps in transit tubes

### DIFF
--- a/code/modules/antagonists/vampire/vamp_datum.dm
+++ b/code/modules/antagonists/vampire/vamp_datum.dm
@@ -223,6 +223,9 @@
 				to_chat(owner.current, "<span class='boldnotice'>[power.gain_desc]</span>")
 
 /datum/antagonist/vampire/proc/check_sun()
+	if(istype(owner.current.loc, /obj/structure/transit_tube_pod))
+		return
+
 	var/ax = owner.current.x
 	var/ay = owner.current.y
 


### PR DESCRIPTION
## What Does This PR Do
This PR skips the damage caused to vamps by the sun if they are inside a transit tube pod. In actuality, because the vampire's location changes to (0, 0) when in a pod, this logic is probably short-circuited in the first place, but this ensures it.
## Why It's Good For The Game
It would only be funny to show up at your destination extra crispy to deadchat.

EDIT: More seriously, this is a pointless knowledge check for vampires. If tubes get used more regularly in station maps, it's not really fair to restrict vampire's movement with something like this.
## Testing
Set a breakpoint in the logic, got vampirized, went through a transit tube, ensured the early return during the check_sun() proc.
## Changelog
:cl:
tweak: Vampires will not be affected by the sun when traveling in a transit tube.
/:cl:
