### PR TITLE
storage items no longer bring up the turf panel on alt-click

### DIFF
--- a/code/datums/outfits/outfit_debug.dm
+++ b/code/datums/outfits/outfit_debug.dm
@@ -172,7 +172,6 @@
 	selected_species = GLOB.all_species[choice]
 
 /obj/item/debug/human_spawner/AltClick(mob/user)
-	. = ..()
 	if(!Adjacent(user))
 		return
 	activate_mind = !activate_mind

--- a/code/game/objects/items/weapons/storage/storage_base.dm
+++ b/code/game/objects/items/weapons/storage/storage_base.dm
@@ -158,7 +158,6 @@
 		open(usr)
 
 /obj/item/storage/AltClick(mob/user)
-	. = ..()
 	if(ishuman(user) && Adjacent(user) && !user.incapacitated(FALSE, TRUE))
 		open(user)
 		add_fingerprint(user)

--- a/code/game/objects/structures/snow.dm
+++ b/code/game/objects/structures/snow.dm
@@ -11,7 +11,6 @@
 	var/cooldown = 0 // very cool down
 
 /obj/structure/snow/AltClick(mob/user)
-	. = ..()
 	if(cooldown > world.time)
 		return
 	if(ishuman(user) && Adjacent(user))

--- a/code/modules/mod/mod_control.dm
+++ b/code/modules/mod/mod_control.dm
@@ -416,7 +416,6 @@
 		..()
 
 /obj/item/mod/control/AltClick(mob/user)
-	. = ..()
 	if(ishuman(user) && Adjacent(user) && !user.incapacitated(FALSE, TRUE) && bag)
 		bag.forceMove(user)
 		bag.show_to(user)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
storage items no longer bring up the turf panel on alt-click

## Why It's Good For The Game
surprise clientside lag is something I'm not for. This is also done for every other alt click interaction

## Testing
you BET I alt clicked a storage item

## Changelog
:cl:
tweak: storage items no longer bring up the turf panel on alt-click
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
