### PR TITLE
Reverts Portable Emitter Hitscan

### DIFF
--- a/code/modules/projectiles/ammunition/energy_lens.dm
+++ b/code/modules/projectiles/ammunition/energy_lens.dm
@@ -286,7 +286,7 @@
 	select_name = "clown"
 
 /obj/item/ammo_casing/energy/emitter
-	projectile_type = /obj/item/projectile/beam/emitter/hitscan
+	projectile_type = /obj/item/projectile/beam/emitter
 	muzzle_flash_color = LIGHT_COLOR_GREEN
 	fire_sound = 'sound/weapons/emitter.ogg'
 	e_cost = 100


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Returns portable emitters (such as those used by malf upgraded/combat upgraded cyborgs) to projectiles. Stationary emitters unaffected, remain hitscan.
Technically a partial revert of https://github.com/ParadiseSS13/Paradise/pull/22754.

I did consult at least one of the balance nerds who approved this PR first.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Hitscan weapons can be very cool - when rare. Death wand? Super limited uses, dramatic effect. Pulse weapons? Admins or DSquad, and both can use the oomph. Stationary Emitters? Very cool, and limited by being difficult to move and set up quickly. Turrets? Again stationary, even moreso than emitters. Cyborgs? Easily mass-produced by a malf AI with a borging factory, as all of them tend to go Engi for the stun arm, and very just generally unfun to fight. I believe these were probably hitscanned to match the floor-mounted emitters, but to be honest I do think it's a bit too strong to be hitscan. The Cyborg Emitters specifically had been buffed before they were hitscanned to go from 2 second cooldown to 1 second, so once hitscanned they became undodgeable gatling guns of death. Hell, the comment for the cyborg emitter justifies the damage as "Reads a lot better than it actually is because people miss shots", which no longer really applies with hitscan.
## Testing
<!-- How did you test the PR, if at all? -->
Ensured all portable emitters used the correct projectiles, ensured stationary emitters still used hitscan. Tested damage, still 30 burn.
## Changelog
:cl:
tweak: Portable Emitters (Cyborg Emitters included) are no longer hitscan and are again projectiles.
/:cl:



<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
