### PR TITLE
Add [s] to pencode.

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -464,6 +464,8 @@
 	text = replacetext(text, "\[/i\]",		"</I>")
 	text = replacetext(text, "\[u\]",		"<U>")
 	text = replacetext(text, "\[/u\]",		"</U>")
+	text = replacetext(text, "\[s\]",		"<S>")
+	text = replacetext(text, "\[/s\]",		"</S>")
 	if(findtext(text, "\[signfont\]") || findtext(text, "\[/signfont\]")) // Make sure the text is there before giving off an error
 		if(check_rights(R_EVENT))
 			text = replacetext(text, "\[signfont\]",		"<font face=\"[signfont]\"><i>")


### PR DESCRIPTION
## What Does This PR Do
Pencode now supports [s] for strikethrough text.

## Why It's Good For The Game
More formatting is good.

## Images of changes
![image](https://github.com/ParadiseSS13/Paradise/assets/98381/121bd558-cced-46ba-b0ef-c9cf5a34803b)

## Testing
See above.

## Changelog
:cl:
add: Strikethrough text is now available in paperwork with [s][/s].
/:cl: