### PR TITLE
Mapped in cryo cells now gives the correct amount of cables when deconstructed

### DIFF
--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -49,7 +49,7 @@
 	else
 		set_light(0)
 
-/obj/machinery/atmospherics/unary/cryo_cell/New()
+/obj/machinery/atmospherics/unary/cryo_cell/Initialize(mapload)
 	..()
 	initialize_directions = dir
 	component_parts = list()
@@ -62,7 +62,7 @@
 	component_parts += new /obj/item/stack/cable_coil(null, 1)
 	RefreshParts()
 
-/obj/machinery/atmospherics/unary/cryo_cell/upgraded/New()
+/obj/machinery/atmospherics/unary/cryo_cell/upgraded/Initialize(mapload)
 	..()
 	component_parts = list()
 	component_parts += new /obj/item/circuitboard/cryo_tube(null)

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -50,7 +50,7 @@
 		set_light(0)
 
 /obj/machinery/atmospherics/unary/cryo_cell/Initialize(mapload)
-	..()
+	. = ..()
 	initialize_directions = dir
 	component_parts = list()
 	component_parts += new /obj/item/circuitboard/cryo_tube(null)
@@ -63,7 +63,7 @@
 	RefreshParts()
 
 /obj/machinery/atmospherics/unary/cryo_cell/upgraded/Initialize(mapload)
-	..()
+	. = ..()
 	component_parts = list()
 	component_parts += new /obj/item/circuitboard/cryo_tube(null)
 	component_parts += new /obj/item/stock_parts/matter_bin/super(null)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Mapped in cryo cells now gives the correct amount of cables when deconstructed (1 cable instead of 30)
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Initialize is already being used by /unary and is prefered.
It giving 30 cables (which is the initial amount the stack has) instead of 1 when deconstructed is a bug.
## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
**BEFORE**

![image](https://github.com/ParadiseSS13/Paradise/assets/77684085/844282f7-93dc-447d-911f-a4d27c472353)

**AFTER**
![cryo](https://github.com/ParadiseSS13/Paradise/assets/77684085/16068fc1-b504-4576-8ef0-eb8e7de0e5ec)

## Testing
<!-- How did you test the PR, if at all? -->
- Healed skrells after beating em up using the cryo cell
- Deconstructed cryo cells from medbay and verified cable amounts
## Changelog
:cl:
fix: Mapped in cryo cells now gives the correct amount of cables when deconstructed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
