### PR TITLE
Adds names and descriptions to most bullets and ammo boxes

### DIFF
--- a/code/modules/projectiles/ammunition/ammo_boxes.dm
+++ b/code/modules/projectiles/ammunition/ammo_boxes.dm
@@ -9,7 +9,7 @@
 
 /obj/item/ammo_box/b357
 	name = "ammo box (.357)"
-	desc = "An ammunition box full of .357 magnum rounds, commonly used in high-caliber revolvers."
+	desc = "An ammunition box filled with seven .357 magnum rounds, commonly used in high-caliber revolvers."
 	w_class = WEIGHT_CLASS_NORMAL
 	ammo_type = /obj/item/ammo_casing/a357
 	max_ammo = 7

--- a/code/modules/projectiles/ammunition/ammo_boxes.dm
+++ b/code/modules/projectiles/ammunition/ammo_boxes.dm
@@ -1,6 +1,6 @@
 /obj/item/ammo_box/a357
 	name = "speed loader (.357)"
-	desc = "A small device designed to quickly reload revolvers."
+	desc = "A small device designed to quickly reload revolvers. Seven round capacity."
 	materials = list()
 	ammo_type = /obj/item/ammo_casing/a357
 	max_ammo = 7
@@ -9,7 +9,7 @@
 
 /obj/item/ammo_box/b357
 	name = "ammo box (.357)"
-	desc = "An ammunition box filled with seven .357 magnum rounds, commonly used in high-caliber revolvers."
+	desc = "An ammunition box filled with .357 magnum rounds, commonly used in high-caliber revolvers."
 	w_class = WEIGHT_CLASS_NORMAL
 	ammo_type = /obj/item/ammo_casing/a357
 	max_ammo = 7
@@ -57,7 +57,7 @@
 
 /obj/item/ammo_box/a762
 	name = "stripper clip (7.62mm)"
-	desc = "A stripper clip for 7.62mm rounds, used in Mosin-Nagant rifles."
+	desc = "A stripper clip for 7.62mm cartridges, used in Mosin-Nagant rifles. Five round capacity."
 	icon_state = "762"
 	ammo_type = /obj/item/ammo_casing/a762
 	max_ammo = 5

--- a/code/modules/projectiles/ammunition/ammo_boxes.dm
+++ b/code/modules/projectiles/ammunition/ammo_boxes.dm
@@ -1,6 +1,6 @@
 /obj/item/ammo_box/a357
 	name = "speed loader (.357)"
-	desc = "Designed to quickly reload revolvers."
+	desc = "A small device designed to quickly reload revolvers."
 	materials = list()
 	ammo_type = /obj/item/ammo_casing/a357
 	max_ammo = 7
@@ -9,7 +9,7 @@
 
 /obj/item/ammo_box/b357
 	name = "ammo box (.357)"
-	desc = "Contains up to seven .357 bullets, intended to either be inserted into a speed loader or into the gun manually."
+	desc = "An ammunition box full of .357 magnum rounds, commonly used in high-caliber revolvers."
 	w_class = WEIGHT_CLASS_NORMAL
 	ammo_type = /obj/item/ammo_casing/a357
 	max_ammo = 7
@@ -18,6 +18,7 @@
 
 /obj/item/ammo_box/c9mm
 	name = "ammo box (9mm)"
+	desc = "An ammunition box filled with 9mm pistol cartridges, commonly used in handguns and submachine guns."
 	icon_state = "9mmbox"
 	origin_tech = "combat=2"
 	ammo_type = /obj/item/ammo_casing/c9mm
@@ -25,6 +26,7 @@
 
 /obj/item/ammo_box/c10mm
 	name = "ammo box (10mm)"
+	desc = "An ammunition box filled with 10mm pistol cartridges, commonly used in Syndicate handguns."
 	icon_state = "10mmbox"
 	origin_tech = "combat=2"
 	ammo_type = /obj/item/ammo_casing/c10mm
@@ -32,6 +34,7 @@
 
 /obj/item/ammo_box/c45
 	name = "ammo box (.45)"
+	desc = "An ammunition box filled with .45 caliber pistol cartridges, commonly used in high-power pistols and submachine guns."
 	icon_state = "45box"
 	origin_tech = "combat=2"
 	ammo_type = /obj/item/ammo_casing/c45
@@ -39,12 +42,14 @@
 
 /obj/item/ammo_box/rubber45
 	name = "ammo box (.45 rubber)"
+	desc = "An ammunition box filled with .45 caliber rubber bullets for less-lethal actions."
 	icon_state = "45box-r"
 	ammo_type = /obj/item/ammo_casing/rubber45
 	max_ammo = 16
 
 /obj/item/ammo_box/a40mm
 	name = "ammo box (40mm grenades)"
+	desc = "An ammunition box full of 40mm grenades, for use with a launcher. Dropping them is ill-advised."
 	icon_state = "40mm"
 	ammo_type = /obj/item/ammo_casing/a40mm
 	max_ammo = 4
@@ -52,7 +57,7 @@
 
 /obj/item/ammo_box/a762
 	name = "stripper clip (7.62mm)"
-	desc = "A stripper clip."
+	desc = "A stripper clip for 7.62mm rounds, used in Mosin-Nagant rifles."
 	icon_state = "762"
 	ammo_type = /obj/item/ammo_casing/a762
 	max_ammo = 5
@@ -60,6 +65,7 @@
 
 /obj/item/ammo_box/n762
 	name = "ammo box (7.62x38mmR)"
+	desc = "An ammunition box full of 7.62x38mmR pistol rounds, for use in antique revolvers."
 	icon_state = "riflebox"
 	origin_tech = "combat=2"
 	ammo_type = /obj/item/ammo_casing/n762
@@ -67,6 +73,7 @@
 
 /obj/item/ammo_box/wt550
 	name = "ammo box (4.6x30mm)"
+	desc = "An ammunition box containing 4.6x30mm PDW rounds, for use in submachine guns and low-caliber rifles."
 	icon_state = "riflebox"
 	origin_tech = "combat=2"
 	ammo_type = /obj/item/ammo_casing/c46x30mm
@@ -76,21 +83,25 @@
 
 /obj/item/ammo_box/wt550/wtap
 	name = "ammo box (Armor Piercing 4.6x30mm)"
+	desc = "An ammunition box containing 4.6x30mm PDW rounds. These are AP rounds, sacrificing damage for armor penetration."
 	icon_state = "wtbox_AP"
 	ammo_type = /obj/item/ammo_casing/c46x30mm/ap
 
 /obj/item/ammo_box/wt550/wtic
 	name = "ammo box (Incendiary 4.6x30mm)"
+	desc = "An ammunition box containing 4.6x30mm PDW ammunition, tipped with an incendiary chemical payload."
 	icon_state = "wtbox_inc"
 	ammo_type = /obj/item/ammo_casing/c46x30mm/inc
 
 /obj/item/ammo_box/wt550/wttx
 	name = "ammo box (Toxin Tipped 4.6x30mm)"
+	desc = "An ammunition box containing 4.6x30mm rounds, tipped with lethal toxins. Possibly a war crime."
 	icon_state = "wtbox_tox"
 	ammo_type = /obj/item/ammo_casing/c46x30mm/tox
 
 /obj/item/ammo_box/laser
 	name = "ammo box (laser)"
+	desc = "An ammunition box containing caseless laser cartridges, for use in IK-series laser rifles."
 	icon_state = "laserbox"
 	origin_tech = "combat=3"
 	ammo_type = /obj/item/ammo_casing/caseless/laser
@@ -99,6 +110,7 @@
 
 /obj/item/ammo_box/shotgun
 	name = "shotgun speedloader (Slug)"
+	desc = "A specialized speedloader for swiftly reloading shotguns. This one is meant for Slugs."
 	icon_state = "slugloader"
 	origin_tech = "combat=2"
 	ammo_type = /obj/item/ammo_casing/shotgun
@@ -108,39 +120,46 @@
 
 /obj/item/ammo_box/shotgun/buck
 	name = "shotgun speedloader (Buckshot)"
+	desc = "A specialized speedloader for swiftly reloading shotguns. This one is meant for Buckshot."
 	icon_state = "buckloader"
 	ammo_type = /obj/item/ammo_casing/shotgun/buckshot
 
 /obj/item/ammo_box/shotgun/confetti
 	name = "shotgun speedloader (Confetti)"
+	desc = "A specialized speedloader for swiftly reloading shotguns. This one is meant for Confetti shot."
 	icon_state = "partyloader"
 	ammo_type = /obj/item/ammo_casing/shotgun/confetti
 	multi_sprite_step = 1
 
 /obj/item/ammo_box/shotgun/dragonsbreath
 	name = "shotgun speedloader (Dragonsbreath)"
+	desc = "A specialized speedloader for swiftly reloading shotguns. This one is meant for Dragonsbreath rounds."
 	icon_state = "dragonsbreathloader"
 	ammo_type = /obj/item/ammo_casing/shotgun/incendiary/dragonsbreath
 
 /obj/item/ammo_box/shotgun/stun
 	name = "shotgun speedloader (Stun shells)"
+	desc = "A specialized speedloader for swiftly reloading shotguns. This one is meant for Stun slugs."
 	icon_state = "stunloader"
 	ammo_type = /obj/item/ammo_casing/shotgun/stunslug
 
 /obj/item/ammo_box/shotgun/beanbag
 	name = "shotgun speedloader (Beanbag shells)"
+	desc = "A specialized speedloader for swiftly reloading shotguns. This one is meant for Beanbag slugs."
 	icon_state = "beanbagloader"
 	ammo_type = /obj/item/ammo_casing/shotgun/beanbag
 	materials = list(MAT_METAL=1750)
 
 /obj/item/ammo_box/shotgun/rubbershot
 	name = "shotgun speedloader (Rubbershot shells)"
+	desc = "A specialized speedloader for swiftly reloading shotguns. This one is meant for Rubbershot shells."
 	icon_state = "rubbershotloader"
 	ammo_type = /obj/item/ammo_casing/shotgun/rubbershot
 	materials = list(MAT_METAL=1750)
 
 /obj/item/ammo_box/shotgun/tranquilizer
 	name = "shotgun speedloader (Tranquilizer darts)"
+	desc = "A specialized speedloader for swiftly reloading shotguns. This one is meant for Tranquilizer dart shells."
 	icon_state = "tranqloader"
 	ammo_type = /obj/item/ammo_casing/shotgun/tranquilizer
 	materials = list(MAT_METAL=1750)
@@ -149,6 +168,7 @@
 //FOAM DARTS
 /obj/item/ammo_box/foambox
 	name = "ammo box (Foam Darts)"
+	desc = "An ammunition box, filled with foam darts for use in toy weapons."
 	icon = 'icons/obj/guns/toy.dmi'
 	icon_state = "foambox"
 	ammo_type = /obj/item/ammo_casing/caseless/foam_dart
@@ -157,11 +177,13 @@
 
 /obj/item/ammo_box/foambox/riot
 	icon_state = "foambox_riot"
+	desc = "An ammunition box, filled with riot darts for use in toy weapons. Not safe for children."
 	ammo_type = /obj/item/ammo_casing/caseless/foam_dart/riot
 	materials = list(MAT_METAL = 50000)
 
 /obj/item/ammo_box/foambox/sniper
 	name = "ammo box (Foam Sniper Darts)"
+	desc = "An ammunition box full of sniper darts for toy weapons."
 	icon = 'icons/obj/guns/toy.dmi'
 	icon_state = "foambox_sniper"
 	ammo_type = /obj/item/ammo_casing/caseless/foam_dart/sniper
@@ -170,12 +192,14 @@
 
 /obj/item/ammo_box/foambox/sniper/riot
 	icon_state = "foambox_sniper_riot"
+	desc = "An ammunition box full of powerful sniper riot darts."
 	ammo_type = /obj/item/ammo_casing/caseless/foam_dart/sniper/riot
 	materials = list(MAT_METAL = 90000)
 
 
 /obj/item/ammo_box/caps
 	name = "speed loader (caps)"
+	desc = "A revolver speedloader for a cap gun. Cannot chamber live ammunition."
 	icon_state = "357"
 	ammo_type = /obj/item/ammo_casing/cap
 	max_ammo = 7

--- a/code/modules/projectiles/ammunition/ammo_boxes.dm
+++ b/code/modules/projectiles/ammunition/ammo_boxes.dm
@@ -65,7 +65,7 @@
 
 /obj/item/ammo_box/n762
 	name = "ammo box (7.62x38mmR)"
-	desc = "An ammunition box full of 7.62x38mmR pistol rounds, for use in antique revolvers."
+	desc = "An ammunition box full of 7.62x38mmR pistol cartridges, for use in antique revolvers."
 	icon_state = "riflebox"
 	origin_tech = "combat=2"
 	ammo_type = /obj/item/ammo_casing/n762
@@ -73,7 +73,7 @@
 
 /obj/item/ammo_box/wt550
 	name = "ammo box (4.6x30mm)"
-	desc = "An ammunition box containing 4.6x30mm PDW rounds, for use in submachine guns and low-caliber rifles."
+	desc = "An ammunition box containing 4.6x30mm PDW cartridges, for use in submachine guns and low-caliber rifles."
 	icon_state = "riflebox"
 	origin_tech = "combat=2"
 	ammo_type = /obj/item/ammo_casing/c46x30mm
@@ -83,7 +83,7 @@
 
 /obj/item/ammo_box/wt550/wtap
 	name = "ammo box (Armor Piercing 4.6x30mm)"
-	desc = "An ammunition box containing 4.6x30mm PDW rounds. These are AP rounds, sacrificing damage for armor penetration."
+	desc = "An ammunition box containing 4.6x30mm PDW cartridges. These are AP rounds, sacrificing damage for armor penetration."
 	icon_state = "wtbox_AP"
 	ammo_type = /obj/item/ammo_casing/c46x30mm/ap
 
@@ -95,7 +95,7 @@
 
 /obj/item/ammo_box/wt550/wttx
 	name = "ammo box (Toxin Tipped 4.6x30mm)"
-	desc = "An ammunition box containing 4.6x30mm rounds, tipped with lethal toxins. Possibly a war crime."
+	desc = "An ammunition box containing 4.6x30mm cartridges, tipped with lethal toxins. Possibly a war crime."
 	icon_state = "wtbox_tox"
 	ammo_type = /obj/item/ammo_casing/c46x30mm/tox
 

--- a/code/modules/projectiles/ammunition/ammo_boxes.dm
+++ b/code/modules/projectiles/ammunition/ammo_boxes.dm
@@ -49,7 +49,7 @@
 
 /obj/item/ammo_box/a40mm
 	name = "ammo box (40mm grenades)"
-	desc = "An ammunition box full of 40mm grenades, for use with a launcher. Dropping them is ill-advised."
+	desc = "An ammunition box containing four 40mm grenades, for use with a launcher. Dropping them is ill-advised."
 	icon_state = "40mm"
 	ammo_type = /obj/item/ammo_casing/a40mm
 	max_ammo = 4

--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -308,7 +308,7 @@
 
 /obj/item/ammo_casing/shotgun/confetti
 	name = "confettishot"
-	desc = "A 12 gauge shell loaded with...confetti?"
+	desc = "A 12 gauge shell loaded with... confetti?"
 	icon_state = "partyshell"
 	projectile_type = /obj/item/projectile/bullet/confetti
 

--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -1,18 +1,21 @@
 /obj/item/ammo_casing/a357
-	desc = "A .357 bullet casing."
+	name = ".357 magnum round"
+	desc = "A .357 magnum cartridge, often used in revolvers. Very deadly."
 	caliber = "357"
 	projectile_type = /obj/item/projectile/bullet
 	muzzle_flash_strength = MUZZLE_FLASH_STRENGTH_NORMAL
 	muzzle_flash_range = MUZZLE_FLASH_RANGE_STRONG
 
 /obj/item/ammo_casing/rubber9mm
-	desc = "A 9mm rubber bullet casing."
+	name = "9mm rubber round"
+	desc = "A 9mm pistol cartridge. This one has a rubber tip for less-lethal takedowns."
 	caliber = "9mm"
 	icon_state = "r-casing"
 	projectile_type = /obj/item/projectile/bullet/weakbullet4
 
 /obj/item/ammo_casing/a762
-	desc = "A 7.62mm bullet casing."
+	name = "7.62mm round"
+	desc = "A 7.62mm rifle cartridge, often used in Soviet rifles."
 	icon_state = "762-casing"
 	caliber = "a762"
 	projectile_type = /obj/item/projectile/bullet
@@ -20,10 +23,13 @@
 	muzzle_flash_range = MUZZLE_FLASH_RANGE_STRONG
 
 /obj/item/ammo_casing/a762/enchanted
+	name = "enchanted 7.62 round"
+	desc = "A 7.62mm rifle cartridge. It sparkles with magic."
 	projectile_type = /obj/item/projectile/bullet/weakbullet3
 
 /obj/item/ammo_casing/a50
-	desc = "A .50AE bullet casing."
+	name = ".50 AE round"
+	desc = "A .50AE pistol cartridge, used in large caliber handguns."
 	caliber = ".50"
 	projectile_type = /obj/item/projectile/bullet
 	muzzle_flash_strength = MUZZLE_FLASH_STRENGTH_NORMAL
@@ -37,62 +43,86 @@
 	projectile_type = /obj/item/projectile/bullet/mime/fake
 
 /obj/item/ammo_casing/c10mm
-	desc = "A 10mm bullet casing."
+	name = "10mm round"
+	desc = "A 10mm pistol cartridge, commonly used in Syndicate sidearms."
 	caliber = "10mm"
 	projectile_type = /obj/item/projectile/bullet/midbullet3
 	muzzle_flash_strength = MUZZLE_FLASH_STRENGTH_NORMAL
 	muzzle_flash_range = MUZZLE_FLASH_RANGE_NORMAL
 
 /obj/item/ammo_casing/c10mm/ap
+	name = "10mm armor piercing round"
+	desc = "A 10mm pistol cartridge, with a Teflon coating to increase armor penetration, at the cost of damage."
 	projectile_type = /obj/item/projectile/bullet/midbullet3/ap
 
 /obj/item/ammo_casing/c10mm/fire
+	name = "10mm incendiary round"
+	desc = "A 10mm pistol cartridge, containing a payload of flammable chemicals."
 	projectile_type = /obj/item/projectile/bullet/midbullet3/fire
 	muzzle_flash_color = LIGHT_COLOR_FIRE
 
 /obj/item/ammo_casing/c10mm/hp
+	name = "10mm hollow point round"
+	desc = "A 10mm pistol cartridge, with an expanding tip that greatly increases stopping power, at the cost of armor penetration."
 	projectile_type = /obj/item/projectile/bullet/midbullet3/hp
 
 /obj/item/ammo_casing/overgrown
+	name = "overgrown round"
+	desc = "A pistol cartridge...probably. Why does it look like a pea?"
 	projectile_type = /obj/item/projectile/bullet/midbullet3/overgrown
 	icon_state = "peashooter_bullet"
 
 /obj/item/ammo_casing/c9mm
-	desc = "A 9mm bullet casing."
+	name = "9mm round"
+	desc = "A 9mm pistol cartridge, commonly used in handguns and submachine guns."
 	caliber = "9mm"
 	projectile_type = /obj/item/projectile/bullet/weakbullet3
 	muzzle_flash_strength = MUZZLE_FLASH_STRENGTH_WEAK
 	muzzle_flash_range = MUZZLE_FLASH_RANGE_NORMAL
 
 /obj/item/ammo_casing/c9mm/ap
+	name = "9mm armor piercing round"
+	desc = "A 9mm pistol cartridge, with a Teflon coating to increase armor penetration, at the cost of stopping power."
 	projectile_type = /obj/item/projectile/bullet/armourpiercing
 
 /obj/item/ammo_casing/c9mm/tox
+	name = "9mm toxic round"
+	desc = "A 9mm pistol cartridge, tipped with lethal toxins. Likely a war crime."
 	projectile_type = /obj/item/projectile/bullet/toxinbullet
 
 /obj/item/ammo_casing/c9mm/inc
+	name = "9mm incendiary round"
+	desc = "A 9mm pistol cartridge, tipped with an incendiary chemical payload."
 	projectile_type = /obj/item/projectile/bullet/incendiary/firebullet
 	muzzle_flash_color = LIGHT_COLOR_FIRE
 
 /obj/item/ammo_casing/c46x30mm
-	desc = "A 4.6x30mm bullet casing."
+	name = "4.6x30mm round"
+	desc = "A 4.6x30mm PDW cartridge, commonly used in submachine guns and small-caliber rifles."
 	caliber = "4.6x30mm"
 	projectile_type = /obj/item/projectile/bullet/weakbullet3
 	muzzle_flash_strength = MUZZLE_FLASH_STRENGTH_WEAK
 	muzzle_flash_range = MUZZLE_FLASH_RANGE_NORMAL
 
 /obj/item/ammo_casing/c46x30mm/ap
+	name = "4.6x30mm armor piercing round"
+	desc = "A 4.6x30mm PDW cartridge, with a tungsten core to increase armor penetration, at the cost of stopping power."
 	projectile_type = /obj/item/projectile/bullet/armourpiercing/wt550
 
 /obj/item/ammo_casing/c46x30mm/tox
+	name = "4.6x30mm toxic round"
+	desc = "A 4.6x30mm PDW cartridge, tipped with lethal toxins. Probably a war crime."
 	projectile_type = /obj/item/projectile/bullet/toxinbullet
 
 /obj/item/ammo_casing/c46x30mm/inc
+	name = "4.6x30 incendiary round"
+	desc = "a 4.6x30mm PDW cartridge, tipped with an incendiary chemical payload."
 	projectile_type = /obj/item/projectile/bullet/incendiary/firebullet
 	muzzle_flash_color = LIGHT_COLOR_FIRE
 
 /obj/item/ammo_casing/rubber45
-	desc = "A .45 rubber bullet casing."
+	name = ".45 rubber round"
+	desc = "A .45 caliber pistol cartridge. Features a rubber bullet for less-lethal takedowns."
 	caliber = ".45"
 	icon_state = "r-casing"
 	projectile_type = /obj/item/projectile/bullet/midbullet_r
@@ -100,7 +130,8 @@
 	muzzle_flash_range = MUZZLE_FLASH_RANGE_NORMAL
 
 /obj/item/ammo_casing/c45
-	desc = "A .45 bullet casing."
+	name = ".45 round"
+	desc = "A .45 caliber pistol cartridge, commonly used in pistols and submachine guns."
 	caliber = ".45"
 	projectile_type = /obj/item/projectile/bullet/midbullet
 	muzzle_flash_strength = MUZZLE_FLASH_STRENGTH_NORMAL
@@ -110,7 +141,8 @@
 	projectile_type = /obj/item/projectile/bullet/midbullet3
 
 /obj/item/ammo_casing/n762
-	desc = "A 7.62x38mmR bullet casing."
+	name = "7.62x38mmR round"
+	desc = "A 7.62x38mmR pistol cartridge, commonly used by antique revolvers."
 	caliber = "n762"
 	projectile_type = /obj/item/projectile/bullet
 	muzzle_flash_strength = MUZZLE_FLASH_STRENGTH_NORMAL
@@ -128,7 +160,7 @@
 
 /obj/item/ammo_casing/shotgun
 	name = "shotgun slug"
-	desc = "A 12 gauge lead slug."
+	desc = "A 12 gauge lead slug. Fires a single solid projectile."
 	icon_state = "blshell"
 	caliber = "shotgun"
 	casing_drop_sound = 'sound/weapons/gun_interactions/shotgun_fall.ogg'
@@ -140,7 +172,7 @@
 
 /obj/item/ammo_casing/shotgun/buckshot
 	name = "buckshot shell"
-	desc = "A 12 gauge buckshot shell."
+	desc = "A 12 gauge buckshot shell. Fires a spread of lethal shot."
 	icon_state = "gshell"
 	projectile_type = /obj/item/projectile/bullet/pellet
 	pellets = 6
@@ -148,7 +180,7 @@
 
 /obj/item/ammo_casing/shotgun/rubbershot
 	name = "rubber shot"
-	desc = "A shotgun casing filled with densely-packed rubber balls, used to incapacitate crowds from a distance."
+	desc = "A 12 gauge shell filled with densely-packed rubber balls, used to incapacitate crowds from a distance."
 	icon_state = "cshell"
 	projectile_type = /obj/item/projectile/bullet/pellet/rubber
 	pellets = 6
@@ -158,7 +190,7 @@
 
 /obj/item/ammo_casing/shotgun/beanbag
 	name = "beanbag slug"
-	desc = "A weak beanbag slug for riot control."
+	desc = "A 12 gauge shell loaded with a beanbag slug for less-lethal takedowns."
 	icon_state = "bshell"
 	projectile_type = /obj/item/projectile/bullet/weakbullet
 	materials = list(MAT_METAL=250)
@@ -167,7 +199,7 @@
 
 /obj/item/ammo_casing/shotgun/stunslug
 	name = "taser slug"
-	desc = "A stunning taser slug."
+	desc = "A 12 gauge shell loaded with a taser cartridge, somehow."
 	icon_state = "stunshell"
 	projectile_type = /obj/item/projectile/bullet/stunshot
 	materials = list(MAT_METAL=250)
@@ -178,35 +210,33 @@
 
 /obj/item/ammo_casing/shotgun/meteorslug
 	name = "meteorslug shell"
-	desc = "A shotgun shell rigged with CMC technology, which launches a massive slug when fired."
+	desc = "A 12 gauge shell rigged with CMC technology, which launches a massive slug when fired."
 	icon_state = "mshell"
 	projectile_type = /obj/item/projectile/bullet/meteorshot
 
 /obj/item/ammo_casing/shotgun/pulseslug
 	name = "proto pulse slug"
-	desc = "A delicate device which can be loaded into a shotgun. The primer acts as a button which triggers the gain medium and fires a powerful \
-	energy blast. While the heat and power drain limit it to one use, it can still allow an operator to engage targets that ballistic ammunition \
-	would have difficulty with."
+	desc = "A 12 gauge shell loaded with a powerful energy emitter, firing a devastating pulse blast."
 	icon_state = "pshell"
 	projectile_type = /obj/item/projectile/beam/pulse/shot
 	muzzle_flash_color = LIGHT_COLOR_DARKBLUE
 
 /obj/item/ammo_casing/shotgun/incendiary
 	name = "incendiary slug"
-	desc = "An incendiary-coated shotgun slug."
+	desc = "A 12 gauge slug shell containing an incendiary chemical payload."
 	icon_state = "ishell"
 	projectile_type = /obj/item/projectile/bullet/incendiary/shell
 	muzzle_flash_color = LIGHT_COLOR_FIRE
 
 /obj/item/ammo_casing/shotgun/frag12
 	name = "\improper FRAG-12 slug"
-	desc = "A high explosive breaching round for a 12 gauge shotgun."
+	desc = "A 12 gauge shell, loaded with a high-explosive slug."
 	icon_state = "heshell"
 	projectile_type = /obj/item/projectile/bullet/frag12
 
 /obj/item/ammo_casing/shotgun/incendiary/dragonsbreath
 	name = "dragonsbreath shell"
-	desc = "A shotgun shell which fires a spread of incendiary pellets."
+	desc = "A 12 gauge shell which fires a spread of incendiary pellets."
 	icon_state = "ishell2"
 	projectile_type = /obj/item/projectile/bullet/incendiary/shell/dragonsbreath
 	pellets = 4
@@ -215,9 +245,7 @@
 
 /obj/item/ammo_casing/shotgun/ion
 	name = "ion shell"
-	desc = "An advanced shotgun shell which uses a subspace ansible crystal to produce an effect similar to a standard ion rifle. \
-	The unique properties of the crystal splot the pulse into a spread of individually weaker bolts."
-	icon_state = "ionshell"
+	desc = "An advanced 12 gauge shell that fires a spread of ion bolts."
 	projectile_type = /obj/item/projectile/ion/weak
 	pellets = 4
 	variance = 35
@@ -227,7 +255,7 @@
 
 /obj/item/ammo_casing/shotgun/lasershot
 	name = "lasershot"
-	desc = "An advanced shotgun shell that uses a multitude of lenses to split a high-powered laser into eight small pellets."
+	desc = "An advanced 12 gauge shell that uses a multitude of lenses to split a high-powered laser into eight small beams."
 	icon_state = "lshell"
 	projectile_type = /obj/item/projectile/beam/scatter
 	pellets = 8
@@ -238,13 +266,13 @@
 
 /obj/item/ammo_casing/shotgun/techshell
 	name = "unloaded technological shell"
-	desc = "A high-tech shotgun shell which can be loaded with materials to produce unique effects."
+	desc = "An empty 12 gauge shell, ready to be loaded with all manner of projectiles."
 	icon_state = "cshell"
 	projectile_type = null
 
 /obj/item/ammo_casing/shotgun/dart
 	name = "shotgun dart"
-	desc = "A dart for use in shotguns. Can be injected with up to 30 units of any chemical."
+	desc = "A 12 gauge shell loaded with a hypodermic needle. Can be injected with up to 30 units of any chemical."
 	icon_state = "cshell"
 	container_type = OPENCONTAINER
 	projectile_type = /obj/item/projectile/bullet/dart
@@ -271,7 +299,7 @@
 
 /obj/item/ammo_casing/shotgun/tranquilizer
 	name = "tranquilizer darts"
-	desc = "A tranquilizer round used to subdue individuals utilizing stimulants."
+	desc = "A 12 gauge dart shell loaded with powerful tranquilizers."
 	icon_state = "nshell"
 	projectile_type = /obj/item/projectile/bullet/dart/syringe/tranquilizer
 	muzzle_flash_strength = MUZZLE_FLASH_STRENGTH_NORMAL
