### PR TITLE
Cigar/pipe cleanup.

### DIFF
--- a/code/game/objects/items/weapons/cigs.dm
+++ b/code/game/objects/items/weapons/cigs.dm
@@ -40,6 +40,13 @@ LIGHTERS ARE IN LIGHTERS.DM
 		"Vulpkanin" = 'icons/mob/clothing/species/vulpkanin/mask.dmi',
 		"Grey" = 'icons/mob/clothing/species/grey/mask.dmi')
 
+	var/static/things_that_light = typecacheof(list(
+		/obj/item/lighter,
+		/obj/item/match,
+		/obj/item/melee/energy/sword/saber,
+		/obj/item/assembly/igniter,
+		/obj/item/gun/magic/wand/fireball))
+
 
 /obj/item/clothing/mask/cigarette/Initialize(mapload)
 	. = ..()
@@ -47,14 +54,14 @@ LIGHTERS ARE IN LIGHTERS.DM
 	reagents.set_reacting(FALSE) // so it doesn't react until you light it
 	if(list_reagents)
 		reagents.add_reagent_list(list_reagents)
-	RegisterSignal(src, COMSIG_ITEM_BEING_ATTACKED, PROC_REF(can_light))
+	RegisterSignal(src, COMSIG_ITEM_BEING_ATTACKED, PROC_REF(try_light))
 
 /obj/item/clothing/mask/cigarette/Destroy()
 	QDEL_NULL(reagents)
 	STOP_PROCESSING(SSobj, src)
 	return ..()
 
-/obj/item/clothing/mask/cigarette/proc/can_light(obj/item/cigarette, obj/item/lighting_item)
+/obj/item/clothing/mask/cigarette/proc/try_light(obj/item/cigarette, obj/item/lighting_item)
 	SIGNAL_HANDLER
 	if(lighting_item.get_heat())
 		light()
@@ -260,6 +267,9 @@ LIGHTERS ARE IN LIGHTERS.DM
 /obj/item/clothing/mask/cigarette/get_heat()
 	return lit * 1000
 
+/obj/item/clothing/mask/cigarette/proc/can_light_fancy(obj/item/lighting_item)
+	return (istype(lighting_item, /obj/item/match) || istype(lighting_item, /obj/item/lighter/zippo))
+
 /obj/item/clothing/mask/cigarette/menthol
 	list_reagents = list("nicotine" = 40, "menthol" = 20)
 
@@ -327,11 +337,8 @@ LIGHTERS ARE IN LIGHTERS.DM
 	chem_volume = 120
 	list_reagents = list("nicotine" = 120)
 
-/obj/item/clothing/mask/cigarette/cigar/proc/can_light_cigar(obj/item/lighting_item)
-	return (istype(lighting_item, /obj/item/match) || istype(lighting_item, /obj/item/lighter/zippo))
-
-/obj/item/clothing/mask/cigarette/cigar/can_light(obj/item/cigar, obj/item/lighting_item)
-	if(can_light_cigar(lighting_item))
+/obj/item/clothing/mask/cigarette/cigar/try_light(obj/item/cigar, obj/item/lighting_item)
+	if(can_light_fancy(lighting_item))
 		return ..()
 
 /obj/item/clothing/mask/cigarette/cigar/cohiba
@@ -379,9 +386,9 @@ LIGHTERS ARE IN LIGHTERS.DM
 
 
 /obj/item/clothing/mask/cigarette/cigar/attackby(obj/item/I, mob/user, params)
-	if(istype(I, /obj/item/reagent_containers))
+	if(!is_type_in_typecache(I, things_that_light))
 		return
-	if(can_light_cigar(I))
+	if(can_light_fancy(I))
 		..()
 	else
 		to_chat(user, "<span class='notice'>[src] straight out REFUSES to be lit by such uncivilized means.</span>")
@@ -509,10 +516,14 @@ LIGHTERS ARE IN LIGHTERS.DM
 		smoketime = initial(smoketime)
 		first_puff = TRUE
 
+/obj/item/clothing/mask/cigarette/pipe/try_light(obj/item/cigar, obj/item/lighting_item)
+	if(can_light_fancy(lighting_item))
+		return ..()
+
 /obj/item/clothing/mask/cigarette/pipe/attackby(obj/item/I, mob/user, params)
-	if(istype(I, /obj/item/reagent_containers))
+	if(!is_type_in_typecache(I, things_that_light))
 		return
-	if(istype(I, /obj/item/match))
+	if(can_light_fancy(I))
 		..()
 	else
 		to_chat(user, "<span class='notice'>[src] straight out REFUSES to be lit by such means.</span>")


### PR DESCRIPTION
## What Does This PR Do
* Cigars and pipes no longer REFUSE to be lit by stuff that can't light anything.
* Pipes will no longer REFUSE to be lit while simultaneously becoming lit.
* Renamed `can_light` to the more accurate `try_light`.

Fixed #6385, except for the FR to allow dried plants to be added.

## Why It's Good For The Game
Your cigar shouldn't refuse to be lit by a package wrapper, since the package wrapper probably wasn't trying to light it in the first place.

## Testing
Got a pipe. Could not light it with a cheap lighter. Did nothing to it with my ID card. Lit it with a zippo.

## Changelog
:cl:
fix: Cigars and pipes no longer REFUSE to be lit by stuff that can't light anything.
fix: Pipes will no longer REFUSE to be lit while simultaneously becoming lit.
/:cl: