### PR TITLE
pepperspray confusion no longer infinitely stacks

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -394,13 +394,13 @@
 /datum/status_effect/pepper_spray/on_apply()
 	. = ..()
 	to_chat(owner, "<span class='danger'>Your throat burns!</span>")
-	owner.AdjustConfused(12 SECONDS)
+	owner.AdjustConfused(12 SECONDS, bound_upper = 20 SECONDS)
 	owner.Slowed(4 SECONDS)
 	owner.apply_damage(40, STAMINA)
 
 /datum/status_effect/pepper_spray/refresh()
 	. = ..()
-	owner.AdjustConfused(12 SECONDS)
+	owner.AdjustConfused(12 SECONDS, bound_upper = 20 SECONDS)
 	owner.Slowed(4 SECONDS)
 	owner.apply_damage(20, STAMINA)
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
pepperspray confusion no longer infinitely stacks. now stacks to a cap of 20 seconds.

## Why It's Good For The Game
Not capping it leads to situations where someone ends up with an ungodly amount of confusion that frankly sucks. This also makes pepperspray less of a crapshoot to use by proxy. 

## Testing
peppersprayed the fuck out of a skrell

## Changelog
:cl:
tweak: pepperspray confusion no longer infinitely stacks. Stacks to 20 seconds now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
