### PR TITLE
Lets you rename a hypospray with a pen.

### DIFF
--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -60,6 +60,13 @@
 /obj/item/reagent_containers/hypospray/attack_self(mob/user)
 	return apply(user, user)
 
+/obj/item/reagent_containers/hypospray/attackby(obj/item/I, mob/user, params)
+	if(is_pen(W))
+		rename_interactive(user, W, use_prefix = TRUE, prompt = "Give [src] a title.")
+		return TRUE
+
+	return ..()
+
 /obj/item/reagent_containers/hypospray/on_reagent_change()
 	if(safety_hypo && !emagged)
 		var/found_forbidden_reagent = FALSE

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -61,8 +61,8 @@
 	return apply(user, user)
 
 /obj/item/reagent_containers/hypospray/attackby(obj/item/I, mob/user, params)
-	if(is_pen(W))
-		rename_interactive(user, W, use_prefix = TRUE, prompt = "Give [src] a title.")
+	if(is_pen(I))
+		rename_interactive(user, I, use_prefix = TRUE, prompt = "Give [src] a title.")
 		return TRUE
 
 	return ..()

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -67,6 +67,11 @@
 
 	return ..()
 
+/obj/item/reagent_containers/hypospray/examine(mob/user)
+	. = ..()
+	if(Adjacent(user))
+		. += "<span class='notice'>You can use a pen to add a label to [src].</span>"
+
 /obj/item/reagent_containers/hypospray/on_reagent_change()
 	if(safety_hypo && !emagged)
 		var/found_forbidden_reagent = FALSE


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds the ability to rename a hypospray with a pen. It'll mark it as "hypospray - label"
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Keeping track of hyposprays is a pain in the ass. While you can use a hand labeler, those aren't always super readily available. This should help you keep tabs on which is which without a reagent scanner.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


## Testing
Loaded in, tried to rename the hypospray, was able to.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
add: You can now rename hyposprays with pens and other writing utensils.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
