### PR TITLE
Allow cyborgs to be displayed on the robotic console no matter on which Z levels they are

### DIFF
--- a/code/game/machinery/computer/robot_control.dm
+++ b/code/game/machinery/computer/robot_control.dm
@@ -47,7 +47,7 @@
 		return FALSE
 	if(R.scrambledcodes)
 		return FALSE
-	if(!atoms_share_level(get_turf(src), get_turf(R)))
+	if(is_away_level(R.z))
 		return FALSE
 	return TRUE
 


### PR DESCRIPTION
## What Does This PR Do
Allow cyborgs to be displayed on the robotic console no matter on which Z levels they are
Therefore Fixes #24996

## Why It's Good For The Game
Oversight fix gud

## Testing
Compiled the game, spawned as a miner cyborg on lavaland. Saw myself on the robotic console on the station, all is well.

## Changelog
:cl:
fix: Cyborgs are now displayed on the robotic console no matter on which Z levels they are
/:cl:
