### PR TITLE
fixes new players getting an unusable verb

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -24,12 +24,11 @@
 		mind.current = null // We best null their mind as well, otherwise /every/ single new player is going to explode the server a little more going in/out of the round
 	return ..()
 
-/mob/new_player/verb/new_player_panel()
+/mob/new_player/proc/new_player_panel()
 	if(client.tos_consent || GLOB.configuration.system.external_tos_handler)
 		new_player_panel_proc()
 	else
 		privacy_consent()
-
 
 /mob/new_player/proc/privacy_consent()
 	var/output = GLOB.join_tos
@@ -46,7 +45,6 @@
 	popup.set_content(output)
 	popup.open(0)
 	return
-
 
 /mob/new_player/proc/new_player_panel_proc()
 	set waitfor = FALSE


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
fixes new players getting an unusable verb "new player panel" by just making it a true proc

## Why It's Good For The Game
this is a proc pretending to be a verb

## Testing
Compiled and ran this code, saw the panel in game

## Changelog
:cl:
fix: new players no longer get an unusable "new player panel" verb
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
