### PR TITLE
Badass people can now execute again

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -170,13 +170,12 @@
 		return
 
 	if(flag)
-		if(user.zone_selected == "mouth")
-			if(HAS_TRAIT(user, TRAIT_BADASS))
+		if(user.zone_selected == "mouth") // Check if we are blowing smoke off of our own gun, otherwise we are trying to execute someone
+			if(target == user && HAS_TRAIT(user, TRAIT_BADASS))
 				user.visible_message("<span class='danger'>[user] blows smoke off of [src]'s barrel. What a badass.</span>")
 			else
 				handle_suicide(user, target, params)
 			return
-
 
 	//Exclude lasertag guns from the CLUMSY check.
 	if(clumsy_check)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -170,8 +170,8 @@
 		return
 
 	if(flag)
-		if(user.zone_selected == "mouth") // Check if we are blowing smoke off of our own gun, otherwise we are trying to execute someone
-			if(target == user && HAS_TRAIT(user, TRAIT_BADASS))
+		if(user.zone_selected == "mouth")
+			if(target == user && HAS_TRAIT(user, TRAIT_BADASS)) // Check if we are blowing smoke off of our own gun, otherwise we are trying to execute someone
 				user.visible_message("<span class='danger'>[user] blows smoke off of [src]'s barrel. What a badass.</span>")
 			else
 				handle_suicide(user, target, params)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Badass people are now allowed to execute people again.
Resolves #24525
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Execution is back in style this summer! All the other badass people are doing it, why not you??
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://github.com/ParadiseSS13/Paradise/assets/108773801/41259dae-5447-43d6-957a-cf641746f4ff)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
See above
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Badass people are now allowed to execute people again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
