### PR TITLE
Swaps the infinite cell on moonoutpost19 for a void core

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/moonoutpost19.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/moonoutpost19.dmm
@@ -6141,8 +6141,8 @@
 "vh" = (
 /obj/structure/rack,
 /obj/item/mecha_parts/core,
-/obj/item/stock_parts/cell/infinite,
 /obj/effect/turf_decal/delivery/hollow,
+/obj/item/stock_parts/cell/infinite/abductor,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Swaps the infinite cell for a void core on moonoutpost19
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
They're functionally the exact same aside from having 20kw more than the infinite cell, its just makes more sense icly for it to be abductor tech rather than 'teehee im infinite' 

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![image](https://github.com/ParadiseSS13/Paradise/assets/96908085/2bff9ff4-8f6f-457a-b47e-3a7083f33869)


## Testing
<!-- How did you test the PR, if at all? -->
compiled, checked if the cell was swapped, yeah

## Changelog
:cl:
tweak: Swapped the infinite cell on moonbase19 to a void core.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
