### PR TITLE
Fixes a runtime with the stethoscope and missing hearts

### DIFF
--- a/code/modules/clothing/under/accessories/accessory.dm
+++ b/code/modules/clothing/under/accessories/accessory.dm
@@ -152,50 +152,55 @@
 	item_color = "stethoscope"
 
 /obj/item/clothing/accessory/stethoscope/attack(mob/living/carbon/human/M, mob/living/user)
-	if(ishuman(M) && isliving(user))
-		if(user == M)
-			user.visible_message("[user] places [src] against [user.p_their()] chest and listens attentively.", "You place [src] against your chest...")
-		else
-			user.visible_message("[user] places \the [src] against [M]'s chest and listens attentively.", "You place \the [src] against [M]'s chest...")
-		var/datum/organ/heart/heart_datum = M.get_int_organ_datum(ORGAN_DATUM_HEART)
-		var/obj/item/organ/internal/H = heart_datum.linked_organ
-		var/datum/organ/lungs/lung_datum = M.get_int_organ_datum(ORGAN_DATUM_LUNGS)
-		var/obj/item/organ/internal/L = lung_datum.linked_organ
-		if(M.pulse && (H || (L && !HAS_TRAIT(M, TRAIT_NOBREATH))))
-			var/color = "notice"
-			if(H)
-				var/heart_sound
-				switch(H.damage)
-					if(0 to 1)
-						heart_sound = "healthy"
-					if(1 to 25)
-						heart_sound = "offbeat"
-					if(25 to 50)
-						heart_sound = "uneven"
-						color = "warning"
-					if(50 to INFINITY)
-						heart_sound = "weak, unhealthy"
-						color = "warning"
-				to_chat(user, "<span class='[color]'>You hear \an [heart_sound] pulse.</span>")
-			if(L)
-				var/lung_sound
-				switch(L.damage)
-					if(0 to 1)
-						lung_sound = "healthy respiration"
-					if(1 to 25)
-						lung_sound = "labored respiration"
-					if(25 to 50)
-						lung_sound = "pained respiration"
-						color = "warning"
-					if(50 to INFINITY)
-						lung_sound = "gurgling"
-						color = "warning"
-				to_chat(user, "<span class='[color]'>You hear [lung_sound].</span>")
-		else
-			to_chat(user, "<span class='warning'>You don't hear anything.</span>")
-		return
-	return ..(M,user)
+	if(!ishuman(M) || !isliving(user))
+		return ..(M, user)
 
+	if(user == M)
+		user.visible_message("[user] places [src] against [user.p_their()] chest and listens attentively.", "You place [src] against your chest...")
+	else
+		user.visible_message("[user] places [src] against [M]'s chest and listens attentively.", "You place [src] against [M]'s chest...")
+	var/datum/organ/heart/heart_datum = M.get_int_organ_datum(ORGAN_DATUM_HEART)
+	var/datum/organ/lungs/lung_datum = M.get_int_organ_datum(ORGAN_DATUM_LUNGS)
+	if(!lung_datum || !heart_datum)
+		to_chat(user, "<span class='warning'>You don't hear anything.</span>")
+		return
+
+	var/obj/item/organ/internal/H = heart_datum.linked_organ
+	var/obj/item/organ/internal/L = lung_datum.linked_organ
+	if(!M.pulse || (!H || !(L && !HAS_TRAIT(M, TRAIT_NOBREATH))))
+		to_chat(user, "<span class='warning'>You don't hear anything.</span>")
+		return
+
+	var/color = "notice"
+	if(H)
+		var/heart_sound
+		switch(H.damage)
+			if(0 to 1)
+				heart_sound = "healthy"
+			if(1 to 25)
+				heart_sound = "offbeat"
+			if(25 to 50)
+				heart_sound = "uneven"
+				color = "warning"
+			if(50 to INFINITY)
+				heart_sound = "weak, unhealthy"
+				color = "warning"
+		to_chat(user, "<span class='[color]'>You hear \an [heart_sound] pulse.</span>")
+
+	if(L)
+		var/lung_sound
+		switch(L.damage)
+			if(0 to 1)
+				lung_sound = "healthy respiration"
+			if(1 to 25)
+				lung_sound = "labored respiration"
+			if(25 to 50)
+				lung_sound = "pained respiration"
+				color = "warning"
+			if(50 to INFINITY)
+				lung_sound = "gurgling"
+				color = "warning"
+		to_chat(user, "<span class='[color]'>You hear [lung_sound].</span>")
 
 //Medals
 /obj/item/clothing/accessory/medal


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes a runtime if you don't have an organ with a heart datum attached to it
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Less runtimes is good, also this proc was a literal sin against our standards
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://github.com/ParadiseSS13/Paradise/assets/108773801/573826b7-934b-470c-a7ee-34a393194492)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
See above
<!-- How did you test the PR, if at all? -->

## Changelog
NPFC
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
