### PR TITLE
Updated the ancient space station awakening text

### DIFF
--- a/code/controllers/subsystem/SSeconomy.dm
+++ b/code/controllers/subsystem/SSeconomy.dm
@@ -116,10 +116,13 @@ SUBSYSTEM_DEF(economy)
 				return FALSE //really fuck off, you're vv editing something to a value that will break the economy
 	return ..()
 
-/datum/controller/subsystem/economy/Initialize()
-	///create main station accounts
+/proc/init_current_date_string()
 	if(!GLOB.current_date_string)
 		GLOB.current_date_string = "[time2text(world.timeofday, "DD Month")], [GLOB.game_year]"
+
+/datum/controller/subsystem/economy/Initialize()
+	init_current_date_string()
+	///create main station accounts
 	if(GLOB.station_money_database)
 		populate_station_database()
 		cargo_account = GLOB.station_money_database.get_account_by_department(DEPARTMENT_SUPPLY)

--- a/code/modules/awaymissions/mission_code/ruins/oldstation.dm
+++ b/code/modules/awaymissions/mission_code/ruins/oldstation.dm
@@ -143,6 +143,7 @@
 	name = "Crew Reawakening Report"
 
 /obj/item/paper/fluff/ruins/oldstation/report/Initialize()
+	..()
 	init_current_date_string()
 	info = "Artificial Program's report to surviving crewmembers.<br><br>Crew were placed into cryostasis 10 March, 2445.<br><br>Crew were awoken from cryostasis [GLOB.current_date_string].<br><br> \
 	<b>SIGNIFICANT EVENTS OF NOTE</b><br>1: The primary radiation detectors were taken offline after [GLOB.game_year - 2445] years due to power failure, secondary radiation detectors showed no residual \

--- a/code/modules/awaymissions/mission_code/ruins/oldstation.dm
+++ b/code/modules/awaymissions/mission_code/ruins/oldstation.dm
@@ -141,8 +141,11 @@
 
 /obj/item/paper/fluff/ruins/oldstation/report
 	name = "Crew Reawakening Report"
-	info = "Artificial Program's report to surviving crewmembers.<br><br>Crew were placed into cryostasis on March 10th, 2445.<br><br>Crew were awoken from cryostasis around June, 2557.<br><br> \
-	<b>SIGNIFICANT EVENTS OF NOTE</b><br>1: The primary radiation detectors were taken offline after 112 years due to power failure, secondary radiation detectors showed no residual \
+
+/obj/item/paper/fluff/ruins/oldstation/report/Initialize()
+	init_current_date_string()
+	info = "Artificial Program's report to surviving crewmembers.<br><br>Crew were placed into cryostasis 10 March, 2445.<br><br>Crew were awoken from cryostasis [GLOB.current_date_string].<br><br> \
+	<b>SIGNIFICANT EVENTS OF NOTE</b><br>1: The primary radiation detectors were taken offline after [GLOB.game_year - 2445] years due to power failure, secondary radiation detectors showed no residual \
 	radiation on station. Deduction, primarily detector was malfunctioning and was producing a radiation signal when there was none.<br><br>2: A data burst from a nearby Nanotrasen Space \
 	Station was received, this data burst contained research data that has been uploaded to our RnD labs.<br><br>3: Unknown invasion force has occupied Theta station."
 


### PR DESCRIPTION
## What Does This PR Do
The ancient space station's crew awakening alert now uses the correct game year and date.

## Why It's Good For The Game
Consistency is good.

## Testing
Spawned as an observer, read paper.

## Changelog
:cl:
tweak: The ancient space station's crew awakening alert now uses the correct game year and date.
/:cl: