### PR TITLE
Make the nuclear beer keg react to the NAD.

### DIFF
--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -279,6 +279,27 @@
 	icon = 'icons/obj/nuclearbomb.dmi'
 	icon_state = "nuclearbomb0"
 	anchored = TRUE
+	var/exploding = FALSE
+
+/obj/structure/reagent_dispensers/beerkeg/nuke/attackby(obj/item/O as obj, mob/user as mob, params)
+	if(exploding)
+		return
+	if(istype(O, /obj/item/disk/nuclear))
+		user.visible_message(
+			"<span class='danger'>[user] inserts [O] into [src] and it begins making a loud beeping noise! Uh-oh!</span>",
+			"<span class='danger'>You prime [src] with [O] and it begins making a loud beeping noise! Better run!</span>")
+		playsound(src, 'sound/machines/alarm.ogg', 100, 0, 0)
+		exploding = TRUE
+		sleep(13 SECONDS)
+		var/datum/reagents/R = new(100)
+		R.my_atom = src
+		R.add_reagent("beer", 100)
+		var/datum/effect_system/smoke_spread/chem/smoke = new
+		smoke.set_up(R, src, TRUE)
+		playsound(src.loc, 'sound/effects/smoke.ogg', 50, 1, -3)
+		smoke.start(3)
+		qdel(R)
+		qdel(src)
 
 /obj/structure/reagent_dispensers/beerkeg/nuke/update_overlays()
 	. = ..()

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -282,24 +282,26 @@
 	var/exploding = FALSE
 
 /obj/structure/reagent_dispensers/beerkeg/nuke/attackby(obj/item/O as obj, mob/user as mob, params)
+	. = ..()
 	if(exploding)
 		return
-	if(istype(O, /obj/item/disk/nuclear))
-		user.visible_message(
-			"<span class='danger'>[user] inserts [O] into [src] and it begins making a loud beeping noise! Uh-oh!</span>",
-			"<span class='danger'>You prime [src] with [O] and it begins making a loud beeping noise! Better run!</span>")
-		playsound(src, 'sound/machines/alarm.ogg', 100, 0, 0)
-		exploding = TRUE
-		sleep(13 SECONDS)
-		var/datum/reagents/R = new(100)
-		R.my_atom = src
-		R.add_reagent("beer", 100)
-		var/datum/effect_system/smoke_spread/chem/smoke = new
-		smoke.set_up(R, src, TRUE)
-		playsound(src.loc, 'sound/effects/smoke.ogg', 50, 1, -3)
-		smoke.start(3)
-		qdel(R)
-		qdel(src)
+	if(!istype(O, /obj/item/disk/nuclear))
+		return
+	user.visible_message(
+		"<span class='danger'>[user] inserts [O] into [src] and it begins making a loud beeping noise! Uh-oh!</span>",
+		"<span class='danger'>You prime [src] with [O] and it begins making a loud beeping noise! Better run!</span>")
+	playsound(src, 'sound/machines/alarm.ogg', 100, 0, 0)
+	exploding = TRUE
+	sleep(13 SECONDS)
+	var/datum/reagents/R = new(100)
+	R.my_atom = src
+	R.add_reagent("beer", 100)
+	var/datum/effect_system/smoke_spread/chem/smoke = new
+	smoke.set_up(R, src, TRUE)
+	playsound(src.loc, 'sound/effects/smoke.ogg', 50, 1, -3)
+	smoke.start(3)
+	qdel(R)
+	qdel(src)
 
 /obj/structure/reagent_dispensers/beerkeg/nuke/update_overlays()
 	. = ..()

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -279,6 +279,7 @@
 	icon = 'icons/obj/nuclearbomb.dmi'
 	icon_state = "nuclearbomb0"
 	anchored = TRUE
+	/// If TRUE, prevents the player from inserting the disk again while it is currently exploding.
 	var/exploding = FALSE
 
 /obj/structure/reagent_dispensers/beerkeg/nuke/attackby(obj/item/O, mob/user, params)

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -292,7 +292,9 @@
 		"<span class='danger'>You prime [src] with [O] and it begins making a loud beeping noise! Better run!</span>")
 	playsound(src, 'sound/machines/alarm.ogg', 100, FALSE, 0)
 	exploding = TRUE
-	sleep(13 SECONDS)
+	addtimer(CALLBACK(src, PROC_REF(explode)), 13 SECONDS)
+
+/obj/structure/reagent_dispensers/beerkeg/nuke/proc/explode()
 	var/datum/reagents/R = new(100)
 	R.my_atom = src
 	R.add_reagent("beer", 100)

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -281,7 +281,7 @@
 	anchored = TRUE
 	var/exploding = FALSE
 
-/obj/structure/reagent_dispensers/beerkeg/nuke/attackby(obj/item/O as obj, mob/user as mob, params)
+/obj/structure/reagent_dispensers/beerkeg/nuke/attackby(obj/item/O, mob/user, params)
 	. = ..()
 	if(exploding)
 		return
@@ -290,7 +290,7 @@
 	user.visible_message(
 		"<span class='danger'>[user] inserts [O] into [src] and it begins making a loud beeping noise! Uh-oh!</span>",
 		"<span class='danger'>You prime [src] with [O] and it begins making a loud beeping noise! Better run!</span>")
-	playsound(src, 'sound/machines/alarm.ogg', 100, 0, 0)
+	playsound(src, 'sound/machines/alarm.ogg', 100, FALSE, 0)
 	exploding = TRUE
 	sleep(13 SECONDS)
 	var/datum/reagents/R = new(100)
@@ -298,7 +298,7 @@
 	R.add_reagent("beer", 100)
 	var/datum/effect_system/smoke_spread/chem/smoke = new
 	smoke.set_up(R, src, TRUE)
-	playsound(src.loc, 'sound/effects/smoke.ogg', 50, 1, -3)
+	playsound(src.loc, 'sound/effects/smoke.ogg', 50, TRUE, -3)
 	smoke.start(3)
 	qdel(R)
 	qdel(src)


### PR DESCRIPTION
## What Does This PR Do
Using the NAD on the beer keg nuke will cause it to explode in a shower of beer.

## Why It's Good For The Game
It's funny.

## Testing
Used other objects, attacked normally.
Used NAD, got drunk.

## Changelog
:cl:
add: Some hooligan added a self destruct device to that beer keg we dressed up like the nuke. Fortunately, it can only be set off by the real nuclear authentication disk, and nobody would do that, right?
/:cl: