### PR TITLE
cere: fix missing pipe in SE waste belt room

### DIFF
--- a/_maps/map_files/cerestation/cerestation.dmm
+++ b/_maps/map_files/cerestation/cerestation.dmm
@@ -39623,6 +39623,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /obj/effect/spawner/random_spawners/dirt_frequent,
 /obj/machinery/door/airlock/maintenance/glass,
+/obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal/external/southeast)
 "fCc" = (


### PR DESCRIPTION
## What Does This PR Do
This PR adds a missing pipe in the waste belt room.
## Why It's Good For The Game
Map fix.
## Images of changes
![2024_02_13__16_23_20__Paradise Station 13](https://github.com/ParadiseSS13/Paradise/assets/59303604/4aa64198-fdef-4346-b949-2fbe1450ed11)

## Testing
Spawned in, double checked. verified airlock properly depressurized as well.

## Changelog
:cl:
fix: Farragus: fixed missing piping in SE waste belt airlock.
/:cl:
