### PR TITLE
Fixes detective holobarriers not fitting inside security belts.

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -287,6 +287,7 @@
 		/obj/item/melee/classic_baton,
 		/obj/item/flashlight/seclite,
 		/obj/item/holosign_creator/security,
+		/obj/item/holosign_creator/detective,
 		/obj/item/melee/classic_baton/telescopic,
 		/obj/item/restraints/legcuffs/bola,
 		/obj/item/clothing/mask/gas/sechailer,


### PR DESCRIPTION
## What Does This PR Do
Allows the detective holobarrier to be put inside security belts.

## Why It's Good For The Game
This fixes an oversight in my original holobarrier PR.

## Testing
Took projector, put in belt.

## Changelog
:cl:
fix: The Detective holobarrier projector now fits in security belts.
/:cl: