### PR TITLE
fix: IAA has access to cargo again

### DIFF
--- a/code/game/jobs/job/supervisor.dm
+++ b/code/game/jobs/job/supervisor.dm
@@ -309,8 +309,6 @@
 	dufflebag = /obj/item/storage/backpack/duffel/security
 
 
-
-//GLOBAL_VAR_INIT(lawyer, 0) //Checks for another lawyer //This changed clothes on 2nd lawyer, both IA get the same dreds. | This was deprecated back in 2014, and its now 2020
 /datum/job/lawyer
 	title = "Internal Affairs Agent"
 	flag = JOB_LAWYER
@@ -322,6 +320,7 @@
 	department_head = list("Captain")
 	selection_color = "#ddddff"
 	access = list(
+		ACCESS_CARGO,
 		ACCESS_CONSTRUCTION,
 		ACCESS_COURT,
 		ACCESS_LAWYER,


### PR DESCRIPTION
## What Does This PR Do
This PR updates IAA access to include cargo office. It also removes a deadcode comment from the IAA type.
## Why It's Good For The Game
When I made supply access more fine-grained in #23819 I neglected to update IAA. This fixes that oversight.
## Testing
Spawned in as IAA on all stations, ensured could enter cargo office.
## Changelog
:cl:
fix: IAA has cargo office access again.
/:cl:
