### PR TITLE
Reverts "makes direction lock no longer a default bind"

### DIFF
--- a/code/datums/keybindings/movement_keybinds.dm
+++ b/code/datums/keybindings/movement_keybinds.dm
@@ -26,6 +26,7 @@
 /datum/keybinding/lock
 	name = "Movement Lock (Prevents Moving When Held)"
 	category = KB_CATEGORY_MOVEMENT
+	keys = list("Ctrl")
 
 /datum/keybinding/lock/down(client/C)
 	. = ..()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Reverts https://github.com/ParadiseSS13/Paradise/pull/24974. Default bind restored.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
A: This has disabled it for people who were still actively using the bind willingly, while doing nothing for people who had voluntarily disabled it.
B: If the fact that we've received quite a few ahelps/mhelps/looc questions about why this is no longer working is any indicator, this feature was still in use by enough people to justify it not being disabled by default.
C: Better to leave this bound by default so new players can see it existing, they have full capacity to unbind it if they do not like it. It's used in roleplay and convenience, after all.

## Testing
<!-- How did you test the PR, if at all? -->
It's a revert, which worked previously and nothing else has changed here, so it should work.
Regardless, it still builds, and I confirmed the default keybind is restored in-game.

## Changelog
:cl:
tweak: Direction lock is now once again binded to ctrl by default
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
