### PR TITLE
Temp cell secure lockers now spawn empty.

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -29103,15 +29103,12 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 1";
-	name = "Cell 1 Locker"
-	},
 /obj/item/radio/intercom{
 	name = "north bump";
 	pixel_y = 28
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/closet/secure_closet/brig/temp/cell_1,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkredcorners"
@@ -29212,10 +29209,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 6";
-	name = "Cell 6 Locker"
-	},
+/obj/structure/closet/secure_closet/brig/temp/cell_6,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkredcorners"
 	},
@@ -70044,13 +70038,10 @@
 	},
 /area/station/maintenance/theatre)
 "glX" = (
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 3";
-	name = "Cell 3 Locker"
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
+/obj/structure/closet/secure_closet/brig/temp/cell_3,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkredcorners"
@@ -74416,13 +74407,10 @@
 	c_tag = "Brig - Cell 2";
 	dir = 8
 	},
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 2";
-	name = "Cell 2 Locker"
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
+/obj/structure/closet/secure_closet/brig/temp/cell_2,
 /turf/simulated/floor/plating,
 /area/station/security/prison/cell_block)
 "iYj" = (
@@ -90727,13 +90715,10 @@
 /turf/simulated/floor/plating,
 /area/station/security/execution)
 "sCu" = (
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 4";
-	name = "Cell 4 Locker"
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
+/obj/structure/closet/secure_closet/brig/temp/cell_4,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkredcorners"
 	},
@@ -94940,10 +94925,6 @@
 /turf/simulated/floor/carpet/purple,
 /area/station/medical/psych)
 "uYc" = (
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 5";
-	name = "Cell 5 Locker"
-	},
 /obj/machinery/camera{
 	c_tag = "Brig - Cell 5"
 	},
@@ -94956,6 +94937,7 @@
 	name = "north bump";
 	pixel_y = 28
 	},
+/obj/structure/closet/secure_closet/brig/temp/cell_5,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkredcorners"

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -48659,10 +48659,6 @@
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
 "eCO" = (
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 1";
-	name = "Cell 1 Locker"
-	},
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
@@ -48672,6 +48668,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/secure_closet/brig/temp/cell_1,
 /turf/simulated/floor/plasteel,
 /area/station/security/prison/cell_block/A)
 "eDj" = (
@@ -53727,10 +53724,6 @@
 /turf/simulated/floor/bluegrid,
 /area/station/maintenance/starboard)
 "gHX" = (
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 3";
-	name = "Cell 3 Locker"
-	},
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
@@ -53740,6 +53733,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/secure_closet/brig/temp/cell_3,
 /turf/simulated/floor/plasteel,
 /area/station/security/prison/cell_block/A)
 "gIb" = (
@@ -66099,14 +66093,11 @@
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
 "lNw" = (
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 2";
-	name = "Cell 2 Locker"
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/secure_closet/brig/temp/cell_2,
 /turf/simulated/floor/plasteel,
 /area/station/security/prison/cell_block/A)
 "lNT" = (
@@ -74172,11 +74163,8 @@
 	},
 /area/station/science/xenobiology)
 "pnB" = (
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 5";
-	name = "Cell 5 Locker"
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/secure_closet/brig/temp/cell_5,
 /turf/simulated/floor/plasteel,
 /area/station/security/brig)
 "pos" = (
@@ -87555,14 +87543,11 @@
 	},
 /area/station/hallway/primary/starboard/east)
 "vbF" = (
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 4";
-	name = "Cell 4 Locker"
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/secure_closet/brig/temp/cell_4,
 /turf/simulated/floor/plasteel,
 /area/station/security/prison/cell_block/A)
 "vbV" = (

--- a/_maps/map_files/cerestation/cerestation.dmm
+++ b/_maps/map_files/cerestation/cerestation.dmm
@@ -20152,10 +20152,6 @@
 	},
 /area/station/maintenance/asmaint)
 "cdv" = (
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 6";
-	name = "Cell 6 Locker"
-	},
 /obj/structure/cable/orange{
 	d1 = 1;
 	d2 = 2;
@@ -20173,6 +20169,7 @@
 	c_tag = "Brig Cell 6";
 	dir = 4
 	},
+/obj/structure/closet/secure_closet/brig/temp/cell_6,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "redcorner"
@@ -28917,10 +28914,6 @@
 	},
 /area/station/engineering/atmos)
 "cZn" = (
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 7";
-	name = "Cell 7 Locker"
-	},
 /obj/structure/cable/orange{
 	d1 = 1;
 	d2 = 2;
@@ -28938,6 +28931,7 @@
 	c_tag = "Brig Cell 7";
 	dir = 4
 	},
+/obj/structure/closet/secure_closet/brig/temp/cell_7,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "redcorner"
@@ -29326,10 +29320,6 @@
 	},
 /area/station/medical/break_room)
 "ddq" = (
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 8";
-	name = "Cell 8 Locker"
-	},
 /obj/structure/cable/orange{
 	d1 = 1;
 	d2 = 2;
@@ -29347,6 +29337,7 @@
 	c_tag = "Brig Cell 8";
 	dir = 4
 	},
