### PR TITLE
Sord missing icon fix

### DIFF
--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -28,10 +28,10 @@
 /obj/item/sord
 	name = "\improper SORD"
 	desc = "This thing is so unspeakably shitty you are having a hard time even holding it."
+	icon = 'icons/obj/weapons/magical_weapons.dmi'
+	icon_state = "sord"
 	lefthand_file = 'icons/mob/inhands/weapons_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons_righthand.dmi'
-	icon_state = "sord"
-	item_state = "sord"
 	slot_flags = SLOT_FLAG_BELT
 	force = 2
 	throwforce = 1


### PR DESCRIPTION
## What Does This PR Do
Returns sord item icon

## Why It's Good For The Game
No invisible items

## Images of changes
![image](https://github.com/ParadiseSS13/Paradise/assets/69762909/da200e79-fa99-48de-a1b2-9057bdfddc59)

## Testing
Hi Henri

## Changelog
:cl:
fix: Fixed missing SORD sprite
/:cl:
