### PR TITLE
Rounds all organ health damage to the second decimal

### DIFF
--- a/code/__HELPERS/mob_helpers.dm
+++ b/code/__HELPERS/mob_helpers.dm
@@ -709,5 +709,5 @@ GLOBAL_LIST_EMPTY(do_after_once_tracker)
 	return out_ckey
 
 /// rounds value to limited symbols after the period for organ damage and other values
-/proc/round_health(var/health)
+/proc/round_health(health)
 	return round(health, 0.01)

--- a/code/__HELPERS/mob_helpers.dm
+++ b/code/__HELPERS/mob_helpers.dm
@@ -707,3 +707,7 @@ GLOBAL_LIST_EMPTY(do_after_once_tracker)
 		out_ckey = "(Disconnected)"
 
 	return out_ckey
+
+/// rounds value to limited symbols after the period for organ damage and other values
+/proc/round_health(var/health)
+	return round(health, 0.01)

--- a/code/modules/surgery/organs/organ.dm
+++ b/code/modules/surgery/organs/organ.dm
@@ -217,7 +217,7 @@
 	if(tough)
 		return
 	damage = clamp(damage + amount, 0, max_damage)
-	damage = round(damage, 0.1)
+	damage = round_health(damage)
 
 	//only show this if the organ is not robotic
 	if(owner && parent_organ && amount > 0)

--- a/code/modules/surgery/organs/organ.dm
+++ b/code/modules/surgery/organs/organ.dm
@@ -217,6 +217,7 @@
 	if(tough)
 		return
 	damage = clamp(damage + amount, 0, max_damage)
+	damage = round(damage, 0.1)
 
 	//only show this if the organ is not robotic
 	if(owner && parent_organ && amount > 0)

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -323,6 +323,8 @@
 
 	if(owner_old)
 		owner_old.updatehealth("limb receive damage")
+	brute_dam = round(brute_dam, 0.1)
+	burn_dam = round(burn_dam, 0.1)
 	return update_state()
 
 #undef LIMB_SHARP_THRESH_INT_DMG
@@ -343,6 +345,8 @@
 	if(updating_health)
 		owner.updatehealth("limb heal damage")
 
+	brute_dam = round(brute_dam, 0.1)
+	burn_dam = round(burn_dam, 0.1)
 	return update_state()
 
 /obj/item/organ/external/emp_act(severity)

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -323,8 +323,8 @@
 
 	if(owner_old)
 		owner_old.updatehealth("limb receive damage")
-	brute_dam = round(brute_dam, 0.1)
-	burn_dam = round(burn_dam, 0.1)
+	brute_dam = round_health(brute_dam)
+	burn_dam = round_health(burn_dam)
 	return update_state()
 
 #undef LIMB_SHARP_THRESH_INT_DMG
@@ -345,8 +345,8 @@
 	if(updating_health)
 		owner.updatehealth("limb heal damage")
 
-	brute_dam = round(brute_dam, 0.1)
-	burn_dam = round(burn_dam, 0.1)
+	brute_dam = round_health(brute_dam)
+	burn_dam = round_health(burn_dam)
 	return update_state()
 
 /obj/item/organ/external/emp_act(severity)

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -34,7 +34,6 @@
 	QDEL_LIST_ASSOC_VAL(organ_datums) // The removal from internal_organ_datums should be handled when the organ is removed
 	. = ..()
 
-
 /obj/item/organ/internal/proc/insert(mob/living/carbon/M, special = 0, dont_remove_slot = 0)
 	if(!iscarbon(M) || owner == M)
 		return


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
This PR makes all organ damage numbers fixed to 2 symbols after the period

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Receiving 0.2359 damage because funny armor blocked some part of it is not really better than receiving just 0.24 damage
0.2359 damage makes all health texts unpredictable while that accuracy is not neccesary
This just makes people's life better, dunno what to say else

## Testing
<!-- How did you test the PR, if at all? -->
Compiled, received some damage, healed

## Changelog
:cl:
tweak: All external and internal organs damage is now limited to 2 symbols after the period
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
