### PR TITLE
Reduces Autolathe cost of E-Revolver Chargepacks

### DIFF
--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -595,6 +595,7 @@
 	name = "DL-88 charge pack"
 	desc = "One-use charge pack for the DL-88 energy revolver."
 	icon_state = "handgun_ammo_battery"
+	materials = list(MAT_METAL = 20000)
 	var/charge = 1000
 
 /obj/item/ammo_box/magazine/detective/speedcharger/update_icon_state()

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -459,7 +459,7 @@
 	name = "E-revolver Charge Pack"
 	id = "e_charger"
 	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 30000, MAT_GLASS = 6000)
+	materials = list(MAT_METAL = 20000, MAT_GLASS = 6000)
 	build_path = /obj/item/ammo_box/magazine/detective/speedcharger
 	category = list("initial", "Security")
 


### PR DESCRIPTION
## What Does This PR Do
Reduces cost of E-Revolver Chargepacks to 20000 metal and 6000 glass from 30000 metal and 6000 glass.

## Why It's Good For The Game
To me it doesn't make much sense why the chargepacks are more expensive than .357 ammo, and it tends to force the detective to ask for a disabler when cargo doesn't have much in terms of materials.

## Testing
Printed more ammo than usual.

## Changelog
:cl:
tweak: E-Revolver Chargepacks are now less costly to print from autolathes.
/:cl: