### PR TITLE
[s] Stop crates and lockers from taking stuff they shouldn't.

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -190,6 +190,9 @@
 		if(!user.drop_item()) //couldn't drop the item
 			to_chat(user, "<span class='notice'>\The [W] is stuck to your hand, you cannot put it in \the [src]!</span>")
 			return
+		if(W.loc != user.loc)
+			// It went somewhere else, don't teleport it back.
+			return
 		if(W)
 			W.forceMove(loc)
 			return TRUE // It's resolved. No afterattack needed. Stops you from emagging lockers when putting in an emag


### PR DESCRIPTION
## What Does This PR Do
Crates and lockers could "steal" objects that were supposed to go somewhere else when dropped. That doesn't happen anymore.
Fixed #24575

## Why It's Good For The Game
Bugs bad.

## Testing
Tried to put a janitor's water nozzle into the crate. It went back to the tank instead.

## Changelog
:cl:
fix: Stopped crates and lockers from taking stuff they shouldn't.
/:cl: