### PR TITLE
Parrots no longer hold items they don't have.

### DIFF
--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -284,6 +284,10 @@
 /mob/living/simple_animal/parrot/Life(seconds, times_fired)
 	..()
 
+	if(held_item.loc != src)
+		held_item = null
+		update_held_icon()
+
 	//Sprite and AI update for when a parrot gets pulled
 	if(pulledby && stat == CONSCIOUS)
 		icon_state = "parrot_fly"

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -284,7 +284,7 @@
 /mob/living/simple_animal/parrot/Life(seconds, times_fired)
 	..()
 
-	if(held_item.loc != src)
+	if(held_item?.loc != src)
 		held_item = null
 		update_held_icon()
 


### PR DESCRIPTION
## What Does This PR Do
Adds a check to parrots' Life to ensure their held item is still inside them. If not, un-holds it.

Fixes #7040

## Why It's Good For The Game
No, Poly, you can't keep holding the pAI card that unfolded and walked away.

## Testing
Spawned parrot and pAI.
Parrot picked up pAI.
Unfolded pAI.
Parrot no longer holding pAI.

Also checked the supposed-duplicate #7053, but it seems to have been fixed independently.

## Changelog
:cl:
fix: Parrots can no longer violate the laws of time and space by holding an item they don't have.
/:cl: