### PR TITLE
Fix runtime when clicking an item that just got deleted.

### DIFF
--- a/code/_onclick/adjacent.dm
+++ b/code/_onclick/adjacent.dm
@@ -79,6 +79,8 @@
 		return TRUE
 	if(!istype(neighbor))
 		return ..()
+	if(isnull(loc))
+		return FALSE
 	if(HAS_TRAIT(loc, TRAIT_ADJACENCY_TRANSPARENT))
 		// Transparent parent, don't decrease recurse.
 		return loc.Adjacent(neighbor, recurse)

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -48,6 +48,9 @@
 	* mob/RangedAttack(atom,params) - used only ranged, only used for tk and laser eyes but could be changed
 */
 /mob/proc/ClickOn(atom/A, params)
+	if(QDELETED(A))
+		return
+
 	if(client.click_intercept)
 		client.click_intercept.InterceptClickOn(src, params, A)
 		return


### PR DESCRIPTION
## What Does This PR Do
Adds some safety to prevent a runtime when clicking an item that just got deleted.

## Why It's Good For The Game
Runtimes bad.

## Testing
Spammed a hatchet on a bamboo log, no runtime.

## Changelog
NPFC