### PR TITLE
Makes head roles not sometimes fail to roll

### DIFF
--- a/code/controllers/subsystem/SSjobs.dm
+++ b/code/controllers/subsystem/SSjobs.dm
@@ -101,7 +101,7 @@ SUBSYSTEM_DEF(jobs)
 					GiveRandomJob(player, TRUE)
 					if(second_pass)
 						AssignRole(player, "Assistant") // No other jobs to give them
-					return
+					return FALSE
 				else
 					probability_of_antag_role_restriction /= 10
 			Debug("Player: [player] is now Rank: [rank], JCP:[job.current_positions], JTP:[job.total_positions], JSP:[job.spawn_positions]")
@@ -116,10 +116,10 @@ SUBSYSTEM_DEF(jobs)
 			unassigned -= player
 			job.current_positions++
 			SSblackbox.record_feedback("nested tally", "manifest", 1, list(rank, (latejoin ? "latejoin" : "roundstart")))
-			return 1
+			return rank
 
 	Debug("AR has failed, Player: [player], Rank: [rank]")
-	return 0
+	return FALSE
 
 /datum/controller/subsystem/jobs/proc/FreeRole(rank, force = FALSE)	//making additional slot on the fly
 	var/datum/job/job = GetJob(rank)

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -53,6 +53,9 @@
 	/// Tracks if this mind has been a rev or not
 	var/has_been_rev = FALSE
 
+	/// Tracks if the player will be rolling antag this round from a random antag role
+	var/will_roll_antag = FALSE
+
 	var/miming = 0 // Mime's vow of silence
 	/// A list of all the antagonist datums that the player is (does not include undatumized antags)
 	var/list/antag_datums

--- a/code/game/gamemodes/autotraitor/autotraitor.dm
+++ b/code/game/gamemodes/autotraitor/autotraitor.dm
@@ -55,13 +55,9 @@
 		if(istype(traitor))
 			traitor.special_role = SPECIAL_ROLE_TRAITOR
 			traitor.restricted_roles = restricted_jobs
+			traitor.will_roll_antag = TRUE
 
