### PR TITLE
Makes the VTEC subtract 1 speed instead of setting it to -1 [NPFC]

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -261,20 +261,7 @@
 		to_chat(usr, "<span class='notice'>There's no room for another VTEC unit!</span>")
 		return
 
-	for(var/obj/item/borg/upgrade/floorbuffer/U in R.contents)
-		if(R.floorbuffer)
-			R.floorbuffer = FALSE
-			R.speed -= U.buffer_speed
-
-	for(var/datum/action/innate/robot_magpulse/magpulse in R.module_actions)
-		if(magpulse.active)
-			REMOVE_TRAIT(R, TRAIT_MAGPULSE, "innate boots")
-			to_chat(R, "You turn your magboots off.")
-			R.speed -= magpulse.slowdown_active
-			magpulse.button_icon_state = initial(magpulse.button_icon_state)
-			magpulse.active = FALSE
-
-	R.speed = -1 // Gotta go fast.
+	R.speed -= 1 // Gotta go fast.
 
 	return TRUE
 

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -262,7 +262,6 @@
 		return
 
 	R.speed -= 1 // Gotta go fast.
-
 	return TRUE
 
 /***********************/


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes VTEC give the slowdown more sanely, ensuring that we don't have to hotfix any speed altering modules the day after merge.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
It's unmaintainable if we keep having to add more checks for modules here, this does the same speed-up while also doing it sanely.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Gave a mediborg VTEC, checked that it sped up properly
Gave an engiborg VTEC with no module on, it sped up properly
Gave an engiborg VTEC with magboot module on, it sped up properly and didn't give more speedboost after turning it off
<!-- How did you test the PR, if at all? -->

## Changelog
NPFC
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
