### PR TITLE
Merges the Janicart Floor Buffer into the Janiborg Floor Buffer

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -365,9 +365,10 @@
 
 /obj/item/borg/upgrade/floorbuffer
 	name = "janitor cyborg floor buffer upgrade"
-	desc = "A floor buffer upgrade kit that can be attached to janitor cyborgs."
+	desc = "A floor buffer upgrade kit that can be attached to janitor cyborgs and mobile janicarts."
 	icon = 'icons/obj/vehicles.dmi'
 	icon_state = "upgrade"
+	origin_tech = "materials=3;engineering=4"
 	require_module = TRUE
 	module_type = /obj/item/robot_module/janitor
 	/// How much speed the cyborg loses while the buffer is active

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -364,7 +364,7 @@
 /***********************/
 
 /obj/item/borg/upgrade/floorbuffer
-	name = "janitor cyborg floor buffer upgrade"
+	name = "janitorial floor buffer upgrade"
 	desc = "A floor buffer upgrade kit that can be attached to janitor cyborgs and mobile janicarts."
 	icon = 'icons/obj/vehicles.dmi'
 	icon_state = "upgrade"

--- a/code/modules/research/designs/janitorial_designs.dm
+++ b/code/modules/research/designs/janitorial_designs.dm
@@ -21,16 +21,6 @@
 	build_path = /obj/item/storage/bag/trash/bluespace
 	category = list("Janitorial")
 
-/datum/design/buffer
-	name = "Floor Buffer Upgrade"
-	desc = "A floor buffer that can be attached to vehicular janicarts."
-	id = "buffer"
-	req_tech = list("materials" = 4, "engineering" = 4)
-	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 3000, MAT_GLASS = 200)
-	build_path = /obj/item/janiupgrade
-	category = list("Janitorial")
-
 /datum/design/holosign
 	name = "Janitorial Holographic Sign Projector"
 	desc = "A holograpic projector used to project wet warning signs."

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -1125,7 +1125,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/borg/upgrade/floorbuffer
 	req_tech = list("materials" = 4, "engineering" = 4)
-	materials = list(MAT_METAL= 9000, MAT_GLASS= 7600)
+	materials = list(MAT_METAL = 9000, MAT_GLASS = 7600)
 	construction_time = 12 SECONDS
 	category = list("Cyborg Upgrade Modules")
 

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -1125,7 +1125,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/borg/upgrade/floorbuffer
 	req_tech = list("materials" = 4, "engineering" = 4)
-	materials = list(MAT_METAL=15000, MAT_GLASS=15000)
+	materials = list(MAT_METAL= 9000, MAT_GLASS= 7600)
 	construction_time = 12 SECONDS
 	category = list("Cyborg Upgrade Modules")
 

--- a/code/modules/vehicle/janivehicle.dm
+++ b/code/modules/vehicle/janivehicle.dm
@@ -43,13 +43,6 @@
 	desc = "A keyring with a small steel key, and a pink fob reading \"Pussy Wagon\"."
 	icon_state = "keyjanitor"
 
-/obj/item/janiupgrade
-	name = "floor buffer upgrade"
-	desc = "An upgrade for mobile janicarts."
-	icon = 'icons/obj/vehicles.dmi'
-	icon_state = "upgrade"
-	origin_tech = "materials=3;engineering=4"
-
 /datum/action/floor_buffer
 	name = "Toggle Floor Buffer"
 	desc = "Movement speed is decreased while active."
@@ -111,7 +104,7 @@
 		mybag = I
 		update_icon(UPDATE_OVERLAYS)
 		return
-	if(istype(I, /obj/item/janiupgrade))
+	if(istype(I, /obj/item/borg/upgrade/floorbuffer))
 		if(buffer_installed)
 			to_chat(user, fail_msg)
 			return


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
The janicart floor buffer upgrade has been removed. The janicart is now upgraded using the janiborg floor buffer.

The cost of the janiborg buffer has been adjusted to be the average of the old costs of the janiborg and janicart buffers.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Having two seemingly identical floor buffer upgrades that are mutually incompatible with each other is dumb. The janicart is made out of a dead janiborg, so it makes sense that a borg upgrade would work on it (as is the case with VTEC).
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Spawned in.
Saw there was no janicart buffer.
Added a janiborg buffer to the janicart. It worked.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
del: Removed the Janicart floor buffer item.
tweak: Janicarts now get their floor buffer from the janiborg buffer upgrade, available in robotics. Changed the cost of the janiborg upgrade.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
