### PR TITLE
Let MMI brains commit suicide.

### DIFF
--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -158,3 +158,7 @@
 		affected.add_autopsy_data(byitem ? "Suicide by [byitem]" : "Suicide", dmgamt)
 
 	updatehealth()
+
+/mob/living/brain/do_suicide()
+	to_chat(viewers(src), "<span class='danger'>[src] is thinking about thinking about thinking about thinking about.... It looks like [p_theyre()] trying to commit suicide.</span>")
+	death()

--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -160,5 +160,5 @@
 	updatehealth()
 
 /mob/living/brain/do_suicide()
-	to_chat(viewers(src), "<span class='danger'>[src] is thinking about thinking about thinking about thinking about.... It looks like [p_theyre()] trying to commit suicide!</span>")
+	visible_message("<span class='danger'>[src] is thinking about thinking about thinking about thinking about.... It looks like [p_theyre()] trying to commit suicide!</span>")
 	death()

--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -160,5 +160,5 @@
 	updatehealth()
 
 /mob/living/brain/do_suicide()
-	to_chat(viewers(src), "<span class='danger'>[src] is thinking about thinking about thinking about thinking about.... It looks like [p_theyre()] trying to commit suicide.</span>")
+	to_chat(viewers(src), "<span class='danger'>[src] is thinking about thinking about thinking about thinking about.... It looks like [p_theyre()] trying to commit suicide!</span>")
 	death()

--- a/code/modules/mob/living/brain/MMI.dm
+++ b/code/modules/mob/living/brain/MMI.dm
@@ -51,6 +51,9 @@
 			brainmob.forceMove(src)
 			REMOVE_TRAIT(brainmob, TRAIT_RESPAWNABLE, GHOSTED)
 			brainmob.set_stat(CONSCIOUS)
+			// If they suicided as an MMI, re-inserting them should
+			// restore their ability to suicide.
+			brainmob.suiciding = FALSE
 			brainmob.see_invisible = initial(brainmob.see_invisible)
 			GLOB.dead_mob_list -= brainmob//Update dem lists
 			GLOB.alive_mob_list += brainmob


### PR DESCRIPTION
## What Does This PR Do
At some point in the past, MMI brains could commit suicide, as evidenced by #12845.  This has been re-added, without that bug.  So, uh, fixes #12845, I guess?

## Why It's Good For The Game
Being in an MMI should not prevent players from becoming an observer.

## Testing
Spawned as robiticist.
Huffed my air tank.
Spawned a new humanoid.
Inserted roboticist brain in MMI.
Took direct control of brain mob.
Committed suicide.
Switched back to the newbie, dumped the brain, put it back.
Took direct control of brain mob again.
Committed suicide again.

## Changelog
:cl:
add: Brains in MMIs can now commit suicide.
/:cl: