### PR TITLE
Add "None" option for Vox Tail Markings

### DIFF
--- a/code/modules/mob/new_player/sprite_accessories/vox/vox_tail_markings.dm
+++ b/code/modules/mob/new_player/sprite_accessories/vox/vox_tail_markings.dm
@@ -2,6 +2,10 @@
 	icon = 'icons/mob/sprite_accessories/vox/vox_tail_markings.dmi'
 	species_allowed = list("Vox")
 
+/datum/sprite_accessory/body_markings/tail/vox/none
+	name = "None"
+	icon_state = "none"
+
 /datum/sprite_accessory/body_markings/tail/vox/vox_band
 	name = "Vox Tail Band"
 	icon_state = "band"


### PR DESCRIPTION


## Why It's Good For The Game

the CMA menu can already select none, should be able to do this on char prefs

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: You can select "None" as an option for Vox Tail Markings
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