@@ -280,19 +308,21 @@
 
 /obj/item/ammo_casing/shotgun/confetti
 	name = "confettishot"
-	desc = "It's party time!"
+	desc = "A 12 gauge shell loaded with...confetti?"
 	icon_state = "partyshell"
 	projectile_type = /obj/item/projectile/bullet/confetti
 
 /obj/item/ammo_casing/a556
-	desc = "A 5.56mm bullet casing."
+	name = "5.56mm round"
+	desc = "A 5.56mm rifle round, produced in incredible quantities by the Trans-Solar Federation."
 	caliber = "a556"
 	projectile_type = /obj/item/projectile/bullet/heavybullet
 	muzzle_flash_strength = MUZZLE_FLASH_STRENGTH_NORMAL
 	muzzle_flash_range = MUZZLE_FLASH_RANGE_NORMAL
 
 /obj/item/ammo_casing/a545
-	desc = "A 5.45x39mm bullet casing."
+	name = "5.45x39mm round"
+	desc = "A 5.45x39mm rifle round, used by the elite marines of the USSP."
 	caliber = "a545"
 	projectile_type = /obj/item/projectile/bullet/midbullet3
 	muzzle_flash_strength = MUZZLE_FLASH_STRENGTH_NORMAL
@@ -300,15 +330,15 @@
 
 /obj/item/ammo_casing/shotgun/fakebeanbag
 	name = "beanbag shell"
-	desc = "A weak beanbag shell."
+	desc = "A 12 gauge beanbag slug. Smells strongly of alcohol."
 	icon_state = "bshell"
 	projectile_type = /obj/item/projectile/bullet/weakbullet/booze
 	muzzle_flash_strength = MUZZLE_FLASH_STRENGTH_NORMAL
 	muzzle_flash_range = MUZZLE_FLASH_RANGE_NORMAL
 
 /obj/item/ammo_casing/rocket
-	name = "rocket shell"
-	desc = "A high explosive designed to be fired from a launcher."
+	name = "rocket propelled grenade"
+	desc = "A high explosive rocket meant to be fired from a launcher."
 	icon_state = "rocketshell"
 	projectile_type = /obj/item/projectile/missile
 	caliber = "rocket"
@@ -325,15 +355,16 @@
 	return FALSE
 
 /obj/item/ammo_casing/caseless/a75
-	desc = "A .75 bullet casing."
+	name = ".75 gyrojet round"
+	desc = "A .75 caliber gyrojet cartridge, for use in experimental weaponry. There's a Sunburst Heavy Industries logo on the side."
 	caliber = "75"
 	projectile_type = /obj/item/projectile/bullet/gyro
 	muzzle_flash_strength = MUZZLE_FLASH_STRENGTH_STRONG
 	muzzle_flash_range = MUZZLE_FLASH_RANGE_STRONG
 
 /obj/item/ammo_casing/a40mm
-	name = "40mm HE shell"
-	desc = "A cased high explosive grenade that can only be activated once fired out of a grenade launcher."
+	name = "40mm HE grenade"
+	desc = "A 40mm high-explosive grenade round, meant to be fired from a grenade launcher."
 	caliber = "40mm"
 	icon_state = "40mmHE"
 	projectile_type = /obj/item/projectile/bullet/a40mm
@@ -442,7 +473,7 @@
 
 /obj/item/ammo_casing/shotgun/assassination
 	name = "assassination shell"
-	desc = "A specialist shrapnel shell that has been laced with a silencing toxin."
+	desc = "A 12 gauge buckshot shell containing a powerful silencing toxin."
 	projectile_type = /obj/item/projectile/bullet/pellet/assassination
 	muzzle_flash_effect = null
 	icon_state = "gshell"
@@ -450,6 +481,7 @@
 	variance = 25
 
 /obj/item/ammo_casing/cap
+	name = "cap"
 	desc = "A cap for children toys."
 	caliber = "cap"
 	projectile_type = /obj/item/projectile/bullet/cap
@@ -458,6 +490,7 @@
 	harmful = FALSE
 
 /obj/item/ammo_casing/caseless/laser
+	name = "caseless laser round"
 	desc = "An experimental laser casing, designed to vaporize when fired."
 	caliber = "laser"
 	projectile_type = /obj/item/projectile/beam/laser/ik //Subtype that breaks on firing if emp'd

--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -68,7 +68,7 @@
 
 /obj/item/ammo_casing/overgrown
 	name = "overgrown round"
-	desc = "A pistol cartridge...probably. Why does it look like a pea?"
+	desc = "A pistol cartridge... probably. Why does it resemble a pea?"
 	projectile_type = /obj/item/projectile/bullet/midbullet3/overgrown
 	icon_state = "peashooter_bullet"
 

--- a/code/modules/projectiles/guns/projectile/saw.dm
+++ b/code/modules/projectiles/guns/projectile/saw.dm
@@ -129,7 +129,8 @@
 //casings//
 
 /obj/item/ammo_casing/mm556x45
-	desc = "A 556x45mm bullet casing."
+	name = "5.56x45mm round"
+	desc = "A 5.56x45mm rifle cartridge, commonly used in light machine guns."
 	icon_state = "762-casing"
 	caliber = "mm55645"
 	projectile_type = /obj/item/projectile/bullet/saw
