### PR TITLE
ci: update maplint for APC mapping helpers

### DIFF
--- a/tools/maplint/lints/apc_pixel_shifts.yml
+++ b/tools/maplint/lints/apc_pixel_shifts.yml
@@ -1,7 +1,0 @@
-help: "Use the directional variants when possible."
-/obj/machinery/power/apc:
-  banned_variables:
-    pixel_x:
-      allow: [24, -24]
-    pixel_y:
-      allow: [24, -24]

--- a/tools/maplint/lints/directional_apcs.yml
+++ b/tools/maplint/lints/directional_apcs.yml
@@ -1,0 +1,33 @@
+help: "Use the specific directional subtypes for this APC."
+/obj/machinery/power/apc:
+  banned_variables:
+  - pixel_x
+  - pixel_y
+=/obj/machinery/power/apc:
+  banned: true
+=/obj/machinery/power/apc/directional:
+  banned: true
+=/obj/machinery/power/apc/important:
+  banned: true
+=/obj/machinery/power/apc/important/directional:
+  banned: true
+=/obj/machinery/power/apc/critical:
+  banned: true
+=/obj/machinery/power/apc/critical/directional:
+  banned: true
+=/obj/machinery/power/apc/off_station:
+  banned: true
+=/obj/machinery/power/apc/off_station/directional:
+  banned: true
+=/obj/machinery/power/apc/syndicate:
+  banned: true
+=/obj/machinery/power/apc/syndicate/directional:
+  banned: true
+=/obj/machinery/power/apc/syndicate/off:
+  banned: true
+=/obj/machinery/power/apc/syndicate/off/directional:
+  banned: true
+=/obj/machinery/power/apc/worn_out:
+  banned: true
+=/obj/machinery/power/apc/worn_out/directional:
+  banned: true


### PR DESCRIPTION
## What Does This PR Do
This PR updates the maplint for APC pixel offsets. It now explicitly bans any subtype that's not a specific directional helper, and it bans any pixel offset varediting for any subtype.
## Why It's Good For The Game
Without this, people could still map in the non-directional mapping helpers. This prevents that, and prevents people from using a directional helper but modifying the pixel offset anyway.
## Testing
Ran CI.
## Changelog
NPFC