### PR TITLE
Added cancel buttons and logging to Modify Station Goals

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -3318,7 +3318,7 @@
 		if(!check_rights(R_EVENT))
 			return
 		var/list/type_choices = typesof(/datum/station_goal) - typesof(/datum/station_goal/secondary)
-		var/picked = input("Choose goal type") in type_choices|null
+		var/picked = input("Choose goal type") as null|anything in type_choices
 		if(!picked)
 			return
 		var/datum/station_goal/G = new picked()
@@ -3327,11 +3327,12 @@
 			if(!newname)
 				return
 			G.name = newname
-			var/description = input("Enter NAS Trurl message contents:") as message|null
+			var/description = input("Enter NAS Trurl message contents:") as null|message
 			if(!description)
 				return
 			G.report_message = description
 		message_admins("[key_name_admin(usr)] created \"[G.name]\" station goal.")
+		log_admin("[key_name_admin(usr)] created \"[G.name]\" station goal.")
 		SSticker.mode.station_goals += G
 		modify_goals()
 
@@ -3365,13 +3366,14 @@
 			var/department_choices = list()
 			for(var/obj/machinery/requests_console/RC in GLOB.allRequestConsoles)
 				department_choices |= RC.department
-			var/department = input("Choose goal department") in department_choices|null
+			var/department = input("Choose goal department") as null|anything in department_choices
 			if(!department)
 				return
 			G.department = department
 			G.should_send_crate = alert("Send a personal crate?","Send crate","Yes","No") == "Yes"
 		G.Initialize()
 		message_admins("[key_name_admin(usr)] created \"[G.name]\" station goal. Description: [G.admin_desc]")
+		log_admin("[key_name_admin(usr)] created \"[G.name]\" station goal. Description: [G.admin_desc]")
 		SSticker.mode.secondary_goals += G
 		modify_goals()
 

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -27,7 +27,7 @@
 		else
 			targets["(No Mob) - [T]"] = T
 	var/list/sorted = sortList(targets)
-	var/target = input(src,"To whom shall we send a message?","Admin PM",null) as null|anything in sorted|null
+	var/target = input(src,"To whom shall we send a message?","Admin PM",null) as null|anything in sorted
 	if(!target)
 		return
 	cmd_admin_pm(targets[target],null)

--- a/code/modules/station_goals/secondary/secondary_goal.dm
+++ b/code/modules/station_goals/secondary/secondary_goal.dm
@@ -91,14 +91,22 @@
 
 	if(href_list["announce"])
 		send_report("CentCom", "A task for [department] has been issued by Central Command:")
+		message_admins("[key_name_admin(usr)] sent an announcement for secondary goal [src] ([admin_desc])")
+		log_admin("[key_name_admin(usr)] sent an announcement for secondary goal [src] ([admin_desc])")
 	else if(href_list["remove"])
 		SSticker.mode.secondary_goals -= src
+		message_admins("[key_name_admin(usr)] removed secondary goal [src] ([admin_desc])")
+		log_admin("[key_name_admin(usr)] removed secondary goal [src] ([admin_desc])")
 		qdel(src)
 		usr.client.modify_goals()
 	else if(href_list["mark_complete"])
 		completed = 1
 		usr.client.modify_goals()
+		message_admins("[key_name_admin(usr)] marked secondary goal [src] ([admin_desc]) as complete")
+		log_admin("[key_name_admin(usr)] marked secondary goal [src] ([admin_desc]) as complete")
 	else if(href_list["reset_progress"])
 		completed = 0
 		tracker.reset()
 		usr.client.modify_goals()
+		message_admins("[key_name_admin(usr)] reset progress of secondary goal [src] ([admin_desc])")
+		log_admin("[key_name_admin(usr)] reset progress of secondary goal [src] ([admin_desc])")

--- a/code/modules/station_goals/station_goal.dm
+++ b/code/modules/station_goals/station_goal.dm
@@ -45,7 +45,11 @@
 	if(href_list["announce"])
 		on_report()
 		send_report()
+		message_admins("[key_name_admin(usr)] sent an announcement for station goal [src]")
+		log_admin("[key_name_admin(usr)] sent an announcement for station goal [src]")
 	else if(href_list["remove"])
 		SSticker.mode.station_goals -= src
+		message_admins("[key_name_admin(usr)] removed station goal [src]")
+		log_admin("[key_name_admin(usr)] removed station goal [src]")
 		qdel(src)
 		usr.client.modify_goals()


### PR DESCRIPTION
## What Does This PR Do
Corrects a couple places in Modify Station Goals where "or null" was being specified wrong for `input()`, leading to a missing cancel button.
Added admin logging to all Modify Station Goals actions.

## Why It's Good For The Game
Better admin tooling is good.

## Testing
Added, modified, and removed some goals.

## Changelog
:cl:
tweak: Modify Station Goals now has more cancel buttons and admin logging.
/:cl: