### PR TITLE
Makes suit sensors randomization apply to non-departmental jumpsuits

### DIFF
--- a/code/__DEFINES/clothing_defines.dm
+++ b/code/__DEFINES/clothing_defines.dm
@@ -3,7 +3,7 @@
 #define HIDESUITSTORAGE	2	//APPLIES ONLY TO THE EXTERIOR SUIT!!
 #define HIDEJUMPSUIT	4	//APPLIES ONLY TO THE EXTERIOR SUIT!!
 #define HIDESHOES		8	//APPLIES ONLY TO THE EXTERIOR SUIT!!
-#define HIDETAIL 		16	//APPLIES ONLY TO THE EXTERIOR SUIT!!
+#define HIDETAIL		16	//APPLIES ONLY TO THE EXTERIOR SUIT!!
 #define HIDEMASK	1	//APPLIES ONLY TO HELMETS/MASKS!!
 #define HIDEEARS	2	//APPLIES ONLY TO HELMETS/MASKS!! (ears means headsets and such)
 #define HIDEEYES	4	//APPLIES ONLY TO HELMETS/MASKS!! (eyes means glasses)
@@ -11,35 +11,35 @@
 
 // Slot defines for var/list/inv_slots, some of these dont really show up on the HUD,
 // but still function like it in other ways. I know thats weird, and I hate it too.
-#define SLOT_HUD_BACK 1
-#define SLOT_HUD_WEAR_MASK 2
-#define SLOT_HUD_HANDCUFFED 3
-#define SLOT_HUD_LEFT_HAND 4 // l_hand
-#define SLOT_HUD_RIGHT_HAND 5 // r_hand
-#define SLOT_HUD_BELT 6
-#define SLOT_HUD_WEAR_ID 7
-#define SLOT_HUD_LEFT_EAR 8 // l_ear
-#define SLOT_HUD_GLASSES 9
-#define SLOT_HUD_GLOVES 10
-#define SLOT_HUD_HEAD 11
-#define SLOT_HUD_SHOES 12
-#define SLOT_HUD_OUTER_SUIT 13 // wear_suit
-#define SLOT_HUD_JUMPSUIT 14 // w_uniform
-#define SLOT_HUD_LEFT_STORE 15 // l_store
-#define SLOT_HUD_RIGHT_STORE 16 // r_store
-#define SLOT_HUD_SUIT_STORE 17
-#define SLOT_HUD_IN_BACKPACK 18 // this just puts stuff a backpack if you have one
-#define SLOT_HUD_LEGCUFFED 19
-#define SLOT_HUD_RIGHT_EAR 20 // r_ear
-#define SLOT_HUD_WEAR_PDA 21
-#define SLOT_HUD_TIE 22
-#define SLOT_HUD_COLLAR 23
-#define SLOT_HUD_AMOUNT 23
+#define SLOT_HUD_BACK			1
+#define SLOT_HUD_WEAR_MASK		2
+#define SLOT_HUD_HANDCUFFED		3
+#define SLOT_HUD_LEFT_HAND		4 // l_hand
+#define SLOT_HUD_RIGHT_HAND		5 // r_hand
+#define SLOT_HUD_BELT			6
+#define SLOT_HUD_WEAR_ID		7
+#define SLOT_HUD_LEFT_EAR		8 // l_ear
+#define SLOT_HUD_GLASSES		9
+#define SLOT_HUD_GLOVES			10
+#define SLOT_HUD_HEAD			11
+#define SLOT_HUD_SHOES			12
+#define SLOT_HUD_OUTER_SUIT		13 // wear_suit
+#define SLOT_HUD_JUMPSUIT		14 // w_uniform
+#define SLOT_HUD_LEFT_STORE		15 // l_store
+#define SLOT_HUD_RIGHT_STORE	16 // r_store
+#define SLOT_HUD_SUIT_STORE		17
+#define SLOT_HUD_IN_BACKPACK	18 // this just puts stuff a backpack if you have one
+#define SLOT_HUD_LEGCUFFED		19
+#define SLOT_HUD_RIGHT_EAR		20 // r_ear
+#define SLOT_HUD_WEAR_PDA		21
+#define SLOT_HUD_TIE			22
+#define SLOT_HUD_COLLAR			23
+#define SLOT_HUD_AMOUNT			23
 
 // accessory slots
-#define ACCESSORY_SLOT_DECOR 1
-#define ACCESSORY_SLOT_UTILITY 2
-#define ACCESSORY_SLOT_ARMBAND 3
+#define ACCESSORY_SLOT_DECOR	1
+#define ACCESSORY_SLOT_UTILITY	2
+#define ACCESSORY_SLOT_ARMBAND	3
 
 ///max number of accessories that can be equiped to one piece of clothing
 #define MAX_EQUIPABLE_ACCESSORIES 5
@@ -81,21 +81,21 @@
 
 //flags for covering body parts
 #define GLASSESCOVERSEYES	1
-#define MASKCOVERSEYES		2		// get rid of some of the other mess in these flags
-#define HEADCOVERSEYES		4		// feel free to realloc these numbers for other purposes
-#define MASKCOVERSMOUTH		8		// on other items, these are just for mask/head
+#define MASKCOVERSEYES		2	// get rid of some of the other mess in these flags
+#define HEADCOVERSEYES		4	// feel free to realloc these numbers for other purposes
+#define MASKCOVERSMOUTH		8	// on other items, these are just for mask/head
 #define HEADCOVERSMOUTH		16
 
 // Suit sensor levels
-#define SUIT_SENSOR_OFF 0
-#define SUIT_SENSOR_BINARY 1
-#define SUIT_SENSOR_VITAL 2
-#define SUIT_SENSOR_TRACKING 3
+#define SUIT_SENSOR_OFF			0
+#define SUIT_SENSOR_BINARY		1
+#define SUIT_SENSOR_VITAL		2
+#define SUIT_SENSOR_TRACKING	3
 
-#define BLOCKHEADHAIR 			4		// temporarily removes the user's hair overlay. Leaves facial hair.
-#define BLOCKHAIR				32768	// temporarily removes the user's hair, facial and otherwise.
+#define BLOCKHEADHAIR	4		// temporarily removes the user's hair overlay. Leaves facial hair.
+#define BLOCKHAIR		32768	// temporarily removes the user's hair, facial and otherwise.
 
 //flags for muzzle speech blocking
-#define MUZZLE_MUTE_NONE 0 // Does not mute you.
-#define MUZZLE_MUTE_MUFFLE 1 // Muffles everything you say "MHHPHHMMM!!!
-#define MUZZLE_MUTE_ALL 2 // Completely mutes you.
+#define MUZZLE_MUTE_NONE	0 // Does not mute you.
+#define MUZZLE_MUTE_MUFFLE	1 // Muffles everything you say "MHHPHHMMM!!!
+#define MUZZLE_MUTE_ALL		2 // Completely mutes you.

--- a/code/__DEFINES/misc_defines.dm
+++ b/code/__DEFINES/misc_defines.dm
@@ -466,12 +466,6 @@
 #define FULLSCREEN_OVERLAY_RESOLUTION_X 15
 #define FULLSCREEN_OVERLAY_RESOLUTION_Y 15
 
-//suit sensors: sensor_mode defines
-#define SENSOR_OFF 0
-#define SENSOR_LIVING 1
-#define SENSOR_VITALS 2
-#define SENSOR_COORDS 3
-
 // Dice rigged options.
 #define DICE_NOT_RIGGED 1
 #define DICE_BASICALLY_RIGGED 2

--- a/code/datums/spells/bloodcrawl.dm
+++ b/code/datums/spells/bloodcrawl.dm
@@ -171,7 +171,7 @@
 			var/mob/living/carbon/human/H = victim
 			if(H.w_uniform && istype(H.w_uniform, /obj/item/clothing/under))
 				var/obj/item/clothing/under/U = H.w_uniform
-				U.sensor_mode = SENSOR_OFF
+				U.sensor_mode = SUIT_SENSOR_OFF
 	else
 		victim.ghostize()
 		qdel(victim)

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -20,10 +20,13 @@
 /datum/atom_hud/data/human/medical/basic
 
 /datum/atom_hud/data/human/medical/basic/proc/check_sensors(mob/living/carbon/human/H)
-	if(!istype(H)) return
+	if(!istype(H))
+		return
+
 	var/obj/item/clothing/under/U = H.w_uniform
-	if(!istype(U)) return
-	if(U.sensor_mode <= SENSOR_VITALS) return
+	if(!istype(U) || U.sensor_mode <= SUIT_SENSOR_VITAL)
+		return
+
 	return TRUE
 
 /datum/atom_hud/data/human/medical/basic/add_to_single_hud(mob/M, mob/living/carbon/H)

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -196,7 +196,7 @@
 	item_state = "bl_suit"
 	item_color = "black"
 	desc = "It's a plain jumpsuit. It has a small dial on the wrist."
-	sensor_mode = SENSOR_OFF //Hey who's this guy on the Syndicate Shuttle??
+	sensor_mode = SUIT_SENSOR_OFF // Hey who's this guy on the Syndicate Shuttle??
 	random_sensor = FALSE
 	resistance_flags = NONE
 	armor = list(MELEE = 5, BULLET = 5, LASER = 5, ENERGY = 0, BOMB = 0, RAD = 0, FIRE = 50, ACID = 50)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -718,7 +718,7 @@
 
 	///For the crew computer 2 = unable to change mode
 	var/has_sensor = TRUE
-	var/sensor_mode = SENSOR_OFF
+	var/sensor_mode = SUIT_SENSOR_OFF
 	var/random_sensor = TRUE
 		/*
 		1 = Report living/dead
@@ -733,7 +733,7 @@
 /obj/item/clothing/under/Initialize(mapload)
 	. = ..()
 	if(random_sensor)
-		sensor_mode = pick(SENSOR_OFF, SENSOR_LIVING, SENSOR_VITALS, SENSOR_COORDS)
+		sensor_mode = pick(SUIT_SENSOR_OFF, SUIT_SENSOR_BINARY, SUIT_SENSOR_VITAL, SUIT_SENSOR_TRACKING)
 
 /obj/item/clothing/under/Destroy()
 	QDEL_LIST_CONTENTS(accessories)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -716,15 +716,12 @@
 		"Grey" = 'icons/mob/clothing/species/grey/under/misc.dmi'
 		)
 
-	///For the crew computer 2 = unable to change mode
+	/// For the crew computer, 2 = unable to change mode
 	var/has_sensor = TRUE
+	/// Current suit sensor mode
 	var/sensor_mode = SUIT_SENSOR_OFF
+	/// Randomize the suit sensor mode when initializing?
 	var/random_sensor = TRUE
-		/*
-		1 = Report living/dead
-		2 = Report detailed damages
-		3 = Report location
-		*/
 	var/list/accessories = list()
 	var/displays_id = TRUE
 	var/rolled_down = FALSE

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -730,7 +730,7 @@
 	var/rolled_down = FALSE
 	var/basecolor
 
-/obj/item/clothing/under/rank/Initialize(mapload)
+/obj/item/clothing/under/Initialize(mapload)
 	. = ..()
 	if(random_sensor)
 		sensor_mode = pick(SENSOR_OFF, SENSOR_LIVING, SENSOR_VITALS, SENSOR_COORDS)

--- a/code/modules/clothing/under/centcom.dm
+++ b/code/modules/clothing/under/centcom.dm
@@ -15,7 +15,7 @@
 		)
 
 /obj/item/clothing/under/rank/centcom/ert
-	sensor_mode = SENSOR_COORDS
+	sensor_mode = SUIT_SENSOR_TRACKING
 	random_sensor = FALSE
 
 /obj/item/clothing/under/rank/centcom/deathsquad
@@ -24,7 +24,7 @@
 	icon_state = "deathsquad"
 	item_state = "deathsquad"
 	item_color = "deathsquad"
-	sensor_mode = SENSOR_OFF // You think the Deathsquad wants to be seen?
+	sensor_mode = SUIT_SENSOR_OFF // You think the Deathsquad wants to be seen?
 	random_sensor = FALSE
 
 /obj/item/clothing/under/rank/centcom/ert/chaplain

--- a/code/modules/clothing/under/color.dm
+++ b/code/modules/clothing/under/color.dm
@@ -73,7 +73,7 @@
 	item_state = "prisoner"
 	item_color = "prisoner"
 	has_sensor = 2
-	sensor_mode = SENSOR_COORDS
+	sensor_mode = SUIT_SENSOR_TRACKING
 
 /obj/item/clothing/under/color/pink
 	name = "pink jumpsuit"
@@ -127,7 +127,7 @@
 
 /// for jani ert
 /obj/item/clothing/under/color/purple/sensor
-	sensor_mode = SENSOR_COORDS
+	sensor_mode = SUIT_SENSOR_TRACKING
 	random_sensor = FALSE
 
 /obj/item/clothing/under/color/lightpurple

--- a/code/modules/clothing/under/jobs/civilian.dm
+++ b/code/modules/clothing/under/jobs/civilian.dm
@@ -63,7 +63,7 @@
 	item_color = "chapblack"
 
 /obj/item/clothing/under/rank/civilian/chaplain/sensor
-	sensor_mode = SENSOR_COORDS
+	sensor_mode = SUIT_SENSOR_TRACKING
 	random_sensor = FALSE
 
 /obj/item/clothing/under/rank/civilian/chef

--- a/code/modules/clothing/under/jobs/engineering_jumpsuits.dm
+++ b/code/modules/clothing/under/jobs/engineering_jumpsuits.dm
@@ -73,7 +73,7 @@
 	resistance_flags = NONE
 
 /obj/item/clothing/under/rank/engineering/engineer/sensor
-	sensor_mode = SENSOR_COORDS
+	sensor_mode = SUIT_SENSOR_TRACKING
 	random_sensor = FALSE
 
 /obj/item/clothing/under/rank/engineering/engineer/skirt

--- a/code/modules/clothing/under/jobs/medical_jumpsuits.dm
+++ b/code/modules/clothing/under/jobs/medical_jumpsuits.dm
@@ -35,7 +35,7 @@
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, RAD = 0, FIRE = 0, ACID = 0)
 
 /obj/item/clothing/under/rank/medical/doctor/sensor
-	sensor_mode = SENSOR_COORDS
+	sensor_mode = SUIT_SENSOR_TRACKING
 	random_sensor = FALSE
 
 /obj/item/clothing/under/rank/medical/doctor/skirt

--- a/code/modules/clothing/under/jobs/security_jumpsuits.dm
+++ b/code/modules/clothing/under/jobs/security_jumpsuits.dm
@@ -37,7 +37,7 @@
 	item_color = "security"
 
 /obj/item/clothing/under/rank/security/officer/sensor
-	sensor_mode = SENSOR_COORDS
+	sensor_mode = SUIT_SENSOR_TRACKING
 	random_sensor = FALSE
 
 /obj/item/clothing/under/rank/security/officer/skirt

--- a/code/modules/customitems/item_defines.dm
+++ b/code/modules/customitems/item_defines.dm
@@ -1213,7 +1213,7 @@
 	item_state = "jane_sid_suit"
 	item_color = "jane_sid_suit"
 	has_sensor = 2
-	sensor_mode = SENSOR_COORDS
+	sensor_mode = SUIT_SENSOR_TRACKING
 
 /obj/item/clothing/under/fluff/jane_sidsuit/verb/toggle_zipper()
 	set name = "Toggle Jumpsuit Zipper"


### PR DESCRIPTION
## What Does This PR Do
Most notably, re-scopes suit sensor randomization from `/obj/item/clothing/under/rank` to `/obj/item/clothing/under`, since the `random_sensor` var is defined on it, the proc lives inbetween other procs scoped to it, and there is no real reason why only departmental jumpsuits should have randomized suit sensors.

Also removes an extraneous set of suit sensor mode defines and cleans up a few bits of code.

## Why It's Good For The Game
CMO/Paramedic fruitlessly yelling at crew every shift start is a bit less necessary.
More seriously, helps new players stay alive a tiny bit, and gives Paramedic/Medbay a tiny bit more to monitor.

## Testing / Images of changes
Spawned in, vended a lot of pant from a ClothesMate.
![2024-03-10 17_50_04](https://github.com/ParadiseSS13/Paradise/assets/100448493/d371c465-078d-4ced-9f47-1e02efeb873b)

## Changelog
:cl:
tweak: Initial suit sensor mode randomization now applies to non-departmental jumpsuits as well
/:cl:
