### PR TITLE
Adds Omnizine Shipment Crate to Supply Orders

### DIFF
--- a/code/modules/supply/supply_packs/pack_medical.dm
+++ b/code/modules/supply/supply_packs/pack_medical.dm
@@ -168,3 +168,9 @@
 					/obj/item/clothing/gloves/color/latex/nitrile)
 	cost = 200
 	containername = "nitrile glove crate"
+
+/datum/supply_packs/medical/omnizine
+	name = "Omnizine Shipment Crate"
+	contains = list(/obj/item/reagent_containers/glass/bottle/reagent/omnizine)
+	cost = 300
+	containername = "omnizine shipment crate"


### PR DESCRIPTION
## What Does This PR Do
Adds Omnizine Shipment Crates to the medical section of cargo, allowing the purchasing of a singular 50u bottle of Omnizine (per crate) for 300 credits.

## Why It's Good For The Game
With the likelihood of omnizine becoming more important to medical in the future, and past issues noticed with gathering omnizine forcing medbay to rather rely on botany of loot maintenance for donk pockets to dialysis omnizine out of and me looking to add more crates for the crew to spend money on, I feel this would be a good way for medical to remain pro-active in solving their own problems as they arrive.

## Testing
Spawned an omnizine crate, opened it, checked the right amount was there. Ordered a crate from cargo, confirmed credit payment, arrived, took crate, opened crate, chugged all the omnizine and keeled over in pain.

## Changelog
:cl:
add: Omnizine Shipment crates can now be ordered from Cargo for 300 credits.
/:cl: