### PR TITLE
Lock down research servers

### DIFF
--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -217,6 +217,10 @@
 		consoles = list()
 		servers = list()
 		for(var/obj/machinery/r_n_d/server/S in GLOB.machines)
+			if(istype(S, /obj/machinery/r_n_d/server/centcom) && !badmin)
+				continue
+			if(!atoms_share_level(get_turf(src), get_turf(S)) && !badmin)
+				continue
 			if(S.server_id == text2num(href_list["access"]) || S.server_id == text2num(href_list["data"]) || S.server_id == text2num(href_list["transfer"]))
 				temp_server = S
 				break
@@ -236,6 +240,13 @@
 
 	else if(href_list["upload_toggle"])
 		var/num = text2num(href_list["upload_toggle"])
+		for(var/obj/machinery/computer/rdconsole/C in consoles)
+			if(C.id != num)
+				continue
+
+			if(!atoms_share_level(get_turf(src), get_turf(C)) && !badmin)
+				to_chat(usr, "<span class='warning'>Unable to modify upload protocols of this console; is it in the same sector?</span>")
+				return
 		if(num in temp_server.id_with_upload)
 			temp_server.id_with_upload -= num
 		else
@@ -295,6 +306,8 @@
 
 			for(var/obj/machinery/r_n_d/server/S in GLOB.machines)
 				if(istype(S, /obj/machinery/r_n_d/server/centcom) && !badmin)
+					continue
+				if(!atoms_share_level(get_turf(src), get_turf(S)) && !badmin)
 					continue
 				dat += "[S.name] || "
 				dat += "<A href='?src=[UID()];access=[S.server_id]'>Access Rights</A> | "


### PR DESCRIPTION
## What Does This PR Do
After more that 100 years, NT has finally changed the password on their research servers.  Or maybe they cheapened out on antennas, IDK.

Regardless, non-admin R&D server controllers can no longer control R&D servers on the different Z-levels, nor can they modify the upload protocols of R&D consoles on different Z-levels. This means that the station, Theta, and the free golems can no longer steal tech from each other.  However, if any of them wish to, they can grant the others download access for the data on their own server (if any).

## Why It's Good For The Game
Stealing tech from the station is problematic both lore-wise and gameplay-wise.  On the lore end, NT really should be protecting their cutting-edge research from trivial cyber attacks.  On the gameplay end, part of the point of ghost spawns is that you're mostly on your own.  If you can convince the station to help you, great, but you shouldn't be able to easily steal from them!

## Testing
Spawned on Theta.  Deleted hivebots.  Powered up.  Deconstructed the research object to get 8s.  Built a R&D server controller.  No servers listed.  Built a server.  Listed in the controller, but got an error message when trying to add upload from the station's consoles.  Added download to the station instead.  Spawned an RD on the station.  Synced research from Theta.  Visited the server controller.  Theta's server not visible, but the stations' were.  Added download access to Theta.  Deconstructed another research object to get 9s.  Synced to station servers.  Returned to Theta.  Synced research from station.

## Changelog
:cl:
del: Non-admin R&D server controllers can no longer control R&D servers on the different Z-levels, nor can they modify the upload protocols of R&D consoles on different Z-levels. This means that the station, Theta, and the free golems can no longer steal tech from each other.  However, if any of them wish to, they can grant the others download access for the data on their own server (if any).
/:cl: