### PR TITLE
Makes glass shards craftable using sheets

### DIFF
--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -15,6 +15,7 @@
  */
 
 GLOBAL_LIST_INIT(glass_recipes, list (
+	new /datum/stack_recipe("glass shard", /obj/item/shard, time = 0 SECONDS),
 	new /datum/stack_recipe/window("directional window", /obj/structure/window/basic, time = 0 SECONDS, on_floor = TRUE, window_checks = TRUE),
 	new /datum/stack_recipe/window("fulltile window", /obj/structure/window/full/basic, 2, time = 0 SECONDS, on_floor = TRUE, window_checks = TRUE),
 	new /datum/stack_recipe("fishbowl", /obj/machinery/fishtank/bowl, 1, time = 1 SECONDS),
@@ -92,6 +93,7 @@ GLOBAL_LIST_INIT(glass_recipes, list (
  */
 
 GLOBAL_LIST_INIT(reinforced_glass_recipes, list (
+	new /datum/stack_recipe("glass shard", /obj/item/shard, time = 0 SECONDS),
 	new /datum/stack_recipe/window("windoor frame", /obj/structure/windoor_assembly, 5, time = 0 SECONDS, on_floor = TRUE, window_checks = TRUE),
 	null,
 	new /datum/stack_recipe/window("directional reinforced window", /obj/structure/window/reinforced, time = 0 SECONDS, on_floor = TRUE, window_checks = TRUE),
@@ -128,6 +130,7 @@ GLOBAL_LIST_INIT(reinforced_glass_recipes, list (
 	. += "<span class='notice'>Reinforced glass is much stronger against damage than normal glass, otherwise it functions like normal glass does.</span>"
 
 GLOBAL_LIST_INIT(pglass_recipes, list (
+	new /datum/stack_recipe("plasma shard", /obj/item/shard/plasma, time = 0 SECONDS),
 	new /datum/stack_recipe/window("directional window", /obj/structure/window/plasmabasic, time = 0 SECONDS, on_floor = TRUE, window_checks = TRUE),
 	new /datum/stack_recipe/window("fulltile window", /obj/structure/window/full/plasmabasic, 2, time = 0 SECONDS, on_floor = TRUE, window_checks = TRUE)
 ))
@@ -184,6 +187,7 @@ GLOBAL_LIST_INIT(pglass_recipes, list (
  */
 
 GLOBAL_LIST_INIT(prglass_recipes, list (
+	new /datum/stack_recipe("plasma shard", /obj/item/shard/plasma, time = 0 SECONDS),
 	new /datum/stack_recipe/window("directional reinforced window", /obj/structure/window/plasmareinforced, time = 0 SECONDS, on_floor = TRUE, window_checks = TRUE),
 	new /datum/stack_recipe/window("fulltile reinforced window", /obj/structure/window/full/plasmareinforced, 2, time = 0 SECONDS, on_floor = TRUE, window_checks = TRUE)
 ))


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Makes glass and plasma glass shards craftable via the in-hand menu for glass, reinforced glass, plasma, and reinforced plasma sheets.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Adds QOL for acquiring shards. Having to place down a bunch of windows is pretty tedious when you want a lot of them.

## Testing
<!-- How did you test the PR, if at all? -->
Spawned and crafted shards using a sheet of each type.
## Changelog
:cl: Chuga
add: Shards can now be crafted using glass and plasmaglass sheets
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
