### PR TITLE
Re-added the account info paper on creating a new account.

### DIFF
--- a/code/modules/economy/economy_machinery/account_terminal.dm
+++ b/code/modules/economy/economy_machinery/account_terminal.dm
@@ -136,8 +136,40 @@
 			var/account_name = params["holder_name"]
 			if(!account_name)
 				return
-			GLOB.station_money_database.create_account(account_name, 0, ACCOUNT_SECURITY_ID, name, supress_log = FALSE)
+			var/datum/money_account/account = GLOB.station_money_database.create_account(account_name, 0, ACCOUNT_SECURITY_ID, name, supress_log = FALSE)
+			print_new_account_info(account)
 			current_page = AUT_ACCLST
+
+/obj/machinery/computer/account_database/proc/print_new_account_info(datum/money_account/account)
+	//create a sealed package containing the account details
+	var/obj/item/smallDelivery/P = new /obj/item/smallDelivery(loc)
+
+	var/obj/item/paper/R = new /obj/item/paper(P)
+	playsound(loc, 'sound/goonstation/machines/printer_thermal.ogg', 50, 1)
+	P.wrapped = R
+	R.name = "Account information: [account.account_name]"
+
+	var/overseer = "Unknown"
+	var/datum/ui_login/L = ui_login_get()
+	if(L.id)
+		overseer = L.id.registered_name
+	R.info = {"<b>Account details (confidential)</b><br><hr><br>
+		<i>Account holder:</i> [account.account_name]<br>
+		<i>Account number:</i> [account.account_number]<br>
+		<i>Account pin:</i> [account.account_pin]<br>
+		<i>Starting balance:</i> $[account.credit_balance]<br>
+		<i>Date and time:</i> [station_time_timestamp()], [GLOB.current_date_string]<br><br>
+		<i>Authorised NT officer overseeing creation:</i> [overseer]<br>"}
+
+	//stamp the paper
+	var/image/stampoverlay = image('icons/obj/bureaucracy.dmi')
+	stampoverlay.icon_state = "paper_stamp-cent"
+	if(!R.stamped)
+		R.stamped = new
+	R.stamped += /obj/item/stamp
+	R.stamp_overlays += stampoverlay
+	R.stamps += "<HR><i>This paper has been stamped by the Accounts Database.</i>"
+	
 
 /obj/machinery/computer/account_database/proc/clear_viewed_account()
 	UnregisterSignal(detailed_account_view, COMSIG_PARENT_QDELETING)

--- a/code/modules/economy/economy_machinery/account_terminal.dm
+++ b/code/modules/economy/economy_machinery/account_terminal.dm
@@ -142,34 +142,33 @@
 
 /obj/machinery/computer/account_database/proc/print_new_account_info(datum/money_account/account)
 	//create a sealed package containing the account details
-	var/obj/item/smallDelivery/P = new /obj/item/smallDelivery(loc)
+	var/obj/item/smallDelivery/package = new /obj/item/smallDelivery(loc)
 
-	var/obj/item/paper/R = new /obj/item/paper(P)
-	playsound(loc, 'sound/goonstation/machines/printer_thermal.ogg', 50, 1)
-	P.wrapped = R
-	R.name = "Account information: [account.account_name]"
+	var/obj/item/paper/printout = new /obj/item/paper(package)
+	playsound(loc, 'sound/goonstation/machines/printer_thermal.ogg', 50, TRUE)
+	package.wrapped = printout
+	printout.name = "Account information: [account.account_name]"
 
 	var/overseer = "Unknown"
 	var/datum/ui_login/L = ui_login_get()
 	if(L.id)
 		overseer = L.id.registered_name
-	R.info = {"<b>Account details (confidential)</b><br><hr><br>
+	printout.info = {"<b>Account details (confidential)</b><br><hr><br>
 		<i>Account holder:</i> [account.account_name]<br>
 		<i>Account number:</i> [account.account_number]<br>
-		<i>Account pin:</i> [account.account_pin]<br>
+		<i>Account PIN:</i> [account.account_pin]<br>
 		<i>Starting balance:</i> $[account.credit_balance]<br>
-		<i>Date and time:</i> [station_time_timestamp()], [GLOB.current_date_string]<br><br>
+		<i>Created at:</i> [GLOB.current_date_string], [station_time_timestamp()]<br><br>
 		<i>Authorised NT officer overseeing creation:</i> [overseer]<br>"}
 
-	//stamp the paper
+	//stamp the paper (icon only)
 	var/image/stampoverlay = image('icons/obj/bureaucracy.dmi')
 	stampoverlay.icon_state = "paper_stamp-cent"
-	if(!R.stamped)
-		R.stamped = new
-	R.stamped += /obj/item/stamp
-	R.stamp_overlays += stampoverlay
-	R.stamps += "<HR><i>This paper has been stamped by the Accounts Database.</i>"
-	
+	if(!printout.stamped)
+		printout.stamped = new
+	printout.stamped += /obj/item/stamp
+	printout.stamp_overlays += stampoverlay
+	printout.stamps += "<hr><i>This paper has been stamped by the Accounts Database.</i>"
 
 /obj/machinery/computer/account_database/proc/clear_viewed_account()
 	UnregisterSignal(detailed_account_view, COMSIG_PARENT_QDELETING)


### PR DESCRIPTION
## What Does This PR Do
We used to print out a wrapped sheet of paper with account details when creating a new account, but it got lost in the economy rework. Re-added.
Fixed #22200.

## Why It's Good For The Game
You should have PIN access to a newly-created account.

## Images of changes
![image](https://github.com/ParadiseSS13/Paradise/assets/98381/da1edb04-5e8a-4270-a757-fe639d2880ac)
![image](https://github.com/ParadiseSS13/Paradise/assets/98381/ecc21d60-e885-4b81-8cdf-2abe4517ceff)

## Testing
Became HoP. Made definitely-not-illegal new account. Got nice printout. Was able to update PIN with the provided one.

## Changelog
:cl:
add: Re-added the account info printout on creating a new account at the Accounts Uplink Terminal.
/:cl: