### PR TITLE
[WIP] Adds true observing -- letting you see what your target sees

### DIFF
--- a/code/__DEFINES/admin_defines.dm
+++ b/code/__DEFINES/admin_defines.dm
@@ -53,6 +53,7 @@
 #define ADMIN_VV(atom,display) "<a href='?_src_=vars;Vars=[atom.UID()]'>[display]</a>"
 #define ADMIN_SM(user,display) "<a href='?_src_=holder;subtlemessage=[user.UID()]'>[display]</a>"
 #define ADMIN_TP(user,display) "<a href='?_src_=holder;traitor=[user.UID()]'>[display]</a>"
+#define ADMIN_OBS(user, display) "<a href='?_src_=holder;adminobserve=[user.UID()]'>[display]</a>"
 #define ADMIN_ALERT(user, display) "<a href='?_src_=holder;adminalert=[user.UID()]'>[display]</a>"
 #define ADMIN_BSA(user,display) "<a href='?_src_=holder;BlueSpaceArtillery=[user.UID()]'>[display]</a>"
 #define ADMIN_CENTCOM_REPLY(user,display) "<a href='?_src_=holder;CentcommReply=[user.UID()]'>[display]</a>"

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -916,6 +916,14 @@
 ///from base of datum/action/proc/Trigger(): (datum/action)
 #define COMSIG_ACTION_TRIGGER "action_trigger"
 	#define COMPONENT_ACTION_BLOCK_TRIGGER (1<<0)
+/// From /datum/action/Grant(): (mob/grant_to)
+#define COMSIG_ACTION_GRANTED "action_grant"
+/// From /datum/action/Grant(): (datum/action)
+#define COMSIG_MOB_GRANTED_ACTION "mob_action_grant"
+/// From /datum/action/Remove(): (mob/removed_from)
+#define COMSIG_ACTION_REMOVED "action_removed"
+/// From /datum/action/Remove(): (datum/action)
+#define COMSIG_MOB_REMOVED_ACTION "mob_action_removed"
 
 //Xenobio hotkeys
 

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -940,6 +940,13 @@
 ///from monkey CtrlClickOn(): (/mob)
 #define COMSIG_XENO_MONKEY_CLICK_CTRL "xeno_monkey_click_ctrl"
 
+// ghost signals
+
+/// from observer_base/do_observe(): (mob/now_followed)
+#define COMSIG_GHOST_START_OBSERVING "ghost_start_observing"
+/// from observer_base/do_observe(): (mob/no_longer_following)
+#define COMSIG_GHOST_STOP_OBSERVING "ghost_stop_observing"
+
 /// Alarm manager signals
 #define COMSIG_TRIGGERED_ALARM "alarmmanager_triggered"
 #define COMSIG_CANCELLED_ALARM "alarmmanager_cancelled"

--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -676,11 +676,14 @@
 #define UNSETEMPTY(L) if(L && !L.len) L = null
 #define LAZYREMOVE(L, I) if(L) { L -= I; if(!L.len) { L = null; } }
 #define LAZYADD(L, I) if(!L) { L = list(); } L += I;
+///Add an item to the list if not already present, if the list is null it will initialize it
+#define LAZYOR(L, I) if(!L) { L = list(); } L |= I;
 /// Adds I to L, initializing L if necessary, if I is not already in L
 #define LAZYDISTINCTADD(L, I) if(!L) { L = list(); } L |= I;
 #define LAZYACCESS(L, I) (L ? (isnum(I) ? (I > 0 && I <= L.len ? L[I] : null) : L[I]) : null)
 #define LAZYLEN(L) length(L) // Despite how pointless this looks, it's still needed in order to convey that the list is specificially a 'Lazy' list.
 #define LAZYCLEARLIST(L) if(L) L.Cut()
+
 
 // LAZYING PT 2: THE LAZENING
 #define LAZYREINITLIST(L) LAZYCLEARLIST(L); LAZYINITLIST(L);

--- a/code/__HELPERS/trait_helpers.dm
+++ b/code/__HELPERS/trait_helpers.dm
@@ -228,6 +228,10 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_HOLY "is_holy" // The mob is holy in regards to religion
 #define TRAIT_TABLE_LEAP "table_leap"
 
+/// used for dead mobs that are observing, but should not be afforded all the same platitudes as full ghosts.
+/// This is a mind trait because ghosts can be frequently deleted and we want to be sure this sticks.
+#define TRAIT_MOBSERVE "mentor_observe"
+
 //***** ITEM AND MOB TRAITS *****//
 /// Show what machine/door wires do when held.
 #define TRAIT_SHOW_WIRE_INFO "show_wire_info"

--- a/code/_onclick/hud/action_button.dm
+++ b/code/_onclick/hud/action_button.dm
@@ -236,3 +236,45 @@
 	var/matrix/M = matrix()
 	M.Translate(x_offset,y_offset)
 	button.transform = M
+
+/**
+ * Show (most) of the another mob's action buttons to this mob
+ *
+ * Used for observers viewing another mob's screen
+ */
+/mob/proc/show_other_mob_action_buttons(mob/take_from)
+	if(!hud_used || !client)
+		return
+
+	for(var/datum/action/action as anything in take_from.actions)
+		if(!action.show_to_observers)
+			continue
+		action.GiveAction(src)
+	RegisterSignal(take_from, COMSIG_MOB_GRANTED_ACTION, PROC_REF(on_observing_action_granted))
+	RegisterSignal(take_from, COMSIG_MOB_REMOVED_ACTION, PROC_REF(on_observing_action_removed))
+
+/**
+ * Hide another mob's action buttons from this mob
+ *
+ * Used for observers viewing another mob's screen
+ */
+/mob/proc/hide_other_mob_action_buttons(mob/take_from)
+	for(var/datum/action/action as anything in take_from.actions)
+		action.HideFrom(src)
+	UnregisterSignal(take_from, list(COMSIG_MOB_GRANTED_ACTION, COMSIG_MOB_REMOVED_ACTION))
+
+/// Signal proc for [COMSIG_MOB_GRANTED_ACTION] - If we're viewing another mob's action buttons,
+/// we need to update with any newly added buttons granted to the mob.
+/mob/proc/on_observing_action_granted(mob/living/source, datum/action/action)
+	SIGNAL_HANDLER
+
+	if(!action.show_to_observers)
+		return
+	action.GiveAction(src)
+
+/// Signal proc for [COMSIG_MOB_REMOVED_ACTION] - If we're viewing another mob's action buttons,
+/// we need to update with any removed buttons from the mob.
+/mob/proc/on_observing_action_removed(mob/living/source, datum/action/action)
+	SIGNAL_HANDLER
+
+	action.HideFrom(src)

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -770,20 +770,23 @@ so as to remain in compliance with the most up-to-date laws."
 // PRIVATE = only edit, use, or override these if you're editing the system as a whole
 
 // Re-render all alerts - also called in /datum/hud/show_hud() because it's needed there
-/datum/hud/proc/reorganize_alerts()
-	var/list/alerts = mymob.alerts
+/datum/hud/proc/reorganize_alerts(mob/viewmob)
+	var/mob/screenmob = viewmob || mymob
+	if(!screenmob.client)
+		return
+	var/list/alerts = screenmob.alerts
 	if(!alerts)
 		return FALSE
 	var/icon_pref
 	if(!hud_shown)
 		for(var/i in 1 to alerts.len)
-			mymob.client.screen -= alerts[alerts[i]]
+			screenmob.client.screen -= alerts[alerts[i]]
 		return TRUE
 	for(var/i in 1 to alerts.len)
 		var/obj/screen/alert/alert = alerts[alerts[i]]
 		if(alert.icon_state == "template")
 			if(!icon_pref)
-				icon_pref = ui_style2icon(mymob.client.prefs.UI_style)
+				icon_pref = ui_style2icon(screenmob.client.prefs.UI_style)
 			alert.icon = icon_pref
 		switch(i)
 			if(1)
@@ -799,7 +802,10 @@ so as to remain in compliance with the most up-to-date laws."
 			else
 				. = ""
 		alert.screen_loc = .
-		mymob.client.screen |= alert
+		screenmob.client.screen |= alert
+	if(!viewmob)
+		for(var/M in mymob.observers)
+			reorganize_alerts(M)
 	return TRUE
 
 /obj/screen/alert/Click(location, control, params)

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -774,7 +774,7 @@ so as to remain in compliance with the most up-to-date laws."
 	var/mob/screenmob = viewmob || mymob
 	if(!screenmob.client)
 		return
-	var/list/alerts = screenmob.alerts
+	var/list/alerts = mymob.alerts
 	if(!alerts)
 		return FALSE
 	var/icon_pref

--- a/code/_onclick/hud/alien_hud.dm
+++ b/code/_onclick/hud/alien_hud.dm
@@ -138,19 +138,22 @@
 			inv_slots[inv.slot_id] = inv
 			inv.update_icon()
 
-/datum/hud/alien/persistent_inventory_update()
+/datum/hud/alien/persistent_inventory_update(mob/viewer)
 	if(!mymob)
 		return
 	var/mob/living/carbon/alien/humanoid/H = mymob
+	var/mob/screenmob = viewer || H
 	if(hud_version != HUD_STYLE_NOHUD)
 		if(H.r_hand)
 			H.r_hand.screen_loc = ui_rhand
-			H.client.screen += H.r_hand
+			screenmob.client.screen += H.r_hand
 		if(H.l_hand)
 			H.l_hand.screen_loc = ui_lhand
-			H.client.screen += H.l_hand
+			screenmob.client.screen += H.l_hand
 	else
 		if(H.r_hand)
 			H.r_hand.screen_loc = null
+			screenmob.client.screen -= H.l_hand
 		if(H.l_hand)
 			H.l_hand.screen_loc = null
+			screenmob.client.screen -= H.l_hand

--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -39,17 +39,18 @@
 	for(var/category in screens)
 		clear_fullscreen(category)
 
-/datum/hud/proc/reload_fullscreen()
-	if(mymob.client)
-		var/obj/screen/fullscreen/screen
-		var/list/screens = mymob.screens
-		for(var/category in screens)
-			screen = screens[category]
-			if(screen.should_show_to(mymob))
-				screen.update_for_view(mymob.client.view)
-				mymob.client.screen |= screen
-			else
-				mymob.client.screen -= screen
+/mob/proc/reload_fullscreen()
+	if(!client)
+		return
+	var/obj/screen/fullscreen/screen
+	// var/list/screens = screens
+	for(var/category in screens)
+		screen = screens[category]
+		if(screen.should_show_to(src))
+			screen.update_for_view(client.view)
+			client.screen |= screen
+		else
+			client.screen -= screen
 
 /obj/screen/fullscreen
 	icon = 'icons/mob/screen_full.dmi'

--- a/code/_onclick/hud/ghost_hud.dm
+++ b/code/_onclick/hud/ghost_hud.dm
@@ -123,19 +123,19 @@
 		return FALSE
 
 	. = ..()
-	// if(!.)
-	// 	return
-	// var/mob/screenmob = viewmob || mymob
+	if(!.)
+		return
+	var/mob/screenmob = viewmob || mymob
 	// if(screenmob.client.prefs.read_preference(/datum/preference/toggle/ghost_hud))
-	// 	screenmob.client.screen += static_inventory
+	screenmob.client.screen += static_inventory
 	// else
-	// 	screenmob.client.screen -= static_inventory
+		// screenmob.client.screen -= static_inventory
 
 
 //We should only see observed mob alerts.
 /datum/hud/ghost/reorganize_alerts(mob/viewmob)
 	var/mob/dead/observer/O = mymob
-	if (istype(O) && O.mob_observed)
+	if(istype(O) && O.mob_observed)
 		return
-	. = ..()
+	return ..()
 

--- a/code/_onclick/hud/ghost_hud.dm
+++ b/code/_onclick/hud/ghost_hud.dm
@@ -80,9 +80,6 @@
 		return
 	GLOB.paiController.recruitWindow(G)
 
-/datum/hud/ghost
-	inventory_shown = FALSE
-
 /datum/hud/ghost/New(mob/owner)
 	..()
 	var/obj/screen/using

--- a/code/_onclick/hud/ghost_hud.dm
+++ b/code/_onclick/hud/ghost_hud.dm
@@ -115,7 +115,27 @@
 	for(var/obj/screen/S in (static_inventory + toggleable_inventory))
 		S.hud = src
 
-/datum/hud/ghost/show_hud()
-	mymob.client.screen = list()
-	mymob.client.screen += static_inventory
-	..()
+/datum/hud/ghost/show_hud(version = 0, mob/viewmob)
+	// don't show this HUD if observing; show the HUD of the observee
+	var/mob/dead/observer/O = mymob
+	if (istype(O) && O.mob_observed)
+		plane_masters_update()
+		return FALSE
+
+	. = ..()
+	// if(!.)
+	// 	return
+	// var/mob/screenmob = viewmob || mymob
+	// if(screenmob.client.prefs.read_preference(/datum/preference/toggle/ghost_hud))
+	// 	screenmob.client.screen += static_inventory
+	// else
+	// 	screenmob.client.screen -= static_inventory
+
+
+//We should only see observed mob alerts.
+/datum/hud/ghost/reorganize_alerts(mob/viewmob)
+	var/mob/dead/observer/O = mymob
+	if (istype(O) && O.mob_observed)
+		return
+	. = ..()
+

--- a/code/_onclick/hud/hud_datum.dm
+++ b/code/_onclick/hud/hud_datum.dm
@@ -107,14 +107,25 @@
 	QDEL_NULL(screentip_text)
 	return ..()
 
-/datum/hud/proc/show_hud(version = 0)
+/**
+ * Shows this hud's hud to some mob
+ *
+ * Arguments
+ * * version - denotes which style should be displayed. blank or 0 means "next version"
+ * * viewmob - what mob to show the hud to. Can be this hud's mob, can be another mob, can be null (will use this hud's mob if so)
+ */
+/datum/hud/proc/show_hud(version = 0, mob/viewmob)
 	if(!ismob(mymob))
 		return FALSE
 
-	if(!mymob.client)
+	var/mob/screenmob = viewmob || mymob
+	if(!screenmob.client)
 		return FALSE
 
-	mymob.client.screen = list()
+	// mymob.client.screen = list()
+
+	screenmob.client.clear_screen()
+	screenmob.client.apply_clickcatcher()
 
 	var/display_hud_version = version
 	if(!display_hud_version)	//If 0 or blank, display the next hud version
@@ -126,15 +137,15 @@
 		if(HUD_STYLE_STANDARD)	//Default HUD
 			hud_shown = TRUE	//Governs behavior of other procs
 			if(static_inventory.len)
-				mymob.client.screen += static_inventory
-			if(toggleable_inventory.len && inventory_shown)
-				mymob.client.screen += toggleable_inventory
+				screenmob.client.screen += static_inventory
+			if(toggleable_inventory.len && screenmob.hud_used?.inventory_shown)
+				screenmob.client.screen += toggleable_inventory
 			if(hotkeybuttons.len && !hotkey_ui_hidden)
-				mymob.client.screen += hotkeybuttons
+				screenmob.client.screen += hotkeybuttons
 			if(infodisplay.len)
-				mymob.client.screen += infodisplay
+				screenmob.client.screen += infodisplay
 
-			mymob.client.screen += hide_actions_toggle
+			screenmob.client.screen += hide_actions_toggle
 
 			if(action_intent)
 				action_intent.screen_loc = initial(action_intent.screen_loc) //Restore intent selection to the original position
@@ -142,41 +153,50 @@
 		if(HUD_STYLE_REDUCED)	//Reduced HUD
 			hud_shown = FALSE	//Governs behavior of other procs
 			if(static_inventory.len)
-				mymob.client.screen -= static_inventory
+				screenmob.client.screen -= static_inventory
 			if(toggleable_inventory.len)
-				mymob.client.screen -= toggleable_inventory
+				screenmob.client.screen -= toggleable_inventory
 			if(hotkeybuttons.len)
-				mymob.client.screen -= hotkeybuttons
+				screenmob.client.screen -= hotkeybuttons
 			if(infodisplay.len)
-				mymob.client.screen += infodisplay
+				screenmob.client.screen += infodisplay
 
 			//These ones are a part of 'static_inventory', 'toggleable_inventory' or 'hotkeybuttons' but we want them to stay
 			if(inv_slots[SLOT_HUD_LEFT_HAND])
-				mymob.client.screen += inv_slots[SLOT_HUD_LEFT_HAND]	//we want the hands to be visible
+				screenmob.client.screen += inv_slots[SLOT_HUD_LEFT_HAND]	//we want the hands to be visible
 			if(inv_slots[SLOT_HUD_RIGHT_HAND])
-				mymob.client.screen += inv_slots[SLOT_HUD_RIGHT_HAND]	//we want the hands to be visible
+				screenmob.client.screen += inv_slots[SLOT_HUD_RIGHT_HAND]	//we want the hands to be visible
 			if(action_intent)
-				mymob.client.screen += action_intent		//we want the intent switcher visible
+				screenmob.client.screen += action_intent		//we want the intent switcher visible
 				action_intent.screen_loc = ui_acti_alt	//move this to the alternative position, where zone_select usually is.
 
 		if(HUD_STYLE_NOHUD)	//No HUD
 			hud_shown = FALSE	//Governs behavior of other procs
 			if(static_inventory.len)
-				mymob.client.screen -= static_inventory
+				screenmob.client.screen -= static_inventory
 			if(toggleable_inventory.len)
-				mymob.client.screen -= toggleable_inventory
+				screenmob.client.screen -= toggleable_inventory
 			if(hotkeybuttons.len)
-				mymob.client.screen -= hotkeybuttons
+				screenmob.client.screen -= hotkeybuttons
 			if(infodisplay.len)
-				mymob.client.screen -= infodisplay
+				screenmob.client.screen -= infodisplay
 
 	hud_version = display_hud_version
-	persistent_inventory_update()
-	mymob.update_action_buttons(1)
-	reorganize_alerts()
-	reload_fullscreen()
-	update_parallax_pref(mymob)
-	plane_masters_update()
+	persistent_inventory_update(screenmob)
+	screenmob.update_action_buttons(TRUE)
+	reorganize_alerts(screenmob)
+	screenmob.reload_fullscreen()
+	update_parallax_pref(screenmob)
+
+	// ensure observers get an accurate and up-to-date view
+	if(!viewmob)
+		// Plane masters are always shown to OUR mob, never to observers
+		plane_masters_update()
+		for(var/M in mymob.observers)
+			show_hud(hud_version, M)
+	else if(viewmob.hud_used)
+		viewmob.hud_used.plane_masters_update()
+		viewmob.show_other_mob_action_buttons(mymob)
 
 /datum/hud/proc/plane_masters_update()
 	// Plane masters are always shown to OUR mob, never to observers
@@ -185,23 +205,18 @@
 		PM.backdrop(mymob)
 		mymob.client.screen += PM
 
-/datum/hud/human/show_hud(version = 0)
-	. = ..()
-	if(!.)
-		return
-	hidden_inventory_update()
-
 /datum/hud/robot/show_hud(version = 0)
 	. = ..()
 	if(!.)
 		return
 	update_robot_modules_display()
 
-/datum/hud/proc/hidden_inventory_update()
+/datum/hud/proc/hidden_inventory_update(mob/screenmob)
 	return
 
-/datum/hud/proc/persistent_inventory_update()
-	return
+/datum/hud/proc/persistent_inventory_update(mob/viewer)
+	if(!mymob)
+		return
 
 /mob/proc/hide_hud()
 	if(hud_used && client)

--- a/code/_onclick/hud/human_hud.dm
+++ b/code/_onclick/hud/human_hud.dm
@@ -404,7 +404,7 @@
 		return
 	var/mob/living/carbon/human/H = mymob
 	var/mob/screenmob = viewer || H
-	if(inventory_shown && hud_shown)
+	if(screenmob.hud_used.inventory_shown && screenmob.hud_used.hud_shown)
 		if(H.shoes)
 			H.shoes.screen_loc = ui_shoes
 			screenmob.client.screen += H.shoes
@@ -458,43 +458,44 @@
 	..()
 	var/mob/living/carbon/human/H = mymob
 	var/mob/screenmob = viewer || H
-	if(hud_shown)
-		if(H.s_store)
-			H.s_store.screen_loc = ui_sstore1
-			screenmob.client.screen += H.s_store
-		if(H.wear_id)
-			H.wear_id.screen_loc = ui_id
-			screenmob.client.screen += H.wear_id
-		if(H.wear_pda)
-			H.wear_pda.screen_loc = ui_pda
-			screenmob.client.screen += H.wear_pda
-		if(H.belt)
-			H.belt.screen_loc = ui_belt
-			screenmob.client.screen += H.belt
-		if(H.back)
-			H.back.screen_loc = ui_back
-			screenmob.client.screen += H.back
-		if(H.l_store)
-			H.l_store.screen_loc = ui_storage1
-			screenmob.client.screen += H.l_store
-		if(H.r_store)
-			H.r_store.screen_loc = ui_storage2
-			screenmob.client.screen += H.r_store
-	else
-		if(H.s_store)
-			screenmob.client.screen -= H.s_store
-		if(H.wear_id)
-			screenmob.client.screen -= H.wear_id
-		if(H.wear_pda)
-			screenmob.client.screen -= H.wear_pda
-		if(H.belt)
-			screenmob.client.screen -= H.belt
-		if(H.back)
-			screenmob.client.screen -= H.back
-		if(H.l_store)
-			screenmob.client.screen -= H.l_store
-		if(H.r_store)
-			screenmob.client.screen -= H.r_store
+	if(screenmob.hud_used)
+		if(screenmob.hud_used.hud_shown)
+			if(H.s_store)
+				H.s_store.screen_loc = ui_sstore1
+				screenmob.client.screen += H.s_store
+			if(H.wear_id)
+				H.wear_id.screen_loc = ui_id
+				screenmob.client.screen += H.wear_id
+			if(H.wear_pda)
+				H.wear_pda.screen_loc = ui_pda
+				screenmob.client.screen += H.wear_pda
+			if(H.belt)
+				H.belt.screen_loc = ui_belt
+				screenmob.client.screen += H.belt
+			if(H.back)
+				H.back.screen_loc = ui_back
+				screenmob.client.screen += H.back
+			if(H.l_store)
+				H.l_store.screen_loc = ui_storage1
+				screenmob.client.screen += H.l_store
+			if(H.r_store)
+				H.r_store.screen_loc = ui_storage2
+				screenmob.client.screen += H.r_store
+		else
+			if(H.s_store)
+				screenmob.client.screen -= H.s_store
+			if(H.wear_id)
+				screenmob.client.screen -= H.wear_id
+			if(H.wear_pda)
+				screenmob.client.screen -= H.wear_pda
+			if(H.belt)
+				screenmob.client.screen -= H.belt
+			if(H.back)
+				screenmob.client.screen -= H.back
+			if(H.l_store)
+				screenmob.client.screen -= H.l_store
+			if(H.r_store)
+				screenmob.client.screen -= H.r_store
 
 	if(hud_version != HUD_STYLE_NOHUD)
 		if(H.r_hand)

--- a/code/_onclick/hud/human_hud.dm
+++ b/code/_onclick/hud/human_hud.dm
@@ -6,14 +6,22 @@
 	icon_state = "toggle"
 
 /obj/screen/human/toggle/Click()
+
+	var/mob/targetmob = usr
+	// catch any observers watching us :eyes:
+	if(isobserver(usr))
+		if(ishuman(usr.client.eye) && (usr.client.eye != usr))
+			var/mob/M = usr.client.eye
+			targetmob = M
+
 	if(usr.hud_used.inventory_shown)
 		usr.hud_used.inventory_shown = FALSE
-		usr.client.screen -= usr.hud_used.toggleable_inventory
+		usr.client.screen -= targetmob.hud_used.toggleable_inventory
 	else
 		usr.hud_used.inventory_shown = TRUE
-		usr.client.screen += usr.hud_used.toggleable_inventory
+		usr.client.screen += targetmob.hud_used.toggleable_inventory
 
-	usr.hud_used.hidden_inventory_update()
+	targetmob.hud_used.hidden_inventory_update(usr)
 
 /obj/screen/human/equip
 	name = "equip"
@@ -41,6 +49,12 @@
 	icon_state = "power_display"
 	screen_loc = ui_lingchemdisplay
 
+/datum/hud/human/show_hud(version = 0, mob/viewmob)
+	. = ..()
+	if(!.)
+		return
+	var/mob/screenmob = viewmob || mymob
+	hidden_inventory_update(screenmob)
 
 /mob/living/carbon/human/proc/remake_hud() //used for preference changes mid-round; can't change hud icons without remaking the hud.
 	QDEL_NULL(hud_used)
@@ -385,103 +399,117 @@
 		else
 			crafting.invisibility = initial(crafting.invisibility)
 
-/datum/hud/human/hidden_inventory_update()
+/datum/hud/human/hidden_inventory_update(mob/viewer)
 	if(!mymob)
 		return
 	var/mob/living/carbon/human/H = mymob
+	var/mob/screenmob = viewer || H
 	if(inventory_shown && hud_shown)
 		if(H.shoes)
 			H.shoes.screen_loc = ui_shoes
-			H.client.screen += H.shoes
+			screenmob.client.screen += H.shoes
 		if(H.gloves)
 			H.gloves.screen_loc = ui_gloves
-			H.client.screen += H.gloves
+			screenmob.client.screen += H.gloves
 		if(H.l_ear)
 			H.l_ear.screen_loc = ui_l_ear
-			H.client.screen += H.l_ear
+			screenmob.client.screen += H.l_ear
 		if(H.r_ear)
 			H.r_ear.screen_loc = ui_r_ear
-			H.client.screen += H.r_ear
+			screenmob.client.screen += H.r_ear
 		if(H.glasses)
 			H.glasses.screen_loc = ui_glasses
-			H.client.screen += H.glasses
+			screenmob.client.screen += H.glasses
 		if(H.w_uniform)
 			H.w_uniform.screen_loc = ui_iclothing
-			H.client.screen += H.w_uniform
+			screenmob.client.screen += H.w_uniform
 		if(H.wear_suit)
 			H.wear_suit.screen_loc = ui_oclothing
-			H.client.screen += H.wear_suit
+			screenmob.client.screen += H.wear_suit
 		if(H.wear_mask)
 			H.wear_mask.screen_loc = ui_mask
-			H.client.screen += H.wear_mask
+			screenmob.client.screen += H.wear_mask
 		if(H.head)
 			H.head.screen_loc = ui_head
-			H.client.screen += H.head
+			screenmob.client.screen += H.head
 	else
-		if(H.shoes)		H.shoes.screen_loc = null
-		if(H.gloves)	H.gloves.screen_loc = null
-		if(H.l_ear)		H.l_ear.screen_loc = null
-		if(H.r_ear)		H.r_ear.screen_loc = null
-		if(H.glasses)	H.glasses.screen_loc = null
-		if(H.w_uniform)	H.w_uniform.screen_loc = null
-		if(H.wear_suit)	H.wear_suit.screen_loc = null
-		if(H.wear_mask)	H.wear_mask.screen_loc = null
-		if(H.head)		H.head.screen_loc = null
+		if(H.shoes)
+			screenmob.client.screen -= H.shoes
+		if(H.gloves)
+			screenmob.client.screen -= H.gloves
+		if(H.l_ear)
+			screenmob.client.screen -= H.l_ear
+		if(H.r_ear)
+			screenmob.client.screen -= H.r_ear
+		if(H.glasses)
+			screenmob.client.screen -= H.glasses
+		if(H.w_uniform)
+			screenmob.client.screen -= H.w_uniform
+		if(H.wear_suit)
+			screenmob.client.screen -= H.wear_suit
+		if(H.wear_mask)
+			screenmob.client.screen -= H.wear_mask
+		if(H.head)
+			screenmob.client.screen -= H.head
 
-/datum/hud/human/persistent_inventory_update()
+/datum/hud/human/persistent_inventory_update(mob/viewer)
 	if(!mymob)
 		return
+	..()
 	var/mob/living/carbon/human/H = mymob
+	var/mob/screenmob = viewer || H
 	if(hud_shown)
 		if(H.s_store)
 			H.s_store.screen_loc = ui_sstore1
-			H.client.screen += H.s_store
+			screenmob.client.screen += H.s_store
 		if(H.wear_id)
 			H.wear_id.screen_loc = ui_id
-			H.client.screen += H.wear_id
+			screenmob.client.screen += H.wear_id
 		if(H.wear_pda)
 			H.wear_pda.screen_loc = ui_pda
-			H.client.screen += H.wear_pda
+			screenmob.client.screen += H.wear_pda
 		if(H.belt)
 			H.belt.screen_loc = ui_belt
-			H.client.screen += H.belt
+			screenmob.client.screen += H.belt
 		if(H.back)
 			H.back.screen_loc = ui_back
-			H.client.screen += H.back
+			screenmob.client.screen += H.back
 		if(H.l_store)
 			H.l_store.screen_loc = ui_storage1
-			H.client.screen += H.l_store
+			screenmob.client.screen += H.l_store
 		if(H.r_store)
 			H.r_store.screen_loc = ui_storage2
-			H.client.screen += H.r_store
+			screenmob.client.screen += H.r_store
 	else
 		if(H.s_store)
-			H.s_store.screen_loc = null
+			screenmob.client.screen -= H.s_store
 		if(H.wear_id)
-			H.wear_id.screen_loc = null
+			screenmob.client.screen -= H.wear_id
 		if(H.wear_pda)
-			H.wear_pda.screen_loc = null
+			screenmob.client.screen -= H.wear_pda
 		if(H.belt)
-			H.belt.screen_loc = null
+			screenmob.client.screen -= H.belt
 		if(H.back)
-			H.back.screen_loc = null
+			screenmob.client.screen -= H.back
 		if(H.l_store)
-			H.l_store.screen_loc = null
+			screenmob.client.screen -= H.l_store
 		if(H.r_store)
-			H.r_store.screen_loc = null
+			screenmob.client.screen -= H.r_store
 
 	if(hud_version != HUD_STYLE_NOHUD)
 		if(H.r_hand)
 			H.r_hand.screen_loc = ui_rhand
-			H.client.screen += H.r_hand
+			screenmob.client.screen += H.r_hand
 		if(H.l_hand)
 			H.l_hand.screen_loc = ui_lhand
-			H.client.screen += H.l_hand
+			screenmob.client.screen += H.l_hand
 	else
 		if(H.r_hand)
 			H.r_hand.screen_loc = null
+			screenmob.client.screen -= H.l_hand
 		if(H.l_hand)
 			H.l_hand.screen_loc = null
+			screenmob.client.screen -= H.l_hand
 
 
 /mob/living/carbon/human/verb/toggle_hotkey_verbs()

--- a/code/_onclick/hud/parallax.dm
+++ b/code/_onclick/hud/parallax.dm
@@ -11,8 +11,11 @@
 	var/parallax_layers_max = 4
 	var/parallax_animate_timer
 
-/datum/hud/proc/create_parallax()
-	var/client/C = mymob.client
+/datum/hud/proc/create_parallax(mob/viewmob)
+	var/mob/screenmob = viewmob || mymob
+	if(!screenmob.client)
+		return
+	var/client/C = screenmob.client
 	if(!apply_parallax_pref())
 		return
 	// this is needed so it blends properly with the space plane and blackness plane.
@@ -47,8 +50,9 @@
 
 	C.screen |= (C.parallax_layers + C.parallax_static_layers_tail)
 
-/datum/hud/proc/remove_parallax()
-	var/client/C = mymob.client
+/datum/hud/proc/remove_parallax(mob/viewmob)
+	var/mob/screenmob = viewmob || mymob
+	var/client/C = screenmob.client
 	C.screen -= (C.parallax_layers_cached + C.parallax_static_layers_tail)
 	C.parallax_layers = null
 	var/obj/screen/plane_master/space/S = plane_masters["[PLANE_SPACE]"]
@@ -85,10 +89,13 @@
 	C.parallax_layers_max = 4
 	return TRUE
 
-/datum/hud/proc/update_parallax_pref()
-	remove_parallax()
-	create_parallax()
-	update_parallax()
+/datum/hud/proc/update_parallax_pref(mob/viewmob)
+	var/mob/screen_mob = viewmob || mymob
+	if(!screen_mob.client)
+		return
+	remove_parallax(screen_mob)
+	create_parallax(screen_mob)
+	update_parallax(screen_mob)
 
 // This sets which way the current shuttle is moving (returns true if the shuttle has stopped moving so the caller can append their animation)
 // Well, it would if our shuttle code had dynamic areas
@@ -171,8 +178,9 @@
 		animate(L, transform = L.transform, time = 0, loop = -1, flags = ANIMATION_END_NOW)
 		animate(transform = matrix(), time = T)
 
-/datum/hud/proc/update_parallax()
-	var/client/C = mymob.client
+/datum/hud/proc/update_parallax(mob/viewmob)
+	var/mob/screenmob = viewmob || mymob
+	var/client/C = screenmob.client
 	var/turf/posobj = get_turf(C.eye)
 	if(!posobj)
 		return
@@ -207,7 +215,7 @@
 
 	for(var/thing in C.parallax_layers)
 		var/obj/screen/parallax_layer/L = thing
-		L.update_status(mymob)
+		L.update_status(screenmob)
 		if(L.view_sized != C.view)
 			L.update_o(C.view)
 

--- a/code/_onclick/hud/robot_hud.dm
+++ b/code/_onclick/hud/robot_hud.dm
@@ -189,6 +189,34 @@
 
 	return ..()
 
+// TODO find a nice way for robot modules to work
+// /datum/hud/robot/persistent_inventory_update(mob/viewer)
+// 	if(!mymob)
+// 		return
+// 	var/mob/living/silicon/robot/R = mymob
+
+// 	var/mob/screenmob = viewer || R
+
+// 	if(screenmob.hud_used)
+// 		if(screenmob.hud_used.hud_shown)
+// 			for(var/i in 1 to R.held_items.len)
+// 				var/obj/item/I = R.held_items[i]
+// 				if(I)
+// 					switch(i)
+// 						if(BORG_CHOOSE_MODULE_ONE)
+// 							I.screen_loc = ui_inv1
+// 						if(BORG_CHOOSE_MODULE_TWO)
+// 							I.screen_loc = ui_inv2
+// 						if(BORG_CHOOSE_MODULE_THREE)
+// 							I.screen_loc = ui_inv3
+// 						else
+// 							return
+// 					screenmob.client.screen += I
+// 		else
+// 			for(var/obj/item/I in R.held_items)
+// 				screenmob.client.screen -= I
+
+
 /datum/hud/proc/toggle_show_robot_modules()
 	if(!isrobot(mymob))
 		return

--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -22,7 +22,7 @@
 	/// Whether or not this will be shown to observers
 	var/show_to_observers = TRUE
 	// TODO find a more sensible way to do this too, seems like GC hell
-	/// All of the buttons that correspond to this action
+	/// List of all HUDs that are "viewing" this action
 	var/list/viewers = list()
 
 
@@ -173,8 +173,8 @@
 
 	var/obj/screen/movable/action_button/button = create_button()
 	// SetId(button, viewer)
-
-	// button.our_hud = our_hud
+//
+	button.our_hud = our_hud
 	viewers[our_hud] = button
 	if(viewer.client)
 		viewer.client.screen += button

--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -22,8 +22,6 @@
 	/// Whether or not this will be shown to observers
 	var/show_to_observers = TRUE
 	// TODO find a more sensible way to do this too, seems like GC hell
-	/// Assoc. list of all huds viewing our action
-	var/list/viewers = list()
 
 
 /datum/action/New(Target)
@@ -39,7 +37,6 @@
 		Remove(owner)
 	if(target)
 		target = null
-	QDEL_LIST_ASSOC_VAL(viewers) // Qdel the buttons in the viewers list **NOT THE HUDS**
 	return ..()
 
 /datum/action/proc/Grant(mob/grant_to)

--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -56,6 +56,9 @@
 	SEND_SIGNAL(src, COMSIG_ACTION_GRANTED, owner)
 	SEND_SIGNAL(owner, COMSIG_MOB_GRANTED_ACTION, src)
 
+	// RegisterSignal(grant_to, COMSIG_MOB_KEYDOWN, PROC_REF(keydown), override = TRUE)
+	GiveAction(M)
+
 /datum/action/proc/Remove(mob/M)
 
 	if(!M)
@@ -63,7 +66,15 @@
 	SEND_SIGNAL(src, COMSIG_ACTION_REMOVED, owner)
 	SEND_SIGNAL(owner, COMSIG_MOB_REMOVED_ACTION, src)
 
-	owner = null
+	for(var/datum/hud/hud in viewers)
+		if(!hud.mymob)
+			continue
+		HideFrom(hud.mymob)
+
+	viewers = list()
+
+	if(owner == M)
+		owner = null
 
 	if(M.client)
 		M.client.screen -= button

--- a/code/game/objects/items/weapons/storage/storage_base.dm
+++ b/code/game/objects/items/weapons/storage/storage_base.dm
@@ -450,6 +450,11 @@
 	if(usr)
 		if(usr.client && usr.s_active != src)
 			usr.client.screen -= I
+		if(length(usr.observers))
+			for(var/mob/observer in usr.observers)
+				if(observer.client)
+					observer.client.screen -= I
+
 		I.dropped(usr, TRUE)
 		add_fingerprint(usr)
 

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1606,6 +1606,18 @@
 		sleep(2)
 		A.ManualFollow(M)
 
+	else if(href_list["adminobserve"])
+		if(!check_rights(R_ADMIN|R_MOD|R_MENTOR))
+			return
+		var/client/C = usr.client
+		var/mob/M = locateUID(href_list["adminobserve"])
+
+		if(!ismob(M))
+			to_chat(usr, "<span class='warning'>This can only be used on instances of type /mob</span>")
+			return
+		C.admin_observe(M)
+
+
 	else if(href_list["check_antagonist"])
 		check_antagonists()
 

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -368,7 +368,7 @@
 	var/client/C = pms[title].client || update_client(title)
 	if(!C)
 		return "[title] (Disconnected)"
-	return "[key_name(C, FALSE)] ([ADMIN_QUE(C.mob,"?")]) ([ADMIN_PP(C.mob,"PP")]) ([ADMIN_VV(C.mob,"VV")]) ([ADMIN_TP(C.mob,"TP")]) ([ADMIN_SM(C.mob,"SM")]) ([admin_jump_link(C.mob)]) ([ADMIN_ALERT(C.mob,"SEND ALERT")])"
+	return "[key_name(C, FALSE)] ([ADMIN_QUE(C.mob,"?")]) ([ADMIN_PP(C.mob,"PP")]) ([ADMIN_VV(C.mob,"VV")]) ([ADMIN_TP(C.mob,"TP")]) ([ADMIN_SM(C.mob,"SM")]) ([admin_jump_link(C.mob)]) ([ADMIN_OBS(C.mob, "OBS")]) ([ADMIN_ALERT(C.mob,"SEND ALERT")])"
 
 /datum/pm_tracker/proc/update_client(title)
 	var/client/C = GLOB.directory[ckey(title)]

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -1158,6 +1158,20 @@
 	var/list/screensize = getviewsize(view)
 	return max(screensize[1], screensize[2])
 
