### PR TITLE
Improved storage UX of labcoats and similar.

### DIFF
--- a/code/game/objects/items/weapons/storage/storage_base.dm
+++ b/code/game/objects/items/weapons/storage/storage_base.dm
@@ -430,6 +430,8 @@
 	if(!istype(I))
 		return FALSE
 	if(usr)
+		if(!Adjacent(usr))
+			return FALSE
 		if(!usr.unEquip(I, silent = TRUE))
 			return FALSE
 		usr.update_icons()	//update our overlays

--- a/code/modules/clothing/suits/suit_storage.dm
+++ b/code/modules/clothing/suits/suit_storage.dm
@@ -34,7 +34,6 @@
 			pockets.hide_from(player)
 
 /obj/item/clothing/suit/storage/AltClick(mob/user)
-	. = ..()
 	if(ishuman(user) && Adjacent(user) && !user.incapacitated(FALSE, TRUE))
 		pockets.open(user)
 		add_fingerprint(user)

--- a/code/modules/clothing/suits/suit_storage.dm
+++ b/code/modules/clothing/suits/suit_storage.dm
@@ -27,11 +27,13 @@
 
 /obj/item/clothing/suit/storage/forceMove(atom/destination)
 	. = ..()
-	if(!ismob(destination.loc) && pockets != null)
-		for(var/mob/player in pockets.mobs_viewing)
-			if(player == destination)
-				continue
-			pockets.hide_from(player)
+	if(ismob(destination.loc) || isnull(pockets))
+		return
+		
+	for(var/mob/player in pockets.mobs_viewing)
+		if(player == destination)
+			continue
+		pockets.hide_from(player)
 
 /obj/item/clothing/suit/storage/AltClick(mob/user)
 	if(ishuman(user) && Adjacent(user) && !user.incapacitated(FALSE, TRUE))

--- a/code/modules/clothing/suits/suit_storage.dm
+++ b/code/modules/clothing/suits/suit_storage.dm
@@ -38,7 +38,8 @@
 	if(ishuman(user) && Adjacent(user) && !user.incapacitated(FALSE, TRUE))
 		pockets.open(user)
 		add_fingerprint(user)
-	else if(isobserver(user))
+		return
+	if(isobserver(user))
 		pockets.show_to(user)
 
 /obj/item/clothing/suit/storage/attackby(obj/item/W as obj, mob/user as mob, params)

--- a/code/modules/clothing/suits/suit_storage.dm
+++ b/code/modules/clothing/suits/suit_storage.dm
@@ -27,7 +27,7 @@
 
 /obj/item/clothing/suit/storage/forceMove(atom/destination)
 	. = ..()
-	if(!ismob(destination.loc))
+	if(!ismob(destination.loc) && pockets != null)
 		for(var/mob/player in pockets.mobs_viewing)
 			if(player == destination)
 				continue

--- a/code/modules/clothing/suits/suit_storage.dm
+++ b/code/modules/clothing/suits/suit_storage.dm
@@ -21,6 +21,26 @@
 	if(pockets.handle_mousedrop(usr, over_object))
 		..(over_object)
 
+/obj/item/clothing/suit/storage/equipped(mob/user, slot)
+	..()
+	pockets.update_viewers()
+
+/obj/item/clothing/suit/storage/forceMove(atom/destination)
+	. = ..()
+	if(!ismob(destination.loc))
+		for(var/mob/player in pockets.mobs_viewing)
+			if(player == destination)
+				continue
+			pockets.hide_from(player)
+
+/obj/item/clothing/suit/storage/AltClick(mob/user)
+	. = ..()
+	if(ishuman(user) && Adjacent(user) && !user.incapacitated(FALSE, TRUE))
+		pockets.open(user)
+		add_fingerprint(user)
+	else if(isobserver(user))
+		pockets.show_to(user)
+
 /obj/item/clothing/suit/storage/attackby(obj/item/W as obj, mob/user as mob, params)
 	..()
 	return pockets.attackby(W, user, params)


### PR DESCRIPTION
## What Does This PR Do
Suit storage items (labcoats and similar) can now be opened with alt-click.
Adds an extra check to make sure items can't be put into distant inventories.
Closes suit storage item inventories when thrown away (Fixes #3588)

## Why It's Good For The Game
Making storage items more consistent is good.
Bug fixing is good.

## Testing
Alt-clicked a labcoat.  Got UI.
Threw it away.  Lost UI.

## Changelog
:cl:
tweak: Suit storage items (labcoats and similar) can now be opened with alt-click.
fix: Throwing suit storage items no longer leaves their UI open.
/:cl:
