### PR TITLE
Halves the damage dealt by PKAs to blobs

### DIFF
--- a/code/modules/events/blob/theblob.dm
+++ b/code/modules/events/blob/theblob.dm
@@ -70,6 +70,11 @@ GLOBAL_LIST_EMPTY(blob_minions)
 /obj/structure/blob/blob_act(obj/structure/blob/B)
 	return
 
+/obj/structure/blob/bullet_act(obj/item/projectile/P)
+	if(istype(P, /obj/item/projectile/kinetic))
+		P.damage /= 2
+	. = ..()
+
 /obj/structure/blob/proc/Life()
 	return
 

--- a/code/modules/events/blob/theblob.dm
+++ b/code/modules/events/blob/theblob.dm
@@ -73,7 +73,7 @@ GLOBAL_LIST_EMPTY(blob_minions)
 /obj/structure/blob/bullet_act(obj/item/projectile/P)
 	if(istype(P, /obj/item/projectile/kinetic))
 		P.damage /= 2
-	. = ..()
+	return ..()
 
 /obj/structure/blob/proc/Life()
 	return


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes PKAs halve their damage if they hit blob tiles
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Currently, a single miner can be a **very** big nuiscance to a blob, either by Crusher to easily deal with blobbernauts (Which is decently okay with me, due to the risk of having to be in melee range) or using their infinite ammo PKA which will, by default, twoshot a normal blob tile, if in space/atmosless areas, which is true 90% of the time because the blob passively destroys the outer station walls.
This way, to 2-shot blob tiles, you'll need 2 damage mods at least, which heavily reduces the amount of recharge mods you can fit in it.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
I killed a blob tile in 4 hits
Used an edited variant with 2x the damage, killed it in 2 hits as it is on live
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: PKAs now deal half damage to blob tiles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
