### PR TITLE
refactor: turn /proc/findEventArea() into a global list

### DIFF
--- a/code/controllers/subsystem/non_firing/SSmapping.dm
+++ b/code/controllers/subsystem/non_firing/SSmapping.dm
@@ -1,3 +1,15 @@
+/// A list of station areas that are generally safe for spawning random events
+/// in. Excludes areas like the SM, holodeck, shuttles, toxins test area, AI sat, etc.
+/// "Safe" here means that things spawned here will not have disproportionately adverse
+/// effects on the round, like spawning something directly onto the supermatter.
+GLOBAL_LIST_EMPTY(event_safe_station_areas)
+
+/// A list of station areas that are used for spawning random events. Unlike
+/// event_safe_station_areas, it includes maintenance and the AI sat. Useful for
+/// events that you know are going to be chaotic, such as destinations of a
+/// tesloose.
+GLOBAL_LIST_EMPTY(event_unrestricted_station_areas)
+
 SUBSYSTEM_DEF(mapping)
 	name = "Mapping"
 	init_order = INIT_ORDER_MAPPING // 9
@@ -111,6 +123,9 @@ SUBSYSTEM_DEF(mapping)
 		var/turf/picked = safepick(get_area_turfs(AR.type))
 		if(picked && is_station_level(picked.z))
 			existing_station_areas += AR
+
+	GLOB.event_safe_station_areas = list_event_safe_station_areas()
+	GLOB.event_unrestricted_station_areas = list_event_unrestricted_station_areas()
 
 	// World name
 	if(GLOB.configuration.general.server_name)

--- a/code/modules/events/anomaly_event.dm
+++ b/code/modules/events/anomaly_event.dm
@@ -16,7 +16,7 @@
 
 /datum/event/anomaly/proc/find_targets(warn_on_fail = FALSE)
 	for(var/tries in 0 to TURF_FIND_TRIES)
-		impact_area = findEventArea()
+		impact_area = pick(GLOB.event_safe_station_areas)
 		if(!impact_area)
 			if(warn_on_fail)
 				stack_trace("No valid areas for anomaly found.")
@@ -38,7 +38,7 @@
 	return target_turf
 
 /datum/event/anomaly/announce(false_alarm)
-	var/area/target = false_alarm ? findEventArea() : impact_area
+	var/area/target = false_alarm ? pick(GLOB.event_safe_station_areas) : impact_area
 	if(false_alarm && !target)
 		log_debug("Failed to find a valid area when trying to make a false alarm anomaly!")
 		return

--- a/code/modules/events/event_procs.dm
+++ b/code/modules/events/event_procs.dm
@@ -18,7 +18,9 @@
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Event Manager") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	return
 
-/proc/findEventArea() //Here's a nice proc to use to find an area for your event to land in!
+/// This proc seeds GLOB.event_safe_station_areas with areas that are safe to
+/// use for most random events.
+/proc/list_event_safe_station_areas()
 	var/list/safe_areas = typecacheof(list(
 		/area/station/turret_protected/ai,
 		/area/station/turret_protected/ai_upload,
@@ -39,9 +41,12 @@
 	var/list/remove_these_areas = safe_areas - allowed_areas
 	var/list/possible_areas = typecache_filter_list_reverse(SSmapping.existing_station_areas, remove_these_areas)
 
-	return pick(possible_areas)
+	return possible_areas
 
-/proc/findUnrestrictedEventArea() //Does almost the same as findEventArea() but hits a few more areas including maintenance and the AI sat, and also returns a list of all the areas, instead of just one area
+/// This proc seeds GLOB.event_unrestricted_station_areas with areas that are
+/// safe for most random events. Unlike GLOB.event_safe_station_areas, this
+/// list includes maintenance, the AI satellite, and shuttles.
+/proc/list_event_unrestricted_station_areas()
 	var/list/safe_areas = typecacheof(list(
 	/area/station/engineering/solar,
 	/area/station/science/toxins/test,

--- a/code/modules/events/tear.dm
+++ b/code/modules/events/tear.dm
@@ -15,7 +15,7 @@
 	var/obj/effect/tear/TE
 
 /datum/event/tear/setup()
-	impact_area = findEventArea()
+	impact_area = pick(GLOB.event_safe_station_areas)
 
 /datum/event/tear/start()
 	var/list/area_turfs = get_area_turfs(impact_area)
@@ -44,7 +44,7 @@
 	var/area/target_area = impact_area
 	if(!target_area)
 		if(false_alarm)
-			target_area = findEventArea()
+			target_area = pick(GLOB.event_safe_station_areas)
 		else
 			log_debug("Tried to announce a tear without a valid area!")
 			kill()

--- a/code/modules/power/engines/tesla/energy_ball.dm
+++ b/code/modules/power/engines/tesla/energy_ball.dm
@@ -39,8 +39,6 @@
 	var/movement_dir
 	/// Variable that defines whether it has a field generator close enough
 	var/has_close_field = FALSE
-	/// Init list that has all the areas that we can possibly move to, to reduce processing impact
-	var/list/all_possible_areas = list()
 
 /obj/singularity/energy_ball/Initialize(mapload, starting_energy = 50, is_miniball = FALSE)
 	miniball = is_miniball
@@ -53,7 +51,6 @@
 	else
 		// This gets added by the parent call
 		GLOB.poi_list -= src
-	all_possible_areas = findUnrestrictedEventArea()
 
 /obj/singularity/energy_ball/ex_act(severity, target)
 	return
@@ -135,7 +132,7 @@
 
 
 /obj/singularity/energy_ball/proc/find_the_basket()
-	var/area/where_to_move = pick(all_possible_areas) // Grabs a random area that isn't restricted
+	var/area/where_to_move = pick(GLOB.event_unrestricted_station_areas)
 	var/turf/target_area_turfs = get_area_turfs(where_to_move) // Grabs the turfs from said area
 	target_turf = pick(target_area_turfs) // Grabs a single turf from the entire list
 	return


### PR DESCRIPTION
## What Does This PR Do
This PR refactors `/proc/findEventArea()` and `/proc/findUnrestrictedEventArea()` into lists generated once after the station is loaded.
## Why It's Good For The Game
`/proc/findEventArea()` has to do a bunch of work and iteration every time it's called. Turning it into a global list makes it faster and more straightforward to use, and hopefully encourages its further use where needed.
## Testing
Tested running events that currently use it.
## Changelog
NPFC