### PR TITLE
Removes code treating actions as a lazy list

### DIFF
--- a/code/_onclick/hud/action_group.dm
+++ b/code/_onclick/hud/action_group.dm
@@ -57,7 +57,7 @@
 	row_offset = clamp(row_offset, 0, total_rows) // You're not allowed to offset so far that we have a row of blank space
 
 	var/button_number = 0
-	for(var/atom/movable/screen/button as anything in actions)
+	for(var/atom/movable/screen/button in actions)
 		var/postion = ButtonNumberToScreenCoords(button_number)
 		button.screen_loc = postion
 		button_number++

--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -54,7 +54,7 @@
 			continue
 		HideFrom(hud.mymob)
 
-	LAZYREMOVE(remove_from?.actions, src) // We aren't always properly inserted into the viewers list, gotta make sure that action's cleared
+	remove_from?.actions -= src // We aren't always properly inserted into the viewers list, gotta make sure that action's cleared
 	viewers = list()
 	// owner = null
 
@@ -142,7 +142,7 @@
 	var/datum/hud/our_hud = viewer.hud_used
 	if(viewers[our_hud]) // Already have a copy of us? go away
 		return
-	LAZYOR(viewer.actions, src) // Move this in
+	viewer.actions |= src // Move this in
 	ShowTo(viewer)
 
 //Adds our action button to the screen of a player
@@ -168,7 +168,7 @@
 /datum/action/proc/HideFrom(mob/viewer)
 	var/datum/hud/our_hud = viewer.hud_used
 	var/atom/movable/screen/movable/action_button/button = viewers[our_hud]
-	LAZYREMOVE(viewer.actions, src)
+	viewer.actions -= src
 	if(button)
 		button.clean_up_keybinds(viewer)
 		qdel(button)

--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -193,7 +193,7 @@
 		if(action == src) // This could be us, which is dumb
 			continue
 		var/atom/movable/screen/movable/action_button/button = action.viewers[owner.hud_used]
-		if(action.name == name && button.id)
+		if(action.name == name && button?.id)
 			bitfield |= button.id
 
 	bitfield = ~bitfield // Flip our possible ids, so we can check if we've found a unique one

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -179,12 +179,7 @@ GLOBAL_DATUM_INIT(welding_sparks, /mutable_appearance, mutable_appearance('icons
 	if(ismob(loc))
 		var/mob/m = loc
 		m.unEquip(src, 1)
-	// actions clear themselves from the list on cut
-	if(islist(actions))
-		for(var/datum/action/A as anything in actions)
-			qdel(A)
-		if(!isnull(actions))
-			actions.Cut()
+	QDEL_LIST_CONTENTS(actions)
 
 	master = null
 	return ..()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Removes some code treating actions as a lazy list, and instead just treats it as a normal list. This fixes some runtimes that have sprung up due to how actions get deleted.
This is a micro-optimization that honestly feels like it causes more trouble than it's worth. Let's just do this and leave it as-is.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Fewer runtimes good, especially if they cause particularly nasty effects.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Compiled, verified that actions were still added and removed.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Action buttons are less likely to cause issues when being removed from you.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
