### PR TITLE
Fixes some issues with TGUI Alerts, and Text Input

### DIFF
--- a/code/controllers/subsystem/non_firing/SSchangelog.dm
+++ b/code/controllers/subsystem/non_firing/SSchangelog.dm
@@ -211,13 +211,11 @@ SUBSYSTEM_DEF(changelog)
 		if("open_pr")
 			var/pr_num = params["pr_number"]
 			if(GLOB.configuration.url.github_url)
-				if(tgui_alert(usr, "This will open PR #[pr_num] in your browser. Are you sure?", "Open PR", list("Yes", "No")) == "No")
-					return
-
-				// If the github URL in the config has a trailing slash, it doesnt matter here, thankfully github accepts having a double slash: https://github.com/org/repo//pull/1
-				var/url = "[GLOB.configuration.url.github_url]/pull/[pr_num]"
-				usr << link(url)
-				return
+				if(tgui_alert(usr, "This will open PR #[pr_num] in your browser. Are you sure?", "Open PR", list("Yes", "No")) == "Yes")
+					// If the github URL in the config has a trailing slash, it doesnt matter here, thankfully github accepts having a double slash: https://github.com/org/repo//pull/1
+					var/url = "[GLOB.configuration.url.github_url]/pull/[pr_num]"
+					usr << link(url)
+					return TRUE
 
 			to_chat(usr, "<span class='danger'>The GitHub URL is not set in the server configuration. PRs cannot be opened from changelog view. Please inform the server host.</span>")
 

--- a/code/controllers/subsystem/non_firing/SSchangelog.dm
+++ b/code/controllers/subsystem/non_firing/SSchangelog.dm
@@ -211,11 +211,13 @@ SUBSYSTEM_DEF(changelog)
 		if("open_pr")
 			var/pr_num = params["pr_number"]
 			if(GLOB.configuration.url.github_url)
-				if(tgui_alert(usr, "This will open PR #[pr_num] in your browser. Are you sure?", "Open PR", list("Yes", "No")) == "Yes")
-					// If the github URL in the config has a trailing slash, it doesnt matter here, thankfully github accepts having a double slash: https://github.com/org/repo//pull/1
-					var/url = "[GLOB.configuration.url.github_url]/pull/[pr_num]"
-					usr << link(url)
-					return TRUE
+				if(tgui_alert(usr, "This will open PR #[pr_num] in your browser. Are you sure?", "Open PR", list("Yes", "No")) != "Yes")
+					return
+
+				// If the github URL in the config has a trailing slash, it doesnt matter here, thankfully github accepts having a double slash: https://github.com/org/repo//pull/1
+				var/url = "[GLOB.configuration.url.github_url]/pull/[pr_num]"
+				usr << link(url)
+				return TRUE
 
 			to_chat(usr, "<span class='danger'>The GitHub URL is not set in the server configuration. PRs cannot be opened from changelog view. Please inform the server host.</span>")
 

--- a/code/datums/outfits/outfit_debug.dm
+++ b/code/datums/outfits/outfit_debug.dm
@@ -39,7 +39,7 @@
 	var/obj/item/card/id/I = H.wear_id
 	if(istype(I))
 		apply_to_card(I, H, get_all_accesses(), "Debugger", "admin")
-		
+
 	H.dna.SetSEState(GLOB.breathlessblock, 1)
 	singlemutcheck(H, GLOB.breathlessblock, MUTCHK_FORCED)
 	H.dna.default_blocks.Add(GLOB.breathlessblock)
@@ -67,10 +67,10 @@
 	to_chat(user, "You switch [src] to [change_voice ? "" : "not "]change your voice on syndicate communications.")
 
 /obj/item/encryptionkey/syndicate/all_channels/AltClick(mob/user)
-	var/new_name = tgui_input_text(user, "Enter new fake agent name...", "New name")
+	var/new_name = tgui_input_text(user, "Enter new fake agent name...", "New name", max_length = MAX_NAME_LEN)
 	if(!new_name)
 		return
-	fake_name = copytext(new_name, 1, MAX_NAME_LEN + 1)
+	fake_name = new_name
 
 /obj/item/clothing/mask/gas/welding/advanced
 	name = "AVD-CNED welding mask"

--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -582,7 +582,7 @@
 	if(!owner_AI.can_place_transformer(src))
 		return
 	active = TRUE
-	if(tgui_alert(owner, "Are you sure you want to place the machine here?", "Are you sure?", list("Yes", "No")) == "No")
+	if(tgui_alert(owner, "Are you sure you want to place the machine here?", "Are you sure?", list("Yes", "No")) != "Yes")
 		active = FALSE
 		return
 	if(!owner_AI.can_place_transformer(src))

--- a/code/game/gamemodes/miniantags/guardian/guardian.dm
+++ b/code/game/gamemodes/miniantags/guardian/guardian.dm
@@ -283,7 +283,7 @@
 		return
 	used = TRUE // Set this BEFORE the popup to prevent people using the injector more than once, polling ghosts multiple times, and receiving multiple guardians.
 	var/choice = tgui_alert(user, "[confirmation_message]", "Confirm", list("Yes", "No"))
-	if(choice == "No")
+	if(choice != "Yes")
 		to_chat(user, "<span class='warning'>You decide against using the [name].</span>")
 		used = FALSE
 		return

--- a/code/game/gamemodes/miniantags/guardian/host_actions.dm
+++ b/code/game/gamemodes/miniantags/guardian/host_actions.dm
@@ -77,7 +77,7 @@
 		return
 
 	var/confirm = tgui_alert(owner, "Are you sure you want replace your guardian's player?", "Confirm", list("Yes", "No"))
-	if(confirm == "No")
+	if(confirm != "Yes")
 		return
 
 	// Do this immediately, so the user can't spam a bunch of polls.

--- a/code/game/gamemodes/nuclear/nuclear_challenge.dm
+++ b/code/game/gamemodes/nuclear/nuclear_challenge.dm
@@ -27,7 +27,7 @@
 	if(!check_allowed(user))
 		return
 
-	if(are_you_sure == "No")
+	if(are_you_sure != "Yes")
 		to_chat(user, "On second thought, the element of surprise isn't so bad after all.")
 		return
 

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -656,13 +656,13 @@
 /datum/spellbook_entry/loadout/Buy(mob/living/carbon/human/user, obj/item/spellbook/book)
 	if(destroy_spellbook)
 		var/response = tgui_alert(user, "The [src] loadout cannot be refunded once bought. Are you sure this is what you want?", "No refunds!", list("No", "Yes"))
-		if(response == "No")
+		if(response != "Yes")
 			return FALSE
 		to_chat(user, "<span class='notice'>[book] crumbles to ashes as you acquire its knowledge.</span>")
 		qdel(book)
 	else if(items_path.len)
 		var/response = tgui_alert(user, "The [src] loadout contains items that will not be refundable if bought. Are you sure this is what you want?", "No refunds!", list("No", "Yes"))
-		if(response == "No")
+		if(response != "Yes")
 			return FALSE
 	if(items_path.len)
 		var/obj/item/storage/box/wizard/B = new(src)

--- a/code/game/machinery/computer/atmos_controllers.dm
+++ b/code/game/machinery/computer/atmos_controllers.dm
@@ -174,7 +174,7 @@ GLOBAL_LIST_EMPTY(gas_sensors)
 // This is its own proc so it can be modified in child types
 /obj/machinery/computer/general_air_control/proc/configure_sensors(mob/living/user, obj/item/multitool/M)
 	var/choice = tgui_alert(user, "Would you like to add or remove a sensor/meter", "Configuration", list("Add", "Remove", "Cancel"))
-	if((choice == "Cancel") || !Adjacent(user))
+	if(!choice || (choice == "Cancel") || !Adjacent(user))
 		return
 
 	switch(choice)
