### PR TITLE
Fixes #24512: Adds Abductor Experimental Dissection surgery for boneless people

### DIFF
--- a/code/game/gamemodes/miniantags/abduction/abduction_surgery.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction_surgery.dm
@@ -14,12 +14,41 @@
 	requires_organic_bodypart = TRUE
 	requires_bodypart = TRUE
 
-/datum/surgery/organ_extraction/can_start(mob/user, mob/living/carbon/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery/organ_extraction/can_start(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	var/mob/living/carbon/human/H = user
 	// You must either: Be of the abductor species, or contain an abductor implant
-	if((isabductor(H) || (locate(/obj/item/bio_chip/abductor) in H)))
-		return TRUE
-	return FALSE
+	if(!isabductor(H) && !(locate(/obj/item/bio_chip/abductor) in H))
+		return FALSE
+
+	if(HAS_TRAIT(target, TRAIT_NO_BONES))
+		return FALSE
+
+	return TRUE
+
+/datum/surgery/organ_extraction_boneless
+	name = "Experimental Dissection"
+	steps = list(
+		/datum/surgery_step/generic/cut_open,
+		/datum/surgery_step/generic/clamp_bleeders,
+		/datum/surgery_step/generic/retract_skin,
+		/datum/surgery_step/internal/extract_organ,
+		/datum/surgery_step/internal/gland_insert,
+		/datum/surgery_step/generic/cauterize
+	)
+	possible_locs = list(BODY_ZONE_CHEST)
+	requires_organic_bodypart = TRUE
+	requires_bodypart = TRUE
+
+/datum/surgery/organ_extraction_boneless/can_start(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	var/mob/living/carbon/human/H = user
+
+	if(!isabductor(H) && !(locate(/obj/item/bio_chip/abductor) in H))
+		return FALSE
+
+	if(!HAS_TRAIT(target, TRAIT_NO_BONES))
+		return FALSE
+
+	return TRUE
 
 /datum/surgery_step/internal/extract_organ
 	name = "remove heart"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Fixes #24512
Adds a mirror surgery that skips the sawing steps of experimental dissection if the target doesn't have any bones. 

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Consistency in surgery steps is good!

## Testing
<!-- How did you test the PR, if at all? -->
Sawed through a skrell, could not saw through a slime.

## Changelog
:cl: Chuga
fix: Abductor Experimental Dissection surgery steps now respect the (non)existence of bones.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
