### PR TITLE
Fixed kudzu mutativeness at 0 potency.

### DIFF
--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -536,7 +536,10 @@
 	color = "#ffffff"
 	spawn_spacevine_piece(loc, null, muts)
 	START_PROCESSING(SSobj, src)
-	if(potency != null && potency > 0)
+	if(!potency)
+		mutativeness = 0
+	else
+		// 0 mutativeness at 1 potency
 		// 1 mutativeness at 10 potency
 		// 4 mutativeness at 100 potency
 		mutativeness = log(10, potency) ** 2


### PR DESCRIPTION
## What Does This PR Do
Kudzu no longer mutates at 0 potency, despite not mutating at 1 potency.
Fixed #15985

## Why It's Good For The Game
0 shouldn't be magically *more* mutating than 1.

## Testing
Planted kudzu with 0 potency. 0 mutativeness.
Planted kudzu with 1 potency. 0 mutativeness.
Planted kudzu with 10 potency. 1 mutativeness.

## Changelog
:cl:
fix: Kudzu no longer mutates at 0 potency, despite not mutating at 1 potency.
/:cl: