### PR TITLE
Disguised clown shoes.

### DIFF
--- a/code/modules/clothing/shoes/misc_shoes.dm
+++ b/code/modules/clothing/shoes/misc_shoes.dm
@@ -133,10 +133,10 @@
 	flags = NODROP
 
 /obj/item/clothing/shoes/clown_shoes/slippers
-	dyeable = FALSE
 	actions_types = list(/datum/action/item_action/slipping)
 	enabled_waddle = FALSE
 	slowdown = 0
+	dyeable = FALSE
 	var/slide_distance = 6
 	var/recharging_rate = 8 SECONDS
 	var/recharging_time = 0
@@ -329,7 +329,6 @@
 
 
 /obj/item/clothing/shoes/clown_shoes/false_cluwne_shoes
-	dyeable = FALSE
 	name = "cursed clown shoes"
 	desc = "Moldering clown flip flops. They're neon green for some reason."
 	icon = 'icons/goonstation/objects/clothing/feet.dmi'
@@ -338,6 +337,7 @@
 	icon_override = 'icons/goonstation/mob/clothing/feet.dmi'
 	lefthand_file = 'icons/goonstation/mob/inhands/clothing_lefthand.dmi'
 	righthand_file = 'icons/goonstation/mob/inhands/clothing_righthand.dmi'
+	dyeable = FALSE
 
 /obj/item/clothing/shoes/singery
 	name = "yellow performer's boots"

--- a/code/modules/clothing/shoes/misc_shoes.dm
+++ b/code/modules/clothing/shoes/misc_shoes.dm
@@ -84,6 +84,10 @@
 	slowdown = SHOES_SLOWDOWN+1
 	item_color = "clown"
 	var/enabled_waddle = TRUE
+	// "Dyeable" in this case is a bit of an understatement, washing these
+	// with a crayon will give them the appearance and name of normal
+	// shoes, but the functionality of clown shoes.
+	dyeable = TRUE
 
 /obj/item/clothing/shoes/clown_shoes/Initialize(mapload)
 	. = ..()

--- a/code/modules/clothing/shoes/misc_shoes.dm
+++ b/code/modules/clothing/shoes/misc_shoes.dm
@@ -119,11 +119,13 @@
 		enabled_waddle = FALSE
 
 /obj/item/clothing/shoes/clown_shoes/nodrop
+	dyeable = FALSE
 	flags = NODROP
 
 /obj/item/clothing/shoes/clown_shoes/magical
 	name = "magical clown shoes"
 	desc = "Standard-issue shoes of the wizarding class clown. Damn they're huge! And powerful! Somehow."
+	dyeable = FALSE
 	magical = TRUE
 
 /obj/item/clothing/shoes/clown_shoes/magical/nodrop
@@ -131,6 +133,7 @@
 	flags = NODROP
 
 /obj/item/clothing/shoes/clown_shoes/slippers
+	dyeable = FALSE
 	actions_types = list(/datum/action/item_action/slipping)
 	enabled_waddle = FALSE
 	slowdown = 0
@@ -326,6 +329,7 @@
 
 
 /obj/item/clothing/shoes/clown_shoes/false_cluwne_shoes
+	dyeable = FALSE
 	name = "cursed clown shoes"
 	desc = "Moldering clown flip flops. They're neon green for some reason."
 	icon = 'icons/goonstation/objects/clothing/feet.dmi'


### PR DESCRIPTION
## What Does This PR Do
Clown shoes can be washed with a crayon to disguise them as normal shoes.

## Why It's Good For The Game
This was most likely originally a bug, but got documented on the wiki as a feature back in 2017. At some point in the intervening years, the bug was unintentionally fixed, and the "feature" went away.

This intentionally reinstates the prior behavior, which was kinda funny.

## Testing
Washed clown shoes with an orange crayon. Got ordinary-looking orange shoes that squeak.
Washed all the clown shoe subtypes that could be placed in the washing machine with a red crayon. No change to any of them.

## Changelog
:cl:
add: Clown shoes can be washed with a crayon to disguise them as normal shoes.
/:cl: