### PR TITLE
Cyborg now always updates damage when taking damage

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_damage.dm
+++ b/code/modules/mob/living/silicon/robot/robot_damage.dm
@@ -115,6 +115,7 @@
 	var/datum/robot_component/armour/A = get_armour()
 	if(A)
 		A.take_damage(brute, burn, sharp)
+		updatehealth()
 		return
 
 	while(LAZYLEN(parts) && (brute > 0 || burn > 0))


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes an issue where a cyborg damage would not update until damage was updated from another source (e.g. repairs or taking damage again)

Fixes: #23600
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
When you take damage you should take damage, rather than receiving delayed damage out of nowhere later.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Unwrench a high pressure pipe, integrity is immediately updated, rather than being at 100% until it is updated from another source.
Walk into a chasm. I die, instead of being alive at the bottom of the chasm.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Cyborgs no longer receive delayed damage when damage goes over a certain threshold.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
