### PR TITLE
Make directional windows and windoors solid

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -192,45 +192,43 @@
 		else //Diagonal move, split it into cardinal moves
 			moving_diagonally = FIRST_DIAG_STEP
 			var/first_step_dir
-			// The `&& moving_diagonally` checks are so that a forceMove taking
-			// place due to a Crossed, Bumped, etc. call will interrupt
-			// the second half of the diagonal movement, or the second attempt
-			// at a first half if the cardinal Move() fails because we hit something.
+			// For each diagonal direction, we try moving NORTH/SOUTH first, and if it fails, we try moving EAST/WEST first.
+			// As long as either succeeds, we try the other.
 			if(direct & NORTH)
 				if(direct & EAST)
-					if(Move(get_step(src,  NORTH),  NORTH) && moving_diagonally)
+					if(Move(get_step(src,  NORTH),  NORTH))
 						first_step_dir = NORTH
 						moving_diagonally = SECOND_DIAG_STEP
 						. = Move(get_step(src,  EAST),  EAST)
-					else if(moving_diagonally && Move(get_step(src,  EAST),  EAST))
+					else if(Move(get_step(src,  EAST),  EAST))
 						first_step_dir = EAST
 						moving_diagonally = SECOND_DIAG_STEP
 						. = Move(get_step(src,  NORTH),  NORTH)
 				else if(direct & WEST)
-					if(Move(get_step(src,  NORTH),  NORTH) && moving_diagonally)
+					if(Move(get_step(src,  NORTH),  NORTH))
 						first_step_dir = NORTH
 						moving_diagonally = SECOND_DIAG_STEP
 						. = Move(get_step(src,  WEST),  WEST)
-					else if(moving_diagonally && Move(get_step(src,  WEST),  WEST))
+					else if(Move(get_step(src,  WEST),  WEST))
 						first_step_dir = WEST
 						moving_diagonally = SECOND_DIAG_STEP
 						. = Move(get_step(src,  NORTH),  NORTH)
 			else if(direct & SOUTH)
 				if(direct & EAST)
-					if(Move(get_step(src,  SOUTH),  SOUTH) && moving_diagonally)
+					if(Move(get_step(src,  SOUTH),  SOUTH))
 						first_step_dir = SOUTH
 						moving_diagonally = SECOND_DIAG_STEP
 						. = Move(get_step(src,  EAST),  EAST)
-					else if(moving_diagonally && Move(get_step(src,  EAST),  EAST))
+					else if(Move(get_step(src,  EAST),  EAST))
 						first_step_dir = EAST
 						moving_diagonally = SECOND_DIAG_STEP
 						. = Move(get_step(src,  SOUTH),  SOUTH)
 				else if(direct & WEST)
-					if(Move(get_step(src,  SOUTH),  SOUTH) && moving_diagonally)
+					if(Move(get_step(src,  SOUTH),  SOUTH))
 						first_step_dir = SOUTH
 						moving_diagonally = SECOND_DIAG_STEP
 						. = Move(get_step(src,  WEST),  WEST)
-					else if(moving_diagonally && Move(get_step(src,  WEST),  WEST))
+					else if(Move(get_step(src,  WEST),  WEST))
 						first_step_dir = WEST
 						moving_diagonally = SECOND_DIAG_STEP
 						. = Move(get_step(src,  SOUTH),  SOUTH)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -110,7 +110,7 @@
 		return 1
 	if(dir == FULLTILE_WINDOW_DIR)
 		return 0	//full tile window, you can't move into it!
-	if(get_dir(loc, target) == dir)
+	if(get_dir(loc, target) & dir)
 		return !density
 	if(istype(mover, /obj/structure/window))
 		var/obj/structure/window/W = mover
@@ -127,14 +127,14 @@
 /obj/structure/window/CheckExit(atom/movable/O, target)
 	if(istype(O) && O.checkpass(PASSGLASS))
 		return 1
-	if(get_dir(O.loc, target) == dir)
+	if(get_dir(O.loc, target) & dir)
 		return 0
 	return 1
 
 /obj/structure/window/CanPathfindPass(obj/item/card/id/ID, to_dir, atom/movable/caller, no_id = FALSE)
 	if(!density)
 		return 1
-	if((dir == FULLTILE_WINDOW_DIR) || (dir == to_dir) || fulltile)
+	if((dir == FULLTILE_WINDOW_DIR) || (dir & to_dir) || fulltile)
 		return 0
 
 	return 1
@@ -414,7 +414,7 @@
 /obj/structure/window/CanAtmosPass(turf/T)
 	if(!anchored || !density)
 		return TRUE
-	return !(FULLTILE_WINDOW_DIR == dir || dir == get_dir(loc, T))
+	return !(FULLTILE_WINDOW_DIR == dir || dir & get_dir(loc, T))
 
 //This proc is used to update the icons of nearby windows.
 /obj/structure/window/proc/update_nearby_icons()

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -414,7 +414,7 @@
 /obj/structure/window/CanAtmosPass(turf/T)
 	if(!anchored || !density)
 		return TRUE
-	return !(FULLTILE_WINDOW_DIR == dir || dir & get_dir(loc, T))
+	return !(FULLTILE_WINDOW_DIR == dir || (dir & get_dir(loc, T)))
 
 //This proc is used to update the icons of nearby windows.
 /obj/structure/window/proc/update_nearby_icons()

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -126,10 +126,12 @@
 
 /obj/structure/window/CheckExit(atom/movable/O, target)
 	if(istype(O) && O.checkpass(PASSGLASS))
-		return 1
+		return TRUE
+	if(dir == FULLTILE_WINDOW_DIR)
+		return TRUE
 	if(get_dir(O.loc, target) & dir)
-		return 0
-	return 1
+		return FALSE
+	return TRUE
 
 /obj/structure/window/CanPathfindPass(obj/item/card/id/ID, to_dir, atom/movable/caller, no_id = FALSE)
 	if(!density)


### PR DESCRIPTION
## What Does This PR Do
Fixes #22396 
The reason this fix is needed is that the first part of the diagonal movement isn't completed before the second part is checked, so if you were moving northwest, `get_dir` will report that you're moving directly north (or west) for the first half of the move, but northwest for the second half of the move.

Also contains a minor refactor to `/atom/movable/Move` because I was digging through it for the fix.  It's impossible for `moving_diagonally` to have any value other than `FIRST_DIAG_STEP` here, so the checks are pointless.

## Why It's Good For The Game
Windows should be solid objects.

## Testing
Built hallways out of directional windows and windoors. Hivebots couldn't dodge out of them.
Built apiary in hydroponics. Planted. Waited outside. No bees came.
Var-edited a bee to target me. It hit the windoor and went back to its business.

## Changelog
:cl:
fix: Stuff that moves diagonally (including bees) should no longer be able to phase through directional windows and windoors.
/:cl: