### PR TITLE
fix ATM names

### DIFF
--- a/code/modules/economy/economy_machinery/atm.dm
+++ b/code/modules/economy/economy_machinery/atm.dm
@@ -32,6 +32,7 @@
 
 /obj/machinery/economy/atm/Initialize(mapload)
 	. = ..()
+	name = "Nanotrasen automatic teller machine"
 	update_icon()
 
 /obj/machinery/economy/atm/update_icon_state()


### PR DESCRIPTION
## What Does This PR Do
This PR gives ATMs actual names instead of their mapping helper names.
## Why It's Good For The Game
"west bump" doesn't mean anything to players.
## Testing
Spawned in a few maps, checked the names of ATMs.
## Changelog
:cl:
fix: ATMs are now named correctly.
/:cl:
