### PR TITLE
cere: bridge has correct supply computer

### DIFF
--- a/_maps/map_files/cerestation/cerestation.dmm
+++ b/_maps/map_files/cerestation/cerestation.dmm
@@ -18091,9 +18091,6 @@
 /turf/simulated/floor/carpet/black,
 /area/station/command/bridge)
 "bRZ" = (
-/obj/machinery/computer/supplycomp/public{
-	dir = 8
-	},
 /obj/structure/railing{
 	dir = 6
 	},
@@ -18101,6 +18098,9 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/computer/supplycomp{
+	dir = 8
 	},
 /turf/simulated/floor/carpet/black,
 /area/station/command/bridge)


### PR DESCRIPTION
## What Does This PR Do
This PR fixes the northmost supply computer on Cere's bridge to be the proper permissions.

I should point out there already is one of these supply computers here:

![2024_03_26__13_58_54__paradise dme  cerestation dmm  - StrongDMM](https://github.com/ParadiseSS13/Paradise/assets/59303604/4db1ac17-fbac-43f9-b63b-990ff6792896)


but I guess I'm keeping both of them for the symmetry.

## Why It's Good For The Game
A public supply computer on the bridge is pretty useless since it can't approve requests.

## Testing
Confirmed that a Command member could approve orders on the new console.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Farragus: The supply console on the bridge correctly allows Command order approval.
/:cl:
