### PR TITLE
(re-)Adds the ability to lock action buttons

### DIFF
--- a/code/_onclick/hud/action_button.dm
+++ b/code/_onclick/hud/action_button.dm
@@ -16,6 +16,8 @@
 	var/id
 	/// UID of the last thing we hovered over. Used for managing action button dragging.
 	var/last_hovered_ref
+	/// Whether or not this button is locked, preventing it from being dragged.
+	var/locked = FALSE
 
 /atom/movable/screen/movable/action_button/Destroy()
 	. = ..()
@@ -38,7 +40,7 @@
 // Very much byond logic, but I want nice behavior, so we fake it with drag
 /atom/movable/screen/movable/action_button/MouseDrag(atom/over_object, src_location, over_location, src_control, over_control, params)
 	. = ..()
-	if(!can_use(usr))
+	if(!can_use(usr) || locked)
 		return
 
 
@@ -64,6 +66,10 @@
 	last_hovered_ref = null
 	if(!can_use(usr))
 		return
+	if(locked)
+		fire_action()
+		return
+
 	var/datum/hud/our_hud = usr.hud_used
 	if(over_object == src)
 		our_hud.hide_landings()
@@ -100,6 +106,12 @@
 	var/position_info = SCRN_OBJ_DEFAULT
 	user.hud_used.position_action(src, position_info)
 
+/atom/movable/screen/movable/action_button/proc/fire_action(left_click = TRUE)
+	linked_action.Trigger(TRUE)
+	transform = transform.Scale(0.8, 0.8)
+	alpha = 200
+	animate(src, transform = matrix(), time = 0.4 SECONDS, alpha = 255)
+
 /atom/movable/screen/movable/action_button/Click(location, control, params)
 	var/list/modifiers = params2list(params)
 	if(modifiers["ctrl"] && modifiers["shift"])
@@ -116,16 +128,21 @@
 		AltClick(usr)
 		return TRUE
 	if(modifiers["middle"])
-		linked_action.Trigger(left_click = FALSE)
+		fire_action(TRUE)
 		return TRUE
 	if(modifiers["ctrl"])
 		CtrlClick(usr)
 		return TRUE
-	linked_action.Trigger(TRUE)
-	transform = transform.Scale(0.8, 0.8)
-	alpha = 200
-	animate(src, transform = matrix(), time = 0.4 SECONDS, alpha = 255)
+
+	fire_action(TRUE)
 	return TRUE
+
+
+/atom/movable/screen/movable/action_button/CtrlClick(mob/user)
+	if(!can_use(user))
+		return
+	locked = !locked
+	to_chat(user, "<span class='notice'>[src]'s button has been [locked ? "":"un"]locked.</span>")
 
 
 /**
@@ -215,7 +232,7 @@
 
 
 /atom/movable/screen/button_palette
-	desc = "<b>Drag</b> buttons to move them.<br><b>Shift-click</b> any button to reset it.<br><b>Alt-click</b> this to reset all buttons.<br><b>Ctrl-click</b> this to get a detailed explanation of how to use this."
+	desc = "<b>Drag</b> buttons to move them.<br><b>Shift-click</b> any button to reset it.<br><b>Alt-click</b> this to reset all buttons.<br><b>Ctrl-click</b> action buttons to lock or unlock them.<br><b>Ctrl-click</b> this to get a detailed explanation of how to use this."
 	icon = 'icons/hud/64x16_actions.dmi'
 	icon_state = "screen_gen_palette"
 	screen_loc = ui_action_palette


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds the ability to lock and unlock action buttons by ctrl-clicking them. When locked, buttons will be triggered if you drag off of them, making it easier to drag them somewhere when frantically combat clicking. Also adds a little blurb on the action palette that explains this.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
I've gotten a few people suggesting this, and it seems like a good idea, especially with the ability to drag. Sorry for the holdup on this!
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Loaded in and dragged buttons around
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Action buttons can now be locked and unlocked with ctrl-click.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
