### PR TITLE
Puts some of the stack crafting code onto the stack recipe datum.

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -221,6 +221,12 @@
 			return
 		R.post_build(usr, src, O)
 
+		if(amount < 1) // Just in case a stack's amount ends up fractional somehow
+			var/oldsrc = src
+			src = null //dont kill proc after qdel()
+			usr.unEquip(oldsrc, 1)
+			qdel(oldsrc)
+
 	if(src && usr.machine == src) //do not reopen closed window
 		spawn(0)
 			interact(usr)

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -213,75 +213,13 @@
 				message_admins("[key_name_admin(usr)] just attempted to href exploit sheet crafting with an invalid multiplier. Ban highly advised.")
 			multiplier = 1
 
-		if(get_amount() < R.req_amount * multiplier)
-			if(R.req_amount * multiplier > 1)
-				to_chat(usr, "<span class='warning'>You haven't got enough [src] to build \the [R.req_amount * multiplier] [R.title]\s!</span>")
-			else
-				to_chat(usr, "<span class='warning'>You haven't got enough [src] to build \the [R.title]!</span>")
-			return FALSE
-
-		if(R.window_checks && !valid_window_location(get_turf(src), usr.dir))
-			to_chat(usr, "<span class='warning'>\The [R.title] won't fit here!</span>")
-			return FALSE
-
-		if(R.one_per_turf && (locate(R.result_type) in get_turf(src)))
-			to_chat(usr, "<span class='warning'>There is another [R.title] here!</span>")
-			return FALSE
-
-		if(R.on_floor && !issimulatedturf(get_turf(src)))
-			to_chat(usr, "<span class='warning'>\The [R.title] must be constructed on the floor!</span>")
-			return FALSE
-		if(R.on_floor_or_lattice && !(issimulatedturf(get_turf(src)) || locate(/obj/structure/lattice) in get_turf(src)))
-			to_chat(usr, "<span class='warning'>\The [R.title] must be constructed on the floor or lattice!</span>")
-			return FALSE
-
-		if(R.cult_structure)
-			if(usr.holy_check())
-				return
-			if(!is_level_reachable(usr.z))
-				to_chat(usr, "<span class='warning'>The energies of this place interfere with the metal shaping!</span>")
-				return
-			if(locate(/obj/structure/cult) in get_turf(src))
-				to_chat(usr, "<span class='warning'>There is a structure here!</span>")
-				return FALSE
-
-		if(R.time)
-			to_chat(usr, "<span class='notice'>Building [R.title]...</span>")
-			if(!do_after(usr, R.time, target = loc))
-				return FALSE
-
-		if(R.cult_structure && locate(/obj/structure/cult) in get_turf(src)) //Check again after do_after to prevent queuing construction exploit.
-			to_chat(usr, "<span class='warning'>There is a structure here!</span>")
-			return FALSE
-
-		if(get_amount() < R.req_amount * multiplier)
+		if(!R.try_build(usr, src, multiplier))
 			return
-
-		var/atom/O
-		if(R.max_res_amount > 1) //Is it a stack?
-			O = new R.result_type(get_turf(src), R.res_amount * multiplier)
-		else
-			O = new R.result_type(get_turf(src))
-		O.setDir(usr.dir)
-		use(R.req_amount * multiplier)
-		updateUsrDialog()
-
-		R.post_build(src, O)
-
-		if(amount < 1) // Just in case a stack's amount ends up fractional somehow
-			var/oldsrc = src
-			src = null //dont kill proc after qdel()
-			usr.unEquip(oldsrc, 1)
-			qdel(oldsrc)
-			if(isitem(O))
-				usr.put_in_hands(O)
-
-		O.add_fingerprint(usr)
-		//BubbleWrap - so newly formed boxes are empty
-		if(isstorage(O))
-			for(var/obj/item/I in O)
-				qdel(I)
-		//BubbleWrap END
+		var/obj/O
+		O = R.do_build(usr, src, multiplier, O)
+		if(!O)
+			return
+		R.post_build(usr, src, O)
 
 	if(src && usr.machine == src) //do not reopen closed window
 		spawn(0)

--- a/code/game/objects/items/stacks/stack_recipe.dm
+++ b/code/game/objects/items/stacks/stack_recipe.dm
@@ -62,6 +62,10 @@
 			to_chat(user, "<span class='warning'>There is a structure here!</span>")
 			return FALSE
 
+	return TRUE
+
+/// Creates the atom defined by the recipe. Should always return the object it creates or FALSE. This proc assumes that the construction is already possible; for checking whether a recipe *can* be built before construction, use try_build()
+/datum/stack_recipe/proc/do_build(mob/user, obj/item/stack/S, multiplier, atom/O)
 	if(time)
 		to_chat(user, "<span class='notice'>Building [title]...</span>")
 		if(!do_after(user, time, target = S.loc))
@@ -71,13 +75,9 @@
 		to_chat(user, "<span class='warning'>There is a structure here!</span>")
 		return FALSE
 
-	if(S.get_amount() < req_amount * multiplier)
+	if(S.get_amount() < req_amount * multiplier) // Check they still have enough.
 		return FALSE
 
-	return TRUE
-
-/// Creates the atom defined by the recipe. Should always return the object it creates. This proc assumes that the construction is already possible; for checking whether a recipe *can* be built before construction, use try_build()
-/datum/stack_recipe/proc/do_build(mob/user, obj/item/stack/S, multiplier, atom/O)
 	if(max_res_amount > 1) //Is it a stack?
 		O = new result_type(get_turf(S), res_amount * multiplier)
 	else

--- a/code/game/objects/items/stacks/stack_recipe.dm
+++ b/code/game/objects/items/stacks/stack_recipe.dm
@@ -28,7 +28,7 @@
 	src.window_checks = window_checks
 	src.cult_structure = cult_structure
 
-///Returns TRUE if the recipe can be built, otherwise returns FALSE.  This proc is only meant as a series of tests to check if construction is possible; the actual creation of the resulting atom should be handled in do_build()
+/// Returns TRUE if the recipe can be built, otherwise returns FALSE. This proc is only meant as a series of tests to check if construction is possible; the actual creation of the resulting atom should be handled in do_build()
 /datum/stack_recipe/proc/try_build(mob/user, obj/item/stack/S, multiplier)
 	if(S.get_amount() < req_amount * multiplier)
 		if(req_amount * multiplier > 1)
@@ -76,7 +76,7 @@
 
 	return TRUE
 
-///Creates the atom defined by the recipe.  Should always return the object it creates.  This proc assumes that the construction is already possible; for checking whether a recipe *can* be built before construction, use try_build()
+/// Creates the atom defined by the recipe. Should always return the object it creates. This proc assumes that the construction is already possible; for checking whether a recipe *can* be built before construction, use try_build()
 /datum/stack_recipe/proc/do_build(mob/user, obj/item/stack/S, multiplier, atom/O)
 	if(max_res_amount > 1) //Is it a stack?
 		O = new result_type(get_turf(S), res_amount * multiplier)
@@ -87,7 +87,7 @@
 	S.updateUsrDialog()
 	return O
 
-///What should be done after the object is built?  obj/item/stack/O might not actually be a stack, but this proc needs access to merge() to work, which is on obj/item/stack, so declare it as obj/item/stack anyways.
+/// What should be done after the object is built? obj/item/stack/O might not actually be a stack, but this proc needs access to merge() to work, which is on obj/item/stack, so declare it as obj/item/stack anyways.
 /datum/stack_recipe/proc/post_build(mob/user, obj/item/stack/S, obj/item/stack/O)
 	if(S.amount < 1) // Just in case a stack's amount ends up fractional somehow
 		var/oldsrc = S

--- a/code/game/objects/items/stacks/stack_recipe.dm
+++ b/code/game/objects/items/stacks/stack_recipe.dm
@@ -28,8 +28,84 @@
 	src.window_checks = window_checks
 	src.cult_structure = cult_structure
 
-/datum/stack_recipe/proc/post_build(obj/item/stack/S, obj/result)
-	return
+///Returns TRUE if the recipe can be built, otherwise returns FALSE.  This proc is only meant as a series of tests to check if construction is possible; the actual creation of the resulting atom should be handled in do_build()
+/datum/stack_recipe/proc/try_build(mob/user, obj/item/stack/S, multiplier)
+	if(S.get_amount() < req_amount * multiplier)
+		if(req_amount * multiplier > 1)
+			to_chat(user, "<span class='warning'>You haven't got enough [S] to build \the [req_amount * multiplier] [title]\s!</span>")
+		else
+			to_chat(user, "<span class='warning'>You haven't got enough [S] to build \the [title]!</span>")
+		return FALSE
+
+	if(window_checks && !valid_window_location(get_turf(S), user.dir))
+		to_chat(user, "<span class='warning'>\The [title] won't fit here!</span>")
+		return FALSE
+
+	if(one_per_turf && (locate(result_type) in get_turf(S)))
+		to_chat(user, "<span class='warning'>There is another [title] here!</span>")
+		return FALSE
+
+	if(on_floor && !issimulatedturf(get_turf(S)))
+		to_chat(user, "<span class='warning'>\The [title] must be constructed on the floor!</span>")
+		return FALSE
+	if(on_floor_or_lattice && !(issimulatedturf(get_turf(S)) || locate(/obj/structure/lattice) in get_turf(S)))
+		to_chat(user, "<span class='warning'>\The [title] must be constructed on the floor or lattice!</span>")
+		return FALSE
+
+	if(cult_structure)
+		if(user.holy_check())
+			return
+		if(!is_level_reachable(user.z))
+			to_chat(user, "<span class='warning'>The energies of this place interfere with the metal shaping!</span>")
+			return
+		if(locate(/obj/structure/cult) in get_turf(S))
+			to_chat(user, "<span class='warning'>There is a structure here!</span>")
+			return FALSE
+
+	if(time)
+		to_chat(user, "<span class='notice'>Building [title]...</span>")
+		if(!do_after(user, time, target = S.loc))
+			return FALSE
+
+	if(cult_structure && locate(/obj/structure/cult) in get_turf(S)) //Check again after do_after to prevent queuing construction exploit.
+		to_chat(user, "<span class='warning'>There is a structure here!</span>")
+		return FALSE
+
+	if(S.get_amount() < req_amount * multiplier)
+		return
+
+	return TRUE
+
+///Creates the atom defined by the recipe.  Should always return the object it creates.  This proc assumes that the construction is already possible; for checking whether a recipe *can* be built before construction, use try_build()
+/datum/stack_recipe/proc/do_build(mob/user, obj/item/stack/S, multiplier, atom/O)
+	if(max_res_amount > 1) //Is it a stack?
+		O = new result_type(get_turf(S), res_amount * multiplier)
+	else
+		O = new result_type(get_turf(S))
+	O.setDir(user.dir)
+	S.use(req_amount * multiplier)
+	S.updateUsrDialog()
+	return O
+
+///What should be done after the object is built?  obj/item/stack/O might not actually be a stack, but this proc needs access to merge() to work, which is on obj/item/stack, so declare it as obj/item/stack anyways.
+/datum/stack_recipe/proc/post_build(mob/user, obj/item/stack/S, obj/item/stack/O)
+	if(S.amount < 1) // Just in case a stack's amount ends up fractional somehow
+		var/oldsrc = S
+		S = null //dont kill proc after qdel()
+		user.unEquip(oldsrc, 1)
+		qdel(oldsrc)
+
+	if(isitem(O))
+		if(isstack(O) && istype(O, user.get_inactive_hand()))
+			O.merge(user.get_inactive_hand())
+		user.put_in_hands(O)
+
+	O.add_fingerprint(user)
+	//BubbleWrap - so newly formed boxes are empty
+	if(isstorage(O))
+		for(var/obj/item/I in O)
+			qdel(I)
+	//BubbleWrap END
 
 /* Special Recipes */
 
@@ -64,6 +140,7 @@
 		W.ini_dir = W.dir
 		W.anchored = FALSE
 		W.state = WINDOW_OUT_OF_FRAME
+	..()
 
 /*
  * Recipe list datum

--- a/code/game/objects/items/stacks/stack_recipe.dm
+++ b/code/game/objects/items/stacks/stack_recipe.dm
@@ -54,10 +54,10 @@
 
 	if(cult_structure)
 		if(user.holy_check())
-			return
+			return FALSE
 		if(!is_level_reachable(user.z))
 			to_chat(user, "<span class='warning'>The energies of this place interfere with the metal shaping!</span>")
-			return
+			return FALSE
 		if(locate(/obj/structure/cult) in get_turf(S))
 			to_chat(user, "<span class='warning'>There is a structure here!</span>")
 			return FALSE
@@ -72,7 +72,7 @@
 		return FALSE
 
 	if(S.get_amount() < req_amount * multiplier)
-		return
+		return FALSE
 
 	return TRUE
 

--- a/code/game/objects/items/stacks/stack_recipe.dm
+++ b/code/game/objects/items/stacks/stack_recipe.dm
@@ -32,13 +32,13 @@
 /datum/stack_recipe/proc/try_build(mob/user, obj/item/stack/S, multiplier)
 	if(S.get_amount() < req_amount * multiplier)
 		if(req_amount * multiplier > 1)
-			to_chat(user, "<span class='warning'>You haven't got enough [S] to build \the [req_amount * multiplier] [title]\s!</span>")
+			to_chat(user, "<span class='warning'>You haven't got enough [S] to build [res_amount * multiplier] [title]\s!</span>")
 		else
-			to_chat(user, "<span class='warning'>You haven't got enough [S] to build \the [title]!</span>")
+			to_chat(user, "<span class='warning'>You haven't got enough [S] to build [title]!</span>")
 		return FALSE
 
 	if(window_checks && !valid_window_location(get_turf(S), user.dir))
-		to_chat(user, "<span class='warning'>\The [title] won't fit here!</span>")
+		to_chat(user, "<span class='warning'>[title] won't fit here!</span>")
 		return FALSE
 
 	if(one_per_turf && (locate(result_type) in get_turf(S)))
@@ -46,10 +46,10 @@
 		return FALSE
 
 	if(on_floor && !issimulatedturf(get_turf(S)))
-		to_chat(user, "<span class='warning'>\The [title] must be constructed on the floor!</span>")
+		to_chat(user, "<span class='warning'>[title] must be constructed on the floor!</span>")
 		return FALSE
 	if(on_floor_or_lattice && !(issimulatedturf(get_turf(S)) || locate(/obj/structure/lattice) in get_turf(S)))
-		to_chat(user, "<span class='warning'>\The [title] must be constructed on the floor or lattice!</span>")
+		to_chat(user, "<span class='warning'>[title] must be constructed on the floor or lattice!</span>")
 		return FALSE
 
 	if(cult_structure)
@@ -89,18 +89,13 @@
 
 /// What should be done after the object is built? obj/item/stack/O might not actually be a stack, but this proc needs access to merge() to work, which is on obj/item/stack, so declare it as obj/item/stack anyways.
 /datum/stack_recipe/proc/post_build(mob/user, obj/item/stack/S, obj/item/stack/O)
-	if(S.amount < 1) // Just in case a stack's amount ends up fractional somehow
-		var/oldsrc = S
-		S = null //dont kill proc after qdel()
-		user.unEquip(oldsrc, 1)
-		qdel(oldsrc)
+	O.add_fingerprint(user)
 
 	if(isitem(O))
 		if(isstack(O) && istype(O, user.get_inactive_hand()))
 			O.merge(user.get_inactive_hand())
 		user.put_in_hands(O)
 
-	O.add_fingerprint(user)
 	//BubbleWrap - so newly formed boxes are empty
 	if(isstorage(O))
 		for(var/obj/item/I in O)
@@ -110,28 +105,27 @@
 /* Special Recipes */
 
 /datum/stack_recipe/cable_restraints
