### PR TITLE
Reagent Grinder refactor'n'fixes

### DIFF
--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -433,16 +433,6 @@
 	// Snacks and Plants
 	for(var/obj/item/food/snacks/O in holdingitems)
 		var/list/special_blend = get_special_blend(O)
-		if(!length(special_blend)) // No special blend reagents, we can just transfer everything
-			O.reagents.trans_to(beaker, O.reagents.total_volume)
-
-			if(!O.reagents.total_volume)
-				remove_object(O)
-			if(beaker.reagents.holder_full())
-				return
-
-			continue
-
 		for(var/r_id in special_blend)
 			var/space = beaker.reagents.maximum_volume - beaker.reagents.total_volume
 			var/amount = special_blend[r_id]
@@ -467,6 +457,8 @@
 
 			if(beaker.reagents.holder_full())
 				break
+
+		O.reagents.trans_to(beaker, O.reagents.total_volume)
 
 		if(!O.reagents.total_volume)
 			remove_object(O)

--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -399,7 +399,7 @@
 	for(var/obj/item/food/snacks/O in holdingitems)
 		var/list/special_juice = get_special_juice(O)
 		if(!length(special_juice))
-			break
+			continue // Ignore food that doesn't juice into anything
 
 		for(var/r_id in special_juice)
 			var/space = beaker.reagents.maximum_volume - beaker.reagents.total_volume
@@ -477,7 +477,7 @@
 	for(var/obj/item/stack/O in holdingitems)
 		var/list/special_blend = get_special_blend(O)
 		if(!length(special_blend))
-			break
+			continue // Ignore stackables that don't grind into anything
 
 		var/space = beaker.reagents.maximum_volume - beaker.reagents.total_volume
 		while(O.amount)

--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -407,9 +407,6 @@
 
 	// Snacks
 	for(var/obj/item/food/snacks/O in holdingitems)
-		if(beaker.reagents.holder_full())
-			break
-
 		var/allowed = get_allowed_juice_by_id(O)
 		if(isnull(allowed))
 			break
@@ -425,6 +422,8 @@
 				break
 
 		remove_object(O)
+		if(beaker.reagents.holder_full())
+			return
 
 /obj/machinery/reagentgrinder/proc/grind()
 	power_change()
@@ -444,17 +443,15 @@
 
 	// Snacks and Plants
 	for(var/obj/item/food/snacks/O in holdingitems)
-		if(beaker.reagents.holder_full())
-			break
-
 		var/allowed = get_allowed_snack_by_id(O)
 		if(!length(allowed)) // We don't have anything specific allowed therefore we can just transfer everything
-			if(beaker.reagents.holder_full())
-				continue
 			var/amount = O.reagents.total_volume
 			O.reagents.trans_to(beaker, amount)
 			if(!O.reagents.total_volume)
 				remove_object(O)
+			if(beaker.reagents.holder_full())
+				return
+
 			continue
 
 		for(var/r_id in allowed)
@@ -481,22 +478,19 @@
 			if(beaker.reagents.holder_full())
 				break
 
-		if(!length(O.reagents.reagent_list))
+		if(!O.reagents.total_volume)
 			remove_object(O)
+		if(beaker.reagents.holder_full())
+			return
 
 	// Sheets and rods(!)
 	for(var/obj/item/stack/O in holdingitems)
-		if(beaker.reagents.holder_full())
-			break
-
 		var/allowed = get_allowed_by_id(O)
 		if(isnull(allowed))
 			break
 
 		var/space = beaker.reagents.maximum_volume - beaker.reagents.total_volume
 		while(O.amount) // Grind until there's no more reagents
-			if(!space) // If no free space - exit
-				break
 			O.amount -= 1 // Remove one from stack
 			for(var/r_id in allowed)
 				var/spaceused = min(allowed[r_id] * efficiency, space)
@@ -505,11 +499,11 @@
 			if(O.amount < 1) // If leftover small - destroy
 				remove_object(O)
 				break
+			if(beaker.reagents.holder_full())
+				return
 
 	// Plants
 	for(var/obj/item/grown/O in holdingitems)
-		if(beaker.reagents.holder_full())
-			break
 		var/allowed = get_allowed_by_id(O)
 		for(var/r_id in allowed)
 			var/space = beaker.reagents.maximum_volume - beaker.reagents.total_volume
@@ -523,11 +517,11 @@
 			if(beaker.reagents.holder_full())
 				break
 		remove_object(O)
+		if(beaker.reagents.holder_full())
+			return
 
 	// Slime Extracts
 	for(var/obj/item/slime_extract/O in holdingitems)
-		if(beaker.reagents.holder_full())
-			break
 		var/space = beaker.reagents.maximum_volume - beaker.reagents.total_volume
 		if(O.reagents != null)
 			var/amount = O.reagents.total_volume
@@ -535,12 +529,14 @@
 		if(O.Uses > 0)
 			beaker.reagents.add_reagent("slimejelly",min(20 * efficiency, space))
 		remove_object(O)
+		if(beaker.reagents.holder_full())
+			return
 
 	// Everything else - Transfers reagents from it into beaker
 	for(var/obj/item/reagent_containers/O in holdingitems)
-		if(beaker.reagents.holder_full())
-			break
 		var/amount = O.reagents.total_volume
 		O.reagents.trans_to(beaker, amount)
 		if(!O.reagents.total_volume)
 			remove_object(O)
+		if(beaker.reagents.holder_full())
+			return

--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -393,7 +393,7 @@
 	power_change()
 	if(stat & (NOPOWER|BROKEN))
 		return
-	if(!beaker || (beaker && beaker.reagents.total_volume >= beaker.reagents.maximum_volume))
+	if(!beaker || (beaker && beaker.reagents.holder_full()))
 		return
 	playsound(src.loc, 'sound/machines/juicer.ogg', 20, 1)
 	var/offset = prob(50) ? -2 : 2
@@ -421,7 +421,7 @@
 
 			beaker.reagents.add_reagent(r_id, min(amount * efficiency, space))
 
-			if(beaker.reagents.total_volume >= beaker.reagents.maximum_volume)
+			if(beaker.reagents.holder_full())
 				break
 
 		remove_object(O)

--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -403,9 +403,8 @@
 
 		for(var/r_id in special_juice)
 			var/space = beaker.reagents.maximum_volume - beaker.reagents.total_volume
-			var/amount = get_juice_amount(O)
 
-			beaker.reagents.add_reagent(r_id, min(amount * efficiency, space))
+			beaker.reagents.add_reagent(r_id, min(get_juice_amount(O) * efficiency, space))
 
 			if(beaker.reagents.holder_full())
 				break
@@ -435,8 +434,7 @@
 	for(var/obj/item/food/snacks/O in holdingitems)
 		var/list/special_blend = get_special_blend(O)
 		if(!length(special_blend)) // No special blend reagents, we can just transfer everything
-			var/amount = O.reagents.total_volume
-			O.reagents.trans_to(beaker, amount)
+			O.reagents.trans_to(beaker, O.reagents.total_volume)
 
 			if(!O.reagents.total_volume)
 				remove_object(O)
@@ -532,8 +530,7 @@
 
 	// Everything else - Transfers reagents from it into beaker
 	for(var/obj/item/reagent_containers/O in holdingitems)
-		var/amount = O.reagents.total_volume
-		O.reagents.trans_to(beaker, amount)
+		O.reagents.trans_to(beaker, O.reagents.total_volume)
 
 		if(!O.reagents.total_volume)
 			remove_object(O)

--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -13,10 +13,9 @@
 	var/limit = null
 	var/efficiency = null
 
-	//IMPORTANT NOTE! A negative number is a multiplier, a positive number is a flat amount to add. 0 means equal to the amount of the original reagent
+	// IMPORTANT NOTE! A negative number is a multiplier, a positive number is a flat amount to add. 0 means equal to the amount of the original reagent
 	var/list/blend_items = list (
-
-		//Sheets
+		// Sheets
 		/obj/item/stack/sheet/mineral/plasma = list("plasma_dust" = 20),
 		/obj/item/stack/sheet/metal = list("iron" = 20),
 		/obj/item/stack/rods = list("iron" = 10),
@@ -34,7 +33,7 @@
 		/obj/item/grown/nettle/death = list("facid" = 0, "sacid" = 0),
 		/obj/item/grown/novaflower = list("capsaicin" = 0, "condensedcapsaicin" = 0),
 
-		//Blender Stuff
+		// Blender Stuff
 		/obj/item/food/snacks/grown/tomato = list("ketchup" = 0),
 		/obj/item/food/snacks/grown/wheat = list("flour" = -5),
 		/obj/item/food/snacks/grown/oat = list("flour" = -5),
@@ -45,13 +44,13 @@
 		/obj/item/food/snacks/grown/olive = list("olivepaste" = 0, "sodiumchloride" = 0),
 		/obj/item/food/snacks/grown/peanuts = list("peanutbutter" = 0),
 
-		//Grinder stuff, but only if dry
+		// Grinder stuff, but only if dry
 		/obj/item/food/snacks/grown/coffee/robusta = list("coffeepowder" = 0, "morphine" = 0),
 		/obj/item/food/snacks/grown/coffee = list("coffeepowder" = 0),
 		/obj/item/food/snacks/grown/tea/astra = list("teapowder" = 0, "salglu_solution" = 0),
 		/obj/item/food/snacks/grown/tea = list("teapowder" = 0),
 
-		//All types that you can put into the grinder to transfer the reagents to the beaker. !Put all recipes above this.!
+		// All types that you can put into the grinder to transfer the reagents to the beaker. !Put all recipes above this.!
 		/obj/item/slime_extract = list(),
 		/obj/item/food = list(),
 		/obj/item/reagent_containers/pill = list(),
@@ -59,8 +58,7 @@
 	)
 
 	var/list/juice_items = list (
-
-		//Juicer Stuff
+		// Juicer Stuff
 		/obj/item/food/snacks/grown/soybeans = list("soymilk" = 0),
 		/obj/item/food/snacks/grown/corn = list("corn_starch" = 0),
 		/obj/item/food/snacks/grown/tomato = list("tomatojuice" = 0),
@@ -74,7 +72,7 @@
 		/obj/item/food/snacks/grown/watermelon = list("watermelonjuice" = 0),
 		/obj/item/food/snacks/watermelonslice = list("watermelonjuice" = 0),
 		/obj/item/food/snacks/grown/berries/poison = list("poisonberryjuice" = 0),
-		/obj/item/food/snacks/grown/pumpkin/blumpkin = list("blumpkinjuice" = 0), //order is important here as blumpkin is a subtype of pumpkin, if switched blumpkins will produce pumpkin juice
+		/obj/item/food/snacks/grown/pumpkin/blumpkin = list("blumpkinjuice" = 0), // Order is important here as blumpkin is a subtype of pumpkin, if switched blumpkins will produce pumpkin juice
 		/obj/item/food/snacks/grown/pumpkin = list("pumpkinjuice" = 0),
 		/obj/item/food/snacks/grown/apple = list("applejuice" = 0),
 		/obj/item/food/snacks/grown/grapes = list("grapejuice" = 0),
@@ -82,8 +80,7 @@
 	)
 
 	var/list/dried_items = list(
-
-		//Grinder stuff, but only if dry,
+		// Grinder stuff, but only if dry,
 		/obj/item/food/snacks/grown/coffee/robusta = list("coffeepowder" = 0, "morphine" = 0),
 		/obj/item/food/snacks/grown/coffee = list("coffeepowder" = 0),
 		/obj/item/food/snacks/grown/tea/astra = list("teapowder" = 0, "salglu_solution" = 0),
@@ -160,7 +157,6 @@
 	default_unfasten_wrench(user, I)
 
 /obj/machinery/reagentgrinder/attackby(obj/item/I, mob/user, params)
-
 	if(exchange_parts(user, I))
 		SStgui.update_uis(src)
 		return
@@ -177,7 +173,7 @@
 			beaker.loc = src
 			update_icon(UPDATE_ICON_STATE)
 			SStgui.update_uis(src)
-		return TRUE //no afterattack
+		return TRUE // No afterattack
 
 	if(is_type_in_list(I, dried_items))
 		if(istype(I, /obj/item/food/snacks/grown))
@@ -190,7 +186,7 @@
 		to_chat(usr, "The machine cannot hold anymore items.")
 		return FALSE
 
-	//Fill machine with a bag!
+	// Fill machine with a bag!
 	if(istype(I, /obj/item/storage/bag))
 		var/obj/item/storage/bag/B = I
 		if(!B.contents.len)
@@ -203,7 +199,7 @@
 			if(is_type_in_list(G, blend_items) || is_type_in_list(G, juice_items))
 				B.remove_from_storage(G, src)
 				holdingitems += G
-				if(holdingitems && holdingitems.len >= limit) //Sanity checking so the blender doesn't overfill
+				if(holdingitems && holdingitems.len >= limit) // Sanity checking so the blender doesn't overfill
 					to_chat(user, "<span class='notice'>You fill the All-In-One grinder to the brim.</span>")
 					break
 
@@ -230,8 +226,6 @@
 		holdingitems += I
 		SStgui.update_uis(src)
 		return FALSE
-
-
 
 /obj/machinery/reagentgrinder/attack_ai(mob/user)
 	return FALSE
@@ -263,9 +257,8 @@
 	var/list/beakerContents = list()
 	if(beaker)
 		for(var/datum/reagent/R in beaker.reagents.reagent_list)
-			beakerContents.Add(list(list("name" = R.name, "volume" = R.volume))) // list in a list because Byond merges the first list...
+			beakerContents.Add(list(list("name" = R.name, "volume" = R.volume))) // List in a list because Byond merges the first list...
 	data["beaker_contents"] = beakerContents
-
 
 	var/list/items_counts = list()
 	var/list/name_overrides = list()
@@ -280,7 +273,7 @@
 				else
 					name_overrides[display_name] = display_name
 				if(S.amount > 1)
-					name_overrides[display_name] = "[name_overrides[display_name]]s" //name_overrides[display_name] Will be set on the first time as the singular form
+					name_overrides[display_name] = "[name_overrides[display_name]]s" // name_overrides[display_name] Will be set on the first time as the singular form
 
 			items_counts[display_name] += S.amount
 			continue
@@ -296,7 +289,7 @@
 				if(food.ingredient_name_plural)
 					name_overrides[display_name] = food.ingredient_name_plural
 				else if(items_counts[display_name] == 1) // Must only add "s" once or you get stuff like "eggsssss"
-					name_overrides[display_name] = "[name_overrides[display_name]]s" //name_overrides[display_name] Will be set on the first time as the singular form
+					name_overrides[display_name] = "[name_overrides[display_name]]s" // name_overrides[display_name] Will be set on the first time as the singular form
 
 		items_counts[display_name]++
 
@@ -404,15 +397,15 @@
 		return
 	playsound(src.loc, 'sound/machines/juicer.ogg', 20, 1)
 	var/offset = prob(50) ? -2 : 2
-	animate(src, pixel_x = pixel_x + offset, time = 0.2, loop = 250) //start shaking
+	animate(src, pixel_x = pixel_x + offset, time = 0.2, loop = 250) // Start shaking
 	operating = TRUE
 	SStgui.update_uis(src)
 	spawn(50)
-		pixel_x = initial(pixel_x) //return to its spot after shaking
+		pixel_x = initial(pixel_x) // Return to its spot after shaking
 		operating = FALSE
 		SStgui.update_uis(src)
 
-	//Snacks
+	// Snacks
 	for(var/obj/item/food/snacks/O in holdingitems)
 		if(beaker.reagents.holder_full())
 			break
@@ -434,7 +427,6 @@
 		remove_object(O)
 
 /obj/machinery/reagentgrinder/proc/grind()
-
 	power_change()
 	if(stat & (NOPOWER|BROKEN))
 		return
@@ -446,11 +438,11 @@
 	operating = TRUE
 	SStgui.update_uis(src)
 	spawn(60)
-		pixel_x = initial(pixel_x) //return to its spot after shaking
+		pixel_x = initial(pixel_x) // Return to its spot after shaking
 		operating = FALSE
 		SStgui.update_uis(src)
 
-	//Snacks and Plants
+	// Snacks and Plants
 	for(var/obj/item/food/snacks/O in holdingitems)
 		if(beaker.reagents.holder_full())
 			break
@@ -466,7 +458,6 @@
 			continue
 
 		for(var/r_id in allowed)
-
 			var/space = beaker.reagents.maximum_volume - beaker.reagents.total_volume
 			var/amount = allowed[r_id]
 			if(amount <= 0)
@@ -484,8 +475,6 @@
 					if(O.reagents != null && O.reagents.has_reagent("plantmatter"))
 						beaker.reagents.add_reagent(r_id, min(round(O.reagents.get_reagent_amount("plantmatter") * abs(amount) * efficiency), space))
 						O.reagents.remove_reagent("plantmatter", min(O.reagents.get_reagent_amount("plantmatter"), space))
-
-
 			else
 				O.reagents.trans_id_to(beaker, r_id, min(amount, space))
 
@@ -495,7 +484,7 @@
 		if(O.reagents.reagent_list.len == 0)
 			remove_object(O)
 
-	//Sheets and rods(!)
+	// Sheets and rods(!)
 	for(var/obj/item/stack/O in holdingitems)
 		if(beaker.reagents.holder_full())
 			break
@@ -505,19 +494,19 @@
 			break
 
 		var/space = beaker.reagents.maximum_volume - beaker.reagents.total_volume
-		while(O.amount) //Grind until there's no more reagents
-			if(!space) //if no free space - exit
+		while(O.amount) // Grind until there's no more reagents
+			if(!space) // If no free space - exit
 				break
-			O.amount -= 1 //remove one from stack
+			O.amount -= 1 // Remove one from stack
 			for(var/r_id in allowed)
 				var/spaceused = min(allowed[r_id] * efficiency, space)
 				space -= spaceused
 				beaker.reagents.add_reagent(r_id, spaceused)
-			if(O.amount < 1) //if leftover small - destroy
+			if(O.amount < 1) // If leftover small - destroy
 				remove_object(O)
 				break
 
-	//Plants
+	// Plants
 	for(var/obj/item/grown/O in holdingitems)
 		if(beaker.reagents.holder_full())
 			break
@@ -535,7 +524,7 @@
 				break
 		remove_object(O)
 
-	//Slime Extractis
+	// Slime Extracts
 	for(var/obj/item/slime_extract/O in holdingitems)
 		if(beaker.reagents.holder_full())
 			break
@@ -547,7 +536,7 @@
 			beaker.reagents.add_reagent("slimejelly",min(20 * efficiency, space))
 		remove_object(O)
 
-	//Everything else - Transfers reagents from it into beaker
+	// Everything else - Transfers reagents from it into beaker
 	for(var/obj/item/reagent_containers/O in holdingitems)
 		if(beaker.reagents.holder_full())
 			break

--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -182,31 +182,31 @@
 				to_chat(user, "<span class='warning'>You must dry that first!</span>")
 				return FALSE
 
-	if(holdingitems && holdingitems.len >= limit)
+	if(length(holdingitems) >= limit)
 		to_chat(usr, "The machine cannot hold anymore items.")
 		return FALSE
 
 	// Fill machine with a bag!
 	if(istype(I, /obj/item/storage/bag))
 		var/obj/item/storage/bag/B = I
-		if(!B.contents.len)
+		if(!length(B.contents))
 			to_chat(user, "<span class='warning'>[B] is empty.</span>")
 			return FALSE
 
-		var/original_contents_len = B.contents.len
+		var/original_contents_len = length(B.contents)
 
 		for(var/obj/item/G in B.contents)
 			if(is_type_in_list(G, blend_items) || is_type_in_list(G, juice_items))
 				B.remove_from_storage(G, src)
 				holdingitems += G
-				if(holdingitems && holdingitems.len >= limit) // Sanity checking so the blender doesn't overfill
+				if(length(holdingitems) >= limit) // Sanity checking so the blender doesn't overfill
 					to_chat(user, "<span class='notice'>You fill the All-In-One grinder to the brim.</span>")
 					break
 
-		if(B.contents.len == original_contents_len)
+		if(length(B.contents) == original_contents_len)
 			to_chat(user, "<span class='warning'>Nothing in [B] can be put into the All-In-One grinder.</span>")
 			return FALSE
-		else if(!B.contents.len)
+		else if(!length(B.contents))
 			to_chat(user, "<span class='notice'>You empty all of [B]'s contents into the All-In-One grinder.</span>")
 		else
 			to_chat(user, "<span class='notice'>You empty some of [B]'s contents into the All-In-One grinder.</span>")
@@ -339,7 +339,7 @@
 /obj/machinery/reagentgrinder/proc/eject(mob/user)
 	if(HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
 		return
-	if(holdingitems && holdingitems.len == 0)
+	if(!length(holdingitems))
 		return
 
 	for(var/obj/item/O in holdingitems)
@@ -481,7 +481,7 @@
 			if(beaker.reagents.holder_full())
 				break
 
-		if(O.reagents.reagent_list.len == 0)
+		if(!length(O.reagents.reagent_list))
 			remove_object(O)
 
 	// Sheets and rods(!)


### PR DESCRIPTION
## What Does This PR Do
Refactors and cleans up some Reagent Grinder code.
Fixes food with special grinding reagents not transfering other reagents.
Fixes plants halting grinder juicing if they don't have a special juicing reagent.

There's still a minor issue with special grinding/juicing reagents overpowering reagents already present in the ground items, but it's a significantly more complex problem that is probably better left for a future PR.

## Why It's Good For The Game
Disappearing reagents bad.

## Images of changes
![2024-02-05 17_44_44](https://github.com/ParadiseSS13/Paradise/assets/100448493/0103a72c-32a9-4631-86ca-858a4ec4a57f)

## Testing
Injected a branch of wheat with some Unstable Mutagen and ground it to receive Flour + Unstable Mutagen.
Placed a few non-juicables and a tomato to check if the tomato can be juiced successfully ignoring the non-juicables.
Stuffed a grinder full of various grindables to make sure it still stops early if beaker gets filled up during grinding.

## Changelog
:cl:
fix: Food with unique grinding reagents transfers other reagents again.
fix: Non-juicable items no longer prevent juicing of other juicable items in the grinder.
/:cl: