### PR TITLE
Update items stored on cryo storage

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -234,7 +234,8 @@
 		/obj/item/melee/rapier,
 		/obj/item/storage/belt/rapier,
 		/obj/item/nuke_core,
-		/obj/item/nuke_core_container
+		/obj/item/nuke_core_container,
+		/obj/item/documents
 	)
 	// These items will NOT be preserved
 	var/list/do_not_preserve_items = list (

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -230,7 +230,7 @@
 		/obj/item/clothing/gloves/color/black/forensics,
 		/obj/item/mod/control,
 		/obj/item/stamp,
-		/obj/item/melee/knuckleduster,
+		/obj/item/melee/knuckleduster/nanotrasen,
 		/obj/item/melee/rapier,
 		/obj/item/storage/belt/rapier,
 		/obj/item/nuke_core,

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -235,7 +235,8 @@
 		/obj/item/storage/belt/rapier,
 		/obj/item/nuke_core,
 		/obj/item/nuke_core_container,
-		/obj/item/documents
+		/obj/item/documents,
+		/obj/item/clothing/gloves/color/black/krav_maga
 	)
 	// These items will NOT be preserved
 	var/list/do_not_preserve_items = list (

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -228,7 +228,6 @@
 		/obj/item/autopsy_scanner,
 		/obj/item/holosign_creator/atmos,
 		/obj/item/clothing/gloves/color/black/forensics,
-		/obj/item/rcd,
 		/obj/item/rpd,
 		/obj/item/mod/control,
 		/obj/item/stamp

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -230,7 +230,8 @@
 		/obj/item/clothing/gloves/color/black/forensics,
 		/obj/item/rcd,
 		/obj/item/rpd,
-		/obj/item/mod/control
+		/obj/item/mod/control,
+		/obj/item/stamp
 	)
 	// These items will NOT be preserved
 	var/list/do_not_preserve_items = list (

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -228,9 +228,9 @@
 		/obj/item/autopsy_scanner,
 		/obj/item/holosign_creator/atmos,
 		/obj/item/clothing/gloves/color/black/forensics,
-		/obj/item/rpd,
 		/obj/item/mod/control,
-		/obj/item/stamp
+		/obj/item/stamp,
+		/obj/item/melee/knuckleduster
 	)
 	// These items will NOT be preserved
 	var/list/do_not_preserve_items = list (

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -230,7 +230,10 @@
 		/obj/item/clothing/gloves/color/black/forensics,
 		/obj/item/mod/control,
 		/obj/item/stamp,
-		/obj/item/melee/knuckleduster
+		/obj/item/melee/knuckleduster,
+		/obj/item/melee/rapier,
+		/obj/item/storage/belt/rapier,
+		/obj/item/nuke_core
 	)
 	// These items will NOT be preserved
 	var/list/do_not_preserve_items = list (

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -233,7 +233,8 @@
 		/obj/item/melee/knuckleduster,
 		/obj/item/melee/rapier,
 		/obj/item/storage/belt/rapier,
-		/obj/item/nuke_core
+		/obj/item/nuke_core,
+		/obj/item/nuke_core_container
 	)
 	// These items will NOT be preserved
 	var/list/do_not_preserve_items = list (


### PR DESCRIPTION
## What Does This PR Do
Add every forgot high risk items on the list of items stored on cryo storage.
Also add up items such as stamps.

## Why It's Good For The Game
For once as a Ntr i don't need to ahelp the admins to get a new stamp back to be allowed to fax them in the first place.

## Testing
Spawned went into storage with my stamp, stamp was on the list, all gucci.

## Changelog
:cl:
tweak: Stamps, knuckleduster and captain rapier can be recovered from cryo storage
del: Delete RCD and RPD from cryo storage
/:cl: