### PR TITLE
Don't pick the color of `cable_coil/random` when splitting a stack

### DIFF
--- a/code/modules/power/cables/cable_coil.dm
+++ b/code/modules/power/cables/cable_coil.dm
@@ -42,7 +42,7 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list (new/datum/stack_recipe/cable_restrain
 
 /obj/item/stack/cable_coil/random/change_stack(mob/user, amount)
 	var/obj/item/stack/cable_coil/new_stack = ..()
-	new_stack.color = src.color
+	new_stack.color = color
 	return new_stack
 
 /obj/item/stack/cable_coil/update_name()

--- a/code/modules/power/cables/cable_coil.dm
+++ b/code/modules/power/cables/cable_coil.dm
@@ -40,6 +40,11 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list (new/datum/stack_recipe/cable_restrain
 	recipes = GLOB.cable_coil_recipes
 	update_wclass()
 
+/obj/item/stack/cable_coil/random/change_stack(mob/user, amount)
+	var/obj/item/stack/cable_coil/new_stack = ..()
+	new_stack.color = src.color
+	return new_stack
+
 /obj/item/stack/cable_coil/update_name()
 	. = ..()
 	if(amount > 2)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This fixes the weird and *tricky* change in the color of a cable when splitting the stack.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Splitting a cable stack looks good now. Please use crayons to change cable color.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Yes.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl: Maxiemar
fix: Fixed changing the color of a cable when splitting the stack.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
