### PR TITLE
change test seed to avoid lavaland procgen runtime

### DIFF
--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -84,7 +84,7 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 /datum/controller/master/New()
 	if(!random_seed)
 		#ifdef UNIT_TESTS
-		random_seed = 29051994
+		random_seed = 29051995
 		#else
 		random_seed = rand(1, 1e9)
 		#endif


### PR DESCRIPTION
## What Does This PR Do
This PR changes the fixed random seed for unit tests to avoid a recurring procgen runtime causing CI runs to fail.
## Why It's Good For The Game
CI should fail for good reasons instead of random coincidence. The underlying issue might actually be fixed by #24192 but that changes the number/order of rand calls anyway so just pulling that in wouldn't actually confirm whether or not the failure would be fixed by it.
## Testing
Ran CI.
## Changelog
NPFC
