### PR TITLE
Gravity Generator can no longuer be destroyed/animated by AI malf

### DIFF
--- a/code/modules/power/gravitygenerator.dm
+++ b/code/modules/power/gravitygenerator.dm
@@ -22,6 +22,7 @@ GLOBAL_LIST_EMPTY(gravity_generators)
 	density = TRUE
 	power_state = NO_POWER_USE
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
+	flags_2 = NO_MALF_EFFECT_2
 
 /obj/machinery/gravity_generator/ex_act(severity)
 	if(severity == 1) // Very sturdy.


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds flags_2 = NO_MALF_EFFECT_2 to the gravity generator code, to avoid it being destroyed by malf AI overide/overload ability.

## Why It's Good For The Game
The gravity generator is supposed to be undestructible by any means. Deleeting the gravgen should be an admin-only action. As it is permanent and unable to be recovered.

## Testing
Loaded a test server, Turned into malf AI, Purchased overload and animate, tried both on the gravity generator. As intended, none work.

## Changelog
:cl:
fix: Gravity generator cant be destroyed by machine overload/overide
/:cl:
