### PR TITLE
box: fix duplicate prefab in janitorial

### DIFF
--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -47922,9 +47922,6 @@
 "ddr" = (
 /turf/simulated/floor/plating,
 /area/station/maintenance/storage)
-"dds" = (
-/turf/simulated/wall,
-/area/station/service/janitor)
 "ddt" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 0;
@@ -126995,8 +126992,8 @@ ryV
 tyQ
 tDd
 xbn
-dds
-dds
+chc
+chc
 aTi
 qcN
 dwV


### PR DESCRIPTION
## What Does This PR Do
This removes a duplicate prefab left over from when SOMEONE hand edited boxstation without properly letting git hooks run.
## Why It's Good For The Game
If I don't do this it'll show up in some other unrelated PR and confuse people.
## Testing
No testing, YOLO
## Changelog
NPFC
