### PR TITLE
don't give directional mappers custom names

### DIFF
--- a/code/__DEFINES/mappers.dm
+++ b/code/__DEFINES/mappers.dm
@@ -1,21 +1,17 @@
 /// Create directional subtypes for a path to simplify mapping.
 #define MAPPING_DIRECTIONAL_HELPERS(path, offset_y, offset_x) ##path/directional/north {\
-	name = "north bump"; \
 	dir = NORTH; \
 	pixel_y = offset_y; \
 } \
 ##path/directional/south {\
-	name = "south bump"; \
 	dir = SOUTH; \
 	pixel_y = -offset_y; \
 } \
 ##path/directional/east {\
-	name = "east bump"; \
 	dir = EAST; \
 	pixel_x = offset_x; \
 } \
 ##path/directional/west {\
-	name = "west bump"; \
 	dir = WEST; \
 	pixel_x = -offset_x; \
 }


### PR DESCRIPTION
## What Does This PR Do
This PR removes the custom names for directional mapping helpers.
## Why It's Good For The Game
This isn't really necessary since the type name now specifies the direction, and so we don't need to rename wallbumps after the fact.
## Testing
Checked in-game, and in map editor, for any weird naming problems, saw none.
## Changelog
:cl:
fix: ATMs are now named correctly.
/:cl:
