### PR TITLE
Removed an unused bit of UI data from the supply console.

### DIFF
--- a/code/modules/supply/supply_console.dm
+++ b/code/modules/supply/supply_console.dm
@@ -208,7 +208,6 @@
 	data["moving"] = SSshuttle.supply.mode != SHUTTLE_IDLE
 	data["at_station"] = SSshuttle.supply.getDockedId() == "supply_home"
 	data["timeleft"] = SSshuttle.supply.timeLeft(60 SECONDS)
-	data["can_launch"] = !SSshuttle.supply.canMove()
 
 	return data
 


### PR DESCRIPTION
## What Does This PR Do
Removes `can_launch` from the supply console's UI data.

## Why It's Good For The Game
Don't send data if you're not going to use it!

## Testing
Compiled, ran, opened shuttle console.  LGTM

## Changelog
NPFC