### PR TITLE
Removed improper \improper

### DIFF
--- a/code/game/gamemodes/cult/blood_magic.dm
+++ b/code/game/gamemodes/cult/blood_magic.dm
@@ -381,7 +381,7 @@
 
 // The "magic hand" items
 /obj/item/melee/blood_magic
-	name = "\improper magical aura"
+	name = "magical aura"
 	desc = "A sinister looking aura that distorts the flow of reality around it."
 	icon = 'icons/obj/items.dmi'
 	lefthand_file = 'icons/mob/inhands/items_lefthand.dmi'

--- a/code/game/gamemodes/wizard/godhand.dm
+++ b/code/game/gamemodes/wizard/godhand.dm
@@ -1,5 +1,5 @@
 /obj/item/melee/touch_attack
-	name = "\improper outstretched hand"
+	name = "outstretched hand"
 	desc = "High Five?"
 	var/catchphrase = "High Five!"
 	var/on_use_sound = null

--- a/code/game/machinery/computer/atmos_controllers.dm
+++ b/code/game/machinery/computer/atmos_controllers.dm
@@ -495,7 +495,7 @@ GLOBAL_LIST_EMPTY(gas_sensors)
 
 // Central atmos control //
 /obj/machinery/computer/atmoscontrol
-	name = "\improper central atmospherics computer"
+	name = "central atmospherics computer"
 	icon = 'icons/obj/computer.dmi'
 	icon_keyboard = "atmos_key"
 	icon_screen = "tank"

--- a/code/game/mecha/paintkits.dm
+++ b/code/game/mecha/paintkits.dm
@@ -22,7 +22,7 @@
 	allowed_types = list("ripley","firefighter")
 
 /obj/item/paintkit/mercenary
-	name = "\improper mercenary APLU \"Ripley\" kit"
+	name = "mercenary APLU \"Ripley\" kit"
 	desc = "A kit containing all the needed tools and parts to turn an APLU \"Ripley\" into an old Mercenaries APLU."
 	new_name = "APLU \"Strike the Earth!\""
 	new_desc = "Looks like an over worked, under maintained Ripley with some horrific damage."

--- a/code/game/objects/items/devices/camera_bug.dm
+++ b/code/game/objects/items/devices/camera_bug.dm
@@ -50,7 +50,7 @@
 	integrated_console.network = list("ERT")
 
 /obj/item/wall_bug
-	name = "\improper small camera"
+	name = "small camera"
 	desc = "A camera with a sticky backside."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "wall_bug"

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -295,7 +295,7 @@
 	frequency = 1480
 
 /obj/item/radio/intercom/locked/prison
-	name = "\improper prison intercom"
+	name = "prison intercom"
 	desc = "Talk through this. It looks like it has been modified to not broadcast."
 
 /obj/item/radio/intercom/locked/prison/New()

--- a/code/game/objects/structures/signs.dm
+++ b/code/game/objects/structures/signs.dm
@@ -232,39 +232,39 @@
 	icon_state = "kidanplaque"
 
 /obj/structure/sign/mech
-	name = "\improper mech painting"
+	name = "mech painting"
 	desc = "A painting of a mech."
 	icon_state = "mech"
 
 /obj/structure/sign/nuke
-	name = "\improper nuke painting"
+	name = "nuke painting"
 	desc = "A painting of a nuke."
 	icon_state = "nuke"
 
 /obj/structure/sign/clown
-	name = "\improper clown painting"
+	name = "clown painting"
 	desc = "A painting of the clown and mime. Awwww."
 	icon_state = "clown"
 
 /obj/structure/sign/bobross
-	name = "\improper calming painting"
+	name = "calming painting"
 	desc = "We don't make mistakes, just happy little accidents."
 	icon_state = "bob"
 
 /obj/structure/sign/singulo
-	name = "\improper singulo painting"
+	name = "singulo painting"
 	desc = "A mesmerizing painting of a singularity. It seems to suck you in..."
 	icon_state = "singulo"
 
 /obj/structure/sign/barber
-	name = "\improper barber shop sign"
+	name = "barber shop sign"
 	desc = "A spinning sign indicating a barbershop is near."
 	icon_state = "barber"
 	does_emissive = TRUE
 	blocks_emissive = FALSE
 
 /obj/structure/sign/chinese
-	name = "\improper chinese restaurant sign"
+	name = "chinese restaurant sign"
 	desc = "A glowing dragon invites you in."
 	icon_state = "chinese"
 	does_emissive = TRUE

--- a/code/game/turfs/simulated/floor/light_floor.dm
+++ b/code/game/turfs/simulated/floor/light_floor.dm
@@ -1,5 +1,5 @@
 /turf/simulated/floor/light
-	name = "\improper light floor"
+	name = "light floor"
 	light_range = 0
 	icon_state = "light_off"
 	floor_tile = /obj/item/stack/tile/light

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -312,7 +312,7 @@
 	actions_types = list(/datum/action/item_action/halt, /datum/action/item_action/selectphrase)
 
 /obj/item/clothing/mask/gas/sechailer/blue
-	name = "\improper blue SWAT mask"
+	name = "blue SWAT mask"
 	desc = "A neon blue swat mask, used for demoralizing Greytide in the wild."
 	icon_state = "blue_sechailer"
 	item_state = "blue_sechailer"

--- a/code/modules/clothing/suits/misc_suits.dm
+++ b/code/modules/clothing/suits/misc_suits.dm
@@ -173,7 +173,7 @@
 	dog_fashion = /datum/dog_fashion/back
 
 /obj/item/clothing/suit/corgisuit/en
-	name = "\improper super-hero E-N suit"
+	name = "super-hero E-N suit"
 	icon_state = "ensuit"
 
 /obj/item/clothing/suit/corgisuit/super_hero
@@ -182,7 +182,7 @@
 	flags = NODROP
 
 /obj/item/clothing/suit/corgisuit/super_hero/en
-	name = "\improper super-hero E-N suit"
+	name = "super-hero E-N suit"
 	icon_state = "ensuit"
 
 /obj/item/clothing/suit/corgisuit/super_hero/en/Initialize(mapload)

--- a/code/modules/crafting/guncrafting.dm
+++ b/code/modules/crafting/guncrafting.dm
@@ -28,84 +28,84 @@
 	var/outcome
 
 /obj/item/weaponcrafting/gunkit/nuclear
-	name = "\improper advanced energy gun parts kit"
+	name = "advanced energy gun parts kit"
 	desc = "A suitcase containing the necessary gun parts to transform a standard energy gun into an advanced energy gun."
 	origin_tech = "combat=4;magnets=4;powerstorage=4"
 	outcome = /obj/item/gun/energy/gun/nuclear
 
 /obj/item/weaponcrafting/gunkit/tesla
-	name = "\improper arc revolver parts kit"
+	name = "arc revolver parts kit"
 	desc = "A suitcase containing the necessary gun parts to construct a arc revolver around a laser rifle. Handle with care."
 	origin_tech = "combat=5;materials=5;powerstorage=5"
 	outcome = /obj/item/gun/energy/arc_revolver
 
 /obj/item/weaponcrafting/gunkit/xray
-	name = "\improper x-ray laser gun parts kit"
+	name = "x-ray laser gun parts kit"
 	desc = "A suitcase containing the necessary gun parts to turn a laser gun into a x-ray laser gun. Do not point most parts directly towards face."
 	origin_tech = "combat=6;materials=4;magnets=4;syndicate=1"
 	outcome = /obj/item/gun/energy/xray
 
 /obj/item/weaponcrafting/gunkit/ion
-	name = "\improper ion carbine parts kit"
+	name = "ion carbine parts kit"
 	desc = "A suitcase containing the necessary gun parts to transform a standard energy gun into a ion carbine."
 	origin_tech = "combat=4;magnets=4"
 	outcome = /obj/item/gun/energy/ionrifle/carbine
 
 /obj/item/weaponcrafting/gunkit/temperature
-	name = "\improper temperature gun parts kit"
+	name = "temperature gun parts kit"
 	desc = "A suitcase containing the necessary gun parts to transform a standard energy gun into a temperature gun. Fantastic at birthday parties and killing indigenious populations of Ash Walkers."
 	origin_tech = "combat=4;materials=4;powerstorage=3;magnets=2"
 	outcome = /obj/item/gun/energy/temperature
 
 /obj/item/weaponcrafting/gunkit/decloner
-	name = "\improper decloner parts kit"
+	name = "decloner parts kit"
 	desc = "An uttery baffling array of gun parts and technology that somehow turns an energy gun into a decloner. Haircut not included."
 	origin_tech = "combat=4;materials=4;biotech=5;plasmatech=6"
 	outcome = /obj/item/gun/energy/decloner
 
 /obj/item/weaponcrafting/gunkit/ebow
-	name = "\improper energy crossbow parts kit"
+	name = "energy crossbow parts kit"
 	desc = "Highly illegal weapons refurbishment kit that allows you to turn a laser gun into a near-duplicate energy crossbow. Almost like the real thing!"
 	origin_tech = "combat=4;magnets=4;syndicate=2"
 	outcome = /obj/item/gun/energy/kinetic_accelerator/crossbow/large
 
 /obj/item/weaponcrafting/gunkit/immolator
