### PR TITLE
Refresh TGUI blank window fix

### DIFF
--- a/code/modules/tgui/tgui_panel/tgui_panel_external.dm
+++ b/code/modules/tgui/tgui_panel/tgui_panel_external.dm
@@ -39,6 +39,19 @@
 	set name = "Refresh TGUI"
 	set category = "Special Verbs"
 
+	if(alert(usr,
+		"Use it ONLY if you have trouble with TGUI window.\
+		That's UI's with EYE on top-left corner.\
+		Otherwise, you will get a white window that will only close when you restart the game!", "Refresh TGUI", "Refresh", "Cancel") != "Refresh")
+		return
+	var/refreshed_count = 0
 	for(var/window_id in tgui_windows)
 		var/datum/tgui_window/window = tgui_windows[window_id]
+		if(!window.locked)
+			window.acquire_lock()
+			continue
 		window.reinitialize()
+		refreshed_count++
+	to_chat(usr, "<span class='notice'>TGUI windows refreshed - [refreshed_count].<br>If you have blank window - restart the game, or open previous TGUI window.</span>")
+	refreshed_count = 0
+

--- a/code/modules/tgui/tgui_panel/tgui_panel_external.dm
+++ b/code/modules/tgui/tgui_panel/tgui_panel_external.dm
@@ -42,7 +42,7 @@
 	if(alert(usr,
 		"Use it ONLY if you have trouble with TGUI window.\
 		That's UI's with EYE on top-left corner.\
-		Otherwise, you will get a white window that will only close when you restart the game!", "Refresh TGUI", "Refresh", "Cancel") != "Refresh")
+		Otherwise, you can get a white window that will only close when you restart the game!", "Refresh TGUI", "Refresh", "Cancel") != "Refresh")
 		return
 	var/refreshed_count = 0
 	for(var/window_id in tgui_windows)
@@ -53,5 +53,4 @@
 		window.reinitialize()
 		refreshed_count++
 	to_chat(usr, "<span class='notice'>TGUI windows refreshed - [refreshed_count].<br>If you have blank window - restart the game, or open previous TGUI window.</span>")
-	refreshed_count = 0
 

--- a/code/modules/tgui/tgui_panel/tgui_panel_external.dm
+++ b/code/modules/tgui/tgui_panel/tgui_panel_external.dm
@@ -39,10 +39,11 @@
 	set name = "Refresh TGUI"
 	set category = "Special Verbs"
 
-	if(alert(usr,
+	var/choice = alert(usr,
 		"Use it ONLY if you have trouble with TGUI window.\
 		That's UI's with EYE on top-left corner.\
-		Otherwise, you can get a white window that will only close when you restart the game!", "Refresh TGUI", "Refresh", "Cancel") != "Refresh")
+		Otherwise, you can get a white window that will only close when you restart the game!", "Refresh TGUI", "Refresh", "Cancel")
+	if(choice != "Refresh")
 		return
 	var/refreshed_count = 0
 	for(var/window_id in tgui_windows)


### PR DESCRIPTION
## What Does This PR Do
Adds alert when you try to Refresh TGUI.
And fixes blank windows if you do it.
TGchat and TGsay will refresh only after first refresh.

## Why It's Good For The Game
No blank windows

## Images of changes
https://github.com/ParadiseSS13/Paradise/assets/69762909/c930b4ce-8ba7-4169-8c92-49e58a7b2350


## Testing
Above

## Changelog
:cl:
fix: There should no longer be a blank windows if you do Refresh TGUI
/:cl:

