### PR TITLE
Restrict !merge_upstream workflow to dev team and PR author

### DIFF
--- a/.github/workflows/merge_upstream_master.yml
+++ b/.github/workflows/merge_upstream_master.yml
@@ -5,7 +5,14 @@ on:
 
 jobs:
   merge-upstream:
-    if: ${{ github.event.issue.pull_request && github.event.comment.body == '!merge_upstream' }}
+    if: |
+      github.event.issue.pull_request &&
+      (github.event.comment.body == '!merge_upstream') &&
+      ((github.event.sender == github.event.issue.user) ||
+      (github.event.issue.author_association == 'COLLABORATOR') ||
+      (github.event.issue.author_association == 'MEMBER') ||
+      (github.event.issue.author_association == 'OWNER'))
+
     runs-on: ubuntu-latest
     steps:
       - name: PR Data

--- a/.github/workflows/merge_upstream_master.yml
+++ b/.github/workflows/merge_upstream_master.yml
@@ -9,9 +9,9 @@ jobs:
       github.event.issue.pull_request &&
       (github.event.comment.body == '!merge_upstream') &&
       ((github.event.sender == github.event.issue.user) ||
-      (github.event.issue.author_association == 'COLLABORATOR') ||
-      (github.event.issue.author_association == 'MEMBER') ||
-      (github.event.issue.author_association == 'OWNER'))
+      (github.event.comment.author_association == 'COLLABORATOR') ||
+      (github.event.comment.author_association == 'MEMBER') ||
+      (github.event.comment.author_association == 'OWNER'))
 
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds some level of security against people spamming our action workflows by skipping the run if not part of the repo org or the PR author.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
The internet is full of horrible people, I was too innocent.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->