### PR TITLE
Added beaker support to RPEDs.

### DIFF
--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -404,6 +404,19 @@
 						to_chat(user, "<span class='notice'>[A.name] replaced with [B.name].</span>")
 						shouldplaysound = 1
 						break
+			for(var/obj/item/reagent_containers/glass/beaker/A in component_parts)
+				for(var/obj/item/reagent_containers/glass/beaker/B in W.contents)
+					//If it's not better -> next content
+					if(B.reagents.maximum_volume <= A.reagents.maximum_volume)
+						continue
+					W.remove_from_storage(B, src)
+					W.handle_item_insertion(A, 1)
+					component_parts -= A
+					component_parts += B
+					B.loc = null
+					to_chat(user, "<span class='notice'>[A.name] replaced with [B.name].</span>")
+					shouldplaysound = 1
+					break
 			RefreshParts()
 		else
 			to_chat(user, display_parts(user))

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -410,12 +410,12 @@
 					if(B.reagents.maximum_volume <= A.reagents.maximum_volume)
 						continue
 					W.remove_from_storage(B, src)
-					W.handle_item_insertion(A, 1)
+					W.handle_item_insertion(A, TRUE)
 					component_parts -= A
 					component_parts += B
 					B.loc = null
 					to_chat(user, "<span class='notice'>[A.name] replaced with [B.name].</span>")
-					shouldplaysound = 1
+					shouldplaysound = TRUE
 					break
 			RefreshParts()
 		else

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -402,11 +402,11 @@
 						component_parts += B
 						B.loc = null
 						to_chat(user, "<span class='notice'>[A.name] replaced with [B.name].</span>")
-						shouldplaysound = 1
+						shouldplaysound = TRUE
 						break
 			for(var/obj/item/reagent_containers/glass/beaker/A in component_parts)
 				for(var/obj/item/reagent_containers/glass/beaker/B in W.contents)
-					//If it's not better -> next content
+					// If it's not better -> next content
 					if(B.reagents.maximum_volume <= A.reagents.maximum_volume)
 						continue
 					W.remove_from_storage(B, src)

--- a/code/game/objects/items/weapons/stock_parts.dm
+++ b/code/game/objects/items/weapons/stock_parts.dm
@@ -6,7 +6,14 @@
 	icon_state = "RPED"
 	item_state = "RPED"
 	w_class = WEIGHT_CLASS_HUGE
-	can_hold = list(/obj/item/stock_parts)
+	can_hold = list(
+		/obj/item/stock_parts,
+		// Added separately in Initialize to avoid picking up unwanted
+		// subtypes.
+		// /obj/item/reagent_containers/glass/beaker,
+		/obj/item/reagent_containers/glass/beaker/large,
+		/obj/item/reagent_containers/glass/beaker/bluespace
+		)
 	storage_slots = 50
 	use_to_pickup = TRUE
 	allow_quick_gather = TRUE
@@ -20,6 +27,10 @@
 	var/alt_sound = null
 	toolspeed = 1
 	usesound = 'sound/items/rped.ogg'
+
+/obj/item/storage/part_replacer/Initialize(mapload)
+	. = ..()
+	can_hold[/obj/item/reagent_containers/glass/beaker] = TRUE
 
 /obj/item/storage/part_replacer/afterattack(obj/machinery/M, mob/user, flag, params)
 	if(!flag && works_from_distance && istype(M))
@@ -56,6 +67,7 @@
 		new /obj/item/stock_parts/micro_laser/quadultra(src)
 		new /obj/item/stock_parts/scanning_module/triphasic(src)
 		new /obj/item/stock_parts/cell/bluespace(src)
+		new /obj/item/reagent_containers/glass/beaker/bluespace(src)
 
 /obj/item/storage/part_replacer/proc/play_rped_sound()
 	//Plays the sound for RPED exchanging or installing parts.
@@ -63,11 +75,6 @@
 		playsound(src, alt_sound, 40, 1)
 	else
 		playsound(src, primary_sound, 40, 1)
-
-//Sorts stock parts inside an RPED by their rating.
-//Only use /obj/item/stock_parts/ with this sort proc!
-/proc/cmp_rped_sort(obj/item/stock_parts/A, obj/item/stock_parts/B)
-	return B.rating - A.rating
 
 /obj/item/stock_parts
 	name = "stock part"

--- a/code/game/objects/items/weapons/stock_parts.dm
+++ b/code/game/objects/items/weapons/stock_parts.dm
@@ -8,8 +8,7 @@
 	w_class = WEIGHT_CLASS_HUGE
 	can_hold = list(
 		/obj/item/stock_parts,
-		// Added separately in Initialize to avoid picking up unwanted
-		// subtypes.
+		// This type is part of can_hold, but is added separately in Initialize to avoid picking up unwanted subtypes.
 		// /obj/item/reagent_containers/glass/beaker,
 		/obj/item/reagent_containers/glass/beaker/large,
 		/obj/item/reagent_containers/glass/beaker/bluespace

--- a/code/game/objects/items/weapons/stock_parts.dm
+++ b/code/game/objects/items/weapons/stock_parts.dm
@@ -31,6 +31,16 @@
 	. = ..()
 	can_hold[/obj/item/reagent_containers/glass/beaker] = TRUE
 
+/obj/item/storage/part_replacer/can_be_inserted(obj/item/I, stop_messages = FALSE)
+	if(!istype(I, /obj/item/reagent_containers/glass/beaker))
+		return ..()
+	var/obj/item/reagent_containers/glass/beaker/B = I
+	if(B.reagents?.total_volume)
+		if(!stop_messages)
+			to_chat(usr, "<span class='warning'>[src] cannot hold [I] while it contains liquid.</span>")
+		return FALSE
+	return ..()
+
 /obj/item/storage/part_replacer/afterattack(obj/machinery/M, mob/user, flag, params)
 	if(!flag && works_from_distance && istype(M))
 		// Make sure its in range


### PR DESCRIPTION
## What Does This PR Do
Adds beaker support to RPEDs.

Deletes an unused RPED-related proc.

## Why It's Good For The Game
The three main-line beakers are functionally stock parts, just not type-wise. This makes them act that way with the RPED.

## Testing
Spawned a preloaded bluespace RPED. Upgraded ChemMaster and Autolathe.
Spawned a normal bluespace RPED. Picked up a stack of all beaker subtypes, only got normal, large, and bluespace. Upgraded another ChemMaster and Autolathe.
Added all the other T4 parts to the bRPED. Upgrade another ChemMaster and Autolathe.
Emptied bRPED. Added all T4 parts to the bRPED. Added all three mainline beakers in opposite order. Upgrade another ChemMaster and Autolathe.
Tried picking up an empty and filled beaker in a few combinations. Sometimes didn't get either, but never got the filled one.

## Changelog
:cl:
add: RPEDs can now pick up and replace (empty) beakers. Chemists rejoice, your ChemMaster can be upgraded easily now!
/:cl: