### PR TITLE
fixes tgui alerts taking WAY longer than they should to delete

### DIFF
--- a/code/modules/tgui/tgui_input/alert_input.dm
+++ b/code/modules/tgui/tgui_input/alert_input.dm
@@ -84,7 +84,6 @@
 /datum/tgui_alert/Destroy(force)
 	SStgui.close_uis(src)
 	state = null
-	QDEL_NULL(buttons)
 	return ..()
 
 /**

--- a/code/modules/tgui/tgui_input/list_input.dm
+++ b/code/modules/tgui/tgui_input/list_input.dm
@@ -103,7 +103,6 @@
 /datum/tgui_list_input/Destroy(force)
 	SStgui.close_uis(src)
 	state = null
-	QDEL_NULL(items)
 	return ..()
 
 /**


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
fixes tgui alerts taking WAY longer than they should to delete
Before: Around ~25MS to delete
```
[2024-03-28T19:14:18] Path: /datum/tgui_list_input
[2024-03-28T19:14:18] 	qdel() Count: 164
[2024-03-28T19:14:18] 	Destroy() Cost: 4057.33ms
```

After:
![lmao thanks dm](https://github.com/ParadiseSS13/Paradise/assets/96800819/8f838bcf-06ec-4fb4-982a-377cb31cc7a7)


## Why It's Good For The Game
GC GO VROOM
This is the highest qdel cost atm

## Testing
see above for a screenshot

## Changelog
NPFC

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
