### PR TITLE
Makes the crowbars of non-construction borgs red

### DIFF
--- a/code/game/objects/items/tools/crowbar.dm
+++ b/code/game/objects/items/tools/crowbar.dm
@@ -112,6 +112,11 @@
 	force = 10
 	toolspeed = 0.5
 
+/obj/item/crowbar/cyborg/red
+	name = "emergency hydraulic crowbar"
+	icon_state = "crowbar_red"
+	desc = "A hydraulic prying tool, compact but powerful. Supplied to non-construction cyborgs primarally to allow them to pry open airlocks during power outages."
+
 /obj/item/crowbar/power
 	name = "jaws of life"
 	desc = "A set of jaws of life, the magic of science has managed to fit it down into a device small enough to fit in a tool belt. It's fitted with a prying head."

--- a/code/game/objects/items/tools/crowbar.dm
+++ b/code/game/objects/items/tools/crowbar.dm
@@ -114,7 +114,7 @@
 
 /obj/item/crowbar/cyborg/red
 	name = "emergency hydraulic crowbar"
-	desc = "A hydraulic prying tool, compact but powerful. Supplied to non-construction cyborgs primaraly to allow them to pry open airlocks during power outages."
+	desc = "A hydraulic prying tool, compact but powerful. Supplied to non-construction cyborgs primarily to allow them to pry open airlocks during power outages."
 	icon_state = "crowbar_red"
 
 /obj/item/crowbar/power

--- a/code/game/objects/items/tools/crowbar.dm
+++ b/code/game/objects/items/tools/crowbar.dm
@@ -114,8 +114,8 @@
 
 /obj/item/crowbar/cyborg/red
 	name = "emergency hydraulic crowbar"
+	desc = "A hydraulic prying tool, compact but powerful. Supplied to non-construction cyborgs primaraly to allow them to pry open airlocks during power outages."
 	icon_state = "crowbar_red"
-	desc = "A hydraulic prying tool, compact but powerful. Supplied to non-construction cyborgs primarally to allow them to pry open airlocks during power outages."
 
 /obj/item/crowbar/power
 	name = "jaws of life"

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -326,7 +326,7 @@
 	subsystems = list(/mob/living/silicon/proc/subsystem_crew_monitor)
 	basic_modules = list(
 		/obj/item/flash/cyborg,
-		/obj/item/crowbar/cyborg,
+		/obj/item/crowbar/cyborg/red,
 		/obj/item/healthanalyzer/advanced,
 		/obj/item/robotanalyzer,
 		/obj/item/reagent_scanner/adv,
@@ -430,7 +430,7 @@
 	subsystems = list(/mob/living/silicon/proc/subsystem_crew_monitor)
 	basic_modules = list(
 		/obj/item/flash/cyborg,
-		/obj/item/crowbar/cyborg,
+		/obj/item/crowbar/cyborg/red,
 		/obj/item/restraints/handcuffs/cable/zipties/cyborg,
 		/obj/item/melee/baton/loaded,
 		/obj/item/gun/energy/disabler/cyborg,
@@ -455,7 +455,7 @@
 	module_type = "Janitor"
 	basic_modules = list(
 		/obj/item/flash/cyborg,
-		/obj/item/crowbar/cyborg,
+		/obj/item/crowbar/cyborg/red,
 		/obj/item/soap/nanotrasen,
 		/obj/item/storage/bag/trash/cyborg,
 		/obj/item/mop/advanced/cyborg,
@@ -514,7 +514,7 @@
 	module_type = "Service"
 	basic_modules = list(
 		/obj/item/flash/cyborg,
-		/obj/item/crowbar/cyborg,
+		/obj/item/crowbar/cyborg/red,
 		/obj/item/handheld_chem_dispenser/booze,
 		/obj/item/handheld_chem_dispenser/soda,
 		/obj/item/pen/multi,
@@ -578,7 +578,7 @@
 	custom_removals = list("KA modkits")
 	basic_modules = list(
 		/obj/item/flash/cyborg,
-		/obj/item/crowbar/cyborg,
+		/obj/item/crowbar/cyborg/red,
 		/obj/item/storage/bag/ore/cyborg,
 		/obj/item/pickaxe/drill/cyborg,
 		/obj/item/shovel,
@@ -625,7 +625,7 @@
 		/obj/item/flash/cyborg,
 		/obj/item/melee/energy/sword/cyborg,
 		/obj/item/gun/energy/pulse/cyborg,
-		/obj/item/crowbar/cyborg
+		/obj/item/crowbar/cyborg/red,
 	)
 	special_rechargables = list(/obj/item/gun/energy/pulse/cyborg)
 
@@ -639,7 +639,7 @@
 		/obj/item/gun/energy/printer,
 		/obj/item/gun/projectile/revolver/grenadelauncher/multi/cyborg,
 		/obj/item/card/emag,
-		/obj/item/crowbar/cyborg,
+		/obj/item/crowbar/cyborg/red,
 		/obj/item/pinpointer/operative
 	)
 
@@ -665,7 +665,7 @@
 		/obj/item/bonegel,
 		/obj/item/FixOVein,
 		/obj/item/card/emag,
-		/obj/item/crowbar/cyborg,
+		/obj/item/crowbar/cyborg/red,
 		/obj/item/pinpointer/operative,
 		/obj/item/stack/medical/bruise_pack/advanced/cyborg/syndicate,
 		/obj/item/stack/medical/ointment/advanced/cyborg/syndicate,
@@ -714,7 +714,7 @@
 	module_actions = list(/datum/action/innate/robot_sight/thermal, /datum/action/innate/robot_magpulse)
 	basic_modules = list(
 		/obj/item/flash/cyborg,
-		/obj/item/crowbar/cyborg,
+		/obj/item/crowbar/cyborg/red,
 		/obj/item/gun/energy/immolator/multi/cyborg, // See comments on /robot_module/combat below
 		/obj/item/melee/baton/loaded, // secondary weapon, for things immune to burn, immune to ranged weapons, or for arresting low-grade threats
 		/obj/item/restraints/handcuffs/cable/zipties/cyborg,
@@ -732,7 +732,7 @@
 	module_actions = list(/datum/action/innate/robot_magpulse)
 	basic_modules = list(
 		/obj/item/flash/cyborg,
-		/obj/item/crowbar/cyborg,
+		/obj/item/crowbar/cyborg/red,
 		/obj/item/gun/energy/immolator/multi/cyborg, // primary weapon, strong at close range (ie: against blob/terror/xeno), but consumes a lot of energy per shot.
 		// Borg gets 40 shots of this weapon. Gamma Sec ERT gets 10.
 		// So, borg has way more burst damage, but also takes way longer to recharge / get back in the fight once depleted. Has to find a borg recharger and sit in it for ages.
@@ -753,7 +753,7 @@
 	module_type = "Standard"
 	module_actions = list(/datum/action/innate/robot_sight/thermal/alien)
 	basic_modules = list(
-		/obj/item/crowbar/cyborg,
+		/obj/item/crowbar/cyborg/red,
 		/obj/item/melee/energy/alien/claws,
 		/obj/item/flash/cyborg/alien,
 		/obj/item/reagent_containers/spray/alien/stun,


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Replaces the crowbars of all borgs except engi and saboteur with a red emergency crowbar with identical stats (change is cosmetic only) and a different description.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Non construction borgs were given crowbars to allow them to pry open doors in the event of power failure. They're *emergency* tools that are not expected to be used during normal operation. Thus, they have been been given a slightly different version that reflects this fact.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Spawned, became various borgs. Saw that they had the different crowbar.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: All borgs except engi and sabotage have red crowbars now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