@@ -354,7 +354,7 @@ GLOBAL_LIST_EMPTY(gas_sensors)
 
 /obj/machinery/computer/general_air_control/large_tank_control/proc/configure_inlet(mob/living/user, obj/item/multitool/M)
 	var/choice = tgui_alert(user, "Would you like to add/replace the existing inlet or clear it?", "Configuration", list("Add/Replace", "Clear", "Cancel"))
-	if((choice == "Cancel") || !Adjacent(user))
+	if(!choice || (choice == "Cancel") || !Adjacent(user))
 		return
 
 	switch(choice)
@@ -390,7 +390,7 @@ GLOBAL_LIST_EMPTY(gas_sensors)
 
 /obj/machinery/computer/general_air_control/large_tank_control/proc/configure_outlet(mob/living/user, obj/item/multitool/M)
 	var/choice = tgui_alert(user, "Would you like to add/replace the existing outlet or clear it?", "Configuration", list("Add/Replace", "Clear", "Cancel"))
-	if((choice == "Cancel") || !Adjacent(user))
+	if(!choice || (choice == "Cancel") || !Adjacent(user))
 		return
 
 	switch(choice)

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -522,7 +522,7 @@
 		opposite_catastasis = "BROAD"
 
 	var/choice = tgui_alert(user, "Current receiver spectrum is set to: [catastasis]", "Multitool-Circuitboard interface", list("Switch to [opposite_catastasis]", "Cancel"))
-	if(choice == "Cancel")
+	if(!choice || choice == "Cancel")
 		return
 
 	contraband_enabled = !contraband_enabled

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -279,7 +279,7 @@
 		return
 	used = TRUE // Set this BEFORE the popup to prevent people using the injector more than once.
 	var/choice = tgui_alert(user, "The injector is still unused. Do you wish to use it?", "Fireproofing injector", list("Yes", "No"))
-	if(choice == "No")
+	if(choice != "Yes")
 		to_chat(user, "<span class='notice'>You decide against using [src].</span>")
 		used = FALSE
 		return

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -38,7 +38,7 @@
 		for(var/obj/O in src)
 			if(O.density)
 				var/response = tgui_alert(usr, "This crate has been packed with bluespace compression, an item inside won't fit back inside. Are you sure you want to open it?", "Bluespace Compression Warning", list("Yes", "No"))
-				if(response == "No" || !Adjacent(usr))
+				if(response != "Yes" || !Adjacent(usr))
 					return FALSE
 				break
 

--- a/code/game/objects/structures/misc_structures.dm
+++ b/code/game/objects/structures/misc_structures.dm
@@ -55,7 +55,7 @@
 /obj/structure/respawner/attack_ghost(mob/dead/observer/user)
 	if(check_rights(R_EVENT))
 		var/outfit_pick = tgui_alert(user, "Do you want to pick an outfit or respawn?", "Pick an Outfit?", list("Pick outfit", "Respawn", "Cancel"))
-		if(outfit_pick == "Cancel")
+		if(!outfit_pick || outfit_pick == "Cancel")
 			return
 		if(outfit_pick == "Pick outfit")
 			var/new_outfit = user.client.robust_dress_shop()

--- a/code/modules/awaymissions/mob_spawn.dm
+++ b/code/modules/awaymissions/mob_spawn.dm
@@ -43,8 +43,8 @@
 /obj/effect/mob_spawn/attack_ghost(mob/user)
 	if(!valid_to_spawn(user))
 		return
-	var/ghost_role = tgui_alert(user, "Become [mob_name]? (Warning, You can no longer be cloned!)", "Respawn", list("Yes","No"))
-	if(ghost_role == "No")
+	var/ghost_role = tgui_alert(user, "Become [mob_name]? (Warning, You can no longer be cloned!)", "Respawn", list("Yes", "No"))
+	if(ghost_role != "Yes")
 		return
 	if(!species_prompt(user))
 		return
@@ -332,7 +332,7 @@
 
 /obj/effect/mob_spawn/human/alive/space_bar_patron/attack_hand(mob/user)
 	var/despawn = tgui_alert(user, "Return to cryosleep? (Warning, Your mob will be deleted!)", "Leave Bar", list("Yes", "No"))
-	if(despawn == "No" || !loc || !Adjacent(user))
+	if(despawn != "Yes" || !loc || !Adjacent(user))
 		return
 	user.visible_message("<span class='notice'>[user.name] climbs back into cryosleep...</span>")
 	qdel(user)

--- a/code/modules/client/preference/link_processing.dm
+++ b/code/modules/client/preference/link_processing.dm
@@ -65,34 +65,25 @@
 			user << browse(null, "window=records")
 
 		if(href_list["task"] == "med_record")
-			var/medmsg = tgui_input_text(usr, "Set your medical notes here.", "Medical Records", active_character.med_record, multiline = TRUE, encode = FALSE)
-
-			if(medmsg != null)
-				medmsg = copytext(medmsg, 1, MAX_PAPER_MESSAGE_LEN)
-				medmsg = html_encode(medmsg)
-
-				active_character.med_record = medmsg
-				active_character.SetRecords(user)
+			var/medmsg = tgui_input_text(usr, "Set your medical notes here.", "Medical Records", active_character.med_record, max_length = MAX_PAPER_MESSAGE_LEN, multiline = TRUE)
+			if(!medmsg)
+				return
+			active_character.med_record = medmsg
+			active_character.SetRecords(user)
 
 		if(href_list["task"] == "sec_record")
-			var/secmsg = tgui_input_text(usr, "Set your security notes here.", "Security Records", active_character.sec_record, multiline = TRUE, encode = FALSE)
-
-			if(secmsg != null)
-				secmsg = copytext(secmsg, 1, MAX_PAPER_MESSAGE_LEN)
-				secmsg = html_encode(secmsg)
-
-				active_character.sec_record = secmsg
-				active_character.SetRecords(user)
+			var/secmsg = tgui_input_text(usr, "Set your security notes here.", "Security Records", active_character.sec_record, max_length = MAX_PAPER_MESSAGE_LEN, multiline = TRUE)
+			if(!secmsg)
+				return
+			active_character.sec_record = secmsg
+			active_character.SetRecords(user)
 
 		if(href_list["task"] == "gen_record")
-			var/genmsg = tgui_input_text(usr, "Set your employment notes here.", "Employment Records", active_character.gen_record, multiline = TRUE, encode = FALSE)
-
-			if(genmsg != null)
-				genmsg = copytext(genmsg, 1, MAX_PAPER_MESSAGE_LEN)
-				genmsg = html_encode(genmsg)
-
-				active_character.gen_record = genmsg
-				active_character.SetRecords(user)
+			var/genmsg = tgui_input_text(usr, "Set your employment notes here.", "Employment Records", active_character.gen_record, max_length = MAX_PAPER_MESSAGE_LEN, multiline = TRUE)
+			if(!genmsg)
+				return
+			active_character.gen_record = genmsg
+			active_character.SetRecords(user)
 
 	if(href_list["preference"] == "gear")
 		if(href_list["toggle_gear"])
@@ -714,13 +705,10 @@
 						active_character.height = new_height
 
 				if("flavor_text")
-					var/msg = tgui_input_text(usr, "Set the flavor text in your 'examine' verb. The flavor text should be a physical descriptor of your character at a glance. SFW Drawn Art of your character is acceptable.", "Flavor Text", active_character.flavor_text, multiline = TRUE, encode = FALSE)
-
-					if(msg != null)
-						msg = copytext(msg, 1, MAX_MESSAGE_LEN)
-						msg = html_encode(msg)
-
-						active_character.flavor_text = msg
+					var/msg = tgui_input_text(usr, "Set the flavor text in your 'examine' verb. The flavor text should be a physical descriptor of your character at a glance. SFW Drawn Art of your character is acceptable.", "Flavor Text", active_character.flavor_text, max_length = MAX_PAPER_MESSAGE_LEN, multiline = TRUE)
+					if(!msg)
+						return
+					active_character.flavor_text = msg
 
 				if("limbs")
 					var/valid_limbs = list("Left Leg", "Right Leg", "Left Arm", "Right Arm", "Left Foot", "Right Foot", "Left Hand", "Right Hand")

--- a/code/modules/games/cards.dm
+++ b/code/modules/games/cards.dm
@@ -67,7 +67,7 @@
 
 		if(length(H.cards) > 1)
 			var/confirm = tgui_alert(user, "Are you sure you want to put your [length(H.cards)] cards back into the deck?", "Return Hand", list("Yes", "No"))
-			if(confirm == "No" || !Adjacent(user) || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
+			if(confirm != "Yes" || !Adjacent(user) || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
 				return
 		for(var/datum/playingcard/P in H.cards)
 			cards += P

--- a/code/modules/library/library_equipment.dm
+++ b/code/modules/library/library_equipment.dm
@@ -415,7 +415,7 @@
 			else
 				confirm = tgui_alert(user, "Are you sure you want to checkout [B] to [computer.user_data.patron_name]?", "Confirm Checkout", list("Yes", "No"))
 
-			if(confirm == "No")
+			if(confirm != "Yes")
 				return
 			if(computer.checkout(B))
 				playsound(src, 'sound/items/scannerbeep.ogg', 15, TRUE)

--- a/code/modules/mining/lavaland/loot/colossus_loot.dm
+++ b/code/modules/mining/lavaland/loot/colossus_loot.dm
@@ -225,7 +225,7 @@
 			to_chat(user, "<span class='warning'>Upon using the antagHUD you forfeited the ability to join the round.</span>")
 			return
 		var/be_helper = tgui_alert(user, "Become a Lightgeist? (Warning, You can no longer be cloned!)", "Respawn", list("Yes","No"))
-		if(be_helper == "No")
+		if(be_helper != "Yes")
 			return
 		if(!loc || QDELETED(src) || QDELETED(user))
 			if(user)

--- a/code/modules/mob/living/simple_animal/hostile/mining/elites/elite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/elites/elite.dm
@@ -50,7 +50,7 @@
 		var/obj/structure/elite_tumor/T = target
 		if(T.mychild == src && T.activity == TUMOR_PASSIVE)
 			var/response = tgui_alert(src, "Re-enter the tumor?", "Despawn yourself?", list("Yes", "No"))
-			if(response == "No" || QDELETED(src) || !Adjacent(T))
+			if(response != "Yes" || QDELETED(src) || !Adjacent(T))
 				return
 			T.clear_activator(src)
 			T.mychild = null

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_ghost_interaction.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_ghost_interaction.dm
@@ -33,7 +33,7 @@
 		return
 	if(error_on_humanize == "")
 		var/spider_ask = tgui_alert(user, humanize_prompt, "Join as Terror Spider?", list("Yes", "No"))
-		if(spider_ask == "No" || !src || QDELETED(src))
+		if(spider_ask != "Yes" || !src || QDELETED(src))
 			return
 	else
 		to_chat(user, "Cannot inhabit spider: [error_on_humanize]")

--- a/code/modules/pda/PDA.dm
+++ b/code/modules/pda/PDA.dm
@@ -381,7 +381,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 		O.show_message(text("[bicon(src)] *[ttone]*"))
 
 /obj/item/pda/proc/set_ringtone(mob/user)
-	var/new_tone = tgui_input_text(user, "Please enter new ringtone", name, ttone)
+	var/new_tone = tgui_input_text(user, "Please enter new ringtone", name, ttone, max_length = 20, encode = FALSE)
 	new_tone = trim(new_tone)
 
 	if(!in_range(src, user) || loc != user)
@@ -396,7 +396,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 		close(user)
 		return TRUE
 
-	ttone = sanitize(copytext(new_tone, 1, 20))
+	ttone = new_tone
 	return TRUE
 
 /obj/item/pda/process()

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -579,7 +579,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 		if("maxresearch")
 			if(!check_rights(R_ADMIN))
 				return
-			if(tgui_alert(usr, "Are you sure you want to maximize research levels?", "Confirmation", list("Yes", "No"))=="No")
+			if(tgui_alert(usr, "Are you sure you want to maximize research levels?", "Confirmation", list("Yes", "No")) != "Yes")
 				return
 			log_admin("[key_name(usr)] has maximized the research levels.")
 			message_admins("[key_name_admin(usr)] has maximized the research levels.")

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -305,7 +305,7 @@
 		return
 
 	prompted = TRUE
-	if(tgui_alert(user, "This will permanently transfer your consciousness to [SM]. Are you sure you want to do this?", "Consciousness Transfer", list("Yes", "No")) == "No")
+	if(tgui_alert(user, "This will permanently transfer your consciousness to [SM]. Are you sure you want to do this?", "Consciousness Transfer", list("Yes", "No")) != "Yes")
 		prompted = FALSE
 		return
 

--- a/code/modules/ruins/ghost_bar.dm
+++ b/code/modules/ruins/ghost_bar.dm
@@ -99,7 +99,7 @@
 	if(!istype(mob_to_delete) || !istype(user) || !Adjacent(user))
 		return
 	if(mob_to_delete.client)
-		if(tgui_alert(mob_to_delete, "Would you like to return to the realm of spirits? (This will delete your current character, but you can rejoin later)", "Ghost Bar", list("Yes", "No")) == "No")
+		if(tgui_alert(mob_to_delete, "Would you like to return to the realm of spirits? (This will delete your current character, but you can rejoin later)", "Ghost Bar", list("Yes", "No")) != "Yes")
 			return
 	mob_to_delete.visible_message("<span class='notice'>[mob_to_delete.name] climbs into [src]...</span>")
 	playsound(src, 'sound/machines/wooden_closet_close.ogg', 50)

--- a/code/modules/ruins/objects_and_mobs/necropolis_gate.dm
+++ b/code/modules/ruins/objects_and_mobs/necropolis_gate.dm
@@ -155,7 +155,7 @@ GLOBAL_DATUM(necropolis_gate, /obj/structure/necropolis_gate/legion_gate)
 /obj/structure/necropolis_gate/legion_gate/attack_hand(mob/user)
 	if(!open && !changing_openness)
 		var/safety = tgui_alert(user, "You think this might be a bad idea...", "Knock on the door?", list("Proceed", "Abort"))
-		if(safety == "Abort" || !in_range(src, user) || !src || open || changing_openness || user.incapacitated())
+		if(!safety || safety == "Abort" || !in_range(src, user) || !src || open || changing_openness || user.incapacitated())
 			return
 		user.visible_message("<span class='warning'>[user] knocks on [src]...</span>", "<span class='boldannounceic'>You tentatively knock on [src]...</span>")
 		playsound(user.loc, 'sound/effects/shieldbash.ogg', 100, 1)

--- a/code/modules/tgui/modules/ghost_hud_panel.dm
+++ b/code/modules/tgui/modules/ghost_hud_panel.dm
@@ -67,7 +67,7 @@ GLOBAL_DATUM_INIT(ghost_hud_panel, /datum/ui_module/ghost_hud_panel, new)
 			// Check if this is the first time they're turning on Antag HUD.
 			if(!check_rights(R_ADMIN | R_MOD, FALSE) && !ghost.is_roundstart_observer() && GLOB.configuration.general.restrict_antag_hud_rejoin && !ghost.has_ahudded())
 				var/response = tgui_alert(ghost, "If you turn this on, you will not be able to take any part in the round.", "Are you sure you want to enable antag HUD?", list("Yes", "No"))
-				if(!response || response == "No")
+				if(response != "Yes")
 					return FALSE
 
 				ghost.can_reenter_corpse = FALSE

--- a/code/modules/tgui/modules/ghost_hud_panel.dm
+++ b/code/modules/tgui/modules/ghost_hud_panel.dm
@@ -67,7 +67,7 @@ GLOBAL_DATUM_INIT(ghost_hud_panel, /datum/ui_module/ghost_hud_panel, new)
 			// Check if this is the first time they're turning on Antag HUD.
 			if(!check_rights(R_ADMIN | R_MOD, FALSE) && !ghost.is_roundstart_observer() && GLOB.configuration.general.restrict_antag_hud_rejoin && !ghost.has_ahudded())
 				var/response = tgui_alert(ghost, "If you turn this on, you will not be able to take any part in the round.", "Are you sure you want to enable antag HUD?", list("Yes", "No"))
-				if(response == "No")
+				if(!response || response == "No")
 					return FALSE
 
 				ghost.can_reenter_corpse = FALSE

--- a/code/modules/tgui/tgui_input/text_input.dm
+++ b/code/modules/tgui/tgui_input/text_input.dm
@@ -123,7 +123,7 @@
 	data["max_length"] = max_length
 	data["message"] = message
 	data["multiline"] = multiline
-	data["placeholder"] = default // Default is a reserved keyword
+	data["placeholder"] = html_decode(default) // Default is a reserved keyword
 	data["large_buttons"] = user.client?.prefs?.toggles2 & PREFTOGGLE_2_LARGE_INPUT_BUTTONS
 	data["swapped_buttons"] = user.client?.prefs?.toggles2 & PREFTOGGLE_2_SWAP_INPUT_BUTTONS
 	data["title"] = title

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -19,10 +19,11 @@
 	set desc = "Visit the forum."
 	set hidden = 1
 	if(GLOB.configuration.url.forum_url)
-		if(tgui_alert(src, "Open the forum in your browser?", "Forum", list("Yes", "No")) == "Yes")
-			if(GLOB.configuration.url.forum_link_url && prefs && !prefs.fuid)
-				link_forum_account()
-			src << link(GLOB.configuration.url.forum_url)
+		if(tgui_alert(src, "Open the forum in your browser?", "Forum", list("Yes", "No")) != "Yes")
+			return
+		if(GLOB.configuration.url.forum_link_url && prefs && !prefs.fuid)
+			link_forum_account()
+		src << link(GLOB.configuration.url.forum_url)
 	else
 		to_chat(src, "<span class='danger'>The forum URL is not set in the server configuration.</span>")
 
@@ -31,8 +32,9 @@
 	set desc = "View the server rules."
 	set hidden = 1
 	if(GLOB.configuration.url.rules_url)
-		if(tgui_alert(src, "This will open the rules in your browser. Are you sure?", "Rules", list("Yes", "No")) == "Yes")
-			src << link(GLOB.configuration.url.rules_url)
+		if(tgui_alert(src, "This will open the rules in your browser. Are you sure?", "Rules", list("Yes", "No")) != "Yes")
+			return
+		src << link(GLOB.configuration.url.rules_url)
 	else
 		to_chat(src, "<span class='danger'>The rules URL is not set in the server configuration.</span>")
 
@@ -41,8 +43,9 @@
 	set desc = "Visit the GitHub page."
 	set hidden = 1
 	if(GLOB.configuration.url.github_url)
-		if(tgui_alert(src, "This will open our GitHub repository in your browser. Are you sure?", "GitHub", list("Yes", "No")) == "Yes")
-			src << link(GLOB.configuration.url.github_url)
+		if(tgui_alert(src, "This will open our GitHub repository in your browser. Are you sure?", "GitHub", list("Yes", "No")) != "Yes")
+			return
+		src << link(GLOB.configuration.url.github_url)
 	else
 		to_chat(src, "<span class='danger'>The GitHub URL is not set in the server configuration.</span>")
 
@@ -63,15 +66,17 @@
 	if(!durl)
 		to_chat(src, "<span class='danger'>The Discord URL is not set in the server configuration.</span>")
 		return
-	if(tgui_alert(src, "This will invite you to our Discord server. Are you sure?", "Discord", list("Yes", "No")) == "Yes")
-		src << link(durl)
+	if(tgui_alert(src, "This will invite you to our Discord server. Are you sure?", "Discord", list("Yes", "No")) != "Yes")
+		return
+	src << link(durl)
 
 /client/verb/donate()
 	set name = "Donate"
 	set desc = "Donate to help with hosting costs."
 	set hidden = 1
 	if(GLOB.configuration.url.donations_url)
-		if(tgui_alert(src, "This will open the donation page in your browser. Are you sure?", "Donate", list("Yes", "No")) == "Yes")
-			src << link(GLOB.configuration.url.donations_url)
+		if(tgui_alert(src, "This will open the donation page in your browser. Are you sure?", "Donate", list("Yes", "No")) != "Yes")
+			return
+		src << link(GLOB.configuration.url.donations_url)
 	else
 		to_chat(src, "<span class='danger'>The rules URL is not set in the server configuration.</span>")

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -31,9 +31,8 @@
 	set desc = "View the server rules."
 	set hidden = 1
 	if(GLOB.configuration.url.rules_url)
-		if(tgui_alert(src, "This will open the rules in your browser. Are you sure?", "Rules", list("Yes", "No")) == "No")
-			return
-		src << link(GLOB.configuration.url.rules_url)
+		if(tgui_alert(src, "This will open the rules in your browser. Are you sure?", "Rules", list("Yes", "No")) == "Yes")
+			src << link(GLOB.configuration.url.rules_url)
 	else
 		to_chat(src, "<span class='danger'>The rules URL is not set in the server configuration.</span>")
 
@@ -42,9 +41,8 @@
 	set desc = "Visit the GitHub page."
 	set hidden = 1
 	if(GLOB.configuration.url.github_url)
-		if(tgui_alert(src, "This will open our GitHub repository in your browser. Are you sure?", "GitHub", list("Yes", "No")) == "No")
-			return
-		src << link(GLOB.configuration.url.github_url)
+		if(tgui_alert(src, "This will open our GitHub repository in your browser. Are you sure?", "GitHub", list("Yes", "No")) == "Yes")
+			src << link(GLOB.configuration.url.github_url)
 	else
 		to_chat(src, "<span class='danger'>The GitHub URL is not set in the server configuration.</span>")
 
@@ -65,17 +63,15 @@
 	if(!durl)
 		to_chat(src, "<span class='danger'>The Discord URL is not set in the server configuration.</span>")
 		return
-	if(tgui_alert(src, "This will invite you to our Discord server. Are you sure?", "Discord", list("Yes", "No")) == "No")
-		return
-	src << link(durl)
+	if(tgui_alert(src, "This will invite you to our Discord server. Are you sure?", "Discord", list("Yes", "No")) == "Yes")
+		src << link(durl)
 
 /client/verb/donate()
 	set name = "Donate"
 	set desc = "Donate to help with hosting costs."
 	set hidden = 1
 	if(GLOB.configuration.url.donations_url)
-		if(tgui_alert(src, "This will open the donation page in your browser. Are you sure?", "Donate", list("Yes", "No")) == "No")
-			return
-		src << link(GLOB.configuration.url.donations_url)
+		if(tgui_alert(src, "This will open the donation page in your browser. Are you sure?", "Donate", list("Yes", "No")) == "Yes")
+			src << link(GLOB.configuration.url.donations_url)
 	else
 		to_chat(src, "<span class='danger'>The rules URL is not set in the server configuration.</span>")


### PR DESCRIPTION
## What Does This PR Do
Fixes #24274 
Added html_decode() to default message into Text Input. I'm sure it's not the best solution, but I haven't found a better one, it almost completely removes the problem with `&#39;` while not affecting the standard inputs.
Flavor text and Employment Records limit is raised 3 times what it used to be

I just hope I didn't make it worse...

P.S. I Hate text Inputs

## Why It's Good For The Game
You can set 3k symbols employment record and edit it freely, without `&#39;`
And you ain't be punished if just close alert window (Probably)

## Images of changes

https://github.com/ParadiseSS13/Paradise/assets/69762909/bf351083-c4ff-49e1-8ead-84f2a81ce62f

## Testing
Images of changes

## Changelog
:cl:
fix: Flavor text and Character Records now have 3072 symbols limit. And doesn't show you `&#39;` instead of '
fix: TGUI Alerts no longer do things if you bad guy and instead of choose, just close the window
/:cl:

