### PR TITLE
Makes Weeping Angel Conversion Clearer

### DIFF
--- a/code/modules/projectiles/projectile/magic_projectiles.dm
+++ b/code/modules/projectiles/projectile/magic_projectiles.dm
@@ -326,7 +326,7 @@
 					H.mind.transfer_to(S)
 					var/list/messages = list()
 					messages.Add("<center><span class='userdanger'>You have been transformed into an animated statue.</span></center>")
-					messages.Add("<center>You cannot move when monitored, but are nearly invincible and deadly when unobserved! Hunt down those who shackle you.</center>")
+					messages.Add("You cannot move when monitored, but are nearly invincible and deadly when unobserved! Hunt down those who shackle you.")
 					messages.Add("<center>Do not harm [firer.name], your creator.</center>")
 					to_chat(S, chat_box_red(messages.Join("<br>")))
 				H = change

--- a/code/modules/projectiles/projectile/magic_projectiles.dm
+++ b/code/modules/projectiles/projectile/magic_projectiles.dm
@@ -326,7 +326,7 @@
 					H.mind.transfer_to(S)
 					var/list/messages = list()
 					messages.Add("<center><span class='userdanger'>You are now an animated statue.</span></center>")
-					messages.Add("<center>You cannot move when monitored, but are nearly invincible and deadly when unobserved!</center>")
+					messages.Add("<center>You cannot move when monitored, but are nearly invincible and deadly when unobserved! Hunt down those who shackle you.</center>")
 					messages.Add("<center>Do not harm [firer.name], your creator.</center>")
 					to_chat(S, chat_box_red(messages.Join("<br>")))
 				H = change

--- a/code/modules/projectiles/projectile/magic_projectiles.dm
+++ b/code/modules/projectiles/projectile/magic_projectiles.dm
@@ -325,7 +325,7 @@
 				if(H.mind)
 					H.mind.transfer_to(S)
 					var/list/messages = list()
-					messages.Add("<center><span class='userdanger'>You are now an animated statue.</span></center>")
+					messages.Add("<center><span class='userdanger'>You have been transformed into an animated statue.</span></center>")
 					messages.Add("<center>You cannot move when monitored, but are nearly invincible and deadly when unobserved! Hunt down those who shackle you.</center>")
 					messages.Add("<center>Do not harm [firer.name], your creator.</center>")
 					to_chat(S, chat_box_red(messages.Join("<br>")))

--- a/code/modules/projectiles/projectile/magic_projectiles.dm
+++ b/code/modules/projectiles/projectile/magic_projectiles.dm
@@ -324,8 +324,11 @@
 				S.icon = change.icon
 				if(H.mind)
 					H.mind.transfer_to(S)
-					to_chat(S, "<span class='warning'>You are an animated statue. You cannot move when monitored, but are nearly invincible and deadly when unobserved!</span>")
-					to_chat(S, "<span class='userdanger'>Do not harm [firer.name], your creator.</span>")
+					var/list/messages = list()
+					messages.Add("<center><span class='userdanger'>You are now an animated statue.</span></center>")
+					messages.Add("<center>You cannot move when monitored, but are nearly invincible and deadly when unobserved!</center>")
+					messages.Add("<center>Do not harm [firer.name], your creator.</center>")
+					to_chat(S, chat_box_red(messages.Join("<br>")))
 				H = change
 				H.loc = S
 				qdel(src)

--- a/code/modules/projectiles/projectile/magic_projectiles.dm
+++ b/code/modules/projectiles/projectile/magic_projectiles.dm
@@ -325,9 +325,9 @@
 				if(H.mind)
 					H.mind.transfer_to(S)
 					var/list/messages = list()
-					messages.Add("<center><span class='userdanger'>You have been transformed into an animated statue.</span></center>")
+					messages.Add("<span class='userdanger'>You have been transformed into an animated statue.</span>")
 					messages.Add("You cannot move when monitored, but are nearly invincible and deadly when unobserved! Hunt down those who shackle you.")
-					messages.Add("<center>Do not harm [firer.name], your creator.</center>")
+					messages.Add("Do not harm [firer.name], your creator.")
 					to_chat(S, chat_box_red(messages.Join("<br>")))
 				H = change
 				H.loc = S


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
re-writes and clarifies the Weeping Angel message when converted by a wizard using the flesh to stone + animate wand.

## Why It's Good For The Game
The old message is simply a boldened red text. its EASILY lost in most high-chaos scenarios. I personally experienced a wizard who was routinely attacked by their own statues because the players did not notice the text saying to not bother the wizard. The message now is extremely obvious, and also added in the fact that you're expected to hunt down other players as a weeping angel. 

## Images of changes
**Before**
![image](https://github.com/ParadiseSS13/Paradise/assets/65205627/6e8cec7c-f734-493f-8d6d-6179af86040e)


**After**
![image](https://github.com/ParadiseSS13/Paradise/assets/65205627/d83b6b59-3f00-46e2-871d-87d42579b2d5)


## Testing
Spawned in. Had friend turn flesh to stone, then animate. Got message and de-statued as anticipated after.
## Changelog
:cl:
tweak: Clarified Weeping Angel Message
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
