### PR TITLE
Change wrench, wirecutters, and powered wirecutters suicides.

### DIFF
--- a/code/game/objects/items/tools/wirecutters.dm
+++ b/code/game/objects/items/tools/wirecutters.dm
@@ -43,9 +43,23 @@
 		return ..()
 
 /obj/item/wirecutters/suicide_act(mob/user)
-	user.visible_message("<span class='suicide'>[user] is cutting at [user.p_their()] arteries with [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>")
+	if(is_robotic_suicide(user))
+		user.visible_message("<span class='suicide'>[user] is cutting at [user.p_their()] wiring with [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>")
+	else
+		user.visible_message("<span class='suicide'>[user] is cutting at [user.p_their()] arteries with [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>")
 	playsound(loc, usesound, 50, 1, -1)
 	return BRUTELOSS
+
+/obj/item/wirecutters/proc/is_robotic_suicide(mob/user)
+	if(!ishuman(user))
+		return FALSE
+
+	var/mob/living/carbon/human/H = user
+	var/obj/item/organ/external/chest/chest = H.bodyparts_by_name["chest"]
+	if(!chest)
+		return FALSE
+
+	return chest.is_robotic()
 
 /obj/item/wirecutters/security
 	name = "security wirecutters"
@@ -125,15 +139,27 @@
 	random_color = FALSE
 
 /obj/item/wirecutters/power/suicide_act(mob/user)
-	user.visible_message("<span class='suicide'>[user] is wrapping \the [src] around [user.p_their()] neck. It looks like [user.p_theyre()] trying to rip [user.p_their()] head off!</span>")
-	playsound(loc, 'sound/items/jaws_cut.ogg', 50, 1, -1)
-	if(ishuman(user))
-		var/mob/living/carbon/human/H = user
-		var/obj/item/organ/external/head/head = H.bodyparts_by_name["head"]
-		if(head)
-			head.droplimb(0, DROPLIMB_BLUNT, FALSE, TRUE)
-			playsound(loc,pick('sound/misc/desceration-01.ogg','sound/misc/desceration-02.ogg','sound/misc/desceration-01.ogg') ,50, 1, -1)
-	return BRUTELOSS
+	user.visible_message("<span class='suicide'>[user] is wrapping [src] around [user.p_their()] neck. It looks like [user.p_theyre()] trying to rip [user.p_their()] head off!</span>")
+
+	if(!use_tool(user, user, 3 SECONDS, volume = tool_volume))
+		return SHAME
+
+	if(!ishuman(user))
+		return BRUTELOSS
+
+	var/mob/living/carbon/human/H = user
+	var/obj/item/organ/external/head/head = H.bodyparts_by_name["head"]
+	if(!head)
+		user.visible_message("<span class='suicide'>...but [user.p_they()] [user.p_are()] already headless! How embarassing.</span>")
+		return SHAME
+
+	head.droplimb(FALSE, DROPLIMB_SHARP, FALSE, TRUE)
+
+	if(user.stat != DEAD)
+		user.visible_message("<span class='suicide'>...but [user.p_they()] didn't need it anyway! How embarassing.</span>")
+		return SHAME
+
+	return OXYLOSS
 
 /obj/item/wirecutters/power/attack_self(mob/user)
 	playsound(get_turf(user), 'sound/items/change_jaws.ogg', 50, 1)

--- a/code/game/objects/items/tools/wirecutters.dm
+++ b/code/game/objects/items/tools/wirecutters.dm
@@ -43,10 +43,7 @@
 		return ..()
 
 /obj/item/wirecutters/suicide_act(mob/user)
-	if(is_robotic_suicide(user))
-		user.visible_message("<span class='suicide'>[user] is cutting at [user.p_their()] wiring with [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>")
-	else
-		user.visible_message("<span class='suicide'>[user] is cutting at [user.p_their()] arteries with [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>")
+	user.visible_message("<span class='suicide'>[user] is cutting at [user.p_their()] [is_robotic_suicide(user) ? "wiring" : "arteries"] with [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>")
 	playsound(loc, usesound, 50, 1, -1)
 	return BRUTELOSS
 

--- a/code/game/objects/items/tools/wrench.dm
+++ b/code/game/objects/items/tools/wrench.dm
@@ -20,7 +20,6 @@
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, RAD = 0, FIRE = 50, ACID = 30)
 	tool_behaviour = TOOL_WRENCH
 
-
 /obj/item/wrench/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is unsecuring [user.p_their()] head with [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>")
 

--- a/code/game/objects/items/tools/wrench.dm
+++ b/code/game/objects/items/tools/wrench.dm
@@ -20,10 +20,29 @@
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, RAD = 0, FIRE = 50, ACID = 30)
 	tool_behaviour = TOOL_WRENCH
 
+
 /obj/item/wrench/suicide_act(mob/user)
-	user.visible_message("<span class='suicide'>[user] is beating [user.p_themselves()] to death with [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>")
-	playsound(loc, 'sound/weapons/genhit.ogg', 50, 1, -1)
-	return BRUTELOSS
+	user.visible_message("<span class='suicide'>[user] is unsecuring [user.p_their()] head with [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>")
+
+	if(!use_tool(user, user, 3 SECONDS, volume = tool_volume))
+		return SHAME
+
+	if(!ishuman(user))
+		return BRUTELOSS
+
+	var/mob/living/carbon/human/H = user
+	var/obj/item/organ/external/head/head = H.bodyparts_by_name["head"]
+	if(!head)
+		user.visible_message("<span class='suicide'>...but [user.p_they()] [user.p_are()] already headless! How embarassing.</span>")
+		return SHAME
+
+	head.droplimb(TRUE, DROPLIMB_SHARP, FALSE, TRUE)
+
+	if(user.stat != DEAD)
+		user.visible_message("<span class='suicide'>...but [user.p_they()] didn't need it anyway! How embarassing.</span>")
+		return SHAME
+
+	return OXYLOSS
 
 /obj/item/wrench/cyborg
 	name = "automatic wrench"


### PR DESCRIPTION
## What Does This PR Do
Wrench and powered wirecutters suicides now remove the head, and do not kill if the head isn't vital.
Normal wirecutters now have a fitting message for machines.

## Why It's Good For The Game
More amusing this way.

## Testing
Spawned as a human.
Tried to suicide with powered wirecutters, but moved. The SHAME.
Suicided with all three tools.
C.M.A. to machine.
Failed to suicide with wrench and powered wirecutters, but head still came off. The SHAME.
Suicided with normal wirecutters.
Failed to suicide with wrench and wirecutters with no head. The SHAME.

## Changelog
:cl:
tweak: Suicide effects for wrench, wirecutters, and powered wirecutters have been adjusted.
/:cl: