### PR TITLE
Add job_globals sanitization, fix duplicate value

### DIFF
--- a/code/game/jobs/job_globals.dm
+++ b/code/game/jobs/job_globals.dm
@@ -76,7 +76,7 @@ GLOBAL_LIST_INIT(supply_positions, list(
 	"Shaft Miner"
 ))
 
-GLOBAL_LIST_INIT(service_positions, (list("Head of Personnel") + (support_positions - supply_positions)))
+GLOBAL_LIST_INIT(service_positions, (support_positions - supply_positions))
 
 /// Roles that include any semblence of security, mostly for jobbans
 GLOBAL_LIST_INIT(security_positions, list(

--- a/code/game/jobs/job_globals.dm
+++ b/code/game/jobs/job_globals.dm
@@ -55,8 +55,7 @@ GLOBAL_LIST_INIT(science_positions, list(
 	"Roboticist",
 ))
 
-//BS12 EDIT
-GLOBAL_LIST_INIT(support_positions, list(
+GLOBAL_LIST_INIT(service_positions, list(
 	"Head of Personnel",
 	"Bartender",
 	"Botanist",
@@ -75,8 +74,6 @@ GLOBAL_LIST_INIT(supply_positions, list(
 	"Cargo Technician",
 	"Shaft Miner"
 ))
-
-GLOBAL_LIST_INIT(service_positions, (support_positions - supply_positions))
 
 /// Roles that include any semblence of security, mostly for jobbans
 GLOBAL_LIST_INIT(security_positions, list(
@@ -133,7 +130,7 @@ GLOBAL_LIST_INIT(nonhuman_positions, list(
 
 GLOBAL_LIST_INIT(exp_jobsmap, list(
 	EXP_TYPE_LIVING = list(), // all living mobs
-	EXP_TYPE_CREW = list(titles = command_positions | engineering_positions | medical_positions | science_positions | support_positions | supply_positions | security_positions | assistant_positions | list("AI","Cyborg")), // crew positions
+	EXP_TYPE_CREW = list(titles = command_positions | engineering_positions | medical_positions | science_positions | service_positions | supply_positions | security_positions | assistant_positions | list("AI","Cyborg")), // crew positions
 	EXP_TYPE_SPECIAL = list(), // antags, ERT, etc
 	EXP_TYPE_GHOST = list(), // dead people, observers
 	EXP_TYPE_COMMAND = list(titles = command_head_positions),

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -512,7 +512,7 @@
 							"Medical" = GLOB.medical_positions,
 							"Science" = GLOB.science_positions,
 							"Security" = GLOB.security_positions,
-							"Support" = GLOB.support_positions,
+							"Service" = GLOB.service_positions,
 							"Supply" = GLOB.supply_positions,
 							"Command" = GLOB.command_positions,
 							"Custom" = null,

--- a/code/modules/admin/db_ban/functions.dm
+++ b/code/modules/admin/db_ban/functions.dm
@@ -160,10 +160,10 @@
 		"rounds" = (rounds ? "[rounds]" : "0"), // And here
 		"ckey" = ckey,
 		"computerid" = computerid,
-		"ip" = ip,
+		"ip" = "[ip ? ip : ""]", // This is important. NULL is not the same as "", and if you directly open the `.dmb` file, you get a NULL IP.
 		"a_ckey" = a_ckey,
 		"a_computerid" = a_computerid,
-		"a_ip" = a_ip,
+		"a_ip" = "[a_ip ? a_ip : ""]",
 		"who" = who,
 		"adminwho" = adminwho,
 		"roundid" = GLOB.round_id,

--- a/code/modules/admin/db_ban/functions.dm
+++ b/code/modules/admin/db_ban/functions.dm
@@ -490,7 +490,7 @@
 		output += "<option value='[j]'>[j]</option>"
 	for(var/j in GLOB.other_roles)
 		output += "<option value='[j]'>[j]</option>"
-	for(var/j in list("commanddept","securitydept","engineeringdept","medicaldept","sciencedept","supportdept","nonhumandept"))
+	for(var/j in list("commanddept","securitydept","engineeringdept","medicaldept","sciencedept","servicedept","nonhumandept"))
 		output += "<option value='[j]'>[j]</option>"
 	for(var/j in list("Syndicate") + GLOB.antag_roles)
 		output += "<option value='[j]'>[j]</option>"

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -161,7 +161,7 @@
 			message_admins("Ban process: A mob matching [playermob.ckey] was found at location [playermob.x], [playermob.y], [playermob.z]. Custom IP and computer id fields replaced with the IP and computer id from the located mob")
 
 		if(job_ban)
-			if(banjob in list("commanddept","securitydept","engineeringdept","medicaldept","sciencedept","supportdept","nonhumandept"))
+			if(banjob in list("commanddept","securitydept","engineeringdept","medicaldept","sciencedept","servicedept","nonhumandept"))
 				multi_job = TRUE
 				switch(banjob)
 					if("commanddept")
@@ -194,8 +194,8 @@
 							var/datum/job/temp = SSjobs.GetJob(jobPos)
 							if(!temp) continue
 							jobs_to_ban += temp.title
-					if("supportdept")
-						for(var/jobPos in GLOB.support_positions)
+					if("servicedept")
+						for(var/jobPos in GLOB.service_positions)
 							if(!jobPos)	continue
 							var/datum/job/temp = SSjobs.GetJob(jobPos)
 							if(!temp) continue
@@ -553,11 +553,11 @@
 				counter = 0
 		jobs += "</tr></table>"
 
-	//Support (Grey)
+	//Service (Grey)
 		counter = 0
 		jobs += "<table cellpadding='1' cellspacing='0' width='100%'>"
-		jobs += "<tr bgcolor='dddddd'><th colspan='[length(GLOB.support_positions)]'><a href='?src=[UID()];jobban3=supportdept;jobban4=[M.UID()];dbbanaddckey=[M.ckey]'>Support Positions</a></th></tr><tr align='center'>"
-		for(var/jobPos in GLOB.support_positions)
+		jobs += "<tr bgcolor='dddddd'><th colspan='[length(GLOB.service_positions)]'><a href='?src=[UID()];jobban3=servicedept;jobban4=[M.UID()];dbbanaddckey=[M.ckey]'>Support Positions</a></th></tr><tr align='center'>"
+		for(var/jobPos in GLOB.service_positions)
 			if(!jobPos)	continue
 			var/datum/job/job = SSjobs.GetJob(jobPos)
 			if(!job) continue
@@ -668,7 +668,7 @@
 			to_chat(usr, "<span class='warning'>SSjobs has not been setup!</span>")
 			return
 
-		//get jobs for department if specified, otherwise just returnt he one job in a list.
+		//get jobs for department if specified, otherwise just return the one job in a list.
 		var/list/joblist = list()
 		switch(href_list["jobban3"])
 			if("commanddept")
@@ -701,8 +701,8 @@
 					var/datum/job/temp = SSjobs.GetJob(jobPos)
 					if(!temp) continue
 					joblist += temp.title
-			if("supportdept")
-				for(var/jobPos in GLOB.support_positions)
+			if("servicedept")
+				for(var/jobPos in GLOB.service_positions)
 					if(!jobPos)	continue
 					var/datum/job/temp = SSjobs.GetJob(jobPos)
 					if(!temp) continue

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -161,7 +161,7 @@
 			message_admins("Ban process: A mob matching [playermob.ckey] was found at location [playermob.x], [playermob.y], [playermob.z]. Custom IP and computer id fields replaced with the IP and computer id from the located mob")
 
 		if(job_ban)
-			if(banjob in list("commanddept","securitydept","engineeringdept","medicaldept","sciencedept","servicedept","nonhumandept"))
+			if(banjob in list("commanddept","securitydept","engineeringdept","medicaldept","sciencedept","servicedept","supplydept","nonhumandept"))
 				multi_job = TRUE
 				switch(banjob)
 					if("commanddept")
@@ -196,6 +196,12 @@
 							jobs_to_ban += temp.title
 					if("servicedept")
 						for(var/jobPos in GLOB.service_positions)
+							if(!jobPos)	continue
+							var/datum/job/temp = SSjobs.GetJob(jobPos)
+							if(!temp) continue
+							jobs_to_ban += temp.title
+					if("supplydept")
+						for(var/jobPos in GLOB.supply_positions)
 							if(!jobPos)	continue
 							var/datum/job/temp = SSjobs.GetJob(jobPos)
 							if(!temp) continue
@@ -556,8 +562,29 @@
 	//Service (Grey)
 		counter = 0
 		jobs += "<table cellpadding='1' cellspacing='0' width='100%'>"
-		jobs += "<tr bgcolor='dddddd'><th colspan='[length(GLOB.service_positions)]'><a href='?src=[UID()];jobban3=servicedept;jobban4=[M.UID()];dbbanaddckey=[M.ckey]'>Support Positions</a></th></tr><tr align='center'>"
+		jobs += "<tr bgcolor='dddddd'><th colspan='[length(GLOB.service_positions)]'><a href='?src=[UID()];jobban3=servicedept;jobban4=[M.UID()];dbbanaddckey=[M.ckey]'>Service Positions</a></th></tr><tr align='center'>"
 		for(var/jobPos in GLOB.service_positions)
+			if(!jobPos)	continue
+			var/datum/job/job = SSjobs.GetJob(jobPos)
+			if(!job) continue
+
+			if(jobban_isbanned(M, job.title))
+				jobs += "<td width='20%'><a href='?src=[UID()];jobban3=[job.title];jobban4=[M.UID()];dbbanaddckey=[M.ckey]'><font color=red>[replacetext(job.title, " ", "&nbsp")]</font></a></td>"
+				counter++
+			else
+				jobs += "<td width='20%'><a href='?src=[UID()];jobban3=[job.title];jobban4=[M.UID()];dbbanaddckey=[M.ckey]'>[replacetext(job.title, " ", "&nbsp")]</a></td>"
+				counter++
+
+			if(counter >= 5) //So things dont get squiiiiished!
+				jobs += "</tr><tr align='center'>"
+				counter = 0
+		jobs += "</tr></table>"
+
+	//Supply (Brown)
+		counter = 0
+		jobs += "<table cellpadding='1' cellspacing='0' width='100%'>"
+		jobs += "<tr bgcolor='e2c59d'><th colspan='[length(GLOB.supply_positions)]'><a href='?src=[UID()];jobban3=supplydept;jobban4=[M.UID()];dbbanaddckey=[M.ckey]'>Supply Positions</a></th></tr><tr align='center'>"
+		for(var/jobPos in GLOB.supply_positions)
 			if(!jobPos)	continue
 			var/datum/job/job = SSjobs.GetJob(jobPos)
 			if(!job) continue
@@ -703,6 +730,12 @@
 					joblist += temp.title
 			if("servicedept")
 				for(var/jobPos in GLOB.service_positions)
+					if(!jobPos)	continue
+					var/datum/job/temp = SSjobs.GetJob(jobPos)
+					if(!temp) continue
+					joblist += temp.title
+			if("supplydept")
+				for(var/jobPos in GLOB.supply_positions)
 					if(!jobPos)	continue
 					var/datum/job/temp = SSjobs.GetJob(jobPos)
 					if(!temp) continue

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -588,6 +588,9 @@
 		if(check_randomizer(connectiontopic))
 			return
 
+	var/client_address = address
+	if(!client_address) // Localhost can sometimes have no address set
+		client_address = "127.0.0.1"
 
 	if(sql_id)
 		//Just the standard check to see if it's actually a number
@@ -595,10 +598,6 @@
 			sql_id = text2num(sql_id)
 		if(!isnum(sql_id))
 			return // Return here because if we somehow didnt pull a number from an INT column, EVERYTHING is breaking
-
-		var/client_address = address
-		if(!client_address) // Localhost can sometimes have no address set
-			client_address = "127.0.0.1"
 
 		//Player already identified previously, we need to just update the 'lastseen', 'ip' and 'computer_id' variables
 		var/datum/db_query/query_update = SSdbcore.NewQuery("UPDATE player SET lastseen=NOW(), ip=:sql_ip, computerid=:sql_cid, lastadminrank=:sql_ar WHERE id=:sql_id", list(
@@ -620,7 +619,7 @@
 		//New player!! Need to insert all the stuff
 		var/datum/db_query/query_insert = SSdbcore.NewQuery("INSERT INTO player (id, ckey, firstseen, lastseen, ip, computerid, lastadminrank) VALUES (null, :ckey, Now(), Now(), :ip, :cid, :rank)", list(
 			"ckey" = ckey,
-			"ip" = address,
+			"ip" = client_address,
 			"cid" = computer_id,
 			"rank" = admin_rank
 		))

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -2,6 +2,7 @@
 //Keep this sorted alphabetically
 
 #ifdef UNIT_TESTS
+#include "jobs\test_job_globals.dm"
 #include "aicard_icons.dm"
 #include "announcements.dm"
 #include "areas_apcs.dm"

--- a/code/modules/unit_tests/jobs/test_job_globals.dm
+++ b/code/modules/unit_tests/jobs/test_job_globals.dm
@@ -1,0 +1,27 @@
+/datum/unit_test/job_globals/Run()
+	return
+
+/datum/unit_test/job_globals/proc/is_list_unique(list/L)
+	var/list_length = length(L)
+	var/unique_list = uniqueList(L)
+	var/unique_list_length = length(unique_list)
+	return list_length == unique_list_length
+
+/datum/unit_test/job_globals/proc/validate_list(list/L, list_name)
+	if(!is_list_unique(L))
+		Fail("job_globals list '[list_name]' contains duplicate values.")
+
+/datum/unit_test/job_globals/no_duplicates/Run()
+	validate_list(GLOB.station_departments, "station_departments")
+	validate_list(GLOB.command_positions, "command_positions")
+	validate_list(GLOB.command_head_positions, "command_head_positions")
+	validate_list(GLOB.engineering_positions, "engineering_positions")
+	validate_list(GLOB.medical_positions, "medical_positions")
+	validate_list(GLOB.science_positions, "science_positions")
+	validate_list(GLOB.support_positions, "support_positions")
+	validate_list(GLOB.supply_positions, "supply_positions")
+	validate_list(GLOB.service_positions, "service_positions")
+	validate_list(GLOB.security_positions, "security_positions")
+	validate_list(GLOB.active_security_positions, "active_security_positions")
+	validate_list(GLOB.assistant_positions, "assistant_positions")
+	validate_list(GLOB.nonhuman_positions, "nonhuman_positions")

--- a/code/modules/unit_tests/jobs/test_job_globals.dm
+++ b/code/modules/unit_tests/jobs/test_job_globals.dm
@@ -18,7 +18,6 @@
 	validate_list(GLOB.engineering_positions, "engineering_positions")
 	validate_list(GLOB.medical_positions, "medical_positions")
 	validate_list(GLOB.science_positions, "science_positions")
-	validate_list(GLOB.support_positions, "support_positions")
 	validate_list(GLOB.supply_positions, "supply_positions")
 	validate_list(GLOB.service_positions, "service_positions")
 	validate_list(GLOB.security_positions, "security_positions")


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #24774: Removes duplicate **Head of Personnel** value from `GLOB.service_positions` (HOP showed up twice on ID computer), adds sanitizing for `job_globals` values via unit-test.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Fixes minor oversight, hopefully prevents it from happening again in the future.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
HOP no longer listed twice in ID computer:
![image](https://github.com/ParadiseSS13/Paradise/assets/22023717/f28d2334-57a6-48fd-8fb0-c0ee3e443fc4)
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Added unit-tests for sanitizing `job_globals` values, checked ID Computer again and verified it was fixed.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl: Zantox
fix: HoP job no longer listed twice in Identification Computer
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
