### PR TITLE
Makes floorlights only toggleable in help intent

### DIFF
--- a/code/game/turfs/simulated/floor/light_floor.dm
+++ b/code/game/turfs/simulated/floor/light_floor.dm
@@ -47,6 +47,8 @@
 /turf/simulated/floor/light/attack_hand(mob/user)
 	if(!can_modify_colour)
 		return
+	if(user.a_intent != INTENT_HELP)
+		return
 	toggle_light(!on)
 
 /turf/simulated/floor/light/attackby(obj/item/C, mob/user, params)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Prevents floor-lights (like the light tiles) from being toggled in any intent that isn't help.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
It's nice to have the option to choose if you want to toggle the lights or not.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Compiled, clicked some lights.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: You can now only toggle floor light tiles in help intent.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
