### PR TITLE
Adjusts some borg hat offsets

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_mob.dm
+++ b/code/modules/mob/living/silicon/robot/robot_mob.dm
@@ -498,7 +498,7 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 			can_be_hatted = TRUE
 			hat_alpha = 0
 			hat_offset_y = 2
-		if("syndi-medi", "surgeon", "toiletbot")
+		if("syndi-medi", "surgeon", "toiletbot", "custodiborg")
 			can_be_hatted = TRUE
 			is_centered = TRUE
 			hat_offset_y = 1
@@ -530,6 +530,17 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 		if("mopgearrex")
 			can_be_hatted = TRUE
 			hat_offset_y = -6
+		if("qualified_doctor")
+			can_be_hatted = TRUE
+			hat_offset_y = 3
+		if("squatminer")
+			can_be_hatted = TRUE
+		if("coffinMiner")
+			can_be_hatted = TRUE
+			hat_offset_y = 3
+		if("heavySec")
+			can_be_hatted = TRUE
+			can_wear_restricted_hats = TRUE
 
 	if(silicon_hat)
 		if(!can_be_hatted)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Fixed the cyborg skins from https://github.com/ParadiseSS13/Paradise/pull/24287 having wrong hat offsets
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
It is an oversight, caused by not adjusting the PR in time after the borg hats was merged.
## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->


![image](https://github.com/ParadiseSS13/Paradise/assets/77684085/89c2fb7d-fb50-4a73-95be-53ead0e3270e)


![image](https://github.com/ParadiseSS13/Paradise/assets/77684085/22a9e4a9-60b0-4fb9-95f7-1ae9a414b113)


## Testing
<!-- How did you test the PR, if at all? -->
- See image above
## Changelog
:cl:
fix: Fixed some cyborg skins having wrong hat offsets
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
