### PR TITLE
[s] Made effect teleporting into a trait.

### DIFF
--- a/code/__HELPERS/trait_helpers.dm
+++ b/code/__HELPERS/trait_helpers.dm
@@ -363,3 +363,6 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 // turf trait sources
 #define FLOOR_EFFECT_TRAIT "floor_effect_trait"
 
+//***** TURF TRAITS *****//
+// Causes the effect to go through a teleporter instead of being deleted by it.
+#define TRAIT_EFFECT_CAN_TELEPORT "trait_effect_can_teleport"

--- a/code/_globalvars/traits.dm
+++ b/code/_globalvars/traits.dm
@@ -111,6 +111,9 @@ GLOBAL_LIST_INIT(traits_by_type, list(
 	),
 	/turf = list(
 		"bluespace_speed_trait" = TRAIT_BLUESPACE_SPEED
+	),
+	/obj/effect = list(
+		"TRAIT_EFFECT_CAN_TELEPORT" = TRAIT_EFFECT_CAN_TELEPORT
 	)
 ))
 

--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -76,7 +76,7 @@
 
 //must succeed in most cases
 /datum/teleport/proc/setTeleatom(atom/movable/ateleatom)
-	if(iseffect(ateleatom) && !istype(ateleatom, /obj/effect/dummy/chameleon))
+	if(iseffect(ateleatom) && !HAS_TRAIT(ateleatom, TRAIT_EFFECT_CAN_TELEPORT))
 		qdel(ateleatom)
 		return FALSE
 	if(istype(ateleatom))

--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -101,6 +101,10 @@
 	var/can_move = TRUE
 	var/obj/item/chameleon/master = null
 
+/obj/effect/dummy/chameleon/Initialize()
+	. = ..()
+	ADD_TRAIT(src, TRAIT_EFFECT_CAN_TELEPORT, ROUNDSTART_TRAIT)
+
 /obj/effect/dummy/chameleon/proc/activate(obj/O, mob/M, new_icon, new_iconstate, new_overlays, new_underlays, obj/item/chameleon/C)
 	name = O.name
 	desc = O.desc

--- a/code/modules/mining/fulton.dm
+++ b/code/modules/mining/fulton.dm
@@ -178,6 +178,10 @@ GLOBAL_LIST_EMPTY(total_extraction_beacons)
 	desc = "you shouldnt see this"
 	var/atom/movable/stored_obj
 
+/obj/effect/extraction_holder/Initialize()
+	. = ..()
+	ADD_TRAIT(src, TRAIT_EFFECT_CAN_TELEPORT, ROUNDSTART_TRAIT)
+
 /obj/item/extraction_pack/proc/check_for_living_mobs(atom/A)
 	if(isliving(A))
 		var/mob/living/L = A

--- a/code/modules/mining/lavaland/loot/tendril_loot.dm
+++ b/code/modules/mining/lavaland/loot/tendril_loot.dm
@@ -405,6 +405,10 @@
 	icon = 'icons/effects/effects.dmi'
 	var/can_destroy = FALSE
 
+/obj/effect/immortality_talisman/Initialize()
+	. = ..()
+	ADD_TRAIT(src, TRAIT_EFFECT_CAN_TELEPORT, ROUNDSTART_TRAIT)
+
 /obj/effect/immortality_talisman/attackby()
 	return
 


### PR DESCRIPTION
## What Does This PR Do
Refactors the list of effects that can teleport into a trait.
Fixes #24636

## Why It's Good For The Game
Hardcoded lists bad.

## Testing
Fultoned a corpse into a teleporter, received a corpse.

## Changelog
:cl:
fix: Fulton recovery beacons can no longer delete corpses that they send into a teleporter.
/:cl: