### PR TITLE
Makes the `isorgan()` define more sane

### DIFF
--- a/code/__DEFINES/mob_defines.dm
+++ b/code/__DEFINES/mob_defines.dm
@@ -276,8 +276,8 @@
 
 #define isnewplayer(A)  (istype((A), /mob/new_player))
 
-#define isexternalorgan(A)		(istype((A), /obj/item/organ/external))
-#define isinternalorgan(A)		(istype((A), /obj/item/organ/internal))
+#define is_external_organ(A)		(istype((A), /obj/item/organ/external))
+#define is_internal_organ(A)		(istype((A), /obj/item/organ/internal))
 #define	isorgan(A)				(istype((A), /obj/item/organ))
 #define hasorgans(A)	(iscarbon(A))
 

--- a/code/__DEFINES/mob_defines.dm
+++ b/code/__DEFINES/mob_defines.dm
@@ -276,7 +276,9 @@
 
 #define isnewplayer(A)  (istype((A), /mob/new_player))
 
-#define isorgan(A)		(istype((A), /obj/item/organ/external))
+#define isexternalorgan(A)		(istype((A), /obj/item/organ/external))
+#define isinternalorgan(A)		(istype((A), /obj/item/organ/internal))
+#define	isorgan(A)				(istype((A), /obj/item/organ))
 #define hasorgans(A)	(iscarbon(A))
 
 #define is_admin(user)	(check_rights(R_ADMIN, 0, (user)) != 0)

--- a/code/__DEFINES/mob_defines.dm
+++ b/code/__DEFINES/mob_defines.dm
@@ -278,7 +278,7 @@
 
 #define is_external_organ(A)		(istype((A), /obj/item/organ/external))
 #define is_internal_organ(A)		(istype((A), /obj/item/organ/internal))
-#define	isorgan(A)				(istype((A), /obj/item/organ))
+#define	is_organ(A)				(istype((A), /obj/item/organ))
 #define hasorgans(A)	(iscarbon(A))
 
 #define is_admin(user)	(check_rights(R_ADMIN, 0, (user)) != 0)

--- a/code/game/dna/mutations/mutation_powers.dm
+++ b/code/game/dna/mutations/mutation_powers.dm
@@ -382,7 +382,7 @@
 			if(!H.bodyparts_by_name[name])
 				continue
 			affecting = H.bodyparts_by_name[name]
-			if(!isexternalorgan(affecting))
+			if(!is_external_organ(affecting))
 				continue
 			affecting.heal_damage(4, 0, updating_health = FALSE)
 		H.UpdateDamageIcon()

--- a/code/game/dna/mutations/mutation_powers.dm
+++ b/code/game/dna/mutations/mutation_powers.dm
@@ -382,7 +382,7 @@
 			if(!H.bodyparts_by_name[name])
 				continue
 			affecting = H.bodyparts_by_name[name]
-			if(!isorgan(affecting))
+			if(!isexternalorgan(affecting))
 				continue
 			affecting.heal_damage(4, 0, updating_health = FALSE)
 		H.UpdateDamageIcon()

--- a/code/game/machinery/clonepod.dm
+++ b/code/game/machinery/clonepod.dm
@@ -570,7 +570,7 @@
 			to_chat(user, "<span class='warning'>Access denied.</span>")
 		return
 
-	if(isorgan(I) || is_type_in_list(I, ALLOWED_ROBOT_PARTS)) //fun fact, robot parts aren't organs!
+	if(is_organ(I) || is_type_in_list(I, ALLOWED_ROBOT_PARTS)) //fun fact, robot parts aren't organs!
 		insert_organ(I, user)
 		return
 

--- a/code/game/machinery/clonepod.dm
+++ b/code/game/machinery/clonepod.dm
@@ -508,7 +508,7 @@
 			to_chat(inserter, "<span class='warning'>[src] refuses [inserted].</span>")
 			return
 
-	if(isorgan(inserted))
+	if(isexternalorgan(inserted))
 		if(is_type_in_list(inserted, FORBIDDEN_LIMBS))
 			to_chat(inserter, "<span class='warning'>[src] refuses [inserted].</span>")
 			return
@@ -570,7 +570,7 @@
 			to_chat(user, "<span class='warning'>Access denied.</span>")
 		return
 
-	if(is_int_organ(I) || isorgan(I) || is_type_in_list(I, ALLOWED_ROBOT_PARTS)) //fun fact, robot parts aren't organs!
+	if(is_int_organ(I) || isexternalorgan(I) || is_type_in_list(I, ALLOWED_ROBOT_PARTS)) //fun fact, robot parts aren't organs!
 		insert_organ(I, user)
 		return
 

--- a/code/game/machinery/clonepod.dm
+++ b/code/game/machinery/clonepod.dm
@@ -570,7 +570,7 @@
 			to_chat(user, "<span class='warning'>Access denied.</span>")
 		return
 
-	if(is_internal_organ(I) || is_external_organ(I) || is_type_in_list(I, ALLOWED_ROBOT_PARTS)) //fun fact, robot parts aren't organs!
+	if(isorgan(I) || is_type_in_list(I, ALLOWED_ROBOT_PARTS)) //fun fact, robot parts aren't organs!
 		insert_organ(I, user)
 		return
 

--- a/code/game/machinery/clonepod.dm
+++ b/code/game/machinery/clonepod.dm
@@ -497,7 +497,7 @@
 		to_chat(inserter, "<span class='warning'>[src]'s organ storage is full!</span>")
 		return
 
-	if(isinternalorgan(inserted))
+	if(is_internal_organ(inserted))
 		if(is_type_in_list(inserted, FORBIDDEN_INTERNAL_ORGANS))
 			to_chat(inserter, "<span class='warning'>[src] refuses [inserted].</span>")
 			return
@@ -508,7 +508,7 @@
 			to_chat(inserter, "<span class='warning'>[src] refuses [inserted].</span>")
 			return
 
-	if(isexternalorgan(inserted))
+	if(is_external_organ(inserted))
 		if(is_type_in_list(inserted, FORBIDDEN_LIMBS))
 			to_chat(inserter, "<span class='warning'>[src] refuses [inserted].</span>")
 			return
@@ -570,7 +570,7 @@
 			to_chat(user, "<span class='warning'>Access denied.</span>")
 		return
 
-	if(isinternalorgan(I) || isexternalorgan(I) || is_type_in_list(I, ALLOWED_ROBOT_PARTS)) //fun fact, robot parts aren't organs!
+	if(is_internal_organ(I) || is_external_organ(I) || is_type_in_list(I, ALLOWED_ROBOT_PARTS)) //fun fact, robot parts aren't organs!
 		insert_organ(I, user)
 		return
 

--- a/code/game/machinery/clonepod.dm
+++ b/code/game/machinery/clonepod.dm
@@ -497,7 +497,7 @@
 		to_chat(inserter, "<span class='warning'>[src]'s organ storage is full!</span>")
 		return
 
-	if(is_int_organ(inserted))
+	if(isinternalorgan(inserted))
 		if(is_type_in_list(inserted, FORBIDDEN_INTERNAL_ORGANS))
 			to_chat(inserter, "<span class='warning'>[src] refuses [inserted].</span>")
 			return
@@ -570,7 +570,7 @@
 			to_chat(user, "<span class='warning'>Access denied.</span>")
 		return
 
-	if(is_int_organ(I) || isexternalorgan(I) || is_type_in_list(I, ALLOWED_ROBOT_PARTS)) //fun fact, robot parts aren't organs!
+	if(isinternalorgan(I) || isexternalorgan(I) || is_type_in_list(I, ALLOWED_ROBOT_PARTS)) //fun fact, robot parts aren't organs!
 		insert_organ(I, user)
 		return
 

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -324,7 +324,7 @@ This function restores all organs.
 
 /mob/living/carbon/human/proc/HealDamage(zone, brute, burn)
 	var/obj/item/organ/external/E = get_organ(zone)
-	if(isorgan(E))
+	if(isexternalorgan(E))
 		if(E.heal_damage(brute, burn))
 			UpdateDamageIcon()
 	else

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -324,7 +324,7 @@ This function restores all organs.
 
 /mob/living/carbon/human/proc/HealDamage(zone, brute, burn)
 	var/obj/item/organ/external/E = get_organ(zone)
-	if(isexternalorgan(E))
+	if(is_external_organ(E))
 		if(E.heal_damage(brute, burn))
 			UpdateDamageIcon()
 	else

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -162,7 +162,7 @@ emp_act
 	var/organnum = 0
 
 	if(def_zone)
-		if(isorgan(def_zone))
+		if(isexternalorgan(def_zone))
 			return getarmor_organ(def_zone, type)
 		var/obj/item/organ/external/affecting = get_organ(def_zone)
 		if(affecting)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -162,7 +162,7 @@ emp_act
 	var/organnum = 0
 
 	if(def_zone)
-		if(isexternalorgan(def_zone))
+		if(is_external_organ(def_zone))
 			return getarmor_organ(def_zone, type)
 		var/obj/item/organ/external/affecting = get_organ(def_zone)
 		if(affecting)

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -425,7 +425,7 @@
 
 	var/obj/item/organ/external/organ = null
 	if(!spread_damage)
-		if(isexternalorgan(def_zone))
+		if(is_external_organ(def_zone))
 			organ = def_zone
 		else
 			if(!def_zone)

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -425,7 +425,7 @@
 
 	var/obj/item/organ/external/organ = null
 	if(!spread_damage)
-		if(isorgan(def_zone))
+		if(isexternalorgan(def_zone))
 			organ = def_zone
 		else
 			if(!def_zone)

--- a/code/modules/surgery/organs/organ_helpers.dm
+++ b/code/modules/surgery/organs/organ_helpers.dm
@@ -44,14 +44,10 @@
 		if(tag == O.organ_tag)
 			return O
 
-/proc/is_int_organ(atom/A)
-	return istype(A, /obj/item/organ/internal)
-
 /mob/living/carbon/human/proc/get_limb_by_name(limb_name) //Look for a limb with the given limb name in the source mob, and return it if found.
 	for(var/obj/item/organ/external/O in bodyparts)
 		if(limb_name == O.limb_name)
 			return O
-
 
 /mob/proc/has_left_hand()
 	return TRUE

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -503,7 +503,7 @@
  * * tool - The tool performing the operation.
  */
 /proc/spread_germs_by_incision(obj/item/organ/external/E, obj/item/tool)
-	if(!isorgan(E))
+	if(!isexternalorgan(E))
 		return
 	if(!E.owner)
 		return

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -503,7 +503,7 @@
  * * tool - The tool performing the operation.
  */
 /proc/spread_germs_by_incision(obj/item/organ/external/E, obj/item/tool)
-	if(!isexternalorgan(E))
+	if(!is_external_organ(E))
 		return
 	if(!E.owner)
 		return


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Changes the `isorgan()` define to `is_external_organ()`
Changes the `is_int_organ()` proc to a define `is_internal_organ()`
Adds 1 new define: `is_organ()`
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
I just spend 10 minutes debugging why `isorgan()` wouldn't say a fleshy mass was an organ, it's not an intuitive name.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
It compiled, and I checked the diff twice
<!-- How did you test the PR, if at all? -->

## Changelog
NPFC

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
