### PR TITLE
Adjusts Species Lung Temperature Tolerances

### DIFF
--- a/code/modules/surgery/organs/brain.dm
+++ b/code/modules/surgery/organs/brain.dm
@@ -77,7 +77,7 @@
 		name = "[dna.real_name]'s [initial(name)]"
 
 	if(!owner) return ..() // Probably a redundant removal; just bail
-	
+
 	if(is_species(owner, /datum/species/monkey))
 		name = "[owner.name]'s [initial(name)]"
 
@@ -201,7 +201,7 @@
 	icon = 'icons/mob/slimes.dmi'
 	icon_state = "green slime extract"
 	mmi_icon_state = "slime_mmi"
-	organ_datums = list(/datum/organ/heart, /datum/organ/lungs)
+	organ_datums = list(/datum/organ/heart, /datum/organ/lungs/slime)
 
 /obj/item/organ/internal/brain/golem
 	name = "Runic mind"

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -27,9 +27,20 @@
 	organ_datums = list(/datum/organ/lungs/vox)
 
 /obj/item/organ/internal/lungs/drask
+	name = "drask lungs"
 	icon = 'icons/obj/species_organs/drask.dmi'
 
 	organ_datums = list(/datum/organ/lungs/drask)
+
+/obj/item/organ/internal/lungs/tajaran
+	name = "tajaran lungs"
+	icon = 'icons/obj/species_organs/tajaran.dmi'
+	organ_datums = list(/datum/organ/lungs/tajaran)
+
+/obj/item/organ/internal/lungs/unathi
+	name = "unathi lungs"
+	icon = 'icons/obj/species_organs/unathi.dmi'
+	organ_datums = list(/datum/organ/lungs/unathi)
 
 /obj/item/organ/internal/lungs/cybernetic
 	name = "cybernetic lungs"

--- a/code/modules/surgery/organs/organ_datums/lung_datum.dm
+++ b/code/modules/surgery/organs/organ_datums/lung_datum.dm
@@ -347,20 +347,20 @@
 	cold_level_2_threshold = 220
 	cold_level_3_threshold = 140
 
-	heat_level_1_threshold = 380
-	heat_level_2_threshold = 420
-	heat_level_3_threshold = 480
+	heat_level_1_threshold = 505
+	heat_level_2_threshold = 540
+	heat_level_3_threshold = 600
 
 /datum/organ/lungs/ashwalker
+	safe_oxygen_min = 4 // 4x as efficient as regular Unathi, can comfortably breathe on lavaland
+
 	cold_level_1_threshold = 280
 	cold_level_2_threshold = 220
 	cold_level_3_threshold = 140
 
-	heat_level_1_threshold = 380
-	heat_level_2_threshold = 420
-	heat_level_3_threshold = 480
-
-	safe_oxygen_min = 4 // 4x as efficient as regular Unathi, can comfortably breathe on lavaland
+	heat_level_1_threshold = 505
+	heat_level_2_threshold = 540
+	heat_level_3_threshold = 600
 
 /datum/organ/lungs/slime
 	cold_level_1_threshold = 280

--- a/code/modules/surgery/organs/organ_datums/lung_datum.dm
+++ b/code/modules/surgery/organs/organ_datums/lung_datum.dm
@@ -361,6 +361,7 @@
 	heat_level_3_threshold = 480
 
 	safe_oxygen_min = 4 // 4x as efficient as regular Unathi, can comfortably breathe on lavaland
+
 /datum/organ/lungs/slime
 	cold_level_1_threshold = 280
 	cold_level_2_threshold = 240

--- a/code/modules/surgery/organs/organ_datums/lung_datum.dm
+++ b/code/modules/surgery/organs/organ_datums/lung_datum.dm
@@ -40,7 +40,7 @@
 	var/hot_message = "your face burning and a searing heat"
 	var/heat_level_1_threshold = 360
 	var/heat_level_2_threshold = 400
-	var/heat_level_3_threshold = 1000
+	var/heat_level_3_threshold = 460
 	var/heat_level_1_damage = HEAT_GAS_DAMAGE_LEVEL_1
 	var/heat_level_2_damage = HEAT_GAS_DAMAGE_LEVEL_2
 	var/heat_level_3_damage = HEAT_GAS_DAMAGE_LEVEL_3
