### PR TITLE
Vampire glare now fully affects people on the same tile as the vampire

### DIFF
--- a/code/modules/antagonists/vampire/vampire_powers/vampire_powers.dm
+++ b/code/modules/antagonists/vampire/vampire_powers/vampire_powers.dm
@@ -234,14 +234,14 @@
 	// Attacker within 45 degrees of where the victim is facing.
 	if(attacker_dir & attacker_to_victim)
 		return DEVIATION_NONE
+	// Are they on the same tile? This is probably the victim crawling under the vampire, and looking down shouldn't be too tough.
+	if(victim.loc == attacker.loc)
+		return DEVIATION_NONE
 	// # # #
 	// - V - Attacker facing south
 	// - - -
 	// Victim at 135 or more degrees of where the victim is facing.
 	if(attacker_dir & reverse_direction(attacker_to_victim))
-		return DEVIATION_FULL
-	// Are they on the same tile? This is probably the victim crawling under the vampire, and looking down shouldn't be too tough.
-	if(victim.loc == attacker.loc)
 		return DEVIATION_FULL
 	// - - -
 	// # V # Attacker facing south

--- a/code/modules/antagonists/vampire/vampire_powers/vampire_powers.dm
+++ b/code/modules/antagonists/vampire/vampire_powers/vampire_powers.dm
@@ -234,18 +234,15 @@
 	// Attacker within 45 degrees of where the victim is facing.
 	if(attacker_dir & attacker_to_victim)
 		return DEVIATION_NONE
-
-	// Are they on the same tile? This is probably the victim crawling under the vampire, and looking down shouldn't be too tough.
-	if(victim.loc == attacker.loc)
-		return DEVIATION_NONE
-
 	// # # #
 	// - V - Attacker facing south
 	// - - -
 	// Victim at 135 or more degrees of where the victim is facing.
 	if(attacker_dir & reverse_direction(attacker_to_victim))
 		return DEVIATION_FULL
-
+	// Are they on the same tile? This is probably the victim crawling under the vampire, and looking down shouldn't be too tough.
+	if(victim.loc == attacker.loc)
+		return DEVIATION_FULL
 	// - - -
 	// # V # Attacker facing south
 	// - - -

--- a/code/modules/antagonists/vampire/vampire_powers/vampire_powers.dm
+++ b/code/modules/antagonists/vampire/vampire_powers/vampire_powers.dm
@@ -222,9 +222,6 @@
 		add_attack_logs(user, target, "(Vampire) Glared at")
 
 /datum/spell/vampire/glare/proc/calculate_deviation(mob/victim, mob/attacker)
-	// Are they on the same tile? We'll return partial deviation. This may be someone flashing while lying down
-	if(victim.loc == attacker.loc)
-		return DEVIATION_PARTIAL
 
 	// If the victim was looking at the attacker, this is the direction they'd have to be facing.
 	var/attacker_to_victim = get_dir(attacker, victim)
@@ -236,6 +233,10 @@
 	// # # #
 	// Attacker within 45 degrees of where the victim is facing.
 	if(attacker_dir & attacker_to_victim)
+		return DEVIATION_NONE
+
+	// Are they on the same tile? This is probably the victim crawling under the vampire, and looking down shouldn't be too tough.
+	if(victim.loc == attacker.loc)
 		return DEVIATION_NONE
 
 	// # # #


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Changes vampire glare to apply the full stun to a person who is on the same tile as you, instead of a partial stun.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
It's kind of lame that currently, the best strategy for avoiding the second glare is to just crawl under the vampire, as the vamp has to then move away, face the right direction, and press the glare button.. at which point the person has had time to crawl under them again. Having your only stun get potentially avoided in such a counterintuitive manner doesn't seem great.

Also discussed this with the balance team before making this PR, and they seemed on board with it.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


## Testing
Glared a fool.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Vampire glare now fully affects people on the same tile as the vampire
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
