### PR TITLE
Swaps most of the pens in the syndicate:tm: themed space ruins for syndi pens

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/listeningpost.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/listeningpost.dmm
@@ -551,7 +551,6 @@
 	info = "Nothing of interest to report.";
 	name = "november report"
 	},
-/obj/item/pen,
 /obj/item/tape,
 /obj/item/radio/intercom{
 	freerange = 1;
@@ -559,7 +558,7 @@
 	name = "intercom"
 	},
 /obj/item/paper_bin,
-/obj/item/pen,
+/obj/item/pen/multi/syndicate,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/syndicate_listening_station)

--- a/_maps/map_files/RandomRuins/SpaceRuins/mechtransport.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/mechtransport.dmm
@@ -523,7 +523,7 @@
 /obj/item/paper_bin{
 	pixel_x = -6
 	},
-/obj/item/pen,
+/obj/item/pen/multi/syndicate,
 /turf/simulated/floor/mineral/plastitanium,
 /area/ruin/space/mech_transport)
 "MA" = (

--- a/_maps/map_files/RandomRuins/SpaceRuins/moonoutpost19.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/moonoutpost19.dmm
@@ -5200,6 +5200,7 @@
 	},
 /obj/item/coin/antagtoken/syndicate,
 /obj/structure/table,
+/obj/item/pen/multi/syndicate,
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/ruin/space/moonbase19)
 "rk" = (

--- a/_maps/map_files/RandomRuins/SpaceRuins/syndicatedruglab.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/syndicatedruglab.dmm
@@ -98,11 +98,11 @@
 	pixel_x = 4
 	},
 /obj/item/paper/syndicate_druglab,
-/obj/item/pen,
 /obj/item/flashlight/lamp/green/off{
 	pixel_y = 12;
 	pixel_x = -6
 	},
+/obj/item/pen/multi/syndicate,
 /turf/simulated/floor/carpet/black,
 /area/ruin/space/syndicate_druglab)
 "qa" = (

--- a/_maps/map_files/RandomRuins/SpaceRuins/syndie_space_base.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/syndie_space_base.dmm
@@ -2985,7 +2985,7 @@
 	dir = 8
 	},
 /obj/item/hand_labeler,
-/obj/item/pen,
+/obj/item/pen/multi/syndicate,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "darkgreen"
@@ -3423,7 +3423,7 @@
 "th" = (
 /obj/structure/table,
 /obj/item/paper_bin,
-/obj/item/pen,
+/obj/item/pen/multi/syndicate,
 /obj/structure/extinguisher_cabinet{
 	name = "north bump";
 	pixel_y = 30
@@ -3760,7 +3760,7 @@
 /area/ruin/unpowered/syndicate_space_base/service)
 "vd" = (
 /obj/structure/table,
-/obj/item/pen,
+/obj/item/pen/multi/syndicate,
 /obj/item/paper_bin,
 /obj/item/stamp/syndicate,
 /obj/machinery/light_switch{
@@ -8462,7 +8462,7 @@
 	dir = 8
 	},
 /obj/item/hand_labeler,
-/obj/item/pen,
+/obj/item/pen/multi/syndicate,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "darkgreen"

--- a/_maps/map_files/RandomRuins/SpaceRuins/syndiecakesfactory.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/syndiecakesfactory.dmm
@@ -498,6 +498,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/item/pen/multi/syndicate,
 /turf/simulated/floor/engine,
 /area/ruin/space/unpowered)
 "tX" = (

--- a/_maps/map_files/RandomRuins/SpaceRuins/syndiedepot.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/syndiedepot.dmm
@@ -665,7 +665,7 @@
 "bV" = (
 /obj/structure/table,
 /obj/item/folder/syndicate/yellow,
-/obj/item/pen,
+/obj/item/pen/multi/syndicate,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Pretty much the title, replaces/adds the pens in the following space ruins with syndicate pens(not edaggers, the new syndi themed pen  #24756 added)

- Listening outpost
- Crashed mech transport shuttle (its cybersun not syndi but close enough)
- Moonbase 19, in the hidden syndi part
- Syndi drug lab
- Syndi research oupost
- Syndi cake factory
- Syndi supply depo

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Syndi pen in syndi places, makes sense
## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

![StrongDMM_4OL2wH0Uah](https://github.com/ParadiseSS13/Paradise/assets/96908085/b9180b3d-b93d-47c5-8c17-f5573c15221f)
these are different spots i swear
![StrongDMM_iP4dO2BLm9](https://github.com/ParadiseSS13/Paradise/assets/96908085/4fd49e73-7aff-4e62-9cee-b507c33ded3a)
![StrongDMM_1c8CJNoTgF](https://github.com/ParadiseSS13/Paradise/assets/96908085/edcca63d-41b0-46c1-88d6-bdd16c12b7af)
![StrongDMM_lyHlyoq7xz](https://github.com/ParadiseSS13/Paradise/assets/96908085/00e28a49-bd33-4019-8050-b8bc06a2b08e)
![StrongDMM_6UdkQrQMHy](https://github.com/ParadiseSS13/Paradise/assets/96908085/e6cf48cf-7aa6-4504-b609-628cedd815e4)
![StrongDMM_DxVwyx5Wie](https://github.com/ParadiseSS13/Paradise/assets/96908085/a2c2999f-842c-4c40-8e58-21897cccdb28)
![StrongDMM_PRVYOxtjCh](https://github.com/ParadiseSS13/Paradise/assets/96908085/0f728f3f-9f8a-479b-b2bc-e008493c863e)
![StrongDMM_ftxgHgwycK](https://github.com/ParadiseSS13/Paradise/assets/96908085/177bb7ef-b60a-440b-a03a-a64844cd5d0c)
![StrongDMM_iFeqY8cwbW](https://github.com/ParadiseSS13/Paradise/assets/96908085/4ca4e422-e331-4bef-81e6-d464c026b35e)
![StrongDMM_GIP0cHx5Yr](https://github.com/ParadiseSS13/Paradise/assets/96908085/29f4b1c6-8161-4121-9b5c-8f15263e2a70)

## Testing
<!-- How did you test the PR, if at all? -->
compiled, they're just a small path change
## Changelog
:cl:
add: Added the syndicate pen to the moonbase 19 space ruin, and syndi cake factory.
tweak: The new syndicate™ themed pen has been delivered to syndicate out coves and outposts. replacing the old ones, see pr for details.  
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
