### PR TITLE
Debug on F5 regardless of file extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ stddef.dm
 *.vscode/*
 !/.vscode/extensions.json
 !/.vscode/tasks.json
+!/.vscode/launch.json
 
 # ignore DMI tool build cache
 /tools/dmitool/bin/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+	"version": "0.2.0",
+	"configurations": [
+	  {
+		"type": "byond",
+		"request": "launch",
+		"name": "Build & DS Debug",
+		"preLaunchTask": "dm: build - ${command:CurrentDME}",
+		"dmb": "${workspaceFolder}/${command:CurrentDMB}"
+	  },
+	  {
+		"type": "byond",
+		"request": "launch",
+		"name": "DS Debug",
+		"dmb": "${workspaceFolder}/${command:CurrentDMB}"
+	  }
+	]
+  }


### PR DESCRIPTION
## What Does This PR Do
Adds launch.json to vscode folder.
That's allow you to start debugging (F5) in any file, not only into dm/dmi/dmm

## Why It's Good For The Game
Dev comfy

## Images of changes
https://github.com/ParadiseSS13/Paradise/assets/69762909/af0a070e-590b-4613-97d0-cc274ea085ac

## Testing
Above

## Changelog
NPFC