### PR TITLE
Updates get_edge_target_turf to work better with diagonals

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -531,7 +531,7 @@ Returns 1 if the chain up to the area contains the given typepath
 	if(IS_DIR_DIAGONAL(direction)) //let's make sure it's accurately-placed for diagonals
 		var/lowest_distance_to_map_edge = min(abs(x - target_atom.x), abs(y - target_atom.y))
 		return get_ranged_target_turf(target_atom, direction, lowest_distance_to_map_edge)
-	return locate(x,y,target_atom.z)
+	return locate(x, y, target_atom.z)
 
 /** returns turf relative to A in given direction at set range
 // result is bounded to map size
@@ -551,7 +551,7 @@ Returns 1 if the chain up to the area contains the given typepath
 	else if(direction & WEST) //if you have both EAST and WEST in the provided direction, then you're gonna have issues
 		x = max(1, x - range)
 
-	return locate(x,y,target_atom.z)
+	return locate(x, y, target_atom.z)
 
 /**
  * Get ranged target turf, but with direct targets as opposed to directions

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -508,46 +508,50 @@ Returns 1 if the chain up to the area contains the given typepath
 // otherwise, just reset the client mob's machine var.
 
 
-// returns the turf located at the map edge in the specified direction relative to A
-// used for mass driver
-/proc/get_edge_target_turf(atom/A, direction)
-
-	var/turf/target = locate(A.x, A.y, A.z)
-	if(!A || !target)
-		return 0
-		//since NORTHEAST == NORTH & EAST, etc, doing it this way allows for diagonal mass drivers in the future
+/// Returns the turf located at the map edge in the specified direction relative to target_atom used for mass driver
+/proc/get_edge_target_turf(atom/target_atom, direction)
+	if(!target_atom)
+		return FALSE
+	var/turf/target = get_turf(target_atom)
+	if(!target)
+		return FALSE
+		//since NORTHEAST == NORTH|EAST, etc, doing it this way allows for diagonal mass drivers in the future
 		//and isn't really any more complicated
 
-		// Note diagonal directions won't usually be accurate
+	var/x = target_atom.x
+	var/y = target_atom.y
 	if(direction & NORTH)
-		target = locate(target.x, world.maxy, target.z)
-	if(direction & SOUTH)
-		target = locate(target.x, 1, target.z)
+		y = world.maxy
+	else if(direction & SOUTH) //you should not have both NORTH and SOUTH in the provided direction
+		y = 1
 	if(direction & EAST)
-		target = locate(world.maxx, target.y, target.z)
-	if(direction & WEST)
-		target = locate(1, target.y, target.z)
+		x = world.maxx
+	else if(direction & WEST)
+		x = 1
+	if(IS_DIR_DIAGONAL(direction)) //let's make sure it's accurately-placed for diagonals
+		var/lowest_distance_to_map_edge = min(abs(x - target_atom.x), abs(y - target_atom.y))
+		return get_ranged_target_turf(target_atom, direction, lowest_distance_to_map_edge)
+	return locate(x,y,target_atom.z)
 
-	return target
-
-// returns turf relative to A in given direction at set range
+/** returns turf relative to A in given direction at set range
 // result is bounded to map size
 // note range is non-pythagorean
 // used for disposal system
-/proc/get_ranged_target_turf(atom/A, direction, range)
+*/
+/proc/get_ranged_target_turf(atom/target_atom, direction, range)
 
-	var/x = A.x
-	var/y = A.y
+	var/x = target_atom.x
+	var/y = target_atom.y
 	if(direction & NORTH)
 		y = min(world.maxy, y + range)
-	if(direction & SOUTH)
+	else if(direction & SOUTH)
 		y = max(1, y - range)
 	if(direction & EAST)
 		x = min(world.maxx, x + range)
-	if(direction & WEST)
+	else if(direction & WEST) //if you have both EAST and WEST in the provided direction, then you're gonna have issues
 		x = max(1, x - range)
 
-	return locate(x,y,A.z)
+	return locate(x,y,target_atom.z)
 
 /**
  * Get ranged target turf, but with direct targets as opposed to directions

--- a/code/game/objects/items/weapons/dice.dm
+++ b/code/game/objects/items/weapons/dice.dm
@@ -207,8 +207,7 @@
 			T.visible_message("<span class='userdanger'>Unseen forces throw [user]!</span>")
 			user.Stun(12 SECONDS)
 			user.adjustBruteLoss(50)
-			var/throw_dir = GLOB.cardinal
-			var/atom/throw_target = get_edge_target_turf(user, throw_dir)
+			var/atom/throw_target = get_edge_target_turf(user, pick(GLOB.cardinal))
 			user.throw_at(throw_target, 200, 4)
 		if(8)
 			//Fueltank Explosion


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Updates get_edge_target_turf to TG's version. This gives us PROPER diagonal support for it.
See changelog for basically everything affected.
Also fixes an issue with the die of fate not being passed a proper direction.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->We have diagonal movement, and I hate that this code says it works with diagonals, but it LIES.

## Testing
<!-- How did you test the PR, if at all? -->
Code compiles, I threw some people around. I tested the fix.

## Changelog
:cl:
tweak: Powerfist, Sleeping Carp's Crashing Kick, Wizard's repulse spell, Energized Fireaxe, Traitor's pushbroom, Vampire's Seismic Stomp, RD's repulse armor, and Cursed Katana all work better with diagonals now.
tweak: Unwrenching pipes with unsafe pressure now considers diagonals
tweak: Gibbing humans will now explode with their organs and items flying more accurately on diagonals.
tweak: Gorillas, kangaroos can throw people diagonally now when attacking, instead of just cardinally.
tweak: Bumping or being attacked by megafauna may knock you diagonally instead of cardinally now.
tweak: Bumping a containment field may throw you diagonally instead of cardinally now.
tweak: Beanbags, and meteorshot may throw you diagonally instead of cardinally now.
tweak: Sorium and liquid dark matter may throw/pull you diagonally now.
fix: Rolling a 7 on a die of fate will properly throw you now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
