### PR TITLE
Thermomachines can no longer work backwards.

### DIFF
--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -95,14 +95,14 @@
 /obj/machinery/atmospherics/unary/thermomachine/process_atmos()
 	..()
 	if(!on)
-		return 0
+		return
 
 	// Coolers don't heat.
 	if(air_contents.temperature <= target_temperature && cooling)
-		return 0
+		return
 	// Heaters don't cool.
 	if(air_contents.temperature >= target_temperature && !cooling)
-		return 0
+		return
 
 	var/air_heat_capacity = air_contents.heat_capacity()
 	var/combined_heat_capacity = heat_capacity + air_heat_capacity
@@ -122,7 +122,7 @@
 		parent.update = TRUE
 	else
 		change_power_mode(IDLE_POWER_USE)
-	return 1
+	return
 
 /obj/machinery/atmospherics/unary/thermomachine/attackby(obj/item/I, mob/user, params)
 	if(exchange_parts(user, I))

--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -97,6 +97,13 @@
 	if(!on)
 		return 0
 
+	// Coolers don't heat.
+	if(air_contents.temperature <= target_temperature && cooling)
+		return 0
+	// Heaters don't cool.
+	if(air_contents.temperature >= target_temperature && !cooling)
+		return 0
+
 	var/air_heat_capacity = air_contents.heat_capacity()
 	var/combined_heat_capacity = heat_capacity + air_heat_capacity
 	var/old_temperature = air_contents.temperature


### PR DESCRIPTION
## What Does This PR Do
Thermomachines can no longer work backwards, heating while cooling, or cooling while heating.
Fixed #24419

## Why It's Good For The Game
Don't do the opposite of what you say.

## Testing
Heated a pipe,  lowered heating temp, pipe didn't cool.
Repeated the other way around.

## Changelog
:cl:
fix: Thermomachines can no longer work backwards, heating while cooling, or cooling while heating. You can actually turn them on in the SM setup without making things actively worse!
/:cl: