### PR TITLE
Borgs without a client can be reset now

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_mob.dm
+++ b/code/modules/mob/living/silicon/robot/robot_mob.dm
@@ -518,8 +518,8 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 	notify_ai(2)
 
 	shown_robot_modules = 0
-	client.screen -= robot_modules_background
-	client.screen -= hud_used.module_store_icon
+	client?.screen -= robot_modules_background
+	client?.screen -= hud_used.module_store_icon
 	uneq_all()
 	SStgui.close_user_uis(src)
 	sight_mode = null


### PR DESCRIPTION
## What Does This PR Do
Fixes a runtime that prevents borgs without a client from being reset

## Why It's Good For The Game
Runtimes bad.

## Testing
Spawned as borg.  Picked a module.  Left module tray open.
Moved to roboticist, reset borg.
Moved back to borg, module tray was not open.

## Changelog
:cl:
fix: Fixed a runtime when resetting a borg without a connected client.
/:cl: