### PR TITLE
[s] Tis just a flesh wound

### DIFF
--- a/code/game/objects/items/stacks/medical_packs.dm
+++ b/code/game/objects/items/stacks/medical_packs.dm
@@ -155,20 +155,20 @@
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/external/affecting = H.get_organ(user.zone_selected)
+		for(var/obj/item/organ/external/E in H.bodyparts)
+			if(E.open == ORGAN_ORGANIC_OPEN)
+				to_chat(user, "<span class='warning'>[E] is cut open, you'll need more than a bandage!</span>")
+				return
+		affecting.germ_level = 0
 
-		if(affecting.open == ORGAN_CLOSED)
-			affecting.germ_level = 0
+		if(stop_bleeding)
+			if(!H.bleedsuppress) //so you can't stack bleed suppression
+				H.suppress_bloodloss(stop_bleeding)
 
-			if(stop_bleeding)
-				if(!H.bleedsuppress) //so you can't stack bleed suppression
-					H.suppress_bloodloss(stop_bleeding)
+		heal(H, user)
 
-			heal(H, user)
-
-			H.UpdateDamageIcon()
-			use(1)
-		else
-			to_chat(user, "<span class='warning'>[affecting] is cut open, you'll need more than a bandage!</span>")
+		H.UpdateDamageIcon()
+		use(1)
 
 /obj/item/stack/medical/bruise_pack/improvised
 	name = "improvised gauze"

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -39,6 +39,7 @@
 		"<span class='notice'> You have made an incision on [target]'s [affected.name] with \the [tool].</span>"
 	)
 	affected.open = ORGAN_ORGANIC_OPEN
+	target.resume_bleeding()
 	return SURGERY_STEP_CONTINUE
 
 /datum/surgery_step/generic/cut_open/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery)

--- a/code/modules/surgery/organs/blood.dm
+++ b/code/modules/surgery/organs/blood.dm
@@ -12,9 +12,9 @@
 		addtimer(CALLBACK(src, PROC_REF(resume_bleeding)), amount)
 
 /mob/living/carbon/human/proc/resume_bleeding()
-	bleedsuppress = FALSE
-	if(stat != DEAD && bleed_rate)
+	if(stat != DEAD && bleed_rate && bleedsuppress)
 		to_chat(src, "<span class='warning'>The blood soaks through your bandage.</span>")
+	bleedsuppress = FALSE
 
 // Takes care blood loss and regeneration
 /mob/living/carbon/human/handle_blood()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Gauze will not work if any limb is open
Bleed suppression removed on surgery start

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Gauze doesn't work on open limbs and should not stop open limbs from bleeding.
As per above, if one gets their limbs opened, gauze should no longer prevent open limbs from bleeding

## Testing
<!-- How did you test the PR, if at all? -->

cut skrells, with gauze before / after

## Changelog
:cl:
fix: Gauze will not work if any limb is open
fix: Bleed suppression removed on surgery start
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