+/obj/structure/closet/secure_closet/brig/temp/cell_8,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "redcorner"
@@ -42041,10 +42032,7 @@
 /turf/simulated/floor/plating,
 /area/station/security/permabrig)
 "gAQ" = (
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 4";
-	name = "Cell 4 Locker"
-	},
+/obj/structure/closet/secure_closet/brig/temp/cell_4,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "redcorner"
@@ -42792,10 +42780,7 @@
 	},
 /area/station/maintenance/asmaint)
 "gME" = (
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 1";
-	name = "Cell 1 Locker"
-	},
+/obj/structure/closet/secure_closet/brig/temp/cell_1,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "redcorner"
@@ -72915,10 +72900,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal/north)
 "qrV" = (
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 2";
-	name = "Cell 2 Locker"
-	},
+/obj/structure/closet/secure_closet/brig/temp/cell_2,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "redcorner"
@@ -93613,10 +93595,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal/external/southeast)
 "wYj" = (
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 3";
-	name = "Cell 3 Locker"
-	},
+/obj/structure/closet/secure_closet/brig/temp/cell_3,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "redcorner"

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -5537,13 +5537,10 @@
 /turf/simulated/floor/carpet/cyan,
 /area/station/security/prison/cell_block/A)
 "atb" = (
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 1";
-	name = "Cell 1 Locker"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
+/obj/structure/closet/secure_closet/brig/temp/cell_1,
 /turf/simulated/floor/carpet/cyan,
 /area/station/security/prison/cell_block/A)
 "atc" = (
@@ -5573,13 +5570,10 @@
 	},
 /area/station/security/prison/cell_block/A)
 "ate" = (
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 3";
-	name = "Cell 3 Locker"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
+/obj/structure/closet/secure_closet/brig/temp/cell_3,
 /turf/simulated/floor/plasteel{
 	icon_state = "redcorner"
 	},
@@ -7856,26 +7850,20 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
 "azN" = (
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 2";
-	name = "Cell 2 Locker"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
+/obj/structure/closet/secure_closet/brig/temp/cell_2,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "redcorner"
 	},
 /area/station/security/prison/cell_block/A)
 "azO" = (
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 4";
-	name = "Cell 4 Locker"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
+/obj/structure/closet/secure_closet/brig/temp/cell_4,
 /turf/simulated/floor/plasteel{
 	icon_state = "redcorner"
 	},
@@ -7939,15 +7927,12 @@
 	},
 /area/station/security/prisonershuttle)
 "azW" = (
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 5";
-	name = "Cell 5 Locker"
-	},
 /obj/machinery/camera{
 	c_tag = "Brig Cell 5";
 	dir = 9
 	},
 /obj/effect/decal/cleanable/cobweb2,
+/obj/structure/closet/secure_closet/brig/temp/cell_5,
 /turf/simulated/floor/plasteel,
 /area/station/security/prison/cell_block/A)
 "azX" = (

--- a/code/game/objects/structures/crates_lockers/closets/secure/security_lockers.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security_lockers.dm
@@ -228,6 +228,44 @@
 	new /obj/item/card/id/prisoner/random(src)
 	new /obj/item/radio/headset(src)
 
+/obj/structure/closet/secure_closet/brig/temp
+	desc = "A locker connected to the cell's timer system, used to store prisioner belongings. It unlocks automatically once the sentence has been served."
+
+/obj/structure/closet/secure_closet/brig/temp/populate_contents()
+	return
+
+/obj/structure/closet/secure_closet/brig/temp/cell_1
+	name = "Cell 1 Locker"
+	id = "Cell 1"
+
+/obj/structure/closet/secure_closet/brig/temp/cell_2
+	name = "Cell 2 Locker"
+	id = "Cell 2"
+
+/obj/structure/closet/secure_closet/brig/temp/cell_3
+	name = "Cell 3 Locker"
+	id = "Cell 3"
+
+/obj/structure/closet/secure_closet/brig/temp/cell_4
+	name = "Cell 4 Locker"
+	id = "Cell 4"
+
+/obj/structure/closet/secure_closet/brig/temp/cell_5
+	name = "Cell 5 Locker"
+	id = "Cell 5"
+
+/obj/structure/closet/secure_closet/brig/temp/cell_6
+	name = "Cell 6 Locker"
+	id = "Cell 6"
+
+/obj/structure/closet/secure_closet/brig/temp/cell_7
+	name = "Cell 7 Locker"
+	id = "Cell 7"
+
+/obj/structure/closet/secure_closet/brig/temp/cell_1
+	name = "Cell 8 Locker"
+	id = "Cell 8"
+
 /obj/structure/closet/secure_closet/brig/gulag
 	name = "labor camp locker"
 	desc = "A special locker designed to store prisoner belongings, allows access when prisoners meet their point quota."


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
As the title says, now the secure lockers in each Temporary Cell will not be populated with any contents. Both these and the Prisioner Transfer lockers were the same subtype, which meant they also were filled with the full attire of a permabrig prisioner. With a new subtype, this is no longer the case.

Also, following the example of the cell timer computers, each cell has now its own locker subtype instead of relying on varedits. Less chance to fuck up.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Tempcells having permabrig outfits and IDs cause two main problems. First, it confuses the hell out of new security players who do not remember all of Legal SOP to a T. When placing the temp prisioner belongings on the locker, they see a set of prisioner clothes and ID in it, and think they have to use them. Usually to the berating of a more experienced player. This is an intuitive contradiction of Brigging SOP.

Second, even if not used during brigging, once the crewmember is released they can now cosplay as a Perma escapee, which usually causes chaos and confusion in the crew, and security.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
- Spawned in
- Checked that the lockers in all tempcells were empty
- Brigged a freshly spawned skrell for indecent exposure
- Lockers locked and unlocked automatically as expected
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: The secure lockers in Temporary Cells no longer contain perma-prisioner clothing and IDs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
