### PR TITLE
Fixes the nanobank tgui input window not being able to accept pin codes above 10000

### DIFF
--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -534,7 +534,7 @@
 						RebuildHTML()
 
 					if("Money Account")
-						var/new_account = tgui_input_number(user, "What money account would you like to link to this card?", "Agent Card Account", 12345)
+						var/new_account = tgui_input_number(user, "What money account would you like to link to this card?", "Agent Card Account", 12345, max_value = 9999999)
 						if(!Adjacent(user) || !new_account)
 							return
 						associated_account_number = new_account

--- a/code/modules/pda/nanobank.dm
+++ b/code/modules/pda/nanobank.dm
@@ -240,8 +240,8 @@
 	else
 		error_message(user, "Incorrect Credentials")
 
-/datum/data/pda/app/nanobank/proc/input_account_pin(mob/user, max_value = 99999)
-	var/attempt_pin = tgui_input_number(user, "Enter pin code", "NanoBank Account Auth")
+/datum/data/pda/app/nanobank/proc/input_account_pin(mob/user)
+	var/attempt_pin = tgui_input_number(user, "Enter pin code", "NanoBank Account Auth", max_value = 99999)
 	if(!user_account || !attempt_pin)
 		return
 	return attempt_pin

--- a/code/modules/pda/nanobank.dm
+++ b/code/modules/pda/nanobank.dm
@@ -240,7 +240,7 @@
 	else
 		error_message(user, "Incorrect Credentials")
 
-/datum/data/pda/app/nanobank/proc/input_account_pin(mob/user)
+/datum/data/pda/app/nanobank/proc/input_account_pin(mob/user, max_value = 99999)
 	var/attempt_pin = tgui_input_number(user, "Enter pin code", "NanoBank Account Auth")
 	if(!user_account || !attempt_pin)
 		return


### PR DESCRIPTION
## What Does This PR Do
When you are entering a PIN code through the nanobank PDA app it uses a tgui input window which as the default allows at max 10000 while pin codes can be at max 99999. This PR sets the max value of the nanobank pin code input window 99999, making all pin codes fit

This PR fixes this same issue but with setting a money account on a agent ID

## Why It's Good For The Game
bugs bad

## Testing
increased account security in nanobank and then decreased it with a pin code which was above 10000

## Changelog
:cl:
fix: Fixed nanobank not being able to accept pin codes above 10000
/:cl:
