### PR TITLE
Revival nests description updated, heals hivenoded humans

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/alien_nests.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/alien_nests.dm
@@ -128,7 +128,6 @@
 		if(user.get_int_organ(/obj/item/organ/internal/alien/hivenode))
 			unbuckle_mob(M)
 			add_fingerprint(user)
-			return
 
 /obj/structure/bed/revival_nest/post_unbuckle_mob(mob/living/M)
 	STOP_PROCESSING(SSobj, src)

--- a/code/game/objects/structures/stool_bed_chair_nest/alien_nests.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/alien_nests.dm
@@ -113,7 +113,7 @@
 
 /obj/structure/bed/revival_nest
 	name = "alien rejuvenation nest"
-	desc = "It's a gruesome pile of thick, sticky resin shaped like a flytrap. Heals damaged aliens and slowly revives the dead, breaks down non xenos and uses their genetic soup to make an alien egg."
+	desc = "It's a gruesome pile of thick, sticky resin shaped like a flytrap. Heals damaged aliens and slowly revives the dead, breaks down non xenos."
 	icon = 'icons/mob/alien.dmi'
 	icon_state = "placeholder_rejuv_nest"
 	max_integrity = 30


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Removes outdated line about them turning humans into eggs.
No longer hurts humans in it, since that is pointless and did not work on huggered people.
Heals humans with hivenodes, will not revive them.
Non hivenoded can not get in it or unbuckle people.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Descriptions being accurate is good.
Hivenoded being able to use xeno structures is good, but we don't need humans reviving from death with it.
No point in a damaging function when it only works on unhugged crew, or dead crew. You want to hugger crew before killing them, and there is no point in damaging a dead body.

## Testing
<!-- How did you test the PR, if at all? -->
Buckled / unbuckled hivenoded alien
Buckled a human with hivenode.
Unbuckled alien with hivenode
unbuckled human with hivenode, etc

## Changelog
:cl:
tweak: Revival nest no longer mentions it being able to turn people into eggs.
tweak: Revival nests now heal anyone with a hivenode
tweak: Revival nests no longer hurt humans inside of them, people without hivenodes can no longer be put in
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