-	name = "\improper immolator laser gun parts kit"
+	name = "immolator laser gun parts kit"
 	desc = "Take a perfectly functioning laser gun. Butcher the inside of the gun so it runs hot and mean. You now have a immolator laser. You monster."
 	origin_tech = "combat=4;magnets=4;powerstorage=3"
 	outcome = /obj/item/gun/energy/immolator
 
 /obj/item/weaponcrafting/gunkit/accelerator
-	name = "\improper accelerator laser cannon parts kit"
+	name = "accelerator laser cannon parts kit"
 	desc = "A suitcase containing the necessary gun parts to transform a standard laser gun into an accelerator laser cannon."
 	origin_tech = "combat=4;magnets=4;powerstorage=3"
 	outcome = /obj/item/gun/energy/lasercannon
 
 /obj/item/weaponcrafting/gunkit/lwap
-	name = "\improper lwap laser sniper parts kit"
+	name = "lwap laser sniper parts kit"
 	desc = "A suitcase containing the necessary gun parts to transform an laser gun into an advanced piercing laser sniper. Now with wall hacks!"
 	origin_tech = "combat=6;magnets=6;powerstorage=4"
 	outcome = /obj/item/gun/energy/lwap
 
 /obj/item/weaponcrafting/gunkit/plasma
-	name = "\improper plasma pistol parts kit"
+	name = "plasma pistol parts kit"
 	desc = "A suitcase containing the necessary gun parts to transform a standard laser gun into a plasma pistol. Wort, wort, wort!"
 	origin_tech = "combat=4;magnets=4;powerstorage=3"
 	outcome = /obj/item/gun/energy/plasma_pistol
 
 /obj/item/weaponcrafting/gunkit/u_ionsilencer
-	name = "\improper u-ion silencer parts kit"
+	name = "u-ion silencer parts kit"
 	desc = "A suitcase containing the necessary gun parts to transform a standard disabler into a silenced and lethal disabling weapon. Look officer, he has no wounds from me!"
 	origin_tech = "combat=6;magnets=6;syndicate=2"
 	outcome = /obj/item/gun/energy/disabler/silencer
 
 /obj/item/weaponcrafting/gunkit/universal_gun_kit
-	name = "\improper universal self assembling gun parts kit"
+	name = "universal self assembling gun parts kit"
 	desc = "A suitcase containing the necessary gun parts to build a full gun, when combined with a gun kit. Use it directly on a gunkit to rapidly assemble it."
 	icon_state = "syndicase"
 
 /obj/item/weaponcrafting/gunkit/universal_gun_kit/sol_gov
-	name = "\improper sol gov universal self assembling gun parts kit"
+	name = "sol gov universal self assembling gun parts kit"
 	icon_state = "solcase" //Ikea reference pending.
 
 /obj/item/weaponcrafting/gunkit/universal_gun_kit/afterattack(obj/item/weaponcrafting/gunkit/gunkit_to_use, mob/user, flag)

--- a/code/modules/mob/living/simple_animal/bot/honkbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/honkbot.dm
@@ -1,5 +1,5 @@
 /mob/living/simple_animal/bot/honkbot
-	name = "\improper honkbot"
+	name = "honkbot"
 	desc = "A little robot. It looks happy with its bike horn."
 	icon = 'icons/obj/aibots.dmi'
 	icon_state = "honkbot"

--- a/code/modules/mob/living/simple_animal/friendly/dog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/dog.dm
@@ -64,7 +64,7 @@
 //Corgis and pugs are now under one dog subtype
 
 /mob/living/simple_animal/pet/dog/corgi
-	name = "\improper corgi"
+	name = "corgi"
 	real_name = "corgi"
 	desc = "It's a corgi."
 	icon_state = "corgi"
@@ -632,7 +632,7 @@
 	adjustBruteLoss(-maxHealth)
 
 /mob/living/simple_animal/pet/dog/corgi/puppy
-	name = "\improper corgi puppy"
+	name = "corgi puppy"
 	real_name = "corgi"
 	desc = "It's a corgi puppy!"
 	icon_state = "puppy"
@@ -649,7 +649,7 @@
 
 /// Tribute to the corgis born in nullspace
 /mob/living/simple_animal/pet/dog/corgi/puppy/void
-	name = "\improper void puppy"
+	name = "void puppy"
 	real_name = "voidy"
 	desc = "A corgi puppy that has been infused with deep space energy. It's staring back..."
 	icon_state = "void_puppy"
