### PR TITLE
Removed #msay (+#asay?) gibberish

### DIFF
--- a/code/modules/admin/verbs/adminsay.dm
+++ b/code/modules/admin/verbs/adminsay.dm
@@ -16,7 +16,7 @@
 			var/list/data = list()
 			data["author"] = usr.ckey
 			data["source"] = GLOB.configuration.system.instance_id
-			data["message"] = msg
+			data["message"] = html_decode(msg)
 			SSredis.publish("byond.asay", json_encode(data))
 
 		for(var/client/C in GLOB.admins)

--- a/code/modules/admin/verbs/adminsay.dm
+++ b/code/modules/admin/verbs/adminsay.dm
@@ -72,7 +72,7 @@
 		var/list/data = list()
 		data["author"] = usr.ckey
 		data["source"] = GLOB.configuration.system.instance_id
-		data["message"] = msg
+		data["message"] = html_decode(msg)
 		SSredis.publish("byond.msay", json_encode(data))
 
 	for(var/client/C in GLOB.admins)


### PR DESCRIPTION
## What Does This PR Do
Corrected over-escaping that lead to HTML gibberish in #msay and, presumably, its admin equivalent..

## Why It's Good For The Game
`People shouldn&#39;t have to interpret &#34;useful&#34; HTML codes.`

## Testing
It compiled, but I don't have a setup that lets me test it.

## Changelog
NPFC