### PR TITLE
Made sleepy pens awake enough to react.

### DIFF
--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -127,10 +127,11 @@
 		contained += "[round(reagent.volume, 0.01)]u [reagent]"
 
 	if(reagents.total_volume && M.reagents)
+		var/fraction = min(transfer_amount / reagents.total_volume, 1)
+		reagents.reaction(M, REAGENT_INGEST, fraction)
 		transfered = reagents.trans_to(M, transfer_amount)
 	to_chat(user, "<span class='warning'>You sneakily stab [M] with the pen.</span>")
 	add_attack_logs(user, M, "Stabbed with (sleepy) [src]. [transfered]u of reagents transfered from pen containing [english_list(contained)].")
-	reagents.reaction(M, REAGENT_INGEST, 0.1)
 	return TRUE
 
 


### PR DESCRIPTION
## What Does This PR Do
Makes sleepy pens trigger reactions correctly.  The existing code doesn't work because the reagents are empty by the time it tries to react.  This updates the call to match a syringe.
Fixes #24158 (the unintended part, at least)

## Why It's Good For The Game
Things that inject should trigger injection reactions.

## Testing
Made advanced mutation toxin, put it in a sleepy pen, injected a monkey, waited.  Am now being glomped by a slime.

## Changelog
:cl:
fix: Sleepy pens will trigger reactions properly.
/:cl: