### PR TITLE
replacing with correct bots list for emag in ion storm

### DIFF
--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -22,20 +22,20 @@
 
 /datum/event/ion_storm/start()
 	//AI laws
-	for(var/mob/living/silicon/ai/M in GLOB.alive_mob_list)
-		if(M.stat != DEAD && M.see_in_dark != FALSE)
+	for(var/mob/living/silicon/ai/ai_player as anything in GLOB.ai_list)
+		if(ai_player.stat != DEAD && ai_player.see_in_dark != FALSE)
 			var/message = generate_ion_law(ionMessage)
 			if(message)
-				M.add_ion_law(message)
-				to_chat(M, "<br>")
-				to_chat(M, "<span class='danger'>[message] ...LAWS UPDATED</span>")
-				to_chat(M, "<br>")
+				ai_player.add_ion_law(message)
+				to_chat(ai_player, "<br>")
+				to_chat(ai_player, "<span class='danger'>[message] ...LAWS UPDATED</span>")
+				to_chat(ai_player, "<br>")
 
-				for(var/player in GLOB.dead_mob_list)
-					to_chat(player, "<span class='deadsay'><b>[M] ([ghost_follow_link(M, player)])</b> has received an ion law:\n<b>'[message]'</b></span>")
+				for(var/ghost in GLOB.dead_mob_list)
+					to_chat(ghost, "<span class='deadsay'><b>[ai_player] ([ghost_follow_link(ai_player, ghost)])</b> has received an ion law:\n<b>'[message]'</b></span>")
 
 	if(botEmagChance)
-		for(var/mob/living/simple_animal/bot/bot in GLOB.machines)
+		for(var/mob/living/simple_animal/bot/bot as anything in GLOB.bots_list)
 			if(prob(botEmagChance))
 				bot.emag_act()
 

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -262,7 +262,8 @@
 		turn_on() //The bot automatically turns on when emagged, unless recently hit with EMP.
 		to_chat(src, "<span class='userdanger'>(#$*#$^^( OVERRIDE DETECTED</span>")
 		show_laws()
-		add_attack_logs(user, src, "Emagged")
+		if(user)
+			add_attack_logs(user, src, "Emagged")
 		return TRUE
 	else //Bot is unlocked, but the maint panel has not been opened with a screwdriver yet.
 		to_chat(user, "<span class='warning'>You need to open maintenance panel first!</span>")


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Now we check the bots for the ion storm in GLOB.bots_list and not in GLOB.machines
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Beepsky no longer considers himself a machine. I think its bugfix...
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
I started local server, trigger ion storm event, some bots are emagged
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: bots emag during an ion storm, as they should
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
