### PR TITLE
Salt shaker suicide refills its salt

### DIFF
--- a/code/modules/food_and_drinks/food/condiment.dm
+++ b/code/modules/food_and_drinks/food/condiment.dm
@@ -153,6 +153,9 @@
 	user.name = newname
 	user.real_name = newname
 	desc = "Salt. From dead crew, presumably."
+	var/space = reagents.maximum_volume - reagents.total_volume
+	if(space > 0)
+		reagents.add_reagent("sodiumchloride", space)
 	return BRUTELOSS
 
 /obj/item/reagent_containers/condiment/peppermill


### PR DESCRIPTION
## What Does This PR Do
When suiciding with the salt shaker, if it has any room left, it will be filled with salt.

## Why It's Good For The Game
Adds a silly detail to an already-silly suicide action.

## Images of changes
![image](https://github.com/ParadiseSS13/Paradise/assets/98381/d122d8eb-53cd-428b-97c0-3f5ed9635323)

## Testing
Emptied 5u out of salt shaker.  Suicided.  Salt shaker was full again.

## Changelog
:cl:
tweak: The salt shaker suicide will now refill the salt shaker. Salt from dead crew indeed.
/:cl: