### PR TITLE
Fixes Plasma tiles not reacting to turf fires caused by chemical reactions.

### DIFF
--- a/code/modules/atmospherics/environmental/LINDA_fire.dm
+++ b/code/modules/atmospherics/environmental/LINDA_fire.dm
@@ -215,6 +215,7 @@
 		H.set_light(l_color = H.color)
 
 		T.hotspot_expose(H.temperature, H.volume)
+		T.temperature_expose(H.temperature, H.volume)
 		for(var/atom/A in T)
 			if(isliving(A))
 				continue


### PR DESCRIPTION
## What Does This PR Do
Fixes Plasma tiles not reacting to fires from chemical reactions.

## Why It's Good For The Game
It makes Plasma tiles as dangerous as normal Plasma. A single spark should light it up.

## Images of changes
Before:
![dreamseeker_h5sH8Bwost](https://github.com/ParadiseSS13/Paradise/assets/156630426/2f9a6b5b-d6fe-4ecd-9e19-aafb44ddc0fd)
After:
![dreamseeker_5n5pB8zCdL](https://github.com/ParadiseSS13/Paradise/assets/156630426/2002626f-cd89-4c18-b4cd-099958f89d68)


## Testing
Tested it on a private instance. The Plasma tiles lit on fire from a CLF3 reaction.

## Changelog
:cl:
fix: Fixed Plasma tiles not reacting to fireflashes.
/:cl:
