### PR TITLE
Increases EMP Shriek Price on Cybernetic Revolution Rounds

### DIFF
--- a/code/modules/antagonists/changeling/datum_changeling.dm
+++ b/code/modules/antagonists/changeling/datum_changeling.dm
@@ -242,7 +242,7 @@
  */
 /datum/antagonist/changeling/proc/get_powers_of_type(power_type)
 	var/list/station_trait_restrictions = list(
-		// "Station trait" = list(Typepath/disabled/when/trait, Typepath/disabled/when/not/trait)
+		// "Station trait" = Replace 1st with 2nd when trait active
 		STATION_TRAIT_CYBERNETIC_REVOLUTION = list(/datum/action/changeling/dissonant_shriek, /datum/action/changeling/dissonant_shriek/cyberrev)
 	)
 
@@ -251,7 +251,6 @@
 		var/datum/action/changeling/power = power_path
 		if(initial(power.power_type) != power_type)
 			continue
-
 		powers += power_path
 
 	for(var/trait in station_trait_restrictions)

--- a/code/modules/antagonists/changeling/datum_changeling.dm
+++ b/code/modules/antagonists/changeling/datum_changeling.dm
@@ -241,12 +241,25 @@
  * * power_type - should be a define related to [/datum/action/changeling/var/power_type].
  */
 /datum/antagonist/changeling/proc/get_powers_of_type(power_type)
+	var/list/station_trait_restrictions = list(
+		// "Station trait" = list(Typepath/disabled/when/trait, Typepath/disabled/when/not/trait)
+		STATION_TRAIT_CYBERNETIC_REVOLUTION = list(/datum/action/changeling/dissonant_shriek, /datum/action/changeling/dissonant_shriek/cyberrev)
+	)
+
 	var/list/powers = list()
 	for(var/power_path in subtypesof(/datum/action/changeling))
 		var/datum/action/changeling/power = power_path
 		if(initial(power.power_type) != power_type)
 			continue
+
 		powers += power_path
+
+	for(var/trait in station_trait_restrictions)
+		if(HAS_TRAIT(SSstation, trait))
+			powers -= station_trait_restrictions[trait][1]
+		else
+			powers -= station_trait_restrictions[trait][2]
+
 	return powers
 
 /**

--- a/code/modules/antagonists/changeling/powers/shriek.dm
+++ b/code/modules/antagonists/changeling/powers/shriek.dm
@@ -55,3 +55,6 @@
 		L.break_light_tube()
 	empulse(get_turf(user), 3, 5, 1)
 	return TRUE
+
+/datum/action/changeling/dissonant_shriek/cyberrev
+	dna_cost = 5

--- a/code/modules/antagonists/changeling/powers/shriek.dm
+++ b/code/modules/antagonists/changeling/powers/shriek.dm
@@ -56,5 +56,6 @@
 	empulse(get_turf(user), 3, 5, 1)
 	return TRUE
 
+/// A more expensive version, used during rounds with cyber rev station trait for balance reasons.
 /datum/action/changeling/dissonant_shriek/cyberrev
 	dna_cost = 5


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Revives #24391

Increases Dissonant Shriek by 2.5x on Cyber Revo rounds.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
All other EMP items cost more - this should be no different.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

With the Cyberrev trait
![image](https://github.com/ParadiseSS13/Paradise/assets/91113370/94b841b9-97dd-45a8-a283-f6389e4d497d)

Without the Cyberrev trait
![image](https://github.com/ParadiseSS13/Paradise/assets/91113370/a0740b18-39a0-446b-88cf-ee89b07c8d43)


## Testing
<!-- How did you test the PR, if at all? -->
See above

## Changelog
:cl:
tweak: Dissonant Shriek costs 2.5x more on Cybernetic Revolution Rounds.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
