### PR TITLE
Make people wearing blindfolds immune to vamp glare

### DIFF
--- a/code/modules/antagonists/vampire/vampire_powers/vampire_powers.dm
+++ b/code/modules/antagonists/vampire/vampire_powers/vampire_powers.dm
@@ -198,6 +198,12 @@
 	for(var/mob/living/target in targets)
 		if(!target.affects_vampire(user))
 			continue
+		if(ishuman(target))
+			var/mob/living/carbon/human/human_target = target
+			if(istype(human_target.glasses, /obj/item/clothing/glasses/sunglasses/blindfold))
+				var/obj/item/clothing/glasses/sunglasses/blindfold/B = human_target.glasses
+				if(B.tint)
+					continue
 
 		var/deviation
 		if(IS_HORIZONTAL(user))


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Makes people wearing blindfolds immune to vampire glares.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
I recently thought I was being very clever by blindfolding myself while capturing a vamp, only to find out that the blindfold doesn't work both ways.
I still harbor delusions of one day being robust enough to fight a vamp while completely blind, and for that dream to become a reality I need it to actually work.

I don't expect this to change balancing much, I reckon few people are willing to sacrifice their sight just to be immune to the glare.

## Testing
<!-- How did you test the PR, if at all? -->
Spawned myself in as a vampire:
Glaring a regular person worked.
Glaring simplemobs worked.
Glaring a person wearing fake blindfolds worked.
Glaring a person wearing real blindfolds didn't work.
No runtimes by the end.

## Changelog
:cl:
tweak: People wearing blindfolds are now immune to vampire glares.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
