### PR TITLE
Gutlunches will no longer eat brains.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining/gutlunch.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/gutlunch.dm
@@ -39,7 +39,8 @@
 	animal_species = /mob/living/simple_animal/hostile/asteroid/gutlunch
 	childtype = list(/mob/living/simple_animal/hostile/asteroid/gutlunch/grublunch = 100)
 
-	wanted_objects = list(/obj/effect/decal/cleanable/blood/gibs, /obj/item/organ/internal)
+	wanted_objects = list(/obj/effect/decal/cleanable/blood/gibs, /obj/item/organ/internal/eyes, /obj/item/organ/internal/heart,
+	/obj/item/organ/internal/lungs, /obj/item/organ/internal/liver, /obj/item/organ/internal/kidneys, /obj/item/organ/internal/appendix)
 	var/obj/item/udder/gutlunch/udder = null
 
 /mob/living/simple_animal/hostile/asteroid/gutlunch/Initialize(mapload)

--- a/code/modules/mob/living/simple_animal/hostile/mining/gutlunch.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/gutlunch.dm
@@ -39,8 +39,10 @@
 	animal_species = /mob/living/simple_animal/hostile/asteroid/gutlunch
 	childtype = list(/mob/living/simple_animal/hostile/asteroid/gutlunch/grublunch = 100)
 
-	wanted_objects = list(/obj/effect/decal/cleanable/blood/gibs, /obj/item/organ/internal/eyes, /obj/item/organ/internal/heart,
-	/obj/item/organ/internal/lungs, /obj/item/organ/internal/liver, /obj/item/organ/internal/kidneys, /obj/item/organ/internal/appendix)
+	wanted_objects = list(/obj/effect/decal/cleanable/blood/gibs, /obj/item/organ/internal/eyes, 
+										/obj/item/organ/internal/heart, /obj/item/organ/internal/lungs, 
+										/obj/item/organ/internal/liver, /obj/item/organ/internal/kidneys, 
+										/obj/item/organ/internal/appendix)
 	var/obj/item/udder/gutlunch/udder = null
 
 /mob/living/simple_animal/hostile/asteroid/gutlunch/Initialize(mapload)


### PR DESCRIPTION
## What Does This PR Do
Changes the list of things gutlunches eat so they do not eat brains or implants by specifying exactly what organs they can eat.

## Why It's Good For The Game
Miners getting their brain eaten by gutlunches if gibbed by ashwalkers feels unnecessarily cruel given the gibbing alone tends to be a round removal. If a miner seeks to go out and recover their friend from an ashwalker, then damn let them have that cool story. Its a bit anticlimactic to see a weird lava planet spider ate your friends' brain after you go through all that effort to rescue them.

## Testing
Tried to eat brains and implants, could only eat what I set to eat.

## Changelog
:cl:
tweak: Gutlunches will no longer eat brains and implants.
/:cl: