### PR TITLE
Made the AI Connection Port setting actually work.

### DIFF
--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -263,7 +263,7 @@
 			if(!aisync)
 				lawsync = FALSE
 
-			var/mob/living/silicon/robot/O = new /mob/living/silicon/robot(get_turf(loc), unfinished = 1, ai_to_sync_to = forced_ai)
+			var/mob/living/silicon/robot/O = new /mob/living/silicon/robot(get_turf(loc), unfinished = 1, connect_to_AI = aisync, ai_to_sync_to = forced_ai)
 			if(!O)
 				return
 


### PR DESCRIPTION
## What Does This PR Do
The panel from using a multitool on an unfinished borg chassis was supposed to let you disable the borg connecting to an AI when built.  That button works now.

## Why It's Good For The Game
Apparently this panel exists? Well, it should work correctly, even if people don't know it's there.

## Testing
Built two borg chassis. Disabled AI Connection Port on one. Finished borgs. The one with a closed port didn't link to the AI, and the other did.

## Changelog
:cl:
fix: The panel from using a multitool on an unfinished borg chassis was supposed to let you disable the borg connecting to an AI when built.  That button works now.
/:cl:
