### PR TITLE
Baseturf helpers fix

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -765,7 +765,7 @@ Returns 1 if the chain up to the area contains the given typepath
 		areatype = areatemp.type
 
 	var/list/turfs = list()
-	for(var/area/N as anything in GLOB.all_areas)
+	for(var/area/N as anything in world)
 		if(istype(N, areatype))
 			for(var/turf/T in N)
 				turfs += T

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -765,7 +765,7 @@ Returns 1 if the chain up to the area contains the given typepath
 		areatype = areatemp.type
 
 	var/list/turfs = list()
-	for(var/area/N as anything in world)
+	for(var/area/N as anything in GLOB.all_areas)
 		if(istype(N, areatype))
 			for(var/turf/T in N)
 				turfs += T

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -100,13 +100,13 @@
 /area/New(loc, ...)
 	if(!there_can_be_many) // Has to be done in New else the maploader will fuck up and find subtypes for the parent
 		GLOB.all_unique_areas[type] = src
-	..()
+	GLOB.all_areas += src
+	return ..()
 
 /area/Initialize(mapload)
 	if(is_station_level(z))
 		RegisterSignal(SSsecurity_level, COMSIG_SECURITY_LEVEL_CHANGED, PROC_REF(on_security_level_update))
 
-	GLOB.all_areas += src
 	icon_state = ""
 	layer = AREA_LAYER
 	uid = ++global_uid


### PR DESCRIPTION
## What Does This PR Do
Baseturf helpers are completely broken, I daresay the all_areas list turns out to be empty, during the initialization of the helper
Soo... i steal TG solution
Closes #25085 <details><summary>(yeah, selfclosed)</summary> ![image](https://github.com/ParadiseSS13/Paradise/assets/69762909/927532eb-8b8e-4e4b-b06e-b5f93f999ab7) </details>



## Why It's Good For The Game
No space holes on lavaland

## Images of changes
![image](https://github.com/ParadiseSS13/Paradise/assets/69762909/47077e2b-3f85-4a15-a4e4-e8d3095995c2)

## Testing
Can i just remove this section, Henri?

## Changelog
:cl:
fix: Space should no longer appear on lavaland, for now
/:cl:

