### PR TITLE
ci: add maplints/fix matching stacked disposals/pipes

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/onehalf.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/onehalf.dmm
@@ -259,7 +259,6 @@
 /area/ruin/space/onehalf/hallway)
 "aM" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/door/poddoor{
 	id_tag = "bayint1";
 	name = "mining drone bay blast door"
@@ -639,23 +638,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel/airless,
 /area/ruin/space/onehalf/hallway)
 "bB" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "glass airlock"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/ruin/space/onehalf/drone_bay)
-"bC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -1643,7 +1630,7 @@ aD
 aq
 aX
 bm
-bC
+bn
 bT
 aa
 cn

--- a/_maps/map_files/stations/boxstation.dmm
+++ b/_maps/map_files/stations/boxstation.dmm
@@ -52970,7 +52970,6 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/disposalpipe/segment,
 /obj/structure/sign/securearea{
 	pixel_x = -32
 	},
@@ -74884,7 +74883,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
 "owP" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating/airless,
 /area/station/maintenance/asmaint)

--- a/_maps/map_files/stations/cerestation.dmm
+++ b/_maps/map_files/stations/cerestation.dmm
@@ -41296,9 +41296,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -64653,7 +64650,6 @@
 /turf/simulated/wall,
 /area/station/hallway/primary/aft/west)
 "nOU" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance/external{
 	name = "External Airlock Access"
 	},
@@ -84659,9 +84655,6 @@
 	name = "Engine Room"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;

--- a/_maps/map_files/stations/deltastation.dmm
+++ b/_maps/map_files/stations/deltastation.dmm
@@ -10843,7 +10843,6 @@
 /area/station/maintenance/incinerator)
 "aLk" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -11826,7 +11825,6 @@
 	},
 /area/station/service/bar)
 "aOd" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 10
 	},
@@ -70009,9 +70007,6 @@
 /area/station/command/office/hop)
 "gFa" = (
 /obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/delivery,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -82594,15 +82589,6 @@
 	},
 /area/station/security/prison/cell_block)
 "ont" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},

--- a/_maps/map_files/stations/metastation.dmm
+++ b/_maps/map_files/stations/metastation.dmm
@@ -71501,20 +71501,6 @@
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
-"oDZ" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/port)
 "oEe" = (
 /obj/machinery/atmospherics/trinary/filter{
 	dir = 4;
@@ -115239,7 +115225,7 @@ nBj
 cgt
 cdT
 wfa
-oDZ
+bqQ
 cCj
 cdT
 kNJ

--- a/tools/maplint/lints/stacked_matching_disposals.yml
+++ b/tools/maplint/lints/stacked_matching_disposals.yml
@@ -1,0 +1,4 @@
+/obj/structure/disposalpipe/segment:
+  banned_neighbors:
+    /obj/structure/disposalpipe/segment:
+      identical: true

--- a/tools/maplint/lints/stacked_matching_pipes.yml
+++ b/tools/maplint/lints/stacked_matching_pipes.yml
@@ -1,0 +1,9 @@
+/obj/machinery/atmospherics/pipe/simple/hidden:
+  banned_neighbors:
+    /obj/machinery/atmospherics/pipe/simple/hidden:
+      identical: true
+
+/obj/machinery/atmospherics/pipe/simple/visible:
+  banned_neighbors:
+    /obj/machinery/atmospherics/pipe/simple/visible:
+      identical: true


### PR DESCRIPTION
## What Does This PR Do
This PR adds maplints for duplicate stacked disposals and atmos pipes, and fixes same on several maps.
## Why It's Good For The Game
Map conformance.
## Images of changes
### Before
<details><summary>onehalf.dmm</summary>
![2024_04_13__14_30_20__paradise dme  onehalf dmm  - StrongDMM](https://github.com/ParadiseSS13/Paradise/assets/59303604/060cc35d-10eb-422e-9597-b3f75c1924e4)

![2024_04_13__14_30_32__paradise dme  onehalf dmm  - StrongDMM](https://github.com/ParadiseSS13/Paradise/assets/59303604/f7942cd6-f944-4f7f-8c22-e18b4e3e20e6)

![2024_04_13__14_30_43__paradise dme  onehalf dmm  - StrongDMM](https://github.com/ParadiseSS13/Paradise/assets/59303604/f72d04ea-da16-42d6-ba0d-fe8f3c23e16a)

</details>

<details><summary>Box</summary>

![2024_04_13__14_31_05__paradise dme  boxstation dmm  - StrongDMM](https://github.com/ParadiseSS13/Paradise/assets/59303604/ef2aa607-31cf-4bd7-9ab5-798770778959)

![2024_04_13__14_31_20__paradise dme  boxstation dmm  - StrongDMM](https://github.com/ParadiseSS13/Paradise/assets/59303604/d76ff270-7f47-4d2f-907f-8aa09f527fd6)

</details>

<details><summary>Cere</summary>

![2024_04_13__14_31_41__paradise dme  cerestation dmm  - StrongDMM](https://github.com/ParadiseSS13/Paradise/assets/59303604/34a5a376-e206-4bb9-b9f2-f70866ee1ae2)

![2024_04_13__14_32_00__paradise dme  cerestation dmm  - StrongDMM](https://github.com/ParadiseSS13/Paradise/assets/59303604/71e0c852-ab8d-4a7d-9f37-2e4e3a8e444f)

![2024_04_13__14_32_17__paradise dme  cerestation dmm  - StrongDMM](https://github.com/ParadiseSS13/Paradise/assets/59303604/e6140ae4-d94a-4433-b7a4-b511805abb21)

</details>

<details><summary>Delta</summary>


Fixed the other duplicate bullshit here:

![2024_04_13__14_32_45__paradise dme  deltastation dmm  - StrongDMM](https://github.com/ParadiseSS13/Paradise/assets/59303604/9280811c-2a56-43c3-b4fb-a0054b948999)

![2024_04_13__14_33_04__paradise dme  deltastation dmm  - StrongDMM](https://github.com/ParadiseSS13/Paradise/assets/59303604/d2534e55-0f9c-4fd9-afd9-c3847b2d1db1)

![2024_04_13__14_33_18__paradise dme  deltastation dmm  - StrongDMM](https://github.com/ParadiseSS13/Paradise/assets/59303604/ec1f9b16-895a-48ac-bf7d-554ec9371297)

![2024_04_13__14_33_33__paradise dme  deltastation dmm  - StrongDMM](https://github.com/ParadiseSS13/Paradise/assets/59303604/141e63a0-c84c-4c73-ae1a-8d60cebb0cde)

![2024_04_13__14_34_27__paradise dme  deltastation dmm  - StrongDMM](https://github.com/ParadiseSS13/Paradise/assets/59303604/1e1b6b2b-c18b-45db-b016-8a46b8cea722)


</details>

<details><summary>Meta</summary>

![2024_04_13__14_33_58__paradise dme  metastation dmm  - StrongDMM](https://github.com/ParadiseSS13/Paradise/assets/59303604/fb17ad16-105c-4edd-aef5-93dbf76c38cf)

</details>

## Testing
Ughghghghghghg

## Changelog
:cl:
fix: Duplicate disposals pipes and other items were fixed on several maps.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
