### PR TITLE
Refactors one ventcrawl proc and fixes a bug

### DIFF
--- a/code/modules/atmospherics/machinery/atmospherics.dm
+++ b/code/modules/atmospherics/machinery/atmospherics.dm
@@ -342,7 +342,7 @@ Pipelines + Other Objects -> Pipe network
 	..()
 
 /obj/machinery/atmospherics/proc/can_crawl_through()
-	return 1
+	return TRUE
 
 /obj/machinery/atmospherics/proc/change_color(new_color)
 	//only pass valid pipe colors please ~otherwise your pipe will turn invisible

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -447,11 +447,11 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 	if(!Adjacent(clicked_on))
 		return
 
-	var/ventcrawlerlocal = 0
+	var/ventcrawlerlocal = VENTCRAWLER_NONE
 	if(ventcrawler)
 		ventcrawlerlocal = ventcrawler
 
-	if(!ventcrawlerlocal)
+	if(ventcrawlerlocal == VENTCRAWLER_NONE) // You can't ventcrawl.
 		return
 
 	if(stat)
@@ -465,9 +465,11 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 	if(has_buckled_mobs())
 		to_chat(src, "<span class='warning'>You can't vent crawl with other creatures on you!</span>")
 		return
+
 	if(buckled)
 		to_chat(src, "<span class='warning'>You can't vent crawl while buckled!</span>")
 		return
+
 	if(ishuman(src))
 		var/mob/living/carbon/human/H = src
 		if(H.w_uniform && istype(H.w_uniform, /obj/item/clothing/under/rank/engineering/atmospheric_technician/contortionist))//IMMA SPCHUL SNOWFLAKE
@@ -484,55 +486,54 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 
 
 	if(!vent_found)
-		for(var/obj/machinery/atmospherics/machine in range(1,src))
+		for(var/obj/machinery/atmospherics/machine in range(1, src))
 			if(is_type_in_list(machine, GLOB.ventcrawl_machinery) && machine.can_crawl_through())
 				vent_found = machine
 				break
 
-	if(vent_found)
-		if(vent_found.parent && (vent_found.parent.members.len || vent_found.parent.other_atmosmch))
-			visible_message("<span class='notice'>[src] begins climbing into the ventilation system...</span>", \
-							"<span class='notice'>You begin climbing into the ventilation system...</span>")
-
-			if(!do_after(src, 45, target = src))
-				return
-
-			if(has_buckled_mobs())
-				to_chat(src, "<span class='warning'>You can't vent crawl with other creatures on you!</span>")
-				return
-
-			if(buckled)
-				to_chat(src, "<span class='warning'>You cannot crawl into a vent while buckled to something!</span>")
-				return
-
-			if(!client)
-				return
-
-			if(iscarbon(src) && contents.len && ventcrawlerlocal < 2)//It must have atleast been 1 to get this far
-				for(var/obj/item/I in contents)
-					var/failed = 0
-					if(istype(I, /obj/item/bio_chip))
-						continue
-					if(istype(I, /obj/item/reagent_containers/patch))
-						continue
-					if(I.flags & ABSTRACT)
-						continue
-					else
-						failed++
-
-					if(failed)
-						to_chat(src, "<span class='warning'>You can't crawl around in the ventilation ducts with items!</span>")
-						return
-
-			visible_message("<b>[src] scrambles into the ventilation ducts!</b>", "You climb into the ventilation system.")
-			var/old_loc = loc
-			loc = vent_found
-			Moved(old_loc, get_dir(old_loc, loc), FALSE)
-			add_ventcrawl(vent_found)
-
-	else
+	if(!vent_found)
 		to_chat(src, "<span class='warning'>This ventilation duct is not connected to anything!</span>")
+		return
 
+	if(vent_found.parent && (length(vent_found.parent.members) || vent_found.parent.other_atmosmch))
+		visible_message("<span class='notice'>[src] begins climbing into the ventilation system...</span>", \
+						"<span class='notice'>You begin climbing into the ventilation system...</span>")
+
+		if(!do_after(src, 4.5 SECONDS, target = src))
+			return
+
+		if(!vent_found.can_crawl_through())
+			to_chat(src, "<span class='warning'>You can't vent crawl through that!</span>")
+			return
+
+		if(has_buckled_mobs())
+			to_chat(src, "<span class='warning'>You can't vent crawl with other creatures on you!</span>")
+			return
+
+		if(buckled)
+			to_chat(src, "<span class='warning'>You cannot crawl into a vent while buckled to something!</span>")
+			return
+
+		if(!client)
+			return
+
+		if(iscarbon(src) && length(contents) && ventcrawlerlocal < VENTCRAWLER_ALWAYS) // If we're here you can only ventcrawl while completely nude
+			for(var/obj/item/I in contents)
+				if(istype(I, /obj/item/bio_chip))
+					continue
+				if(istype(I, /obj/item/reagent_containers/patch))
+					continue
+				if(I.flags & ABSTRACT)
+					continue
+
+				to_chat(src, "<span class='warning'>You can't crawl around in the ventilation ducts with items!</span>")
+				return
+
+		visible_message("<b>[src] scrambles into the ventilation ducts!</b>", "You climb into the ventilation system.")
+		var/old_loc = loc
+		loc = vent_found
+		Moved(old_loc, get_dir(old_loc, loc), FALSE)
+		add_ventcrawl(vent_found)
 
 /mob/living/proc/add_ventcrawl(obj/machinery/atmospherics/starting_machine, obj/machinery/atmospherics/target_move)
 	if(!istype(starting_machine) || !starting_machine.returnPipenet(target_move) || !starting_machine.can_see_pipes())

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -495,44 +495,45 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 		to_chat(src, "<span class='warning'>This ventilation duct is not connected to anything!</span>")
 		return
 
-	if(vent_found.parent && (length(vent_found.parent.members) || vent_found.parent.other_atmosmch))
-		visible_message("<span class='notice'>[src] begins climbing into the ventilation system...</span>", \
-						"<span class='notice'>You begin climbing into the ventilation system...</span>")
+	if(!vent_found.parent || !(length(vent_found.parent.members) || vent_found.parent.other_atmosmch))
+		return
 
-		if(!do_after(src, 4.5 SECONDS, target = src))
+	visible_message("<span class='notice'>[src] begins climbing into the ventilation system...</span>", \
+					"<span class='notice'>You begin climbing into the ventilation system...</span>")
+
+	if(!do_after(src, 4.5 SECONDS, target = src))
+		return
+
+	if(!client)
+		return
+
+	if(!vent_found.can_crawl_through())
+		to_chat(src, "<span class='warning'>You can't vent crawl through that!</span>")
+		return
+
+	if(has_buckled_mobs())
+		to_chat(src, "<span class='warning'>You can't vent crawl with other creatures on you!</span>")
+		return
+
+	if(buckled)
+		to_chat(src, "<span class='warning'>You cannot crawl into a vent while buckled to something!</span>")
+		return
+
+	if(iscarbon(src) && length(contents) && ventcrawlerlocal < VENTCRAWLER_ALWAYS) // If we're here you can only ventcrawl while completely nude
+		for(var/obj/item/I in contents)
+			if(istype(I, /obj/item/bio_chip))
+				continue
+			if(istype(I, /obj/item/reagent_containers/patch))
+				continue
+			if(I.flags & ABSTRACT)
+				continue
+
+			to_chat(src, "<span class='warning'>You can't crawl around in the ventilation ducts with items!</span>")
 			return
 
-		if(!client)
-			return
-
-		if(!vent_found.can_crawl_through())
-			to_chat(src, "<span class='warning'>You can't vent crawl through that!</span>")
-			return
-
-		if(has_buckled_mobs())
-			to_chat(src, "<span class='warning'>You can't vent crawl with other creatures on you!</span>")
-			return
-
-		if(buckled)
-			to_chat(src, "<span class='warning'>You cannot crawl into a vent while buckled to something!</span>")
-			return
-
-		if(iscarbon(src) && length(contents) && ventcrawlerlocal < VENTCRAWLER_ALWAYS) // If we're here you can only ventcrawl while completely nude
-			for(var/obj/item/I in contents)
-				if(istype(I, /obj/item/bio_chip))
-					continue
-				if(istype(I, /obj/item/reagent_containers/patch))
-					continue
-				if(I.flags & ABSTRACT)
-					continue
-
-				to_chat(src, "<span class='warning'>You can't crawl around in the ventilation ducts with items!</span>")
-				return
-
-		visible_message("<b>[src] scrambles into the ventilation ducts!</b>", "You climb into the ventilation system.")
-		var/old_loc = loc
-		forceMove(vent_found)
-		add_ventcrawl(vent_found)
+	visible_message("<b>[src] scrambles into the ventilation ducts!</b>", "You climb into the ventilation system.")
+	forceMove(vent_found)
+	add_ventcrawl(vent_found)
 
 /mob/living/proc/add_ventcrawl(obj/machinery/atmospherics/starting_machine, obj/machinery/atmospherics/target_move)
 	if(!istype(starting_machine) || !starting_machine.returnPipenet(target_move) || !starting_machine.can_see_pipes())

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -443,7 +443,7 @@
 
 GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/vent_pump, /obj/machinery/atmospherics/unary/vent_scrubber))
 
-/mob/living/handle_ventcrawl(atom/clicked_on) // -- TLE -- Merged by Carn
+/mob/living/handle_ventcrawl(atom/clicked_on) // Why is this proc even in carbon.dm ...
 	if(!Adjacent(clicked_on))
 		return
 
@@ -502,6 +502,9 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 		if(!do_after(src, 4.5 SECONDS, target = src))
 			return
 
+		if(!client)
+			return
+
 		if(!vent_found.can_crawl_through())
 			to_chat(src, "<span class='warning'>You can't vent crawl through that!</span>")
 			return
@@ -512,9 +515,6 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 
 		if(buckled)
 			to_chat(src, "<span class='warning'>You cannot crawl into a vent while buckled to something!</span>")
-			return
-
-		if(!client)
 			return
 
 		if(iscarbon(src) && length(contents) && ventcrawlerlocal < VENTCRAWLER_ALWAYS) // If we're here you can only ventcrawl while completely nude
@@ -531,8 +531,7 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 
 		visible_message("<b>[src] scrambles into the ventilation ducts!</b>", "You climb into the ventilation system.")
 		var/old_loc = loc
-		loc = vent_found
-		Moved(old_loc, get_dir(old_loc, loc), FALSE)
+		forceMove(vent_found)
 		add_ventcrawl(vent_found)
 
 /mob/living/proc/add_ventcrawl(obj/machinery/atmospherics/starting_machine, obj/machinery/atmospherics/target_move)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Refactors `handle_ventcrawl`
Fixes #24205
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
You shouldn't be able to climb into vents that are welded shut before you get in it
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
I tested the refactor by ventcrawling as various mobs, I didnt have the reaction speed to test the bugfix.
The logic however is (in my opinion) sound, a check after the `do_after` if you can crawl into the machine. The fix is on line 505 to 507
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Fixed ventcrawlers being able to go into welded vents if they were already climbing inside it before the welding was finished
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
