### PR TITLE
Adds superconductivity blocking to fulltile plasma windows.

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -680,6 +680,9 @@
 	edge_overlay_file = 'icons/obj/smooth_structures/windows/window_edges.dmi'
 	env_smash_level = ENVIRONMENT_SMASH_WALLS  // these windows are a fair bit tougher
 
+/obj/structure/window/full/plasmabasic/BlockSuperconductivity()
+	return 1
+
 /obj/structure/window/full/plasmareinforced
 	name = "reinforced plasma window"
 	desc = "A plasma-glass alloy window, with rods supporting it. It looks hopelessly tough to break. It also looks completely fireproof, considering how basic plasma windows are insanely fireproof."
@@ -700,6 +703,9 @@
 
 /obj/structure/window/full/plasmareinforced/temperature_expose(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	return
+
+/obj/structure/window/full/plasmareinforced/BlockSuperconductivity()
+	return 1
 
 /obj/structure/window/full/reinforced
 	name = "reinforced window"

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -681,7 +681,7 @@
 	env_smash_level = ENVIRONMENT_SMASH_WALLS  // these windows are a fair bit tougher
 
 /obj/structure/window/full/plasmabasic/BlockSuperconductivity()
-	return 1
+	return TRUE
 
 /obj/structure/window/full/plasmareinforced
 	name = "reinforced plasma window"
@@ -705,7 +705,7 @@
 	return
 
 /obj/structure/window/full/plasmareinforced/BlockSuperconductivity()
-	return 1
+	return TRUE
 
 /obj/structure/window/full/reinforced
 	name = "reinforced window"

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -56,7 +56,7 @@
 	/// The neighbors of the turf.
 	var/list/atmos_adjacent_turfs = list()
 	/// makes turfs less picky about where they transfer gas. Largely just used in the SM
-	var/atmos_supeconductivity = 0
+	var/atmos_superconductivity = 0
 
 	/*
 	Lighting Vars

--- a/code/modules/atmospherics/environmental/LINDA_system.dm
+++ b/code/modules/atmospherics/environmental/LINDA_system.dm
@@ -9,9 +9,9 @@
 			R = 1
 			if(O.BlockSuperconductivity()) 	//the direction and open/closed are already checked on CanAtmosPass() so there are no arguments
 				var/D = get_dir(src, T)
-				atmos_supeconductivity |= D
+				atmos_superconductivity |= D
 				D = get_dir(T, src)
-				T.atmos_supeconductivity |= D
+				T.atmos_superconductivity |= D
 				return 0						//no need to keep going, we got all we asked
 
 	for(var/obj/O in T.contents)
@@ -19,15 +19,15 @@
 			R = 1
 			if(O.BlockSuperconductivity())
 				var/D = get_dir(src, T)
-				atmos_supeconductivity |= D
+				atmos_superconductivity |= D
 				D = get_dir(T, src)
-				T.atmos_supeconductivity |= D
+				T.atmos_superconductivity |= D
 				return 0
 
 	var/D = get_dir(src, T)
-	atmos_supeconductivity &= ~D
+	atmos_superconductivity &= ~D
 	D = get_dir(T, src)
-	T.atmos_supeconductivity &= ~D
+	T.atmos_superconductivity &= ~D
 
 	if(!R)
 		return 1

--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -404,7 +404,7 @@
 		//Does particate in air exchange so only consider directions not considered during process_cell()
 		for(var/direction in GLOB.cardinal)
 			var/turf/T = get_step(src, direction)
-			if(!(T in atmos_adjacent_turfs) && !(atmos_supeconductivity & direction))
+			if(!(T in atmos_adjacent_turfs) && !(atmos_superconductivity & direction))
 				conductivity_directions += direction
 
 	if(conductivity_directions > 0)


### PR DESCRIPTION
## What Does This PR Do
Adds superconductivity blocking to fulltile plasma windows.
Corrects a related typo.

## Why It's Good For The Game
The SM should not leak heat. Fulltile plasma windows shouldn't be worse than their directional versions.

## Testing
Varedited a suncan. Surrounded it with fulltile basic and reinforced plasma windows. Opened it. Successful containment.

## Changelog
:cl:
fix: Fulltile plasma windows will no longer leak heat.
/:cl: