### PR TITLE
fix: do more ruin checks for lavaland procgen

### DIFF
--- a/code/game/turfs/simulated/floor/asteroid_floors.dm
+++ b/code/game/turfs/simulated/floor/asteroid_floors.dm
@@ -342,6 +342,8 @@ GLOBAL_LIST_INIT(megafauna_spawn_list, list(/mob/living/simple_animal/hostile/me
 /obj/effect/spawner/oasisrock/proc/make_rock(radius)
 	var/our_turf = get_turf(src)
 	for(var/turf/oasis in circlerangeturfs(our_turf, radius))
+		if(istype(oasis.loc, /area/ruin))
+			continue
 		oasis.ChangeTurf(/turf/simulated/mineral/random/high_chance/volcanic, ignore_air = TRUE)
 	var/list/valid_turfs = circlerangeturfs(our_turf, radius + 1)
 	valid_turfs -= circlerangeturfs(our_turf, radius)
@@ -352,6 +354,9 @@ GLOBAL_LIST_INIT(megafauna_spawn_list, list(/mob/living/simple_animal/hostile/me
 	qdel(src)
 
 /turf/simulated/floor/plating/asteroid/airless/cave/proc/SpawnFloor(turf/T, monsterprob = 30)
+	if(istype(T.loc, /area/ruin))
+		return
+
 	for(var/S in RANGE_TURFS(1, src))
 		var/turf/NT = S
 		if(!NT || isspaceturf(NT) || istype(NT.loc, /area/mine/explored) || istype(NT.loc, /area/lavaland/surface/outdoors/explored))
@@ -365,6 +370,9 @@ GLOBAL_LIST_INIT(megafauna_spawn_list, list(/mob/living/simple_animal/hostile/me
 	T.ChangeTurf(turf_type, FALSE, FALSE, TRUE)
 
 /turf/simulated/floor/plating/asteroid/airless/cave/proc/SpawnMonster(turf/T, monsterprob = 30)
+	if(istype(T.loc, /area/ruin))
+		return
+
 	if(prob(monsterprob))
 		if(istype(loc, /area/mine/explored) || !istype(loc, /area/lavaland/surface/outdoors/unexplored))
 			return
@@ -406,6 +414,9 @@ GLOBAL_LIST_INIT(megafauna_spawn_list, list(/mob/living/simple_animal/hostile/me
 #undef RECURSION_MAX
 
 /turf/simulated/floor/plating/asteroid/airless/cave/proc/SpawnFlora(turf/T)
+	if(istype(T.loc, /area/ruin))
+		return
+
 	var/floraprob = 12
 	switch(SSmapping.cave_theme)
 		if(BLOCKED_BURROWS)

--- a/code/game/turfs/simulated/floor/asteroid_floors.dm
+++ b/code/game/turfs/simulated/floor/asteroid_floors.dm
@@ -279,7 +279,9 @@ GLOBAL_LIST_INIT(megafauna_spawn_list, list(/mob/living/simple_animal/hostile/me
 		// Move our tunnel forward
 		tunnel = get_step(tunnel, dir)
 
-		if(istype(tunnel))
+		// Separate ruin area check here because of the raw ChangeTurf call that
+		// doesn't go through SpawnFloor/Flora/Monster.
+		if(istype(tunnel) && !istype(tunnel.loc, /area/ruin))
 			// Small chance to have forks in our tunnel; otherwise dig our tunnel.
 			var/caveprob = 20
 			switch(SSmapping.cave_theme)


### PR DESCRIPTION
## What Does This PR Do
This PR does a few more checks in Lavaland cave generation for ruin areas.
## Why It's Good For The Game
Ruin areas should be basically guaranteed not to be overwritten by procgen.
## Images of changes
### Before
Using the hermit ruin as an example
![a](https://github.com/ParadiseSS13/Paradise/assets/59303604/a2f65b8d-a0b9-4109-8582-16fbf2fe03b9)

![b](https://github.com/ParadiseSS13/Paradise/assets/59303604/f003a422-940e-4dbb-a27c-d8aea21eb90f)

### After
Not a bad spawn in sight

![2024_04_06__02_18_10__](https://github.com/ParadiseSS13/Paradise/assets/59303604/742db5e5-d4be-4ba0-ac86-6e5867bbc829)


<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
See above
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Lavaland tunnels are now less likely to overwrite ruins.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
