### PR TITLE
Fixes the voice changer

### DIFF
--- a/code/game/objects/items/devices/voice_changer.dm
+++ b/code/game/objects/items/devices/voice_changer.dm
@@ -34,7 +34,7 @@
 		A.UpdateButtons()
 
 /obj/item/voice_changer/proc/set_voice(mob/user)
-	var/chosen_voice = input("What voice would you like to mimic? Leave this empty to use the voice on your ID card.", "Set Voice Changer", voice, user)
+	var/chosen_voice = tgui_input_text(user, "What voice would you like to mimic? Leave this empty to use the voice on your ID card.", "Set Voice Changer")
 	if(!chosen_voice)
 		voice = null
 		to_chat(user, "<span class='notice'>You are now mimicking the voice on your ID card.</span>")


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Allows you to select a voice to imitate again with the voice changer.
Fixes: #25054
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Voice changer should allow you to change your voice.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Get a chameleon mask.
Change the voice.
My voice is changed.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Voice changer voice can now be selected again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
