### PR TITLE
Mice pull cheese wedges under doors

### DIFF
--- a/code/modules/food_and_drinks/food/foods/ingredients.dm
+++ b/code/modules/food_and_drinks/food/foods/ingredients.dm
@@ -53,6 +53,13 @@
 	filling_color = "#FFF700"
 	tastes = list("cheese" = 1)
 
+/obj/item/food/snacks/cheesewedge/checkpass(passflag)
+	if(passflag != PASSDOOR)
+		return ..()
+	if(!ismouse(pulledby))
+		return ..()
+	return TRUE
+
 /obj/item/food/snacks/cheesewedge/presliced
 	list_reagents = list("nutriment" = 3, "vitamin" = 1, "cheese" = 4)
 

--- a/code/modules/food_and_drinks/food/foods/ingredients.dm
+++ b/code/modules/food_and_drinks/food/foods/ingredients.dm
@@ -54,11 +54,9 @@
 	tastes = list("cheese" = 1)
 
 /obj/item/food/snacks/cheesewedge/checkpass(passflag)
-	if(passflag != PASSDOOR)
-		return ..()
-	if(!ismouse(pulledby))
-		return ..()
-	return TRUE
+	if(passflag == PASSDOOR && ismouse(pulledby))
+		return TRUE
+	return ..()
 
 /obj/item/food/snacks/cheesewedge/presliced
 	list_reagents = list("nutriment" = 3, "vitamin" = 1, "cheese" = 4)

--- a/code/modules/food_and_drinks/food/foods/ingredients.dm
+++ b/code/modules/food_and_drinks/food/foods/ingredients.dm
@@ -54,7 +54,7 @@
 	tastes = list("cheese" = 1)
 
 /obj/item/food/snacks/cheesewedge/checkpass(passflag)
-	if(passflag & PASSDOOR && ismouse(pulledby))
+	if((passflag & PASSDOOR) && ismouse(pulledby))
 		return TRUE
 	return ..()
 

--- a/code/modules/food_and_drinks/food/foods/ingredients.dm
+++ b/code/modules/food_and_drinks/food/foods/ingredients.dm
@@ -54,7 +54,7 @@
 	tastes = list("cheese" = 1)
 
 /obj/item/food/snacks/cheesewedge/checkpass(passflag)
-	if(passflag == PASSDOOR && ismouse(pulledby))
+	if(passflag & PASSDOOR && ismouse(pulledby))
 		return TRUE
 	return ..()
 


### PR DESCRIPTION
## What Does This PR Do
Mice can now pull cheese wedges under doors

## Why It's Good For The Game
Minor QOL for the humblest of station pets.

## Testing
Spawned as mouse. Spawned cheese wedge. Pulled it under a door.
Spawned a grille. Could not pull it under the grille.
Spawned a skrell with PASSDOOR. Could not pull cheese wedge under a door or a grille.

## Changelog
:cl:
add: The station's mice have learned how to sneak cheese wedges under a door.
/:cl: