### PR TITLE
Tweak recipes of glasses

### DIFF
--- a/code/modules/crafting/tailoring.dm
+++ b/code/modules/crafting/tailoring.dm
@@ -46,7 +46,7 @@
 	name = "Durathread Bandana"
 	result = list(/obj/item/clothing/mask/bandana/durathread)
 	reqs = list(/obj/item/stack/sheet/durathread = 1)
-	time = 3 SECONDS
+	time = 2.5 SECONDS
 	category = CAT_CLOTHING
 
 /datum/crafting_recipe/fannypack
@@ -308,7 +308,7 @@
 /datum/crafting_recipe/ghostsheet
 	name = "Ghost Sheet"
 	result = list(/obj/item/clothing/suit/ghost_sheet)
-	time = 1 SECONDS
+	time = 0.5 SECONDS
 	tools = list(TOOL_WIRECUTTER)
 	reqs = list(/obj/item/bedsheet = 1)
 	category = CAT_CLOTHING
@@ -316,7 +316,7 @@
 /datum/crafting_recipe/cowboyboots
 	name = "Cowboy Boots"
 	result = list(/obj/item/clothing/shoes/cowboy)
-	time = 5 SECONDS
+	time = 4.5 SECONDS
 	reqs = list(/obj/item/stack/sheet/leather = 2)
 	category = CAT_CLOTHING
 
@@ -330,7 +330,7 @@
 /datum/crafting_recipe/rubberduckyshoes
 	name = "Rubber Ducky Shoes"
 	result = list(/obj/item/clothing/shoes/ducky)
-	time = 5 SECONDS
+	time = 4.5 SECONDS
 	tools = list(TOOL_WIRECUTTER)
 	reqs = list(/obj/item/bikehorn/rubberducky = 2,
 				/obj/item/clothing/shoes/sandal = 1)
@@ -349,7 +349,7 @@
 /datum/crafting_recipe/voice_modulator
 	name = "Voice Modulator Mask"
 	result = list(/obj/item/clothing/mask/gas/voice_modulator)
-	time = 5 SECONDS
+	time = 4.5 SECONDS
 	tools = list(TOOL_SCREWDRIVER, TOOL_MULTITOOL)
 	reqs = list(/obj/item/clothing/mask/gas = 1,
 				/obj/item/assembly/voice = 1,

--- a/code/modules/crafting/tailoring.dm
+++ b/code/modules/crafting/tailoring.dm
@@ -1,3 +1,10 @@
+#define ALLOWED_INGREDIENT_SUNGLASSES list( \
+	/obj/item/clothing/glasses/sunglasses, \
+	/obj/item/clothing/glasses/sunglasses/noir, \
+	/obj/item/clothing/glasses/sunglasses/yeah, \
+	/obj/item/clothing/glasses/sunglasses/big \
+)
+
 /datum/crafting_recipe/durathread_vest
 	name = "Durathread Vest"
 	result = list(/obj/item/clothing/suit/armor/vest/durathread)
@@ -173,7 +180,7 @@
 /datum/crafting_recipe/hudsunsec/New()
 	..()
 	blacklist = subtypesof(/obj/item/clothing/glasses/hud/security) \
-		| subtypesof(/obj/item/clothing/glasses/sunglasses)
+		| typesof(/obj/item/clothing/glasses/sunglasses) - ALLOWED_INGREDIENT_SUNGLASSES
 
 /datum/crafting_recipe/hudsunsecremoval
 	name = "Security HUD removal"
@@ -196,7 +203,7 @@
 /datum/crafting_recipe/hudsunmed/New()
 	..()
 	blacklist = subtypesof(/obj/item/clothing/glasses/hud/health) \
-		| subtypesof(/obj/item/clothing/glasses/sunglasses)
+		| typesof(/obj/item/clothing/glasses/sunglasses) - ALLOWED_INGREDIENT_SUNGLASSES
 
 /datum/crafting_recipe/hudsunmedremoval
 	name = "Medical HUD removal"
@@ -219,7 +226,7 @@
 /datum/crafting_recipe/hudsundiag/New()
 	..()
 	blacklist = subtypesof(/obj/item/clothing/glasses/hud/diagnostic) \
-		| subtypesof(/obj/item/clothing/glasses/sunglasses)
+		| typesof(/obj/item/clothing/glasses/sunglasses) - ALLOWED_INGREDIENT_SUNGLASSES
 
 /datum/crafting_recipe/hudsundiagremoval
 	name = "Diagnostic HUD removal"
@@ -242,7 +249,7 @@
 /datum/crafting_recipe/hudsunjani/New()
 	..()
 	blacklist = subtypesof(/obj/item/clothing/glasses/hud/janitor) \
-		| subtypesof(/obj/item/clothing/glasses/sunglasses)
+		| typesof(/obj/item/clothing/glasses/sunglasses) - ALLOWED_INGREDIENT_SUNGLASSES
 
 /datum/crafting_recipe/hudsunjaniremoval
 	name = "Janitor HUD sunglasses removal"
@@ -265,7 +272,7 @@
 /datum/crafting_recipe/hudsunmeson/New()
 	..()
 	blacklist = subtypesof(/obj/item/clothing/glasses/meson) \
-		| subtypesof(/obj/item/clothing/glasses/sunglasses)
+		| typesof(/obj/item/clothing/glasses/sunglasses) - ALLOWED_INGREDIENT_SUNGLASSES
 
 /datum/crafting_recipe/hudsunmesonremoval
 	name = "Meson HUD sunglasses removal"
@@ -288,7 +295,7 @@
 /datum/crafting_recipe/beergoggles/New()
 	..()
 	blacklist = subtypesof(/obj/item/clothing/glasses/science) \
-		| subtypesof(/obj/item/clothing/glasses/sunglasses)
+		| typesof(/obj/item/clothing/glasses/sunglasses) - ALLOWED_INGREDIENT_SUNGLASSES
 
 /datum/crafting_recipe/beergogglesremoval
 	name = "Sunscanners removal"
@@ -385,3 +392,5 @@
 	time = 2 SECONDS
 	reqs = list(/obj/item/food/snacks/grown/geranium = 5)
 	category = CAT_CLOTHING
+
+#undef ALLOWED_INGREDIENT_SUNGLASSES

--- a/code/modules/crafting/tailoring.dm
+++ b/code/modules/crafting/tailoring.dm
@@ -3,7 +3,7 @@
 	result = list(/obj/item/clothing/suit/armor/vest/durathread)
 	reqs = list(/obj/item/stack/sheet/durathread = 5,
 				/obj/item/stack/sheet/leather = 4)
-	time = 50
+	time = 5 SECONDS
 	category = CAT_CLOTHING
 
 /datum/crafting_recipe/durathread_helmet
@@ -11,35 +11,35 @@
 	result = list(/obj/item/clothing/head/helmet/durathread)
 	reqs = list(/obj/item/stack/sheet/durathread = 4,
 				/obj/item/stack/sheet/leather = 5)
-	time = 40
+	time = 4 SECONDS
 	category = CAT_CLOTHING
 
 /datum/crafting_recipe/durathread_jumpsuit
 	name = "Durathread Jumpsuit"
 	result = list(/obj/item/clothing/under/misc/durathread)
 	reqs = list(/obj/item/stack/sheet/durathread = 4)
-	time = 40
+	time = 4 SECONDS
 	category = CAT_CLOTHING
 
 /datum/crafting_recipe/durathread_beret
 	name = "Durathread Beret"
 	result = list(/obj/item/clothing/head/beret/durathread)
 	reqs = list(/obj/item/stack/sheet/durathread = 2)
-	time = 40
+	time = 4 SECONDS
 	category = CAT_CLOTHING
 
 /datum/crafting_recipe/durathread_beanie
 	name = "Durathread Beanie"
 	result = list(/obj/item/clothing/head/beanie/durathread)
 	reqs = list(/obj/item/stack/sheet/durathread = 2)
-	time = 40
+	time = 4 SECONDS
 	category = CAT_CLOTHING
 
 /datum/crafting_recipe/durathread_bandana
 	name = "Durathread Bandana"
 	result = list(/obj/item/clothing/mask/bandana/durathread)
 	reqs = list(/obj/item/stack/sheet/durathread = 1)
-	time = 25
+	time = 3 SECONDS
 	category = CAT_CLOTHING
 
 /datum/crafting_recipe/fannypack
@@ -47,7 +47,7 @@
 	result = list(/obj/item/storage/belt/fannypack)
 	reqs = list(/obj/item/stack/sheet/cloth = 2,
 				/obj/item/stack/sheet/leather = 1)
-	time = 20
+	time = 2 SECONDS
 	category = CAT_CLOTHING
 
 /datum/crafting_recipe/hudgogsec
@@ -59,6 +59,10 @@
 				/obj/item/clothing/glasses/goggles = 1,
 				/obj/item/stack/cable_coil = 5)
 	category = CAT_CLOTHING
+
+/datum/crafting_recipe/hudgogsec/New()
+	..()
+	blacklist = subtypesof(/obj/item/clothing/glasses/hud/security)
 
 /datum/crafting_recipe/hudgogsecremoval
 	name = "Security HUD removal (goggles)"
@@ -78,6 +82,10 @@
 				/obj/item/stack/cable_coil = 5)
 	category = CAT_CLOTHING
 
+/datum/crafting_recipe/hudgoghealth/New()
+	..()
+	blacklist = subtypesof(/obj/item/clothing/glasses/hud/health)
+
 /datum/crafting_recipe/hudgoghealthremoval
 	name = "Health HUD removal (goggles)"
 	result = list(/obj/item/clothing/glasses/goggles, /obj/item/clothing/glasses/hud/health)
@@ -95,6 +103,10 @@
 				/obj/item/clothing/glasses/goggles = 1,
 				/obj/item/stack/cable_coil = 5)
 	category = CAT_CLOTHING
+
+/datum/crafting_recipe/hudgogdiagnostic/New()
+	..()
+	blacklist = subtypesof(/obj/item/clothing/glasses/hud/diagnostic)
 
 /datum/crafting_recipe/hudgogdiagnosticremoval
 	name = "Diagnostic HUD removal (goggles)"
@@ -114,6 +126,10 @@
 				/obj/item/stack/cable_coil = 5)
 	category = CAT_CLOTHING
 
+/datum/crafting_recipe/hudgoghydroponic/New()
+	..()
+	blacklist = subtypesof(/obj/item/clothing/glasses/hud/hydroponic)
+
 /datum/crafting_recipe/hudgoghydroponicremoval
 	name = "Hydroponic HUD removal (goggles)"
 	result = list(/obj/item/clothing/glasses/goggles, /obj/item/clothing/glasses/hud/hydroponic)
@@ -132,6 +148,10 @@
 				/obj/item/stack/cable_coil = 5)
 	category = CAT_CLOTHING
 
+/datum/crafting_recipe/hudgogskills/New()
+	..()
+	blacklist = subtypesof(/obj/item/clothing/glasses/hud/skills)
+
 /datum/crafting_recipe/hudgogskillsremoval
 	name = "Skills HUD removal (goggles)"
 	result = list(/obj/item/clothing/glasses/goggles, /obj/item/clothing/glasses/hud/skills)
@@ -143,17 +163,22 @@
 /datum/crafting_recipe/hudsunsec
 	name = "Security HUDsunglasses"
 	result = list(/obj/item/clothing/glasses/hud/security/sunglasses)
