### PR TITLE
Secures the Delta Kitchen's Exposed Area.

### DIFF
--- a/_maps/map_files/stations/deltastation.dmm
+++ b/_maps/map_files/stations/deltastation.dmm
@@ -19246,12 +19246,18 @@
 /area/station/hallway/primary/fore/south)
 "bhH" = (
 /obj/machinery/smartfridge,
-/obj/machinery/door/window/reinforced/normal{
-	dir = 8;
-	name = "kitchen ingrediant storage"
+/obj/effect/mapping_helpers/airlock/windoor/access/all/service/hydroponics{
+	dir = 8
 	},
 /obj/effect/mapping_helpers/airlock/windoor/access/all/service/hydroponics{
 	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/all/service/hydroponics{
+	dir = 8
+	},
+/obj/machinery/door/window/reinforced/reversed{
+	dir = 8;
+	name = "kitchen ingredient storage"
 	},
 /turf/simulated/floor/plasteel,
 /area/station/service/kitchen)

--- a/_maps/map_files/stations/deltastation.dmm
+++ b/_maps/map_files/stations/deltastation.dmm
@@ -18924,6 +18924,7 @@
 "bgB" = (
 /obj/effect/turf_decal/delivery/hollow,
 /obj/structure/table,
+/obj/item/reagent_containers/condiment/enzyme,
 /turf/simulated/floor/plasteel{
 	icon_state = "redfull"
 	},
@@ -19245,6 +19246,13 @@
 /area/station/hallway/primary/fore/south)
 "bhH" = (
 /obj/machinery/smartfridge,
+/obj/machinery/door/window/reinforced/normal{
+	dir = 8;
+	name = "kitchen ingrediant storage"
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/all/service/hydroponics{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/station/service/kitchen)
 "bhI" = (
@@ -19323,6 +19331,7 @@
 "bhR" = (
 /obj/effect/turf_decal/delivery/hollow,
 /obj/structure/table,
+/obj/item/food/snacks/mint,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -20746,8 +20755,6 @@
 /turf/simulated/floor/plasteel,
 /area/station/service/kitchen)
 "blk" = (
-/obj/item/food/snacks/mint,
-/obj/item/reagent_containers/condiment/enzyme,
 /obj/machinery/reagentgrinder,
 /obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
@@ -98417,7 +98424,9 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/window/reinforced/normal,
+/obj/machinery/door/window/reinforced/normal{
+	dir = 8
+	},
 /obj/effect/mapping_helpers/airlock/windoor/autoname,
 /obj/machinery/door/window/reinforced/normal{
 	dir = 1;


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Resolves #25020.

Provides an anti theft shield to the Delta kitchen's fridge, locked behind botany access. The fridge itself is still public, so anyone that has physically gained access to the inside of the kitchen can use it (say, if the chef got destroyed).
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Delta is the only station that allows random assistants to casually take all the food out of the fridge with zero effort. All other stations have the fridge secured inside a wall separating the kitchen and botany.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://github.com/ParadiseSS13/Paradise/assets/143041327/b2c21213-2335-497c-bb35-3917853b3c5a)
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Spawned in as botanist.
Opened and closed windoor.
Threw away ID.
Could not open windoor.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
add: Added an anti-theft windoor to the delta kitchen fridge.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
