### PR TITLE
Make the Changelog button change color when unread.

### DIFF
--- a/code/controllers/subsystem/non_firing/SSchangelog.dm
+++ b/code/controllers/subsystem/non_firing/SSchangelog.dm
@@ -74,7 +74,7 @@ SUBSYSTEM_DEF(changelog)
 
 	// If we are ready, process the button style
 	if(C.prefs.lastchangelog != current_cl_timestamp)
-		winset(C, "rpane.changelog", "border=line;font-style=bold")
+		winset(C, "rpane.changelog", "border=line;background-color=#bb7700;text-color=#FFFFFF;font-style=bold")
 		to_chat(C, "<span class='boldnotice'>Changelog has changed since your last visit.</span>")
 
 /datum/controller/subsystem/changelog/proc/OpenChangelog(client/C)


### PR DESCRIPTION
## What Does This PR Do
Make the Changelog button change color when unread, again.

This seems to have been accidentally removed by #23726.

## Why It's Good For The Game
It's good to know when things change.

## Testing
It compiled and ran OK. My test setup doesn't have a working changelog, so I can't really test that the color changes when there's a new change.

## Changelog
:cl:
fix: Changelog button will change color when unread again. But you saw that already, right?
/:cl: