### PR TITLE
Fixes #24198

### DIFF
--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -303,7 +303,7 @@
 		return
 	if(world.time < (last_upgrade + UPGRADE_COOLDOWN))
 		return
-	if(assailant.restrained() || IS_HORIZONTAL(assailant))
+	if(HAS_TRAIT(assailant, TRAIT_HANDS_BLOCKED) || IS_HORIZONTAL(assailant))
 		qdel(src)
 		return
 

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -303,7 +303,7 @@
 		return
 	if(world.time < (last_upgrade + UPGRADE_COOLDOWN))
 		return
-	if(!(assailant.mobility_flags & MOBILITY_MOVE) || IS_HORIZONTAL(assailant))
+	if(assailant.restrained() || IS_HORIZONTAL(assailant))
 		qdel(src)
 		return
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Fixes #24198 
Makes reinforcing a grab only check whether or not a mob is restrained, not immobilized. This allows mobs to reinforce above yellow grab if they're buckled in a chair or otherwise do not have the MOBILITY_MOVE flag.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Not being able to reinforce grabs while you're sitting in a chair is kind of silly, and the reinforcement failing silently is just confusing and unintuitive. If you can yellow grab while in a chair, you should be able to go all the way.

## Testing
<!-- How did you test the PR, if at all? -->
Tested all of the edge cases that I thought could cause issues, like anything that adds TRAIT_IMMOBILIZED with the intention to stun or otherwise debilitate the user. I'm pretty sure that any potential grabbing-after-stun issues are resolved by the grab dropping before the user can reinforce it.

## Changelog
:cl: Chuga
fix: Grabs can now be reinforced while the assailant is buckled.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