@@ -137,19 +138,23 @@
 	muzzle_flash_range = MUZZLE_FLASH_RANGE_STRONG
 
 /obj/item/ammo_casing/mm556x45/bleeding
-	desc = "A 556x45mm bullet casing with specialized inner-casing, that when it makes contact with a target, release tiny shrapnel to induce internal bleeding."
+	name = "5.56x45mm 'Shredder' round"
+	desc = "A 5.56x45mm 'Shredder' cartridge, with a heavily serrated tip intended to cause massive bleeding."
 	icon_state = "762-casing"
 	projectile_type = /obj/item/projectile/bullet/saw/bleeding
 
 /obj/item/ammo_casing/mm556x45/hollow
-	desc = "A 556x45mm bullet casing designed to cause more damage to unarmored targets."
+	name = "5.56x45mm hollow point round"
+	desc = "A 5.56x45mm rifle cartridge designed to cause more damage to unarmored targets."
 	projectile_type = /obj/item/projectile/bullet/saw/hollow
 
 /obj/item/ammo_casing/mm556x45/ap
-	desc = "A 556x45mm bullet casing designed with a hardened-tipped core to help penetrate armored targets."
+	name = "5.56x45mm armor piercing round"
+	desc = "A 5.56x45mm rifle cartridge with a hardened tungsten core to increase armor penetration."
 	projectile_type = /obj/item/projectile/bullet/saw/ap
 
 /obj/item/ammo_casing/mm556x45/incen
-	desc = "A 556x45mm bullet casing designed with a chemical-filled capsule on the tip that when bursted, reacts with the atmosphere to produce a fireball, engulfing the target in flames. "
+	name = "5.56x45mm incendiary round"
+	desc = "A 5.56x45mm rifle cartridge with an incendiary chemical payload."
 	projectile_type = /obj/item/projectile/bullet/saw/incen
 	muzzle_flash_color = LIGHT_COLOR_FIRE

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -56,7 +56,8 @@
 		icon_state = "[initial(icon_state)]"
 
 /obj/item/ammo_casing/point50
-	desc = "A .50 bullet casing."
+	name = ".50 BMG round"
+	desc = "A .50 BMG rifle cartridge, commonly used in anti-materiel rifles and heavy machine guns."
 	caliber = ".50"
 	projectile_type = /obj/item/projectile/bullet/sniper
 	muzzle_flash_strength = MUZZLE_FLASH_STRENGTH_STRONG
@@ -79,7 +80,8 @@
 	ammo_type = /obj/item/ammo_casing/antimatter
 
 /obj/item/ammo_casing/antimatter
-	desc = "A .50 antimatter bullet casing, designed to cause massive damage to whatever is hit."
+	name = ".50 BMG anti-matter round"
+	desc = "A .50 BMG high-explosive cartridge. Does not actually contain antimatter."
 	caliber = ".50"
 	projectile_type = /obj/item/projectile/bullet/sniper/antimatter
 	icon_state = ".50"
@@ -105,7 +107,8 @@
 	max_ammo = 3
 
 /obj/item/ammo_casing/soporific
-	desc = "A .50 bullet casing, specialised in sending the target to sleep, instead of hell."
+	name = ".50 BMG soporific round"
+	desc = "A .50 BMG hypodermic cartridge, loaded with sedatives for instant incapacitation."
 	caliber = ".50"
 	projectile_type = /obj/item/projectile/bullet/sniper/soporific
 	icon_state = ".50"
@@ -132,7 +135,8 @@
 	max_ammo = 5
 
 /obj/item/ammo_casing/haemorrhage
-	desc = "A .50 bullet casing, specialised in causing massive bloodloss"
+	name = ".50 BMG shredder round"
+	desc = "A .50 BMG 'Shredder' cartridge, with a heavily serrated bullet intended to cause massive blood loss."
 	caliber = ".50"
 	projectile_type = /obj/item/projectile/bullet/sniper/haemorrhage
 	icon_state = ".50"
@@ -159,7 +163,8 @@
 	max_ammo = 5
 
 /obj/item/ammo_casing/penetrator
-	desc = "A .50 caliber penetrator round casing."
+	name = ".50 BMG sabot round"
+	desc = "A .50 BMG Sabot Penetrator cartridge, capable of punching through just about anything."
 	caliber = ".50"
 	projectile_type = /obj/item/projectile/bullet/sniper/penetrator
 	icon_state = ".50"


### PR DESCRIPTION
## What Does This PR Do
See title.

## Why It's Good For The Game
Currently, every single bullet in the game has the exact same name and near-identical descriptions, which doesn't make much sense.

Secondly, I am aware many of our players and staff do not come from the Land of the Free, and thus may need help identifying what a bullet does, and to what gun it goes.

This should hopefully rectify both issues.

## Testing
- Loaded in
- Spawned many bullets and ammo boxes
- Names and descriptions have changed

## Changelog
:cl:
tweak: Added names and descriptions to many bullets and ammo boxes
/:cl: