### PR TITLE
Fix simplemobs' see_through_darkness

### DIFF
--- a/code/_onclick/hud/other_mobs_hud.dm
+++ b/code/_onclick/hud/other_mobs_hud.dm
@@ -13,6 +13,8 @@
 	static_inventory += using
 	action_intent = using
 
+	user.overlay_fullscreen("see_through_darkness", /atom/movable/screen/fullscreen/see_through_darkness)
+
 
 /mob/living/simple_animal/pet/create_mob_hud()
 	if(client && !hud_used)


### PR DESCRIPTION
## What Does This PR Do
Simplemobs have a see_through_darkness variable that has been going unused because they didn't enable the overlay that makes it work.  This enables that overlay.

In effect, this grants most simplemobs a very slight amount of vision in darkness.  It's darker than a small light fixture, but you can barely see stuff now, with a larger range based on your see_through_darkness.

## Why It's Good For The Game
Humanoids already have this (most at level 2), and simplemobs have values set for it, they just seem to have forgotten to turn it on.

## Images of changes
Mouse (6):
![image](https://github.com/ParadiseSS13/Paradise/assets/98381/e32f1252-6024-4e30-b4b9-43a76ace1025)

Headslug (2):
![image](https://github.com/ParadiseSS13/Paradise/assets/98381/23b315f4-1ee8-45a2-9470-862157198d4e)

## Testing
See images.

## Changelog
:cl:
fix: Simplemobs were supposed to have slight vision in pitch black areas, like humans do, but with species-specific values. The overlay responsible for this was not activated until now.
/:cl: