### PR TITLE
Fix negative temperature and pressure.

### DIFF
--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -79,13 +79,20 @@ What are the archived variables for?
 
 	///Update archived versions of variables. Returns: TRUE in all cases
 /datum/gas_mixture/proc/archive()
+	oxygen = max(0, oxygen)
 	oxygen_archived = oxygen
+	carbon_dioxide = max(0, carbon_dioxide)
 	carbon_dioxide_archived = carbon_dioxide
+	nitrogen = max(0, nitrogen)
 	nitrogen_archived =  nitrogen
+	toxins = max(0, toxins)
 	toxins_archived = toxins
+	sleeping_agent = max(0, sleeping_agent)
 	sleeping_agent_archived = sleeping_agent
+	agent_b = max(0, agent_b)
 	agent_b_archived = agent_b
 
+	temperature = max(0, temperature)
 	temperature_archived = temperature
 
 	return TRUE


### PR DESCRIPTION
## What Does This PR Do
Negative temperature and pressure will now be zeroed out, rather than allowing them to spread.
Fixed #16187

## Why It's Good For The Game
Honestly, I'm not sure why nobody's done this before. How we end up with negative temperature or pressure isn't that important; what matters is that we don't let it break the server. The atmos system isn't so super-optimized that a few max() calls will degrade its performance by any substantial amount.

## Testing
Set a tile to -1,000,000 of all gasses and temperature. Walked near to activate it. Was briefly sucked into the vacuum tile before temp and pressure stabilized.
I'd like to test this against a negative pressure wave as well, but I haven't figured out how to create one with VV yet.

## Changelog
:cl:
fix: No more negative temperature/pressure waves.
/:cl: