### PR TITLE
Updates the spraycan

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -136,7 +136,8 @@
 		busy = FALSE
 
 /obj/item/toy/crayon/attack(mob/M, mob/user)
-	var/huffable = istype(src,/obj/item/toy/crayon/spraycan)
+	if(istype(src, /obj/item/toy/crayon/spraycan))	// Eating the spraycan is TOO silly!
+		return
 	if(M == user)
 		if(ishuman(user))
 			var/mob/living/carbon/human/H = user
@@ -147,7 +148,7 @@
 		playsound(loc, 'sound/items/eatfood.ogg', 50, 0)
 		user.adjust_nutrition(5)
 		if(times_eaten < max_bites)
-			to_chat(user, "<span class='notice'>You take a [huffable ? "huff" : "bite"] of the [name]. Delicious!</span>")
+			to_chat(user, "<span class='notice'>You take a bite of the [name]. Delicious!</span>")
 		else
 			to_chat(user, "<span class='warning'>There is no more of [name] left!</span>")
 			qdel(src)
@@ -329,6 +330,7 @@
 	if(!proximity)
 		return
 	if(capped)
+		to_chat(user, "<span class='warning'>You cannot spray [target] while the cap is still on!</span>")
 		return
 	else
 		if(iscarbon(target))

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -136,8 +136,6 @@
 		busy = FALSE
 
 /obj/item/toy/crayon/attack(mob/M, mob/user)
-	if(istype(src, /obj/item/toy/crayon/spraycan))	// Eating the spraycan is TOO silly!
-		return
 	if(M == user)
 		if(ishuman(user))
 			var/mob/living/carbon/human/H = user
@@ -303,7 +301,7 @@
 
 /obj/item/toy/crayon/spraycan
 	name = "\improper Nanotrasen-brand Rapid Paint Applicator"
-	desc = "A metallic container containing tasty paint."
+	desc = "A metallic container containing spray paint."
 	icon_state = "spraycan_cap"
 	var/capped = TRUE
 	instant = TRUE
@@ -312,6 +310,9 @@
 /obj/item/toy/crayon/spraycan/New()
 	..()
 	update_icon()
+
+/obj/item/toy/crayon/spraycan/attack(mob/M, mob/user)
+	return // To stop you from eating spraycans. It's TOO SILLY!
 
 /obj/item/toy/crayon/spraycan/attack_self(mob/living/user)
 	var/choice = tgui_input_list(user, "Do you want to...", "Spraycan Options", list("Toggle Cap","Change Drawing", "Change Color"))
@@ -332,25 +333,24 @@
 	if(capped)
 		to_chat(user, "<span class='warning'>You cannot spray [target] while the cap is still on!</span>")
 		return
-	else
-		if(iscarbon(target))
-			if(uses - 10 > 0)
-				uses = uses - 10
-				var/mob/living/carbon/C = target
-				user.visible_message("<span class='danger'> [user] sprays [src] into the face of [target]!</span>")
-				if(C.client)
-					C.EyeBlurry(6 SECONDS)
-					C.EyeBlind(2 SECONDS)
-					if(ishuman(target))
-						var/mob/living/carbon/human/H = target
-						if(H.check_eye_prot() <= 0) // no eye protection? ARGH IT BURNS.
-							H.Confused(6 SECONDS)
-							H.KnockDown(6 SECONDS)
-						H.lip_style = "spray_face"
-						H.lip_color = colour
-						H.update_body()
-		playsound(user, 'sound/effects/spray.ogg', 5, TRUE, 5)
-		..()
+	if(iscarbon(target))
+		if(uses - 10 > 0)
+			uses = uses - 10
+			var/mob/living/carbon/C = target
+			user.visible_message("<span class='danger'> [user] sprays [src] into the face of [target]!</span>")
+			if(C.client)
+				C.EyeBlurry(6 SECONDS)
+				C.EyeBlind(2 SECONDS)
+				if(ishuman(target))
+					var/mob/living/carbon/human/H = target
+					if(H.check_eye_prot() <= 0) // no eye protection? ARGH IT BURNS.
+						H.Confused(6 SECONDS)
+						H.KnockDown(6 SECONDS)
+					H.lip_style = "spray_face"
+					H.lip_color = colour
+					H.update_body()
+	playsound(user, 'sound/effects/spray.ogg', 5, TRUE, 5)
+	..()
 
 /obj/item/toy/crayon/spraycan/update_icon_state()
 	icon_state = "spraycan[capped ? "_cap" : ""]"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Spraycan now warns you when you try to spray stuff while the cap is on.

You can no longer use spraycans as a source of nourishment (whyyyyyyy!?)
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Knowing why ye cannot spray ye flaske is good.

Being able to casually print nutrition is silly. When that nutrition is literally spraypaint that doesn't even have any negative side effects, it is even more silly. IT DOESN'T EVEN USE A SPRAY SOUND AGGHHH!
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Tried to spray stuff with cap on. Got told to remove cap.
Tried to eat the spraycan. Could not.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Spraycans now warn you if you try to use them without removing the cap. You can no longer fill your nutrition bar with solvent abuse.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
