### PR TITLE
Contort Body Auto-Deactivates on Death

### DIFF
--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -69,6 +69,11 @@
 	update_action_buttons_icon()
 	ADD_TRAIT(src, TRAIT_FLOORED, STAT_TRAIT)
 	ADD_TRAIT(src, TRAIT_HANDS_BLOCKED, STAT_TRAIT) // immobilized is superfluous as moving when dead ghosts you.
+	if(HAS_TRAIT_FROM(src, TRAIT_CONTORTED_BODY, CHANGELING_TRAIT))
+		REMOVE_TRAIT(src, TRAIT_CONTORTED_BODY, CHANGELING_TRAIT)
+		to_chat(src, "<span class='notice'>As you fall into stasis, your body goes rigid once more.</span>")
+		if(IS_HORIZONTAL(src))
+			src.layer = initial(src.layer)
 	update_damage_hud()
 	update_health_hud()
 	med_hud_set_health()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Contort Body now auto-disables on death.

## Why It's Good For The Game
This is a stealth ability. It is a toggle, yes. However, if you have it on and are killed by Security who DONT know you are a Changeling, they can see you fall under things (i.e. body bags in execution) and then SPRINT to gib you.

This is very fucking cringe. To quote the Heads of Staff when we asked for clarification:

`"I just...Thats so **gamey**", "Its like the shooting everyone on station with nerf dart guns to see if they had sleeping carp"`

Now, to counter - you COULD also do this test theoretically with Cling Eye Upgrade (the classic Flash Test). This, however, requires you to be alive for it and you can usually see it coming. One is an active check that you can react to and the other is one that you cant do anything about since youre dead.

## Testing
Done went and killed myself as a Changeling on a table a few times.

## Changelog
:cl:
tweak: Contort Body auto-disables on death.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