@@ -777,7 +777,7 @@
 ///Pugs
 
 /mob/living/simple_animal/pet/dog/pug
-	name = "\improper pug"
+	name = "pug"
 	real_name = "pug"
 	desc = "It's a pug."
 	icon = 'icons/mob/pets.dmi'

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -1,6 +1,6 @@
 //goat
 /mob/living/simple_animal/hostile/retaliate/goat
-	name = "\improper goat"
+	name = "goat"
 	desc = "Not known for their pleasant disposition."
 	icon_state = "goat"
 	icon_living = "goat"
@@ -109,7 +109,7 @@
 
 //cow
 /mob/living/simple_animal/cow
-	name = "\improper cow"
+	name = "cow"
 	desc = "Known for their milk, just don't tip them over."
 	icon_state = "cow"
 	icon_living = "cow"
@@ -187,7 +187,7 @@
 	return FALSE
 
 /mob/living/simple_animal/chick
-	name = "\improper chick"
+	name = "chick"
 	desc = "Adorable! They make such a racket though."
 	icon_state = "chick"
 	icon_living = "chick"
@@ -241,7 +241,7 @@
 GLOBAL_VAR_INIT(chicken_count, 0)
 
 /mob/living/simple_animal/chicken
-	name = "\improper chicken"
+	name = "chicken"
 	desc = "Hopefully the eggs are good this season."
 	gender = FEMALE
 	mob_biotypes = MOB_ORGANIC | MOB_BEAST
@@ -368,7 +368,7 @@ GLOBAL_VAR_INIT(chicken_count, 0)
 	return FALSE
 
 /mob/living/simple_animal/pig
-	name = "\improper pig"
+	name = "pig"
 	desc = "Oink oink."
 	icon_state = "pig"
 	icon_living = "pig"
@@ -394,7 +394,7 @@ GLOBAL_VAR_INIT(chicken_count, 0)
 	footstep_type = FOOTSTEP_MOB_SHOE
 
 /mob/living/simple_animal/turkey
-	name = "\improper turkey"
+	name = "turkey"
 	desc = "Benjamin Franklin would be proud."
 	icon_state = "turkey"
 	icon_living = "turkey"
@@ -419,7 +419,7 @@ GLOBAL_VAR_INIT(chicken_count, 0)
 	footstep_type = FOOTSTEP_MOB_CLAW
 
 /mob/living/simple_animal/goose
-	name = "\improper goose"
+	name = "goose"
 	desc = "A pretty goose. Would make a nice comforter."
 	icon_state = "goose"
 	icon_living = "goose"
@@ -444,7 +444,7 @@ GLOBAL_VAR_INIT(chicken_count, 0)
 	footstep_type = FOOTSTEP_MOB_CLAW
 
 /mob/living/simple_animal/seal
-	name = "\improper seal"
+	name = "seal"
 	desc = "A beautiful white seal."
 	icon_state = "seal"
 	icon_living = "seal"
@@ -469,7 +469,7 @@ GLOBAL_VAR_INIT(chicken_count, 0)
 	blood_volume = BLOOD_VOLUME_NORMAL
 
 /mob/living/simple_animal/walrus
-	name = "\improper walrus"
+	name = "walrus"
 	desc = "A big brown walrus."
 	icon_state = "walrus"
 	icon_living = "walrus"

--- a/code/modules/mob/living/simple_animal/hostile/bat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bat.dm
@@ -1,5 +1,5 @@
 /mob/living/simple_animal/hostile/scarybat
-	name = "\improper space bats"
+	name = "space bats"
 	desc = "A swarm of cute little blood sucking bats that looks pretty pissed."
 	icon = 'icons/mob/bats.dmi'
 	icon_state = "bat"

--- a/code/modules/mob/living/simple_animal/hostile/jungle_animals.dm
+++ b/code/modules/mob/living/simple_animal/hostile/jungle_animals.dm
@@ -3,7 +3,7 @@
 //*********//
 
 /mob/living/simple_animal/hostile/panther
-	name = "\improper panther"
+	name = "panther"
 	desc = "A long sleek, black cat with sharp teeth and claws."
 	icon = 'icons/mob/alienqueen.dmi'
 	icon_state = "panther"

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/fish.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/fish.dm
@@ -1,6 +1,6 @@
 
 /mob/living/simple_animal/hostile/retaliate/carp
-	name = "\improper sea carp"
+	name = "sea carp"
 	desc = "A large fish bearing similarities to a certain space-faring menace."
 	icon = 'icons/mob/carp.dmi'
 	icon_state = "carp"

