### PR TITLE
Allowed cyborgs to set transfer amounts on their modules.

### DIFF
--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -44,6 +44,9 @@
 	if(!new_transfer_rate)
 		return
 
+	// This looks redundant, but it's not. Time elapsed while the input
+	// list was open, so we need to re-check our conditions and give an
+	// error if they changed.
 	if(!can_set_transfer_amount(user))
 		if(!Adjacent(user))
 			to_chat(user, "<span class='warning'>You have moved too far away!</span>")

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -50,10 +50,9 @@
 	if(!can_set_transfer_amount(user))
 		if(!Adjacent(user))
 			to_chat(user, "<span class='warning'>You have moved too far away!</span>")
-			return
 		if(!ishuman(user) || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
 			to_chat(user, "<span class='warning'>You can't use your hands!</span>")
-			return
+		return
 
 	amount_per_transfer_from_this = new_transfer_rate
 	to_chat(user, "<span class='notice'>[src] will now transfer [amount_per_transfer_from_this] units at a time.</span>")

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -15,20 +15,42 @@
 	var/temperature_min = 0 // To limit the temperature of a reagent container can atain when exposed to heat/cold
 	var/temperature_max = 10000
 
+/obj/item/reagent_containers/proc/can_set_transfer_amount(mob/user)
+	if(!length(possible_transfer_amounts))
+		// Nothing to configure.
+		return FALSE
+	if(isrobot(user) && src.loc == user)
+		// Borgs can configure their modules.
+		return TRUE
+	if(!Adjacent(user))
+		// No configuring the beaker across the room.
+		return FALSE
+	if(!ishuman(user))
+		// Although a funny idea, station pets changing transfer
+		// amounts on random conatiners would probably be frustrating
+		// for the crew.
+		return FALSE
+	if(HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
+		// I guess there's, like, a switch or a dial or something?
+		// Whatever, you need to use your hands for this.
+		return FALSE
+	return TRUE
+
 /obj/item/reagent_containers/AltClick(mob/user)
-	if(!Adjacent(user) || !length(possible_transfer_amounts) || !ishuman(user) || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
+	if(!can_set_transfer_amount(user))
 		return
 
 	var/new_transfer_rate = tgui_input_list(user, "Amount per transfer from this:", "[src]", possible_transfer_amounts, "[amount_per_transfer_from_this]")
 	if(!new_transfer_rate)
 		return
 
-	if(!Adjacent(user))
-		to_chat(user, "<span class='warning'>You have moved too far away!</span>")
-		return
-	if(!ishuman(user) || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
-		to_chat(user, "<span class='warning'>You can't use your hands!</span>")
-		return
+	if(!can_set_transfer_amount(user))
+		if(!Adjacent(user))
+			to_chat(user, "<span class='warning'>You have moved too far away!</span>")
+			return
+		if(!ishuman(user) || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
+			to_chat(user, "<span class='warning'>You can't use your hands!</span>")
+			return
 
 	amount_per_transfer_from_this = new_transfer_rate
 	to_chat(user, "<span class='notice'>[src] will now transfer [amount_per_transfer_from_this] units at a time.</span>")


### PR DESCRIPTION
## What Does This PR Do
Cyborgs with reagent container modules (currently service and medical) can now set transfer amounts on them.
Fixes #23824

## Why It's Good For The Game
The examine text said you could, and it really didn't make sense that a cyborg couldn't control their own modules.

## Testing
Became human. Set transfer amount on a bucket.
Walked away. Could not set transfer amount.
Handcuffed myself. Could not set transfer amount.
Became corgi. Could not set transfer amount.
Became human again. Tried to set transfer amount, walked away before finishing. Failed to set.
Tried to set transfer amount, handcuffed self before finishing. Failed to set.
Tried to set transfer amount, became corgi before finishing. Window closed, couldn't even try to set.
Became mediborg. Was able to set transfer amount on beaker and dropper while in hotbar.
Became service borg. Was able to set transfer amount on shaker and industrial dropper while in hotbar.

## Changelog
:cl:
add: Machine learning has taught cyborgs how to set transfer amounts on their own modules without hands. This currently only affects medical and service modules.
/:cl: