### PR TITLE
Adds the Proto-Adrenaline Bio-chip

### DIFF
--- a/code/datums/uplink_items/uplink_general.dm
+++ b/code/datums/uplink_items/uplink_general.dm
@@ -808,6 +808,13 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/bio_chip_implanter/traitor
 	cost = 50
 
+/datum/uplink_item/bio_chips/proto_adrenal
+	name = "Proto-Adrenal Bio-chip"
+	desc = "A cheaper version of Adrenals, that grants the user 4 seconds of antistun, getting them back on their feet instantly, but nothing more. No speed or healing is provided"
+	reference = "PAI"
+	item = /obj/item/bio_chip_implanter/proto_adrenalin
+	cost = 18
+
 /datum/uplink_item/bio_chips/adrenal
 	name = "Adrenal Bio-chip"
 	desc = "A bio-chip injected into the body, and later activated manually to inject a chemical cocktail, which has a mild healing effect along with removing and reducing the time of all stuns and increasing movement speed. Can be activated up to 3 times."

--- a/code/datums/uplink_items/uplink_general.dm
+++ b/code/datums/uplink_items/uplink_general.dm
@@ -810,7 +810,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/bio_chips/proto_adrenal
 	name = "Proto-Adrenal Bio-chip"
-	desc = "A cheaper version of Adrenals, that grants the user 4 seconds of antistun, getting them back on their feet instantly, but nothing more. No speed or healing is provided"
+	desc = "A old prototype of the Adrenalin implant, that grants the user 4 seconds of antistun, getting them back on their feet instantly once, but nothing more. Speed and healing sold seperately."
 	reference = "PAI"
 	item = /obj/item/bio_chip_implanter/proto_adrenalin
 	cost = 18

--- a/code/game/objects/items/weapons/bio_chips/bio_chip_adrenalin.dm
+++ b/code/game/objects/items/weapons/bio_chips/bio_chip_adrenalin.dm
@@ -32,3 +32,35 @@
 	name = "bio-chip case - 'Adrenaline'"
 	desc = "A glass case containing an adrenaline bio-chip."
 	implant_type = /obj/item/bio_chip/adrenalin
+
+/obj/item/bio_chip/proto_adrenalin
+	name = "proto-adrenal bio-chip"
+	desc = "Removes all stuns and knockdowns."
+	icon_state = "adrenal"
+	origin_tech = "materials=2;biotech=4;combat=3;syndicate=2"
+	uses = 1
+	implant_data = /datum/implant_fluff/proto_adrenaline
+	implant_state = "implant-syndicate"
+
+/obj/item/bio_chip/proto_adrenalin/activate()
+	uses--
+	to_chat(imp_in, "<span class='notice'>You feel a sudden surge of energy!</span>")
+	imp_in.SetStunned(0)
+	imp_in.SetWeakened(0)
+	imp_in.SetKnockDown(0)
+	imp_in.SetParalysis(0)
+	imp_in.setStaminaLoss(0) //Since it doesn't have a good followup like adrenals, and getting batoned the moment after triggering it will stamina crit you, will set to zero over - 75
+	imp_in.stand_up(TRUE)
+	SEND_SIGNAL(imp_in, COMSIG_LIVING_CLEAR_STUNS)
+	imp_in.reagents.add_reagent("stimulative_cling", 1)
+	if(!uses)
+		qdel(src)
+
+/obj/item/bio_chip_implanter/proto_adrenalin
+	name = "bio-chip implanter (proto-adrenalin)"
+	implant_type = /obj/item/bio_chip/proto_adrenalin
+
+/obj/item/bio_chip_case/proto_adrenalin
+	name = "bio-chip case - 'proto-adrenalin'"
+	desc = "A glass case containing an proto-adrenalin bio-chip."
+	implant_type = /obj/item/bio_chip/proto_adrenalin

--- a/code/game/objects/items/weapons/bio_chips/bio_chip_fluff.dm
+++ b/code/game/objects/items/weapons/bio_chips/bio_chip_fluff.dm
@@ -22,6 +22,12 @@
 	notes = "One of Cybersun Industries oldest and simplest implants, even in its simplicity it is rumoured to be one of Cybersun Industries best-selling products."
 	function = "Subjects injected with this bio-chip can activate an injection of medical cocktails that removes stuns, increases speed, and has mild healing effects."
 
+/datum/implant_fluff/proto_adrenaline
+	name = "Cybersun Industries FX-1 Proto-Adrenaline Bio-chip"
+	life = "Destroyed after 1 use."
+	notes = "A prototype version of the classic. The dose is incredibly small, but still gets you right on your feet."
+	function = "Subjects injected with this bio-chip can activate an injection of medical cocktails that removes stuns, increases speed, and has mild healing effects."
+
 /datum/implant_fluff/supercharge
 	name = "Cybersun Industries RX-4 Synthetic Supercharge Bio-chip"
 	life = "Known to last for up to a year."

--- a/code/game/objects/items/weapons/bio_chips/bio_chip_fluff.dm
+++ b/code/game/objects/items/weapons/bio_chips/bio_chip_fluff.dm
@@ -25,8 +25,8 @@
 /datum/implant_fluff/proto_adrenaline
 	name = "Cybersun Industries FX-1 Proto-Adrenaline Bio-chip"
 	life = "Destroyed after 1 use."
-	notes = "A prototype version of the classic. The dose is incredibly small, but still gets you right on your feet."
-	function = "Subjects injected with this bio-chip can activate an injection of medical cocktails that removes stuns, increases speed, and has mild healing effects."
+	notes = "Originally developed as part of Cybersun's medical line for preventing high-G sickness during space travel, but today it is sold for less legal uses."
+	function = "Subjects injected with this bio-chip can activate an injection of medical cocktails that gets them back up on their feet."
 
 /datum/implant_fluff/supercharge
 	name = "Cybersun Industries RX-4 Synthetic Supercharge Bio-chip"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Adds the Proto-Adrenaline Bio-chip. 18 Tc. Acts like adrenals in unstuning you and healing stamina, and grants 1 unit of changeling antistun chemical, same as the changeling overdose. No speed. No healing. Only a few short precious seconds of antistun. Enough to get you out of a stun and survive one extra baton hit, but nothing more. 1 use.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

The adrenals tax is real. Freedoms are nice, but you are not always going to be cuffed, or waiting to be cuffed will make the situation much worse.
This implant ensures to you a stamina crit will not be the end, but will not require you to be lethaled, nor will it let you dunk an entire security team. It will allow you to get one extra time, or to start running away again, activate an item, or something else.

It will also hopefully add some nice deniablity to radio callouts such as: (Security) 'the fact you were kidnapping someone, and stood up without adrenals'

Since it looks like vampire rejuvinate, or changeling antistun, you can no longer assume someone is a specific antagonist just by "they got up without speed"

## Testing
<!-- How did you test the PR, if at all? -->

Batoned self, used implant, got up, and a moment of the chemical

## Changelog
:cl:
add: Adds the Proto-Adrenaline Bio-chip. 18 Tc. Acts like adrenals in unstuning you and healing stamina, and grants 1 unit of changeling antistun chemical, same as the changeling overdose. No speed. No healing. Only a few short precious seconds of antistun. Enough to get you out of a stun and survive one extra baton hit, but nothing more. 1 use.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