+/client/proc/set_eye(new_eye)
+	if(new_eye == eye)
+		return
+	// var/atom/old_eye = eye
+	eye = new_eye
+	// SEND_SIGNAL(src, COMSIG_CLIENT_SET_EYE, old_eye, new_eye)
+
+/client/proc/clear_screen()
+	for(var/object in screen)
+		// if(istype(object, /obj/screen))
+		// 	var/obj/screen/obj = object
+
+		screen -= object
+
 #undef LIMITER_SIZE
 #undef CURRENT_SECOND
 #undef SECOND_COUNT

--- a/code/modules/mob/dead/observer/observer_base.dm
+++ b/code/modules/mob/dead/observer/observer_base.dm
@@ -37,6 +37,7 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 	var/datum/orbit_menu/orbit_menu
 	/// UID of the mob which we are currently observing
 	var/mob_observed
+	var/kaboshed_alerts = list()
 
 /mob/dead/observer/New(mob/body=null, flags=1)
 	set_invisibility(GLOB.observer_default_invisibility)
@@ -229,7 +230,7 @@ Works together with spawning an observer, noted above.
 			LAZYOR(mob_eye.observers, src)
 			mob_eye.hud_used.show_hud(mob_eye.hud_used.hud_version, src)
 			mob_observed = mob_eye
-			client.mob.sight
+			// client.mob.sight
 
 		RegisterSignal(src, COMSIG_MOVABLE_MOVED, PROC_REF(on_observer_move))
 

--- a/code/modules/mob/dead/observer/observer_base.dm
+++ b/code/modules/mob/dead/observer/observer_base.dm
@@ -200,7 +200,7 @@ Works together with spawning an observer, noted above.
 /mob/dead/observer/proc/do_observe(mob/mob_eye)
 	set name = "\[Observer\] Observe"
 	set desc = "Observe the target atom."
-	set category = null
+	set category = "Ghost"
 
 	if(isnewplayer(mob_eye))
 		stack_trace("/mob/dead/new_player: \[[mob_eye]\] is being observed by [key_name(src)]. This should never happen and has been blocked.")

--- a/code/modules/mob/dead/observer/observer_base.dm
+++ b/code/modules/mob/dead/observer/observer_base.dm
@@ -229,7 +229,7 @@ Works together with spawning an observer, noted above.
 			client.clear_screen()
 			LAZYOR(mob_eye.observers, src)
 			mob_eye.hud_used.show_hud(mob_eye.hud_used.hud_version, src)
-			mob_observed = mob_eye
+			mob_observed = mob_eye.UID()
 			// client.mob.sight
 
 		RegisterSignal(src, COMSIG_MOVABLE_MOVED, PROC_REF(on_observer_move))

--- a/code/modules/mob/inventory_procs.dm
+++ b/code/modules/mob/inventory_procs.dm
@@ -316,3 +316,6 @@
 	for(var/obj/B in L)
 		if(B.type == path)
 			return B
+
+/mob/proc/get_held_index_of_item(obj/item/I)
+	return list(l_hand, r_hand).Find(I)

--- a/code/modules/mob/living/carbon/carbon_update_icons.dm
+++ b/code/modules/mob/living/carbon/carbon_update_icons.dm
@@ -31,6 +31,32 @@
 /mob/living/carbon/proc/handle_transform_change()
 	return
 
+
+
+/// Generate held item overlays
+// /mob/living/carbon/proc/get_held_overlays()
+// 	var/list/hands = list()
+// 	for(var/obj/item/I in list(l_hand, r_hand))
+// 		if(client && hud_used && hud_used.hud_version != HUD_STYLE_NOHUD)
+// 			I.screen_loc = ui_hand_position(get_held_index_of_item(I))
+// 			client.screen += I
+// 			if(length(observers))
+// 				for(var/mob/dead/observe as anything in observers)
+// 					if(observe.client && observe.client.eye == src)
+// 						observe.client.screen += I
+// 					else
+// 						observers -= observe
+// 						if(!length(observers))
+// 							observers = null
+// 							break
+
+// 		var/icon_file = I.lefthand_file
+// 		if(get_held_index_of_item(I) % 2 == 0)
+// 			icon_file = I.righthand_file
+
+// 		hands += I.build_worn_icon(default_layer = HANDS_LAYER, default_icon_file = icon_file, isinhands = TRUE)
+// 	return hands
+
 //update whether handcuffs appears on our hud.
 /mob/living/carbon/proc/update_hands_hud()
 	if(!hud_used)
@@ -48,6 +74,17 @@
 		if(client && hud_used && hud_used.hud_version != HUD_STYLE_NOHUD)
 			r_hand.screen_loc = ui_rhand
 			client.screen += r_hand
+			// todo probably do away with this copypaste job
+
+		if(length(observers))
+			for(var/mob/dead/observe as anything in observers)
+				if(observe.client && observe.client.eye == src)
+					observe.client.screen += r_hand
+				else
+					observers -= observe
+					if(!length(observers))
+						observers = null
+						break
 
 /mob/living/carbon/update_inv_l_hand(ignore_cuffs)
 	if(handcuffed && !ignore_cuffs)
@@ -57,6 +94,15 @@
 		if(client && hud_used && hud_used.hud_version != HUD_STYLE_NOHUD)
 			l_hand.screen_loc = ui_lhand
 			client.screen += l_hand
+		if(length(observers))
+			for(var/mob/dead/observe as anything in observers)
+				if(observe.client && observe.client.eye == src)
+					observe.client.screen += l_hand
+				else
+					observers -= observe
+					if(!length(observers))
+						observers = null
+						break
 
 /mob/living/carbon/update_inv_wear_mask()
 	if(istype(wear_mask, /obj/item/clothing/mask))

--- a/code/modules/mob/living/carbon/carbon_update_icons.dm
+++ b/code/modules/mob/living/carbon/carbon_update_icons.dm
@@ -76,15 +76,10 @@
 			client.screen += r_hand
 			// todo probably do away with this copypaste job
 
-		if(length(observers))
-			for(var/mob/dead/observe as anything in observers)
-				if(observe.client && observe.client.eye == src)
-					observe.client.screen += r_hand
-				else
-					observers -= observe
-					if(!length(observers))
-						observers = null
-						break
+		update_observer_view(r_hand)
+
+
+
 
 /mob/living/carbon/update_inv_l_hand(ignore_cuffs)
 	if(handcuffed && !ignore_cuffs)
@@ -94,15 +89,7 @@
 		if(client && hud_used && hud_used.hud_version != HUD_STYLE_NOHUD)
 			l_hand.screen_loc = ui_lhand
 			client.screen += l_hand
-		if(length(observers))
-			for(var/mob/dead/observe as anything in observers)
-				if(observe.client && observe.client.eye == src)
-					observe.client.screen += l_hand
-				else
-					observers -= observe
-					if(!length(observers))
-						observers = null
-						break
+		update_observer_view(l_hand)
 
 /mob/living/carbon/update_inv_wear_mask()
 	if(istype(wear_mask, /obj/item/clothing/mask))
@@ -122,6 +109,7 @@
 
 //update whether our head item appears on our hud.
 /mob/living/carbon/proc/update_hud_head(obj/item/I)
+
 	return
 
 //update whether our mask item appears on our hud.
@@ -132,3 +120,17 @@
 /mob/living/carbon/proc/update_hud_back(obj/item/I)
 	return
 
+/mob/living/carbon/proc/update_observer_view(obj/item/worn_item, inventory)
+	if(!length(observers))
+		return
+	for(var/mob/dead/observe as anything in observers)
+		if(observe.client && observe.client.eye == src)
+			if(observe.hud_used)
+				if(inventory && !observe.hud_used.inventory_shown)
+					continue
+				observe.client.screen += worn_item
+		else
+			observers -= observe
+			if(!length(observers))
+				observers = null
+				break

--- a/code/modules/mob/living/carbon/human/human_inventory.dm
+++ b/code/modules/mob/living/carbon/human/human_inventory.dm
@@ -185,6 +185,13 @@
 		src.r_hand = null
 		update_inv_r_hand()
 
+	if(client)
+		client.screen -= I
+	if(length(observers))
+		for(var/mob/dead/observe as anything in observers)
+			if(observe.client)
+				observe.client.screen -= I
+
 	I.screen_loc = null
 	I.forceMove(src)
 	I.equipped(src, slot, initial)
@@ -271,8 +278,8 @@
 				var/obj/item/clothing/head/hat = I
 				if(hat.vision_flags || hat.see_in_dark || !isnull(hat.lighting_alpha))
 					update_sight()
-			head_update(I)
-			update_inv_head()
+			head_update(I)  // this calls update_inv_head() on its own
+			// update_inv_head()
 		if(SLOT_HUD_SHOES)
 			shoes = I
 			update_inv_shoes()

--- a/code/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/code/modules/mob/living/carbon/human/human_update_icons.dm
@@ -1071,6 +1071,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 	apply_overlay(R_HAND_LAYER)
 
 
+
 /mob/living/carbon/human/update_inv_l_hand()
 	..()
 	remove_overlay(L_HAND_LAYER)

--- a/code/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/code/modules/mob/living/carbon/human/human_update_icons.dm
@@ -578,10 +578,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 			inv.update_icon()
 
 	if(w_uniform && istype(w_uniform, /obj/item/clothing/under))
-		if(client && hud_used && hud_used.hud_shown)
-			if(hud_used.inventory_shown)			//if the inventory is open ...
-				w_uniform.screen_loc = ui_iclothing //...draw the item in the inventory screen
-			client.screen += w_uniform				//Either way, add the item to the HUD
+		update_hud_uniform(w_uniform)
 
 		var/t_color = w_uniform.item_color
 		if(!t_color)
@@ -655,9 +652,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 			inv.update_icon()
 
 	if(wear_id)
-		if(client && hud_used && hud_used.hud_shown)
-			wear_id.screen_loc = ui_id
-			client.screen += wear_id
+		update_hud_id(wear_id)
 
 		if(w_uniform && w_uniform:displays_id)
 			overlays_standing[ID_LAYER]	= mutable_appearance('icons/mob/mob.dmi', "id", layer = -ID_LAYER)
@@ -671,10 +666,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 			inv.update_icon()
 
 	if(gloves)
-		if(client && hud_used && hud_used.hud_shown)
-			if(hud_used.inventory_shown)			//if the inventory is open ...
-				gloves.screen_loc = ui_gloves		//...draw the item in the inventory screen
-			client.screen += gloves					//Either way, add the item to the HUD
+		update_hud_gloves(gloves)
 
 		var/t_state = gloves.item_state
 		if(!t_state)	t_state = gloves.icon_state
@@ -711,12 +703,9 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 			inv.update_icon()
 
 	if(glasses)
+		update_hud_glasses(glasses)
 		var/mutable_appearance/new_glasses
 		var/obj/item/organ/external/head/head_organ = get_organ("head")
-		if(client && hud_used && hud_used.hud_shown)
-			if(hud_used.inventory_shown)			//if the inventory is open ...
-				glasses.screen_loc = ui_glasses		//...draw the item in the inventory screen
-			client.screen += glasses				//Either way, add the item to the HUD
 
 		if(glasses.icon_override)
 			new_glasses = mutable_appearance(glasses.icon_override, "[glasses.icon_state]", layer = -GLASSES_LAYER)
@@ -755,10 +744,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 
 	if(l_ear || r_ear)
 		if(l_ear)
-			if(client && hud_used && hud_used.hud_shown)
-				if(hud_used.inventory_shown)			//if the inventory is open ...
-					l_ear.screen_loc = ui_l_ear			//...draw the item in the inventory screen
-				client.screen += l_ear					//Either way, add the item to the HUD
+			update_hud_l_ear(l_ear)
 
 			var/t_type = l_ear.item_state
 			if(!t_type)
@@ -772,10 +758,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 				overlays_standing[EARS_LAYER] = mutable_appearance('icons/mob/clothing/ears.dmi', "[t_type]", layer = -EARS_LAYER)
 
 		if(r_ear)
-			if(client && hud_used && hud_used.hud_shown)
-				if(hud_used.inventory_shown)			//if the inventory is open ...
-					r_ear.screen_loc = ui_r_ear			//...draw the item in the inventory screen
-				client.screen += r_ear					//Either way, add the item to the HUD
+			update_hud_r_ear(r_ear)
 
 			var/t_type = r_ear.item_state
 			if(!t_type)
@@ -797,10 +780,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 			inv.update_icon()
 
 	if(shoes)
-		if(client && hud_used && hud_used.hud_shown)
-			if(hud_used.inventory_shown)			//if the inventory is open ...
-				shoes.screen_loc = ui_shoes			//...draw the item in the inventory screen
-			client.screen += shoes					//Either way, add the item to the HUD
+		update_hud_shoes(shoes)
 
 		if(!wear_suit || !(wear_suit.flags_inv & HIDESHOES))
 			var/mutable_appearance/standing
@@ -833,9 +813,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 			inv.update_icon()
 
 	if(s_store)
-		if(client && hud_used && hud_used.hud_shown)
-			s_store.screen_loc = ui_sstore1
-			client.screen += s_store
+		update_hud_s_store(s_store)
 
 		var/t_state = s_store.item_state
 		if(!t_state)
@@ -855,6 +833,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 			inv.update_icon()
 
 	if(head)
+		update_hud_head(head)
 		var/mutable_appearance/standing
 		if(head.icon_override)
 			standing = mutable_appearance(head.icon_override, "[head.icon_state]", layer = -HEAD_LAYER)
@@ -888,6 +867,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 			belt.screen_loc = ui_belt
 
 	if(belt)
+		update_observer_view(belt)
 		var/t_state = belt.item_state
 		if(!t_state)
 			t_state = belt.icon_state
@@ -910,10 +890,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 			inv.update_icon()
 
 	if(wear_suit && istype(wear_suit, /obj/item/clothing/suit))
-		if(client && hud_used && hud_used.hud_shown)
-			if(hud_used.inventory_shown)					//if the inventory is open ...
-				wear_suit.screen_loc = ui_oclothing	//TODO	//...draw the item in the inventory screen
-			client.screen += wear_suit						//Either way, add the item to the HUD
+		update_observer_view(wear_suit)
 
 		var/mutable_appearance/standing
 		if(wear_suit.icon_override)
@@ -959,14 +936,18 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 		if(inv)
 			inv.update_icon()
 
-		if(hud_used.hud_shown)
-			if(l_store)
-				client.screen += l_store
-				l_store.screen_loc = ui_storage1
 
-			if(r_store)
+		if(l_store)
+			l_store.screen_loc = ui_storage1
+			if(hud_used.hud_shown)
+				client.screen += l_store
+			update_observer_view(l_store)
+
+		if(r_store)
+			r_store.screen_loc = ui_storage2
+			if(hud_used.hud_shown)
 				client.screen += r_store
-				r_store.screen_loc = ui_storage2
+			update_observer_view(r_store)
 
 /mob/living/carbon/human/update_inv_wear_pda()
 	if(client && hud_used)
@@ -974,9 +955,11 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 		if(inv)
 			inv.update_icon()
 
-		if(wear_pda)
-			client.screen += wear_pda
-			wear_pda.screen_loc = ui_pda
+	if(wear_pda)
+		update_hud_wear_pda(wear_pda)
+			// client.screen += wear_pda
+			// wear_pda.screen_loc = ui_pda
+			// update_observer_view(wear_pda)
 
 /mob/living/carbon/human/update_inv_wear_mask()
 	..()
