### PR TITLE
Removes the mech from the syndie space base

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/syndie_space_base.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/syndie_space_base.dmm
@@ -1803,10 +1803,6 @@
 	icon_state = "grimy"
 	},
 /area/ruin/unpowered/syndicate_space_base/service)
-"jC" = (
-/obj/machinery/mech_bay_recharge_port,
-/turf/simulated/floor/redgrid,
-/area/ruin/unpowered/syndicate_space_base/main)
 "jH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -5777,18 +5773,6 @@
 	icon_state = "yellow"
 	},
 /area/ruin/unpowered/syndicate_space_base/atmos)
-"FV" = (
-/obj/machinery/door_control{
-	name = "Syndicate Sentry Bot Storage Door Control";
-	pixel_x = 24;
-	pixel_y = 24;
-	req_access_txt = "151";
-	id = "syndicatebotstorage"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/ruin/unpowered/syndicate_space_base/main)
 "FZ" = (
 /obj/effect/spawner/window/plastitanium,
 /turf/simulated/floor/plating,
@@ -6711,15 +6695,6 @@
 /obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/wood,
 /area/ruin/unpowered/syndicate_space_base/service)
-"Lb" = (
-/obj/machinery/door/poddoor/multi_tile/two_tile_hor{
-	name = "Syndie Sentry Bot Storage";
-	id_tag = "syndicatebotstorage"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/ruin/unpowered/syndicate_space_base/main)
 "Lc" = (
 /obj/machinery/computer/cryopod{
 	pixel_x = -32;
@@ -12295,9 +12270,9 @@ kE
 AD
 kE
 kE
-RX
-jC
-Lb
+Ox
+am
+am
 jk
 Ky
 SW
@@ -12367,10 +12342,10 @@ kE
 kE
 kE
 kE
-RX
+Ox
 am
 am
-FV
+am
 am
 wK
 am

--- a/_maps/map_files/RandomRuins/SpaceRuins/syndie_space_base.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/syndie_space_base.dmm
@@ -3421,12 +3421,6 @@
 	icon_state = "dark"
 	},
 /area/ruin/unpowered/syndicate_space_base/main)
-"sX" = (
-/mob/living/simple_animal/bot/ed209/syndicate,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/ruin/unpowered/syndicate_space_base/main)
 "tb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -12374,7 +12368,7 @@ kE
 kE
 kE
 RX
-sX
+am
 am
 FV
 am


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Removes the sentry bot from the syndicate research facility
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
- It will bug out because it can't pathfind, making extra unnecessary debug logs
- The shutters are admin access only, which if they want to protect the base they can already either spawn a sentry bot in, or do other ways, like summoning syndicate reinforcements/borgs.
   This also means that the researchers can't use it as a helper if they quickly need support, because it requires admin intervention
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://github.com/ParadiseSS13/Paradise/assets/108773801/363d5ef0-c33b-49a8-a353-e995a17cc671)

I made it a rock wall, inspired by the hallway to the right of it
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
It compiled, it looked correct in the Syndie space base
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
del: The sentry bot and shutters on the Syndicate research facility have been removed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
