### PR TITLE
Bunny can now ventcrawl

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/bunny.dm
+++ b/code/modules/mob/living/simple_animal/friendly/bunny.dm
@@ -27,6 +27,7 @@
 	holder_type = /obj/item/holder/bunny
 	can_collar = TRUE
 	gold_core_spawnable = FRIENDLY_SPAWN
+	ventcrawler = VENTCRAWLER_ALWAYS
 
 /mob/living/simple_animal/bunny/attack_hand(mob/living/carbon/human/M)
 	if(M.a_intent == INTENT_HELP)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Allows the bunny mob to ventcrawl, fixes #24174
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Fixing issues good, allowing to player to roll as a sentient mob but not letting them escape the room they are in is bad

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

https://github.com/ParadiseSS13/Paradise/assets/13879982/021d914f-8bdb-4958-b1ec-853a93f0ef71

## Testing
<!-- How did you test the PR, if at all? -->
Loaded game, became bunny, scurried into the vent.

## Changelog
:cl:
tweak: Bunny can now ventcrawl
fix: Fixed Spaghetti not being able to escape atmos when rolled as a sentient mob on Farragus
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
