### PR TITLE
Make admin and mentor tickets actually update their info in the table view

### DIFF
--- a/code/controllers/subsystem/tickets/mentor_tickets.dm
+++ b/code/controllers/subsystem/tickets/mentor_tickets.dm
@@ -30,7 +30,7 @@ GLOBAL_REAL(SSmentor_tickets, /datum/controller/subsystem/tickets/mentor_tickets
 	message_mentorTicket(msg, important)
 
 /datum/controller/subsystem/tickets/mentor_tickets/create_other_system_ticket(datum/ticket/T)
-	SStickets.newTicket(get_client_by_ckey(T.client_ckey), T.first_raw_response, T.raw_title)
+	SStickets.newTicket(get_client_by_ckey(T.client_ckey), T.first_raw_response, T.title)
 
 /datum/controller/subsystem/tickets/mentor_tickets/autoRespond(N)
 	return

--- a/code/controllers/subsystem/tickets/tickets.dm
+++ b/code/controllers/subsystem/tickets/tickets.dm
@@ -132,6 +132,7 @@ SUBSYSTEM_DEF(tickets)
 	else if(isclient(target))
 		var/client/C = target
 		M = C.mob
+		key_and_name = key_name(M, TRUE, ticket_help_type)
 
 	var/list/L = list()
 	L += "<span class='[ticket_help_span]'>[ticket_help_type]: </span><span class='boldnotice'>[key_and_name] "


### PR DESCRIPTION
## What Does This PR Do
One of the mentors complained the other day, "you know what, maybe it is a good rule of thumb to check if client is still connected before taking a ticket". And I thought, "Huh, it'd be nice if the ticket view showed that they're DC'd." Well, it was supposed to.

It turns out we've been caching the initial message, with all its details and links, and regurgitating it back every time the admin/mentor ticket view was opened. So you couldn't see if they mindswapped to a different mob, became a ghost, respawned as something else, or disconnected.

This has been fixed.

Also added some hardening against null mobs/clients, since that's a bigger concern now.

## Why It's Good For The Game
Stale info is bad. Current info is good.

## Images of changes
Disconnected user:
![image](https://github.com/ParadiseSS13/Paradise/assets/98381/4ce3f398-77dc-4899-8541-5fb1aee5ce50)

Deleted mob:
![image](https://github.com/ParadiseSS13/Paradise/assets/98381/211fc1b0-7c3f-48d6-b8b3-969b61a559c1)

## Testing
Filed a mentor and admin ticket. Opened the views. Changed to a different mob (by joining the game). Re-opened one, hit Refresh on the other. Aghosted. Var-edited the ticket and my old mob to belong to funnyman1337, my cool alter-ego. Re-opened and refreshed the interfaces again. Yay, cool me is shown as disconnected! Var-edited a ticket to belong to funnyman31337, who's too cool to even join the server. Refreshed again. Shows as funnyman31337 (DC)/(DELETED).

## Changelog
:cl:
fix: Admin and mentor ticket interfaces now show more current information.
/:cl: