### PR TITLE
Increases EMP Shriek on Cybernetic Revolution Rounds

### DIFF
--- a/code/datums/station_traits/postive_traits.dm
+++ b/code/datums/station_traits/postive_traits.dm
@@ -160,6 +160,7 @@
 	trait_type = STATION_TRAIT_POSITIVE
 	show_in_report = TRUE
 	weight = 2
+	force = TRUE //MMTODO - this needs to be removed after testing you idiot.
 	report_message = "The new trends in cybernetics have come to the station! Everyone has some form of cybernetic implant."
 	trait_to_give = STATION_TRAIT_CYBERNETIC_REVOLUTION
 	/// List of all job types with the cybernetics they should receive.

--- a/code/modules/antagonists/changeling/powers/shriek.dm
+++ b/code/modules/antagonists/changeling/powers/shriek.dm
@@ -46,6 +46,11 @@
 	power_type = CHANGELING_PURCHASABLE_POWER
 	category = /datum/changeling_power_category/utility
 
+/datum/action/changeling/dissonant_shriek/New()
+	..()
+	if(HAS_TRAIT(SSstation, STATION_TRAIT_CYBERNETIC_REVOLUTION))
+		dna_cost *= 2.5
+
 //A flashy ability, good for crowd control and sewing chaos.
 /datum/action/changeling/dissonant_shriek/sting_action(mob/user)
 	if(istype(user.loc, /obj/machinery/atmospherics))


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Increases Dissonant Shriek by `2.5x` on Cyber Revo rounds.

## Why It's Good For The Game
All other EMP items cost more - this should be no different.

## Testing
Currently testing. Costs applies but does not show on UI.

**REMOVE FORCED CYBER REVO VAR (MMTODO) BEFORE TAKING OUT OF DRAFT**

I hate TGUI I hate TGUI I hate TGUI

## Changelog
:cl:
tweak: Dissonant Shriek costs 2.5x more on Cybernetic Revolution Rounds.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
