### PR TITLE
remove russian from some GUI titles

### DIFF
--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -110,7 +110,7 @@
 		dat += "<a href='?src=[UID()];op=temp;val=5'>+</a><br>"
 
 		user.set_machine(src)
-		user << browse("<meta charset='utf-8'><head><title>Space Heater Control Panel Панель</title></head><tt>[dat]</tt>", "window=spaceheater")
+		user << browse("<meta charset='utf-8'><head><title>Space Heater Control Panel</title></head><tt>[dat]</tt>", "window=spaceheater")
 		onclose(user, "spaceheater")
 
 	else

--- a/code/game/objects/structures/noticeboard.dm
+++ b/code/game/objects/structures/noticeboard.dm
@@ -37,7 +37,7 @@
 	var/dat = "<b>Noticeboard</b><br>"
 	for(var/obj/item/paper/P in src)
 		dat += "<a href='?src=[UID()];read=\ref[P]'>[P.name]</a> <a href='?src=[UID()];write=\ref[P]'>Write</a> <a href='?src=[UID()];remove=\ref[P]'>Remove</a><br>"
-	user << browse("<meta charset='utf-8'><head><title>Notices Записки</title></head>[dat]","window=noticeboard")
+	user << browse("<meta charset='utf-8'><head><title>Notices</title></head>[dat]","window=noticeboard")
 	onclose(user, "noticeboard")
 
 /obj/structure/noticeboard/deconstruct(disassembled = TRUE)


### PR DESCRIPTION
## What Does This PR Do
This PR removes some Russian text from the Noticeboard and Space heater GUI titles. These were just "panel" and "notices" translated.
## Why It's Good For The Game
English
## Testing
Forgive me if I assume this just works

## Changelog
:cl:
fix: Some Russian text has been removed from the Noticeboard and Space Heater GUIs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