@@ -329,8 +329,42 @@
 	cold_level_3_damage = -COLD_GAS_DAMAGE_LEVEL_3
 	cold_damage_types = list(BRUTE = 0.5, BURN = 0.25)
 
+	heat_level_1_threshold = 310
+	heat_level_2_threshold = 340
+	heat_level_3_threshold = 400
+
+/datum/organ/lungs/tajaran
+	cold_level_1_threshold = 240
+	cold_level_2_threshold = 180
+	cold_level_3_threshold = 100
+
+	heat_level_1_threshold = 340
+	heat_level_2_threshold = 380
+	heat_level_3_threshold = 440
+
+/datum/organ/lungs/unathi
+	cold_level_1_threshold = 280
+	cold_level_2_threshold = 220
+	cold_level_3_threshold = 140
+
+	heat_level_1_threshold = 380
+	heat_level_2_threshold = 420
+	heat_level_3_threshold = 480
+
 /datum/organ/lungs/ashwalker
+	cold_level_1_threshold = 280
+	cold_level_2_threshold = 220
+	cold_level_3_threshold = 140
+
+	heat_level_1_threshold = 380
+	heat_level_2_threshold = 420
+	heat_level_3_threshold = 480
+
 	safe_oxygen_min = 4 // 4x as efficient as regular Unathi, can comfortably breathe on lavaland
+/datum/organ/lungs/slime
+	cold_level_1_threshold = 280
+	cold_level_2_threshold = 240
+	cold_level_3_threshold = 200
 
 /datum/organ/lungs/advanced_cyber/New(obj/item/organ/internal/link_em)
 	. = ..()

--- a/code/modules/surgery/organs/subtypes/tajaran_organs.dm
+++ b/code/modules/surgery/organs/subtypes/tajaran_organs.dm
@@ -27,10 +27,6 @@
 	mmi_icon = 'icons/obj/species_organs/tajaran.dmi'
 	mmi_icon_state = "mmi_full"
 
-/obj/item/organ/internal/lungs/tajaran
-	name = "tajaran lungs"
-	icon = 'icons/obj/species_organs/tajaran.dmi'
-
 /obj/item/organ/internal/kidneys/tajaran
 	name = "tajaran kidneys"
 	icon = 'icons/obj/species_organs/tajaran.dmi'

--- a/code/modules/surgery/organs/subtypes/unathi_organs.dm
+++ b/code/modules/surgery/organs/subtypes/unathi_organs.dm
@@ -21,10 +21,6 @@
 	mmi_icon = 'icons/obj/species_organs/unathi.dmi'
 	mmi_icon_state = "mmi_full"
 
-/obj/item/organ/internal/lungs/unathi
-	name = "unathi lungs"
-	icon = 'icons/obj/species_organs/unathi.dmi'
-
 /obj/item/organ/internal/kidneys/unathi
 	name = "unathi kidneys"
 	icon = 'icons/obj/species_organs/unathi.dmi'


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Adds Heat and Cold tolerances to species lungs who are missing it. (Tajaran, Unathi, Drask, Ashwalker and Slime People)
Lowers Heat Tolerance Level 3 from 1000 to 460 to align with body tolerances.
Gives Drask Lungs a name instead of just being called lungs which no other species apart from Human have.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
It's never really made sense to me why these species can't breathe what they can withstand or are just fine in these ranges where they wouldn't be able to.
Allowing species to breathe their suitable temperatures and take damage in areas that aren't adds more depth and helps to separate them from the rest of the playable species, it can be used in creative ways or even malicious ways to either add a bit to rounds or even change the course of them with enough imagination.


## Testing
<!-- How did you test the PR, if at all? -->
Meticulously checked each threshold for each species through use of internals and some in rooms with temperatures suitable and unsuitable towards them.

## Changelog
:cl:
add: Unathi, Drask, Ashwalker, Slime People and Tajara now properly breathe temperatures their bodies can withstand.
add: Names Drask Lungs as drask lungs.
tweak: Adjusts base Heat tolerance Level 3 for lungs to match body temperature tolerances.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
