### PR TITLE
vsc: run check_grep2 before build

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,13 +2,34 @@
 	"version": "2.0.0",
 	"tasks": [
 		{
+			"type": "shell",
+			"command": "paracode/linters/check_grep2",
+			"windows": {
+				"command": ".\\tools\\bootstrap\\python.bat .\\tools\\ci\\check_grep2.py ${relativeFile}",
+			},
+			"problemMatcher": {
+				"owner": "dm",
+				"fileLocation": "relative",
+				"pattern": {
+					"regexp": "^(.*):(\\d+):\\s+(.*)$",
+					"file": 1,
+					"line": 2,
+					"message": 3,
+				}
+			},
+			"label": "linters: run check_grep2"
+		},
+		{
 			"type": "dreammaker",
 			"dme": "paradise.dme",
 			"problemMatcher": [
 				"$dreammaker"
 			],
 			"group": "build",
-			"label": "dm: build - paradise.dme"
+			"label": "dm: build - paradise.dme",
+			"dependsOn": [
+				"linters: run check_grep2",
+			]
 		},
 		{
 			"type": "shell",
@@ -36,6 +57,5 @@
 			"group": "build",
 			"label": "tgui: run dev server"
 		}
-		,
 	]
 }

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -27,13 +27,9 @@
 	var/hidden = FALSE //are we invisible to shuttle navigation computers?
 
 	//these objects are indestructable
-
-
-/var/my_prohibited_global_var = 3
-
 /obj/docking_port/Destroy(force)
 	if(force)
-	    ..()
+		..()
 		. = QDEL_HINT_HARDDEL_NOW
 	else
 

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -27,9 +27,13 @@
 	var/hidden = FALSE //are we invisible to shuttle navigation computers?
 
 	//these objects are indestructable
+
+
+/var/my_prohibited_global_var = 3
+
 /obj/docking_port/Destroy(force)
 	if(force)
-		..()
+	    ..()
 		. = QDEL_HINT_HARDDEL_NOW
 	else
 

--- a/tools/ci/check_grep2.py
+++ b/tools/ci/check_grep2.py
@@ -167,7 +167,12 @@ if __name__ == "__main__":
     exit_code = 0
     start = time.time()
 
-    for code_filepath in glob.glob("**/*.dm", recursive=True):
+    dm_files = glob.glob("**/*.dm", recursive=True)
+
+    if len(sys.argv) > 1:
+        dm_files = [sys.argv[1]]
+
+    for code_filepath in dm_files:
         with open(code_filepath, encoding="UTF-8") as code:
             filename = code_filepath.split(os.path.sep)[-1]
             # 515 proc syntax check is unique in running on all files but one,


### PR DESCRIPTION
## What Does This PR Do
This PR adds a new task to the VSC tasks listing which runs check_grep2, and makes it a dependency on the build task so that the compiler won't run unless check_grep2 is happy. It also ensures the errors actually show up in the editor.

It is technically feasible to run these on save, but that would require a 'watch task', essentially something that sits in the background and waits on file changes to run. Custom tasks can't be run on save. I'd link to the GitHub issue describing this but I already closed the tab.

Rather than try and get all our linters working at once, I'm starting with just one to make sure it works for other users and to refine them if I have to, later.
## Why It's Good For The Game
If someone isn't comfortable with the command line, the only way to get CI results is to push a PR and run CI. Even if you are comfortable with the command line, we have a ton of linters at this point, and running them manually is tedious. By adding results directly into VSC we can make development iteration faster.
## Images of changes
![2024_03_10__10_54_19__code_modules_shuttle_shuttle dm - Paradise - Visual Studio Code](https://github.com/ParadiseSS13/Paradise/assets/59303604/29c894fb-b8d5-400b-b8ba-a6e42a374bc6)
![2024_03_10__10_57_06__code_modules_shuttle_shuttle dm - Paradise - Visual Studio Code](https://github.com/ParadiseSS13/Paradise/assets/59303604/203e1a32-0592-4364-a453-81b54cc3fd4a)
## Testing
Made lintable mistakes in code, attempted to run the build task.
<!-- How did you test the PR, if at all? -->

## Changelog
NPFC