### PR TITLE
fix: stop charging plasma mod core when full

### DIFF
--- a/code/modules/mod/mod_core.dm
+++ b/code/modules/mod/mod_core.dm
@@ -233,7 +233,7 @@
 	mod.update_charge_alert()
 
 /obj/item/mod/core/plasma
-	name = "MOD plasma core"
+	name = "\improper MOD plasma core"
 	desc = "Nanotrasen's attempt at capitalizing on their plasma research. These plasma cores are refueled \
 		through plasma fuel, allowing for easy continued use by their mining squads."
 	icon_state = "mod-core-plasma"
@@ -290,6 +290,10 @@
 	var/charge_given = is_type_in_list(plasma, charger_list)
 	if(!charge_given)
 		return FALSE
+	if(charge_amount() == max_charge_amount())
+		to_chat(user, "<span class='notice'>[src] is already fully charged!</span>")
+		// We didn't succeed but we don't want to treat it as an attackby
+		return TRUE
 	var/uses_needed = min(plasma.amount, ((max_charge_amount() - charge_amount()) / 2000))
 	if(!plasma.use(uses_needed))
 		return FALSE


### PR DESCRIPTION
## What Does This PR Do
This PR notifies modsuit users with plasma cores when they can't be charged anymore.
## Why It's Good For The Game
Without this, you can just keep clicking the plasma on the modsuit and not get the correct textual feedback.
## Images of changes
![2024_02_04__14_41_14__Paradise Station 13](https://github.com/ParadiseSS13/Paradise/assets/59303604/9d56b9f7-b391-4a8d-87ce-b766672ea374)
## Testing
Wore modsuit, charged with plasma.
## Changelog
:cl:
fix: Modsuits with plasma mod cores now properly notify you when they're fully charged.
/:cl:
