### PR TITLE
Fixes the blowgun being an excellent suicide method

### DIFF
--- a/code/modules/projectiles/guns/syringe_gun.dm
+++ b/code/modules/projectiles/guns/syringe_gun.dm
@@ -408,8 +408,8 @@
 	item_state = "gun"
 
 /obj/item/gun/syringe/blowgun/process_fire(atom/target, mob/living/user, message = TRUE, params = null, zone_override = "", bonus_spread = 0)
-	visible_message("<span class='danger'>[user] shoots the blowgun!</span>")
-
-	user.adjustStaminaLoss(20, FALSE)
-	user.adjustOxyLoss(20)
+	if(chambered.BB)
+		visible_message("<span class='danger'>[user] shoots the blowgun!</span>")
+		user.adjustStaminaLoss(20, FALSE)
+		user.adjustOxyLoss(20)
 	return ..()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes the blowgun only do stamina and oxy damage if there's actually something in it
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Haha spamclick into instant death goes brrrr
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Tried to spamclick, only heard clicks and no deathgasps
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Fixed the blowgun dealing oxy damage when you tried to fire an empty one
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
