### PR TITLE
Adds workflow for automatic handling of stale PRs and issues, tidies other workflows and adds better logging

### DIFF
--- a/.github/workflows/label_stale.yml
+++ b/.github/workflows/label_stale.yml
@@ -12,13 +12,13 @@ jobs:
         uses: actions/stale@v4
         with:
           stale-pr-message: 'This pull request seems to be stale as there have been no changes in 14 days, please make changes within 7 days or the PR will be closed. If you believe this is a mistake, please inform a development team member on Discord.'
-          close-pr-message: 'This pull request was marked as stale, yet no changes have been observed in the specified time. Please feel free to open a new pull request when your project has been updated, however this pull request has been closed.'
-          stale-issue-message: 'This issue either requires verification or is unreproducible, but has had no updates for 60 days. Please provide an update within 14 days or this issue will be closed. If you believe this is a mistake, please contact an issue manager on Discord'
+          close-pr-message: 'This pull request has not received any updates since being marked stale, and as such is now being automatically closed. Please feel free to re-open this pull request or open a new one once you have new updates.'
+          stale-issue-message: 'This issue either requires verification or is unreproducible, but has had no updates for 60 days. Please provide an update within 14 days or this issue will be closed. If you believe this is a mistake, please contact an issue manager on Discord.'
           close-issue-message: 'This issue was marked as stale, yet no changes have been observed in the specified time. The issue has been closed.'
           days-before-stale: 14
           days-before-issue-stale: 60
           days-before-close: 7
           days-before-issue-close: 14
           exempt-issue-labels: '"Stale Exempt"'
-          exempt-pr-labels: '"Stale Exempt", "-Status: Awaiting approval"'
+          exempt-pr-labels: '"Stale Exempt", "-Status: Awaiting approval", "-Status: Awaiting Merge", "-Status: Awaiting type assignment"'
           only-issue-labels: '"Need Verification", "Cannot Reproduce", "Not A Bug", "(99% Sure) Not A Bug"'

--- a/.github/workflows/label_stale.yml
+++ b/.github/workflows/label_stale.yml
@@ -1,0 +1,24 @@
+name: Label and close stale PRs and Issues
+
+on:
+  schedule:
+    - cron: '0 0 * * *'  # Runs at midnight UTC every day
+
+jobs:
+  stale-prs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Seek and destroy stale PRs and Issues
+        uses: actions/stale@v4
+        with:
+          stale-pr-message: 'This pull request seems to be stale as there has been no changes in 14 days, please make changes within 7 days or we will close the PR. If you believe this PR is not stale, please inform a development team member on Discord.'
+          close-pr-message: 'This pull request was marked as stale, yet no changes have been observed in the specified time. Please feel free to open a new pull request when your project has been updated, however this pull request has been closed.'
+          stale-issue-message: 'This issue either requires verification or is unreproducable, but has had no updates for 60 days. Please provide an update within 14 days or this issue will be closed.'
+          close-issue-message: 'This issue was marked as stale, yet no changes have been observed in the specified time. The issue has been closed.'
+          days-before-stale: 14
+          days-before-issue-stale: 60
+          days-before-close: 7
+          days-before-issue-close: 14
+          exempt-issue-labels: '"Stale Exempt"'
+          exempt-pr-labels: '"Stale Exempt"'
+          only-issue-labels: '"Need Verification", "Cannot Reproduce", "Not A Bug", "(99% Sure) Not A Bug"'

--- a/.github/workflows/label_stale.yml
+++ b/.github/workflows/label_stale.yml
@@ -11,14 +11,14 @@ jobs:
       - name: Seek and destroy stale PRs and Issues
         uses: actions/stale@v4
         with:
-          stale-pr-message: 'This pull request seems to be stale as there has been no changes in 14 days, please make changes within 7 days or we will close the PR. If you believe this PR is not stale, please inform a development team member on Discord.'
+          stale-pr-message: 'This pull request seems to be stale as there have been no changes in 14 days, please make changes within 7 days or the PR will be closed. If you believe this is a mistake, please inform a development team member on Discord.'
           close-pr-message: 'This pull request was marked as stale, yet no changes have been observed in the specified time. Please feel free to open a new pull request when your project has been updated, however this pull request has been closed.'
-          stale-issue-message: 'This issue either requires verification or is unreproducable, but has had no updates for 60 days. Please provide an update within 14 days or this issue will be closed.'
+          stale-issue-message: 'This issue either requires verification or is unreproducible, but has had no updates for 60 days. Please provide an update within 14 days or this issue will be closed. If you believe this is a mistake, please contact an issue manager on Discord'
           close-issue-message: 'This issue was marked as stale, yet no changes have been observed in the specified time. The issue has been closed.'
           days-before-stale: 14
           days-before-issue-stale: 60
           days-before-close: 7
           days-before-issue-close: 14
           exempt-issue-labels: '"Stale Exempt"'
-          exempt-pr-labels: '"Stale Exempt"'
+          exempt-pr-labels: '"Stale Exempt", "-Status: Awaiting approval"'
           only-issue-labels: '"Need Verification", "Cannot Reproduce", "Not A Bug", "(99% Sure) Not A Bug"'

--- a/.github/workflows/merge_upstream_master.yml
+++ b/.github/workflows/merge_upstream_master.yml
@@ -25,7 +25,6 @@ jobs:
 
       - name: PR Data
         run: |
-          echo "FAIL_NOTIFIED=true" >> $GITHUB_ENV
           pr_json=$(curl -L -s --fail-with-body -H "Authorization: token ${{ github.token }}" ${{ github.event.issue.pull_request.url }})
           if [ `jq -r '.maintainer_can_modify' <<<$pr_json` == "false" ] ; then
             gh pr comment ${{ github.event.issue.html_url }} --body 'GitHub Actions can not push to the repository without "Allow edits and access to secrets by maintainers" checked.'

--- a/.github/workflows/merge_upstream_master.yml
+++ b/.github/workflows/merge_upstream_master.yml
@@ -89,8 +89,6 @@ jobs:
           chmod +x tools/hooks/*.merge tgui/bin/tgui
 
           # Actual Merge
-          git config user.name github-actions
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git remote add upstream "https://github.com/$BASE_REPOSITORY.git"
 
           git fetch origin "$PR_BRANCH" --depth=$((ahead_by + 1))

--- a/.github/workflows/merge_upstream_master.yml
+++ b/.github/workflows/merge_upstream_master.yml
@@ -16,18 +16,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: create_token
-        uses: tibdex/github-app-token@v2
+        uses: actions/create-github-app-token@v1
         with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.PRIVATE_KEY }}
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
+
+      - run: echo "GH_TOKEN=${{ steps.create_token.outputs.token }}" >> "$GITHUB_ENV"
 
       - name: PR Data
-        env:
-          GH_TOKEN: ${{ steps.create_token.outputs.token }}
         run: |
+          echo "FAIL_NOTIFIED=true" >> $GITHUB_ENV
           pr_json=$(curl -L -s --fail-with-body -H "Authorization: token ${{ github.token }}" ${{ github.event.issue.pull_request.url }})
           if [ `jq -r '.maintainer_can_modify' <<<$pr_json` == "false" ] ; then
             gh pr comment ${{ github.event.issue.html_url }} --body 'GitHub Actions can not push to the repository without "Allow edits and access to secrets by maintainers" checked.'
+            echo "FAIL_NOTIFIED=true" >> $GITHUB_ENV
             exit 1
           fi
           echo "PR_REPO=`jq -r '.head.repo.full_name' <<<$pr_json`" >> $GITHUB_ENV
@@ -35,24 +37,18 @@ jobs:
           echo "PR_HEAD_LABEL=`jq -r '.head.label' <<<$pr_json`" >> $GITHUB_ENV
 
       - uses: actions/checkout@v4
-        env:
-          GH_TOKEN: ${{ steps.create_token.outputs.token }}
         with:
           repository: ${{ env.PR_REPO }}
           ref: ${{ env.PR_BRANCH }}
-          token: ${{ steps.create_token.outputs.token }}
+          token: ${{ env.GH_TOKEN }}
 
       - uses: actions/setup-node@v4
-        env:
-          GH_TOKEN: ${{ steps.create_token.outputs.token }}
         with:
           node-version: 20
           cache: 'yarn'
           cache-dependency-path: ./tgui/yarn.lock
 
       - uses: actions/setup-python@v5
-        env:
-          GH_TOKEN: ${{ steps.create_token.outputs.token }}
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -61,7 +57,6 @@ jobs:
         env:
           BASE_BRANCH: ${{ github.event.repository.default_branch }}
           BASE_REPOSITORY: ${{ github.repository }}
-          GH_TOKEN: ${{ steps.create_token.outputs.token }}
         run: |
           # Compare head branch and base branch
           compare_result=$(curl -L -s --fail-with-body \
@@ -93,11 +88,19 @@ jobs:
 
           git fetch origin "$PR_BRANCH" --depth=$((ahead_by + 1))
           git fetch upstream "$BASE_BRANCH" --depth=$((behind_by + 1))
+
+          # Check if a workflow file would be modified by the merge
+          latest_workflow_commit=$(git log -n 1 --pretty=format:"%H" upstream/$BASE_BRANCH -- .github/workflows)
+          if ! git branch --contains $latest_workflow_commit | grep -q "$(git rev-parse --abbrev-ref HEAD)"; then
+            gh pr comment ${{ github.event.issue.html_url }} --body "GitHub Actions can not push to this branch as it would modify a workflow file, please update your branch past https://github.com/ParadiseSS13/Paradise/commit/$latest_workflow_commit before using this command again."
+            echo "FAIL_NOTIFIED=true" >> $GITHUB_ENV
+            exit 1
+          fi
+
           git merge FETCH_HEAD
           git push origin
 
       - name: Notify Failure
-        if: failure()
-        env:
-          GH_TOKEN: ${{ steps.create_token.outputs.token }}
-        run: gh pr comment ${{ github.event.issue.html_url }} -b "Merging upstream failed:\nhttps://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        if: failure() && ${{ !env.FAIL_NOTIFIED == 'true' }}
+        run: |
+          gh pr comment ${{ github.event.issue.html_url }} -b "Merging upstream failed, see the action run log for details: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/merge_upstream_master.yml
+++ b/.github/workflows/merge_upstream_master.yml
@@ -92,7 +92,7 @@ jobs:
           # Check if a workflow file would be modified by the merge
           latest_workflow_commit=$(git log -n 1 --pretty=format:"%H" upstream/$BASE_BRANCH -- .github/workflows)
           if ! git branch --contains $latest_workflow_commit | grep -q "$(git rev-parse --abbrev-ref HEAD)"; then
-            gh pr comment ${{ github.event.issue.html_url }} --body "GitHub Actions can not push to this branch as it would modify a workflow file, please update your branch past https://github.com/ParadiseSS13/Paradise/commit/$latest_workflow_commit before using this command again."
+            gh pr comment ${{ github.event.issue.html_url }} --body "GitHub Actions can not push to this branch as workflow files have been changed since your branch was last updated. Please update your branch past https://github.com/ParadiseSS13/Paradise/commit/$latest_workflow_commit before using this command again."
             echo "FAIL_NOTIFIED=true" >> $GITHUB_ENV
             exit 1
           fi

--- a/.github/workflows/merge_upstream_master.yml
+++ b/.github/workflows/merge_upstream_master.yml
@@ -99,5 +99,4 @@ jobs:
 
       - name: Notify Failure
         if: failure()
-        run: |
-          gh pr comment ${{ github.event.issue.html_url }} -b "Merging upstream failed, see the action run log for details: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        run: gh pr comment ${{ github.event.issue.html_url }} -b "Merging upstream failed, see the action run log for details: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/merge_upstream_master.yml
+++ b/.github/workflows/merge_upstream_master.yml
@@ -23,6 +23,15 @@ jobs:
 
       - run: echo "GH_TOKEN=${{ steps.create_token.outputs.token }}" >> "$GITHUB_ENV"
 
+      - name: Like the comment
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/ParadiseSS13/Paradise/issues/comments/${{ github.event.comment.id }}/reactions \
+            -f content='+1'
+
       - name: PR Data
         run: |
           pr_json=$(curl -L -s --fail-with-body -H "Authorization: token ${{ github.token }}" ${{ github.event.issue.pull_request.url }})
@@ -97,6 +106,26 @@ jobs:
           git merge FETCH_HEAD
           git push origin
 
+      - name: Approve Workflows
+        run: |
+          # Get the list of pending workflow runs for paradisess13bot
+          runs=$(gh api \
+                  --method POST \
+                  -H "Accept: application/vnd.github+json" \
+                  -H "X-GitHub-Api-Version: 2022-11-28" \
+                  /repos/ParadiseSS13/Paradise/actions/runs?actor=paradisess13bot&status=action_required)
+          run_ids=$(echo $runs | jq -r '.workflow_runs[].id')
+
+          # Iterate over the run IDs, approving each one
+          for run_id in $run_ids; do
+              gh api \
+                --method POST \
+                -H "Accept: application/vnd.github+json" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                /repos/OWNER/REPO/actions/runs/$run_id/approve
+          done
+
       - name: Notify Failure
         if: failure()
-        run: gh pr comment ${{ github.event.issue.html_url }} -b "Merging upstream failed, see the action run log for details: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        run: |
+          gh pr comment ${{ github.event.issue.html_url }} -b 'Merging upstream failed, see the action run log for details: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/merge_upstream_master.yml
+++ b/.github/workflows/merge_upstream_master.yml
@@ -122,7 +122,7 @@ jobs:
                 --method POST \
                 -H "Accept: application/vnd.github+json" \
                 -H "X-GitHub-Api-Version: 2022-11-28" \
-                /repos/OWNER/REPO/actions/runs/$run_id/approve
+                /repos/ParadiseSS13/Paradise/actions/runs/$run_id/approve
           done
 
       - name: Notify Failure

--- a/.github/workflows/merge_upstream_master.yml
+++ b/.github/workflows/merge_upstream_master.yml
@@ -29,8 +29,7 @@ jobs:
           pr_json=$(curl -L -s --fail-with-body -H "Authorization: token ${{ github.token }}" ${{ github.event.issue.pull_request.url }})
           if [ `jq -r '.maintainer_can_modify' <<<$pr_json` == "false" ] ; then
             gh pr comment ${{ github.event.issue.html_url }} --body 'GitHub Actions can not push to the repository without "Allow edits and access to secrets by maintainers" checked.'
-            echo "FAIL_NOTIFIED=true" >> $GITHUB_ENV
-            exit 1
+            exit 0
           fi
           echo "PR_REPO=`jq -r '.head.repo.full_name' <<<$pr_json`" >> $GITHUB_ENV
           echo "PR_BRANCH=`jq -r '.head.ref' <<<$pr_json`" >> $GITHUB_ENV
@@ -89,18 +88,17 @@ jobs:
           git fetch origin "$PR_BRANCH" --depth=$((ahead_by + 1))
           git fetch upstream "$BASE_BRANCH" --depth=$((behind_by + 1))
 
-          # Check if a workflow file would be modified by the merge
+          # Check if a workflow file would be modified by the merge (permissions prevent pushes if so)
           latest_workflow_commit=$(git log -n 1 --pretty=format:"%H" upstream/$BASE_BRANCH -- .github/workflows)
           if ! git branch --contains $latest_workflow_commit | grep -q "$(git rev-parse --abbrev-ref HEAD)"; then
             gh pr comment ${{ github.event.issue.html_url }} --body "GitHub Actions can not push to this branch as workflow files have been changed since your branch was last updated. Please update your branch past https://github.com/ParadiseSS13/Paradise/commit/$latest_workflow_commit before using this command again."
-            echo "FAIL_NOTIFIED=true" >> $GITHUB_ENV
-            exit 1
+            exit 0
           fi
 
           git merge FETCH_HEAD
           git push origin
 
       - name: Notify Failure
-        if: failure() && ${{ !env.FAIL_NOTIFIED == 'true' }}
+        if: failure()
         run: |
           gh pr comment ${{ github.event.issue.html_url }} -b "Merging upstream failed, see the action run log for details: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/render_nanomaps.yml
+++ b/.github/workflows/render_nanomaps.yml
@@ -15,34 +15,28 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - id: create_token
-      uses: tibdex/github-app-token@v2
+      uses: actions/create-github-app-token@v1
       with:
-        app_id: ${{ secrets.APP_ID }}
-        private_key: ${{ secrets.PRIVATE_KEY }}
+        app-id: ${{ secrets.APP_ID }}
+        private-key: ${{ secrets.PRIVATE_KEY }}
+
+    - run: echo "GH_TOKEN=${{ steps.create_token.outputs.token }}" >> "$GITHUB_ENV"
 
     - name: 'Update Branch'
       uses: actions/checkout@v4
-      env:
-        GH_TOKEN: ${{ steps.create_token.outputs.token }}
       with:
         token: ${{ steps.create_token.outputs.token }}
 
     - name: Branch
-      env:
-        GH_TOKEN: ${{ steps.create_token.outputs.token }}
       run: |
         git branch -f nanomap-render
         git checkout nanomap-render
         git reset --hard origin/master
 
     - name: 'Generate Maps'
-      env:
-        GH_TOKEN: ${{ steps.create_token.outputs.token }}
       run: './tools/github-actions/nanomap-renderer-invoker.sh'
 
     - name: 'Commit Maps and open PR'
-      env:
-        GH_TOKEN: ${{ steps.create_token.outputs.token }}
       run: |
         git config --local user.email "action@github.com"
         git config --local user.name "NanoMap Generation"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Current stale labels are applied if and when a maintainer realises any given PR or issue is stale, this makes the process fairer for all by automating it based on certain rules.
PRs are marked as stale after 14 days of no activity (comments or commits) unless they have the labels `"Stale Exempt", "-Status: Awaiting approval"`. They are then closed after a further 7 days of no activity.
Issues with the labels `"Need Verification", "Cannot Reproduce", "Not A Bug", "(99% Sure) Not A Bug"` are marked as stale after 60 days of inactivity, and close after a further 14 days of inactivity.

Comments are left by the bot at all stages to keep users informed.

I also tidy up existing workflows to better manage how we sort github tokens.
The `!merge_upstream` workflow also has:
Likes the requesting comment to let the user know it is being run.
Better logging, tells the user if it failed because it touched a workflow file (if it has, permissions currently prevent from pushing, so better to fail in a sensible way.)
Better approvals flow, workflows generated by this bot get auto-approved by said bot.
