### PR TITLE
Remove account login from EFTPOS

### DIFF
--- a/code/modules/economy/economy_machinery/eftpos.dm
+++ b/code/modules/economy/economy_machinery/eftpos.dm
@@ -105,25 +105,7 @@
 		if("link_account")
 			if(!account_database)
 				reconnect_database()
-			if(account_database)
-				var/attempt_account_num = tgui_input_number(user, "Enter account number to pay EFTPOS charges into:", "New account number", max_value = 9999999, min_value = 1000000)
-				if(!attempt_account_num)
-					return
-				var/attempt_pin = tgui_input_number(user, "Enter pin code", "Account pin", max_value = 99999, min_value = 10000)
-				if(!check_user_position(user) || !account_database || !attempt_pin)
-					return
-				var/datum/money_account/target_account = GLOB.station_money_database.find_user_account(attempt_account_num, include_departments = TRUE)
-				if(!target_account)
-					for(var/department_key in GLOB.station_money_database.department_accounts)
-						var/datum/money_account/department_account = GLOB.station_money_database.department_accounts[department_key]
-						if(department_account.account_number == attempt_account_num)
-							target_account = department_account
-				if(target_account && GLOB.station_money_database.try_authenticate_login(target_account, attempt_pin, TRUE, FALSE, FALSE))
-					linked_account = target_account
-				else
-					to_chat(user, "[bicon(src)]<span class='warning'>Unable to connect to inputed account.</span>")
-					return
-			else
+			if(!account_database)
 				to_chat(user, "[bicon(src)]<span class='warning'>Unable to connect to accounts database.</span>")
 				return
 			var/datum/money_account/target_account = locateUID(params["account"])


### PR DESCRIPTION
## What Does This PR Do
Removes the account login from the EFTPOS.

## Why It's Good For The Game
This was actually supposed to be removed by PR #20095, but the merge in commit e4510f576 undid it by accident.  With the current state of the code, it checks to make sure the account info is valid... but then doesn't actually link to that account.  It uses the one you selected in the dropdown instead.

## Testing
Spawned as chef, set EFTPOS to deposit into my own account without a prompt, paid, checked ATM, $20 successfully paid to myself, instead of the default service account.

## Changelog
:cl:
fix: EFTPOS will no longer ask you for account ID and password.  They didn't use them anyway.
/:cl: