### PR TITLE
Slightly modifies the logging of runtimes

### DIFF
--- a/code/modules/error_handler/error_handler.dm
+++ b/code/modules/error_handler/error_handler.dm
@@ -132,7 +132,7 @@ GLOBAL_VAR_INIT(total_runtimes_skipped, 0)
 
 	// Now to actually output the error info...
 	log_world("\[[time_stamp()]] Runtime in [e.file]:[e.line]: [e]")
-	log_runtime_txt("Runtime in [e.file]:[e.line]: [e]")
+	log_runtime_txt("Runtime in [e.file],[e.line]: [e]") // All other runtimes show as [e.file]:[e.line] except this one to prevent fuckery with analyzing both old and new runtimes. runtime.log should stay in the [e.file],[e.line] format.
 	for(var/line in desclines)
 		log_world(line)
 		log_runtime_txt(line)

--- a/code/modules/error_handler/error_handler.dm
+++ b/code/modules/error_handler/error_handler.dm
@@ -72,13 +72,13 @@ GLOBAL_VAR_INIT(total_runtimes_skipped, 0)
 			var/skipcount = abs(GLOB.error_cooldown[erroruid]) - 1
 			GLOB.error_cooldown[erroruid] = 0
 			if(skipcount > 0)
-				log_world("\[[time_stamp()]] Skipped [skipcount] runtimes in [e.file],[e.line].")
+				log_world("\[[time_stamp()]] Skipped [skipcount] runtimes in [e.file]:[e.line].")
 				GLOB.error_cache.logError(e, skipCount = skipcount)
 	GLOB.error_last_seen[erroruid] = world.time
 	GLOB.error_cooldown[erroruid] = cooldown
 
 	// This line will log a runtime summary to a file which can be publicly distributed without sending player data
-	log_runtime_summary("Runtime in [e.file],[e.line]: [e]")
+	log_runtime_summary("Runtime in [e.file]:[e.line]: [e]")
 
 	// The detailed error info needs some tweaking to make it look nice
 	var/list/srcinfo = null
@@ -131,8 +131,8 @@ GLOBAL_VAR_INIT(total_runtimes_skipped, 0)
 		desclines += "  (This error will now be silenced for [ERROR_SILENCE_TIME / 600] minutes)"
 
 	// Now to actually output the error info...
-	log_world("\[[time_stamp()]] Runtime in [e.file],[e.line]: [e]")
-	log_runtime_txt("Runtime in [e.file],[e.line]: [e]")
+	log_world("\[[time_stamp()]] Runtime in [e.file]:[e.line]: [e]")
+	log_runtime_txt("Runtime in [e.file]:[e.line]: [e]")
 	for(var/line in desclines)
 		log_world(line)
 		log_runtime_txt(line)

--- a/code/modules/error_handler/error_viewer.dm
+++ b/code/modules/error_handler/error_viewer.dm
@@ -117,7 +117,7 @@ GLOBAL_DATUM(error_cache, /datum/ErrorViewer/ErrorCache)
 	//  from the same source hasn't been shown too recently
 	if(error_source.next_message_at <= world.time)
 		var/const/viewtext = "\[view]" // Nesting these in other brackets went poorly
-		log_debug("Runtime in [e.file],[e.line]: [html_encode(e.name)] [error_entry.makeLink(viewtext)]")
+		log_debug("Runtime in [e.file]:[e.line]: [html_encode(e.name)] [error_entry.makeLink(viewtext)]")
 		error_source.next_message_at = world.time + ERROR_MSG_DELAY
 
 /datum/ErrorViewer/ErrorSource
@@ -128,7 +128,7 @@ GLOBAL_DATUM(error_cache, /datum/ErrorViewer/ErrorCache)
 	if(!istype(e))
 		name = "\[[time_stamp()]] Uncaught exceptions"
 		return
-	name = "\[[time_stamp()]] Runtime in [e.file],[e.line]: [e]"
+	name = "\[[time_stamp()]] Runtime in [e.file]:[e.line]: [e]"
 
 /datum/ErrorViewer/ErrorSource/showTo(user, datum/ErrorViewer/back_to, linear)
 	if(!istype(back_to))
@@ -156,10 +156,10 @@ GLOBAL_DATUM(error_cache, /datum/ErrorViewer/ErrorCache)
 		name = "\[[time_stamp()]] Uncaught exception: [e]"
 		return
 	if(skipCount)
-		name = "\[[time_stamp()]] Skipped [skipCount] runtimes in [e.file],[e.line]."
+		name = "\[[time_stamp()]] Skipped [skipCount] runtimes in [e.file]:[e.line]."
 		isSkipCount = TRUE
 		return
-	name = "\[[time_stamp()]] Runtime in [e.file],[e.line]: [e]"
+	name = "\[[time_stamp()]] Runtime in [e.file]:[e.line]: [e]"
 	exc = e
 	if(istype(desclines))
 		for(var/line in desclines)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
`DEBUG: Runtime in code/modules/error_handler/error_handler.dm,154: Division by zero`
is now
`DEBUG: Runtime in code/modules/error_handler/error_handler.dm:154: Division by zero`

Paraphrased from AA: "Kibana only touches the full runtime.log", so all of the runtime logging locations except for writing to that one have been changed. It will stay this way unless "unless Denghi can edit the pipeline beforehand to allow file,line as well as file:line"

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->By changing the comma to a colon between the filename and line number, it makes it much easier to copy paste the error into VSCode to search for the line on which the error occured.

## Images of changes and Testing
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![image](https://github.com/ParadiseSS13/Paradise/assets/91113370/983e92d3-da36-4f6d-9349-428e45dfa6ce)
![image](https://github.com/ParadiseSS13/Paradise/assets/91113370/f93d615a-3fba-486a-963e-0cb56d771666)


## Changelog
NPFC

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
