### PR TITLE
Reverts Limits Command Antagonist Eligibility #24057

### DIFF
--- a/code/controllers/subsystem/SSjobs.dm
+++ b/code/controllers/subsystem/SSjobs.dm
@@ -12,7 +12,6 @@ SUBSYSTEM_DEF(jobs)
 	var/list/type_occupations = list()	//Dict of all jobs, keys are types
 	var/list/prioritized_jobs = list() // List of jobs set to priority by HoP/Captain
 	var/list/id_change_records = list() // List of all job transfer records
-	var/probability_of_antag_role_restriction = 100 // Dict probability of a job rolling an antagonist role
 	var/id_change_counter = 1
 	//Players who need jobs
 	var/list/unassigned = list()
@@ -152,12 +151,6 @@ SUBSYSTEM_DEF(jobs)
 		if(player.mind && (job.title in player.mind.restricted_roles))
 			Debug("FOC incompatbile with antagonist role, Player: [player]")
 			continue
-		if(player.mind && (job.title in SSticker.mode.single_antag_positions))
-			if(!prob(probability_of_antag_role_restriction))
-				Debug("Failed probability of getting a second antagonist position in this job, Player: [player], Job:[job.title]")
-				continue
-			else
-				probability_of_antag_role_restriction /= 10
 		if(player.client.prefs.active_character.GetJobDepartment(job, level) & job.flag)
 			Debug("FOC pass, Player: [player], Level:[level]")
 			candidates += player
@@ -201,12 +194,6 @@ SUBSYSTEM_DEF(jobs)
 		if(player.mind && (job.title in player.mind.restricted_roles))
 			Debug("GRJ incompatible with antagonist role, Player: [player], Job: [job.title]")
 			continue
-		if(player.mind && (job.title in SSticker.mode.single_antag_positions))
-			if(!prob(probability_of_antag_role_restriction))
-				Debug("Failed probability of getting a second antagonist position in this job, Player: [player], Job:[job.title]")
-				continue
-			else
-				probability_of_antag_role_restriction /= 10
 		if((job.current_positions < job.spawn_positions) || job.spawn_positions == -1)
 			Debug("GRJ Random job given, Player: [player], Job: [job]")
 			AssignRole(player, job.title)
@@ -388,12 +375,6 @@ SUBSYSTEM_DEF(jobs)
 				if(player.mind && (job.title in player.mind.restricted_roles))
 					Debug("DO incompatible with antagonist role, Player: [player], Job:[job.title]")
 					continue
-				if(player.mind && (job.title in SSticker.mode.single_antag_positions))
-					if(!prob(probability_of_antag_role_restriction))
-						Debug("Failed probability of getting a second antagonist position in this job, Player: [player], Job:[job.title]")
-						continue
-					else
-						probability_of_antag_role_restriction /= 10
 				// If the player wants that job on this level, then try give it to him.
 				if(player.client.prefs.active_character.GetJobDepartment(job, level) & job.flag)
 

--- a/code/game/gamemodes/extended/extended.dm
+++ b/code/game/gamemodes/extended/extended.dm
@@ -2,7 +2,6 @@
 	name = "extended"
 	config_tag = "extended"
 	required_players = 0
-	single_antag_positions = list()
 
 /datum/game_mode/announce()
 	to_chat(world, "<B>The current game mode is - Extended Role-Playing!</B>")

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -43,12 +43,9 @@
 
 	var/list/datum/station_goal/station_goals = list() // A list of all station goals for this game mode
 
-	/// Each item in this list can only be rolled once on average.
-	var/list/single_antag_positions = list("Head of Personnel", "Chief Engineer", "Research Director", "Chief Medical Officer", "Quartermaster")
 
 /datum/game_mode/proc/announce() //to be calles when round starts
 	to_chat(world, "<B>Notice</B>: [src] did not define announce()")
-
 
 ///can_start()
 ///Checks to see if the game can be setup and ran with the current number of players or whatnot.

--- a/code/game/gamemodes/miniantags/abduction/abduction.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction.dm
@@ -10,7 +10,6 @@
 	required_players = 15
 	var/max_teams = 4
 	abductor_teams = 1
-	single_antag_positions = list()
 	var/list/datum/mind/scientists = list()
 	var/list/datum/mind/agents = list()
 	var/list/datum/objective/team_objectives = list()

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -13,7 +13,6 @@
 	required_players = 30	// 30 players - 5 players to be the nuke ops = 25 players remaining
 	required_enemies = 5
 	recommended_enemies = 5
-	single_antag_positions = list()
 
 	var/const/agents_possible = 5 //If we ever need more syndicate agents.
 

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -9,7 +9,6 @@
 	required_players = 20
 	required_enemies = 1
 	recommended_enemies = 1
-	single_antag_positions = list()
 	var/use_huds = TRUE
 
 	var/finished = FALSE


### PR DESCRIPTION
## What Does This PR Do
Reverts #24057.

## Why It's Good For The Game
That PR could probably have done with a test merge and has had the unintended consequence of limiting the amount of people who can ACTUALLY roll Command positions.

TL;DR.

Less command antags? Good.
Less command? Bad.
My bad.

## Testing
This is exactly as it was previously.

## Changelog
:cl:
del: There is no longer a cap on the amount of Command members that can roll antagonist positions.
/:cl:
