### PR TITLE
Adds a DNA Modifier circuit board

### DIFF
--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -75,7 +75,7 @@
 /obj/machinery/dna_scannernew/Initialize(mapload)
 	. = ..()
 	component_parts = list()
-	component_parts += new /obj/item/circuitboard/clonescanner(null)
+	component_parts += new /obj/item/circuitboard/dna_scanner(null)
 	component_parts += new /obj/item/stock_parts/scanning_module(null)
 	component_parts += new /obj/item/stock_parts/manipulator(null)
 	component_parts += new /obj/item/stock_parts/micro_laser(null)
@@ -87,7 +87,7 @@
 /obj/machinery/dna_scannernew/upgraded/Initialize(mapload)
 	. = ..()
 	component_parts = list()
-	component_parts += new /obj/item/circuitboard/clonescanner(null)
+	component_parts += new /obj/item/circuitboard/dna_scanner(null)
 	component_parts += new /obj/item/stock_parts/scanning_module/phasic(null)
 	component_parts += new /obj/item/stock_parts/manipulator/pico(null)
 	component_parts += new /obj/item/stock_parts/micro_laser/ultra(null)
@@ -252,14 +252,6 @@
 	occupant = M
 	update_icon(UPDATE_ICON_STATE)
 	SStgui.update_uis(src)
-
-	// search for ghosts, if the corpse is empty and the scanner is connected to a cloner
-	if(locate(/obj/machinery/computer/cloning, get_step(src, NORTH)) \
-		|| locate(/obj/machinery/computer/cloning, get_step(src, SOUTH)) \
-		|| locate(/obj/machinery/computer/cloning, get_step(src, EAST)) \
-		|| locate(/obj/machinery/computer/cloning, get_step(src, WEST)))
-
-		occupant.notify_ghost_cloning(source = src)
 
 /obj/machinery/dna_scannernew/proc/go_out(mob/user, force)
 	if(!occupant)

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -841,6 +841,18 @@ to destroy them and players will be able to make replacements.
 							/obj/item/stack/sheet/glass = 1,
 							/obj/item/stack/cable_coil = 2,)
 
+/obj/item/circuitboard/dna_scanner
+	board_name = "DNA Modifier"
+	icon_state = "medical"
+	build_path = /obj/machinery/dna_scannernew
+	board_type = "machine"
+	origin_tech = "programming=2;biotech=2"
+	req_components = list(/obj/item/stock_parts/scanning_module = 1,
+						/obj/item/stock_parts/manipulator = 1,
+						/obj/item/stock_parts/micro_laser = 1,
+						/obj/item/stack/sheet/glass = 1,
+						/obj/item/stack/cable_coil = 2)
+
 /obj/item/circuitboard/mech_recharger
 	board_name = "Mech Bay Recharger"
 	icon_state = "science"

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -172,6 +172,16 @@
 	build_path = /obj/item/circuitboard/clonescanner
 	category = list("Medical Machinery")
 
+/datum/design/dna_scanner
+	name = "Machine Board (DNA Modifier)"
+	desc = "Allows for the construction of circuit boards used to build a DNA Modifier."
+	id = "dna_scanner"
+	req_tech = list("programming" = 4, "biotech" = 3)
+	build_type = IMPRINTER
+	materials = list(MAT_GLASS = 1000)
+	build_path = /obj/item/circuitboard/dna_scanner
+	category = list("Medical Machinery")
+
 /datum/design/cryotube
 	name = "Machine Board (Cryotube Board)"
 	desc = "Allows for the construction of circuit boards used to build a Cryotube."


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds the DNA Modifier circuit board, allowing the DNA Modifier  to be rebuilt and to have new copies of it built.
Also removes some now deprecated code that interacted with cloning
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
It's weird that DNA modifiers have a cloner scanner board inside of it, especially because it doesn't allow it to be rebuilt now
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Deconstructed a DNA Modifier, rebuilt it with what came out of the DNA Modifier
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
add: Adds the DNA Modifier circuit board, printable at the same levels as a Cloning scanner (Programming 4 and Biotech 3)
fix: Fixed the DNA Modifier not being rebuildable after deconstructing it
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
