### PR TITLE
Finally adds a decontruction act to wooden barricades!

### DIFF
--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -105,6 +105,15 @@
 			return //return is need to prevent people from exploiting zero-hit cooldowns with the do_after here
 	return ..()
 
+/obj/structure/barricade/wooden/crowbar_act(mob/living/user, obj/item/I)
+	. = TRUE
+	if(!I.tool_use_check(user, 0))
+		return
+	user.visible_message("<span class='notice'>[user] starts ripping [src] down!</span>", "<span class='notice'>You struggle to pull [src] apart...</span>", "<span class='warning'>You hear wood splintering..</span>")
+	if(!I.use_tool(src, user, 3 SECONDS, volume = I.tool_volume))
+		return
+	new /obj/item/stack/sheet/wood(get_turf(src), 5)
+	qdel(src)
 /obj/structure/barricade/wooden/crude
 	name = "crude plank barricade"
 	desc = "This space is blocked off by a crude assortment of planks."

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -109,7 +109,7 @@
 	. = TRUE
 	if(!I.tool_use_check(user, 0))
 		return
-	user.visible_message("<span class='notice'>[user] starts ripping [src] down!</span>", "<span class='notice'>You struggle to pull [src] apart...</span>", "<span class='warning'>You hear wood splintering..</span>")
+	user.visible_message("<span class='notice'>[user] starts ripping [src] down!</span>", "<span class='notice'>You struggle to pull [src] apart...</span>", "<span class='warning'>You hear wood splintering...</span>")
 	if(!I.use_tool(src, user, 6 SECONDS, volume = I.tool_volume))
 		return
 	new /obj/item/stack/sheet/wood(get_turf(src), 5)

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -110,11 +110,11 @@
 	if(!I.tool_use_check(user, 0))
 		return
 	user.visible_message("<span class='notice'>[user] starts ripping [src] down!</span>", "<span class='notice'>You struggle to pull [src] apart...</span>", "<span class='warning'>You hear wood splintering..</span>")
-	if(!I.use_tool(src, user, 3 SECONDS, volume = I.tool_volume))
+	if(!I.use_tool(src, user, 6 SECONDS, volume = I.tool_volume))
 		return
 	new /obj/item/stack/sheet/wood(get_turf(src), 5)
 	qdel(src)
-	
+
 /obj/structure/barricade/wooden/crude
 	name = "crude plank barricade"
 	desc = "This space is blocked off by a crude assortment of planks."

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -114,6 +114,7 @@
 		return
 	new /obj/item/stack/sheet/wood(get_turf(src), 5)
 	qdel(src)
+	
 /obj/structure/barricade/wooden/crude
 	name = "crude plank barricade"
 	desc = "This space is blocked off by a crude assortment of planks."


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Adds a deconstruction act, to wooden barricades. 
Takes six seconds, you need a crowbar, returns the 5 planks it takes to craft them
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Before this we've needed to wack the planks 15 times, this changes that to be better.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![dreamseeker_1xn6EPxzJ8](https://github.com/ParadiseSS13/Paradise/assets/96908085/fa7f585b-5588-4ae2-bd8b-9dfd86010ca8)

## Testing
<!-- How did you test the PR, if at all? -->
see images of changes

## Changelog
:cl:
tweak: You can now deconstruct wooden barricades with a crowbar.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