--- a/code/modules/paperwork/stamps.dm
+++ b/code/modules/paperwork/stamps.dm
@@ -1,5 +1,5 @@
 /obj/item/stamp
-	name = "\improper rubber stamp"
+	name = "rubber stamp"
 	desc = "A rubber stamp for stamping important documents."
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "stamp-ok"

--- a/code/modules/power/engines/singularity/collector.dm
+++ b/code/modules/power/engines/singularity/collector.dm
@@ -5,7 +5,7 @@
 #define RAD_COLLECTOR_OUTPUT min(stored_energy, (stored_energy * RAD_COLLECTOR_STORED_OUT) + 1000) //Produces at least 1000 watts if it has more than that stored
 
 /obj/machinery/power/rad_collector
-	name = "\improper radiation collector array"
+	name = "radiation collector array"
 	desc = "A device which uses Hawking Radiation and plasma to produce power."
 	icon = 'icons/obj/singularity.dmi'
 	icon_state = "ca"

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -114,7 +114,7 @@
 
 /// Summoned by the Finger Gun spell, from advanced mimery traitor item
 /obj/item/gun/projectile/revolver/fingergun
-	name = "\improper finger gun"
+	name = "finger gun"
 	desc = "Bang bang bang!"
 	icon_state = "fingergun"
 	force = 0

--- a/code/modules/research/anomaly/anomaly.dm
+++ b/code/modules/research/anomaly/anomaly.dm
@@ -18,42 +18,42 @@
 
 //Anomaly cores
 /obj/item/assembly/signaler/anomaly/pyro
-	name = "\improper pyroclastic anomaly core"
+	name = "pyroclastic anomaly core"
 	desc = "The neutralized core of a pyroclastic anomaly. It feels warm to the touch. It'd probably be valuable for research."
 	icon_state = "pyro_core"
 	anomaly_type = /obj/effect/anomaly/pyro
 	origin_tech = "plasmatech=7"
 
 /obj/item/assembly/signaler/anomaly/cryo
-	name = "\improper cryogenic anomaly core"
+	name = "cryogenic anomaly core"
 	desc = "The neutralized core of a cryogenic anomaly. Rime is forming on its cold surface. It'd probably be valuable for research."
 	icon_state = "cryo_core"
 	anomaly_type = /obj/effect/anomaly/cryo
 	origin_tech = "biotech=7"
 
 /obj/item/assembly/signaler/anomaly/grav
-	name = "\improper gravitational anomaly core"
+	name = "gravitational anomaly core"
 	desc = "The neutralized core of a gravitational anomaly. It feels much heavier than it looks. It'd probably be valuable for research."
 	icon_state = "grav_core"
 	anomaly_type = /obj/effect/anomaly/grav
 	origin_tech = "magnets=7"
 
 /obj/item/assembly/signaler/anomaly/flux
-	name = "\improper flux anomaly core"
+	name = "flux anomaly core"
 	desc = "The neutralized core of a flux anomaly. Touching it makes your skin tingle. It'd probably be valuable for research."
 	icon_state = "flux_core"
 	anomaly_type = /obj/effect/anomaly/flux
 	origin_tech = "powerstorage=7"
 
 /obj/item/assembly/signaler/anomaly/bluespace
-	name = "\improper bluespace anomaly core"
+	name = "bluespace anomaly core"
 	desc = "The neutralized core of a bluespace anomaly. It keeps phasing in and out of view. It'd probably be valuable for research."
 	icon_state = "anomaly_core"
 	anomaly_type = /obj/effect/anomaly/bluespace
 	origin_tech = "bluespace=7"
 
 /obj/item/assembly/signaler/anomaly/vortex
-	name = "\improper vortex anomaly core"
+	name = "vortex anomaly core"
 	desc = "The neutralized core of a vortex anomaly. It won't sit still, as if some invisible force is acting on it. It'd probably be valuable for research."
 	icon_state = "vortex_core"
 	anomaly_type = /obj/effect/anomaly/bhole


### PR DESCRIPTION
## What Does This PR Do
\improper makes a capitalized word not omit "the", e.g. "You pick up CPU." (without) vs "You pick up the CPU." (with).

This makes no sense to use if the next letter isn't capitalized.  So we shouldn't.

## Why It's Good For The Game
Consistency is good.  Using BYOND features incorrectly is not.

## Testing
Compiled, spawned a random object from the list of previously-\improper objects.
`You put the pyroclastic anomaly core into the backpack.`

## Changelog
NPFC