### PR TITLE
Revert #24361, fixes double screaming

### DIFF
--- a/code/datums/emote.dm
+++ b/code/datums/emote.dm
@@ -477,9 +477,9 @@
 	. = TRUE
 	if(!is_type_in_typecache(user, mob_type_allowed_typecache))
 		return FALSE
+	if(is_type_in_typecache(user, mob_type_blacklist_typecache))
+		return FALSE
 
-	// the user's mob type may not be allowed, but its species could be
-	var/species_can_use = FALSE
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		if(H.dna)
@@ -489,10 +489,6 @@
 
 			if(species_type_blacklist_typecache && is_type_in_typecache(H.dna.species, species_type_blacklist_typecache))
 				return FALSE
-			species_can_use = TRUE
-
-	if(is_type_in_typecache(user, mob_type_blacklist_typecache) && !species_can_use)
-		return FALSE
 
 	if(intentional && only_unintentional)
 		return FALSE


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
#24361 added a check to let an emote pass if their species was able to use it even if their mob type was in the blacklist typecache. This had the unintended side effect of letting both /living/scream and /living/carbon/human/scream pass at the same time for humans and subspecies, and caused both double screaming and blocked species specific noises like moth buzzing.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Bugs are bad, but adding even more bugs is worse.

## Testing
<!-- How did you test the PR, if at all? -->
It theoretically compiles

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