-//	if(!traitors.len)
-//		return 0
-	return 1
-
-
-
+	return TRUE
 
 /datum/game_mode/traitor/autotraitor/post_setup()
 	..()

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -44,6 +44,7 @@ GLOBAL_LIST_INIT(possible_changeling_IDs, list("Alpha","Beta","Gamma","Delta","E
 		pre_changelings += changeling
 		changeling.restricted_roles = restricted_jobs
 		changeling.special_role = SPECIAL_ROLE_CHANGELING
+		changeling.will_roll_antag = TRUE
 
 	if(!length(pre_changelings))
 		return FALSE

--- a/code/game/gamemodes/changeling/traitor_chan.dm
+++ b/code/game/gamemodes/changeling/traitor_chan.dm
@@ -38,6 +38,7 @@
 		pre_changelings += changeling
 		changeling.restricted_roles = (restricted_jobs + secondary_restricted_jobs)
 		changeling.special_role = SPECIAL_ROLE_CHANGELING
+		changeling.will_roll_antag = TRUE
 
 	return ..()
 

--- a/code/game/gamemodes/cult/cult_mode.dm
+++ b/code/game/gamemodes/cult/cult_mode.dm
@@ -74,6 +74,7 @@
 		cult += cultist
 		cultist.restricted_roles = restricted_jobs
 		cultist.special_role = SPECIAL_ROLE_CULTIST
+		cultist.will_roll_antag = TRUE
 	return (length(cult) > 0)
 
 /datum/game_mode/cult/post_setup()

--- a/code/game/gamemodes/extended/extended.dm
+++ b/code/game/gamemodes/extended/extended.dm
@@ -9,7 +9,7 @@
 	to_chat(world, "<B>Just have fun and role-play!</B>")
 
 /datum/game_mode/extended/pre_setup()
-	return 1
+	return TRUE
 
 /datum/game_mode/extended/post_setup()
 	..()

--- a/code/game/gamemodes/miniantags/abduction/abduction.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction.dm
@@ -28,7 +28,7 @@
 	possible_abductors = get_players_for_role(ROLE_ABDUCTOR)
 
 	if(!possible_abductors.len)
-		return 0
+		return FALSE
 
 	abductor_teams = max(1, min(max_teams,round(num_players()/15)))
 	var/possible_teams = max(1,round(possible_abductors.len / 2))
@@ -42,7 +42,7 @@
 
 	for(var/i=1,i<=abductor_teams,i++)
 		if(!make_abductor_team(i))
-			return 0
+			return FALSE
 	..()
 	return 1
 
@@ -77,11 +77,13 @@
 
 	scientist.assigned_role = SPECIAL_ROLE_ABDUCTOR_SCIENTIST
 	scientist.special_role = SPECIAL_ROLE_ABDUCTOR_SCIENTIST
+	scientist.will_roll_antag = TRUE
 	scientist.offstation_role = TRUE
 	log_game("[key_name(scientist)] has been selected as an abductor team [team_number] scientist.")
 
 	agent.assigned_role = SPECIAL_ROLE_ABDUCTOR_AGENT
 	agent.special_role = SPECIAL_ROLE_ABDUCTOR_AGENT
+	agent.will_roll_antag = TRUE
 	agent.offstation_role = TRUE
 	log_game("[key_name(agent)] has been selected as an abductor team [team_number] agent.")
 

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -55,6 +55,7 @@
 	for(var/datum/mind/synd_mind in syndicates)
 		synd_mind.assigned_role = SPECIAL_ROLE_NUKEOPS //So they aren't chosen for other jobs.
 		synd_mind.special_role = SPECIAL_ROLE_NUKEOPS
+		synd_mind.will_roll_antag = TRUE
 	return 1
 
 

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -64,6 +64,7 @@
 		var/datum/mind/new_headrev = pick_n_take(pre_revolutionaries)
 		new_headrev.add_antag_datum(/datum/antagonist/rev/head)
 		rev_team.add_member(new_headrev)
+		new_headrev.will_roll_antag = TRUE
 
 	..()
 

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -53,6 +53,7 @@
 		pre_traitors += traitor
 		traitor.special_role = SPECIAL_ROLE_TRAITOR
 		traitor.restricted_roles = restricted_jobs
+		traitor.will_roll_antag = TRUE
 
 	if(!length(pre_traitors))
 		return FALSE

--- a/code/game/gamemodes/trifecta/trifecta.dm
+++ b/code/game/gamemodes/trifecta/trifecta.dm
@@ -43,6 +43,7 @@
 		pre_vampires += vampire
 		vampire.special_role = SPECIAL_ROLE_VAMPIRE
 		vampire.restricted_roles = (restricted_jobs + secondary_restricted_jobs + vampire_restricted_jobs)
+		vampire.will_roll_antag = TRUE
 
 	//Vampires made, off to changelings
 	var/list/datum/mind/possible_changelings = get_players_for_role(ROLE_CHANGELING)
@@ -58,6 +59,7 @@
 		pre_changelings += changeling
 		changeling.restricted_roles = (restricted_jobs + secondary_restricted_jobs)
 		changeling.special_role = SPECIAL_ROLE_CHANGELING
+		changeling.will_roll_antag = TRUE
 
 	//And now traitors
 	var/list/datum/mind/possible_traitors = get_players_for_role(ROLE_TRAITOR)
@@ -74,6 +76,7 @@
 		pre_traitors += traitor
 		traitor.special_role = SPECIAL_ROLE_TRAITOR
 		traitor.restricted_roles = restricted_jobs
+		traitor.will_roll_antag = TRUE
 
 	return TRUE
 

--- a/code/game/gamemodes/vampire/traitor_vamp.dm
+++ b/code/game/gamemodes/vampire/traitor_vamp.dm
@@ -36,6 +36,7 @@
 			pre_vampires += vampire
 			vampire.special_role = SPECIAL_ROLE_VAMPIRE
 			vampire.restricted_roles = (restricted_jobs + secondary_restricted_jobs)
+			vampire.will_roll_antag = TRUE
 		..()
 		return 1
 	else

--- a/code/game/gamemodes/vampire/vampire_gamemode.dm
+++ b/code/game/gamemodes/vampire/vampire_gamemode.dm
@@ -36,6 +36,7 @@
 			pre_vampires += vampire
 			vampire.special_role = SPECIAL_ROLE_VAMPIRE
 			vampire.restricted_roles = restricted_jobs
+			vampire.will_roll_antag = TRUE
 
 		..()
 		return TRUE

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -31,6 +31,7 @@
 	modePlayer += wizard
 	wizard.assigned_role = SPECIAL_ROLE_WIZARD //So they aren't chosen for other jobs.
 	wizard.special_role = SPECIAL_ROLE_WIZARD
+	wizard.will_roll_antag = TRUE
 	wizard.set_original_mob(wizard.current)
 	if(GLOB.wizardstart.len == 0)
 		to_chat(wizard.current, "<span class='danger'>A starting location for you could not be found, please report this bug!</span>")

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -328,10 +328,10 @@
 		to_chat(src, alert("[rank] is not available due to your character having amputated limbs without a prosthetic replacement. Please try another."))
 		return 0
 
-	SSjobs.AssignRole(src, rank, 1)
+	var/role_to_assign = SSjobs.AssignRole(src, rank, 1)
 
 	var/mob/living/character = create_character()	//creates the human and transfers vars and mind
-	character = SSjobs.AssignRank(character, rank, TRUE)					//equips the human
+	character = SSjobs.AssignRank(character, role_to_assign, TRUE)					//equips the human
 
 	// AIs don't need a spawnpoint, they must spawn at an empty core
 	if(character.mind.assigned_role == "AI")
@@ -339,7 +339,7 @@
 
 		// IsJobAvailable for AI checks that there is an empty core available in this list
 		ai_character.moveToEmptyCore()
-		AnnounceCyborg(ai_character, rank, "has been downloaded to the empty core in \the [get_area(ai_character)]")
+		AnnounceCyborg(ai_character, role_to_assign, "has been downloaded to the empty core in \the [get_area(ai_character)]")
 
 		SSticker.mode.latespawn(ai_character)
 		qdel(src)
@@ -348,10 +348,10 @@
 	//Find our spawning point.
 	var/join_message
 
-	if(IsAdminJob(rank))
-		if(IsERTSpawnJob(rank))
+	if(IsAdminJob(role_to_assign))
+		if(IsERTSpawnJob(role_to_assign))
 			character.loc = pick(GLOB.ertdirector)
-		else if(IsSyndicateCommand(rank))
+		else if(IsSyndicateCommand(role_to_assign))
 			character.loc = pick(GLOB.syndicateofficer)
 		else
 			character.forceMove(pick(GLOB.aroomwarp))
@@ -366,18 +366,18 @@
 		character.buckled.forceMove(character.loc)
 		character.buckled.dir = character.dir
 
-	character = SSjobs.EquipRank(character, rank, 1)					//equips the human
+	character = SSjobs.EquipRank(character, role_to_assign, 1)					//equips the human
 	SSticker.equip_cuis(character) // Gives them their CUIs
 
 	SSticker.mode.latespawn(character)
 
 	if(character.mind.assigned_role == "Cyborg")
-		AnnounceCyborg(character, rank, join_message)
+		AnnounceCyborg(character, role_to_assign, join_message)
 	else
 		SSticker.minds += character.mind//Cyborgs and AIs handle this in the transform proc.	//TODO!!!!! ~Carn
-		if(!IsAdminJob(rank))
+		if(!IsAdminJob(role_to_assign))
 			GLOB.data_core.manifest_inject(character)
-			AnnounceArrival(character, rank, join_message)
+			AnnounceArrival(character, role_to_assign, join_message)
 
 			if(length(GLOB.current_pending_diseases) && character.ForceContractDisease(GLOB.current_pending_diseases[1], TRUE, TRUE))
 				popleft(GLOB.current_pending_diseases)

--- a/data/mode.txt
+++ b/data/mode.txt
@@ -1,1 +1,1 @@
-traitor
+extended

--- a/data/mode.txt
+++ b/data/mode.txt
@@ -1,1 +1,1 @@
-extended
+traitor


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes head roles not sometimes fail to roll
If a lot of people have head roles on high startshift (Like a LOT) and RNG is bad, there's a chance people who should roll head roles won't properly roll it. Most of the time this just caused a bunch of bogus errors instead of any real issues though
Also just generally cleans up the code. We gotta refactor jobs at some point

## Why It's Good For The Game
Bugs bad

## Testing
Joined as a tot twice, once with a 100% chance of getting my head role and a 0% chance of getting a head role. worked both times
## Changelog
:cl:
fix: Fixed a rare case of head roles fizzling and not being assigned
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
