### PR TITLE
Blueshield armour no longer refers to the blueshield as a lieutenant

### DIFF
--- a/code/modules/clothing/suits/armor_suits.dm
+++ b/code/modules/clothing/suits/armor_suits.dm
@@ -88,7 +88,7 @@
 
 /obj/item/clothing/suit/armor/vest/blueshield
 	name = "blueshield's security armor"
-	desc = "An armored vest with the badge of a Blueshield Lieutenant."
+	desc = "An armored vest with the badge of a Blueshield."
 	sprite_sheets = list(
 		"Grey" = 'icons/mob/clothing/species/grey/suit.dmi'
 	)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
Dishonourably demotes the blueshield from the rank of lieutenant for failing to ensure all the child locks are enabled on the station maint tunnels, allowing the captain to wander into the tunnels where he proceeded to get lost for more than 6 hours until a passing engineer found him curled up in the foetal position crying for help.

Fixes an oversight in #12701.
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
The blueshield is not worthy of holding the rank of lieutenant.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Became a blueshield. Saw my armour. Was sad that I was no longer an officer of the Nanotrasen Navy.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Blueshield's security armour no longer refers to the blueshield as a lieutenant.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
