### PR TITLE
No more black borders on the sides with different size

### DIFF
--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -273,14 +273,25 @@ GLOBAL_VAR_INIT(admin_ooc_colour, "#b82e00")
 
 	var/list/map_size = splittext(sizes["paramapwindow.size"], "x")
 
-	// Looks like we didn't expect paramapwindow.size to be "ixj" where i and j are numbers.
-	// If we don't get our expected 2 outputs, let's give some useful error info.
-	if(length(map_size) != 2)
-		CRASH("map_size of incorrect length --- map_size var: [map_size] --- map_size length: [length(map_size)]")
+	// Gets the type of zoom we're currently using
+	// If it's 0 we do our pixel calculations based off the size of the mapwindow
+	// If it's not, we already know how big we want our window to be, since zoom is the exact pixel ratio of the map
+	var/icon_size = params2list(winget(src, "mainwindow.mainvsplit;paramapwindow;map", "icon-size")) || 0
+	var/zoom_value = text2num(icon_size["map.icon-size"]) / 32
 
+	var/desired_width = 0
+	if(zoom_value)
+		desired_width = round(view_size[1] * zoom_value * world.icon_size)
+	else
 
-	var/height = text2num(map_size[2])
-	var/desired_width = round(height * aspect_ratio)
+		// Looks like we didn't expect paramapwindow.size to be "ixj" where i and j are numbers.
+		// If we don't get our expected 2 outputs, let's give some useful error info.
+		if(length(map_size) != 2)
+			CRASH("map_size of incorrect length --- map_size var: [map_size] --- map_size length: [length(map_size)]")
+
+		var/height = text2num(map_size[2])
+		desired_width = round(height * aspect_ratio)
+
 	if(text2num(map_size[1]) == desired_width)
 		// Nothing to do.
 		return


### PR DESCRIPTION
## What Does This PR Do
Fit Viewport now changes size of map window according to icon size thus removing black borders on the sides

## Why It's Good For The Game
More chat space. Also perfectionists should be happy

## Images of changes
https://youtu.be/s-ZfJystP8A

## Testing
Localhost

## Changelog
:cl:
tweak: Tweaked "Fit Viewport" to scale without black borders on the sides with different icon size
/:cl: