### PR TITLE
mail now lists the job of the recipient on examine

### DIFF
--- a/code/game/objects/mail.dm
+++ b/code/game/objects/mail.dm
@@ -15,6 +15,8 @@
 	var/list/job_list = list()
 	/// The real name required to open the letter
 	var/recipient
+	/// The job of the recipient
+	var/recipient_job
 	var/has_been_scanned = FALSE
 
 /obj/item/envelope/suicide_act(mob/user)
@@ -49,10 +51,15 @@
 		if(mail_attracted_people.assigned_role in job_list)
 			recipient = mail_attracted_people.current.real_name
 			name = "letter to [recipient]"
+			recipient_job = lowertext(mail_attracted_people.assigned_role)
 			return
 	if(!admin_spawned)
 		log_debug("Failed to find a new name to assign to [src]!")
 		qdel(src)
+
+/obj/item/envelope/examine(mob/user)
+	. = ..()
+	. += "This letter is addressed to [recipient], the [recipient_job]."
 
 /obj/item/envelope/security
 	icon_state = "mail_sec"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
mail now lists the job of the recipient on examine

## Why It's Good For The Game
we got colorblind people in this community. Also it just makes sense to have tbh.

## Testing
examined a letter in game

## Changelog
:cl:
tweak: mail now lists the job of the recipient on examine
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
