### PR TITLE
Combat Baguette now bonks correctly

### DIFF
--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -50,6 +50,8 @@
 	return
 
 /obj/item/food/snacks/attack(mob/M, mob/user, def_zone)
+	if(user.a_intent == INTENT_HARM && src.force > 0)
+		return ..()
 	if(reagents && !reagents.total_volume)						//Shouldn't be needed but it checks to see if it has anything left in it.
 		to_chat(user, "<span class='warning'>None of [src] left, oh no!</span>")
 		M.unEquip(src)	//so icons update :[

--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -50,7 +50,7 @@
 	return
 
 /obj/item/food/snacks/attack(mob/M, mob/user, def_zone)
-	if(user.a_intent == INTENT_HARM && src.force > 0)
+	if(user.a_intent == INTENT_HARM && force)
 		return ..()
 	if(reagents && !reagents.total_volume)						//Shouldn't be needed but it checks to see if it has anything left in it.
 		to_chat(user, "<span class='warning'>None of [src] left, oh no!</span>")


### PR DESCRIPTION

## What Does This PR Do
Attacking someone on harm intent with a food item that has a force value attacks with the item rather than force eating. Effectively fixes the combat baguette. 
Fixes #23763 
Separate issue with the throwing croissants, double clicking when throwing causes croissant to damage self on return, moving while boomerang is active makes catching unreliable, might have something to do with walls, throwing to X location from Y position will 100% fail

## Why It's Good For The Game
Combat Baguette should bonk

## Testing
Spawned in, fed and bonked with baguette, tested other food items still functioned correctly

## Changelog
:cl:
fix: Combat Baguette bonks correctly
/:cl:
