### PR TITLE
White cables no longer spontaneously change color

### DIFF
--- a/code/modules/power/cables/cable.dm
+++ b/code/modules/power/cables/cable.dm
@@ -140,9 +140,7 @@ By design, d1 is the smallest direction and d2 is the highest
 	deconstruct()
 
 /obj/structure/cable/proc/cable_color(colorC)
-	if(!colorC)
-		color = COLOR_RED
-	else if(colorC == "rainbow")
+	if(colorC == "rainbow")
 		color = color_rainbow()
 	else if(colorC == "orange") //byond only knows 16 colors by name, and orange isn't one of them
 		color = COLOR_ORANGE

--- a/code/modules/power/cables/cable_coil.dm
+++ b/code/modules/power/cables/cable_coil.dm
@@ -53,8 +53,6 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list (new/datum/stack_recipe/cable_restrain
 		name = "cable piece"
 
 /obj/item/stack/cable_coil/update_icon_state()
-	if(!color)
-		color = pick(COLOR_RED, COLOR_BLUE, COLOR_GREEN, COLOR_ORANGE, COLOR_WHITE, COLOR_PINK, COLOR_YELLOW, COLOR_CYAN)
 	if(amount == 1)
 		icon_state = "coil1"
 	else if(amount == 2)


### PR DESCRIPTION
## What Does This PR Do
White cables no longer spontaneously change color.
Fixed #7104

## Why It's Good For The Game
White is nice.

## Testing
Spawned white cable. Placed wires. Got white wires.
Colored cable white with the mime's crayon. Same result.

## Changelog
:cl:
fix: White cables no longer spontaneously change color. When asked why he didn't tell us about this bug, the mime made a rude gesture.
/:cl: