### PR TITLE
Allow PR Authors to use !merge_upstream

### DIFF
--- a/.github/workflows/merge_upstream_master.yml
+++ b/.github/workflows/merge_upstream_master.yml
@@ -8,7 +8,7 @@ jobs:
     if: |
       github.event.issue.pull_request &&
       (github.event.comment.body == '!merge_upstream') &&
-      ((github.event.sender == github.event.issue.user) ||
+      ((github.event.sender.id == github.event.issue.user.id) ||
       (github.event.comment.author_association == 'COLLABORATOR') ||
       (github.event.comment.author_association == 'MEMBER') ||
       (github.event.comment.author_association == 'OWNER'))


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes logic which prevents the PR's author from using `!merge_upstream`.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
More convenient for PR authors.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
