### PR TITLE
BBQ ribs no longer require rods

### DIFF
--- a/code/modules/food_and_drinks/recipes/recipes_grill.dm
+++ b/code/modules/food_and_drinks/recipes/recipes_grill.dm
@@ -286,6 +286,5 @@
 	items = list(
 		/obj/item/food/snacks/meat,
 		/obj/item/food/snacks/meat,
-		/obj/item/stack/rods
 	)
 	result = /obj/item/food/snacks/bbqribs

--- a/code/modules/food_and_drinks/recipes/recipes_grill.dm
+++ b/code/modules/food_and_drinks/recipes/recipes_grill.dm
@@ -285,6 +285,6 @@
 	reagents = list("bbqsauce" = 5)
 	items = list(
 		/obj/item/food/snacks/meat,
-		/obj/item/food/snacks/meat,
+		/obj/item/food/snacks/meat
 	)
 	result = /obj/item/food/snacks/bbqribs


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Removed the requirement for 1 metal rod from BBQ ribs.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
The metal rods are silly. They do not get consumed in the recipe, and eating the ribs does not return a rod with which to hit yourself when you scarf it down too fast (unlike skewers).
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Cooked rodless BBQ ribs.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: BBQ ribs no longer require a metal rod to cook.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
