### PR TITLE
Require stamping manifests.

### DIFF
--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -490,6 +490,22 @@
 
 	var/obj/item/paper/manifest/slip = AM
 
+	var/error = FALSE
+	if(/obj/item/stamp/denied in slip.stamped)
+		error = "Package [slip.ordernumber] rejected. A Nanotrasen supply department official will reach out to you in 2-3 business days."
+		SSblackbox.record_feedback("tally", "cargo manifests rejected", 1, "amount")
+	else if(!(/obj/item/stamp/granted in slip.stamped))
+		error = "Received unstamped anifest for package [slip.ordernumber]. Remember to stamp all manifests before returning them."
+		SSblackbox.record_feedback("tally", "cargo manifests not stamped", 1, "amount")
+
+	if(error)
+		var/datum/economy/line_item/item = new
+		item.account = SSeconomy.cargo_account
+		item.credits = 0
+		item.reason = error
+		manifest.line_items += item
+		return
+
 	var/datum/economy/line_item/item = new
 	item.account = SSeconomy.cargo_account
 	item.credits = SSeconomy.credits_per_manifest

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -495,7 +495,7 @@
 		error = "Package [slip.ordernumber] rejected. A Nanotrasen supply department official will reach out to you in 2-3 business days."
 		SSblackbox.record_feedback("tally", "cargo manifests rejected", 1, "amount")
 	else if(!(/obj/item/stamp/granted in slip.stamped))
-		error = "Received unstamped anifest for package [slip.ordernumber]. Remember to stamp all manifests before returning them."
+		error = "Received unstamped manifest for package [slip.ordernumber]. Remember to stamp all manifests before returning them."
 		SSblackbox.record_feedback("tally", "cargo manifests not stamped", 1, "amount")
 
 	if(error)


### PR DESCRIPTION
## What Does This PR Do
Manifests have to be stamped before sending them back to CC.

## Why It's Good For The Game
Everyone thought this was true already.

## Images of changes
![image](https://github.com/ParadiseSS13/Paradise/assets/98381/16491116-73bf-4ea5-af07-349068dd551c)

## Testing
Sent back an unstamped manifes.
Sent back a manifest only stamped with irrelevant stamps.
Sent back a manifest stamped GRANTED and with an irrelevant stamp.
Sent back a manifest stamped both GRANTED and DENIED.

## Changelog
:cl:
add: Manifests must now be stamped GRANTED before returning them to CC. Yes, this is a new feature.
/:cl: