### PR TITLE
Don't try to run queries when the database isn't enabled.

### DIFF
--- a/code/controllers/subsystem/SSdbcore.dm
+++ b/code/controllers/subsystem/SSdbcore.dm
@@ -382,6 +382,8 @@ SUBSYSTEM_DEF(dbcore)
   * * log_error - Do we want to log errors this creates? Disable this if you are running sensitive queries where you dont want errors logged in plain text (EG: Auth token stuff)
   */
 /datum/db_query/proc/warn_execute(async = TRUE, log_error = TRUE)
+	if(!GLOB.configuration.database.enabled)
+		return
 	. = Execute(async, log_error)
 	if(!.)
 		SSdbcore.total_errors++


### PR DESCRIPTION
## What Does This PR Do
Adds a check to prevent the database subsystem from attempting (and loudly failing) to run queries when the database isn't enabled.

## Why It's Good For The Game
A SQL error occurred during this operation, please inform an admin or a coder. xLOTS
ADMIN LOG: An SQL error has occurred. Please check the server logs, with the following timestamp ID: [2024-03-13T02:11:25] xLOTS

## Testing
Toggled hearing instruments.
```
You will no longer hear musical instruments.
You will now hear people playing musical instruments.
```
No whining about SQL.

## Changelog
NPFC