### PR TITLE
refactor: remove unused var /area/no_air

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -35,8 +35,6 @@
 
 	var/has_gravity = TRUE
 
-	var/no_air = null
-
 	var/air_doors_activated = FALSE
 
 	var/tele_proof = FALSE


### PR DESCRIPTION
## What Does This PR Do
This PR removes an unused variable from `/area`.
## Why It's Good For The Game
Unused variables bad.
## Testing
Searched codebase, found no instances of use. Built project, saw no errors.
## Changelog
NPFC
