### PR TITLE
refactor: don't call `get_available_cameras` each time camera is switched on camera console, slightly optimize `get_available_cameras`

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -45,7 +45,7 @@
 	assembly.anchored = TRUE
 	assembly.update_icon()
 
-	GLOB.cameranet.cameras += src
+	GLOB.cameranet.register_camera(src)
 	part_of_camera_network = should_add_to_cameranet
 	if(part_of_camera_network)
 		GLOB.cameranet.addCamera(src)
@@ -67,7 +67,7 @@
 	kick_out_watchers()
 	QDEL_NULL(assembly)
 	QDEL_NULL(wires)
-	GLOB.cameranet.cameras -= src
+	GLOB.cameranet.unregister_camera(src)
 	if(isarea(get_area(src)))
 		LAZYREMOVE(get_area(src).cameras, UID())
 	var/area/station/ai_monitored/A = get_area(src)
@@ -315,11 +315,7 @@
 			to_chat(O, "The screen bursts into static.")
 
 /obj/machinery/camera/proc/can_use()
-	if(!status)
-		return 0
-	if(stat & EMPED)
-		return 0
-	return 1
+	return status && !(stat & EMPED)
 
 /obj/machinery/camera/proc/can_see()
 	var/list/see = null

--- a/code/modules/mob/living/silicon/ai/freelook/cameranet.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/cameranet.dm
@@ -8,12 +8,31 @@ GLOBAL_DATUM_INIT(cameranet, /datum/cameranet, new())
 
 	// The cameras on the map, no matter if they work or not. Updated in obj/machinery/camera.dm by New() and Destroy().
 	var/list/cameras = list()
+	/// Assoc list of camera tags associated with cameras: `c_tag => camera`
+	var/list/cameras_by_tag = list()
 	// The chunks of the map, mapping the areas that the cameras can see.
 	var/list/chunks = list()
 	var/ready = FALSE
 
 	// The object used for the clickable stat() button.
 	var/obj/effect/statclick/statclick
+
+/datum/cameranet/proc/register_camera(obj/machinery/camera/camera)
+	if(!istype(camera))
+		CRASH("Not `/obj/machinery/camera` was tried to be registered")
+
+	cameras |= camera
+	cameras_by_tag[camera.c_tag] = camera
+
+/datum/cameranet/proc/unregister_camera(obj/machinery/camera/camera)
+	if(!istype(camera))
+		CRASH("Not `/obj/machinery/camera` was tried to be unregistered")
+
+	cameras -= camera
+	cameras_by_tag -= camera.c_tag
+
+/datum/cameranet/proc/get_camera_by_tag(c_tag)
+	return cameras_by_tag[c_tag]
 
 // Checks if a chunk has been Generated in x, y, z.
 /datum/cameranet/proc/chunkGenerated(x, y, z)
@@ -178,21 +197,3 @@ GLOBAL_DATUM_INIT(cameranet, /datum/cameranet, new())
 		if(chunk.visibleTurfs[position])
 			return 1
 	return 0
-
-/*
-/datum/cameranet/proc/stat_entry()
-	if(!statclick)
-		statclick = new/obj/effect/statclick/debug(null, "Initializing...", src)
-
-	stat(name, statclick.update("Cameras: [cameranet.cameras.len] | Chunks: [cameranet.chunks.len]"))
-*/
-
-// Debug verb for VVing the chunk that the turf is in.
-/*
-/turf/verb/view_chunk()
-	set src in world
-
-	if(cameranet.chunkGenerated(x, y, z))
-		var/datum/camerachunk/chunk = cameranet.getCameraChunk(x, y, z)
-		usr.client.debug_variables(chunk)
-*/

--- a/code/modules/mob/living/silicon/ai/freelook/cameranet.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/cameranet.dm
@@ -195,5 +195,5 @@ GLOBAL_DATUM_INIT(cameranet, /datum/cameranet, new())
 		if(chunk.changed)
 			chunk.hasChanged(1) // Update now, no matter if it's visible or not.
 		if(chunk.visibleTurfs[position])
-			return 1
-	return 0
+			return TRUE
+	return FALSE


### PR DESCRIPTION
## What Does This PR Do
Optimize camera console slightly (`get_available_cameras` proc)
Don't call `get_available_cameras` each time camera is switched on camera console.

## Why It's Good For The Game
Less lags, cleaner code.

## Testing
Compiles, cameras works. Didn't bench it.

