### PR TITLE
Makes the cloner not stop at 10,5 %

### DIFF
--- a/code/game/machinery/clonepod.dm
+++ b/code/game/machinery/clonepod.dm
@@ -170,12 +170,12 @@
 /obj/machinery/clonepod/RefreshParts()
 	speed_modifier = 0 //Since we have multiple manipulators, which affect this modifier, we reset here so we can just use += later
 	for(var/obj/item/stock_parts/SP as anything in component_parts)
-		if(istype(SP, /obj/item/stock_parts/matter_bin/)) //Matter bins for storage modifier
-			storage_modifier = round(10 * (SP.rating / 2)) //5 at tier 1, 10 at tier 2, 15 at tier 3, 20 at tier 4
+		if(istype(SP, /obj/item/stock_parts/matter_bin/)) // Matter bins for storage modifier
+			storage_modifier = round(10 * (SP.rating / 2)) // 5 at tier 1, 10 at tier 2, 15 at tier 3, 20 at tier 4
 		else if(istype(SP, /obj/item/stock_parts/scanning_module)) //Scanning modules for price modifier (more accurate scans = more efficient)
-			price_modifier = -(SP.rating / 10) + 1.2 //1.1 at tier 1, 1 at tier 2, 0.9 at tier 3, 0.8 at tier 4
+			price_modifier = -(SP.rating / 10) + 1.2 // 1.1 at tier 1, 1 at tier 2, 0.9 at tier 3, 0.8 at tier 4
 		else if(istype(SP, /obj/item/stock_parts/manipulator)) //Manipulators for speed modifier
-			speed_modifier += SP.rating / 2 //1 at tier 1, 2 at tier 2, et cetera
+			speed_modifier += SP.rating / 2 // 1 at tier 1, 2 at tier 2, et cetera
 
 	for(var/obj/item/reagent_containers/glass/beaker/B in component_parts)
 		if(istype(B))
@@ -184,9 +184,7 @@
 	organ_storage_capacity = storage_modifier
 	biomass_storage_capacity = storage_modifier * 400
 
-
-
-//Process
+// Process
 /obj/machinery/clonepod/process()
 
 	//Basically just isolate_reagent() with extra functionality.
@@ -239,7 +237,7 @@
 				desc_flavor = "You see muscle quickly growing on a ribcage and skull inside [src]."
 				clone_progress += speed_modifier
 				return
-			if(11 to 90)
+			if(10 to 90)
 				clone_progress += speed_modifier
 				if(!clone)
 					create_clone()
@@ -282,7 +280,7 @@
 					clone.regenerate_icons()
 					return
 
-			if(91 to 100)
+			if(90 to 100)
 				if(length(limbs_to_grow) || current_limb) //This shouldn't happen, but just in case.. (no more feetless clones)
 					clone_progress -= 5
 				if(eject_clone())
@@ -291,7 +289,7 @@
 				desc_flavor = "You see [src] finalizing the cloning process."
 				clone_progress += speed_modifier
 				return
-			if(101 to INFINITY) //this state can be reached with an upgraded cloner
+			if(100 to INFINITY) //this state can be reached with an upgraded cloner
 				if(eject_clone())
 					return
 				clone.setCloneLoss(0) //get out of the pod!!

--- a/code/game/machinery/clonepod.dm
+++ b/code/game/machinery/clonepod.dm
@@ -295,6 +295,9 @@
 				clone.setCloneLoss(0) //get out of the pod!!
 				return
 
+			else
+				clone_progress += 1 // I don't know how we got here but we just keep incrementing
+
 //Clonepod-specific procs
 //This just begins the cloning process. Called by the cloning console.
 /obj/machinery/clonepod/proc/start_cloning(datum/cloning_data/_patient_data, datum/cloning_data/_desired_data)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes the switch statement in the `process()` of the cloner decimal proof
Resolves #25072
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
The cloner shouldn't be stuck because some scientist loaded in a rating 4 and rating 3 manipulator in the cloner
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Cloned myself, set progress to 10,5 , it happily went to 11,5.
Set progress to 150, still completed
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Fixed the cloner randomly stopping sometimes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
