### PR TITLE
[TWEAK] Makes headslug mob_size MOB_SIZE_SMALL

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/headslug.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headslug.dm
@@ -21,6 +21,7 @@
 	environment_smash = 0
 	speak_emote = list("squeaks")
 	pass_flags = PASSTABLE | PASSMOB
+	mob_size = MOB_SIZE_SMALL
 	density = FALSE
 	ventcrawler = VENTCRAWLER_ALWAYS
 	a_intent = INTENT_HARM


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes the mob size of changeling headslugs small rather than normal. In practice, this has three effects.

- They can no longer open morgue trays and the like.
- They can only pull items of normal size or smaller.
- They can only pull mobs that are also small or smaller (So they can no longer pull humans.
- They can no longer strip mobs of their items.

Fixes: #24617
(I have more general issues with simple mobs being able to open morgue trays at all but that is out of the scope for this PR.)
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
As a headslug you are a slug; You should be fairly limited in what you can do since you are a small slug with no hands. This should making getting a new body at least slightly less trivial than just crawling into the morgue and opening a morgue tray.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Be a headslug.
Attempt to open a morgue tray, I can't.
Attempt to strip a skrell, I can't.
Attempt to pull a skrell, I can't.
Attempt to pull a cat instead, I am succesful.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Headslugs are now small mobs, meaning they can no longer open morgue trays or pull humans.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
