### PR TITLE
Transient status effects now have a default upper bound of 5 minutes

### DIFF
--- a/code/modules/mob/living/living_status_procs.dm
+++ b/code/modules/mob/living/living_status_procs.dm
@@ -409,7 +409,7 @@ STATUS EFFECTS
 		P = apply_status_effect(STATUS_EFFECT_PARALYZED, amount)
 	return P
 
-/mob/living/proc/AdjustParalysis(amount, bound_lower = 0, bound_upper = INFINITY, ignore_canstun = FALSE)
+/mob/living/proc/AdjustParalysis(amount, bound_lower = 0, bound_upper = 5 MINUTES, ignore_canstun = FALSE)
 	return SetParalysis(directional_bounded_sum(AmountParalyzed(), amount, bound_lower, bound_upper), ignore_canstun)
 
 // SILENT

--- a/code/modules/mob/living/living_status_procs.dm
+++ b/code/modules/mob/living/living_status_procs.dm
@@ -196,9 +196,9 @@ STATUS EFFECTS
  * Arguments:
  * * amount - Amount to add. Can be negative to reduce duration.
  * * bound_lower - Minimum bound to set at least to. Defaults to 0.
- * * bound_upper - Maximum bound to set up to. Defaults to infinity.
+ * * bound_upper - Maximum bound to set up to. Defaults to 5 minutes.
  */
-/mob/living/proc/AdjustConfused(amount, bound_lower = 0, bound_upper = INFINITY)
+/mob/living/proc/AdjustConfused(amount, bound_lower = 0, bound_upper = 5 MINUTES)
 	SetConfused(directional_bounded_sum(get_confusion(), amount, bound_lower, bound_upper))
 
 // DIZZY
@@ -227,9 +227,9 @@ STATUS EFFECTS
  * Arguments:
  * * amount - Amount to add. Can be negative to reduce duration.
  * * bound_lower - Minimum bound to set at least to. Defaults to 0.
- * * bound_upper - Maximum bound to set up to. Defaults to infinity.
+ * * bound_upper - Maximum bound to set up to. Defaults to 5 minutes.
  */
-/mob/living/proc/AdjustDizzy(amount, bound_lower = 0, bound_upper = INFINITY)
+/mob/living/proc/AdjustDizzy(amount, bound_lower = 0, bound_upper = 5 MINUTES)
 	SetDizzy(directional_bounded_sum(get_dizziness(), amount, bound_lower, bound_upper))
 
 // DROWSY
@@ -258,9 +258,9 @@ STATUS EFFECTS
  * Arguments:
  * * amount - Amount to add. Can be negative to reduce duration.
  * * bound_lower - Minimum bound to set at least to. Defaults to 0.
- * * bound_upper - Maximum bound to set up to. Defaults to infinity.
+ * * bound_upper - Maximum bound to set up to. Defaults to 5 minutes.
  */
-/mob/living/proc/AdjustDrowsy(amount, bound_lower = 0, bound_upper = INFINITY)
+/mob/living/proc/AdjustDrowsy(amount, bound_lower = 0, bound_upper = 5 MINUTES)
 	SetDrowsy(directional_bounded_sum(get_drowsiness(), amount, bound_lower, bound_upper))
 
 // DRUNK
@@ -289,9 +289,9 @@ STATUS EFFECTS
  * Arguments:
  * * amount - Amount to add. Can be negative to reduce duration.
  * * bound_lower - Minimum bound to set at least to. Defaults to 0.
- * * bound_upper - Maximum bound to set up to. Defaults to infinity.
+ * * bound_upper - Maximum bound to set up to. Defaults to 5 minutes.
  */
-/mob/living/proc/AdjustDrunk(amount, bound_lower = 0, bound_upper = INFINITY)
+/mob/living/proc/AdjustDrunk(amount, bound_lower = 0, bound_upper = 5 MINUTES)
 	SetDrunk(directional_bounded_sum(get_drunkenness(), amount, bound_lower, bound_upper))
 
 // DRUGGY
@@ -305,7 +305,7 @@ STATUS EFFECTS
 /mob/living/proc/SetDruggy(amount)
 	SET_STATUS_EFFECT_STRENGTH(STATUS_EFFECT_DRUGGED, amount)
 
-/mob/living/proc/AdjustDruggy(amount, bound_lower = 0, bound_upper = INFINITY)
+/mob/living/proc/AdjustDruggy(amount, bound_lower = 0, bound_upper = 5 MINUTES)
 	SetDruggy(directional_bounded_sum(AmountDruggy(), amount, bound_lower, bound_upper))
 
 // EYE_BLIND
@@ -318,7 +318,7 @@ STATUS EFFECTS
 /mob/living/proc/SetEyeBlind(amount)
 	SET_STATUS_EFFECT_STRENGTH(STATUS_EFFECT_BLINDED, amount)
 
-/mob/living/proc/AdjustEyeBlind(amount, bound_lower = 0, bound_upper = INFINITY, updating = TRUE)
+/mob/living/proc/AdjustEyeBlind(amount, bound_lower = 0, bound_upper = 5 MINUTES, updating = TRUE)
 	SetEyeBlind(directional_bounded_sum(AmountBlinded(), amount, bound_lower, bound_upper))
 
 // EYE_BLURRY
@@ -331,7 +331,7 @@ STATUS EFFECTS
 /mob/living/proc/SetEyeBlurry(amount)
 	SET_STATUS_EFFECT_STRENGTH(STATUS_EFFECT_BLURRY_EYES, amount)
 
-/mob/living/proc/AdjustEyeBlurry(amount, bound_lower = 0, bound_upper = INFINITY)
+/mob/living/proc/AdjustEyeBlurry(amount, bound_lower = 0, bound_upper = 5 MINUTES)
 	SetEyeBlurry(directional_bounded_sum(AmountEyeBlurry(), amount, bound_lower, bound_upper))
 
 // HALLUCINATION
@@ -344,7 +344,7 @@ STATUS EFFECTS
 /mob/living/proc/SetHallucinate(amount)
 	SET_STATUS_EFFECT_STRENGTH(STATUS_EFFECT_HALLUCINATION, amount)
 
-/mob/living/proc/AdjustHallucinate(amount, bound_lower = 0, bound_upper = INFINITY)
+/mob/living/proc/AdjustHallucinate(amount, bound_lower = 0, bound_upper = 5 MINUTES)
 	SetHallucinate(directional_bounded_sum(AmountHallucinate(), amount, bound_lower, bound_upper))
 
 // JITTER
@@ -360,7 +360,7 @@ STATUS EFFECTS
 		return
 	SET_STATUS_EFFECT_STRENGTH(STATUS_EFFECT_JITTER, amount)
 
-/mob/living/proc/AdjustJitter(amount, bound_lower = 0, bound_upper = INFINITY, force = 0)
+/mob/living/proc/AdjustJitter(amount, bound_lower = 0, bound_upper = 5 MINUTES, force = 0)
 	SetJitter(directional_bounded_sum(AmountJitter(), amount, bound_lower, bound_upper), force)
 
 // LOSE_BREATH
@@ -376,7 +376,7 @@ STATUS EFFECTS
 		return
 	SET_STATUS_EFFECT_STRENGTH(STATUS_EFFECT_LOSE_BREATH, amount)
 
-/mob/living/proc/AdjustLoseBreath(amount, bound_lower = 0, bound_upper = INFINITY)
+/mob/living/proc/AdjustLoseBreath(amount, bound_lower = 0, bound_upper = 5 MINUTES)
 	SetLoseBreath(directional_bounded_sum(AmountLoseBreath(), amount, bound_lower, bound_upper))
 
 // PARALYSE
@@ -440,7 +440,7 @@ STATUS EFFECTS
 /mob/living/proc/SetPreventOxyHeal(amount)
 	SET_STATUS_EFFECT_STRENGTH(STATUS_EFFECT_NO_OXY_HEAL, amount)
 
-/mob/living/proc/AdjustSilence(amount, bound_lower = 0, bound_upper = INFINITY)
+/mob/living/proc/AdjustSilence(amount, bound_lower = 0, bound_upper = 5 MINUTES)
 	SetSilence(directional_bounded_sum(AmountSilenced(), amount, bound_lower, bound_upper))
 
 //DEAFNESS
@@ -453,7 +453,7 @@ STATUS EFFECTS
 /mob/living/proc/SetDeaf(amount)
 	SET_STATUS_EFFECT_STRENGTH(STATUS_EFFECT_DEAF, amount)
 
-/mob/living/proc/AdjustDeaf(amount, bound_lower = 0, bound_upper = INFINITY)
+/mob/living/proc/AdjustDeaf(amount, bound_lower = 0, bound_upper = 5 MINUTES)
 	SetDeaf(directional_bounded_sum(AmountDeaf(), amount, bound_lower, bound_upper))
 
 // SLEEPING
@@ -506,7 +506,7 @@ STATUS EFFECTS
 		S = apply_status_effect(STATUS_EFFECT_SLEEPING, -1)
 	return S
 
-/mob/living/proc/AdjustSleeping(amount, bound_lower = 0, bound_upper = INFINITY)
+/mob/living/proc/AdjustSleeping(amount, bound_lower = 0, bound_upper = 5 MINUTES)
 	SetSleeping(directional_bounded_sum(AmountSleeping(), amount, bound_lower, bound_upper))
 
 // SLOWED
@@ -556,7 +556,7 @@ STATUS EFFECTS
 /mob/living/proc/SetSlur(amount)
 	SET_STATUS_EFFECT_STRENGTH(STATUS_EFFECT_SLURRING, amount)
 
-/mob/living/proc/AdjustSlur(amount, bound_lower = 0, bound_upper = INFINITY)
+/mob/living/proc/AdjustSlur(amount, bound_lower = 0, bound_upper = 5 MINUTES)
 	SetSlur(directional_bounded_sum(AmountSluring(), amount, bound_lower, bound_upper))
 
 // CULTSLURRING
@@ -569,7 +569,7 @@ STATUS EFFECTS
 /mob/living/proc/SetCultSlur(amount)
 	SET_STATUS_EFFECT_STRENGTH(STATUS_EFFECT_CULT_SLUR, amount)
 
-/mob/living/proc/AdjustCultSlur(amount, bound_lower = 0, bound_upper = INFINITY)
+/mob/living/proc/AdjustCultSlur(amount, bound_lower = 0, bound_upper = 5 MINUTES)
 	SetCultSlur(directional_bounded_sum(AmountCultSlurring(), amount, bound_lower, bound_upper))
 
 /* STUN */
@@ -678,7 +678,7 @@ STATUS EFFECTS
 		return
 	SET_STATUS_EFFECT_STRENGTH(STATUS_EFFECT_STAMMER, amount)
 
-/mob/living/proc/AdjustStuttering(amount, bound_lower = 0, bound_upper = INFINITY, ignore_canstun = FALSE)
+/mob/living/proc/AdjustStuttering(amount, bound_lower = 0, bound_upper = 5 MINUTES, ignore_canstun = FALSE)
 	SetStuttering(directional_bounded_sum(AmountStuttering(), amount, bound_lower, bound_upper), ignore_canstun)
 
 // WEAKEN


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Transient status effects now have a default upper bound of 5 minutes

## Why It's Good For The Game
we have adjust druggy and other kind of status effects just kind of sitting around the codebase with no upper limit. this prevents situations where you literally can't get rid of it.

## Testing
Made sure Afreeze worked fine with these changes

## Changelog
:cl:
tweak: Transient status effects now have a default upper bound of 5 minutes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
