### PR TITLE
Cyborgs can now engage/disengage disposals units and also eject contents from them.

### DIFF
--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -317,16 +317,15 @@
 			mode = 0
 			update()
 
-		if(!issilicon(usr))
-			if(action == "engageHandle")
-				flush = 1
-				update()
-			if(action == "disengageHandle")
-				flush = 0
-				update()
+		if(action == "engageHandle")
+			flush = 1
+			update()
+		if(action == "disengageHandle")
+			flush = 0
+			update()
 
-			if(action == "eject")
-				eject()
+		if(action == "eject")
+			eject()
 
 	return TRUE
 

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -318,10 +318,10 @@
 			update()
 
 		if(action == "engageHandle")
-			flush = 1
+			flush = TRUE
 			update()
 		if(action == "disengageHandle")
-			flush = 0
+			flush = FALSE
 			update()
 
 		if(action == "eject")

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -317,6 +317,8 @@
 			mode = 0
 			update()
 
+		if(!Adjacent(usr))	// Forces borgs to be next to the bin to use the following buttons.
+			return TRUE
 		if(action == "engageHandle")
 			flush = TRUE
 			update()
@@ -337,7 +339,9 @@
 	update()
 
 /obj/machinery/disposal/AltClick(mob/user)
-	if(!Adjacent(user) || !ishuman(user) || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
+	if(!Adjacent(user) || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
+		return
+	if(!ishuman(user) && !issilicon(user))	// Humans and borgs can eject, but not other mobs.
 		return
 	user.visible_message(
 		"<span class='notice'>[user] tries to eject the contents of [src] manually.</span>",


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #24965. Allows cyborgs to use the "engage", "disengage", and "eject contents" buttons.

A cyborg cannot use the controls from inside the disposals unit, it has to be on the outside (thus, disposals diving works the same for humans and borgs). They cannot use these new buttons unless they are directly adjacent to the disposals unit. This also means the AI cannot use them.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
It's kind of weird that borgs are specifically excluded from doing these things. They're able to interface with the chutes and turn the power on/off already. Just seems weird.

This also allows engiborgs to actually disassemble disposals bins that have objects stuck inside them by allowing them to eject the object.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Spawned as borg. Had a skrell throw some stuff into a chute. I was able to eject it. Climbed into the chute and engaged it at the same time. Successfully disposal dived. Tried to engage whilst already inside the disposal chute, could not engage. Tried to engage, disengage, and eject at when not next to the bin. I could not.

Repeated the above as an AI. Could not do any of the things at all.

Attempted to use the disposals UI and the alt click ejection as a corgi. I could not.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Borgs can now utilise the disposal chute's full power.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
