### PR TITLE
The grey autocloner now works properly on greys

### DIFF
--- a/code/game/objects/structures/grey_autocloner.dm
+++ b/code/game/objects/structures/grey_autocloner.dm
@@ -65,7 +65,7 @@
 
 	H.dna = R.dna.Clone()
 
-	H.set_species(/datum/species/grey) //This is a grey cloner after all. Funnier this way tbh
+	H.set_species(/datum/species/grey, skip_same_check = TRUE) //This is a grey cloner after all. Funnier this way tbh
 
 	for(var/datum/language/L in R.languages)
 		H.add_language(L.name)


### PR DESCRIPTION
## What Does This PR Do
Made the gery autocloner work properly on greys.

In delicious irony, #24038 made everyone using the grey autocloner become greys, except greys, who became human.

Fixed #24862.

## Why It's Good For The Game
While this is also funny, the grey autocloner should probably, you know, work correctly on greys.

## Testing
Spawned as grey.
Made autcloner.
Implanted self.
Died.
Revived as grey.
Became human.
Implanted self.
Died.
Revived as grey.

## Changelog
:cl:
fix: The greys' infiltration project has completed, so they no longer become semi-human when using their advanced cloning system. This was definitely intended, and in no way a flaw in their advanced technology.
/:cl: