### PR TITLE
Don't runtime when creating nukies.

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -166,7 +166,7 @@
 	if(ishuman(new_character))
 		var/mob/living/carbon/human/H = new_character
 		if(H.mind in SSticker.mode.syndicates)
-			SSticker.mode.update_synd_icons_added()
+			SSticker.mode.update_synd_icons_added(H.mind)
 
 /datum/mind/proc/store_memory(new_text)
 	memory += "[new_text]<br>"


### PR DESCRIPTION
## What Does This PR Do
Fixes a call that was supposed to include a mind to include the mind.

## Why It's Good For The Game
Runtimes suck, doubly so when they spoil the gamemode to admins.

## Testing
It compiled.

## Changelog
NPFC