### PR TITLE
makes direction lock no longer a default bind

### DIFF
--- a/code/datums/keybindings/movement_keybinds.dm
+++ b/code/datums/keybindings/movement_keybinds.dm
@@ -26,7 +26,6 @@
 /datum/keybinding/lock
 	name = "Movement Lock (Prevents Moving When Held)"
 	category = KB_CATEGORY_MOVEMENT
-	keys = list("Ctrl")
 
 /datum/keybinding/lock/down(client/C)
 	. = ..()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
makes direction lock no longer a default bind

## Why It's Good For The Game
so this is bound to ctrl, a very commonly used keybind for pulling things. most people end up unbinding this instantly so they don't get locked in place when they're trying to pull something. either way having an "unbind instantly" keybind ain't great.

## Testing
compiled and ran
## Changelog
:cl:
tweak: Direction lock is no longer binded to ctrl by default
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
