### PR TITLE
OpenDream Typemaker Prep

### DIFF
--- a/code/datums/radio_frequency.dm
+++ b/code/datums/radio_frequency.dm
@@ -1,6 +1,6 @@
 
 /datum/radio_frequency
-	var/frequency as num|null
+	var/frequency
 	var/list/obj/devices = list()
 
 /datum/radio_frequency/proc/post_signal(obj/source as obj|null, datum/signal/signal, filter = null as text|null, range = null as num|null)


### PR DESCRIPTION
## About The Pull Request

OpenDream is adding support for proc and var typechecking using `as` in https://github.com/OpenDreamProject/OpenDream/pull/1705

BYOND silently ignores most uses of `as`, but OpenDream can leverage it for static typing.

E.g. the following code will error in OpenDream while doing nothing in BYOND:
```
/datum/proc/meep() as text
    return "meep"

/datum/foobar/meep()
    return 5
```
`Warning OD2701 at code.dm:29:8: /datum/foobar/meep(): Invalid return type "num", expected "text"`

Pragmas allow these type emissions to be warnings, errors, or suppressed entirely.

This PR modifies some existing uses of `as` in Paradise to prevent `ImplicitNullType` warnings (which is when a var with a null value doesn't explicitly have the `|null` type specified). This specific pragma is a bit opinionated so it could simply be disabled, but since this has no impact on BYOND behavior I don't see a reason not to fix these examples anyways.

## Why It's Good For The Game

Typechecking.

## Changelog

no cl no fun
