### PR TITLE
(Hopefully) Fixes the runtime where a hallucination tries to pick from an empty list

### DIFF
--- a/code/modules/hallucinations/effects/moderate.dm
+++ b/code/modules/hallucinations/effects/moderate.dm
@@ -366,12 +366,8 @@
 /obj/effect/hallucination/energy_sword/Initialize(mapload, mob/living/carbon/target)
 	. = ..()
 
-	var/list/turfs = list()
-	for(var/turf/T in RANGE_TURFS(15, target))
-		turfs += T
-
-	var/turf/T = pick(turfs)
-	loc = T
+	var/turf/T = pick(RANGE_TURFS(15, target))
+	forceMove(T)
 	target.playsound_local(T, 'sound/weapons/saberon.ogg', 20, TRUE)
 
 	var/scream_sound = pick('sound/goonstation/voice/female_scream.ogg', 'sound/goonstation/voice/male_scream.ogg')

--- a/code/modules/hallucinations/effects/moderate.dm
+++ b/code/modules/hallucinations/effects/moderate.dm
@@ -344,11 +344,7 @@
 /obj/effect/hallucination/stunprodding/Initialize(mapload, mob/living/carbon/target)
 	. = ..()
 
-	var/list/turfs = list()
-	for(var/turf/T in range(world.view, target))
-		turfs += T
-
-	var/turf/T = pick(turfs)
+	var/turf/T = pick(RANGE_TURFS(15, target))
 	target.playsound_local(T, 'sound/weapons/egloves.ogg', 25, TRUE)
 	target.playsound_local(T, get_sfx("bodyfall"), 25, TRUE)
 	target.playsound_local(T, "sparks", 50, TRUE)
@@ -371,7 +367,7 @@
 	. = ..()
 
 	var/list/turfs = list()
-	for(var/turf/T in range(world.view, target))
+	for(var/turf/T in RANGE_TURFS(15, target))
 		turfs += T
 
 	var/turf/T = pick(turfs)
@@ -406,12 +402,8 @@
 /obj/effect/hallucination/gunfire/Initialize(mapload, mob/living/carbon/target)
 	. = ..()
 
-	var/list/turfs = list()
-	for(var/turf/T in range(world.view, target))
-		turfs += T
-
-	var/turf/T = pick(turfs)
-	loc = T
+	var/turf/T = pick(RANGE_TURFS(15, target))
+	forceMove(T)
 
 	var/gun_sound = pick('sound/weapons/gunshots/gunshot_pistol.ogg', 'sound/weapons/gunshots/gunshot_strong.ogg')
 	var/scream_sound = pick('sound/goonstation/voice/female_scream.ogg', 'sound/goonstation/voice/male_scream.ogg')

--- a/code/modules/hallucinations/hallucinations.dm
+++ b/code/modules/hallucinations/hallucinations.dm
@@ -52,9 +52,12 @@ GLOBAL_LIST_INIT(hallucinations, list(
 	/// Lazy list of images created as part of the hallucination. Cleared on destruction.
 	var/list/image/images = null
 
-/obj/effect/hallucination/Initialize(mapload, mob/living/carbon/target)
+/obj/effect/hallucination/Initialize(mapload, mob/living/carbon/hallucination_target)
 	. = ..()
-	src.target = target
+	if(QDELETED(hallucination_target))
+		qdel(src)
+		return
+	target = hallucination_target
 	if(hallucination_icon && hallucination_icon_state)
 		var/image/I = image(hallucination_icon, hallucination_override ? src : get_turf(src), hallucination_icon_state)
 		I.override = hallucination_override


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds a check if the target is qdeleted, and uses the `block()` proc over `range()`, as it is faster
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Performance + less runtimes is good
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Gave myself hallucinations, heard and saw various hallucinations, including but not limited to the gunshot hallucination, which is one of the ones that sometimes runtimed
<!-- How did you test the PR, if at all? -->

## Changelog
NPFC
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
