### PR TITLE
Increases security of CC armory

### DIFF
--- a/_maps/map_files/generic/centcomm.dmm
+++ b/_maps/map_files/generic/centcomm.dmm
@@ -2936,7 +2936,6 @@
 /turf/simulated/floor/plasteel/dark,
 /area/syndicate_mothership)
 "ko" = (
-/obj/structure/closet/secure_closet/guncabinet,
 /obj/item/gun/energy/bsg/prebuilt{
 	pixel_x = 3;
 	pixel_y = -3
@@ -2946,6 +2945,7 @@
 	pixel_x = -3;
 	pixel_y = 3
 	},
+/obj/structure/closet/secure_closet/guncabinet/cc,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "darkred"
@@ -3214,7 +3214,6 @@
 /turf/simulated/floor/plasteel/dark,
 /area/syndicate_mothership/jail)
 "ln" = (
-/obj/structure/closet/secure_closet/guncabinet,
 /obj/item/gun/energy/immolator/multi{
 	pixel_x = -4;
 	pixel_y = 4
@@ -3224,6 +3223,7 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
+/obj/structure/closet/secure_closet/guncabinet/cc,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkred"
 	},
@@ -3854,7 +3854,6 @@
 /area/abductor_ship)
 "mX" = (
 /obj/machinery/door/window{
-	dir = 2;
 	name = "Cockpit";
 	req_access_txt = "150"
 	},
@@ -4139,15 +4138,11 @@
 /turf/simulated/floor/plasteel/freezer,
 /area/syndicate_mothership)
 "nN" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/corner,
 /turf/simulated/floor/plating/airless,
 /area/syndicate_mothership)
 "nO" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plating/airless,
 /area/syndicate_mothership)
 "nP" = (
@@ -4687,7 +4682,6 @@
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/assault_pod)
 "pT" = (
-/obj/structure/closet/secure_closet/guncabinet,
 /obj/item/gun/energy/pulse/pistol{
 	pixel_x = -3;
 	pixel_y = 3
@@ -4697,6 +4691,7 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
+/obj/structure/closet/secure_closet/guncabinet/cc,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkred"
 	},
@@ -4908,8 +4903,7 @@
 "qJ" = (
 /obj/structure/table,
 /obj/machinery/door/window/classic/normal{
-	name = "security checkpoint";
-	dir = 2
+	name = "security checkpoint"
 	},
 /turf/simulated/floor/carpet,
 /area/admin)
@@ -7909,9 +7903,7 @@
 /turf/simulated/floor/wood,
 /area/ghost_bar)
 "Cl" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plating/airless,
 /area/centcom/control)
 "Cm" = (
@@ -8482,7 +8474,6 @@
 /area/holodeck/source_basketball)
 "Ej" = (
 /obj/machinery/door/window/reinforced/normal{
-	dir = 2;
 	name = "Cell Door";
 	req_access_txt = "150"
 	},
@@ -11383,9 +11374,7 @@
 /obj/machinery/door/airlock/medical/glass{
 	name = "Escape Shuttle Infirmary"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "Of" = (
@@ -14333,8 +14322,7 @@
 "YJ" = (
 /obj/machinery/door/window/classic/normal{
 	name = "Cell B";
-	req_access_txt = "101";
-	dir = 2
+	req_access_txt = "101"
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/admin)
@@ -14487,16 +14475,6 @@
 "Ze" = (
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/transport)
-"Zg" = (
-/obj/machinery/door_control/no_emag{
-	id = "CCTELE";
-	name = "Specops Teleporter Shutters";
-	pixel_x = 24;
-	pixel_y = null;
-	req_access_txt = "114"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/centcom/specops)
 "Zi" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plasteel{
@@ -14551,7 +14529,6 @@
 /turf/simulated/wall/indestructible/riveted,
 /area/centcom/specops)
 "Zt" = (
-/obj/structure/closet/secure_closet/guncabinet,
 /obj/item/ammo_box/magazine/smgm9mm/toxin,
 /obj/item/ammo_box/magazine/smgm9mm/toxin,
 /obj/item/ammo_box/magazine/smgm9mm/toxin,
@@ -14573,6 +14550,7 @@
 	pixel_x = 6;
 	pixel_y = -6
 	},
+/obj/structure/closet/secure_closet/guncabinet/cc,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "darkred"
@@ -14586,7 +14564,6 @@
 /turf/simulated/floor/beach/coastline,
 /area/holodeck/source_beach)
 "Zw" = (
-/obj/structure/closet/secure_closet/guncabinet,
 /obj/item/gun/energy/plasma_pistol{
 	pixel_x = -3;
 	pixel_y = 3
@@ -14596,6 +14573,7 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
+/obj/structure/closet/secure_closet/guncabinet/cc,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkred"
@@ -14616,7 +14594,6 @@
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/control)
 "ZD" = (
-/obj/structure/closet/secure_closet/guncabinet,
 /obj/item/gun/energy/mindflayer{
 	pixel_x = -3;
 	pixel_y = 3
@@ -14626,6 +14603,7 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
+/obj/structure/closet/secure_closet/guncabinet/cc,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkred"
@@ -35731,7 +35709,7 @@ Ra
 Xz
 Zr
 Zm
-Zg
+Ra
 Ra
 Ra
 Ra

--- a/_maps/map_files/generic/centcomm.dmm
+++ b/_maps/map_files/generic/centcomm.dmm
@@ -1982,7 +1982,7 @@
 /turf/simulated/floor/plating,
 /area/shuttle/syndicate_sit)
 "hm" = (
-/obj/machinery/door_control/no_emag{
+/obj/machinery/door_control/no_emag/no_cyborg{
 	pixel_y = 24;
 	req_access_txt = "114";
 	name = "Engineering Storage Shutters";
@@ -13950,10 +13950,16 @@
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/specops)
 "Xo" = (
-/obj/machinery/door_control/no_emag{
-	id = "SPECOPS";
+/obj/machinery/door_control/no_emag/no_cyborg{
 	name = "Nanotrasen Asset Protection Shutters";
-	pixel_y = -24
+	req_access_txt = "114";
+	pixel_y = 24
+	},
+/obj/machinery/door_control/no_emag/no_cyborg{
+	name = "Nanotrasen Asset Protection Shutters";
+	req_access_txt = "114";
+	pixel_y = -24;
+	id = "SPECOPS"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;

--- a/_maps/map_files/generic/centcomm.dmm
+++ b/_maps/map_files/generic/centcomm.dmm
@@ -1438,6 +1438,19 @@
 /mob/living/carbon/human/monkey/magic,
 /turf/simulated/floor/wood,
 /area/wizard_station)
+"fA" = (
+/obj/machinery/mech_bay_recharge_port/upgraded/unsimulated{
+	dir = 8;
+	name = "Mech Bay Power Port"
+	},
+/obj/machinery/door_control/no_emag/no_cyborg{
+	pixel_x = 24
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "darkred"
+	},
+/area/centcom/specops)
 "fE" = (
 /obj/structure/table,
 /obj/item/storage/box/handcuffs,
@@ -7270,6 +7283,15 @@
 /obj/effect/landmark/spawner/aroomwarp,
 /turf/simulated/floor/plasteel,
 /area/admin)
+"zK" = (
+/obj/machinery/door_control/no_emag/no_cyborg{
+	pixel_x = 24;
+	req_access_txt = "114";
+	name = "Specops Teleporter Shutters";
+	id = "CCTELE"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/centcom/specops)
 "zL" = (
 /obj/machinery/economy/arcade/claw,
 /turf/simulated/floor/carpet/arcade,
@@ -35709,7 +35731,7 @@ Ra
 Xz
 Zr
 Zm
-Ra
+zK
 Ra
 Ra
 Ra
@@ -38283,7 +38305,7 @@ ZC
 ZC
 YA
 tQ
-VS
+fA
 VS
 OH
 ZT

--- a/_maps/map_files/generic/centcomm.dmm
+++ b/_maps/map_files/generic/centcomm.dmm
@@ -1438,19 +1438,6 @@
 /mob/living/carbon/human/monkey/magic,
 /turf/simulated/floor/wood,
 /area/wizard_station)
-"fA" = (
-/obj/machinery/mech_bay_recharge_port/upgraded/unsimulated{
-	dir = 8;
-	name = "Mech Bay Power Port"
-	},
-/obj/machinery/door_control/no_emag/no_cyborg{
-	pixel_x = 24
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "darkred"
-	},
-/area/centcom/specops)
 "fE" = (
 /obj/structure/table,
 /obj/item/storage/box/handcuffs,
@@ -13950,11 +13937,6 @@
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/specops)
 "Xo" = (
-/obj/machinery/door_control/no_emag/no_cyborg{
-	name = "Nanotrasen Asset Protection Shutters";
-	req_access_txt = "114";
-	pixel_y = 24
-	},
 /obj/machinery/door_control/no_emag/no_cyborg{
 	name = "Nanotrasen Asset Protection Shutters";
 	req_access_txt = "114";
@@ -38311,7 +38293,7 @@ ZC
 ZC
 YA
 tQ
-fA
+VS
 VS
 OH
 ZT

--- a/code/game/machinery/door_control.dm
+++ b/code/game/machinery/door_control.dm
@@ -138,6 +138,6 @@
 	desc = "A remote control-switch for a door. Looks strangely analog in design."
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 
-/obj/machinery/door_control/no_emag/no_cyborg/attack_ai(mob/user as mob)
+/obj/machinery/door_control/no_emag/no_cyborg/attack_ai(mob/user)
 	to_chat(user, "Error, no route to host.")
 	return

--- a/code/game/machinery/door_control.dm
+++ b/code/game/machinery/door_control.dm
@@ -133,3 +133,11 @@
 /obj/machinery/door_control/no_emag/emag_act(user as mob)
 	to_chat(user, "<span class='notice'>The electronic systems in this button are far too advanced for your primitive hacking peripherals.</span>")
 	return
+
+/obj/machinery/door_control/no_emag/no_cyborg
+	desc = "A remote control-switch for a door. Looks strangely analog in design."
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
+
+/obj/machinery/door_control/no_emag/no_cyborg/attack_ai(mob/user as mob)
+	to_chat(user, "Error, no route to host.")
+	return

--- a/code/game/machinery/door_control.dm
+++ b/code/game/machinery/door_control.dm
@@ -139,5 +139,5 @@
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 
 /obj/machinery/door_control/no_emag/no_cyborg/attack_ai(mob/user)
-	to_chat(user, "Error, no route to host.")
+	to_chat(user, "<span class='warning'>Error, no route to host.</span>")
 	return

--- a/code/game/objects/structures/crates_lockers/closets/secure/guncabinet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/guncabinet.dm
@@ -53,24 +53,4 @@
 			. += "locked"
 
 /obj/structure/closet/secure_closet/guncabinet/cc
-	name = "gun cabinet"
 	req_access = list(ACCESS_CENT_SPECOPS_COMMANDER)
-	icon = 'icons/obj/guncabinet.dmi'
-	icon_state = "base"
-	anchored = TRUE
-
-/obj/structure/closet/secure_closet/guncabinet/toggle()
-	..()
-	update_icon()
-
-/obj/structure/closet/secure_closet/guncabinet/take_contents()
-	..()
-	update_icon()
-
-/obj/structure/closet/secure_closet/guncabinet/emag_act(mob/user)
-	if(!broken)
-		broken = TRUE
-		locked = FALSE
-		to_chat(user, "<span class='notice'>You break the lock on [src].</span>")
-		update_icon()
-		return TRUE

--- a/code/game/objects/structures/crates_lockers/closets/secure/guncabinet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/guncabinet.dm
@@ -1,4 +1,4 @@
-/obj/structure/closet/secure_closest/guncabinet
+/obj/structure/closet/secure_closet/guncabinet
 	name = "gun cabinet"
 	req_access = list(ACCESS_ARMORY)
 	icon = 'icons/obj/guncabinet.dmi'
@@ -54,5 +54,3 @@
 
 /obj/structure/closet/secure_closet/guncabinet/cc
 	req_access = list(ACCESS_CENT_SPECOPS_COMMANDER)
-	icon = 'icons/obj/guncabinet.dmi'  //if this isnt here, it uses the secure locker sprite. I dont know why, but it does and this is needed.
-	icon_state = "base" // same as above

--- a/code/game/objects/structures/crates_lockers/closets/secure/guncabinet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/guncabinet.dm
@@ -51,3 +51,26 @@
 			. += "off"
 		else if(locked)
 			. += "locked"
+
+/obj/structure/closet/secure_closet/guncabinet/cc
+	name = "gun cabinet"
+	req_access = list(ACCESS_CENT_SPECOPS_COMMANDER)
+	icon = 'icons/obj/guncabinet.dmi'
+	icon_state = "base"
+	anchored = TRUE
+
+/obj/structure/closet/secure_closet/guncabinet/toggle()
+	..()
+	update_icon()
+
+/obj/structure/closet/secure_closet/guncabinet/take_contents()
+	..()
+	update_icon()
+
+/obj/structure/closet/secure_closet/guncabinet/emag_act(mob/user)
+	if(!broken)
+		broken = TRUE
+		locked = FALSE
+		to_chat(user, "<span class='notice'>You break the lock on [src].</span>")
+		update_icon()
+		return TRUE

--- a/code/game/objects/structures/crates_lockers/closets/secure/guncabinet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/guncabinet.dm
@@ -1,4 +1,4 @@
-/obj/structure/closet/secure_closet/guncabinet
+/obj/structure/closet/secure_closest/guncabinet
 	name = "gun cabinet"
 	req_access = list(ACCESS_ARMORY)
 	icon = 'icons/obj/guncabinet.dmi'
@@ -54,3 +54,5 @@
 
 /obj/structure/closet/secure_closet/guncabinet/cc
 	req_access = list(ACCESS_CENT_SPECOPS_COMMANDER)
+	icon = 'icons/obj/guncabinet.dmi'  //if this isnt here, it uses the secure locker sprite. I dont know why, but it does and this is needed.
+	icon_state = "base" // same as above


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
The button allowing access to the CC armory from the OUTSIDE has been changed to prevent cyborg usage. The gun cabinets in the armory now require NNO/SOO access to open. Additionally, the CC engineering bay, and CC bridge now require an NNO/SOO to open, and cannot be opened by cyborgs.

## Why It's Good For The Game
Admins should not need to stand by with a taser when they spawn an ERT with a cyborg to prevent the ERT from equipping themselves with gamer gear. This PR secures that button, as well as secures the cabinets in the armory if the blast door is somehow opened.


## Testing
Confirmed button was gone. Confirmed station AA could not open cabinets/shutters. Confirmed borgs can not open shutters via buttons. Confirmed ERT cannot open cabinets/shutters. Confirmed SOO/NNO CAN open the cabinets/shutters. 

## Changelog
:cl:
tweak: Increased security of CC armory
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
