### PR TITLE
Subminute Upstream Merge & Add Comment for Access Denied

### DIFF
--- a/.github/workflows/merge_upstream_master.yml
+++ b/.github/workflows/merge_upstream_master.yml
@@ -14,7 +14,6 @@ jobs:
       (github.event.comment.author_association == 'OWNER'))
 
     runs-on: ubuntu-latest
-    permissions: write-all
     steps:
       - name: PR Data
         env:

--- a/.github/workflows/merge_upstream_master.yml
+++ b/.github/workflows/merge_upstream_master.yml
@@ -14,18 +14,25 @@ jobs:
       (github.event.comment.author_association == 'OWNER'))
 
     runs-on: ubuntu-latest
+    permissions: write-all
     steps:
       - name: PR Data
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          curl -H "Authorization: token ${{ github.token }}" ${{ github.event.issue.pull_request.url }} > pr.json
-          echo "PR_REPO=`jq -r '.head.repo.full_name' < pr.json`" >> $GITHUB_ENV
-          echo "PR_BRANCH=`jq -r '.head.ref' < pr.json`" >> $GITHUB_ENV
+          pr_json=$(curl -L -s --fail-with-body -H "Authorization: token ${{ github.token }}" ${{ github.event.issue.pull_request.url }})
+          if [ `jq -r '.maintainer_can_modify' <<<$pr_json` == "false" ] ; then
+            gh pr comment ${{ github.event.issue.html_url }} --body 'GitHub Actions can not push to the repository without "Allow edits and access to secrets by maintainers" checked.'
+            exit 1
+          fi
+          echo "PR_REPO=`jq -r '.head.repo.full_name' <<<$pr_json`" >> $GITHUB_ENV
+          echo "PR_BRANCH=`jq -r '.head.ref' <<<$pr_json`" >> $GITHUB_ENV
+          echo "PR_HEAD_LABEL=`jq -r '.head.label' <<<$pr_json`" >> $GITHUB_ENV
 
       - uses: actions/checkout@v4
         with:
           repository: ${{ env.PR_REPO }}
           ref: ${{ env.PR_BRANCH }}
-          fetch-depth: 0
 
       - uses: actions/setup-node@v4
         with:
@@ -39,16 +46,42 @@ jobs:
           cache: 'pip'
 
       - name: Perform Merge
+        env:
+          BASE_BRANCH: ${{ github.event.repository.default_branch }}
+          BASE_REPOSITORY: ${{ github.repository }}
         run: |
+          # Compare head branch and base branch
+          compare_result=$(curl -L -s --fail-with-body \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/$BASE_REPOSITORY/compare/$BASE_BRANCH...$PR_HEAD_LABEL")
+          # Assign multiple variables with one jq execution
+          if IFS=$'\n' read -d '' -r behind_by ahead_by <<<$(jq '.behind_by, .ahead_by' <<<$compare_result) ; [ -z "$behind_by" ] || [ -z "$ahead_by" ] ; then
+            echo '- Unable to determine the distance between the head branch and the base branch.' | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+          if [ "$behind_by" -le 0 ] ; then
+            echo '- Skipping merge. Up-to-date with base branch.' | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 0
+          else
+            echo '- Merging base branch. Head branch is behind by '"$behind_by"' commits and ahead by '"$ahead_by"' commits.' | tee -a "$GITHUB_STEP_SUMMARY"
+          fi
+
+          # Install Tools
           chmod +x tools/bootstrap/python
           bash tools/hooks/install.sh
           bash tgui/bin/tgui --install-git-hooks
           chmod +x tools/hooks/*.merge tgui/bin/tgui
+
+          # Actual Merge
           git config user.name github-actions
-          git config user.email github-actions@github.com
-          git remote add upstream "https://github.com/${{ github.repository }}.git"
-          git fetch upstream master
-          git merge upstream/master && git push origin
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git remote add upstream "https://github.com/$BASE_REPOSITORY.git"
+
+          git fetch origin "$PR_BRANCH" --depth=$((ahead_by + 1))
+          git fetch upstream "$BASE_BRANCH" --depth=$((behind_by + 1))
+          git merge FETCH_HEAD
+          git push origin
 
       - name: Notify Failure
         if: failure()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
- Changed curl call in "PR Data" step to send the response to a variable instead of to the file system(pr.json does not appear to be used elsewhere.)
- Added code to check whether the PR has "Allow edits and access to secrets by maintainers" checked. If not, then the action will comment `GitHub Actions can not push to the repository without "Allow edits and access to secrets by maintainers" checked.`. Demonstration https://github.com/ActionsProxy2/Paradise/pull/1#issuecomment-2016374088
- Optimized checkout to only fetch the commits needed.
- Fixed the avatar shown in the commit.
  - Changed commit email from `github-actions@github.com` to `41898282+github-actions[bot]@users.noreply.github.com`. The latter email was extracted from a commit made by actions in the distant past. The ID does actually belong to GitHub Actions, according to the GitHub API https://api.github.com/users/github-actions%5Bbot%5D. Note: I believe that `user.email` and `user.name` need not be explicitly set, in which case it'll use the email and ID of another GitHub Actions bot.
    There is currently no avatar associated with the current email.
    ![Image of Commits](https://github.com/ParadiseSS13/Paradise/assets/41360489/79a3129f-c0c7-4ef6-9399-237fc8800a68)
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Subminute /tg/ui resolve speeds are nice. Currently, checkout takes up around 80% of the run time; the solution implemented, reduces that to less than 50%.

A less obscure error for failing to check a checkbox is more intuitive than access denied
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
https://github.com/ActionsProxy2/Paradise/pull/1#issuecomment-2016373562
(Note: ActionsProxy2 and ParadiseTest will be deleted after the PR is merged/closed, I only set them up as test repositories)
<!-- How did you test the PR, if at all? -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
