### PR TITLE
Make pAIs show correctly in diagnostic HUDs

### DIFF
--- a/code/modules/mob/living/silicon/pai/pai_death.dm
+++ b/code/modules/mob/living/silicon/pai/pai_death.dm
@@ -13,5 +13,8 @@
 	if(!.)
 		return FALSE
 
+	diag_hud_set_status()
+	diag_hud_set_health()
+
 	if(icon_state != "[chassis]_dead" || cleanWipe)
 		qdel(src)

--- a/code/modules/mob/living/silicon/pai/pai_life.dm
+++ b/code/modules/mob/living/silicon/pai/pai_life.dm
@@ -21,3 +21,4 @@
 	else
 		health = 100 - getBruteLoss() - getFireLoss()
 		update_stat("updatehealth([reason])")
+		diag_hud_set_health()


### PR DESCRIPTION
## What Does This PR Do
Make pAIs show correctly in diagnostic HUDs
Fixes #5260

## Why It's Good For The Game
Bugs bad. Especially that terror spider..

## Testing
Spawned a pAI, put it in mobile form.
Spawned a terror spider, gave it diagnostic HUD, used it to bite the pAI to death.

## Changelog
:cl:
fix: pAIs now show their health and status correctly in diagnostic HUDs.
/:cl: