### PR TITLE
Spectral blade now shows orbs, not ghosts

### DIFF
--- a/code/modules/mining/lavaland/loot/ashdragon_loot.dm
+++ b/code/modules/mining/lavaland/loot/ashdragon_loot.dm
@@ -39,7 +39,8 @@
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "rended")
 	flags_2 = RANDOM_BLOCKER_2
 	var/summon_cooldown = 0
-	var/list/mob/dead/observer/spirits
+	// var/list/mob/dead/observer/spirits
+	var/list/obj/effect/wisp/ghost/spirits
 
 /obj/item/melee/ghost_sword/New()
 	..()
@@ -51,7 +52,6 @@
 /obj/item/melee/ghost_sword/Destroy()
 	for(var/mob/dead/observer/G in spirits)
 		remove_ghost(G)
-	spirits.Cut()
 	remove_signals(src)
 	UnregisterSignal(src, COMSIG_MOVABLE_MOVED)
 	GLOB.poi_list -= src
@@ -93,7 +93,10 @@
 
 	register_signals(ghost) // Pull in any ghosts that may be orbiting other ghosts TODO THIS MIGHT BE THE FUCKIN PROBLEM
 
-	spirits |= ghost
+	var/obj/effect/wisp/ghost/orb = new(src)
+	orb.color = ghost.get_runechat_color()
+	orb.orbit(src, clockwise = FALSE)
+	spirits[ghost] = orb
 	ghost.invisibility = 0
 
 /obj/item/melee/ghost_sword/proc/remove_ghost(atom/movable/orbited, atom/orbiter)
@@ -106,8 +109,9 @@
 
 	remove_signals(ghost)
 
+	var/attached_orb = spirits[ghost]
+	qdel(attached_orb)
 	spirits -= ghost
-	ghost.invisibility = initial(ghost.invisibility)
 
 /obj/item/melee/ghost_sword/proc/remove_signals(atom/A)
 	UnregisterSignal(A, COMSIG_ATOM_ORBIT_STOP)

--- a/code/modules/mining/lavaland/loot/ashdragon_loot.dm
+++ b/code/modules/mining/lavaland/loot/ashdragon_loot.dm
@@ -95,6 +95,7 @@
 
 	var/obj/effect/wisp/ghost/orb = new(src)
 	orb.color = ghost.get_runechat_color()
+	orb.alpha = 128
 	orb.orbit(src, clockwise = FALSE)
 	spirits[ghost] = orb
 

--- a/code/modules/mining/lavaland/loot/ashdragon_loot.dm
+++ b/code/modules/mining/lavaland/loot/ashdragon_loot.dm
@@ -91,7 +91,7 @@
 		// they'll get added to spirits (and turned visible) when the sword enters a mob's hand then
 		return
 
-	register_signals(ghost) // Pull in any ghosts that may be orbiting other ghosts TODO THIS MIGHT BE THE FUCKIN PROBLEM
+	register_signals(ghost) // Pull in any ghosts that may be orbiting other ghosts
 
 	var/obj/effect/wisp/ghost/orb = new(src)
 	orb.color = ghost.get_runechat_color()
@@ -108,7 +108,8 @@
 
 	remove_signals(ghost)
 
-	var/attached_orb = spirits[ghost]
+	var/obj/effect/wisp/ghost/attached_orb = spirits[ghost]
+	attached_orb.stop_orbit()
 	qdel(attached_orb)
 	spirits -= ghost
 

--- a/code/modules/mining/lavaland/loot/ashdragon_loot.dm
+++ b/code/modules/mining/lavaland/loot/ashdragon_loot.dm
@@ -97,14 +97,13 @@
 	orb.color = ghost.get_runechat_color()
 	orb.orbit(src, clockwise = FALSE)
 	spirits[ghost] = orb
-	ghost.invisibility = 0
 
 /obj/item/melee/ghost_sword/proc/remove_ghost(atom/movable/orbited, atom/orbiter)
 	SIGNAL_HANDLER	// COMSIG_ATOM_ORBIT_STOP
 
 	var/mob/dead/observer/ghost = orbiter
 
-	if(!istype(ghost) || !isobserver(ghost) || !(ghost in spirits))
+	if(!istype(ghost) || !(ghost in spirits))
 		return
 
 	remove_signals(ghost)

--- a/code/modules/mining/lavaland/loot/ashdragon_loot.dm
+++ b/code/modules/mining/lavaland/loot/ashdragon_loot.dm
@@ -39,19 +39,25 @@
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "rended")
 	flags_2 = RANDOM_BLOCKER_2
 	var/summon_cooldown = 0
-	// var/list/mob/dead/observer/spirits
-	var/list/obj/effect/wisp/ghost/spirits
+	/// List of wisps we have active, for cleanup purposes in case a ghost gets randomly deleted.
+	var/list/obj/effect/wisp/ghost/orbs
+	/// List of ghosts currently orbiting us.
+	var/list/mob/dead/observer/ghosts
 
 /obj/item/melee/ghost_sword/New()
 	..()
-	spirits = list()
+	ghosts = list()
+	orbs = list()
 	register_signals(src)
 	RegisterSignal(src, COMSIG_MOVABLE_MOVED, PROC_REF(on_move))
 	GLOB.poi_list |= src
 
 /obj/item/melee/ghost_sword/Destroy()
-	for(var/mob/dead/observer/G in spirits)
+	for(var/mob/dead/observer/G in ghosts)
 		remove_ghost(G)
+	// if there are any orbs left (possibly detached from ghosts) ensure they don't stick around
+	for(var/spirit as anything in orbs)
+		qdel(spirit)
 	remove_signals(src)
 	UnregisterSignal(src, COMSIG_MOVABLE_MOVED)
 	GLOB.poi_list -= src
@@ -59,8 +65,8 @@
 
 /obj/item/melee/ghost_sword/examine()
 	. = ..()
-	if(length(spirits))
-		. += "It appears to pulse with the power of [length(spirits)] vengeful spirits!"
+	if(length(orbs))
+		. += "It appears to pulse with the power of [length(orbs)] vengeful spirit\s!"
 	else
 		. += "It glows weakly."
 
@@ -83,7 +89,7 @@
 /obj/item/melee/ghost_sword/proc/add_ghost(atom/movable/orbited, atom/orbiter)
 	SIGNAL_HANDLER	// COMSIG_ATOM_ORBIT_BEGIN
 	var/mob/dead/observer/ghost = orbiter
-	if(!istype(ghost) || !isobserver(orbiter) || (ghost in spirits))
+	if(!istype(ghost) || !isobserver(orbiter) || (ghost in ghosts))
 		return
 
 	if(!ismob(loc))
@@ -93,26 +99,32 @@
 
 	register_signals(ghost) // Pull in any ghosts that may be orbiting other ghosts
 
+
 	var/obj/effect/wisp/ghost/orb = new(src)
 	orb.color = ghost.get_runechat_color()
 	orb.alpha = 128
 	orb.orbit(src, clockwise = FALSE)
-	spirits[ghost] = orb
+	ghosts[ghost] = orb
+	orbs.Add(orb)
+
+	// if a ghost gets deleted, the orb cleans itself up
+	// which then passes the torch to us to clean ourselves up
+	RegisterSignal(orb, COMSIG_PARENT_QDELETING, PROC_REF(on_orb_qdel))
 
 /obj/item/melee/ghost_sword/proc/remove_ghost(atom/movable/orbited, atom/orbiter)
 	SIGNAL_HANDLER	// COMSIG_ATOM_ORBIT_STOP
 
 	var/mob/dead/observer/ghost = orbiter
 
-	if(!istype(ghost) || !(ghost in spirits))
+	if(!istype(ghost) || !(ghost in ghosts))
 		return
 
 	remove_signals(ghost)
 
-	var/obj/effect/wisp/ghost/attached_orb = spirits[ghost]
+	var/obj/effect/wisp/ghost/attached_orb = ghosts[ghost]
 	attached_orb.stop_orbit()
 	qdel(attached_orb)
-	spirits -= ghost
+	ghosts -= ghost
 
 /obj/item/melee/ghost_sword/proc/remove_signals(atom/A)
 	UnregisterSignal(A, COMSIG_ATOM_ORBIT_STOP)
@@ -131,7 +143,7 @@
 
 	if(ismob(old_loc))
 		remove_signals(old_loc)
-		for(var/mob/dead/observer/orbiter in spirits)
+		for(var/mob/dead/observer/orbiter in ghosts)
 			remove_ghost(src, orbiter)
 
 	if(ismob(loc))
@@ -140,19 +152,47 @@
 		for(var/mob/dead/observer/orbiter in get_orbiters_up_hierarchy(recursive = TRUE))
 			add_ghost(src, orbiter)
 
+// clean up wisps
+/obj/item/melee/ghost_sword/proc/on_orb_qdel(obj/effect/wisp/ghost/orb)
+	SIGNAL_HANDLER  // COMSIG_PARENT_QDELETING
+	orbs -= orb
+	for(var/ghost in ghosts)
+		if(ghosts[ghost] == orb)
+			ghosts -= ghost
+			break
+
+
 /obj/item/melee/ghost_sword/attack(mob/living/target, mob/living/carbon/human/user)
 	force = 0
-	var/ghost_counter = length(spirits)
+	var/ghost_counter = length(orbs)
 
 	force = clamp((ghost_counter * 4), 0, 75)
-	user.visible_message("<span class='danger'>[user] strikes with the force of [ghost_counter] vengeful spirits!</span>")
+	user.visible_message("<span class='danger'>[user] strikes with the force of [ghost_counter] vengeful spirit\s!</span>")
 	..()
 
 /obj/item/melee/ghost_sword/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
-	var/ghost_counter = length(spirits)
+	var/ghost_counter = length(orbs)
 	final_block_chance += clamp((ghost_counter * 5), 0, 75)
-	owner.visible_message("<span class='danger'>[owner] is protected by a ring of [ghost_counter] ghosts!</span>")
+	owner.visible_message("<span class='danger'>[owner] is protected by a ring of [ghost_counter] ghost\s!</span>")
 	return ..()
+
+
+/obj/effect/wisp/ghost
+	name = "mischievous wisp"
+	desc = "A wisp that seems to want to get up to shenanigans. It often seems disappointed, for some reason."
+	light_range = 0
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+
+/obj/effect/wisp/ghost/Initialize(mapload, mob/dead/observer/ghost)
+	. = ..()
+	RegisterSignal(ghost, COMSIG_PARENT_QDELETING, PROC_REF(on_ghost_qdel))
+
+/obj/effect/wisp/ghost/proc/on_ghost_qdel(mob/dead/observer/ghost)
+	SIGNAL_HANDLER  // COMSIG_PARENT_QDELETING
+	stop_orbit()
+	// we only live as long as our attached ghost
+	qdel(src)
+
 
 // Blood
 

--- a/code/modules/mining/lavaland/loot/tendril_loot.dm
+++ b/code/modules/mining/lavaland/loot/tendril_loot.dm
@@ -246,7 +246,6 @@
 	light_range = 7
 	layer = ABOVE_ALL_MOB_LAYER
 
-
 //Red/Blue Cubes
 /obj/item/warp_cube
 	name = "blue cube"

--- a/code/modules/mining/lavaland/loot/tendril_loot.dm
+++ b/code/modules/mining/lavaland/loot/tendril_loot.dm
@@ -246,11 +246,6 @@
 	light_range = 7
 	layer = ABOVE_ALL_MOB_LAYER
 
-/obj/effect/wisp/ghost
-	name = "mischievous wisp"
-	desc = "A wisp that seems to want to get up to shenanigans. It often seems disappointed, for some reason."
-	light_range = 0
-	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 
 //Red/Blue Cubes
 /obj/item/warp_cube

--- a/code/modules/mining/lavaland/loot/tendril_loot.dm
+++ b/code/modules/mining/lavaland/loot/tendril_loot.dm
@@ -246,6 +246,12 @@
 	light_range = 7
 	layer = ABOVE_ALL_MOB_LAYER
 
+/obj/effect/wisp/ghost
+	name = "mischievous wisp"
+	desc = "A wisp that seems to want to get up to shenanigans. It often seems disappointed, for some reason."
+	light_range = 0
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+
 //Red/Blue Cubes
 /obj/item/warp_cube
 	name = "blue cube"

--- a/code/modules/mob/dead/observer/observer_base.dm
+++ b/code/modules/mob/dead/observer/observer_base.dm
@@ -35,6 +35,8 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 	///toggle for ghost gas analyzer
 	var/gas_analyzer = FALSE
 	var/datum/orbit_menu/orbit_menu
+	/// The "color" their runechat would have had
+	var/alive_runechat_color = "#FFFFFF"
 
 /mob/dead/observer/New(mob/body=null, flags=1)
 	set_invisibility(GLOB.observer_default_invisibility)
@@ -59,6 +61,7 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 	if(ismob(body))
 		T = get_turf(body)				//Where is the body located?
 		attack_log_old = body.attack_log_old	//preserve our attack logs by copying them to our ghost
+		alive_runechat_color = body.get_runechat_color()
 
 		var/mutable_appearance/MA = copy_appearance(body)
 		if(body.mind && body.mind.name)
@@ -841,3 +844,6 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		return allow_roundstart_observers
 	return FALSE
 
+
+/mob/dead/observer/get_runechat_color()
+	return alive_runechat_color


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Tweaks the spectral blade to show small orbs to represent the ghosts orbiting it, rather than the ghosts themselves. This means no concerns about ghosts being stuck visible, or ghosts pointing. The only thing the living will see are the little orbs.
The orbs will still have the colors of the ghosts, meaning they will still have a bit of character, but they will not have any of the same levels of identifiability as the original characters.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
The spectral blade is one of the few places in the game where the dead can be manifested by the living. Ghost invisibility has been kind of a problem with ghosts getting stuck visible due to weird interactions with the spectral blade, which leads to ghosts travelling everywhere across the station. Pointing also leads to some pretty troublesome interactions of people pointing out antags or whatnot.

This solves all of those problems, and does it in kind of a cute, charming way, I think.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://github.com/ParadiseSS13/Paradise/assets/89928798/f212b90c-2560-425d-a9d3-77541575f139)
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Loaded in, swung the sword around a little, orbited it. Would like to see this TMed for at least a round just to load-test it.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Ghosts are now no longer visible when orbiting the spectral blade, instead manifesting in the form of orbs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
