### PR TITLE
Allow an empty string when editing records, flavors, OOC notes

### DIFF
--- a/code/modules/client/preference/link_processing.dm
+++ b/code/modules/client/preference/link_processing.dm
@@ -66,21 +66,21 @@
 
 		if(href_list["task"] == "med_record")
 			var/medmsg = tgui_input_text(usr, "Set your medical notes here.", "Medical Records", active_character.med_record, max_length = MAX_PAPER_MESSAGE_LEN, multiline = TRUE)
-			if(!medmsg)
+			if(isnull(medmsg))
 				return
 			active_character.med_record = medmsg
 			active_character.SetRecords(user)
 
 		if(href_list["task"] == "sec_record")
 			var/secmsg = tgui_input_text(usr, "Set your security notes here.", "Security Records", active_character.sec_record, max_length = MAX_PAPER_MESSAGE_LEN, multiline = TRUE)
-			if(!secmsg)
+			if(isnull(secmsg))
 				return
 			active_character.sec_record = secmsg
 			active_character.SetRecords(user)
 
 		if(href_list["task"] == "gen_record")
 			var/genmsg = tgui_input_text(usr, "Set your employment notes here.", "Employment Records", active_character.gen_record, max_length = MAX_PAPER_MESSAGE_LEN, multiline = TRUE)
-			if(!genmsg)
+			if(isnull(genmsg))
 				return
 			active_character.gen_record = genmsg
 			active_character.SetRecords(user)
@@ -319,7 +319,7 @@
 
 				if("metadata")
 					var/new_metadata = tgui_input_text(user, "Enter any information you'd like others to see, such as Roleplay-preferences:", "Game Preference", active_character.metadata, multiline = TRUE, encode = FALSE)
-					if(!new_metadata)
+					if(isnull(new_metadata))
 						return
 					active_character.metadata = new_metadata
 
@@ -706,7 +706,7 @@
 
 				if("flavor_text")
 					var/msg = tgui_input_text(usr, "Set the flavor text in your 'examine' verb. The flavor text should be a physical descriptor of your character at a glance. SFW Drawn Art of your character is acceptable.", "Flavor Text", active_character.flavor_text, max_length = MAX_PAPER_MESSAGE_LEN, multiline = TRUE)
-					if(!msg)
+					if(isnull(msg))
 						return
 					active_character.flavor_text = msg
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Slightly changes the input checks when editing records, flavors and OOC notes.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Brings back convenient records deletion.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Yes.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl: Maxiemar
fix: Fixed the impossibility to delete records, flavor text and OOC notes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
