### PR TITLE
delta: fix whiteship docking port

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -72080,13 +72080,11 @@
 	},
 /area/station/science/break_room)
 "hDZ" = (
-/obj/docking_port/stationary{
+/obj/docking_port/stationary/whiteship{
 	dir = 8;
-	dwidth = 10;
-	height = 35;
-	id = "whiteship_home";
+	id = "whiteship_kerberos";
 	name = "north of Kerberos";
-	width = 21
+	
 	},
 /turf/space,
 /area/space)

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -72083,8 +72083,7 @@
 /obj/docking_port/stationary/whiteship{
 	dir = 8;
 	id = "whiteship_kerberos";
-	name = "north of Kerberos";
-	
+	name = "north of Kerberos"
 	},
 /turf/space,
 /area/space)


### PR DESCRIPTION
## What Does This PR Do
This PR fixes Delta's whiteship docking port. I have no idea how long this has been broken but it hasn't been using the correct docking port subtype.
## Why It's Good For The Game
The whiteship should at the very least be able to dock near the station.
## Testing
Spawned in, moved whiteship.
## Changelog
:cl:
fix: The whiteship can now properly dock near the NSS Kerberos.
/:cl:
