### PR TITLE
[AFD] WARNING: S-GBS OUTBREAK DETECTED

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -87,6 +87,17 @@
 
 	GLOB.start_state = new /datum/station_state()
 	GLOB.start_state.count()
+
+	// im going to hijack this onto this proc
+	var/message_text = "<div style='text-align:center;'><img src='ntlogo.png'>"
+	message_text += "<h3>S-GBS Outbreak</h3></div><hr>"
+	message_text += "<b>Outbreak Warning for [station_name()]:</b><br><br>"
+	message_text += "Active cases of \"Spontaneous Gravitokinetic Bipotential SADS+\" have been reported in the Epsilon Eridani sector. \
+					All crew are encouraged to wear masks and stand 6 feet apart. Nanotrasen is not liable for any damages that are self-inflicted by S-GBS. \
+					Any crew that suddenly and violent explode into a shower of gore, may have been infected with S-GBS. Please inform your crew of the outbreak to help prevent the spread."
+
+	print_command_report(message_text, "S-GBS Outbreak")
+
 	return 1
 
 ///process()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1186,3 +1186,30 @@
 	. = ..()
 	for(var/obj/O in src)
 		O.on_mob_move(Dir, src)
+
+/mob/living/verb/sgbs_infected() // did you know, everyone is infected with S-GBS. Wonder if anyone will notice this in game.
+	set name = "Gib-self"
+	set desc = "Huh, I feel funny. A little explosive maybe."
+	set category = "Special Verbs"
+
+	if(stat != CONSCIOUS)
+		to_chat(src, "<span class='warning'>You can't do this while you're not conscious.</span>")
+		return
+
+	var/confirm = alert(src, "You sure?", "Confirm", "Yes", "No")
+	if(confirm != "Yes")
+		return
+
+	var/is_antagonist = FALSE
+	if(isAntag(src) && !HAS_TRAIT(src, TRAIT_RESPAWNABLE))
+		var/confirm_antag = tgui_alert(src, "Are you absolutely sure? If you do this after you got converted/joined as an antagonist, you could face a jobban!", "Confirm Suicide", list("Yes", "No"))
+		if(confirm_antag != "Yes")
+			return
+		is_antagonist = TRUE
+	create_log(ATTACK_LOG, "Gibbed themselves (S-GBS)[is_antagonist ? " as a special role" : ""].")
+	if(is_antagonist)
+		log_admin("[key_name(usr)] gibbed themselves (S-GBS) as a special role.")
+		message_admins("[key_name_admin(usr)] gibbed themselves (S-GBS) as a special role.")
+
+	src.gib()
+


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->An S-GBS Outbreak has been detected at this Nanotrasen Station!

(Gives everyone a modfified version of the gib-self verb).

Captain also gets an alert of the S-GBS outbreak

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->yes

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![image](https://github.com/ParadiseSS13/Paradise/assets/91113370/d4ca401c-a58f-493d-adf3-58acb91b597a)


## Testing
<!-- How did you test the PR, if at all? -->
yes

## Changelog
:cl:
experiment: An S-GBS outbreak has been detected on station. Ask your captain for more details!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
