### PR TITLE
Fix bugs with observer crew monitor

### DIFF
--- a/code/modules/tgui/modules/crew_monitor.dm
+++ b/code/modules/tgui/modules/crew_monitor.dm
@@ -70,8 +70,8 @@
 
 	data["is_advanced"] = is_advanced
 	data["possible_levels"] = list()
-	for(var/z in 1 to world.maxz)
-		data["possible_levels"] |= z
+	for(var/zl in GLOB.space_manager.z_list)
+		data["possible_levels"] |= zl
 
 	return data
 
@@ -79,3 +79,6 @@
 	name = "Crew monitor (Observer)"
 	is_advanced = TRUE
 	ignore_sensors = TRUE
+
+/datum/ui_module/crew_monitor/ghost/ui_state(mob/user)
+	return GLOB.observer_state


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes a UI state issue that seems to have been preventing non-admins from using the orbit button on the crew monitor.
Also, fixes the z-level dropdown to now properly show and switch between z-levels.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Fixing bugs on a recent PR, good to have this work in the way that it should.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://github.com/ParadiseSS13/Paradise/assets/89928798/293d19a6-8d83-4f94-8f1b-a993f19507c0)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Loaded in, tried the orbit stuff
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Switching between z-levels on the observer and CC crew monitors should now work properly.
fix: Observers should now be able to properly use the orbit button on the observer crew monitor.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
