### PR TITLE
Backpressure surge now checks if a scrubber is welded

### DIFF
--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -17,7 +17,10 @@
 
 /datum/event/vent_clog/tick()
 	if(activeFor % interval == 0)
-		var/obj/vent = pick_n_take(vents)
+		var/obj/machinery/atmospherics/unary/vent_scrubber/vent = pick_n_take(vents)
+		
+		if(!vent || vent.welded)
+			return
 
 		var/list/gunk = list("water","carbon","flour","radium","toxin","cleaner","nutriment","condensedcapsaicin","psilocybin","lube",
 							"atrazine","banana","charcoal","space_drugs","methamphetamine","holywater","ethanol","hot_coco","facid",

--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -18,8 +18,9 @@
 /datum/event/vent_clog/tick()
 	if(activeFor % interval == 0)
 		var/obj/machinery/atmospherics/unary/vent_scrubber/vent = pick_n_take(vents)
-		
+
 		if(!vent || vent.welded)
+			endWhen++
 			return
 
 		var/list/gunk = list("water","carbon","flour","radium","toxin","cleaner","nutriment","condensedcapsaicin","psilocybin","lube",


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Scrubber backpressure surge no longer causes gas to spew through welded scrubbers.
Fixes: #23955
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
It doesn't make much sense for gas to escape via a welded scrubber.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Weld a bunch of scrubbers.
Start the backpressure surge event.
No gas.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Scrubber backpressure surge can no longer spew gas through welded scrubbers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
