### PR TITLE
Makes the mousetrap mortar fire armed mousetraps

### DIFF
--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -424,7 +424,7 @@
 	equip_cooldown = 1 SECONDS
 	name = "mousetrap mortar"
 	icon_state = "mecha_mousetrapmrtr"
-	projectile = /obj/item/assembly/mousetrap
+	projectile = /obj/item/assembly/mousetrap/armed
 	fire_sound = 'sound/items/bikehorn.ogg'
 	projectiles = 15
 	missile_speed = 1.5
@@ -441,7 +441,7 @@
 	if(!action_checks(target))
 		return
 	set_ready_state(0)
-	var/obj/item/assembly/mousetrap/M = new projectile(chassis.loc)
+	var/obj/item/assembly/mousetrap/armed/M = new projectile(chassis.loc)
 	M.secured = TRUE
 	playsound(chassis, fire_sound, 60, 1)
 	M.throw_at(target, missile_range, missile_speed)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
As title says: Mousetrap Mortar for the HONKER mech now fires armed mousetraps.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
There's no humor if you just fire the thing and it's NOT armed. How am I meant to slip these under peoples feet and make them scream as they step on them?
Yes, this is a shameless clown buff.
## Testing
<!-- How did you test the PR, if at all? -->
Built, ran, shot mouse traps, ran across them, joyous glee when they snapped.
## Changelog
:cl:
tweak: The Mousetrap Mortar now fires armed mousetraps
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