@@ -986,6 +969,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 		if(inv)
 			inv.update_icon()
 	if(wear_mask && (istype(wear_mask, /obj/item/clothing/mask) || istype(wear_mask, /obj/item/clothing/accessory)))
+		update_hud_wear_mask(wear_mask)
 		if(!(SLOT_HUD_WEAR_MASK in check_obscured_slots()))
 			var/obj/item/organ/external/head/head_organ = get_organ("head")
 			if(!istype(head_organ))
@@ -1021,6 +1005,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 	remove_overlay(BACK_LAYER)
 	if(back)
 		//determine the icon to use
+		update_hud_back(back)
 		var/t_state = back.item_state
 		if(!t_state)
 			t_state = back.icon_state
@@ -1092,25 +1077,92 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 
 //human HUD updates for items in our inventory
 
-//update whether our head item appears on our hud.
-/mob/living/carbon/human/update_hud_head(obj/item/I)
-	if(client && hud_used && hud_used.hud_shown)
-		if(hud_used.inventory_shown)
-			I.screen_loc = ui_head
-		client.screen += I
+
+/mob/living/carbon/human/proc/update_hud_uniform(obj/item/worn_item)
+	worn_item.screen_loc = ui_iclothing
+	if((client && hud_used) && (hud_used.inventory_shown && hud_used.hud_shown))
+		client.screen += worn_item
+	update_observer_view(worn_item, TRUE)
+
+/mob/living/carbon/human/proc/update_hud_id(obj/item/worn_item)
+	worn_item.screen_loc = ui_id
+	if((client && hud_used?.hud_shown))
+		client.screen += worn_item
+	update_observer_view(worn_item)
+
+/mob/living/carbon/human/proc/update_hud_wear_pda(obj/item/worn_item)
+	worn_item.screen_loc = ui_pda
+	if((client && hud_used?.hud_shown))
+		client.screen += worn_item
+	update_observer_view(worn_item)
+
+/mob/living/carbon/human/proc/update_hud_gloves(obj/item/worn_item)
+	worn_item.screen_loc = ui_gloves
+	if((client && hud_used) && (hud_used.inventory_shown && hud_used.hud_shown))
+		client.screen += worn_item
+	update_observer_view(worn_item, TRUE)
+
+/mob/living/carbon/human/proc/update_hud_glasses(obj/item/worn_item)
+	worn_item.screen_loc = ui_glasses
+	if((client && hud_used) && (hud_used.inventory_shown && hud_used.hud_shown))
+		client.screen += worn_item
+	update_observer_view(worn_item, TRUE)
+
+/mob/living/carbon/human/proc/update_hud_l_ear(obj/item/worn_item)
+	worn_item.screen_loc = ui_l_ear
+	if((client && hud_used) && (hud_used.inventory_shown && hud_used.hud_shown))
+		client.screen += worn_item
+	update_observer_view(worn_item, TRUE)
+
+/mob/living/carbon/human/proc/update_hud_r_ear(obj/item/worn_item)
+	worn_item.screen_loc = ui_r_ear
+	if((client && hud_used) && (hud_used.inventory_shown && hud_used.hud_shown))
+		client.screen += worn_item
+	update_observer_view(worn_item, TRUE)
+
+/mob/living/carbon/human/proc/update_hud_shoes(obj/item/worn_item)
+	worn_item.screen_loc = ui_shoes
+	if((client && hud_used) && (hud_used.inventory_shown && hud_used.hud_shown))
+		client.screen += worn_item
+	update_observer_view(worn_item, TRUE)
+
+/mob/living/carbon/human/proc/update_hud_s_store(obj/item/worn_item)
+	worn_item.screen_loc = ui_sstore1
+	if(client && hud_used?.hud_shown)
+		client.screen += worn_item
+	update_observer_view(worn_item, TRUE)
+
+/mob/living/carbon/human/proc/update_hud_wear_suit(obj/item/worn_item)
+	worn_item.screen_loc = ui_oclothing
+	if((client && hud_used) && (hud_used.inventory_shown && hud_used.hud_shown))
+		client.screen += worn_item
+	update_observer_view(worn_item, TRUE)
+
+/mob/living/carbon/human/proc/update_hud_belt(obj/item/worn_item)
+	belt.screen_loc = ui_belt
+	if(client && hud_used?.hud_shown)
+		client.screen += worn_item
+	update_observer_view(worn_item, TRUE)
+
+/mob/living/carbon/human/update_hud_head(obj/item/worn_item)
+	worn_item.screen_loc = ui_head
+	if((client && hud_used) && (hud_used.inventory_shown && hud_used.hud_shown))
+		client.screen += worn_item
+	update_observer_view(worn_item, TRUE)
 
 //update whether our mask item appears on our hud.
-/mob/living/carbon/human/update_hud_wear_mask(obj/item/I)
-	if(client && hud_used && hud_used.hud_shown)
-		if(hud_used.inventory_shown)
-			I.screen_loc = ui_mask
-		client.screen += I
+/mob/living/carbon/human/update_hud_wear_mask(obj/item/worn_item)
+	worn_item.screen_loc = ui_mask
+	if((client && hud_used) && (hud_used.inventory_shown && hud_used.hud_shown))
+		client.screen += worn_item
+	update_observer_view(worn_item, TRUE)
 
 //update whether our back item appears on our hud.
-/mob/living/carbon/human/update_hud_back(obj/item/I)
-	if(client && hud_used && hud_used.hud_shown)
-		I.screen_loc = ui_back
-		client.screen += I
+/mob/living/carbon/human/update_hud_back(obj/item/worn_item)
+	worn_item.screen_loc = ui_back
+	if(client && hud_used?.hud_shown)
+		client.screen += worn_item
+	update_observer_view(worn_item, TRUE)
 
 /mob/living/carbon/human/proc/update_wing_layer()
 	remove_overlay(WING_UNDERLIMBS_LAYER)

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -64,7 +64,7 @@
 	if(mind && suiciding)
 		mind.suicided = TRUE
 	reset_perspective(null)
-	hud_used?.reload_fullscreen()
+	reload_fullscreen()
 	update_sight()
 	update_action_buttons_icon()
 	ADD_TRAIT(src, TRAIT_FLOORED, STAT_TRAIT)

--- a/code/modules/mob/living/stat_states.dm
+++ b/code/modules/mob/living/stat_states.dm
@@ -69,7 +69,7 @@
 		update_blind_effects()
 		update_sight()
 		updatehealth("update revive")
-		hud_used?.reload_fullscreen()
+		reload_fullscreen()
 
 	SEND_SIGNAL(src, COMSIG_LIVING_REVIVE, updating)
 

--- a/code/modules/mob/mob_vars.dm
+++ b/code/modules/mob/mob_vars.dm
@@ -252,3 +252,6 @@
 	var/next_click_modifier = 1
 	/// Tracks the open UIs that a mob has, used in TGUI for various things, such as updating UIs
 	var/list/open_uis = list()
+
+	// TODO replace this with something that doesn't actually track mobs
+	var/mob/dead/observer/observers = list()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds a new observation method, ported from Nova/TG.
Instead of just orbiting your target, this basically puts you behind their eyes. All of their hud elements, including (ideally) their overlays, will become visible to you.

While I'm still fleshing this out, the goal is to make it usable especially for mentors, who would be able to use this as a sort of limited "mghost", where they can hop out of their bodies temporarily to take a peek at what someone's dealing with.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
This is a pretty interesting feature, as it lets you poke around living people's inventories to see what they have. This would be very useful for mentors and the like to be able to see what's in folks' pockets without having to vv them, and would probably just be nice for observers to have access to as well.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

This is a bit of a WIP, but shows more or less how it'll look. The left client is currently observing the client on the right.

https://github.com/ParadiseSS13/Paradise/assets/89928798/d6b62591-4ebb-4fe7-b8df-bf4012c18ebf


<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Still needs plenty of it! This will absolutely need a TM.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
add: Adds the ability to observe people directly as if you were them, seeing their inventory and HUD elements.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
