### PR TITLE
Electrical activity plant gene adds a bit of teslium when you recharge your items

### DIFF
--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -299,6 +299,7 @@
 				C.update_icon()
 				batteries_recharged = 1
 		if(batteries_recharged)
+			target.reagents.add_reagent("teslium", 2)
 			to_chat(target, "<span class='notice'>Your batteries are recharged!</span>")
 
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds 2u of teslium if you eat and recharge something with a plant that has the electrical activity gene
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Currently you can easily just grab 10 of these that you can use as a one click recharge for your guns, this PR punishes you a little bit if you eat only one, and punishes you a lot more if you eat many in a short time period.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Ate a glowcap to recharge my gun, I got unlucky and got shocked
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: The plant gene "Electrical activity" now gives you teslium when you charge a gun with it
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
