### PR TITLE
[TM ONLY] Live debugging hooks for misdelivered chat messages.

### DIFF
--- a/code/datums/chat_payload.dm
+++ b/code/datums/chat_payload.dm
@@ -11,9 +11,9 @@
 	var/delivery_attempt = 0
 
 /datum/chat_payload/Destroy(force = FALSE, ...)
-	. = ..()
 	target = null
 	targets.Cut()
+	return ..()
 
 /// Converts the chat payload into a JSON string
 /datum/chat_payload/proc/into_message()

--- a/code/datums/chat_payload.dm
+++ b/code/datums/chat_payload.dm
@@ -6,6 +6,9 @@
 	var/list/content
 	/// Resend count
 	var/resends = 0
+	var/target
+	var/list/targets
+	var/delivery_attempt = 0
 
 /// Converts the chat payload into a JSON string
 /datum/chat_payload/proc/into_message()

--- a/code/datums/chat_payload.dm
+++ b/code/datums/chat_payload.dm
@@ -10,6 +10,11 @@
 	var/list/targets
 	var/delivery_attempt = 0
 
+/datum/chat_payload/Destroy(force = FALSE, ...)
+	. = ..()
+	target = null
+	targets.Cut()
+
 /// Converts the chat payload into a JSON string
 /datum/chat_payload/proc/into_message()
 	return "{\"sequence\":[sequence],\"content\":[json_encode(content)]}"


### PR DESCRIPTION
## What Does This PR Do
TM ONLY
Adds temporary debugging hooks for misdelivered chat messages.

## Why It's Good For The Game
We've had a sporadic bug for quite a while, where occasionally a chat message you should hear goes missing, or you hear one you definitely shouldn't, like non-admins being told their admin verbs were hidden.

So far, it's a mystery whether this is a bug in our code or BYOND, though I suspect at least some of it is on our end. This debug info will help me track down what's happening, assuming it's not just a pure BYOND bug.

## Testing
Started server. Heard chat normally.
Put in a setting I could varedit to make all messages "misdeliver", successfully heard misdelivery notices.

## Changelog
NPFC that should not be merged.