### PR TITLE
Made eating Keeki a bit smarter.

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -241,7 +241,10 @@
 	deathmessage = "loses its false life and collapses!"
 	death_sound = "bodyfall"
 	var/final_bites = 0
-	var/total_final_bites = 6 // The first bite is the one that kills
+	// In practice, this is one less than it appears, because final_bites
+	// gets incremented by the bite that kills Keeki.  So total_final_bites
+	// of 6 means that the 5th bite post-death will finish off Keeki.
+	var/total_final_bites = 6
 
 /mob/living/simple_animal/pet/cat/cak/Life()
 	..()

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -240,11 +240,14 @@
 	attacked_sound = "sound/items/eatfood.ogg"
 	deathmessage = "loses its false life and collapses!"
 	death_sound = "bodyfall"
+	var/final_bites = 0
+	var/total_final_bites = 5 + 1 // The first bite is the one that kills
 
 /mob/living/simple_animal/pet/cat/cak/Life()
 	..()
 	if(stat)
 		return
+	final_bites = 0
 	if(health < maxHealth)
 		adjustBruteLoss(-4)
 	for(var/obj/item/food/snacks/donut/D in range(1, src))
@@ -256,9 +259,23 @@
 
 /mob/living/simple_animal/pet/cat/cak/attack_hand(mob/living/L)
 	..()
-	if(L.a_intent == INTENT_HARM && L.reagents && !stat)
-		L.reagents.add_reagent("nutriment", 0.4)
-		L.reagents.add_reagent("vitamin", 0.4)
+	if(L.a_intent != INTENT_HARM && L.a_intent != INTENT_DISARM)
+		return
+	if(!ishuman(L))
+		return
+	var/mob/living/carbon/human/H = L
+
+	if(stat == DEAD)
+		final_bites++
+		if(final_bites >= total_final_bites)
+			visible_message("<span class='danger'>[H] finished eating [src], there's nothing left!</src>")
+			if(H.dna && H.dna.species.reagent_tag == PROCESS_ORG)
+				to_chat(L, "<span class='info'>That last bite didn't taste like cake.  You have a bad feeling about this....")
+				L.reagents.add_reagent("prions", 5)
+			qdel(src)
+
+	H.reagents.add_reagent("nutriment", 0.4)
+	H.reagents.add_reagent("vitamin", 0.4)
 
 /mob/living/simple_animal/pet/cat/cak/CheckParts(list/parts)
 	..()

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -240,6 +240,7 @@
 	attacked_sound = "sound/items/eatfood.ogg"
 	deathmessage = "loses its false life and collapses!"
 	death_sound = "bodyfall"
+	/// Number of times the corpse has been bitten
 	var/final_bites = 0
 	// In practice, this is one less than it appears, because final_bites
 	// gets incremented by the bite that kills Keeki.  So total_final_bites

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -241,7 +241,7 @@
 	deathmessage = "loses its false life and collapses!"
 	death_sound = "bodyfall"
 	var/final_bites = 0
-	var/total_final_bites = 5 + 1 // The first bite is the one that kills
+	var/total_final_bites = 6 // The first bite is the one that kills
 
 /mob/living/simple_animal/pet/cat/cak/Life()
 	..()
@@ -261,21 +261,18 @@
 	..()
 	if(L.a_intent != INTENT_HARM && L.a_intent != INTENT_DISARM)
 		return
-	if(!ishuman(L))
+	if(!L.reagents)
 		return
-	var/mob/living/carbon/human/H = L
 
 	if(stat == DEAD)
-		final_bites++
-		if(final_bites >= total_final_bites)
-			visible_message("<span class='danger'>[H] finished eating [src], there's nothing left!</src>")
-			if(H.dna && H.dna.species.reagent_tag == PROCESS_ORG)
-				to_chat(L, "<span class='info'>That last bite didn't taste like cake.  You have a bad feeling about this....")
-				L.reagents.add_reagent("prions", 5)
+		if(++final_bites >= total_final_bites)
+			visible_message("<span class='danger'>[L] finished eating [src], there's nothing left!</src>")
+			to_chat(L, "<span class='info'>Whoa, that last bite tasted weird.")
+			L.reagents.add_reagent("teslium", 5)
 			qdel(src)
 
-	H.reagents.add_reagent("nutriment", 0.4)
-	H.reagents.add_reagent("vitamin", 0.4)
+	L.reagents.add_reagent("nutriment", 0.4)
+	L.reagents.add_reagent("vitamin", 0.4)
 
 /mob/living/simple_animal/pet/cat/cak/CheckParts(list/parts)
 	..()

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -269,8 +269,8 @@
 
 	if(stat == DEAD)
 		if(++final_bites >= total_final_bites)
-			visible_message("<span class='danger'>[L] finished eating [src], there's nothing left!</src>")
-			to_chat(L, "<span class='info'>Whoa, that last bite tasted weird.")
+			visible_message("<span class='danger'>[L] finished eating [src], there's nothing left!</span>")
+			to_chat(L, "<span class='info'>Whoa, that last bite tasted weird.</span>")
 			L.reagents.add_reagent("teslium", 5)
 			qdel(src)
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
* Fixes #24365
* Fixes #24366
* Punishes anyone cruel enough to eat the last bite of Keeki with 5u of Teslium.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Bug fixes are good.
It's bad enough to kill Keeki, but you ate him completely?  You monster.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
* Bit Keeki on harm intent, got reagents.
* Bit Keeki on disarm intent, got reagents.
* Almost ate up Keeki's corpse, revived him, killed him again, and took a few more bites without finishing him.
* Ate the last bit of Keeki.  Waited.   Bzaaaap.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Eating Keeki on disarm intent actually feeds you.
tweak: Eating a dead Keeki now gives nutrition, but there's only so much.
add: An unpleasant surprise awaits anyone who dares to eat the last bite of Keeki.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
