### PR TITLE
Fixes robotics brains not showing status of speaker on examine.

### DIFF
--- a/code/modules/mob/living/brain/robotic_brain.dm
+++ b/code/modules/mob/living/brain/robotic_brain.dm
@@ -158,8 +158,8 @@
 
 
 /obj/item/mmi/robotic_brain/examine(mob/user)
-	. += "Its speaker is turned [silenced ? "off" : "on"]."
 	. = ..()
+	. += "Its speaker is turned [silenced ? "off" : "on"]."
 
 	var/list/msg = list("<span class='info'>")
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
This PR fixes the oversight that makes it so robotic/positronic brains don't tell the examiner if the speaker is toggled on or off.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Bugs are bad, being a conscious brain with a disabled speaker is painful so making it easier for other people to tell if you're silenced is nice.

## Testing
<!-- How did you test the PR, if at all? -->
Gibbed a robit and Looked at the brain
## Changelog
:cl:
fix: Examining a robotic or positronic brain will tell you if the speaker is on or off.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
