### PR TITLE
throw a stack trace if a light has no source atom

### DIFF
--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -41,6 +41,10 @@
 
 	source_turf = top_atom
 	pixel_turf = get_turf_pixel(top_atom) || source_turf
+	if(!pixel_turf)
+		stack_trace("[src] had no pixel turf assigned to it")
+		qdel(src)
+		return // Get us out of here before we do unneded operations
 
 	light_power = source_atom.light_power
 	light_range = source_atom.light_range


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
if a lighting object has no attached target we throw a stack trace now

## Why It's Good For The Game
We need to figure out why this error has been happening

## Testing
I can't, we don't know what causes it