### PR TITLE
Removes an attempted <span> from a medbot line.

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -273,7 +273,7 @@
 /mob/living/simple_animal/bot/medbot/process_scan(mob/living/carbon/human/H)
 	if(buckled)
 		if((last_warning + 300) < world.time)
-			speak("<span class='danger'>Movement restrained! Unit on standby!</span>")
+			speak("Movement restrained! Unit on standby!")
 			playsound(loc, 'sound/machines/buzz-two.ogg', 50, FALSE)
 			last_warning = world.time
 		return


### PR DESCRIPTION
## What Does This PR Do
Removes an attempted `<span>` from a medbot line.

## Why It's Good For The Game
It looked like this:
![image](https://github.com/ParadiseSS13/Paradise/assets/98381/4fc485e3-b44b-439e-9e87-e947d183cb24)

## Testing
Yolo. (it compiles)

## Changelog
:cl:
fix: A rare medbot line no longer attempts to speak the forbidden tongue of HTML.
/:cl: