### PR TITLE
Revert "vsc: run check_grep2 before build"

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,34 +2,13 @@
 	"version": "2.0.0",
 	"tasks": [
 		{
-			"type": "shell",
-			"command": "paracode/linters/check_grep2",
-			"windows": {
-				"command": ".\\tools\\bootstrap\\python.bat .\\tools\\ci\\check_grep2.py ${relativeFile}",
-			},
-			"problemMatcher": {
-				"owner": "dm",
-				"fileLocation": "relative",
-				"pattern": {
-					"regexp": "^(.*):(\\d+):\\s+(.*)$",
-					"file": 1,
-					"line": 2,
-					"message": 3,
-				}
-			},
-			"label": "linters: run check_grep2"
-		},
-		{
 			"type": "dreammaker",
 			"dme": "paradise.dme",
 			"problemMatcher": [
 				"$dreammaker"
 			],
 			"group": "build",
-			"label": "dm: build - paradise.dme",
-			"dependsOn": [
-				"linters: run check_grep2",
-			]
+			"label": "dm: build - paradise.dme"
 		},
 		{
 			"type": "shell",
@@ -57,5 +36,6 @@
 			"group": "build",
 			"label": "tgui: run dev server"
 		}
+		,
 	]
 }

--- a/tools/ci/check_grep2.py
+++ b/tools/ci/check_grep2.py
@@ -167,12 +167,7 @@ if __name__ == "__main__":
     exit_code = 0
     start = time.time()
 
-    dm_files = glob.glob("**/*.dm", recursive=True)
-
-    if len(sys.argv) > 1:
-        dm_files = [sys.argv[1]]
-
-    for code_filepath in dm_files:
+    for code_filepath in glob.glob("**/*.dm", recursive=True):
         with open(code_filepath, encoding="UTF-8") as code:
             filename = code_filepath.split(os.path.sep)[-1]
             # 515 proc syntax check is unique in running on all files but one,


### PR DESCRIPTION
Reverts ParadiseSS13/Paradise#24538. If someone has a non-DM file open and focused when they try to build, the linter will break trying to lint the non-DM file.