### PR TITLE
Buffs Carpfu

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -8,10 +8,7 @@
 			if(AM.GetComponent(/datum/component/two_handed))
 				if(get_inactive_hand())
 					return FALSE
-			if(mind.martial_art.try_deflect(src))
-				var/obj/item/TT = AM
-				addtimer(CALLBACK(TT, TYPE_PROC_REF(/atom/movable, throw_at), pick(GLOB.alldirs), 10, 4, src), 0.2 SECONDS) //Timer set to 0.2 seconds to ensure item finshes the throwing to prevent double embeds
-				return FALSE
+
 			throw_mode_off()
 			put_in_active_hand(AM)
 			visible_message("<span class='warning'>[src] catches [AM]!</span>")

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -8,6 +8,10 @@
 			if(AM.GetComponent(/datum/component/two_handed))
 				if(get_inactive_hand())
 					return FALSE
+			if(mind.martial_art.try_deflect(src))
+				var/obj/item/TT = AM
+				addtimer(CALLBACK(TT, TYPE_PROC_REF(/atom/movable, throw_at), pick(GLOB.alldirs), 10, 4, src), 0.2 SECONDS) //Timer set to 0.2 seconds to ensure item finshes the throwing to prevent double embeds
+				return FALSE
 			throw_mode_off()
 			put_in_active_hand(AM)
 			visible_message("<span class='warning'>[src] catches [AM]!</span>")

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -56,7 +56,7 @@ emp_act
 			if(mind.martial_art.reroute_deflection)
 				var/refl_angle = get_angle(loc, get_step(src, dir))
 				P.firer = src
-				P.set_angle(rand(refl_angle - 10, refl_angle + 10))
+				P.set_angle(rand(refl_angle - 30, refl_angle + 30))
 				return -1
 			else
 				return FALSE
@@ -578,6 +578,16 @@ emp_act
 		hitpush = FALSE
 		skipcatch = TRUE
 		blocked = TRUE
+
+	else if(mind.martial_art.try_deflect(src))
+		var/obj/item/TT = AM
+		var/direction = pick(GLOB.alldirs)
+		var/turf/target = get_turf(src)
+		for(var/i in 1 to rand(6, 10))
+			target = get_step(target, direction)
+		addtimer(CALLBACK(TT, TYPE_PROC_REF(/atom/movable, throw_at), target, 10, 4, src), 0.2 SECONDS) //Timer set to 0.2 seconds to ensure item finshes the throwing to prevent double embeds
+		return FALSE
+
 	else if(I)
 		if(((throwingdatum ? throwingdatum.speed : I.throw_speed) >= EMBED_THROWSPEED_THRESHOLD) || I.embedded_ignore_throwspeed_threshold)
 			if(can_embed(I))

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -585,7 +585,7 @@ emp_act
 		var/turf/target = get_turf(src)
 		for(var/i in 1 to rand(6, 10))
 			target = get_step(target, direction)
-		addtimer(CALLBACK(TT, TYPE_PROC_REF(/atom/movable, throw_at), target, 10, 4, src), 0.2 SECONDS) //Timer set to 0.2 seconds to ensure item finshes the throwing to prevent double embeds
+		addtimer(CALLBACK(TT, TYPE_PROC_REF(/atom/movable, throw_at), target, 10, 4, src), 0.2 SECONDS) //Timer set to 0.2 seconds to ensure item finishes the throwing to prevent double embeds
 		return FALSE
 
 	else if(I)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -579,7 +579,7 @@ emp_act
 		skipcatch = TRUE
 		blocked = TRUE
 
-	else if(mind.martial_art?.try_deflect(src))
+	else if(mind?.martial_art?.try_deflect(src))
 		var/obj/item/TT = AM
 		var/direction = pick(GLOB.alldirs)
 		var/turf/target = get_turf(src)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -579,7 +579,7 @@ emp_act
 		skipcatch = TRUE
 		blocked = TRUE
 
-	else if(mind.martial_art.try_deflect(src))
+	else if(mind.martial_art?.try_deflect(src))
 		var/obj/item/TT = AM
 		var/direction = pick(GLOB.alldirs)
 		var/turf/target = get_turf(src)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -586,7 +586,7 @@ emp_act
 		for(var/i in 1 to rand(6, 10))
 			target = get_step(target, direction)
 		addtimer(CALLBACK(TT, TYPE_PROC_REF(/atom/movable, throw_at), target, 10, 4, src), 0.2 SECONDS) //Timer set to 0.2 seconds to ensure item finishes the throwing to prevent double embeds
-		return FALSE
+		return TRUE
 
 	else if(I)
 		if(((throwingdatum ? throwingdatum.speed : I.throw_speed) >= EMBED_THROWSPEED_THRESHOLD) || I.embedded_ignore_throwspeed_threshold)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -54,8 +54,9 @@ emp_act
 
 			visible_message("<span class='danger'>[src] deflects the projectile!</span>", "<span class='userdanger'>You deflect the projectile!</span>")
 			if(mind.martial_art.reroute_deflection)
+				var/refl_angle = get_angle(loc, get_step(src, dir))
 				P.firer = src
-				P.set_angle(rand(0, 360))
+				P.set_angle(rand(refl_angle - 10, refl_angle + 10))
 				return -1
 			else
 				return FALSE


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
- Makes reflected bullets reflect in a 60 degree arc (subject to change) in front of the user
- Makes thrown items be reflected in a random arc in a direction
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Carpfu is in a weird spot of being very expensive (65 TC) while also being not really worth it. You can easily disable the ranged immunity by throwing any item. This prevents that from happening while also buffing the offensive potential a bit.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

https://github.com/ParadiseSS13/Paradise/assets/108773801/f4649dd8-2fd8-413c-a37f-e2cbea7b6364

## Testing
See above
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Carpfu now reflects bullets and projectiles in a 60 degree arc in front of the user
tweak: Carpfu now reflects thrown items
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
