### PR TITLE
[TM ONLY] disables random light flicking 

### DIFF
--- a/code/modules/events/prison_break.dm
+++ b/code/modules/events/prison_break.dm
@@ -61,7 +61,7 @@
 		if(areas && areas.len > 0)
 			for(var/area/A in areas)
 				for(var/obj/machinery/light/L in A)
-					L.flicker(10)
+					L.force_flicker(10)
 
 /datum/event/prison_break/end()
 	for(var/area/A in shuffle(areas))

--- a/code/modules/mob/living/simple_animal/hostile/angel_statue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/angel_statue.dm
@@ -176,8 +176,7 @@
 /obj/effect/proc_holder/spell/aoe/flicker_lights/cast(list/targets, mob/user = usr)
 	for(var/turf/T in targets)
 		for(var/obj/machinery/light/L in T)
-			L.flicker()
-	return
+			L.force_flicker()
 
 //Blind AOE
 /obj/effect/proc_holder/spell/aoe/blindness

--- a/code/modules/mob/living/simple_animal/hostile/floorcluwne.dm
+++ b/code/modules/mob/living/simple_animal/hostile/floorcluwne.dm
@@ -300,7 +300,7 @@
 				manifested = FALSE
 				addtimer(CALLBACK(src, TYPE_PROC_REF(/mob/living/simple_animal/hostile/floor_cluwne, Manifest)), 2)
 				for(var/obj/machinery/light/L in range(H, 8))
-					L.flicker()
+					L.force_flicker()
 
 		if(STAGE_ATTACK)
 

--- a/code/modules/power/lights.dm
+++ b/code/modules/power/lights.dm
@@ -650,7 +650,7 @@
 	if(current_apc)
 		RegisterSignal(machine_powernet, COMSIG_POWERNET_POWER_CHANGE, PROC_REF(update), override = TRUE)
 
-/obj/machinery/light/flicker(amount = rand(20, 30))
+/obj/machinery/light/proc/force_flicker(amount = rand(20, 30))
 	if(flickering)
 		return FALSE
 

--- a/code/modules/power/powernets/local_powernet.dm
+++ b/code/modules/power/powernets/local_powernet.dm
@@ -175,14 +175,3 @@
 /datum/local_powernet/proc/handle_flicker()
 	if(prob(MACHINE_FLICKER_CHANCE))
 		powernet_apc?.flicker()
-
-	// lights don't have their own processing loop, so local powernets will be the father they never had. 3x as likely to cause a light flicker in a particular area, pick a light to flicker at random
-	if(prob(MACHINE_FLICKER_CHANCE * 3))
-		var/list/lights = list()
-		for(var/obj/machinery/light/L in powernet_area)
-			lights += L
-
-		if(length(lights))
-			var/obj/machinery/light/picked_light = pick(lights)
-			ASSERT(istype(picked_light))
-			picked_light.flicker()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
disables random light flicking 

## Why It's Good For The Game
I've always been curious about why lighting is so much more expensive than most other functions, and more importantly, why it was consistently expensive. Through testing I wasn't able to find anything conclusive, this is subsystem bound so we can't check the true function costs. On live I couldn't actually find much of a consistent way to track, every time something needed updating it was in a different place or nearly the exact same place. There also weren't any affecting sources around either.
Then, out of the blue, I looked into flickering. it's nearly unnoticeable in game so it shouldn't be an issue?
On average we flicker one light per second (local literally is running slower than production as well), which will call update 41-61 TIMES. There's a good chance this light isn't EVEN ON THE STATION Z LEVEL.
My local literally had it's lighting costs disappear by doing this. If this manages to remove a lot of cpu time from update I'll make a patch to keep the system in but require a player check,
Lighting is 20% of our total cpu usage so yeah this would be big.
## Testing
Tried it on local
## Changelog
:cl:
experiment: A TM only pr got merged
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
