### PR TITLE
Custom food can now be renamed, as the tip indicates.

### DIFF
--- a/code/modules/food_and_drinks/food/customizables.dm
+++ b/code/modules/food_and_drinks/food/customizables.dm
@@ -337,8 +337,8 @@ do {\
 
 /obj/item/food/snacks/customizable/attackby(obj/item/I, mob/user, params)
 	if(is_pen(I))
-		var/t = rename_interactive(user, I, use_prefix = FALSE)
-		if(!isnull(t))
+		var/new_name = rename_interactive(user, I, use_prefix = FALSE)
+		if(!isnull(new_name))
 			to_chat(user, "<span class='notice'>You declare this to be \a [name]. Delicious!</span>")
 			return
 

--- a/code/modules/food_and_drinks/food/customizables.dm
+++ b/code/modules/food_and_drinks/food/customizables.dm
@@ -336,6 +336,12 @@ do {\
 
 
 /obj/item/food/snacks/customizable/attackby(obj/item/I, mob/user, params)
+	if(is_pen(I))
+		var/t = rename_interactive(user, I, use_prefix = FALSE)
+		if(!isnull(t))
+			to_chat(user, "<span class='notice'>You declare this to be \a [name]. Delicious!</span>")
+			return
+
 	if(!istype(I, /obj/item/food/snacks))
 		to_chat(user, "<span class='warning'>[I] isn't exactly something that you would want to eat.</span>")
 		return


### PR DESCRIPTION
## What Does This PR Do
Food can now be named.
Creative chefs can rejoice.
This is a haiku.

Fixes #24028

## Why It's Good For The Game
There's been a tip that says this is possible for years, but I'm not clear that it was ever actually possible.  Now the tip and the reality will match.

## Testing
Spawned French onion soup and a slice of bread.  Put the soup on the bread.  Pulled out a pen.
```
You declare this to be Bread Bowl of French Onion Soup. Delicious!
You declare this to be a mistake. Delicious!
You declare this to be an iconic dish. Delicious!
```
(the name updated, too)

## Changelog
:cl:
add: Custom food can now be renamed.  Yes, there's been a tip claiming this was possible for years.  No, it wasn't until now.
/:cl: