### PR TITLE
Add a cmag interaction to the honkbot

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -1102,6 +1102,8 @@ Pass a positive integer as an argument to override a bot's default speed.
 		to_chat(src, "0. [paicard.pai.pai_law0]")
 	if(emagged)
 		to_chat(src, "<span class='danger'>1. #$!@#$32K#$</span>")
+	else if(HAS_TRAIT(src, TRAIT_CMAGGED))
+		to_chat(src, "<span class='sans'>1. Be funny.</span>")
 	else
 		to_chat(src, "1. You are a machine built to serve the station's crew and AI(s).")
 		to_chat(src, "2. Your function is to [bot_purpose].")

--- a/code/modules/mob/living/simple_animal/bot/honkbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/honkbot.dm
@@ -134,7 +134,7 @@
 	if(HAS_TRAIT(src, TRAIT_CMAGGED))
 		return
 	if(locked || !open)
-		to_chat(user, "<span class='warning'>Unlock and open it with a screwdriver first!")
+		to_chat(user, "<span class='warning'>Unlock and open it with a screwdriver first!</span>")
 		return FALSE
 
 	ADD_TRAIT(src, TRAIT_CMAGGED, CLOWN_EMAG)
@@ -144,7 +144,7 @@
 	bot_reset()
 	turn_on()
 	if(user)
-		to_chat(user, "<span class='notice'>You smear bananium ooze all over [src]'s circuitry")
+		to_chat(user, "<span class='notice'>You smear bananium ooze all over [src]'s circuitry!</span>")
 		add_attack_logs(user, src, "Cmagged")
 	show_laws()
 

--- a/code/modules/mob/living/simple_animal/bot/honkbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/honkbot.dm
@@ -207,6 +207,16 @@
 	C.SetDeaf(0)
 	playsound(loc, pick('sound/voice/bgod.ogg', 'sound/voice/biamthelaw.ogg', 'sound/voice/bsecureday.ogg', 'sound/voice/bradio.ogg', 'sound/voice/bcreep.ogg'), 50, FALSE)
 
+/mob/living/simple_animal/bot/honkbot/proc/cuff_callback(mob/living/carbon/C)
+	mode = BOT_ARREST
+	if(!do_after(src, 6 SECONDS, target = C))
+		mode = BOT_IDLE
+		return
+	if(!C.handcuffed && on)
+		C.handcuffed = new /obj/item/restraints/handcuffs/twimsts(C)
+		C.update_handcuffed()
+	mode = BOT_IDLE
+
 /mob/living/simple_animal/bot/honkbot/proc/stun_attack(mob/living/carbon/C) // airhorn stun
 	if(spam_flag)
 		return
@@ -240,6 +250,10 @@
 	add_attack_logs(src, C, "honked by [src]")
 	C.visible_message("<span class='danger'>[src] has honked [C]!</span>",\
 			"<span class='userdanger'>[src] has honked you!</span>")
+	playsound(loc, 'sound/weapons/cablecuff.ogg', 30, 1, -2)
+	C.visible_message("<span class='danger'>[src] is trying to put zipties on [C]!</span>",\
+						"<span class='userdanger'>[src] is trying to put zipties on you!</span>")
+	INVOKE_ASYNC(src, PROC_REF(cuff_callback), C)
 
 
 /mob/living/simple_animal/bot/honkbot/handle_automated_action()

--- a/code/modules/mob/living/simple_animal/bot/honkbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/honkbot.dm
@@ -130,6 +130,29 @@
 		playsound(src, 'sound/machines/honkbot_evil_laugh.ogg', 75, 1, -1) // evil laughter
 		update_icon()
 
+/mob/living/simple_animal/bot/honkbot/cmag_act(mob/user)
+	if(HAS_TRAIT(src, TRAIT_CMAGGED))
+		return
+	if(locked || !open)
+		to_chat(user, "<span class='warning'>Unlock and open it with a screwdriver first!")
+		return FALSE
+
+	ADD_TRAIT(src, TRAIT_CMAGGED, CLOWN_EMAG)
+	remote_disabled = TRUE
+	locked = TRUE
+	open = FALSE
+	bot_reset()
+	turn_on()
+	if(user)
+		to_chat(user, "<span class='notice'>You smear bananium ooze all over [src]'s circuitry")
+		add_attack_logs(user, src, "Cmagged")
+	show_laws()
+
+/mob/living/simple_animal/bot/honkbot/examine(mob/user)
+	. = ..()
+	if(HAS_TRAIT(src, TRAIT_CMAGGED))
+		. += "<span class='warning'>Yellow ooze seems to be seeping from the case...</span>"
+
 /mob/living/simple_animal/bot/honkbot/bullet_act(obj/item/projectile/Proj)
 	if((istype(Proj,/obj/item/projectile/beam)) || (istype(Proj,/obj/item/projectile/bullet) && (Proj.damage_type == BURN))||(Proj.damage_type == BRUTE) && (!Proj.nodamage && Proj.damage < health && ishuman(Proj.firer)))
 		retaliate(Proj.firer)
@@ -180,34 +203,43 @@
 		sensor_blink()
 		addtimer(VARSET_CALLBACK(src, spam_flag, FALSE), cooldowntimehorn)
 
+/mob/living/simple_animal/bot/honkbot/proc/declare_victory(mob/living/carbon/C)
+	C.SetDeaf(0)
+	playsound(loc, pick('sound/voice/bgod.ogg', 'sound/voice/biamthelaw.ogg', 'sound/voice/bsecureday.ogg', 'sound/voice/bradio.ogg', 'sound/voice/bcreep.ogg'), 50, FALSE)
+
 /mob/living/simple_animal/bot/honkbot/proc/stun_attack(mob/living/carbon/C) // airhorn stun
-	if(!spam_flag)
-		playsound(src, 'sound/items/AirHorn.ogg', 100, TRUE, -1) //HEEEEEEEEEEEENK!!
-		sensor_blink()
-	if(!spam_flag)
-		if(ishuman(C))
-			var/mob/living/carbon/human/H = C
-			if(H.check_ear_prot() >= HEARING_PROTECTION_MAJOR)
-				return
-			C.SetStuttering(40 SECONDS) //stammer
-			C.Deaf(5 SECONDS) //far less damage than the H.O.N.K.
-			C.Jitter(100 SECONDS)
-			C.Weaken(10 SECONDS)
-			if(client) //prevent spam from players..
-				spam_flag = TRUE
-			if(!emagged) //HONK once, then leave
-				threatlevel -= 6
-				target = oldtarget_name
-			else // you really don't want to hit an emagged honkbot
-				threatlevel = 6 // will never let you go
-			addtimer(VARSET_CALLBACK(src, spam_flag, FALSE), cooldowntimehorn)
-			add_attack_logs(src, C, "honked by [src]")
-			C.visible_message("<span class='danger'>[src] has honked [C]!</span>",\
-					"<span class='userdanger'>[src] has honked you!</span>")
-		else
-			C.Stuttering(40 SECONDS)
-			C.Stun(20 SECONDS)
-			addtimer(VARSET_CALLBACK(src, spam_flag, FALSE), cooldowntimehorn)
+	if(spam_flag)
+		return
+	playsound(src, 'sound/items/AirHorn.ogg', 100, TRUE, -1) //HEEEEEEEEEEEENK!!
+	sensor_blink()
+
+	if(HAS_TRAIT(src, TRAIT_CMAGGED))
+		var/area/location = get_area(src)
+		speak("Arresting level 4 scumbag <b>[C]</b> in [location].", radio_channel)
+		addtimer(CALLBACK(src, PROC_REF(declare_victory), C), 5 SECONDS)
+
+	if(!ishuman(C))
+		C.Stuttering(40 SECONDS)
+		C.Stun(20 SECONDS)
+		addtimer(VARSET_CALLBACK(src, spam_flag, FALSE), cooldowntimehorn)
+	var/mob/living/carbon/human/H = C
+	if(H.check_ear_prot() >= HEARING_PROTECTION_MAJOR)
+		return
+	C.SetStuttering(40 SECONDS) //stammer
+	C.Deaf(5 SECONDS) //far less damage than the H.O.N.K.
+	C.Jitter(100 SECONDS)
+	C.Weaken(10 SECONDS)
+	if(client) //prevent spam from players..
+		spam_flag = TRUE
+	if(!emagged) //HONK once, then leave
+		threatlevel -= 6
+		target = oldtarget_name
+	else // you really don't want to hit an emagged honkbot
+		threatlevel = 6 // will never let you go
+	addtimer(VARSET_CALLBACK(src, spam_flag, FALSE), cooldowntimehorn)
+	add_attack_logs(src, C, "honked by [src]")
+	C.visible_message("<span class='danger'>[src] has honked [C]!</span>",\
+			"<span class='userdanger'>[src] has honked you!</span>")
 
 
 /mob/living/simple_animal/bot/honkbot/handle_automated_action()
@@ -237,9 +269,9 @@
 					honk_attack(target)
 				else
 					if(threatlevel >= 6)
+						target_lastloc = target.loc
 						stun_attack(target)
 						anchored = FALSE
-						target_lastloc = target.loc
 				return
 
 			try_chasing_target(target)
@@ -278,6 +310,8 @@
 		if((C.name == oldtarget_name) && (world.time < last_found + 100))
 			continue
 
+		if(HAS_TRAIT(src, TRAIT_CMAGGED))
+			threatlevel = 6
 		if(threatlevel < 4)
 			if(emagged) // actually emagged
 				bike_horn()
@@ -292,8 +326,13 @@
 		target = C
 		oldtarget_name = C.name
 		bike_horn()
-		speak("Honk!")
-		visible_message("<b>[src]</b> starts chasing [C.name]!")
+		if(HAS_TRAIT(src, TRAIT_CMAGGED))
+			speak("Level 4 infraction alert!")
+			playsound(loc, pick('sound/voice/bcriminal.ogg', 'sound/voice/bjustice.ogg', 'sound/voice/bfreeze.ogg'), 50, FALSE)
+			visible_message("<b>[src]</b> points at [C.name]!")
+		else
+			speak("Honk!")
+			visible_message("<b>[src]</b> starts chasing [C.name]!")
 		mode = BOT_HUNT
 		INVOKE_ASYNC(src, PROC_REF(handle_automated_action))
 		return TRUE

--- a/code/modules/mob/living/simple_animal/bot/honkbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/honkbot.dm
@@ -203,18 +203,20 @@
 		sensor_blink()
 		addtimer(VARSET_CALLBACK(src, spam_flag, FALSE), cooldowntimehorn)
 
-/mob/living/simple_animal/bot/honkbot/proc/declare_victory(mob/living/carbon/C)
-	C.SetDeaf(0)
-	playsound(loc, pick('sound/voice/bgod.ogg', 'sound/voice/biamthelaw.ogg', 'sound/voice/bsecureday.ogg', 'sound/voice/bradio.ogg', 'sound/voice/bcreep.ogg'), 50, FALSE)
-
 /mob/living/simple_animal/bot/honkbot/proc/cuff_callback(mob/living/carbon/C)
 	mode = BOT_ARREST
-	if(!do_after(src, 6 SECONDS, target = C))
+	sleep(1 SECONDS)
+	playsound(loc, 'sound/weapons/cablecuff.ogg', 30, 1, -2)
+	C.visible_message("<span class='danger'>[src] is trying to put zipties on [C]!</span>",\
+						"<span class='userdanger'>[src] is trying to put zipties on you!</span>")
+	if(!do_after(src, 6 SECONDS, target = C) || !on)
 		mode = BOT_IDLE
 		return
-	if(!C.handcuffed && on)
+	if(!C.handcuffed)
 		C.handcuffed = new /obj/item/restraints/handcuffs/twimsts(C)
 		C.update_handcuffed()
+	C.SetDeaf(0)
+	playsound(loc, pick('sound/voice/bgod.ogg', 'sound/voice/biamthelaw.ogg', 'sound/voice/bsecureday.ogg', 'sound/voice/bradio.ogg', 'sound/voice/bcreep.ogg'), 50, FALSE)
 	mode = BOT_IDLE
 
 /mob/living/simple_animal/bot/honkbot/proc/stun_attack(mob/living/carbon/C) // airhorn stun
@@ -226,12 +228,12 @@
 	if(HAS_TRAIT(src, TRAIT_CMAGGED))
 		var/area/location = get_area(src)
 		speak("Arresting level 4 scumbag <b>[C]</b> in [location].", radio_channel)
-		addtimer(CALLBACK(src, PROC_REF(declare_victory), C), 5 SECONDS)
 
 	if(!ishuman(C))
 		C.Stuttering(40 SECONDS)
 		C.Stun(20 SECONDS)
 		addtimer(VARSET_CALLBACK(src, spam_flag, FALSE), cooldowntimehorn)
+		return
 	var/mob/living/carbon/human/H = C
 	if(H.check_ear_prot() >= HEARING_PROTECTION_MAJOR)
 		return
@@ -250,10 +252,8 @@
 	add_attack_logs(src, C, "honked by [src]")
 	C.visible_message("<span class='danger'>[src] has honked [C]!</span>",\
 			"<span class='userdanger'>[src] has honked you!</span>")
-	playsound(loc, 'sound/weapons/cablecuff.ogg', 30, 1, -2)
-	C.visible_message("<span class='danger'>[src] is trying to put zipties on [C]!</span>",\
-						"<span class='userdanger'>[src] is trying to put zipties on you!</span>")
-	INVOKE_ASYNC(src, PROC_REF(cuff_callback), C)
+	if(HAS_TRAIT(src, TRAIT_CMAGGED))
+		INVOKE_ASYNC(src, PROC_REF(cuff_callback), C)
 
 
 /mob/living/simple_animal/bot/honkbot/handle_automated_action()


### PR DESCRIPTION
## What Does This PR Do
Honkbots have a cmag interaction now. It makes them think and act like secbots, except with the air horn in place of a stunprod, and twimsts cuffs in place of zip cuffs.

## Why It's Good For The Game
It's funny.

## Images of changes
https://github.com/ParadiseSS13/Paradise/assets/98381/8e069386-3602-4823-8001-0f9944e1a00c
(pre-handcuffs)

## Testing
Kicked a honkbot. Got airhorned normally.
Cmagged a honkbot. Got airhorned with no provocation, was restrained with licoriche. Heard some secbot lines along the way.

## Changelog
:cl:
add: Honkbots can now be cmagged.
/:cl: