### PR TITLE
[Meta] Fixes the tint button in Prisoner Processing.

### DIFF
--- a/_maps/map_files/stations/metastation.dmm
+++ b/_maps/map_files/stations/metastation.dmm
@@ -45501,6 +45501,7 @@
 	name = "processing tint control";
 	pixel_x = -6;
 	pixel_y = 24;
+	range = 4;
 	req_access_txt = "63"
 	},
 /obj/machinery/light_switch{


### PR DESCRIPTION
## What Does This PR Do
Fixes the tint button in Prisoner Processing on Meta.

## Why It's Good For The Game
If it ain't broke, don't fix it!

Wait, this *was* broke...

## Testing
Glass goes on. Glass goes off.

## Changelog
:cl:
fix: [Meta] Fixes the tint button in Prisoner Processing.
/:cl: