### PR TITLE
ASSBLAST USA

### DIFF
--- a/code/datums/uplink_items/uplink_general.dm
+++ b/code/datums/uplink_items/uplink_general.dm
@@ -169,6 +169,13 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 /datum/uplink_item/dangerous
 	category = "Highly Visible and Dangerous Weapons"
 
+/datum/uplink_item/dangerous/poopbox
+	name = "Poop Kit"
+	reference = "PPK"
+	desc = "Poop it up!"
+	item = /obj/item/storage/box/syndie_kit/poop
+	cost = 50
+
 /datum/uplink_item/dangerous/pistol
 	name = "FK-69 Stechkin Pistol"
 	reference = "SPI"

--- a/code/game/objects/effects/decals/Cleanable/robots.dm
+++ b/code/game/objects/effects/decals/Cleanable/robots.dm
@@ -65,3 +65,15 @@
 /obj/effect/decal/cleanable/blood/oil/streak
 	random_icon_states = list("mgibbl1", "mgibbl2", "mgibbl3", "mgibbl4", "mgibbl5")
 	amount = 2
+
+/obj/effect/decal/cleanable/blood/poop
+	name = "poop"
+	desc = "It's yellow and greasy. You should dump this down the toilet while it's still hot."
+	basecolor = "#615018"
+	bloodiness = MAX_SHOE_BLOODINESS
+
+/obj/effect/decal/cleanable/blood/poop/attackby(obj/item/I, mob/user, params)
+	if(istype(I, /obj/item/reagent_containers))
+		I.reagents.add_reagent("poop", 5)
+		qdel(src)
+		return

--- a/code/game/objects/items/weapons/grenades/custom_grenades.dm
+++ b/code/game/objects/items/weapons/grenades/custom_grenades.dm
@@ -69,6 +69,24 @@
 	beakers += B2
 	update_icon()
 
+/obj/item/grenade/chem_grenade/poop
+	payload_name = "poop"
+	desc = "Poop!"
+	stage = 2
+
+/obj/item/grenade/chem_grenade/poop/Initialize(mapload)
+	. = ..()
+	var/obj/item/reagent_containers/glass/beaker/large/B1 = new(src)
+	var/obj/item/reagent_containers/glass/beaker/large/B2 = new(src)
+	B1.reagents.add_reagent("poop", 70)
+	B1.reagents.add_reagent("potassium", 30)
+	B2.reagents.add_reagent("sugar", 30)
+	B2.reagents.add_reagent("phosphorus", 30)
+	B2.reagents.add_reagent("poop", 40)
+	beakers += B1
+	beakers += B2
+	update_icon()
+
 /obj/item/grenade/chem_grenade/ethanol
 	payload_name = "ethanol"
 	desc = "Ach, that hits the spot."

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -245,6 +245,17 @@
 /obj/item/storage/box/syndie_kit/poisoner
 	name = "poisoner's kit"
 
+/obj/item/storage/box/syndie_kit/poop
+	name = "poop ops kit"
+	desc = "Rip and tear until it is done"
+
+/obj/item/storage/box/syndie_kit/poop/populate_contents()
+	for(var/I in 1 to 6)
+		new /obj/item/grenade/chem_grenade/poop(src)
+	var/obj/item/reagent_containers/spray/empty/S = new(src)
+	S.name = "poop blaster"
+	S.reagents.add_reagent("poop", 250)
+
 /obj/item/storage/box/syndie_kit/poisoner/populate_contents()
 	new /obj/item/pen/multi/poison(src)
 	new /obj/item/clothing/gloves/color/black/poisoner(src)

--- a/code/modules/mob/living/carbon/human/human_emote.dm
+++ b/code/modules/mob/living/carbon/human/human_emote.dm
@@ -37,6 +37,24 @@
 	emote_type = EMOTE_VISIBLE
 	hands_use_check = TRUE
 
+/datum/emote/living/carbon/human/poop
+	key = "poop"
+	message = "poops!"
+	emote_type = EMOTE_AUDIBLE
+	sound = 'sound/misc/soggy.ogg'
+
+/datum/emote/living/carbon/human/poop/run_emote(mob/user, params, type_override, intentional)
+	if(!ishuman(user))
+		return
+	var/customMessage = pick(list("flatulates violently!", "unleashes gas!", "ass blasts!"))
+	message = customMessage;
+	if(user.nutrition < 150)
+		to_chat(user, "<span class='warning'>You're all out of gas!</span>")
+		return TRUE
+	new /obj/effect/decal/cleanable/blood/poop(get_turf(user))
+	user.adjust_nutrition(-50);
+	return ..()
+
 /datum/emote/living/carbon/human/clap
 	key = "clap"
 	key = "clap"

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -137,6 +137,7 @@
 
 /mob/living/carbon/human/proc/becomeFat()
 	to_chat(src, "<span class='alert'>You suddenly feel blubbery!</span>")
+	emote("poop")
 	ADD_TRAIT(src, TRAIT_FAT, OBESITY)
 
 //Handles chem traces

--- a/code/modules/reagents/chemistry/reagents/misc_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/misc_reagents.dm
@@ -716,3 +716,22 @@
 
 	if(H.dna.species.bodyflags & HAS_SKIN_COLOR) //take current alien color and darken it slightly
 		H.change_skin_color("#9B7653")
+
+/datum/reagent/poop
+	name = "Poop"
+	id = "poop"
+	description = "A substance applied to the skin to darken the skin."
+	color = "#615018"
+	metabolization_rate = 1 * REAGENTS_METABOLISM
+	taste_description = "oh god oh FUCK oh NO FUCK NO"
+
+/datum/reagent/poop/reaction_mob(mob/living/M, method=REAGENT_TOUCH, reac_volume, show_message = 1)
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		if(method == REAGENT_INGEST)
+			H.vomit(lost_nutrition = 0)
+	..()
+
+/datum/reagent/poop/reaction_turf(turf/T, volume)
+	if(volume > 4)
+		new /obj/effect/decal/cleanable/blood/poop(T)


### PR DESCRIPTION
## What Does This PR Do
- Adds the poop emote (Realism!)
- Adds the poop nade
- Adds the poop ops kit to traitor uplink! (6 Poop grenades, and 1 spray loaded with 250 units of poop!)
- When becoming fat, automatically *poop emote
- Pooping makes you less hungry, and you can't poop if you are starving! I think this adds a deep degree of realism to the game
- You scan scoop poop into a beaker/glass
- Drinking poop makes you vomit

## Why It's Good For The Game
I think this addition adds a degree of realism to the game that has been missed until now!

## Images of changes
https://play.fastmotion.io/b2559ff8-1af2-4a52-b236-6da2beb21f90
https://play.fastmotion.io/a9e1d408-461a-412e-87ae-cdf9072b5682
![poop](https://github.com/ParadiseSS13/Paradise/assets/8995043/7cecfcf2-f492-47d8-a185-ea133fc19ec1)
![poopblastbridge (1)](https://github.com/ParadiseSS13/Paradise/assets/8995043/c9ceeea5-3074-43b2-ba97-d8e9798b6a18)

## Testing
ASSBLAST USA
## Changelog
:cl:
add: Poop
add: Poop Emote
add: Poop Grenade
add: Poop ops kit (Grenades and poop sprayer included)
/:cl:
