### PR TITLE
Adds Secway Crate to Cargo orderables.

### DIFF
--- a/code/game/objects/structures/crates_lockers/largecrate.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate.dm
@@ -105,7 +105,6 @@
 
 /obj/structure/largecrate/secway
 	name = "secway crate"
-	icon_state = "lisacrate"
 
 /obj/structure/largecrate/secway/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/crowbar))

--- a/code/game/objects/structures/crates_lockers/largecrate.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate.dm
@@ -102,3 +102,13 @@
 	if(istype(W, /obj/item/crowbar))
 		new /mob/living/simple_animal/pet/cat(loc)
 	return ..()
+
+/obj/structure/largecrate/secway
+	name = "secway crate"
+	icon_state = "lisacrate"
+
+/obj/structure/largecrate/secway/attackby(obj/item/W as obj, mob/user as mob, params)
+	if(istype(W, /obj/item/crowbar))
+		new /obj/vehicle/secway(loc)
+		new /obj/item/key/security(loc)
+	return ..()

--- a/code/game/objects/structures/crates_lockers/largecrate.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate.dm
@@ -107,7 +107,7 @@
 	name = "secway crate"
 	icon_state = "lisacrate"
 
-/obj/structure/largecrate/secway/attackby(obj/item/W as obj, mob/user as mob, params)
+/obj/structure/largecrate/secway/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/crowbar))
 		new /obj/vehicle/secway(loc)
 		new /obj/item/key/security(loc)

--- a/code/modules/supply/supply_packs/pack_security.dm
+++ b/code/modules/supply/supply_packs/pack_security.dm
@@ -349,3 +349,10 @@
 				/obj/item/clothing/suit/armor/secjacket)
 	cost = 500 // Convenience has a price and this pack is genuinely loaded
 	containername = "officer starter crate"
+
+/datum/supply_packs/security/secway
+	name = "Secway Crate"
+	cost = 800
+	containertype = /obj/structure/largecrate/secway
+	containername = "secway crate"
+	access = ACCESS_HEADS


### PR DESCRIPTION
## What Does This PR Do
Adds a secway crate to cargo, requiring head approval and 800 credits. (To avoid random tiders buying them. They should STEAL them.)

## Why It's Good For The Game
In general I feel there's a lack of things to order from cargo each round, and if Security want to go around larping as mall cops I think that's their god given right as the founding harmbatoners intended.

![image](https://github.com/ParadiseSS13/Paradise/assets/85680653/ad0583e1-c91e-4aba-b977-b7602a5a0f38)


## Testing
I ordered one and opened one, confirmed the right money had been taken out.

## Changelog
:cl:
add: Secways can now be ordered from cargo.
/:cl: