### PR TITLE
make no_lava mapping helper visible above rock walls

### DIFF
--- a/code/modules/mapping/mapping_helpers.dm
+++ b/code/modules/mapping/mapping_helpers.dm
@@ -66,6 +66,7 @@
 
 /obj/effect/mapping_helpers/no_lava
 	icon_state = "no_lava"
+	layer = ON_EDGED_TURF_LAYER
 
 /obj/effect/mapping_helpers/no_lava/New()
 	var/turf/T = get_turf(src)


### PR DESCRIPTION
## What Does This PR Do
This PR sets the layer of `/obj/effect/mapping_helpers/no_lava` to `ON_EDGED_TURF_LAYER`, which is just above `/turf/simulated/mineral`'s layer of `EDGED_TURF_LAYER`.
## Why It's Good For The Game
This makes the mapping helper show up above the rock walls so that it's visible in map editors. Not being able to see this on e.g. ruin maps is confusing and frustrating.
## Images of changes
### Before
![StrongDMM-2024-03-02 08 08 28](https://github.com/ParadiseSS13/Paradise/assets/59303604/25ba98b9-3d4a-4085-b1c2-c4104bf800bb)
### After
![StrongDMM-2024-03-02 08 07 10](https://github.com/ParadiseSS13/Paradise/assets/59303604/619c5386-3ba8-4fa4-ac89-7256a980ba80)
## Testing
Checked map editor output before and after change.
## Changelog
NPFC