-/datum/stack_recipe/cable_restraints/post_build(obj/item/stack/S, obj/result)
+/datum/stack_recipe/cable_restraints/post_build(mob/user, obj/item/stack/S, obj/result)
 	if(istype(result, /obj/item/restraints/handcuffs/cable))
 		result.color = S.color
 	..()
 
-
 /datum/stack_recipe/dangerous
-/datum/stack_recipe/dangerous/post_build(obj/item/stack/S, obj/result)
-	var/turf/targ = get_turf(usr)
-	message_admins("[title] made by [key_name_admin(usr)](<A HREF='?_src_=holder;adminmoreinfo=\ref[usr]'>?</A>) in [get_area(usr)] [ADMIN_COORDJMP(targ)]!",0,1)
-	log_game("[title] made by [key_name_admin(usr)] at [get_area(usr)] [targ.x], [targ.y], [targ.z].")
+/datum/stack_recipe/dangerous/post_build(mob/user, obj/item/stack/S, obj/result)
+	var/turf/targ = get_turf(user)
+	message_admins("[title] made by [key_name_admin(user)](<A HREF='?_src_=holder;adminmoreinfo=\ref[user]'>?</A>) in [get_area(user)] [ADMIN_COORDJMP(targ)]!",0,1)
+	log_game("[title] made by [key_name_admin(user)] at [get_area(user)] [targ.x], [targ.y], [targ.z].")
 	..()
 
 /datum/stack_recipe/rods
-/datum/stack_recipe/rods/post_build(obj/item/stack/S, obj/result)
+/datum/stack_recipe/rods/post_build(mob/user, obj/item/stack/S, obj/result)
 	if(istype(result, /obj/item/stack/rods))
 		var/obj/item/stack/rods/R = result
 		R.update_icon()
 	..()
 
 /datum/stack_recipe/window
-/datum/stack_recipe/window/post_build(obj/item/stack/S, obj/result)
+/datum/stack_recipe/window/post_build(mob/user, obj/item/stack/S, obj/result)
 	if(istype(result, /obj/structure/windoor_assembly))
 		var/obj/structure/windoor_assembly/W = result
 		W.ini_dir = W.dir


### PR DESCRIPTION
## What Does This PR Do
Creates two new procs on /datum/stack_recipe/ - try_build() and do_build().

try_build() is a series of checks to prevent impossible constructions while do_build() handles the actual construction.  This code is not new and is just relocated from /obj/item/stack into a better and more sensible place.

This PR also makes it so stack-crafted items will go into the player's off-hand if it's free - this was always intended behavior but it wasn't functional in most situations.

## Why It's Good For The Game
Allows recipes to have custom construction checks and behavior.

## Testing
Things still craft correctly.

## Changelog
:cl:
fix: Items crafted by using stacks in-hand will now be properly placed in your off-hand if it's free.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
