### PR TITLE
soften borders of althland excavation ruin

### DIFF
--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_althland_excavation.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_althland_excavation.dmm
@@ -797,6 +797,9 @@
 /obj/effect/turf_decal/delivery/white,
 /turf/simulated/floor/plating/airless,
 /area/ruin/unpowered/althland_excavation)
+"oh" = (
+/turf/simulated/mineral/volcanic/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "or" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -1271,6 +1274,9 @@
 	nitrogen = 0
 	},
 /area/lavaland/surface/outdoors)
+"Mm" = (
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "MT" = (
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/glass,
@@ -1564,6 +1570,19 @@
 /area/ruin/unpowered/althland_excavation)
 
 (1,1,1) = {"
+oh
+oh
+oh
+oh
+oh
+oh
+oh
+oh
+oh
+Mm
+Mm
+Mm
+Mm
 Ei
 Ei
 Ei
@@ -1575,6 +1594,25 @@ Ei
 Ei
 Ei
 Ei
+Mm
+Mm
+oh
+oh
+oh
+oh
+"}
+(2,1,1) = {"
+oh
+oh
+oh
+oh
+Mm
+Mm
+Mm
+Mm
+Mm
+Mm
+Mm
 TN
 TN
 TN
@@ -1591,17 +1629,17 @@ Ei
 Ei
 Ei
 Ei
-Ei
-Ei
-Ei
+oh
+oh
+oh
 "}
-(2,1,1) = {"
-Ei
-Ei
-Ei
-Ei
-Ei
-Ei
+(3,1,1) = {"
+oh
+oh
+Mm
+Mm
+Mm
+Mm
 TN
 TN
 TN
@@ -1624,14 +1662,14 @@ Ei
 Ei
 Ei
 Ei
-Ei
-Ei
+oh
+oh
 "}
-(3,1,1) = {"
-Ei
-Ei
-Ei
-Ei
+(4,1,1) = {"
+oh
+Mm
+Mm
+Mm
 TN
 TN
 TN
@@ -1656,13 +1694,13 @@ TN
 TN
 Ei
 Ei
-Ei
-Ei
+Mm
+Mm
 "}
-(4,1,1) = {"
-Ei
-Ei
-Ei
+(5,1,1) = {"
+oh
+Mm
+Mm
 TN
 sp
 aU
@@ -1689,11 +1727,11 @@ TN
 TN
 Ei
 Ei
-Ei
+Mm
 "}
-(5,1,1) = {"
-Ei
-Ei
+(6,1,1) = {"
+Mm
+Mm
 TN
 TN
 Ri
@@ -1723,9 +1761,9 @@ bm
 Ei
 Ei
 "}
-(6,1,1) = {"
-Ei
-Ei
+(7,1,1) = {"
+Mm
+Mm
 TN
 PL
 BZ
@@ -1755,8 +1793,8 @@ bm
 Ei
 Ei
 "}
-(7,1,1) = {"
-Ei
+(8,1,1) = {"
+Mm
 TN
 TN
 pE
@@ -1787,8 +1825,8 @@ Ei
 Ei
 Ei
 "}
-(8,1,1) = {"
-Ei
+(9,1,1) = {"
+Mm
 TN
 sp
 bC
@@ -1819,8 +1857,8 @@ aB
 Ei
 Ei
 "}
-(9,1,1) = {"
-Ei
+(10,1,1) = {"
+Mm
 TN
 TN
 TN
@@ -1851,8 +1889,8 @@ Ei
 bm
 Ei
 "}
-(10,1,1) = {"
-Ei
+(11,1,1) = {"
+Mm
 TN
 ct
 Pe
@@ -1883,8 +1921,8 @@ Ei
 bm
 Ei
 "}
-(11,1,1) = {"
-Ei
+(12,1,1) = {"
+Mm
 TN
 pC
 yb
@@ -1915,7 +1953,7 @@ Ei
 TN
 Ei
 "}
-(12,1,1) = {"
+(13,1,1) = {"
 Ei
 TN
 TN
@@ -1945,9 +1983,9 @@ Ei
 Ei
 Ei
 TN
-Ei
+Mm
 "}
-(13,1,1) = {"
+(14,1,1) = {"
 Ei
 TN
 aU
@@ -1977,9 +2015,9 @@ XS
 Ei
 Ei
 TN
-Ei
+Mm
 "}
-(14,1,1) = {"
+(15,1,1) = {"
 Ei
 TN
 Yz
@@ -2009,9 +2047,9 @@ Ei
 Ei
 Ei
 TN
-Ei
+Mm
 "}
-(15,1,1) = {"
+(16,1,1) = {"
 Ei
 TN
 TN
@@ -2041,9 +2079,9 @@ Ei
 BW
 aB
 TN
-Ei
+Mm
 "}
-(16,1,1) = {"
+(17,1,1) = {"
 Ei
 TN
 Ei
@@ -2073,9 +2111,9 @@ mK
 uG
 BW
 TN
-Ei
+Mm
 "}
-(17,1,1) = {"
+(18,1,1) = {"
 Ei
 bm
 Ei
@@ -2105,9 +2143,9 @@ BW
 LK
 PM
 TN
-Ei
+Mm
 "}
-(18,1,1) = {"
+(19,1,1) = {"
 Ei
 bm
 Ei
@@ -2137,9 +2175,9 @@ aB
 BW
 KU
 TN
-Ei
+Mm
 "}
-(19,1,1) = {"
+(20,1,1) = {"
 Ei
 TN
 Ei
@@ -2169,9 +2207,9 @@ aB
 aB
 uG
 TN
-Ei
+Mm
 "}
-(20,1,1) = {"
+(21,1,1) = {"
 Ei
 TN
 TN
@@ -2201,9 +2239,9 @@ aB
 aB
 aB
 TN
-Ei
+Mm
 "}
-(21,1,1) = {"
+(22,1,1) = {"
 Ei
 TN
 ao
@@ -2233,9 +2271,9 @@ BW
 TJ
 BW
 TN
-Ei
+Mm
 "}
-(22,1,1) = {"
+(23,1,1) = {"
 Ei
 TN
 at
@@ -2265,9 +2303,9 @@ mh
 mK
 uG
 TN
-Ei
+Mm
 "}
-(23,1,1) = {"
+(24,1,1) = {"
 Ei
 TN
 aG
@@ -2297,10 +2335,10 @@ mh
 mh
 Gc
 TN
-Ei
+Mm
 "}
-(24,1,1) = {"
-Ei
+(25,1,1) = {"
+Mm
 TN
 TN
 bU
@@ -2329,11 +2367,11 @@ gg
 bN
 TN
 TN
-Ei
+Mm
 "}
-(25,1,1) = {"
-Ei
-Ei
+(26,1,1) = {"
+Mm
+Mm
 TN
 az
 DS
@@ -2360,12 +2398,12 @@ jL
 Nv
 jS
 TN
-Ei
-Ei
+Mm
+Mm
 "}
-(26,1,1) = {"
-Ei
-Ei
+(27,1,1) = {"
+oh
+Mm
 TN
 TN
 ap
@@ -2392,13 +2430,13 @@ bL
 YE
 TN
 TN
-Ei
-Ei
+Mm
+Mm
 "}
-(27,1,1) = {"
-Ei
-Ei
-Ei
+(28,1,1) = {"
+oh
+Mm
+Mm
 TN
 TN
 iA
@@ -2423,15 +2461,15 @@ kh
 aE
 TN
 TN
-Ei
-Ei
-Ei
+Mm
+Mm
+oh
 "}
-(28,1,1) = {"
-Ei
-Ei
-Ei
-Ei
+(29,1,1) = {"
+oh
+Mm
+Mm
+Mm
 TN
 TN
 TN
@@ -2454,18 +2492,18 @@ TN
 TN
 TN
 TN
-Ei
-Ei
-Ei
-Ei
+Mm
+Mm
+oh
+oh
 "}
-(29,1,1) = {"
-Ei
-Ei
-Ei
-Ei
-Ei
-Ei
+(30,1,1) = {"
+oh
+oh
+Mm
+Mm
+Mm
+Mm
 TN
 TN
 TN
@@ -2484,25 +2522,25 @@ TN
 TN
 TN
 TN
-Ei
-Ei
-Ei
-Ei
-Ei
-Ei
+Mm
+Mm
+Mm
+oh
+oh
+oh
 "}
-(30,1,1) = {"
-Ei
-Ei
-Ei
-Ei
-Ei
-Ei
-Ei
-Ei
-Ei
-Ei
-Ei
+(31,1,1) = {"
+oh
+oh
+oh
+Mm
+Mm
+Mm
+Mm
+Mm
+Mm
+Mm
+Mm
 TN
 TN
 TN
@@ -2512,14 +2550,14 @@ TN
 TN
 TN
 TN
-Ei
-Ei
-Ei
-Ei
-Ei
-Ei
-Ei
-Ei
-Ei
-Ei
+Mm
+Mm
+Mm
+Mm
+Mm
+oh
+oh
+oh
+oh
+oh
 "}


### PR DESCRIPTION
## What Does This PR Do
This PR modifies the borders of lavaland_surface_althland_excavation.dmm to allow for more lava generation and cave generation around it. It keeps the no-lava helpers around the entrances to the facility, and increases the width by 1 to ensure the primary entrance can be bordered by no-lava helpers.
## Why It's Good For The Game
Currently the excavation site has a hard rectangular border around it, making its placement feel awkward. This helps the ruin feel a bit more naturally placed.
## Images of changes

<details><summary>SDMM screenshots</summary>

### Before

![2024_04_06__12_16_57__paradise dme  lavaland_surface_althland_excavation dmm  - StrongDMM](https://github.com/ParadiseSS13/Paradise/assets/59303604/772a8046-a903-4f96-bed3-b6245d6b3cfa)

### After

![2024_04_06__12_16_01__paradise dme  lavaland_surface_althland_excavation dmm  - StrongDMM](https://github.com/ParadiseSS13/Paradise/assets/59303604/59fed7f3-c3fe-46d8-a1b6-89ce5cb66c4a)

</details>

<details><summary>In-game screenshots</summary>

### Before

![2024_04_06__11_38_02__Paradise Station 13](https://github.com/ParadiseSS13/Paradise/assets/59303604/d64a1873-53bd-43f4-8c4b-ea697d9028bb)

### After

![2024_04_06__11_59_05__Paradise Station 13](https://github.com/ParadiseSS13/Paradise/assets/59303604/10bf1d8c-00b4-4c8a-b027-c5d1c1f28a29)
![2024_04_06__12_04_12__Paradise Station 13](https://github.com/ParadiseSS13/Paradise/assets/59303604/9b7266c6-9ca2-448b-8809-ca26cb1fc39f)
![2024_04_06__12_07_32__](https://github.com/ParadiseSS13/Paradise/assets/59303604/9e032b80-98ad-43ab-a3b7-2da1b13a8e09)
</details>

## Testing
See above.

## Changelog
:cl:
tweak: The Althland Excavation ruin no longer has a hard rectangular border of rock around it.
/:cl:
