### PR TITLE
Cult offer puts shard in hands instead of dropping on the floor

### DIFF
--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -425,6 +425,9 @@ structure_check() searches for nearby cultist structures required for the invoca
 		stone.invisibility = INVISIBILITY_MAXIMUM // So it's not picked up during transfer_soul()
 		stone.transfer_soul("FORCE", offering, user) // If it cannot be added
 		stone.invisibility = 0
+		var/put_in_hands = user.put_in_any_hand_if_possible(stone)
+		if(put_in_hands)
+			to_chat(user, "<span class='cultitalic'>Shiny dark red shard appears in your hand - your new ally.</span>")
 	else
 		if(isrobot(offering))
 			offering.dust() //To prevent the MMI from remaining

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -427,7 +427,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 		stone.invisibility = 0
 		var/put_in_hands = user.put_in_any_hand_if_possible(stone)
 		if(put_in_hands)
-			to_chat(user, "<span class='cultitalic'>Shiny dark red shard appears in your hand - your new ally.</span>")
+			to_chat(user, "<span class='cultitalic'>A glowing crimson shard appears in your hand - your new ally contained within.</span>")
 	else
 		if(isrobot(offering))
 			offering.dust() //To prevent the MMI from remaining


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
This PR makes shards put in invoker's hand instead of dropping on the floor

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
When there is many security fallen on the offer rune, its cluttered with tons of items and bringing shards out of it becomes a real problem. Imagine being a shard in newbie's cult hands, being dropped on the floor and forgot forever.
This supposed to be QoL change for any cultists

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![image](https://github.com/ParadiseSS13/Paradise/assets/61080616/76686504-1c36-4833-b396-8eceac1b86e3)

## Testing
<!-- How did you test the PR, if at all? -->
Compiled, logged in, sharded security.

## Changelog
:cl:
tweak: Cult offering someone by sharding(mindshields, cyborgs) will put shard in invoker's hand instead of dropping it on the floor.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
