### PR TITLE
Gives explorers service radio headset

### DIFF
--- a/code/game/jobs/job/support.dm
+++ b/code/game/jobs/job/support.dm
@@ -509,5 +509,6 @@
 	shoes = /obj/item/clothing/shoes/workboots
 	glasses = /obj/item/clothing/glasses/welding
 	belt = /obj/item/storage/belt/utility
+	l_ear = /obj/item/radio/headset/headset_service
 	l_pocket = /obj/item/gps
 	id = /obj/item/card/id/explorer

--- a/code/game/jobs/job/support.dm
+++ b/code/game/jobs/job/support.dm
@@ -511,4 +511,5 @@
 	belt = /obj/item/storage/belt/utility
 	l_ear = /obj/item/radio/headset/headset_service
 	l_pocket = /obj/item/gps
+	r_pocket = /obj/item/radio
 	id = /obj/item/card/id/explorer


### PR DESCRIPTION
## What Does This PR Do
Makes explorers start with Service headset instead of default ones, they also start with station bounced radio in their right pocket.

## Why It's Good For The Game
Explorer is a member of service, they should start with service headset.
Headset radios do not work on most layers of space, but the station bounced ones work everywhere you need!

## Testing
Joined as explorer, proper headset in place, proper radio in pocket.

## Changelog
:cl:
tweak: Explorers now start with service headset and station bounced radio.
/:cl:
