### PR TITLE
Adds the delay back to the cloning scanner

### DIFF
--- a/code/game/machinery/clonescanner.dm
+++ b/code/game/machinery/clonescanner.dm
@@ -99,8 +99,6 @@
 	if(!scanned)
 		return
 
-	occupant.notify_ghost_cloning()
-
 	has_scanned = TRUE
 
 	if(!scanned.dna || HAS_TRAIT(scanned, TRAIT_GENELESS))


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds the 5 second delay back to the cloning scanner to give ghosts some time to get back in their body
Also fixes some issues where these actions would wipe your current cloning data:
- Scanning a patient who already has a scan
- Clicking the `scan` button while the machine is on cooldown

Also changes the feedback text of those actions to green ... which is the fix. Yeah.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
You can't expect ghosts to always be stuck in their boring dead bodies, also it's unintended
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Got the proper cooldown, UI data didn't get wiped when I did the actions above
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Added the 5 second delay back to scanning a person's body in the cloning scanner
fix: Fixed a few actions in the cloning scanner that could remove your patient UI data
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
