### PR TITLE
Add cargo bay and supply shuttle accesses to identification computer

### DIFF
--- a/code/game/jobs/access.dm
+++ b/code/game/jobs/access.dm
@@ -190,9 +190,13 @@
 /proc/get_access_desc(A)
 	switch(A)
 		if(ACCESS_CARGO)
-			return "Cargo Bay"
+			return "Cargo Office"
 		if(ACCESS_CARGO_BOT)
 			return "Cargo Bot Delivery"
+		if(ACCESS_CARGO_BAY)
+			return "Cargo Bay"
+		if(ACCESS_SUPPLY_SHUTTLE)
+			return "Supply Shuttle"
 		if(ACCESS_SECURITY)
 			return "Security"
 		if(ACCESS_BRIG)
@@ -290,7 +294,7 @@
 		if(ACCESS_MINING_OFFICE)
 			return "Mining Office"
 		if(ACCESS_MAILSORTING)
-			return "Cargo Office"
+			return "Mail Sorting"
 		if(ACCESS_MINT)
 			return "Mint"
 		if(ACCESS_MINT_VAULT)

--- a/code/modules/mapping/access_helpers.dm
+++ b/code/modules/mapping/access_helpers.dm
@@ -218,6 +218,9 @@
 /obj/effect/mapping_helpers/airlock/access/any/supply/cargo_bay
 	access = ACCESS_CARGO_BAY
 
+/obj/effect/mapping_helpers/airlock/access/any/supply/supply_shuttle
+	access = ACCESS_SUPPLY_SHUTTLE
+
 /obj/effect/mapping_helpers/airlock/access/any/supply/mail_sorting
 	access = ACCESS_MAILSORTING
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
These accesses were added in #23819, but we still do not have them in the identification computer, which leads to the fact that selecting all supply accesses one by one does not actually provide full access to the supply area. This PR fixes that.
One more access helper as a bonus.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Consistency cool.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

![image](https://github.com/ParadiseSS13/Paradise/assets/39908528/96a1379d-8dc2-4879-8017-618d92487dfc)
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Tested locally, fine.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl: Maxiemar
tweak: 'Cargo Bay' and 'Supply Shuttle' accesses were added to the identification computer.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
