### PR TITLE
Buffs clockwork and cult floortiles

### DIFF
--- a/code/game/turfs/simulated/floor/misc_floor.dm
+++ b/code/game/turfs/simulated/floor/misc_floor.dm
@@ -181,7 +181,7 @@
 
 /turf/simulated/floor/clockwork/Entered(atom/A, atom/OL, ignoreRest)
 	. = ..()
-	if(!. && isliving(A))
+	if(!. && isliving(A) && !(locate(/obj/effect/temp_visual/ratvar/floor) in contents))
 		sleep(2 DECISECONDS)
 		new /obj/effect/temp_visual/ratvar/floor(src)
 

--- a/code/game/turfs/simulated/floor/misc_floor.dm
+++ b/code/game/turfs/simulated/floor/misc_floor.dm
@@ -179,6 +179,11 @@
 		realappearence = new /obj/effect/clockwork/overlay/floor(src)
 		realappearence.linked = src
 
+/turf/simulated/floor/clockwork/Entered(atom/A, atom/OL, ignoreRest)
+	. = ..()
+	if(!. && isliving(A))
+		new /obj/effect/temp_visual/ratvar/floor(src)
+
 /turf/simulated/floor/clockwork/Destroy()
 	if(uses_overlay && realappearence)
 		QDEL_NULL(realappearence)

--- a/code/game/turfs/simulated/floor/misc_floor.dm
+++ b/code/game/turfs/simulated/floor/misc_floor.dm
@@ -181,7 +181,12 @@
 
 /turf/simulated/floor/clockwork/Entered(atom/A, atom/OL, ignoreRest)
 	. = ..()
-	if(!. && isliving(A) && !(locate(/obj/effect/temp_visual/ratvar/floor) in contents))
+	var/counter = 0
+	for(var/obj/effect/temp_visual/ratvar/floor/floor in contents)
+		if(++counter == 3)
+			return
+
+	if(!. && isliving(A))
 		sleep(2 DECISECONDS)
 		new /obj/effect/temp_visual/ratvar/floor(src)
 

--- a/code/game/turfs/simulated/floor/misc_floor.dm
+++ b/code/game/turfs/simulated/floor/misc_floor.dm
@@ -182,6 +182,7 @@
 /turf/simulated/floor/clockwork/Entered(atom/A, atom/OL, ignoreRest)
 	. = ..()
 	if(!. && isliving(A))
+		sleep(2 DECISECONDS)
 		new /obj/effect/temp_visual/ratvar/floor(src)
 
 /turf/simulated/floor/clockwork/Destroy()

--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -240,7 +240,12 @@
 
 /turf/simulated/floor/engine/cult/Entered(atom/A, atom/OL, ignoreRest)
 	. = ..()
-	if(!. && isliving(A) && !(locate(/obj/effect/temp_visual/cult/turf/open/floor) in contents))
+	var/counter = 0
+	for(var/obj/effect/temp_visual/cult/turf/open/floor/floor in contents)
+		if(++counter == 3)
+			return
+
+	if(!. && isliving(A))
 		sleep(2 DECISECONDS)
 		new /obj/effect/temp_visual/cult/turf/open/floor(src)
 

--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -241,6 +241,7 @@
 /turf/simulated/floor/engine/cult/Entered(atom/A, atom/OL, ignoreRest)
 	. = ..()
 	if(!. && isliving(A))
+		sleep(2 DECISECONDS)
 		new /obj/effect/temp_visual/cult/turf/open/floor(src)
 
 /turf/simulated/floor/engine/cult/narsie_act()

--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -240,7 +240,7 @@
 
 /turf/simulated/floor/engine/cult/Entered(atom/A, atom/OL, ignoreRest)
 	. = ..()
-	if(!. && isliving(A))
+	if(!. && isliving(A) && !(locate(/obj/effect/temp_visual/cult/turf/open/floor) in contents))
 		sleep(2 DECISECONDS)
 		new /obj/effect/temp_visual/cult/turf/open/floor(src)
 

--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -238,6 +238,11 @@
 	if(SSticker.mode)//only do this if the round is going..otherwise..fucking asteroid..
 		icon_state = SSticker.cultdat.cult_floor_icon_state
 
+/turf/simulated/floor/engine/cult/Entered(atom/A, atom/OL, ignoreRest)
+	. = ..()
+	if(!. && isliving(A))
+		new /obj/effect/temp_visual/cult/turf/open/floor(src)
+
 /turf/simulated/floor/engine/cult/narsie_act()
 	return
 

--- a/code/game/turfs/simulated/walls_misc.dm
+++ b/code/game/turfs/simulated/walls_misc.dm
@@ -21,6 +21,10 @@
 	name = "runed stone wall"
 	desc = "A cold stone wall engraved with indecipherable symbols. Studying them causes your head to pound."
 
+/turf/simulated/wall/cult/artificer/bullet_act(obj/item/projectile/Proj)
+	. = ..()
+	new /obj/effect/temp_visual/cult/turf(src)
+
 /turf/simulated/wall/cult/artificer/break_wall()
 	new /obj/effect/temp_visual/cult/turf(get_turf(src))
 	return null //excuse me we want no runed metal here

--- a/code/game/turfs/simulated/walls_misc.dm
+++ b/code/game/turfs/simulated/walls_misc.dm
@@ -17,17 +17,17 @@
 		new /obj/effect/temp_visual/cult/turf(src)
 		icon_state = SSticker.cultdat.cult_wall_icon_state
 
+/turf/simulated/wall/cult/bullet_act(obj/item/projectile/Proj)
+	. = ..()
+	new /obj/effect/temp_visual/cult/turf(src)
+
 /turf/simulated/wall/cult/artificer
 	name = "runed stone wall"
 	desc = "A cold stone wall engraved with indecipherable symbols. Studying them causes your head to pound."
 
-/turf/simulated/wall/cult/artificer/bullet_act(obj/item/projectile/Proj)
-	. = ..()
-	new /obj/effect/temp_visual/cult/turf(src)
-
 /turf/simulated/wall/cult/artificer/break_wall()
 	new /obj/effect/temp_visual/cult/turf(get_turf(src))
-	return null //excuse me we want no runed metal here
+	return //excuse me we want no runed metal here
 
 /turf/simulated/wall/cult/artificer/devastate_wall()
 	new /obj/effect/temp_visual/cult/turf(get_turf(src))
@@ -66,6 +66,11 @@
 /turf/simulated/wall/clockwork/Destroy()
 	QDEL_NULL(realappearance)
 	return ..()
+
+/turf/simulated/wall/clockwork/bullet_act(obj/item/projectile/Proj)
+	. = ..()
+	new /obj/effect/temp_visual/ratvar/wall(get_turf(src))
+	new /obj/effect/temp_visual/ratvar/beam(get_turf(src))
 
 /turf/simulated/wall/clockwork/narsie_act()
 	..()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Majorly buffs clockwork tiles to be 134% cooler
Does the same for cult tiles
Gives cult walls an on-hit effect
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Restore a small part of the glory of Ratvar
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

https://github.com/ParadiseSS13/Paradise/assets/108773801/8648606e-7250-4cb4-a725-d8063a0e542c


https://github.com/ParadiseSS13/Paradise/assets/108773801/245b6e90-ab5a-43d0-b485-3a5229f93307


<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Changelog
:cl:
add: Clockwork/Cult tiles now give a glow effect when you walk over them
add: Cult walls now show an effect when they are hit by a bullet
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
