### PR TITLE
Makes weeping angel blindness not affect other angels

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/angel_statue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/angel_statue.dm
@@ -57,7 +57,7 @@
 	. = ..()
 	// Give spells
 	AddSpell(new /obj/effect/proc_holder/spell/aoe/flicker_lights(null))
-	AddSpell(new /obj/effect/proc_holder/spell/aoe/blindness(null))
+	AddSpell(new /obj/effect/proc_holder/spell/blindness(null))
 	AddSpell(new /obj/effect/proc_holder/spell/night_vision(null))
 
 	// Set creator
@@ -180,28 +180,22 @@
 	return
 
 //Blind AOE
-/obj/effect/proc_holder/spell/aoe/blindness
+/obj/effect/proc_holder/spell/blindness
 	name = "Blindness"
 	desc = "Your prey will be momentarily blind for you to advance on them."
 
 	message = "<span class='notice'>You glare your eyes.</span>"
 	base_cooldown = 600
 	clothes_req = FALSE
-	aoe_range = 10
 
-/obj/effect/proc_holder/spell/aoe/blindness/create_new_targeting()
-	var/datum/spell_targeting/aoe/turf/targeting = new()
-	targeting.range = aoe_range
-	return targeting
+/obj/effect/proc_holder/spell/blindness/create_new_targeting()
+	return new /datum/spell_targeting/self
 
-/obj/effect/proc_holder/spell/aoe/blindness/cast(list/targets, mob/user = usr)
-	for(var/mob/living/L in GLOB.alive_mob_list)
-		if(L == user)
+/obj/effect/proc_holder/spell/blindness/cast(list/targets, mob/user = usr)
+	for(var/mob/living/M in orange(10, user))
+		if(M == user || istype(M, /mob/living/simple_animal/hostile/statue))
 			continue
-		var/turf/T = get_turf(L.loc)
-		if(T && (T in targets))
-			L.EyeBlind(8 SECONDS)
-	return
+		M.EyeBlind(8 SECONDS)
 
 /mob/living/simple_animal/hostile/statue/sentience_act()
 	faction -= "neutral"
@@ -209,4 +203,4 @@
 /mob/living/simple_animal/hostile/statue/restrained()
 	. = ..()
 	if(can_be_seen(loc))
-		return 1
+		return TRUE

--- a/code/modules/mob/living/simple_animal/hostile/angel_statue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/angel_statue.dm
@@ -197,7 +197,7 @@
 
 /obj/effect/proc_holder/spell/aoe/blindness/cast(list/targets, mob/user = usr)
 	for(var/mob/living/L in targets)
-		if(L == user || istype(L, /mob/living/simple_animal/hostile/statue))
+		if(istype(L, /mob/living/simple_animal/hostile/statue))
 			continue
 		L.EyeBlind(8 SECONDS)
 

--- a/code/modules/mob/living/simple_animal/hostile/angel_statue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/angel_statue.dm
@@ -57,7 +57,7 @@
 	. = ..()
 	// Give spells
 	AddSpell(new /obj/effect/proc_holder/spell/aoe/flicker_lights(null))
-	AddSpell(new /obj/effect/proc_holder/spell/blindness(null))
+	AddSpell(new /obj/effect/proc_holder/spell/aoe/blindness(null))
 	AddSpell(new /obj/effect/proc_holder/spell/night_vision(null))
 
 	// Set creator
@@ -180,22 +180,28 @@
 	return
 
 //Blind AOE
-/obj/effect/proc_holder/spell/blindness
+/obj/effect/proc_holder/spell/aoe/blindness
 	name = "Blindness"
 	desc = "Your prey will be momentarily blind for you to advance on them."
 
 	message = "<span class='notice'>You glare your eyes.</span>"
 	base_cooldown = 600
 	clothes_req = FALSE
+	aoe_range = 10
 
-/obj/effect/proc_holder/spell/blindness/create_new_targeting()
-	return new /datum/spell_targeting/self
+/obj/effect/proc_holder/spell/aoe/blindness/create_new_targeting()
+	var/datum/spell_targeting/aoe/turf/targeting = new()
+	targeting.range = aoe_range
+	return targeting
 
-/obj/effect/proc_holder/spell/blindness/cast(list/targets, mob/user = usr)
-	for(var/mob/living/M in orange(10, user))
-		if(M == user || istype(M, /mob/living/simple_animal/hostile/statue))
+/obj/effect/proc_holder/spell/aoe/blindness/cast(list/targets, mob/user = usr)
+	for(var/mob/living/L in GLOB.alive_mob_list)
+		if(L == user)
 			continue
-		M.EyeBlind(8 SECONDS)
+		var/turf/T = get_turf(L.loc)
+		if(T && (T in targets))
+			L.EyeBlind(8 SECONDS)
+	return
 
 /mob/living/simple_animal/hostile/statue/sentience_act()
 	faction -= "neutral"
@@ -203,4 +209,4 @@
 /mob/living/simple_animal/hostile/statue/restrained()
 	. = ..()
 	if(can_be_seen(loc))
-		return TRUE
+		return 1

--- a/code/modules/mob/living/simple_animal/hostile/angel_statue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/angel_statue.dm
@@ -190,16 +190,16 @@
 	aoe_range = 10
 
 /obj/effect/proc_holder/spell/aoe/blindness/create_new_targeting()
-	var/datum/spell_targeting/aoe/turf/targeting = new()
+	var/datum/spell_targeting/aoe/targeting = new()
 	targeting.range = aoe_range
+	targeting.allowed_type = /mob/living
 	return targeting
 
 /obj/effect/proc_holder/spell/aoe/blindness/cast(list/targets, mob/user = usr)
-	for(var/turf/T in targets)
-		for(var/mob/living/L in T)
-			if(L == user || istype(L, /mob/living/simple_animal/hostile/statue))
-				continue
-			L.EyeBlind(8 SECONDS)
+	for(var/mob/living/L in targets)
+		if(L == user || istype(L, /mob/living/simple_animal/hostile/statue))
+			continue
+		L.EyeBlind(8 SECONDS)
 
 /mob/living/simple_animal/hostile/statue/sentience_act()
 	faction -= "neutral"

--- a/code/modules/mob/living/simple_animal/hostile/angel_statue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/angel_statue.dm
@@ -195,13 +195,11 @@
 	return targeting
 
 /obj/effect/proc_holder/spell/aoe/blindness/cast(list/targets, mob/user = usr)
-	for(var/mob/living/L in GLOB.alive_mob_list)
-		if(L == user)
-			continue
-		var/turf/T = get_turf(L.loc)
-		if(T && (T in targets))
+	for(var/turf/T in targets)
+		for(var/mob/living/L in T)
+			if(L == user || istype(L, /mob/living/simple_animal/hostile/statue))
+				continue
 			L.EyeBlind(8 SECONDS)
-	return
 
 /mob/living/simple_animal/hostile/statue/sentience_act()
 	faction -= "neutral"
@@ -209,4 +207,4 @@
 /mob/living/simple_animal/hostile/statue/restrained()
 	. = ..()
 	if(can_be_seen(loc))
-		return 1
+		return TRUE


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Slightly refactors the blindness spell and adds a check for other weeping angels. 

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Being able to blind other angels during a wizard round that contains multiple angels is not very fun or intuitive.

## Testing
<!-- How did you test the PR, if at all? -->
It selects the correct targets and blinds them.

## Changelog
:cl: Chuga
tweak: Weeping angels no longer blind other weeping angels
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
