### PR TITLE
Fix tgui-dev-server crashing when reloading clients shortly after one disconnects

### DIFF
--- a/tgui/packages/tgui-dev-server/reloader.js
+++ b/tgui/packages/tgui-dev-server/reloader.js
@@ -121,10 +121,17 @@ export const reloadByondCache = async (bundleDir) => {
   if (dss.length > 0) {
     logger.log(`notifying dreamseeker`);
     for (let dreamseeker of dss) {
-      dreamseeker.topic({
-        tgui: 1,
-        type: 'cacheReloaded',
-      });
+      try {
+        await dreamseeker.topic({
+          tgui: 1,
+          type: 'cacheReloaded',
+        });
+      } catch (error) {
+        logger.error(
+          `Unable to broadcast reload to ${dreamseeker.addr}@${dreamseeker.pid}`,
+          error
+        );
+      }
     }
   }
 };


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
- Added a try-catch around the code which reloads BYOND clients so that when one disconnects during the reload, the dev server doesn't crash
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Reduces time wasted having to wait for dev server to restart because it failed a fetch request
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
1. Opened DreamSeeker
2. Opened tgui-dev-server
3. Disconnected DreamSeeker
4. Immediately hit save on a random tgui interface file
5. tgui-dev-server should print error but not crash
<!-- How did you test the PR, if at all? -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
