### PR TITLE
Adds Lexorin to the Uplink Poison Bottle Bool. Also, Fixes Lexorin.

### DIFF
--- a/code/modules/mob/living/carbon/carbon_life.dm
+++ b/code/modules/mob/living/carbon/carbon_life.dm
@@ -50,6 +50,8 @@
 
 //Second link in a breath chain, calls check_breath()
 /mob/living/carbon/proc/breathe()
+	if(reagents.has_reagent("lexorin"))
+		return
 	if(istype(loc, /obj/machinery/atmospherics/unary/cryo_cell))
 		return
 

--- a/code/modules/mob/living/carbon/carbon_life.dm
+++ b/code/modules/mob/living/carbon/carbon_life.dm
@@ -50,8 +50,6 @@
 
 //Second link in a breath chain, calls check_breath()
 /mob/living/carbon/proc/breathe()
-	if(reagents.has_reagent("lexorin"))
-		return
 	if(istype(loc, /obj/machinery/atmospherics/unary/cryo_cell))
 		return
 

--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -264,6 +264,7 @@
 
 /datum/reagent/lexorin/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
+	update_flags |= M.adjustOxyLoss(5, FALSE)
 	update_flags |= M.adjustToxLoss(1, FALSE)
 	return ..() | update_flags
 

--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -264,6 +264,7 @@
 
 /datum/reagent/lexorin/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
+	update_flags |= M.LoseBreath(10) // No breathing for you! The effects will linger for a bit after it purges.
 	update_flags |= M.adjustOxyLoss(5, FALSE)
 	update_flags |= M.adjustToxLoss(1, FALSE)
 	return ..() | update_flags

--- a/strings/chemistry_tools.json
+++ b/strings/chemistry_tools.json
@@ -468,6 +468,7 @@
 		"spidereggs",
 		"concentrated_initro",
 		"heartworms",
-		"bacon_grease"
+		"bacon_grease",
+		"lexorin"
 	]
 }


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Lexorin is now one of the poisons that can spawn when you buy a poison bottle from the Syndicate uplink.

Lexorin was broken before, all it did was make you completely ignore breathing code (you could smoke a Lexorin enigma cigarette and walk through N2O, Plasma, or an area with no breathable atmos for your species and be completely unaffected). It now does breathloss like all other chems that stop you breathing. It now also does 5 oxygen damage per cycle (you can't breathe, dummy!). This also means that smoking the aforementioned cigarettes will now absolutely screw you up (just as god intended).
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Lexorin is an underappreciated chem, it adds a dedicated oxyloss chem to the uplink, we don't really have a chem that primarily works via oxyloss. It doesn't leave much permanent damage aside from the smidge of toxins. Technically could be used as an effective kidnapping tool. It silences you!

The lexorin enigma cigarettes are supposed to destroy you, not let you avoid breathing without consequences.

## Testing
Spawned a bunch of poison bottles, eventually got lexorin. Downed it in one. Suffocated to death.
Got a lexorin cigarette, smoked it, died.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
add: Adds lexorin to the poison bottle uplink item pool.
fix: Fixes Lexorin not suffocating you.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
