### PR TITLE
Fix mime/clown picked names not being on their bank account.

### DIFF
--- a/code/modules/mob/mob_misc_procs.dm
+++ b/code/modules/mob/mob_misc_procs.dm
@@ -607,6 +607,8 @@
 	name = newname
 	if(mind)
 		mind.name = newname
+		if(mind.initial_account?.account_name == oldname)
+			mind.initial_account.account_name = newname
 	if(dna)
 		dna.real_name = real_name
 


### PR DESCRIPTION
## What Does This PR Do
Fixes #12161.

This will also make bank accounts update properly when admins rename a player.

## Why It's Good For The Game
Consistency good.

## Testing
Spawned as a clown, named myself Not A Clown.
Opened ATM.
"Welcome, Not A Clown"

## Changelog
:cl:
fix: Nanotrasen's accounting department has finally ruled that the clown and mime's chosen names can appear on their bank accounts.
/:cl: