### PR TITLE
[FIX] Borg hat fixes

### DIFF
--- a/code/modules/mob/living/silicon/!silicon_mob.dm
+++ b/code/modules/mob/living/silicon/!silicon_mob.dm
@@ -596,9 +596,6 @@
 		drop_hat()
 	. = ..()
 
-/mob/living/silicon/grabbedby(mob/living/user)
-	remove_from_head(user)
-
 /mob/living/silicon/examine(mob/user)
 	. = ..()
 	if(silicon_hat)

--- a/code/modules/mob/living/silicon/robot/!robot_mob.dm
+++ b/code/modules/mob/living/silicon/robot/!robot_mob.dm
@@ -1703,11 +1703,3 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 		old_ai.connected_robots -= src
 	if(connected_ai)
 		connected_ai.connected_robots |= src
-
-/datum/emote/flip/run_emote(mob/user, params, type_override, intentional)
-	. = ..()
-	if(isrobot(user))
-		var/mob/living/silicon/robot/borg = user
-		if(borg.drop_hat())
-			borg.visible_message("<span class='warning'><span class='name'>[src]</span> drops their hat!</span>",
-							"<span class='warning'>Your hat falls off!</span>")

--- a/code/modules/mob/living/silicon/silicon_defense.dm
+++ b/code/modules/mob/living/silicon/silicon_defense.dm
@@ -1,6 +1,5 @@
 /mob/living/silicon/grabbedby(mob/living/user)
 	remove_from_head(user)
-	return
 
 /mob/living/silicon/attack_alien(mob/living/carbon/alien/humanoid/M)
 	if(..()) //if harm or disarm intent

--- a/code/modules/mob/living/silicon/silicon_defense.dm
+++ b/code/modules/mob/living/silicon/silicon_defense.dm
@@ -1,4 +1,5 @@
 /mob/living/silicon/grabbedby(mob/living/user)
+	remove_from_head(user)
 	return
 
 /mob/living/silicon/attack_alien(mob/living/carbon/alien/humanoid/M)

--- a/code/modules/mob/mob_emote.dm
+++ b/code/modules/mob/mob_emote.dm
@@ -159,6 +159,12 @@
 
 	user.SpinAnimation(5, 1)
 
+	if(isrobot(user))
+		var/mob/living/silicon/robot/borg = user
+		if(borg.drop_hat())
+			borg.visible_message("<span class='warning'><span class='name'>[user]</span> drops their hat!</span>",
+							"<span class='warning'>As you flip your hat falls off!</span>")
+
 	if(prob(5) && ishuman(user))
 		message = "attempts a flip and crashes to the floor!"
 		sleep(0.3 SECONDS)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes some issues with borg hats.

- When a robot drops their hat from flipping it tells you that the robot dropped the hat, not "/datum/emote/flip"
- It is now possible to remove hats from drones an AIs by using an empty hand on them with grab intent.

Also cleaned up some code by moving emote behaviour to the proper file.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Bugs bad
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Be a drone, have a hat on, have a hat remove. Flip with a hat on. People can see I dropped the hat, not some emote.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: It is now possible to remove hats from drones an AIs by using an empty hand on them with grab intent.
fix: When a robot with a hat does a flip it now properly displays the name of the robot that dropped the hat instead of a path.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
