### PR TITLE
fixes a very hilarious grey autocloner bug

### DIFF
--- a/code/game/objects/structures/grey_autocloner.dm
+++ b/code/game/objects/structures/grey_autocloner.dm
@@ -56,7 +56,6 @@
 		R.dna = new /datum/dna()
 
 	var/mob/living/carbon/human/H = new /mob/living/carbon/human(src)
-	H.set_species(/datum/species/grey) //This is a grey cloner after all. Funnier this way tbh
 	occupant = H
 
 	if(!R.dna.real_name)	//to prevent null names
@@ -68,6 +67,8 @@
 
 	for(var/datum/language/L in R.languages)
 		H.add_language(L.name)
+
+	H.set_species(/datum/species/grey) //This is a grey cloner after all. Funnier this way tbh
 
 	domutcheck(H, MUTCHK_FORCED) //Ensures species that get powers by the species proc handle_dna keep them
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
The person is turned into a grey, rather than keeping their species but _having all grey organs, limbs, language, and abilities, but otherwise being the old species_

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

It is very funny to see a unathi that looks like a grey but uses unathi masks / clothing.
However, they should fully be a grey, rather than look like one in every way bar examine.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
<!-- How did you test the PR, if at all? -->
Cloned as before
Confirm species changed, vs just limbs and organs and language.
confirmed modsuit sprite looked right.

## Changelog
:cl:
fix: Fixes a very hilarious grey autocloner bug where the species is not updated correctly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
