### PR TITLE
Clicking Action-Buttons now checks if it's left-click

### DIFF
--- a/code/_onclick/hud/action_button.dm
+++ b/code/_onclick/hud/action_button.dm
@@ -107,7 +107,7 @@
 	user.hud_used.position_action(src, position_info)
 
 /atom/movable/screen/movable/action_button/proc/fire_action(left_click = TRUE)
-	linked_action.Trigger(TRUE)
+	linked_action.Trigger(left_click)
 	transform = transform.Scale(0.8, 0.8)
 	alpha = 200
 	animate(src, transform = matrix(), time = 0.4 SECONDS, alpha = 255)
@@ -128,7 +128,7 @@
 		AltClick(usr)
 		return TRUE
 	if(modifiers["middle"])
-		fire_action(TRUE)
+		fire_action(FALSE)
 		return TRUE
 	if(modifiers["ctrl"])
 		CtrlClick(usr)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

fixes https://github.com/ParadiseSS13/Paradise/issues/24895

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Fixing bugs good

## Testing
<!-- How did you test the PR, if at all? -->

MODsuit checked

## Changelog
:cl:
fix: MMB-ing action buttons now is different again from LMB-ing them
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
