### PR TITLE
fix: golem ship no longer hears ash storm in space

### DIFF
--- a/code/datums/weather/weather_types/ash_storm.dm
+++ b/code/datums/weather/weather_types/ash_storm.dm
@@ -32,9 +32,7 @@
 
 /datum/weather/ash_storm/proc/is_shuttle_docked(shuttleId, dockId)
 	var/obj/docking_port/mobile/M = SSshuttle.getShuttle(shuttleId)
-	var/obj/docking_port/stationary/S = M.get_docked()
-
-	return S.id == dockId
+	return M && M.getDockedId() == dockId
 
 /datum/weather/ash_storm/proc/update_eligible_areas()
 	var/list/inside_areas = list()

--- a/code/datums/weather/weather_types/ash_storm.dm
+++ b/code/datums/weather/weather_types/ash_storm.dm
@@ -52,6 +52,10 @@
 	if(!laborShuttleDocked)
 		eligible_areas -= get_areas(/area/shuttle/siberia)
 
+	var/golemShuttleOnPlanet = is_shuttle_docked("freegolem", "freegolem_lavaland")
+	if(!golemShuttleOnPlanet)
+		eligible_areas -= get_areas(/area/shuttle/freegolem)
+
 	for(var/i in 1 to eligible_areas.len)
 		var/area/place = eligible_areas[i]
 		if(place.outdoors)


### PR DESCRIPTION
## What Does This PR Do
This PR excludes the golem ship from the ash storm weather ambience. `is_shuttle_docked` calls into `SSshuttle.getShuttle` which has a `WARNING` call if the shuttle ID can't be found, but we always spawn ghost roles now, so this shouldn't increase the amount of log spam.
## Why It's Good For The Game
Hearing the ash storm in space isn't correct.
## Testing
Went into space with golem shuttle, triggered ash storm in Admin secrets.
## Changelog
:cl:
fix: The golem ship will no longer hear ash storms when in space.
/:cl: