### PR TITLE
Slightly cleans up shotgun code

### DIFF
--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -15,8 +15,9 @@
 	origin_tech = "combat=4;materials=2"
 	mag_type = /obj/item/ammo_box/magazine/internal/shot
 	fire_sound = 'sound/weapons/gunshots/gunshot_shotgun.ogg'
-	var/recentpump = 0 // to prevent spammage
 	weapon_weight = WEAPON_HEAVY
+	var/pump_time = 1 SECONDS // To prevent spammage
+	COOLDOWN_DECLARE(pump_cooldown)
 
 /obj/item/gun/projectile/shotgun/examine(mob/user)
 	. = ..()
@@ -37,37 +38,32 @@
 
 
 /obj/item/gun/projectile/shotgun/process_chamber()
-	return ..(0, 0)
+	return ..(FALSE, FALSE)
 
 /obj/item/gun/projectile/shotgun/chamber_round()
 	return
 
 /obj/item/gun/projectile/shotgun/can_shoot()
 	if(!chambered)
-		return 0
-	return (chambered.BB ? 1 : 0)
+		return FALSE
+	return chambered.BB
 
 /obj/item/gun/projectile/shotgun/attack_self(mob/living/user)
-	if(recentpump)
+	if(!COOLDOWN_FINISHED(src, pump_cooldown))
 		return
 	pump(user)
-	recentpump = 1
-	spawn(10)
-		recentpump = 0
-	return
-
+	COOLDOWN_START(src, pump_cooldown, pump_time)
 
 /obj/item/gun/projectile/shotgun/proc/pump(mob/M)
 	playsound(M, 'sound/weapons/gun_interactions/shotgunpump.ogg', 60, 1)
 	pump_unload(M)
 	pump_reload(M)
-	return 1
 
 /obj/item/gun/projectile/shotgun/proc/pump_unload(mob/M)
 	if(chambered)//We have a shell in the chamber
-		chambered.loc = get_turf(src)//Eject casing
+		chambered.forceMove(get_turf(src))
 		chambered.SpinAnimation(5, 1)
-		playsound(src, chambered.casing_drop_sound, 60, 1)
+		playsound(src, chambered.casing_drop_sound, 60, TRUE)
 		chambered = null
 
 /obj/item/gun/projectile/shotgun/proc/pump_reload(mob/M)

--- a/code/modules/projectiles/guns/projectile_gun.dm
+++ b/code/modules/projectiles/guns/projectile_gun.dm
@@ -48,7 +48,7 @@
 	if(bayonet && can_bayonet)
 		. += knife_overlay
 
-/obj/item/gun/projectile/process_chamber(eject_casing = 1, empty_chamber = 1)
+/obj/item/gun/projectile/process_chamber(eject_casing = TRUE, empty_chamber = TRUE)
 	var/obj/item/ammo_casing/ammo_chambered = chambered //Find chambered round
 	if(!istype(ammo_chambered))
 		chamber_round()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
- Changes some 0's and 1's to `TRUE`'s and `FALSE`'s
- Makes the pump use a cooldown macro instead of using a `spawn(10)` to set the variable back
- Removes an unnecessary tertiary
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Code quality and cleanup are good
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
- Shot a skrell with rubbershot
- Shot a skrell with beanbags
- Checked if I still couldn't fire if I had a spent ammo casing in the shotgun left
This was all done with a Riot shotgun
<!-- How did you test the PR, if at all? -->

## Changelog
NPFC
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
