### PR TITLE
APCs stay disabled until EMP timer ends

### DIFF
--- a/code/modules/power/apc/apc.dm
+++ b/code/modules/power/apc/apc.dm
@@ -993,7 +993,7 @@
 	if(occupier)
 		occupier.emp_act(severity)
 
-	var/time = severity * 30 SECONDS
+	var/time = severity * (20 + rand(1, 20)) SECONDS
 	lighting_channel = 0
 	equipment_channel = 0
 	environment_channel = 0


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
This PR changes how APC works after being EMPd. Now APC will be unable to be turned on until the timer ends.
APC disabled time from EMP was tweaked to emp_severity * 20-40 SECONDS, which means that weak EMP will disable it for about 30 seconds, strong for 60
When APCs turns on after EMP timer ends, it will emit a silent synthetic ping sound and will say "Emergency reboot complete"

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Currently, if APC is being EMPd, that just means that it is turned off. Any personnel or cyborg can enable it in couple clicks. Given that there is a timer for EMP recharge, this looks like thats not intended and it should be offline the whole time. So, this fixes it.

## Testing
<!-- How did you test the PR, if at all? -->
Compiled, EMPd APC, tried turning it on and off.

## Changelog
:cl:
tweak: EMPd APC will be offline the whole EMP recharge time which is 20-80 seconds
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
