### PR TITLE
Wall lockers now require a click-drag to put a mob into them

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -25,8 +25,8 @@
 	var/material_drop = /obj/item/stack/sheet/metal
 	var/material_drop_amount = 2
 	var/transparent
-	/// Whether or not this can store mobs
-	var/holds_mobs = TRUE
+	/// Whether or not this will pick up mobs on its tile while closing
+	var/picks_up_mobs = TRUE
 
 // Please dont override this unless you absolutely have to
 /obj/structure/closet/Initialize(mapload)
@@ -129,7 +129,7 @@
 		if(!I.anchored)
 			I.forceMove(src)
 			itemcount++
-	if(holds_mobs)
+	if(picks_up_mobs)
 		for(var/mob/M in loc)
 			if(itemcount >= storage_capacity)
 				break

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -25,6 +25,8 @@
 	var/material_drop = /obj/item/stack/sheet/metal
 	var/material_drop_amount = 2
 	var/transparent
+	/// Whether or not this can store mobs
+	var/holds_mobs = TRUE
 
 // Please dont override this unless you absolutely have to
 /obj/structure/closet/Initialize(mapload)
@@ -127,21 +129,21 @@
 		if(!I.anchored)
 			I.forceMove(src)
 			itemcount++
+	if(holds_mobs)
+		for(var/mob/M in loc)
+			if(itemcount >= storage_capacity)
+				break
+			if(isobserver(M))
+				continue
+			if(istype(M, /mob/living/simple_animal/bot/mulebot) || iscameramob(M))
+				continue
+			if(M.buckled || M.anchored || M.has_buckled_mobs())
+				continue
+			if(isAI(M))
+				continue
 
-	for(var/mob/M in loc)
-		if(itemcount >= storage_capacity)
-			break
-		if(isobserver(M))
-			continue
-		if(istype(M, /mob/living/simple_animal/bot/mulebot) || iscameramob(M))
-			continue
-		if(M.buckled || M.anchored || M.has_buckled_mobs())
-			continue
-		if(isAI(M))
-			continue
-
-		M.forceMove(src)
-		itemcount++
+			M.forceMove(src)
+			itemcount++
 
 	opened = FALSE
 	update_icon()

--- a/code/game/objects/structures/crates_lockers/walllocker.dm
+++ b/code/game/objects/structures/crates_lockers/walllocker.dm
@@ -10,6 +10,7 @@
 	anchored = TRUE
 	icon_closed = "wall-locker"
 	icon_opened = "wall-lockeropen"
+	holds_mobs = FALSE
 
 /obj/structure/closet/walllocker/close()
 	. = ..()

--- a/code/game/objects/structures/crates_lockers/walllocker.dm
+++ b/code/game/objects/structures/crates_lockers/walllocker.dm
@@ -10,11 +10,32 @@
 	anchored = TRUE
 	icon_closed = "wall-locker"
 	icon_opened = "wall-lockeropen"
-	holds_mobs = FALSE
+	picks_up_mobs = FALSE
 
 /obj/structure/closet/walllocker/close()
 	. = ..()
 	density = FALSE //It's a locker in a wall, you aren't going to be walking into it.
+
+/obj/structure/closet/walllocker/MouseDrop_T(atom/movable/O, mob/living/user)
+	// don't call parent here -- we don't want to try to climb
+	if(!isliving(O) || !Adjacent(user) || !O.Adjacent(user) || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED) || !opened)
+		return
+
+	user.visible_message(
+		"<span class='warning'>[user] starts trying to stuff [user == O ? user.p_themselves() : O] into [src]!</span>",
+		"<span class='danger'>You start trying to stuff [user == O ? "yourself" : O] into [src]!</span>",
+		"<span class='notice'>You hear something rustling.</span>"
+	)
+	if(!do_after_once(user, 3 SECONDS, target = O) || !opened)
+		return
+
+	if(user == O)
+		user.visible_message("<span class='notice'>[src] slams shut!</span>", "<span class='warning'>You manage to squeeze yourself into [src].</span>")
+	else
+		user.visible_message("span class='warning'>[user] stuffs [O] into [src]!</span>")
+
+	O.forceMove(src)
+	close()
 
 /obj/structure/closet/walllocker/emerglocker
 	name = "emergency locker"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes wall lockers, when closed, only pick up items on their tile instead of mobs. 
You can still fit a mob into the locker if you click-drag, but you'll only be able to fit one inside.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Wall lockers are pretty much little cabinets, you shouldn't really be able to instantly stow yourself away in them, at least not without a little bit of difficulty.
Letting you click-drag yourself (or another mob) still lets these be used as little stashes, but now it requires at least a bit of work, and they'll still only hold one.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![txDOLUvP](https://github.com/ParadiseSS13/Paradise/assets/89928798/bf98bae9-47e9-4690-b630-c6215dad8af9)


<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
See images
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Mobs can now only be put in wall lockers after a short delay by click-dragging.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
