### PR TITLE
Show poll alert for admins anyway

### DIFF
--- a/code/_globalvars/lists/mob_lists.dm
+++ b/code/_globalvars/lists/mob_lists.dm
@@ -27,7 +27,7 @@ GLOBAL_LIST_EMPTY(non_respawnable_keys)	//List of ckeys that are excluded from r
 GLOBAL_LIST_INIT(simple_animals, list(list(), list(), list(), list()))			//One for each AI_* status define, List of all simple animals, including clientless
 GLOBAL_LIST_EMPTY(bots_list) 					//List of all bots(beepsky, medibots,etc)
 GLOBAL_LIST_EMPTY(roundstart_observer_keys)	//List of ckeys who ghosted before the game began.
-GLOBAL_LIST_EMPTY(antag_hud_users) 			// ckeys of (non-admin) users who have enabled ahud at some point during the game
+GLOBAL_LIST_EMPTY(antag_hud_users) 			// ckeys of users who have enabled ahud at some point during the game
 
 GLOBAL_LIST_EMPTY(surgeries_list)
 GLOBAL_LIST_EMPTY(hear_radio_list)			//Mobs that hear the radio even if there's no client

--- a/code/modules/mob/dead/observer/observer_base.dm
+++ b/code/modules/mob/dead/observer/observer_base.dm
@@ -362,6 +362,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	if(!check_rights((R_ADMIN | R_MOD), FALSE, user))
 		return
 	antagHUD = TRUE
+	GLOB.antag_hud_users |= user.ckey
 	for(var/datum/atom_hud/antag/H in GLOB.huds)
 		H.add_hud_to(src)
 
@@ -842,6 +843,9 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
  * If allow_roundstart_observers is FALSE (TRUE by default), then any observers who were able to ahud due to joining roundstart will be excluded as well.
  */
 /mob/dead/observer/proc/check_ahud_rejoin_eligibility(allow_roundstart_observers = TRUE)
+	if(check_rights(R_ADMIN | R_MOD, FALSE, src))
+		return TRUE
+
 	if(!GLOB.configuration.general.restrict_antag_hud_rejoin || !has_ahudded())
 		return TRUE
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Puts admins having antag HUD enabled round start into global list.
Shows 'poll candidates' alerts for admins even if they have enabled antag HUD.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Admins re-enabling their antag HUD makes it impossible for them to see and participate in candidate polls. I don't see any reason for this.
Having admins with antag HUD enabled in `GLOB.antag_hud_users` is just for consistency and some messages.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Tested locally.

<!-- How did you test the PR, if at all? -->

## Changelog
:cl: Maxiemar
fix: Admins should see candidate polls in all circumstances from now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
