### PR TITLE
Knuckledusters lose their abstract flag on dropped now.

### DIFF
--- a/code/game/objects/items/weapons/knuckledusters.dm
+++ b/code/game/objects/items/weapons/knuckledusters.dm
@@ -29,9 +29,13 @@
 		to_chat(user, "You relax your grip on [src].")
 		flags &= ~(NODROP | ABSTRACT)
 
+/obj/item/melee/knuckleduster/dropped(mob/user, silent)
+	. = ..()
+	gripped = FALSE
+	flags &= ~(NODROP | ABSTRACT)
+
 /obj/item/melee/knuckleduster/attack/(mob/living/user)
-	hitsound = pick('sound/weapons/punch1.ogg', 'sound/weapons/punch2.ogg', 'sound/weapons/punch3.ogg', 
-'sound/weapons/punch4.ogg')
+	hitsound = pick('sound/weapons/punch1.ogg', 'sound/weapons/punch2.ogg', 'sound/weapons/punch3.ogg', 'sound/weapons/punch4.ogg')
 	return ..()
 
 /obj/item/melee/knuckleduster/attack(mob/living/target, mob/living/user)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Knuckledusters lose their abstract flag on dropped now.
Fixes #24329

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
bug bad

## Testing
<!-- How did you test the PR, if at all? -->
Code compiles, I can more thoroughly test in a few hours.

## Changelog
:cl:
fix: Knuckledusters can be re-picked up if removed via surgery.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
