### PR TITLE
Nerfs Botany Maximum Yield + Plant Bags

### DIFF
--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -202,8 +202,8 @@
 	name = "plant bag"
 	icon = 'icons/obj/hydroponics/equipment.dmi'
 	icon_state = "plantbag"
-	storage_slots = 50 //the number of plant pieces it can carry.
-	max_combined_w_class = 50  //Doesn't matter what this is, so long as it's more or equal to storage_slots * plants.w_class
+	storage_slots = 40 //the number of plant pieces it can carry.
+	max_combined_w_class = 40  //Doesn't matter what this is, so long as it's more or equal to storage_slots * plants.w_class
 	max_w_class = WEIGHT_CLASS_NORMAL
 	w_class = WEIGHT_CLASS_TINY
 	can_hold = list(/obj/item/food/snacks/grown,/obj/item/seeds,/obj/item/grown,/obj/item/food/snacks/grown/ash_flora,/obj/item/food/snacks/honeycomb)

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -202,8 +202,8 @@
 	name = "plant bag"
 	icon = 'icons/obj/hydroponics/equipment.dmi'
 	icon_state = "plantbag"
-	storage_slots = 100 //the number of plant pieces it can carry.
-	max_combined_w_class = 100 //Doesn't matter what this is, so long as it's more or equal to storage_slots * plants.w_class
+	storage_slots = 50 //the number of plant pieces it can carry.
+	max_combined_w_class = 50  //Doesn't matter what this is, so long as it's more or equal to storage_slots * plants.w_class
 	max_w_class = WEIGHT_CLASS_NORMAL
 	w_class = WEIGHT_CLASS_TINY
 	can_hold = list(/obj/item/food/snacks/grown,/obj/item/seeds,/obj/item/grown,/obj/item/food/snacks/grown/ash_flora,/obj/item/food/snacks/honeycomb)

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -203,7 +203,7 @@
 	icon = 'icons/obj/hydroponics/equipment.dmi'
 	icon_state = "plantbag"
 	storage_slots = 40 //the number of plant pieces it can carry.
-	max_combined_w_class = 40  //Doesn't matter what this is, so long as it's more or equal to storage_slots * plants.w_class
+	max_combined_w_class = 40 //Doesn't matter what this is, so long as it's more or equal to storage_slots * plants.w_class
 	max_w_class = WEIGHT_CLASS_NORMAL
 	w_class = WEIGHT_CLASS_TINY
 	can_hold = list(/obj/item/food/snacks/grown,/obj/item/seeds,/obj/item/grown,/obj/item/food/snacks/grown/ash_flora,/obj/item/food/snacks/honeycomb)

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -179,7 +179,7 @@
 /// Setter procs ///
 /obj/item/seeds/proc/adjust_yield(adjustamt)
 	if(yield != -1) // Unharvestable shouldn't suddenly turn harvestable
-		yield = clamp(yield + adjustamt, 0, 10)
+		yield = clamp(yield + adjustamt, 0, 5)
 
 		if(yield <= 0 && get_gene(/datum/plant_gene/trait/plant_type/fungal_metabolism))
 			yield = 1 // Mushrooms always have a minimum yield of 1.


### PR DESCRIPTION
## What Does This PR Do
This PR lowers plant bag capacity from 100 to 40.

This PR also lowers the upper limit of the amount of plants botany can gain per tray per harvest to make it a little less ridiculous. The upper clamp that handles maximum plant yield has been lowered from 10 to 5, making it so Botany will at most be harvesting plants per yield in the 10s, rather than in the 20s.

## Why It's Good For The Game
The sheer amount of instantdeath plants botany can carry on their person is a little silly at times. Combining this with general plantspam from both war crime instantdeath plants, but also the amount of plants that can be grown, left on the floor to create alt+click piles of instant lag.

Basically, its a bit much and a bit silly. This PR should hopefully make the numbers just that little more reasonable.

## Testing
Grew a lot of tobacco, just not as much as usual. Put it in bags.

## Changelog
:cl:
tweak: Botany plant bags and associated subtypes now their maximum capacity lowered from 100 to 40.
tweak: Overall botany plant yield has been lowered.
/:cl: