### PR TITLE
Retaliate mobs no longer break stuff after revived with a laz injector.

### DIFF
--- a/code/__DEFINES/mob_defines.dm
+++ b/code/__DEFINES/mob_defines.dm
@@ -241,6 +241,7 @@
 #define isguardian(A)		(istype((A), /mob/living/simple_animal/hostile/guardian))
 #define isnymph(A)      	(istype((A), /mob/living/simple_animal/diona))
 #define ishostile(A) 		(istype((A), /mob/living/simple_animal/hostile))
+#define isretaliate(A) 		(istype((A), /mob/living/simple_animal/hostile/retaliate))
 #define isterrorspider(A) 	(istype((A), /mob/living/simple_animal/hostile/poison/terror_spider))
 #define isslaughterdemon(A) (istype((A), /mob/living/simple_animal/demon/slaughter))
 #define isdemon(A) 			(istype((A), /mob/living/simple_animal/demon))

--- a/code/modules/mining/equipment/lazarus_injector.dm
+++ b/code/modules/mining/equipment/lazarus_injector.dm
@@ -29,6 +29,12 @@
 				M.can_collar = TRUE
 				if(ishostile(target))
 					var/mob/living/simple_animal/hostile/H = M
+					if(isretaliate(target))
+						// Clear the enemies list so we don't break windows
+						// to get to people we no longer hate.
+						var/mob/living/simple_animal/hostile/retaliate/R = H
+						R.enemies.Cut()
+
 					if(malfunctioning)
 						H.faction |= list("lazarus", "\ref[user]")
 						H.robust_searching = TRUE


### PR DESCRIPTION
## What Does This PR Do
Retaliate mobs no longer break stuff after revived with a laz injector.
Fixes #4152

## Why It's Good For The Game
Bugs bad. Except Araneus, she's nice.

## Testing
Upset Araneus. She broke windows.
Revived her with a Lazarus Injector. She no longer broke windows.

## Changelog
:cl:
fix: Mobs that retaliate when attacked will no longer continue breaking terrain after being revived with a Lazarus Injector.
/:cl: