### PR TITLE
Fix for null "atoms_to_show" runtimes

### DIFF
--- a/code/controllers/subsystem/SSstatpanel.dm
+++ b/code/controllers/subsystem/SSstatpanel.dm
@@ -110,7 +110,7 @@ SUBSYSTEM_DEF(statpanels)
 		atoms_to_display += turf_content
 
 	/// Set the atoms we're meant to display
-	var/datum/object_window_info/obj_window = target.obj_window
+	var/datum/object_window_info/obj_window = istype(target.obj_window) ? target.obj_window : new(target)
 	obj_window.atoms_to_show = atoms_to_display
 	START_PROCESSING(SSobj_tab_items, obj_window)
 	refresh_client_obj_view(target)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes a statpanel runtime:
```
[2024-03-08T01:00:23] Runtime in code/controllers/subsystem/SSstatpanel.dm,114: Cannot modify null.atoms_to_show.
   proc name: set turf examine tab (/datum/controller/subsystem/statpanels/proc/set_turf_examine_tab)
   src: Stat Panels (/datum/controller/subsystem/statpanels)
   call stack:
   Stat Panels (/datum/controller/subsystem/statpanels): set_turf_examine_tab
   Stat Panels (/datum/controller/subsystem/statpanels): fire
   Stat Panels (/datum/controller/subsystem/statpanels): ignite
   Master (/datum/controller/master): RunQueue
   Master (/datum/controller/master): Loop
   Master (/datum/controller/master): StartProcessing
```

I'm not really sure how this runtime is happening, but there we go.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Testing
Loaded up the game and checked functionality
<!-- How did you test the PR, if at all? -->
