### PR TITLE
Added a setting that gates random station traits on round start.

### DIFF
--- a/code/controllers/configuration/sections/gamemode_configuration.dm
+++ b/code/controllers/configuration/sections/gamemode_configuration.dm
@@ -20,6 +20,8 @@
 	var/traitor_objectives_amount = 2
 	/// Enable player limits on gamemodes? Disabling can be useful for testing
 	var/enable_gamemode_player_limit = TRUE
+	/// Should we generate random station traits at game start?
+	var/add_random_station_traits = TRUE
 
 // Dynamically setup a list of all gamemodes
 /datum/configuration_section/gamemode_configuration/New()
@@ -51,6 +53,7 @@
 	CONFIG_LOAD_BOOL(prevent_mindshield_antags, data["prevent_mindshield_antag"])
 	CONFIG_LOAD_BOOL(disable_certain_round_early_end, data["disable_certain_round_early_end"])
 	CONFIG_LOAD_BOOL(enable_gamemode_player_limit, data["enable_gamemode_player_limit"])
+	CONFIG_LOAD_BOOL(add_random_station_traits, data["add_random_station_traits"])
 
 	CONFIG_LOAD_NUM(traitor_objectives_amount, data["traitor_objective_amount"])
 

--- a/code/controllers/subsystem/processing/SSstation.dm
+++ b/code/controllers/subsystem/processing/SSstation.dm
@@ -34,6 +34,9 @@ PROCESSING_SUBSYSTEM_DEF(station)
 
 		return
 
+	if(!GLOB.configuration.gamemode.add_random_station_traits)
+		return
+
 	for(var/i in subtypesof(/datum/station_trait))
 		var/datum/station_trait/trait_typepath = i
 

--- a/config/example/config.toml
+++ b/config/example/config.toml
@@ -254,6 +254,8 @@ disable_certain_round_early_end = false
 traitor_objective_amount = 2
 # Enable player limits on gamemodes. Disable if testing
 enable_gamemode_player_limit = true
+# Enable to generate zero or more random station traits on game start.
+add_random_station_traits = false
 
 
 ################################################################


### PR DESCRIPTION
## What Does This PR Do
Added a setting that gates random station traits on round start.

The setting is on by default, but disabled in the example config, to help test servers be more predictable.

## Why It's Good For The Game
I'm testing something with the NAD now, so I'll spawn as the Captain... and I'm drunk in AI upload. Great.

## Testing
Started the game. Spawned as Captain at roundstart. Was in my office.
Edited the code to force hangover to be added "randomly" (by setting `force = TRUE`). Started the game again. Spawned as Captain at roundstart. Was in my office.

## Changelog
NPFC