### PR TITLE
The seed vendor now has 3 of all seeds/mycelium except strange seeds.

### DIFF
--- a/code/game/machinery/vendors/departmental_vendors.dm
+++ b/code/game/machinery/vendors/departmental_vendors.dm
@@ -184,13 +184,13 @@
 					/obj/item/seeds/chili = 3,
 					/obj/item/seeds/cocoapod = 3,
 					/obj/item/seeds/coffee = 3,
-					/obj/item/seeds/comfrey =3,
+					/obj/item/seeds/comfrey = 3,
 					/obj/item/seeds/corn = 3,
 					/obj/item/seeds/cotton = 3,
-					/obj/item/seeds/nymph =3,
+					/obj/item/seeds/nymph = 3,
 					/obj/item/seeds/eggplant = 3,
 					/obj/item/seeds/garlic = 3,
-					/obj/item/seeds/glowshroom = 2,
+					/obj/item/seeds/glowshroom = 3,
 					/obj/item/seeds/grape = 3,
 					/obj/item/seeds/grass = 3,
 					/obj/item/seeds/lemon = 3,
@@ -219,13 +219,13 @@
 					/obj/item/seeds/whitebeet = 3)
 
 	contraband = list(/obj/item/seeds/cannabis = 3,
-					/obj/item/seeds/amanita = 2,
+					/obj/item/seeds/amanita = 3,
 					/obj/item/seeds/fungus = 3,
-					/obj/item/seeds/liberty = 2,
-					/obj/item/seeds/nettle = 2,
-					/obj/item/seeds/plump = 2,
-					/obj/item/seeds/reishi = 2,
-					/obj/item/seeds/starthistle = 2,
+					/obj/item/seeds/liberty = 3,
+					/obj/item/seeds/nettle = 3,
+					/obj/item/seeds/plump = 3,
+					/obj/item/seeds/reishi = 3,
+					/obj/item/seeds/starthistle = 3,
 					/obj/item/seeds/random = 2)
 
 	refill_canister = /obj/item/vending_refill/hydroseeds


### PR DESCRIPTION
## What Does This PR Do
All of the seeds in the seed vendor now have a stock of 3, with the sole exception of strange seeds, which remain at 2.

## Why It's Good For The Game
Long, long ago, before Fox ported TG's botany in #6236, the seeds in the vendor were divided into two categories. The non-contraband seeds all had a stock of 3, and the contraband seeds all had a stock of 2. The port added two contraband seeds with a stock of 3, and much later, #22891 moved glowshrooms to the non-contraband section, while keeping their stock of 2.

You could argue several ways on what the "correct" number of seeds should be for each category, but I'm standardizing at the higher value of 3 for the simple fact that getting more seeds isn't hard, it's just a bit slow.

The only one I've left at 2 is strange seeds, because each of those is unique, so it would have slightly stronger implications if we added a third one.

## Testing
Compiled, ran, hacked a vendor, looked inside. 1 water flower, 2 strange seeds, 3 of everything else.

## Changelog
:cl:
tweak: The seed vendor now has 3 of all seeds/mycelium except strange seeds.
/:cl: