### PR TITLE
fixes xenos being nullspaced in rare situations

### DIFF
--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -98,7 +98,7 @@
 
 		spawn(6)
 			owner.cut_overlay(overlay)
-			var/mob/living/carbon/alien/larva/new_xeno = new(owner.drop_location())
+			var/mob/living/carbon/alien/larva/new_xeno = new(get_turf(owner))
 			new_xeno.key = C.key
 			dust_if_respawnable(C)
 			if(SSticker && SSticker.mode)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
fixes xenos being nullspaced in rare situations

## Why It's Good For The Game
Do not send xenos directly to FALSE (This is not a joke)

## Testing
This is just a change to get_turf(), I didn't
## Changelog
:cl:
fix: Xenos will no longer be sent to null in some odd situations
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
