### PR TITLE
Fix janicarts with trashbags mounted now accepting trash

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -116,6 +116,9 @@ GLOBAL_LIST_INIT(glass_sheet_types, typecacheof(list(
 // Structures
 #define isstructure(A)	(istype((A), /obj/structure))
 
+// Vehicles
+#define isvehicle(A) istype(A, /obj/vehicle)
+
 // Misc
 #define isclient(A) istype(A, /client)
 #define isradio(A) istype(A, /obj/item/radio)

--- a/code/_onclick/adjacent.dm
+++ b/code/_onclick/adjacent.dm
@@ -74,7 +74,7 @@
 // This is necessary for storage items not on your person.
 /obj/item/Adjacent(atom/neighbor, recurse = 1)
 	if(neighbor == loc) return 1
-	if(isitem(loc))
+	if(isitem(loc) || isstructure(loc) || isvehicle(loc))
 		if(recurse > 0)
 			return loc.Adjacent(neighbor,recurse - 1)
 		return 0


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes `/obj/item/Adjacent` handle if the item's `loc` is a structure or vehicle. This is to fix not being able to put items into trashbags if they're mounted on the `janitorialcart` or `janicart` (Fixes #24608). Examples of cases:

| Situation | Current behavior | With this PR |
|--------|--------|--------|
| Putting a pill into a pill box, inside a box | ✅ `Adjacent` for items inside items works | ✅ same behavior |
| Putting trash into trashbag, when mounted on `janitorialcart` | ❌ `Adjacent` for items inside structure doesn't work | ✅ now works |
| Putting trash into trashbag, when mounted on `janicart` | ❌ `Adjacent` for items inside vehicles doesn't work | ✅ now works | 

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Makes the trashbag/janicart more intuitive to use, no longer needing to remove it from cart to discard trash.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Played around with janitorialcarts, and it now works as expected. Putting items into containers inside boxes still works. Wandered around station looking for obvious broken behavior, but couldn't find anything.

Browsed both `/obj/structures` and `/obj/vehicles` looking for scenarios where this conditional would break behavior, but couldn't find anything obvious.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl: Zantox
fix: Fixed trashbags mounted on janitorialcart/janicart now accept trash.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
