### PR TITLE
Tweak: Prevent send multiple messages to same radio channel

### DIFF
--- a/code/game/objects/items/devices/radio/beacon.dm
+++ b/code/game/objects/items/devices/radio/beacon.dm
@@ -26,6 +26,9 @@
 /obj/item/radio/beacon/hear_talk()
 	return
 
+/obj/item/radio/beacon/talk_into(verbage)
+	return FALSE
+
 /// Probably a better way of doing this, I'm lazy.
 /obj/item/radio/beacon/bacon
 

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -291,12 +291,22 @@ GLOBAL_LIST_EMPTY(channel_to_radio_key)
 	else //Turf, leave speech bubbles to the mob
 		speech_bubble("[bubble_icon][speech_bubble_test]", src, speech_bubble_recipients)
 
+	hear_message_obj(listening_obj, src, message_pieces, verb)
+
+	return 1
+
+/proc/hear_message_obj(list/listening_obj, mob/M, list/message_pieces, verbage)
+	var/list/transmited_channels = list()
 	for(var/obj/O in listening_obj)
 		spawn(0) // KILL THIS
-			if(O) //It's possible that it could be deleted in the meantime.
-				O.hear_talk(src, message_pieces, verb)
-
-	return TRUE
+			if(O) // It's possible that it could be deleted in the meantime.
+				if(isradio(O))
+					var/obj/item/radio/radio = O
+					if(radio.broadcasting && get_dist(radio, M) <= radio.canhear_range && !(radio.frequency in transmited_channels))
+						if(radio.talk_into(M, message_pieces, null, verbage))
+							transmited_channels += radio.frequency
+				else
+					O.hear_talk(M, message_pieces, verbage)
 
 /obj/effect/speech_bubble
 	var/mob/parent
@@ -410,11 +420,8 @@ GLOBAL_LIST_EMPTY(channel_to_radio_key)
 		if(get_turf(M) in hearturfs)
 			listening |= M
 
-	//pass on the message to objects that can hear us.
-	for(var/obj/O in view(message_range, whisper_loc))
-		spawn(0)
-			if(O)
-				O.hear_talk(src, message_pieces, verb)
+	// Pass on the message to objects that can hear us.
+	hear_message_obj(view(message_range, whisper_loc), src, message_pieces, verb)
 
 	var/list/eavesdropping = hearers(eavesdropping_range, whisper_loc)
 	eavesdropping -= src

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -293,7 +293,7 @@ GLOBAL_LIST_EMPTY(channel_to_radio_key)
 
 	hear_message_obj(listening_obj, src, message_pieces, verb)
 
-	return 1
+	return TRUE
 
 /proc/hear_message_obj(list/listening_obj, mob/M, list/message_pieces, verbage)
 	var/list/transmited_channels = list()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Prevents sending multiple messages to same radio channel
Ported from here: https://github.com/ss220-space/Paradise/pull/3337

## Why It's Good For The Game
No laging and spam

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Tested in-game

## Changelog
NPFC?

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
