### PR TITLE
add no-lava helpers to hermit ruin

### DIFF
--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_hermit.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_hermit.dmm
@@ -175,6 +175,10 @@
 /obj/effect/baseturf_helper,
 /turf/simulated/floor/plating,
 /area/ruin/powered)
+"P" = (
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "X" = (
 /obj/item/flashlight/lantern,
 /turf/simulated/floor/plating,
@@ -189,14 +193,14 @@ a
 a
 a
 a
-s
-s
-s
-s
-s
-s
-s
-s
+P
+P
+P
+a
+a
+a
+a
+a
 "}
 (2,1,1) = {"
 a
@@ -209,12 +213,12 @@ a
 a
 a
 a
+P
+P
 s
-s
-s
-s
-s
-s
+a
+a
+a
 "}
 (3,1,1) = {"
 a
@@ -227,12 +231,12 @@ a
 a
 a
 a
+P
+P
+P
 s
-s
-s
-s
-s
-s
+a
+a
 "}
 (4,1,1) = {"
 a
@@ -246,11 +250,11 @@ a
 a
 a
 a
+P
+P
+P
 s
-s
-s
-s
-s
+a
 "}
 (5,1,1) = {"
 a
@@ -266,9 +270,9 @@ t
 t
 t
 t
-s
-s
-s
+P
+P
+a
 "}
 (6,1,1) = {"
 a
@@ -284,8 +288,8 @@ v
 x
 B
 t
-s
-s
+P
+P
 s
 "}
 (7,1,1) = {"
@@ -302,9 +306,9 @@ w
 y
 y
 D
-s
-s
-s
+P
+P
+a
 "}
 (8,1,1) = {"
 a
@@ -320,9 +324,9 @@ o
 z
 C
 t
-s
-s
-s
+P
+P
+a
 "}
 (9,1,1) = {"
 b
@@ -338,9 +342,9 @@ o
 t
 t
 t
+P
 s
-s
-s
+a
 "}
 (10,1,1) = {"
 b
@@ -356,8 +360,8 @@ o
 A
 b
 a
-s
-s
+P
+P
 s
 "}
 (11,1,1) = {"
@@ -375,7 +379,7 @@ c
 b
 a
 a
-s
+P
 s
 "}
 (12,1,1) = {"
@@ -446,7 +450,7 @@ a
 a
 a
 a
-G
+F
 J
 G
 "}


### PR DESCRIPTION
## What Does This PR Do
This PR adds no-lava helpers around the entrance to the hermit shelter and shuttle. It also adds some rock around the square border of the ruin to make it a bit more organic-looking when being placed.

**Note that the lava under the shuttle and shelter corners is an icon-smoothing problem, _not_ a procgen problem.**

## Why It's Good For The Game
The hermit should be able to exit their shelter. While it is possible for them to mine around it, this sucks the atmosphere out of their cavern which would be a bad idea IC. Also, they must have been able to walk to these areas to create the shelter in the first place. This is still a pretty precarious setup since there's only a few thin tiles between the shelter and the external rock.

## Images of changes
<details><summary>SDMM screenshots</summary>

### Before

![2024_04_06__13_41_18__paradise dme  lavaland_surface_hermit dmm  - StrongDMM](https://github.com/ParadiseSS13/Paradise/assets/59303604/82ce1f5e-20b4-435d-b4c7-831114353920)


### After

![2024_04_06__13_39_12__paradise dme  lavaland_surface_hermit dmm  - StrongDMM](https://github.com/ParadiseSS13/Paradise/assets/59303604/8360cf3e-8ca6-45d1-aa0a-c10999036f7d)

</details>

<details><summary>In-game screenshots</summary>

### Before

![2024_04_06__12_23_35__Paradise Station 13](https://github.com/ParadiseSS13/Paradise/assets/59303604/d3476b63-6951-4d2f-82b9-1355267dddc5)

![2024_04_06__12_23_48__Paradise Station 13](https://github.com/ParadiseSS13/Paradise/assets/59303604/bb7ed616-c916-4163-897c-c2fe26ed206e)


### After

![2024_04_06__13_32_14__Paradise Station 13](https://github.com/ParadiseSS13/Paradise/assets/59303604/9c954043-f489-4c4d-967d-89bf2a9f705a)


</details>

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: The hermit ruin now prevents lava from spawning directly in front of its shelter and shuttle doors.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
