### PR TITLE
Reduce the move delay buffer to 1 tick

### DIFF
--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -44,8 +44,6 @@
 			mob.control_object.forceMove(get_step(mob.control_object, direct))
 	return
 
-#define MOVEMENT_DELAY_BUFFER 0.75
-#define MOVEMENT_DELAY_BUFFER_DELTA 1.25
 #define CONFUSION_LIGHT_COEFFICIENT		0.15
 #define CONFUSION_HEAVY_COEFFICIENT		0.075
 #define CONFUSION_MAX					80 SECONDS
@@ -54,9 +52,10 @@
 /client/Move(n, direct)
 	if(world.time < move_delay)
 		return
-	else
-		input_data.desired_move_dir_add = NONE
-		input_data.desired_move_dir_sub = NONE
+
+	input_data.desired_move_dir_add = NONE
+	input_data.desired_move_dir_sub = NONE
+
 	var/old_move_delay = move_delay
 	move_delay = world.time + world.tick_lag //this is here because Move() can now be called multiple times per tick
 	if(!mob || !mob.loc)
@@ -131,10 +130,8 @@
 					M.stop_pulling()
 
 
-	//We are now going to move
-	moving = 1
 	var/delay = mob.movement_delay()
-	if(old_move_delay + (delay * MOVEMENT_DELAY_BUFFER_DELTA) + MOVEMENT_DELAY_BUFFER > world.time)
+	if(old_move_delay + world.tick_lag > world.time)
 		move_delay = old_move_delay
 	else
 		move_delay = world.time
@@ -185,7 +182,6 @@
 	if(prev_pulling_loc && mob.pulling?.face_while_pulling && (mob.pulling.loc != prev_pulling_loc))
 		mob.setDir(get_dir(mob, mob.pulling)) // Face welding tanks and stuff when pulling
 
-	moving = 0
 	if(mob && . && mob.throwing)
 		mob.throwing.finalize(FALSE)
 

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -508,6 +508,3 @@
 		hud_used.move_intent.icon_state = icon_toggle
 		for(var/atom/movable/screen/mov_intent/selector in hud_used.static_inventory)
 			selector.update_icon()
-
-#undef MOVEMENT_DELAY_BUFFER
-#undef MOVEMENT_DELAY_BUFFER_DELTA


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Probably needs TM
Ports https://github.com/tgstation/tgstation/pull/63332, explanation included in PR
Thanks to this https://github.com/ss220-space/Paradise/pull/4628 PR for pointing at that (also for comparsion showcase)

## Why It's Good For The Game
Better smooth when moving

## Images of changes
Included in attached PR's above

## Testing
Tested locally

## Changelog
:cl: LemonInTheDark, dj-34
fix: Fixed hitting a move input inside a small grace period in move code leading to teleportation. It's a side effect of when movement used to be verbs, and holding a button down meant constantly sending the server move commands
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
