### PR TITLE
Fixes issues with althland ruins causing space on lavaland

### DIFF
--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_althland_excavation.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_althland_excavation.dmm
@@ -1511,6 +1511,10 @@
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating/airless,
 /area/ruin/unpowered/althland_excavation)
+"XS" = (
+/obj/effect/spawner/random_spawners/wall_rusted_maybe,
+/turf/simulated/wall/r_wall,
+/area/lavaland/surface/outdoors)
 "Ya" = (
 /obj/structure/railing,
 /obj/effect/decal/cleanable/dirt,
@@ -1807,10 +1811,10 @@ aB
 aB
 aA
 TD
-TN
+XS
 Ei
 zp
-TN
+XS
 BW
 aB
 Ei
@@ -1970,7 +1974,7 @@ aB
 aB
 aL
 or
-TN
+XS
 Ei
 Ei
 TN
@@ -1999,7 +2003,7 @@ aB
 aB
 aB
 aB
-TN
+XS
 eC
 Ei
 Ei

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_althland_facility.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_althland_facility.dmm
@@ -379,6 +379,10 @@
 	nitrogen = 23
 	},
 /area/ruin/unpowered/althland_processing)
+"hI" = (
+/obj/effect/spawner/random_spawners/wall_rusted_maybe,
+/turf/simulated/wall/r_wall,
+/area/lavaland/surface/outdoors)
 "hP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -971,6 +975,18 @@
 	nitrogen = 23
 	},
 /area/ruin/unpowered/althland_processing)
+"zv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced,
+/obj/machinery/conveyor/west,
+/obj/effect/baseturf_helper/lava_land/surface,
+/turf/simulated/floor{
+	temperature = 300;
+	oxygen = 14;
+	nitrogen = 23
+	},
+/area/ruin/unpowered/althland_processing)
 "zE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/pickaxe,
@@ -1364,6 +1380,15 @@
 	nitrogen = 23
 	},
 /area/ruin/unpowered/althland_processing)
+"Hs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/baseturf_helper/lava_land/surface,
+/turf/simulated/floor/plasteel{
+	temperature = 300;
+	oxygen = 14;
+	nitrogen = 23
+	},
+/area/ruin/unpowered/althland_processing)
 "Hx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -1371,6 +1396,16 @@
 /mob/living/simple_animal/hostile/asteroid/hivelord/legion,
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor{
+	temperature = 300;
+	oxygen = 14;
+	nitrogen = 23
+	},
+/area/ruin/unpowered/althland_processing)
+"Hz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/baseturf_helper/lava_land/surface,
+/turf/simulated/floor/plasteel{
 	temperature = 300;
 	oxygen = 14;
 	nitrogen = 23
@@ -1889,6 +1924,11 @@
 	nitrogen = 23
 	},
 /area/ruin/unpowered/althland_processing)
+"WU" = (
+/obj/effect/mapping_helpers/no_lava,
+/obj/effect/baseturf_helper/lava_land/surface,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "Xn" = (
 /obj/effect/mapping_helpers/no_lava,
 /obj/effect/mapping_helpers/no_lava,
@@ -2395,7 +2435,7 @@ ui
 QE
 af
 BM
-no
+Hz
 bO
 In
 dM
@@ -2445,7 +2485,7 @@ bV
 bL
 ab
 af
-ui
+hI
 bT
 ab
 ab
@@ -2524,7 +2564,7 @@ bT
 bT
 bT
 ui
-hP
+zv
 UP
 Ic
 ui
@@ -2711,7 +2751,7 @@ ui
 ab
 ab
 ab
-ab
+WU
 ab
 ab
 ab
@@ -2760,7 +2800,7 @@ KJ
 af
 bT
 bT
-ui
+hI
 ab
 bL
 "}
@@ -2830,7 +2870,7 @@ bT
 bT
 bT
 bT
-ui
+hI
 af
 bT
 ab
@@ -2841,7 +2881,7 @@ bV
 bL
 ab
 ab
-ui
+hI
 af
 bT
 bT
@@ -2882,7 +2922,7 @@ ab
 bT
 bT
 bT
-ui
+hI
 bT
 bT
 bT
@@ -2932,12 +2972,12 @@ lZ
 ui
 Yd
 nN
-ui
+hI
 af
 AL
 af
 af
-ui
+hI
 bT
 ab
 ab
@@ -2957,7 +2997,7 @@ bT
 bT
 af
 af
-ui
+hI
 af
 bT
 ui
@@ -3143,17 +3183,17 @@ YK
 hj
 Az
 BV
-hj
+Hs
 Dz
 ui
 bT
 Wp
-ui
+hI
 af
 af
 af
 af
-ui
+hI
 bT
 bT
 ab
@@ -3247,7 +3287,7 @@ bT
 bT
 bT
 bT
-ui
+hI
 bT
 bT
 bT


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Adds missing baseturf helpers to areas on:

- `_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_althland_facility.dmm`

Removes unconnected one-tile areas with no baseturf helpers in:

- `_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_althland_facility.dmm`
- `_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_althland_excavation.dmm`

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Space on lavaland is really bad for the CPU
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed being able to make space on lavaland
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
