### PR TITLE
Fix: Necropolis gate is now opens when Legion takes damage

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
@@ -196,6 +196,11 @@ Difficulty: Medium
 	. = ..()
 	if(QDELETED(src))
 		return
+	if(!GLOB.necropolis_gate)
+		return
+	if(GLOB.necropolis_gate.legion_triggered)
+		return
+	GLOB.necropolis_gate.toggle_the_gate(src, TRUE)
 	if(.)
 		var/matrix/M = new
 		resize = (enraged ? 0.33 : 1) + (health / maxHealth)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
@@ -196,11 +196,8 @@ Difficulty: Medium
 	. = ..()
 	if(QDELETED(src))
 		return
-	if(!GLOB.necropolis_gate)
-		return
-	if(GLOB.necropolis_gate.legion_triggered)
-		return
-	GLOB.necropolis_gate.toggle_the_gate(src, TRUE)
+	if(GLOB.necropolis_gate && !GLOB.necropolis_gate.open)
+		GLOB.necropolis_gate.toggle_the_gate(src)
 	if(.)
 		var/matrix/M = new
 		resize = (enraged ? 0.33 : 1) + (health / maxHealth)

--- a/code/modules/ruins/objects_and_mobs/necropolis_gate.dm
+++ b/code/modules/ruins/objects_and_mobs/necropolis_gate.dm
@@ -141,6 +141,7 @@ GLOBAL_DATUM(necropolis_gate, /obj/structure/necropolis_gate/legion_gate)
 /obj/structure/necropolis_gate/legion_gate
 	desc = "A tremendous, impossibly large gateway, set into a massive tower of stone."
 	sight_blocker_distance = 2
+	var/legion_triggered = FALSE
 
 /obj/structure/necropolis_gate/legion_gate/Initialize()
 	. = ..()
@@ -164,6 +165,7 @@ GLOBAL_DATUM(necropolis_gate, /obj/structure/necropolis_gate/legion_gate)
 /obj/structure/necropolis_gate/legion_gate/toggle_the_gate(mob/user)
 	if(open)
 		return
+	GLOB.necropolis_gate.legion_triggered = TRUE
 	if(..())
 		locked = TRUE
 		var/turf/T = get_turf(src)

--- a/code/modules/ruins/objects_and_mobs/necropolis_gate.dm
+++ b/code/modules/ruins/objects_and_mobs/necropolis_gate.dm
@@ -141,7 +141,6 @@ GLOBAL_DATUM(necropolis_gate, /obj/structure/necropolis_gate/legion_gate)
 /obj/structure/necropolis_gate/legion_gate
 	desc = "A tremendous, impossibly large gateway, set into a massive tower of stone."
 	sight_blocker_distance = 2
-	var/legion_triggered = FALSE
 
 /obj/structure/necropolis_gate/legion_gate/Initialize()
 	. = ..()
@@ -165,7 +164,6 @@ GLOBAL_DATUM(necropolis_gate, /obj/structure/necropolis_gate/legion_gate)
 /obj/structure/necropolis_gate/legion_gate/toggle_the_gate(mob/user)
 	if(open)
 		return
-	GLOB.necropolis_gate.legion_triggered = TRUE
 	if(..())
 		locked = TRUE
 		var/turf/T = get_turf(src)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
It partially "carries over" [this](https://github.com/ss220club/Paradise-SS220/pull/872) PR from our downstream to fix an issue where miners use the Hirepohant club to kill Legion without any difficulties, because Legion couldn't leave Necropolis as the gates remained closed.

## Why It's Good For The Game
No abuse from miners with Hiero club

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Tested in-game

## Changelog
:cl:
fix: Necropolis gate is now opens when Legion takes damage
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
