### PR TITLE
Makes vendors unanchor themselves when tipping over.

### DIFF
--- a/code/game/machinery/vendors/vending.dm
+++ b/code/game/machinery/vendors/vending.dm
@@ -962,6 +962,7 @@
 		. = fall_and_crush(get_turf(victim), damage, should_crit, crit_damage_factor, null, from_combat ? 4 SECONDS : 6 SECONDS, 12 SECONDS, FALSE, picked_angle)
 		if(.)
 			tilted = TRUE
+			anchored = FALSE
 			layer = ABOVE_MOB_LAYER
 
 	var/should_throw_at_target = TRUE


### PR DESCRIPTION
## What Does This PR Do
Title.

## Why It's Good For The Game
They should do this.

## Testing
It works.

## Changelog
:cl:
tweak: Vendors now unanchor when tipping over.
/:cl: