### PR TITLE
Fixes multitile doors and multitile engines on shuttles. Gives raven it's big engines back

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/whiteship.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/whiteship.dmm
@@ -157,7 +157,9 @@
 /turf/simulated/floor/wood,
 /area/shuttle/abandoned)
 "tV" = (
-/obj/machinery/door/airlock/titanium/glass,
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 1
+	},
 /turf/simulated/floor/mineral/plastitanium,
 /area/shuttle/abandoned)
 "uo" = (
@@ -461,7 +463,7 @@ zO
 zO
 zO
 zO
-tV
+wF
 tV
 zO
 zO

--- a/_maps/map_files/shuttles/emergency_raven.dmm
+++ b/_maps/map_files/shuttles/emergency_raven.dmm
@@ -1328,6 +1328,10 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/shuttle/escape)
+"JM" = (
+/obj/structure/shuttle/engine/large,
+/turf/simulated/floor/plating/airless,
+/area/shuttle/escape)
 "JO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -1434,6 +1438,9 @@
 	dir = 1;
 	icon_state = "darkred"
 	},
+/area/shuttle/escape)
+"So" = (
+/turf/simulated/floor/plating/airless,
 /area/shuttle/escape)
 "Ux" = (
 /obj/effect/turf_decal/stripes/white/corner,
@@ -1656,8 +1663,8 @@ dI
 dE
 Mm
 cP
-cP
-aa
+So
+JM
 "}
 (6,1,1) = {"
 aa
@@ -1690,8 +1697,8 @@ dE
 dE
 Nd
 fn
-em
-aa
+So
+So
 "}
 (7,1,1) = {"
 ab
@@ -1792,8 +1799,8 @@ dE
 dE
 vw
 fn
-em
-aa
+So
+JM
 "}
 (10,1,1) = {"
 ab
@@ -1826,8 +1833,8 @@ dE
 dE
 cP
 cP
-cP
-aa
+So
+So
 "}
 (11,1,1) = {"
 ab
@@ -1860,7 +1867,7 @@ Sa
 Sa
 ed
 cP
-aa
+cP
 aa
 "}
 (12,1,1) = {"
@@ -1894,8 +1901,8 @@ dE
 dE
 cP
 cP
-cP
-aa
+So
+JM
 "}
 (13,1,1) = {"
 ab
@@ -1928,8 +1935,8 @@ dE
 dE
 sr
 fn
-em
-aa
+So
+So
 "}
 (14,1,1) = {"
 ab
@@ -2030,8 +2037,8 @@ dE
 dE
 NK
 fn
-em
-aa
+So
+JM
 "}
 (17,1,1) = {"
 aa
@@ -2064,8 +2071,8 @@ dQ
 dT
 qC
 cP
-cP
-aa
+So
+So
 "}
 (18,1,1) = {"
 aa

--- a/code/game/shuttle_engines.dm
+++ b/code/game/shuttle_engines.dm
@@ -5,9 +5,6 @@
 	max_integrity = 500
 	armor = list(melee = 100, bullet = 10, laser = 10, energy = 0, bomb = 0, rad = 0, fire = 50, acid = 70) //default + ignores melee
 
-/obj/structure/shuttle/shuttleRotate(rotation)
-	return //This override is needed to properly rotate the object when on a shuttle that is rotated.
-
 /obj/structure/shuttle/engine
 	name = "engine"
 	density = TRUE

--- a/code/modules/awaymissions/mission_code/ruins/oldstation.dm
+++ b/code/modules/awaymissions/mission_code/ruins/oldstation.dm
@@ -295,7 +295,7 @@
 	desc = "A very large bluespace engine used to propel very large ships."
 	bound_width = 64
 	bound_height = 64
-	appearance_flags = 0
+	appearance_flags = LONG_GLIDE
 
 // areas
 //Ruin of ancient Space Station

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -508,6 +508,8 @@
 
 			//move mobile to new location
 			for(var/atom/movable/AM in T0)
+				if(AM.loc != T0) //fix for multi-tile objects
+					continue
 				AM.onShuttleMove(T0, T1, rotation, last_caller)
 
 			if(rotation)

--- a/code/modules/shuttle/shuttle_rotate.dm
+++ b/code/modules/shuttle/shuttle_rotate.dm
@@ -24,6 +24,19 @@ If ever any of these procs are useful for non-shuttles, rename it to proc/rotate
 			pixel_x = oldPY
 			pixel_y = (oldPX*(-1))
 
+
+/atom/movable/shuttleRotate(rotation, params)
+	. = ..()
+	//rotate the physical bounds and offsets for multitile atoms too. Owerride base "rotate the pixel offsets" for multitile atoms.
+	//Owerride non zero bound_x, bound_y, pixel_x, pixel_y to zero.
+	//Dont take in account starting bound_x, bound_y, pixel_x, pixel_y.
+	//So it can unintentionally shift physical bounds of things that starts with non zero bound_x, bound_y.
+	if(((bound_height != world.icon_size) || (bound_width != world.icon_size)) && (bound_x == 0) && (bound_y == 0)) //Dont shift things that have non zero bound_x and bound_y, or it move somewhere. Now it BSA and Gateway.
+		pixel_x = dir & (NORTH|EAST) ? -bound_width+world.icon_size : 0
+		pixel_y = dir & (NORTH|WEST) ? -bound_width+world.icon_size : 0
+		bound_x = pixel_x
+		bound_y = pixel_y
+
 /************************************Turf rotate procs************************************/
 
 /************************************Mob rotate procs************************************/
@@ -55,9 +68,6 @@ If ever any of these procs are useful for non-shuttles, rename it to proc/rotate
 		d1 = d2
 		d2 = temp
 	update_icon(UPDATE_ICON_STATE)
-
-/obj/structure/shuttle/engine/shuttleRotate(rotation, params)
-	setDir(angle2dir(rotation+dir2angle(dir)))
 
 //Fixes dpdir on shuttle rotation
 /obj/structure/disposalpipe/shuttleRotate(rotation, params)

--- a/code/modules/shuttle/shuttle_rotate.dm
+++ b/code/modules/shuttle/shuttle_rotate.dm
@@ -32,8 +32,8 @@ If ever any of these procs are useful for non-shuttles, rename it to proc/rotate
 	//Dont take in account starting bound_x, bound_y, pixel_x, pixel_y.
 	//So it can unintentionally shift physical bounds of things that starts with non zero bound_x, bound_y.
 	if(((bound_height != world.icon_size) || (bound_width != world.icon_size)) && (bound_x == 0) && (bound_y == 0)) //Dont shift things that have non zero bound_x and bound_y, or it move somewhere.
-		pixel_x = dir & (NORTH|EAST) ? -bound_width+world.icon_size : 0
-		pixel_y = dir & (NORTH|WEST) ? -bound_width+world.icon_size : 0
+		pixel_x = dir & (NORTH|EAST) ? (world.icon_size - bound_width) : 0
+		pixel_y = dir & (NORTH|WEST) ? (world.icon_size - bound_width) : 0
 		bound_x = pixel_x
 		bound_y = pixel_y
 

--- a/code/modules/shuttle/shuttle_rotate.dm
+++ b/code/modules/shuttle/shuttle_rotate.dm
@@ -31,7 +31,7 @@ If ever any of these procs are useful for non-shuttles, rename it to proc/rotate
 	//Override non zero bound_x, bound_y, pixel_x, pixel_y to zero.
 	//Dont take in account starting bound_x, bound_y, pixel_x, pixel_y.
 	//So it can unintentionally shift physical bounds of things that starts with non zero bound_x, bound_y.
-	if(((bound_height != world.icon_size) || (bound_width != world.icon_size)) && (bound_x == 0) && (bound_y == 0)) //Dont shift things that have non zero bound_x and bound_y, or it move somewhere.
+	if((bound_height != world.icon_size || bound_width != world.icon_size) && (bound_x == 0) && (bound_y == 0)) //Dont shift things that have non zero bound_x and bound_y, or it move somewhere.
 		pixel_x = dir & (NORTH|EAST) ? (world.icon_size - bound_width) : 0
 		pixel_y = dir & (NORTH|WEST) ? (world.icon_size - bound_width) : 0
 		bound_x = pixel_x

--- a/code/modules/shuttle/shuttle_rotate.dm
+++ b/code/modules/shuttle/shuttle_rotate.dm
@@ -31,7 +31,7 @@ If ever any of these procs are useful for non-shuttles, rename it to proc/rotate
 	//Owerride non zero bound_x, bound_y, pixel_x, pixel_y to zero.
 	//Dont take in account starting bound_x, bound_y, pixel_x, pixel_y.
 	//So it can unintentionally shift physical bounds of things that starts with non zero bound_x, bound_y.
-	if(((bound_height != world.icon_size) || (bound_width != world.icon_size)) && (bound_x == 0) && (bound_y == 0)) //Dont shift things that have non zero bound_x and bound_y, or it move somewhere. Now it BSA and Gateway.
+	if(((bound_height != world.icon_size) || (bound_width != world.icon_size)) && (bound_x == 0) && (bound_y == 0)) //Dont shift things that have non zero bound_x and bound_y, or it move somewhere.
 		pixel_x = dir & (NORTH|EAST) ? -bound_width+world.icon_size : 0
 		pixel_y = dir & (NORTH|WEST) ? -bound_width+world.icon_size : 0
 		bound_x = pixel_x


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Fixes multitile doors and multitile engines on shuttles. Also pods if they existed still.
Grants the NTSS Raven it's large engines it was intended to have, but I removed when porting due to the bug that this fixes.
Fixes #24610

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Bugs are bad.
More creative shuttles with huge engines good.
Raven having big boy engines is good.

## Testing
<!-- How did you test the PR, if at all? -->
example on discord

## Changelog
:cl:
tweak: Gives NTSS Raven it's big engines back, gives whiteship multi tile cockpit per request
fix: Fixes multitile doors and multitile engines on shuttles.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