-	time = 20
+	time = 2 SECONDS
 	tools = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
 	reqs = list(/obj/item/clothing/glasses/hud/security = 1,
 				/obj/item/clothing/glasses/sunglasses = 1,
 				/obj/item/stack/cable_coil = 5)
 	category = CAT_CLOTHING
 
+/datum/crafting_recipe/hudsunsec/New()
+	..()
+	blacklist = subtypesof(/obj/item/clothing/glasses/hud/security) \
+		| subtypesof(/obj/item/clothing/glasses/sunglasses)
+
 /datum/crafting_recipe/hudsunsecremoval
 	name = "Security HUD removal"
 	result = list(/obj/item/clothing/glasses/sunglasses, /obj/item/clothing/glasses/hud/security)
-	time = 20
+	time = 2 SECONDS
 	tools = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
 	reqs = list(/obj/item/clothing/glasses/hud/security/sunglasses = 1)
 	category = CAT_CLOTHING
@@ -161,17 +186,22 @@
 /datum/crafting_recipe/hudsunmed
 	name = "Medical HUDsunglasses"
 	result = list(/obj/item/clothing/glasses/hud/health/sunglasses)
-	time = 20
+	time = 2 SECONDS
 	tools = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
 	reqs = list(/obj/item/clothing/glasses/hud/health = 1,
 				/obj/item/clothing/glasses/sunglasses = 1,
 				/obj/item/stack/cable_coil = 5)
 	category = CAT_CLOTHING
 
+/datum/crafting_recipe/hudsunmed/New()
+	..()
+	blacklist = subtypesof(/obj/item/clothing/glasses/hud/health) \
+		| subtypesof(/obj/item/clothing/glasses/sunglasses)
+
 /datum/crafting_recipe/hudsunmedremoval
 	name = "Medical HUD removal"
 	result = list(/obj/item/clothing/glasses/sunglasses, /obj/item/clothing/glasses/hud/health)
-	time = 20
+	time = 2 SECONDS
 	tools = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
 	reqs = list(/obj/item/clothing/glasses/hud/health/sunglasses = 1)
 	category = CAT_CLOTHING
@@ -179,17 +209,22 @@
 /datum/crafting_recipe/hudsundiag
 	name = "Diagnostic HUDsunglasses"
 	result = list(/obj/item/clothing/glasses/hud/diagnostic/sunglasses)
-	time = 20
+	time = 2 SECONDS
 	tools = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
 	reqs = list(/obj/item/clothing/glasses/hud/diagnostic = 1,
 				/obj/item/clothing/glasses/sunglasses = 1,
 				/obj/item/stack/cable_coil = 5)
 	category = CAT_CLOTHING
 
+/datum/crafting_recipe/hudsundiag/New()
+	..()
+	blacklist = subtypesof(/obj/item/clothing/glasses/hud/diagnostic) \
+		| subtypesof(/obj/item/clothing/glasses/sunglasses)
+
 /datum/crafting_recipe/hudsundiagremoval
 	name = "Diagnostic HUD removal"
 	result = list(/obj/item/clothing/glasses/sunglasses, /obj/item/clothing/glasses/hud/diagnostic)
-	time = 20
+	time = 2 SECONDS
 	tools = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
 	reqs = list(/obj/item/clothing/glasses/hud/diagnostic/sunglasses = 1)
 	category = CAT_CLOTHING
@@ -197,17 +232,22 @@
 /datum/crafting_recipe/hudsunjani
 	name = "Janitor HUD sunglasses"
 	result = list(/obj/item/clothing/glasses/hud/janitor/sunglasses)
-	time = 20
+	time = 2 SECONDS
 	tools = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
 	reqs = list(/obj/item/clothing/glasses/hud/janitor = 1,
 				/obj/item/clothing/glasses/sunglasses = 1,
 				/obj/item/stack/cable_coil = 5)
 	category = CAT_CLOTHING
 
+/datum/crafting_recipe/hudsunjani/New()
+	..()
+	blacklist = subtypesof(/obj/item/clothing/glasses/hud/janitor) \
+		| subtypesof(/obj/item/clothing/glasses/sunglasses)
+
 /datum/crafting_recipe/hudsunjaniremoval
 	name = "Janitor HUD sunglasses removal"
 	result = list(/obj/item/clothing/glasses/sunglasses, /obj/item/clothing/glasses/hud/janitor)
-	time = 20
+	time = 2 SECONDS
 	tools = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
 	reqs = list(/obj/item/clothing/glasses/hud/janitor/sunglasses = 1)
 	category = CAT_CLOTHING
@@ -222,6 +262,11 @@
 				/obj/item/stack/cable_coil = 5)
 	category = CAT_CLOTHING
 
+/datum/crafting_recipe/hudsunmeson/New()
+	..()
+	blacklist = subtypesof(/obj/item/clothing/glasses/meson) \
+		| subtypesof(/obj/item/clothing/glasses/sunglasses)
+
 /datum/crafting_recipe/hudsunmesonremoval
 	name = "Meson HUD sunglasses removal"
 	result = list(/obj/item/clothing/glasses/sunglasses, /obj/item/clothing/glasses/meson)
@@ -233,17 +278,22 @@
 /datum/crafting_recipe/beergoggles
 	name = "Sunscanners"
 	result = list(/obj/item/clothing/glasses/sunglasses/reagent)
-	time = 20
+	time = 2 SECONDS
 	tools = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
 	reqs = list(/obj/item/clothing/glasses/science = 1,
 				/obj/item/clothing/glasses/sunglasses = 1,
 				/obj/item/stack/cable_coil = 5)
 	category = CAT_CLOTHING
 
+/datum/crafting_recipe/beergoggles/New()
+	..()
+	blacklist = subtypesof(/obj/item/clothing/glasses/science) \
+		| subtypesof(/obj/item/clothing/glasses/sunglasses)
+
 /datum/crafting_recipe/beergogglesremoval
 	name = "Sunscanners removal"
 	result = list(/obj/item/clothing/glasses/sunglasses, /obj/item/clothing/glasses/science)
-	time = 20
+	time = 2 SECONDS
 	tools = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
 	reqs = list(/obj/item/clothing/glasses/sunglasses/reagent = 1)
 	category = CAT_CLOTHING
@@ -251,7 +301,7 @@
 /datum/crafting_recipe/ghostsheet
 	name = "Ghost Sheet"
 	result = list(/obj/item/clothing/suit/ghost_sheet)
-	time = 5
+	time = 1 SECONDS
 	tools = list(TOOL_WIRECUTTER)
 	reqs = list(/obj/item/bedsheet = 1)
 	category = CAT_CLOTHING
@@ -259,40 +309,40 @@
 /datum/crafting_recipe/cowboyboots
 	name = "Cowboy Boots"
 	result = list(/obj/item/clothing/shoes/cowboy)
+	time = 5 SECONDS
 	reqs = list(/obj/item/stack/sheet/leather = 2)
-	time = 45
 	category = CAT_CLOTHING
 
 /datum/crafting_recipe/lizardboots
 	name = "Lizard Skin Boots"
 	result = list(/obj/effect/spawner/lootdrop/lizardboots)
+	time = 6 SECONDS
 	reqs = list(/obj/item/stack/sheet/animalhide/lizard = 1, /obj/item/stack/sheet/leather = 1)
-	time = 60
 	category = CAT_CLOTHING
 
 /datum/crafting_recipe/rubberduckyshoes
 	name = "Rubber Ducky Shoes"
 	result = list(/obj/item/clothing/shoes/ducky)
-	time = 45
+	time = 5 SECONDS
+	tools = list(TOOL_WIRECUTTER)
 	reqs = list(/obj/item/bikehorn/rubberducky = 2,
 				/obj/item/clothing/shoes/sandal = 1)
-	tools = list(TOOL_WIRECUTTER)
 	category = CAT_CLOTHING
 
 /datum/crafting_recipe/salmonsuit
 	name = "Salmon Suit"
 	result = list(/obj/item/clothing/suit/hooded/salmon_costume)
-	time = 60
+	time = 6 SECONDS
+	tools = list(TOOL_WIRECUTTER)
 	reqs = list(/obj/item/fish/salmon = 20,
 				/obj/item/stack/tape_roll = 5)
-	tools = list(TOOL_WIRECUTTER)
 	pathtools = list(/obj/item/kitchen/knife)
 	category = CAT_CLOTHING
 
 /datum/crafting_recipe/voice_modulator
 	name = "Voice Modulator Mask"
 	result = list(/obj/item/clothing/mask/gas/voice_modulator)
-	time = 45
+	time = 5 SECONDS
 	tools = list(TOOL_SCREWDRIVER, TOOL_MULTITOOL)
 	reqs = list(/obj/item/clothing/mask/gas = 1,
 				/obj/item/assembly/voice = 1,
@@ -302,37 +352,36 @@
 /datum/crafting_recipe/flower_crown
 	name = "Flower Crown"
 	result = list(/obj/item/clothing/head/flower_crown)
-	reqs = list(/obj/item/food/snacks/grown/poppy = 3,
-					/obj/item/food/snacks/grown/lily = 3,
-					/obj/item/grown/sunflower = 3
-					)
 	time = 2 SECONDS
+	reqs = list(/obj/item/food/snacks/grown/poppy = 3,
+				/obj/item/food/snacks/grown/lily = 3,
+				/obj/item/grown/sunflower = 3)
 	category = CAT_CLOTHING
 
 /datum/crafting_recipe/sunflower_crown
 	name = "Sunflower Crown"
 	result = list(/obj/item/clothing/head/sunflower_crown)
-	reqs = list(/obj/item/grown/sunflower = 5)
 	time = 2 SECONDS
+	reqs = list(/obj/item/grown/sunflower = 5)
 	category = CAT_CLOTHING
 
 /datum/crafting_recipe/poppy_crown
 	name = "Poppy Crown"
 	result = list(/obj/item/clothing/head/poppy_crown)
-	reqs = list(/obj/item/food/snacks/grown/poppy = 5)
 	time = 2 SECONDS
+	reqs = list(/obj/item/food/snacks/grown/poppy = 5)
 	category = CAT_CLOTHING
 
 /datum/crafting_recipe/lily_crown
 	name = "Lily Crown"
 	result = list(/obj/item/clothing/head/lily_crown)
-	reqs = list(/obj/item/food/snacks/grown/lily = 5)
 	time = 2 SECONDS
+	reqs = list(/obj/item/food/snacks/grown/lily = 5)
 	category = CAT_CLOTHING
 
 /datum/crafting_recipe/geranium_crown
 	name = "Geranium Crown"
 	result = list(/obj/item/clothing/head/geranium_crown)
-	reqs = list(/obj/item/food/snacks/grown/geranium = 5)
 	time = 2 SECONDS
+	reqs = list(/obj/item/food/snacks/grown/geranium = 5)
 	category = CAT_CLOTHING


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Tweaks recipes of glasses to fix some issues. Uses defines for time values.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
1. We better forbid using subtypes of a HUD to disable crafting some HUD from another crafted HUD because it consumes resources irrevocably (ok for cables).
2. We better forbid using subtypes of sunglasses because:
    a. Removal recipes return simple sunglasses.
    b. Different sunglasses have different features that HUD sunglasses do not have.

UPD. Came to the conclusion that these are ok:
```dm
/obj/item/clothing/glasses/sunglasses
/obj/item/clothing/glasses/sunglasses/noir
/obj/item/clothing/glasses/sunglasses/yeah
/obj/item/clothing/glasses/sunglasses/big
```
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Local server ok.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl: Maxiemar
tweak: Different HUD sunglasses and HUD goggles recipes allow simple HUDs and only some sunglasses now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
