### PR TITLE
Changes some of the cyber implants that you get from the cybernetic revolution trait 

### DIFF
--- a/code/datums/station_traits/postive_traits.dm
+++ b/code/datums/station_traits/postive_traits.dm
@@ -167,7 +167,7 @@
 		/datum/job/atmos = /obj/item/organ/internal/lungs/cybernetic/upgraded,
 		/datum/job/bartender = /obj/item/organ/internal/liver/cybernetic,
 		/datum/job/hydro = /obj/item/organ/internal/cyberimp/arm/botanical,
-		/datum/job/captain = /obj/item/organ/internal/cyberimp/arm/telebaton,
+		/datum/job/captain = /obj/item/organ/internal/heart/cybernetic/upgraded,
 		/datum/job/cargo_tech = /obj/item/organ/internal/cyberimp/brain/anti_sleep,
 		/datum/job/chaplain = /obj/item/organ/internal/cyberimp/brain/anti_drop,
 		/datum/job/chemist = /obj/item/organ/internal/liver/cybernetic,

--- a/code/datums/station_traits/postive_traits.dm
+++ b/code/datums/station_traits/postive_traits.dm
@@ -164,25 +164,25 @@
 	/// List of all job types with the cybernetics they should receive.
 	var/static/list/job_to_cybernetic = list(
 		/datum/job/assistant = /obj/item/organ/internal/heart/cybernetic, //real action, real bloodshed
-		/datum/job/atmos = /obj/item/organ/internal/cyberimp/mouth/breathing_tube,
+		/datum/job/atmos = /obj/item/organ/internal/lungs/cybernetic/upgraded,
 		/datum/job/bartender = /obj/item/organ/internal/liver/cybernetic,
-		/datum/job/hydro = /obj/item/organ/internal/cyberimp/chest/nutriment,
-		/datum/job/captain = /obj/item/organ/internal/heart/cybernetic/upgraded,
+		/datum/job/hydro = /obj/item/organ/internal/cyberimp/arm/botanical,
+		/datum/job/captain = /obj/item/organ/internal/cyberimp/arm/telebaton,
 		/datum/job/cargo_tech = /obj/item/organ/internal/cyberimp/brain/anti_sleep,
 		/datum/job/chaplain = /obj/item/organ/internal/cyberimp/brain/anti_drop,
 		/datum/job/chemist = /obj/item/organ/internal/liver/cybernetic,
-		/datum/job/chief_engineer = /obj/item/organ/internal/eyes/cybernetic/meson,
+		/datum/job/chief_engineer = /obj/item/organ/internal/cyberimp/brain/wire_interface,
 		/datum/job/cmo = /obj/item/organ/internal/cyberimp/chest/reviver,
 		/datum/job/clown = /obj/item/organ/internal/cyberimp/brain/anti_stam, //HONK!
 		/datum/job/chef = /obj/item/organ/internal/cyberimp/chest/nutriment/plus,
 		/datum/job/coroner = /obj/item/organ/internal/cyberimp/eyes/hud/medical, //hes got a bone to pick with you
-		/datum/job/librarian = /obj/item/organ/internal/cyberimp/brain/speech_translator,
+		/datum/job/librarian = /obj/item/organ/internal/cyberimp/brain/speech_translator, //dunno what to replace this with, but this is useless since no wingdings?
 		/datum/job/detective = /obj/item/organ/internal/eyes/cybernetic/meson,
 		/datum/job/doctor = /obj/item/organ/internal/cyberimp/arm/surgery,
 		/datum/job/geneticist = /obj/item/organ/internal/alien/plasmavessel/hunter, //we don't care about implants, we have cancer.
 		/datum/job/hop = /obj/item/organ/internal/eyes/cybernetic/shield,
-		/datum/job/hos = /obj/item/organ/internal/cyberimp/arm/telebaton, //not giving them thermals
-		/datum/job/janitor = /obj/item/organ/internal/cyberimp/arm/janitorial, //Not giving them bloody xray
+		/datum/job/hos = /obj/item/organ/internal/cyberimp/brain/anti_stam, //not giving them thermals
+		/datum/job/janitor = /obj/item/organ/internal/cyberimp/eyes/hud/jani, //Not giving them bloody xray. //blood xray then?. ~cat
 		/datum/job/lawyer = /obj/item/organ/internal/heart/cybernetic/upgraded,
 		/datum/job/mime = /obj/item/organ/internal/cyberimp/brain/anti_stam, //...
 		/datum/job/paramedic = /obj/item/organ/internal/cyberimp/mouth/breathing_tube,
@@ -192,14 +192,14 @@
 		/datum/job/roboticist = /obj/item/organ/internal/cyberimp/eyes/hud/diagnostic,
 		/datum/job/scientist = /obj/item/organ/internal/ears/cybernetic,
 		/datum/job/officer = /obj/item/organ/internal/cyberimp/eyes/hud/security,
-		/datum/job/mining = /obj/item/organ/internal/cyberimp/mouth/breathing_tube,
-		/datum/job/engineer = /obj/item/organ/internal/cyberimp/brain/wire_interface,
-		/datum/job/virologist = /obj/item/organ/internal/cyberimp/mouth/breathing_tube,
+		/datum/job/mining = /obj/item/organ/internal/eyes/cybernetic/meson,
+		/datum/job/engineer = /obj/item/organ/internal/eyes/cybernetic/shield,
+		/datum/job/virologist = /obj/item/organ/internal/cyberimp/eyes/hud/medical,
 		/datum/job/warden = /obj/item/organ/internal/cyberimp/arm/flash,
 		/datum/job/judge = /obj/item/organ/internal/cyberimp/arm/telebaton,
 		/datum/job/explorer = /obj/item/organ/internal/cyberimp/arm/toolset,
 		/datum/job/nanotrasenrep = /obj/item/organ/internal/heart/cybernetic/upgraded,
-		/datum/job/blueshield = /obj/item/organ/internal/heart/cybernetic/upgraded,
+		/datum/job/blueshield = /obj/item/organ/internal/cyberimp/arm/flash,
 	)
 
 /datum/station_trait/cybernetic_revolution/New()

--- a/code/datums/station_traits/postive_traits.dm
+++ b/code/datums/station_traits/postive_traits.dm
@@ -199,7 +199,7 @@
 		/datum/job/judge = /obj/item/organ/internal/cyberimp/arm/telebaton,
 		/datum/job/explorer = /obj/item/organ/internal/cyberimp/arm/toolset,
 		/datum/job/nanotrasenrep = /obj/item/organ/internal/heart/cybernetic/upgraded,
-		/datum/job/blueshield = /obj/item/organ/internal/cyberimp/arm/flash,
+		/datum/job/blueshield = /obj/item/organ/internal/cyberimp/arm/flash
 	)
 
 /datum/station_trait/cybernetic_revolution/New()

--- a/code/datums/station_traits/postive_traits.dm
+++ b/code/datums/station_traits/postive_traits.dm
@@ -182,7 +182,7 @@
 		/datum/job/geneticist = /obj/item/organ/internal/alien/plasmavessel/hunter, //we don't care about implants, we have cancer.
 		/datum/job/hop = /obj/item/organ/internal/eyes/cybernetic/shield,
 		/datum/job/hos = /obj/item/organ/internal/cyberimp/brain/anti_stam, //not giving them thermals
-		/datum/job/janitor = /obj/item/organ/internal/cyberimp/eyes/hud/jani, //Not giving them bloody xray. //blood xray then?. ~cat
+		/datum/job/janitor = /obj/item/organ/internal/cyberimp/eyes/hud/jani,
 		/datum/job/lawyer = /obj/item/organ/internal/heart/cybernetic/upgraded,
 		/datum/job/mime = /obj/item/organ/internal/cyberimp/brain/anti_stam, //...
 		/datum/job/paramedic = /obj/item/organ/internal/cyberimp/mouth/breathing_tube,


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Replaces the following implants with the following implants on the marked jobs
Atmos: Upgraded lungs. swapped from breathing tube
Hydro: Botanical toolset implant. Lost feeding implant
CE: Wire interface implant. Lost mesons
Hos: CNS rebooter. Lost telebaton implant
Janitor: Jani hud implant. Lost jani toolset implant
Miner: Meson eyes. Lost breathing tube
Engineer: Welding shielded eyes. Lost wire interface implant
Viro: medhud implant. Lost breathing tube
Bluesheild: Flash arm implant. Lost upgraded heart.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Some of the choices were very strange, ce getting objectively worse stuff than engineers, some of the heads getting upgraded hearts over.. useful things? and hydro feeding implant makes no sense the botany toolset existed i guess it was forgotten about.
hopefully these changes are liked.


## Testing
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Changes some of the implants some jobs get for cybernetic revolution, see PR for details.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
