### PR TITLE
Sharp attacks no longer get randomly blunted when the target is dead

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -512,11 +512,11 @@ emp_act
 
 	apply_damage(I.force + bonus_damage , I.damtype, affecting, armor, sharp = weapon_sharp, used_weapon = I)
 
-	var/bloody = TRUE
+	var/bloody = FALSE
 	if(I.damtype == BRUTE && I.force && prob(25 + I.force * 2))
 		I.add_mob_blood(src)	//Make the weapon bloody, not the person.
 		if(prob(I.force * 2)) //blood spatter!
-			bloody = FALSE
+			bloody = TRUE
 			var/turf/location = loc
 			if(issimulatedturf(location))
 				add_splatter_floor(location, emittor_intertia = inertia_next_move > world.time ? last_movement_dir : null)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -497,11 +497,14 @@ emp_act
 		return FALSE //item force is zero
 
 	var/armor = run_armor_check(affecting, MELEE, "<span class='warning'>Your armour has protected your [hit_area].</span>", "<span class='warning'>Your armour has softened hit to your [hit_area].</span>", armour_penetration_flat = I.armour_penetration_flat, armour_penetration_percentage = I.armour_penetration_percentage)
-	var/weapon_sharp = is_sharp(I)
-	if(weapon_sharp && prob(getarmor(user.zone_selected, MELEE)))
-		weapon_sharp = 0
+	var/weapon_sharp = I.sharp
+
+	// do not roll for random blunt if the target mob is dead for the ease of decaps
+	if(stat != DEAD)
+		if(weapon_sharp && prob(getarmor(user.zone_selected, MELEE)))
+			weapon_sharp = FALSE
 	if(armor == INFINITY)
-		return 0
+		return FALSE
 	var/bonus_damage = 0
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
@@ -509,11 +512,11 @@ emp_act
 
 	apply_damage(I.force + bonus_damage , I.damtype, affecting, armor, sharp = weapon_sharp, used_weapon = I)
 
-	var/bloody = 0
+	var/bloody = TRUE
 	if(I.damtype == BRUTE && I.force && prob(25 + I.force * 2))
 		I.add_mob_blood(src)	//Make the weapon bloody, not the person.
 		if(prob(I.force * 2)) //blood spatter!
-			bloody = 1
+			bloody = FALSE
 			var/turf/location = loc
 			if(issimulatedturf(location))
 				add_splatter_floor(location, emittor_intertia = inertia_next_move > world.time ? last_movement_dir : null)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -497,14 +497,15 @@ emp_act
 		return FALSE //item force is zero
 
 	var/armor = run_armor_check(affecting, MELEE, "<span class='warning'>Your armour has protected your [hit_area].</span>", "<span class='warning'>Your armour has softened hit to your [hit_area].</span>", armour_penetration_flat = I.armour_penetration_flat, armour_penetration_percentage = I.armour_penetration_percentage)
-	var/weapon_sharp = I.sharp
+	if(armor == INFINITY)
+		return FALSE
 
+	var/weapon_sharp = I.sharp
 	// do not roll for random blunt if the target mob is dead for the ease of decaps
 	if(stat != DEAD)
 		if(weapon_sharp && prob(getarmor(user.zone_selected, MELEE)))
 			weapon_sharp = FALSE
-	if(armor == INFINITY)
-		return FALSE
+
 	var/bonus_damage = 0
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
APPARENTLY, there has been a probability equivalent to the targeted limb's armor that your sharp attack becomes blunt this entire time. This heavily contributes to the current difficulty of decapitating people, and does not need to happen if the target is dead.
fixes https://github.com/ParadiseSS13/Paradise/issues/24455

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Makes it a little bit easier to decapitate dead bodies with armor on them. This shouldn't have been a thing for dead people in the first place to be honest.

## Testing
<!-- How did you test the PR, if at all? -->
Confirmed that the check only happens if the target is not dead.

## Changelog
:cl: Chuga
tweak: It is now easier to whack off an armored limb with a sharp weapon if the target is dead.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
