### PR TITLE
Improves the admin room

### DIFF
--- a/_maps/map_files/generic/centcomm.dmm
+++ b/_maps/map_files/generic/centcomm.dmm
@@ -6036,7 +6036,6 @@
 	name = "Lockdown";
 	pixel_y = 24
 	},
-/obj/item/bio_chip_implanter/uplink/admin,
 /turf/simulated/floor/carpet,
 /area/admin)
 "uz" = (

--- a/_maps/map_files/generic/centcomm.dmm
+++ b/_maps/map_files/generic/centcomm.dmm
@@ -7343,7 +7343,9 @@
 /area/admin)
 "Ac" = (
 /obj/structure/table/wood/fancy/royalblack,
-/obj/item/butcher_chainsaw,
+/obj/item/radio/uplink/admin{
+	name = "admin uplink"
+	},
 /turf/simulated/floor/carpet/royalblack,
 /area/admin)
 "Ad" = (

--- a/_maps/map_files/generic/centcomm.dmm
+++ b/_maps/map_files/generic/centcomm.dmm
@@ -2676,10 +2676,6 @@
 /obj/machinery/recharger,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/syndicate)
-"jw" = (
-/obj/item/bio_chip_implanter/uplink/admin,
-/turf/space,
-/area/space/centcomm)
 "jx" = (
 /obj/structure/table,
 /obj/item/screwdriver{
@@ -6040,6 +6036,7 @@
 	name = "Lockdown";
 	pixel_y = 24
 	},
+/obj/item/bio_chip_implanter/uplink/admin,
 /turf/simulated/floor/carpet,
 /area/admin)
 "uz" = (
@@ -7347,7 +7344,7 @@
 /area/admin)
 "Ac" = (
 /obj/structure/table/wood/fancy/royalblack,
-/obj/item/bio_chip_implanter/uplink/admin,
+/obj/item/butcher_chainsaw,
 /turf/simulated/floor/carpet/royalblack,
 /area/admin)
 "Ad" = (
@@ -78146,7 +78143,7 @@ aN
 aN
 aN
 aN
-jw
+aN
 aN
 aN
 aN

--- a/_maps/map_files/generic/centcomm.dmm
+++ b/_maps/map_files/generic/centcomm.dmm
@@ -7343,9 +7343,7 @@
 /area/admin)
 "Ac" = (
 /obj/structure/table/wood/fancy/royalblack,
-/obj/item/radio/uplink/admin{
-	name = "admin uplink"
-	},
+/obj/item/radio/uplink/admin,
 /turf/simulated/floor/carpet/royalblack,
 /area/admin)
 "Ad" = (

--- a/_maps/map_files/generic/centcomm.dmm
+++ b/_maps/map_files/generic/centcomm.dmm
@@ -1350,6 +1350,11 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/syndicate_mothership/jail)
+"fl" = (
+/obj/structure/table/wood/fancy/purple,
+/obj/item/gun/magic/staff,
+/turf/simulated/floor/carpet,
+/area/admin)
 "fm" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -4086,11 +4091,6 @@
 /obj/structure/flora/junglebush,
 /turf/simulated/floor/grass/jungle,
 /area/centcom/evac)
-"nD" = (
-/obj/item/gun/magic/wand/death/debug,
-/obj/structure/table/wood/fancy/purple,
-/turf/simulated/floor/carpet,
-/area/admin)
 "nF" = (
 /obj/structure/table/wood,
 /obj/item/folder/red,
@@ -4268,14 +4268,16 @@
 /turf/simulated/floor/grass/jungle,
 /area/centcom/evac)
 "oi" = (
-/obj/structure/table/wood/fancy/royalblack,
-/obj/item/gun/projectile/automatic/pistol,
-/turf/simulated/floor/carpet/royalblack,
+/obj/structure/table/wood/fancy/purple,
+/obj/item/reagent_containers/drinks/mugwort,
+/turf/simulated/floor/carpet,
 /area/admin)
 "oj" = (
-/obj/structure/table/wood/fancy/royalblue,
-/obj/item/reagent_containers/drinks/cans/adminbooze,
-/turf/simulated/floor/plasteel,
+/obj/machinery/door/airlock/hatch{
+	desc = "For all your shady business needs";
+	name = "Gambling Den"
+	},
+/turf/space,
 /area/admin)
 "ol" = (
 /obj/structure/chair/comfy/black{
@@ -4495,11 +4497,6 @@
 "pc" = (
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/trade/sol)
-"pd" = (
-/obj/item/debug/human_spawner,
-/obj/structure/table/wood/fancy/purple,
-/turf/simulated/floor/carpet,
-/area/admin)
 "pe" = (
 /obj/structure/table/wood,
 /obj/item/folder/red,
@@ -5411,6 +5408,11 @@
 	},
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/trade/sol)
+"si" = (
+/obj/item/gun/magic/wand/death/debug,
+/obj/structure/table/wood/fancy/purple,
+/turf/simulated/floor/carpet,
+/area/admin)
 "sj" = (
 /turf/simulated/floor/plasteel/dark,
 /area/tdome/tdomeadmin)
@@ -5553,18 +5555,19 @@
 /obj/effect/turf_decal/delivery/red/hollow,
 /turf/simulated/floor/plasteel/dark,
 /area/syndicate_mothership)
-"sN" = (
-/obj/item/spellbook{
-	name = "admin spell book";
-	uses = 1000
-	},
-/obj/structure/table/wood/fancy/purple,
-/turf/simulated/floor/carpet,
-/area/admin)
 "sO" = (
 /obj/structure/sign/goldenplaque,
 /turf/simulated/wall/indestructible/riveted,
 /area/ghost_bar)
+"sP" = (
+/obj/structure/table/wood/fancy/royalblack,
+/obj/item/melee/energy/sword,
+/obj/item/melee/energy/sword{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/turf/simulated/floor/carpet/royalblack,
+/area/admin)
 "sQ" = (
 /obj/machinery/computer/mech_bay_power_console,
 /turf/simulated/floor/plasteel/dark,
@@ -6941,9 +6944,9 @@
 /turf/simulated/wall/indestructible/fakeglass,
 /area/centcom/suppy)
 "xK" = (
-/obj/structure/table/wood/fancy/purple,
-/obj/item/reagent_containers/drinks/mugwort,
-/turf/simulated/floor/carpet,
+/obj/item/bodyanalyzer/debug,
+/obj/structure/table/wood/fancy/royalblack,
+/turf/simulated/floor/carpet/royalblack,
 /area/admin)
 "xM" = (
 /obj/machinery/computer/shuttle/admin{
@@ -7339,13 +7342,16 @@
 /turf/simulated/floor/plasteel/dark,
 /area/admin)
 "Ac" = (
-/obj/item/bodyanalyzer/debug,
-/obj/structure/table/wood/fancy/royalblack,
-/turf/simulated/floor/carpet/royalblack,
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
 /area/admin)
 "Ad" = (
-/obj/item/clothing/glasses/hud/debug,
 /obj/structure/table/wood/fancy/royalblack,
+/obj/item/radio/uplink/admin{
+	name = "admin uplink"
+	},
 /turf/simulated/floor/carpet/royalblack,
 /area/admin)
 "Ae" = (
@@ -7461,11 +7467,12 @@
 /turf/simulated/floor/plasteel,
 /area/admin)
 "As" = (
-/obj/machinery/door/airlock/hatch{
-	desc = "For all your shady business needs";
-	name = "Gambling Den"
+/obj/item/spellbook{
+	name = "admin spell book";
+	uses = 1000
 	},
-/turf/simulated/wall/indestructible/syndicate,
+/obj/structure/table/wood/fancy/purple,
+/turf/simulated/floor/carpet,
 /area/admin)
 "At" = (
 /obj/structure/chair/comfy/black{
@@ -7475,7 +7482,7 @@
 /area/admin)
 "Au" = (
 /obj/structure/table/wood/fancy/royalblack,
-/obj/item/gun/projectile/revolver,
+/obj/item/gun/projectile/automatic/pistol,
 /turf/simulated/floor/carpet/royalblack,
 /area/admin)
 "Av" = (
@@ -7500,11 +7507,6 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/ghost_bar)
-"AD" = (
-/obj/item/gun/magic/wand/resurrection/debug,
-/obj/structure/table/wood/fancy/purple,
-/turf/simulated/floor/carpet,
-/area/admin)
 "AE" = (
 /obj/item/paper/monitorkey,
 /obj/machinery/computer/message_monitor{
@@ -7796,12 +7798,6 @@
 /obj/structure/musician/piano,
 /turf/simulated/floor/wood,
 /area/ghost_bar)
-"BK" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/admin)
 "BL" = (
 /obj/machinery/light/spot{
 	dir = 8
@@ -7852,13 +7848,6 @@
 "BZ" = (
 /turf/simulated/wall/indestructible/opsglass,
 /area/syndicate_mothership)
-"Ca" = (
-/obj/structure/table/wood/fancy/royalblack,
-/obj/item/radio/uplink/admin{
-	name = "admin uplink"
-	},
-/turf/simulated/floor/carpet/royalblack,
-/area/admin)
 "Cb" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/grassybush,
@@ -8117,6 +8106,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/control)
+"CL" = (
+/obj/item/debug/human_spawner,
+/obj/structure/table/wood/fancy/purple,
+/turf/simulated/floor/carpet,
+/area/admin)
 "CM" = (
 /obj/machinery/door/airlock/external{
 	name = "Supply Shuttle";
@@ -10229,15 +10223,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/control)
-"Kj" = (
-/obj/structure/table/wood/fancy/royalblack,
-/obj/item/melee/energy/sword,
-/obj/item/melee/energy/sword{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/turf/simulated/floor/carpet/royalblack,
-/area/admin)
 "Km" = (
 /obj/machinery/kitchen_machine/microwave/upgraded,
 /obj/structure/table,
@@ -12493,6 +12478,11 @@
 /obj/item/storage/fancy/donut_box,
 /turf/simulated/floor/wood,
 /area/centcom/control)
+"RJ" = (
+/obj/structure/table/wood/fancy/royalblack,
+/obj/item/gun/projectile/revolver,
+/turf/simulated/floor/carpet/royalblack,
+/area/admin)
 "RK" = (
 /turf/simulated/floor/carpet/arcade,
 /area/ghost_bar)
@@ -12782,6 +12772,11 @@
 	icon_state = "blue"
 	},
 /area/holodeck/source_knightarena)
+"SZ" = (
+/obj/item/gun/magic/wand/resurrection/debug,
+/obj/structure/table/wood/fancy/purple,
+/turf/simulated/floor/carpet,
+/area/admin)
 "Ta" = (
 /turf/simulated/wall/indestructible/riveted,
 /area/tdome/arena)
@@ -12797,11 +12792,6 @@
 	icon_state = "bar"
 	},
 /area/tdome/tdomeobserve)
-"Ti" = (
-/obj/structure/table/wood/fancy/purple,
-/obj/item/gun/magic/staff,
-/turf/simulated/floor/carpet,
-/area/admin)
 "Tj" = (
 /obj/structure/chair/stool{
 	dir = 4
@@ -13213,6 +13203,11 @@
 "UK" = (
 /turf/simulated/floor/holofloor/carpet,
 /area/holodeck/source_theatre)
+"UL" = (
+/obj/item/clothing/glasses/hud/debug,
+/obj/structure/table/wood/fancy/royalblack,
+/turf/simulated/floor/carpet/royalblack,
+/area/admin)
 "UM" = (
 /obj/structure/flora/grass/brown,
 /turf/simulated/floor/holofloor{
@@ -14403,6 +14398,11 @@
 /obj/structure/railing,
 /turf/simulated/floor/plasteel,
 /area/centcom/evac)
+"YP" = (
+/obj/structure/table/wood/fancy/royalblue,
+/obj/item/reagent_containers/drinks/cans/adminbooze,
+/turf/simulated/floor/plasteel,
+/area/admin)
 "YR" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -68885,8 +68885,8 @@ lZ
 lZ
 nq
 wk
-oj
-BK
+YP
+Ac
 wk
 qL
 lZ
@@ -75067,7 +75067,7 @@ wk
 wk
 zM
 zM
-As
+oj
 wk
 wk
 wk
@@ -75319,14 +75319,14 @@ aN
 aN
 aN
 wk
-nD
-AD
-pd
+si
+SZ
+CL
 uz
 vK
 wZ
-Ad
-Ac
+UL
+xK
 Av
 wk
 aN
@@ -76869,7 +76869,7 @@ vK
 wZ
 wZ
 wZ
-Au
+RJ
 lH
 aN
 aN
@@ -77118,7 +77118,7 @@ aN
 aN
 aN
 wk
-Ti
+fl
 uz
 uz
 uz
@@ -77126,7 +77126,7 @@ vK
 wZ
 wZ
 wZ
-oi
+Au
 wk
 aN
 aN
@@ -77375,15 +77375,15 @@ aN
 aN
 aN
 wk
-xK
-sN
+oi
+As
 uz
 uz
 vK
 wZ
 wZ
-Ca
-Kj
+Ad
+sP
 wk
 aN
 aN

--- a/_maps/map_files/generic/centcomm.dmm
+++ b/_maps/map_files/generic/centcomm.dmm
@@ -4263,23 +4263,14 @@
 /turf/simulated/floor/grass/jungle,
 /area/centcom/evac)
 "oi" = (
-/obj/machinery/door/airlock/external{
-	req_access_txt = "114"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "ADMINLOCKDOWN";
-	name = "Security Doors";
-	opacity = 0
+/obj/structure/chair/wood{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/admin)
 "oj" = (
-/obj/machinery/door/airlock/centcom/glass{
-	name = "External Airlock";
-	req_access_txt = "114"
-	},
+/obj/structure/table/wood/fancy/royalblue,
+/obj/item/reagent_containers/drinks/cans/adminbooze,
 /turf/simulated/floor/plasteel,
 /area/admin)
 "ol" = (
@@ -67804,11 +67795,11 @@ aN
 aN
 aN
 aN
-wk
-wk
-oi
-wk
-wk
+aN
+aN
+aN
+aN
+aN
 aN
 aN
 aN
@@ -68062,9 +68053,9 @@ aN
 wk
 aN
 aN
-wk
-lZ
-wk
+aN
+aN
+aN
 aN
 aN
 aN
@@ -68319,10 +68310,10 @@ lH
 wk
 wk
 wk
-wk
-oj
-wk
-wk
+aN
+aN
+aN
+aN
 aN
 aN
 aN
@@ -68576,8 +68567,8 @@ mx
 mU
 nm
 wk
-wk
-lZ
+lH
+lH
 wk
 wk
 lH
@@ -68833,8 +68824,8 @@ lZ
 lZ
 nq
 wk
-lZ
-lZ
+oj
+oi
 wk
 qL
 lZ

--- a/_maps/map_files/generic/centcomm.dmm
+++ b/_maps/map_files/generic/centcomm.dmm
@@ -3854,7 +3854,6 @@
 /area/abductor_ship)
 "mX" = (
 /obj/machinery/door/window{
-	dir = 2;
 	name = "Cockpit";
 	req_access_txt = "150"
 	},
@@ -4139,15 +4138,11 @@
 /turf/simulated/floor/plasteel/freezer,
 /area/syndicate_mothership)
 "nN" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/corner,
 /turf/simulated/floor/plating/airless,
 /area/syndicate_mothership)
 "nO" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plating/airless,
 /area/syndicate_mothership)
 "nP" = (
@@ -4268,7 +4263,9 @@
 /turf/simulated/floor/grass/jungle,
 /area/centcom/evac)
 "oi" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external{
+	req_access_txt = "114"
+	},
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "open";
@@ -4279,8 +4276,9 @@
 /turf/simulated/floor/plasteel,
 /area/admin)
 "oj" = (
-/obj/machinery/door/airlock/hatch{
-	name = "External Airlock"
+/obj/machinery/door/airlock/centcom/glass{
+	name = "External Airlock";
+	req_access_txt = "114"
 	},
 /turf/simulated/floor/plasteel,
 /area/admin)
@@ -4908,8 +4906,7 @@
 "qJ" = (
 /obj/structure/table,
 /obj/machinery/door/window/classic/normal{
-	name = "security checkpoint";
-	dir = 2
+	name = "security checkpoint"
 	},
 /turf/simulated/floor/carpet,
 /area/admin)
@@ -7909,9 +7906,7 @@
 /turf/simulated/floor/wood,
 /area/ghost_bar)
 "Cl" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plating/airless,
 /area/centcom/control)
 "Cm" = (
@@ -8482,7 +8477,6 @@
 /area/holodeck/source_basketball)
 "Ej" = (
 /obj/machinery/door/window/reinforced/normal{
-	dir = 2;
 	name = "Cell Door";
 	req_access_txt = "150"
 	},
@@ -11383,9 +11377,7 @@
 /obj/machinery/door/airlock/medical/glass{
 	name = "Escape Shuttle Infirmary"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "Of" = (
@@ -14333,8 +14325,7 @@
 "YJ" = (
 /obj/machinery/door/window/classic/normal{
 	name = "Cell B";
-	req_access_txt = "101";
-	dir = 2
+	req_access_txt = "101"
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/admin)
@@ -30318,9 +30309,9 @@ aN
 aN
 aN
 YA
-YN
-YN
-YN
+sm
+sm
+sm
 YA
 Te
 JD
@@ -30574,7 +30565,7 @@ aN
 aN
 aN
 aN
-YN
+sm
 EW
 Gd
 GR
@@ -30831,7 +30822,7 @@ aN
 aN
 aN
 aN
-YN
+sm
 vt
 vt
 vt
@@ -31088,7 +31079,7 @@ aN
 aN
 aN
 aN
-YN
+sm
 vt
 vt
 vt
@@ -31345,7 +31336,7 @@ aN
 aN
 aN
 aN
-YN
+sm
 EZ
 Ge
 vt

--- a/_maps/map_files/generic/centcomm.dmm
+++ b/_maps/map_files/generic/centcomm.dmm
@@ -6785,6 +6785,10 @@
 /area/admin)
 "wZ" = (
 /obj/structure/table/wood/fancy/purple,
+/obj/item/spellbook{
+	uses = 250;
+	name = "admin spell book"
+	},
 /turf/simulated/floor/carpet,
 /area/admin)
 "xa" = (

--- a/_maps/map_files/generic/centcomm.dmm
+++ b/_maps/map_files/generic/centcomm.dmm
@@ -7343,6 +7343,9 @@
 /area/admin)
 "Ac" = (
 /obj/structure/table/wood/fancy/royalblack,
+/obj/item/radio/uplink/admin{
+	name = "admin uplink"
+	},
 /turf/simulated/floor/carpet/royalblack,
 /area/admin)
 "Ad" = (

--- a/_maps/map_files/generic/centcomm.dmm
+++ b/_maps/map_files/generic/centcomm.dmm
@@ -4086,6 +4086,11 @@
 /obj/structure/flora/junglebush,
 /turf/simulated/floor/grass/jungle,
 /area/centcom/evac)
+"nD" = (
+/obj/item/gun/magic/wand/death/debug,
+/obj/structure/table/wood/fancy/purple,
+/turf/simulated/floor/carpet,
+/area/admin)
 "nF" = (
 /obj/structure/table/wood,
 /obj/item/folder/red,
@@ -4263,10 +4268,9 @@
 /turf/simulated/floor/grass/jungle,
 /area/centcom/evac)
 "oi" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
+/obj/structure/table/wood/fancy/royalblack,
+/obj/item/gun/projectile/automatic/pistol,
+/turf/simulated/floor/carpet/royalblack,
 /area/admin)
 "oj" = (
 /obj/structure/table/wood/fancy/royalblue,
@@ -4491,6 +4495,11 @@
 "pc" = (
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/trade/sol)
+"pd" = (
+/obj/item/debug/human_spawner,
+/obj/structure/table/wood/fancy/purple,
+/turf/simulated/floor/carpet,
+/area/admin)
 "pe" = (
 /obj/structure/table/wood,
 /obj/item/folder/red,
@@ -5544,6 +5553,14 @@
 /obj/effect/turf_decal/delivery/red/hollow,
 /turf/simulated/floor/plasteel/dark,
 /area/syndicate_mothership)
+"sN" = (
+/obj/item/spellbook{
+	name = "admin spell book";
+	uses = 1000
+	},
+/obj/structure/table/wood/fancy/purple,
+/turf/simulated/floor/carpet,
+/area/admin)
 "sO" = (
 /obj/structure/sign/goldenplaque,
 /turf/simulated/wall/indestructible/riveted,
@@ -6779,7 +6796,7 @@
 /turf/simulated/floor/plasteel/freezer,
 /area/admin)
 "wZ" = (
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/royalblack,
 /area/admin)
 "xa" = (
 /obj/structure/toilet{
@@ -6924,8 +6941,9 @@
 /turf/simulated/wall/indestructible/fakeglass,
 /area/centcom/suppy)
 "xK" = (
-/obj/structure/chair/comfy/black,
-/turf/simulated/floor/wood,
+/obj/structure/table/wood/fancy/purple,
+/obj/item/reagent_containers/drinks/mugwort,
+/turf/simulated/floor/carpet,
 /area/admin)
 "xM" = (
 /obj/machinery/computer/shuttle/admin{
@@ -7321,13 +7339,14 @@
 /turf/simulated/floor/plasteel/dark,
 /area/admin)
 "Ac" = (
-/obj/structure/table/wood,
-/turf/simulated/floor/wood,
+/obj/item/bodyanalyzer/debug,
+/obj/structure/table/wood/fancy/royalblack,
+/turf/simulated/floor/carpet/royalblack,
 /area/admin)
 "Ad" = (
-/obj/structure/table/wood,
-/obj/item/deck/cards/syndicate,
-/turf/simulated/floor/wood,
+/obj/item/clothing/glasses/hud/debug,
+/obj/structure/table/wood/fancy/royalblack,
+/turf/simulated/floor/carpet/royalblack,
 /area/admin)
 "Ae" = (
 /obj/structure/table/wood,
@@ -7442,9 +7461,11 @@
 /turf/simulated/floor/plasteel,
 /area/admin)
 "As" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/drinks/drinkingglass/devilskiss,
-/turf/simulated/floor/wood,
+/obj/machinery/door/airlock/hatch{
+	desc = "For all your shady business needs";
+	name = "Gambling Den"
+	},
+/turf/simulated/wall/indestructible/syndicate,
 /area/admin)
 "At" = (
 /obj/structure/chair/comfy/black{
@@ -7453,14 +7474,15 @@
 /turf/simulated/floor/plasteel,
 /area/admin)
 "Au" = (
-/obj/structure/chair/stool,
-/turf/simulated/floor/wood,
+/obj/structure/table/wood/fancy/royalblack,
+/obj/item/gun/projectile/revolver,
+/turf/simulated/floor/carpet/royalblack,
 /area/admin)
 "Av" = (
-/obj/structure/table/wood,
-/obj/item/lighter/zippo/engraved,
-/obj/item/storage/fancy/cigarettes/dromedaryco,
-/turf/simulated/floor/wood,
+/obj/structure/table/wood/fancy/royalblack,
+/obj/item/soap/syndie/debug,
+/obj/item/reagent_containers/spray/cleaner/advanced/debug,
+/turf/simulated/floor/carpet/royalblack,
 /area/admin)
 "Aw" = (
 /obj/machinery/computer/communications{
@@ -7478,6 +7500,11 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/ghost_bar)
+"AD" = (
+/obj/item/gun/magic/wand/resurrection/debug,
+/obj/structure/table/wood/fancy/purple,
+/turf/simulated/floor/carpet,
+/area/admin)
 "AE" = (
 /obj/item/paper/monitorkey,
 /obj/machinery/computer/message_monitor{
@@ -7769,6 +7796,12 @@
 /obj/structure/musician/piano,
 /turf/simulated/floor/wood,
 /area/ghost_bar)
+"BK" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/admin)
 "BL" = (
 /obj/machinery/light/spot{
 	dir = 8
@@ -7819,6 +7852,13 @@
 "BZ" = (
 /turf/simulated/wall/indestructible/opsglass,
 /area/syndicate_mothership)
+"Ca" = (
+/obj/structure/table/wood/fancy/royalblack,
+/obj/item/radio/uplink/admin{
+	name = "admin uplink"
+	},
+/turf/simulated/floor/carpet/royalblack,
+/area/admin)
 "Cb" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/grassybush,
@@ -10189,6 +10229,15 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/control)
+"Kj" = (
+/obj/structure/table/wood/fancy/royalblack,
+/obj/item/melee/energy/sword,
+/obj/item/melee/energy/sword{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/turf/simulated/floor/carpet/royalblack,
+/area/admin)
 "Km" = (
 /obj/machinery/kitchen_machine/microwave/upgraded,
 /obj/structure/table,
@@ -12748,6 +12797,11 @@
 	icon_state = "bar"
 	},
 /area/tdome/tdomeobserve)
+"Ti" = (
+/obj/structure/table/wood/fancy/purple,
+/obj/item/gun/magic/staff,
+/turf/simulated/floor/carpet,
+/area/admin)
 "Tj" = (
 /obj/structure/chair/stool{
 	dir = 4
@@ -14479,6 +14533,13 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/specops)
+"Zh" = (
+/obj/structure/table/wood/fancy/purple,
+/obj/item/clothing/shoes/sandal/magic,
+/obj/item/clothing/suit/wizrobe,
+/obj/item/clothing/head/wizard,
+/turf/simulated/floor/carpet,
+/area/admin)
 "Zi" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plasteel{
@@ -68825,7 +68886,7 @@ lZ
 nq
 wk
 oj
-oi
+BK
 wk
 qL
 lZ
@@ -74749,7 +74810,7 @@ wk
 wk
 lZ
 lZ
-wk
+lZ
 wk
 wk
 wk
@@ -75000,13 +75061,13 @@ wk
 wk
 lH
 lH
-lH
+wk
 wk
 wk
 wk
 zM
 zM
-wk
+As
 wk
 wk
 wk
@@ -75257,17 +75318,17 @@ aN
 aN
 aN
 aN
-aN
-aN
 wk
-wk
+nD
+AD
+pd
+uz
+vK
 wZ
-wZ
+Ad
+Ac
+Av
 wk
-wk
-aN
-aN
-aN
 aN
 aN
 aN
@@ -75514,17 +75575,17 @@ aN
 aN
 aN
 aN
-aN
-aN
-aN
-lH
+wk
+uz
+uz
+uz
+uz
+vK
+wZ
+wZ
 wZ
 wZ
 wk
-aN
-aN
-aN
-aN
 aN
 aN
 aN
@@ -75771,17 +75832,17 @@ aN
 aN
 aN
 aN
-aN
-aN
-wk
-wk
+lH
+uz
+uz
+uz
+uz
+vK
 wZ
 wZ
-wk
-wk
-aN
-aN
-aN
+wZ
+wZ
+lH
 aN
 aN
 aN
@@ -76028,17 +76089,17 @@ aN
 aN
 aN
 aN
-aN
 wk
-wk
-wk
+uz
+uz
+uz
+uz
+vK
+wZ
+wZ
 wZ
 wZ
 wk
-wk
-wk
-aN
-aN
 aN
 aN
 aN
@@ -76286,16 +76347,16 @@ aN
 aN
 aN
 wk
-wk
-wk
+uz
+uz
+uz
+uz
+vK
 wZ
 wZ
 wZ
 wZ
 wk
-wk
-wk
-aN
 aN
 aN
 aN
@@ -76543,16 +76604,16 @@ aN
 aN
 aN
 wk
+uz
+uz
+uz
+uz
+vK
+wZ
+wZ
+wZ
+wZ
 wk
-wZ
-wZ
-wZ
-Au
-wZ
-wZ
-wk
-wk
-aN
 aN
 aN
 aN
@@ -76800,16 +76861,16 @@ aN
 aN
 aN
 lH
+Zh
+uz
+uz
+uz
+vK
 wZ
 wZ
 wZ
-Ac
-Av
 Au
-wZ
-wZ
 lH
-aN
 aN
 aN
 aN
@@ -77056,17 +77117,17 @@ aN
 aN
 aN
 aN
-lH
+wk
+Ti
+uz
+uz
+uz
+vK
 wZ
 wZ
-xK
-Ad
-Ac
-Au
 wZ
-wZ
-lH
-aN
+oi
+wk
 aN
 aN
 aN
@@ -77313,17 +77374,17 @@ aN
 aN
 aN
 aN
-lH
+wk
+xK
+sN
+uz
+uz
+vK
 wZ
 wZ
-wZ
-As
-Ac
-Au
-wZ
-wZ
-lH
-aN
+Ca
+Kj
+wk
 aN
 aN
 aN
@@ -77572,15 +77633,15 @@ aN
 aN
 wk
 wk
-wZ
-wZ
-wZ
-Au
-wZ
-wZ
+wk
+lH
 wk
 wk
-aN
+wk
+lH
+wk
+wk
+wk
 aN
 aN
 aN
@@ -77827,16 +77888,16 @@ aN
 aN
 aN
 aN
-wk
-wk
-wk
-wZ
-wZ
-wZ
-wZ
-wk
-wk
-wk
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
 aN
 aN
 aN
@@ -78085,14 +78146,14 @@ aN
 aN
 aN
 aN
-wk
-wk
-wk
-wZ
-wZ
-wk
-wk
-wk
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
 aN
 aN
 aN
@@ -78343,12 +78404,12 @@ aN
 aN
 aN
 aN
-wk
-wk
-lH
-lH
-wk
-wk
+aN
+aN
+aN
+aN
+aN
+aN
 aN
 aN
 aN

--- a/_maps/map_files/generic/centcomm.dmm
+++ b/_maps/map_files/generic/centcomm.dmm
@@ -1350,11 +1350,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/syndicate_mothership/jail)
-"fl" = (
-/obj/structure/table/wood/fancy/purple,
-/obj/item/gun/magic/staff,
-/turf/simulated/floor/carpet,
-/area/admin)
 "fm" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -3214,6 +3209,12 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/ghost_bar)
+"lk" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/admin)
 "lm" = (
 /obj/structure/chair/office/dark,
 /turf/simulated/floor/plasteel/dark,
@@ -4268,16 +4269,14 @@
 /turf/simulated/floor/grass/jungle,
 /area/centcom/evac)
 "oi" = (
+/obj/item/gun/magic/wand/death/debug,
 /obj/structure/table/wood/fancy/purple,
-/obj/item/reagent_containers/drinks/mugwort,
 /turf/simulated/floor/carpet,
 /area/admin)
 "oj" = (
-/obj/machinery/door/airlock/hatch{
-	desc = "For all your shady business needs";
-	name = "Gambling Den"
-	},
-/turf/space,
+/obj/item/clothing/glasses/hud/debug,
+/obj/structure/table/wood/fancy/royalblack,
+/turf/simulated/floor/carpet/royalblack,
 /area/admin)
 "ol" = (
 /obj/structure/chair/comfy/black{
@@ -5408,11 +5407,6 @@
 	},
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/trade/sol)
-"si" = (
-/obj/item/gun/magic/wand/death/debug,
-/obj/structure/table/wood/fancy/purple,
-/turf/simulated/floor/carpet,
-/area/admin)
 "sj" = (
 /turf/simulated/floor/plasteel/dark,
 /area/tdome/tdomeadmin)
@@ -5559,15 +5553,6 @@
 /obj/structure/sign/goldenplaque,
 /turf/simulated/wall/indestructible/riveted,
 /area/ghost_bar)
-"sP" = (
-/obj/structure/table/wood/fancy/royalblack,
-/obj/item/melee/energy/sword,
-/obj/item/melee/energy/sword{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/turf/simulated/floor/carpet/royalblack,
-/area/admin)
 "sQ" = (
 /obj/machinery/computer/mech_bay_power_console,
 /turf/simulated/floor/plasteel/dark,
@@ -6799,7 +6784,12 @@
 /turf/simulated/floor/plasteel/freezer,
 /area/admin)
 "wZ" = (
-/turf/simulated/floor/carpet/royalblack,
+/obj/item/spellbook{
+	name = "admin spell book";
+	uses = 1000
+	},
+/obj/structure/table/wood/fancy/purple,
+/turf/simulated/floor/carpet,
 /area/admin)
 "xa" = (
 /obj/structure/toilet{
@@ -6944,9 +6934,9 @@
 /turf/simulated/wall/indestructible/fakeglass,
 /area/centcom/suppy)
 "xK" = (
-/obj/item/bodyanalyzer/debug,
-/obj/structure/table/wood/fancy/royalblack,
-/turf/simulated/floor/carpet/royalblack,
+/obj/item/gun/magic/wand/resurrection/debug,
+/obj/structure/table/wood/fancy/purple,
+/turf/simulated/floor/carpet,
 /area/admin)
 "xM" = (
 /obj/machinery/computer/shuttle/admin{
@@ -7045,6 +7035,11 @@
 	},
 /turf/simulated/floor/wood,
 /area/centcom/control)
+"yj" = (
+/obj/structure/table/wood/fancy/royalblack,
+/obj/item/gun/projectile/automatic/pistol,
+/turf/simulated/floor/carpet/royalblack,
+/area/admin)
 "yk" = (
 /obj/machinery/economy/vending/shoedispenser,
 /obj/machinery/light/small{
@@ -7225,6 +7220,11 @@
 	},
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/transport)
+"zu" = (
+/obj/structure/table/wood/fancy/royalblack,
+/obj/item/gun/projectile/revolver,
+/turf/simulated/floor/carpet/royalblack,
+/area/admin)
 "zv" = (
 /obj/item/flag/wiz,
 /turf/simulated/floor/wood,
@@ -7291,10 +7291,10 @@
 /area/ghost_bar)
 "zM" = (
 /obj/machinery/door/airlock/hatch{
-	desc = "For all your shady business needs";
-	name = "Gambling Den"
+	desc = "You've heard rumors of the horrors that go on within this lab.";
+	name = "Debug Room"
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/plasteel/dark,
 /area/admin)
 "zN" = (
 /obj/machinery/computer/cryopod/robot,
@@ -7342,16 +7342,16 @@
 /turf/simulated/floor/plasteel/dark,
 /area/admin)
 "Ac" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/admin)
-"Ad" = (
 /obj/structure/table/wood/fancy/royalblack,
 /obj/item/radio/uplink/admin{
 	name = "admin uplink"
 	},
+/turf/simulated/floor/carpet/royalblack,
+/area/admin)
+"Ad" = (
+/obj/structure/table/wood/fancy/royalblack,
+/obj/item/soap/syndie/debug,
+/obj/item/reagent_containers/spray/cleaner/advanced/debug,
 /turf/simulated/floor/carpet/royalblack,
 /area/admin)
 "Ae" = (
@@ -7467,12 +7467,9 @@
 /turf/simulated/floor/plasteel,
 /area/admin)
 "As" = (
-/obj/item/spellbook{
-	name = "admin spell book";
-	uses = 1000
-	},
-/obj/structure/table/wood/fancy/purple,
-/turf/simulated/floor/carpet,
+/obj/item/bodyanalyzer/debug,
+/obj/structure/table/wood/fancy/royalblack,
+/turf/simulated/floor/carpet/royalblack,
 /area/admin)
 "At" = (
 /obj/structure/chair/comfy/black{
@@ -7481,14 +7478,15 @@
 /turf/simulated/floor/plasteel,
 /area/admin)
 "Au" = (
-/obj/structure/table/wood/fancy/royalblack,
-/obj/item/gun/projectile/automatic/pistol,
 /turf/simulated/floor/carpet/royalblack,
 /area/admin)
 "Av" = (
 /obj/structure/table/wood/fancy/royalblack,
-/obj/item/soap/syndie/debug,
-/obj/item/reagent_containers/spray/cleaner/advanced/debug,
+/obj/item/melee/energy/sword,
+/obj/item/melee/energy/sword{
+	pixel_x = -5;
+	pixel_y = 5
+	},
 /turf/simulated/floor/carpet/royalblack,
 /area/admin)
 "Aw" = (
@@ -8106,11 +8104,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/control)
-"CL" = (
-/obj/item/debug/human_spawner,
-/obj/structure/table/wood/fancy/purple,
-/turf/simulated/floor/carpet,
-/area/admin)
 "CM" = (
 /obj/machinery/door/airlock/external{
 	name = "Supply Shuttle";
@@ -8479,6 +8472,11 @@
 	},
 /turf/simulated/floor/wood,
 /area/trader_station/sol)
+"Ed" = (
+/obj/structure/table/wood/fancy/royalblue,
+/obj/item/reagent_containers/drinks/cans/adminbooze,
+/turf/simulated/floor/plasteel,
+/area/admin)
 "Ee" = (
 /obj/structure/flora/rock/pile/largejungle,
 /turf/simulated/floor/grass/jungle,
@@ -9527,6 +9525,13 @@
 	icon_state = "vault"
 	},
 /area/centcom/specops)
+"HS" = (
+/obj/structure/table/wood/fancy/purple,
+/obj/item/clothing/shoes/sandal/magic,
+/obj/item/clothing/suit/wizrobe,
+/obj/item/clothing/head/wizard,
+/turf/simulated/floor/carpet,
+/area/admin)
 "HT" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/ywflowers,
@@ -9666,6 +9671,11 @@
 /obj/effect/decal/cleanable/ants,
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/control)
+"It" = (
+/obj/structure/table/wood/fancy/purple,
+/obj/item/reagent_containers/drinks/mugwort,
+/turf/simulated/floor/carpet,
+/area/admin)
 "Iu" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/donkpockets,
@@ -9752,6 +9762,11 @@
 /obj/structure/railing,
 /turf/simulated/floor/grass,
 /area/centcom/evac)
+"IJ" = (
+/obj/item/debug/human_spawner,
+/obj/structure/table/wood/fancy/purple,
+/turf/simulated/floor/carpet,
+/area/admin)
 "IK" = (
 /obj/structure/table/holotable,
 /obj/item/clothing/head/helmet/thunderdome,
@@ -9951,6 +9966,11 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/grass,
 /area/centcom/specops)
+"Js" = (
+/obj/structure/table/wood/fancy/purple,
+/obj/item/gun/magic/staff,
+/turf/simulated/floor/carpet,
+/area/admin)
 "Jt" = (
 /obj/structure/railing{
 	dir = 6
@@ -12478,11 +12498,6 @@
 /obj/item/storage/fancy/donut_box,
 /turf/simulated/floor/wood,
 /area/centcom/control)
-"RJ" = (
-/obj/structure/table/wood/fancy/royalblack,
-/obj/item/gun/projectile/revolver,
-/turf/simulated/floor/carpet/royalblack,
-/area/admin)
 "RK" = (
 /turf/simulated/floor/carpet/arcade,
 /area/ghost_bar)
@@ -12772,11 +12787,6 @@
 	icon_state = "blue"
 	},
 /area/holodeck/source_knightarena)
-"SZ" = (
-/obj/item/gun/magic/wand/resurrection/debug,
-/obj/structure/table/wood/fancy/purple,
-/turf/simulated/floor/carpet,
-/area/admin)
 "Ta" = (
 /turf/simulated/wall/indestructible/riveted,
 /area/tdome/arena)
@@ -13203,11 +13213,6 @@
 "UK" = (
 /turf/simulated/floor/holofloor/carpet,
 /area/holodeck/source_theatre)
-"UL" = (
-/obj/item/clothing/glasses/hud/debug,
-/obj/structure/table/wood/fancy/royalblack,
-/turf/simulated/floor/carpet/royalblack,
-/area/admin)
 "UM" = (
 /obj/structure/flora/grass/brown,
 /turf/simulated/floor/holofloor{
@@ -14398,11 +14403,6 @@
 /obj/structure/railing,
 /turf/simulated/floor/plasteel,
 /area/centcom/evac)
-"YP" = (
-/obj/structure/table/wood/fancy/royalblue,
-/obj/item/reagent_containers/drinks/cans/adminbooze,
-/turf/simulated/floor/plasteel,
-/area/admin)
 "YR" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -14533,13 +14533,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/specops)
-"Zh" = (
-/obj/structure/table/wood/fancy/purple,
-/obj/item/clothing/shoes/sandal/magic,
-/obj/item/clothing/suit/wizrobe,
-/obj/item/clothing/head/wizard,
-/turf/simulated/floor/carpet,
-/area/admin)
 "Zi" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plasteel{
@@ -68885,8 +68878,8 @@ lZ
 lZ
 nq
 wk
-YP
-Ac
+Ed
+lk
 wk
 qL
 lZ
@@ -75067,7 +75060,7 @@ wk
 wk
 zM
 zM
-oj
+zM
 wk
 wk
 wk
@@ -75319,15 +75312,15 @@ aN
 aN
 aN
 wk
-si
-SZ
-CL
+oi
+xK
+IJ
 uz
 vK
-wZ
-UL
-xK
-Av
+Au
+oj
+As
+Ad
 wk
 aN
 aN
@@ -75581,10 +75574,10 @@ uz
 uz
 uz
 vK
-wZ
-wZ
-wZ
-wZ
+Au
+Au
+Au
+Au
 wk
 aN
 aN
@@ -75838,10 +75831,10 @@ uz
 uz
 uz
 vK
-wZ
-wZ
-wZ
-wZ
+Au
+Au
+Au
+Au
 lH
 aN
 aN
@@ -76095,10 +76088,10 @@ uz
 uz
 uz
 vK
-wZ
-wZ
-wZ
-wZ
+Au
+Au
+Au
+Au
 wk
 aN
 aN
@@ -76352,10 +76345,10 @@ uz
 uz
 uz
 vK
-wZ
-wZ
-wZ
-wZ
+Au
+Au
+Au
+Au
 wk
 aN
 aN
@@ -76609,10 +76602,10 @@ uz
 uz
 uz
 vK
-wZ
-wZ
-wZ
-wZ
+Au
+Au
+Au
+Au
 wk
 aN
 aN
@@ -76861,15 +76854,15 @@ aN
 aN
 aN
 lH
-Zh
+HS
 uz
 uz
 uz
 vK
-wZ
-wZ
-wZ
-RJ
+Au
+Au
+Au
+zu
 lH
 aN
 aN
@@ -77118,15 +77111,15 @@ aN
 aN
 aN
 wk
-fl
+Js
 uz
 uz
 uz
 vK
-wZ
-wZ
-wZ
 Au
+Au
+Au
+yj
 wk
 aN
 aN
@@ -77375,15 +77368,15 @@ aN
 aN
 aN
 wk
-oi
-As
+It
+wZ
 uz
 uz
 vK
-wZ
-wZ
-Ad
-sP
+Au
+Au
+Ac
+Av
 wk
 aN
 aN

--- a/_maps/map_files/generic/centcomm.dmm
+++ b/_maps/map_files/generic/centcomm.dmm
@@ -2676,6 +2676,10 @@
 /obj/machinery/recharger,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/syndicate)
+"jw" = (
+/obj/item/bio_chip_implanter/uplink/admin,
+/turf/space,
+/area/space/centcomm)
 "jx" = (
 /obj/structure/table,
 /obj/item/screwdriver{
@@ -7343,7 +7347,7 @@
 /area/admin)
 "Ac" = (
 /obj/structure/table/wood/fancy/royalblack,
-/obj/item/radio/uplink/admin,
+/obj/item/bio_chip_implanter/uplink/admin,
 /turf/simulated/floor/carpet/royalblack,
 /area/admin)
 "Ad" = (
@@ -78142,7 +78146,7 @@ aN
 aN
 aN
 aN
-aN
+jw
 aN
 aN
 aN

--- a/_maps/map_files/generic/centcomm.dmm
+++ b/_maps/map_files/generic/centcomm.dmm
@@ -6784,10 +6784,6 @@
 /turf/simulated/floor/plasteel/freezer,
 /area/admin)
 "wZ" = (
-/obj/item/spellbook{
-	name = "admin spell book";
-	uses = 1000
-	},
 /obj/structure/table/wood/fancy/purple,
 /turf/simulated/floor/carpet,
 /area/admin)
@@ -7343,9 +7339,6 @@
 /area/admin)
 "Ac" = (
 /obj/structure/table/wood/fancy/royalblack,
-/obj/item/radio/uplink/admin{
-	name = "admin uplink"
-	},
 /turf/simulated/floor/carpet/royalblack,
 /area/admin)
 "Ad" = (

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -34,7 +34,6 @@
 	var/newscaster_announcements = null
 	var/ert_disabled = FALSE
 	var/uplink_welcome = "Syndicate Uplink Console:"
-	var/uplink_uses = 100
 
 	var/list/player_draft_log = list()
 	var/list/datum/mind/xenos = list()

--- a/code/game/objects/items/devices/uplinks.dm
+++ b/code/game/objects/items/devices/uplinks.dm
@@ -426,6 +426,7 @@ GLOBAL_LIST_EMPTY(world_uplinks)
 
 /obj/item/radio/uplink/admin/New()
 	..()
+	hidden_uplink = new(src)
 	hidden_uplink.update_uplink_type(UPLINK_TYPE_ADMIN)
 	hidden_uplink.uses = 2500
 

--- a/code/game/objects/items/devices/uplinks.dm
+++ b/code/game/objects/items/devices/uplinks.dm
@@ -426,9 +426,8 @@ GLOBAL_LIST_EMPTY(world_uplinks)
 
 /obj/item/radio/uplink/admin/New()
 	..()
-	if(hidden_uplink)
-		hidden_uplink.update_uplink_type(UPLINK_TYPE_ADMIN)
-		hidden_uplink.uses = 2500
+	hidden_uplink.update_uplink_type(UPLINK_TYPE_ADMIN)
+	hidden_uplink.uses = 2500
 
 /obj/item/multitool/uplink/New()
 	..()

--- a/code/game/objects/items/devices/uplinks.dm
+++ b/code/game/objects/items/devices/uplinks.dm
@@ -36,7 +36,7 @@ GLOBAL_LIST_EMPTY(world_uplinks)
 
 /obj/item/uplink/New()
 	..()
-	uses = SSticker.mode.uplink_uses
+	uses = 100
 	uplink_items = get_uplink_items(src)
 
 	GLOB.world_uplinks += src

--- a/code/game/objects/items/devices/uplinks.dm
+++ b/code/game/objects/items/devices/uplinks.dm
@@ -17,7 +17,7 @@ GLOBAL_LIST_EMPTY(world_uplinks)
 	var/list/uplink_items
 
 	var/purchase_log = ""
-	var/uplink_owner = null//text-only
+	var/uplink_owner = null //text-only
 	var/used_TC = 0
 
 	var/job = null

--- a/code/game/objects/items/devices/uplinks.dm
+++ b/code/game/objects/items/devices/uplinks.dm
@@ -426,9 +426,9 @@ GLOBAL_LIST_EMPTY(world_uplinks)
 
 /obj/item/radio/uplink/admin/New()
 	..()
-	hidden_uplink = new(src)
-	hidden_uplink.update_uplink_type(UPLINK_TYPE_ADMIN)
-	hidden_uplink.uses = 2500
+	if(hidden_uplink)
+		hidden_uplink.update_uplink_type(UPLINK_TYPE_ADMIN)
+		hidden_uplink.uses = 2500
 
 /obj/item/multitool/uplink/New()
 	..()

--- a/code/game/objects/items/weapons/bio_chips/bio_chip_uplink.dm
+++ b/code/game/objects/items/weapons/bio_chips/bio_chip_uplink.dm
@@ -25,7 +25,6 @@
 /obj/item/bio_chip/uplink/admin/Initialize(mapload)
 	. = ..()
 	if(hidden_uplink)
-		hidden_uplink.uses = 2500
 		hidden_uplink.update_uplink_type(UPLINK_TYPE_ADMIN)
 
 
@@ -48,10 +47,6 @@
 /obj/item/bio_chip_implanter/uplink
 	name = "bio-chip implanter (uplink)"
 	implant_type = /obj/item/bio_chip/uplink
-
-/obj/item/bio_chip_implanter/uplink/admin
-	name = "bio-chip implanter (admin uplink)"
-	implant_type = /obj/item/bio_chip/uplink/admin
 
 /obj/item/bio_chip_case/uplink
 	name = "bio-chip case - 'Syndicate Uplink'"

--- a/code/game/objects/items/weapons/bio_chips/bio_chip_uplink.dm
+++ b/code/game/objects/items/weapons/bio_chips/bio_chip_uplink.dm
@@ -25,6 +25,7 @@
 /obj/item/bio_chip/uplink/admin/Initialize(mapload)
 	. = ..()
 	if(hidden_uplink)
+		hidden_uplink.uses = 2500
 		hidden_uplink.update_uplink_type(UPLINK_TYPE_ADMIN)
 
 
@@ -47,6 +48,10 @@
 /obj/item/bio_chip_implanter/uplink
 	name = "bio-chip implanter (uplink)"
 	implant_type = /obj/item/bio_chip/uplink
+
+/obj/item/bio_chip_implanter/uplink/admin
+	name = "bio-chip implanter (admin uplink)"
+	implant_type = /obj/item/bio_chip/uplink/admin
 
 /obj/item/bio_chip_case/uplink
 	name = "bio-chip case - 'Syndicate Uplink'"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Replaces the meeting room on the admin room with some wizard and syndicate equipment, as well as debug tools.
Replaces the no access requirement airlock on the admin shuttle with a window and a bit of fluff.
Makes the windows of the BSA room indestructible.
Makes uplinks placed down before gamemode is set not cause a runtime.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Players could theoretically get to the admin room on any round in which ERT was spawned. Admins can still teleport trough windows from the right click menu.
Players could either spacewalk to the airlock or abuse z level wrapping to get into the admin room. This fixes both cases, and replaces the very seldom used meeting room with a more practical testing area. 
BSA room windows are indestructible for consistency.
Players can still theoretically float about if they send away the specops shuttle whilst standing in the airlock, but there's nowhere for them to actually go, and I don't want to ruin the aesthetic by surrounding the shuttles with walls on all sides.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![image](https://github.com/ParadiseSS13/Paradise/assets/18598676/60dc222d-5e49-478b-abef-0eeff529e9ca)
![image](https://github.com/ParadiseSS13/Paradise/assets/18598676/2cef812e-c57e-4d0b-8c51-6519cbff0b17)
![image](https://github.com/ParadiseSS13/Paradise/assets/18598676/0987175b-7aa2-4d3d-b2e0-205d8287bb82)



## Testing
<!-- How did you test the PR, if at all? -->
Drank the admin booze.
Tested all the debug stuff.
Observed the indestructibility of windows.
Made sure traitor uplinks still worked.

## Changelog
:cl:
fix: Players can no longer raid the admin room.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
