### PR TITLE
Hierophant Club can no longer become ashes

### DIFF
--- a/code/modules/mining/lavaland/loot/hierophant_loot.dm
+++ b/code/modules/mining/lavaland/loot/hierophant_loot.dm
@@ -16,6 +16,7 @@
 	attack_verb = list("clubbed", "beat", "pummeled")
 	hitsound = 'sound/weapons/sonic_jackhammer.ogg'
 	actions_types = list(/datum/action/item_action/vortex_recall, /datum/action/item_action/toggle_unfriendly_fire)
+	resistance_flags = LAVA_PROOF | FIRE_PROOF
 	var/cooldown_time = 20 //how long the cooldown between non-melee ranged attacks is
 	var/chaser_cooldown = 81 //how long the cooldown between firing chasers at mobs is
 	var/chaser_timer = 0 //what our current chaser cooldown is


### PR DESCRIPTION
## What Does This PR Do
Stops the Hierophant Club from turning to ash.

## Why It's Good For The Game
So when an ash drake desides to sneeze in your general direction the club doesn't turn to ash. The club is basically the body of the dead boss,(I know that the old sprite was the boss holding the club, but with the current sprite, the club itself is the boss) so it doesn't make much sense for the club to be turned to ash so easily, even more so that the boss literally lives on lavaland.

## Images of changes
![7f4aee99a85537211865982e050991ba](https://github.com/ParadiseSS13/Paradise/assets/115121249/6ca6b955-6fe7-423d-9d29-c0e8dfd21b54)

## Testing
(My VSCode is borked. Funnyman let me test it on his local)
Spawned Lava turf and the hierophant club.
Threw the club into lava, watched it not burn.
Spawned an ash drake and pulled the hierophant club behind me.
Watched the club not get turned to ash while being mauled by an ash drake.

## Changelog
:cl:
tweak: Gives the Hierophant Club the resistance flags LAVA_PROOF and FIRE_PROOF.
/:cl:
