### PR TITLE
Makes kudzu much more likely to entangle you

### DIFF
--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -8,6 +8,8 @@
 	var/creates_cover = FALSE
 	var/mob/living/climber
 	var/broken = FALSE
+	/// How long this takes to unbuckle yourself from.
+	var/unbuckle_time = 0 SECONDS
 
 /obj/structure/New()
 	..()

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -510,10 +510,15 @@
 	wither()
 
 /obj/structure/spacevine/Crossed(mob/crosser, oldloc)
-	if(isliving(crosser))
-		for(var/SM_type in mutations)
-			var/datum/spacevine_mutation/SM = mutations[SM_type]
-			SM.on_cross(src, crosser)
+	if(!isliving(crosser))
+		return
+	for(var/SM_type in mutations)
+		var/datum/spacevine_mutation/SM = mutations[SM_type]
+		SM.on_cross(src, crosser)
+
+
+	if(prob(30 * energy))
+		entangle(crosser)
 
 /obj/structure/spacevine/attack_hand(mob/user)
 	for(var/SM_type in mutations)

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -517,7 +517,6 @@
 		var/datum/spacevine_mutation/SM = mutations[SM_type]
 		SM.on_cross(src, crosser)
 
-
 	if(prob(30 * energy))
 		entangle(crosser)
 

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -395,6 +395,7 @@
 	mouse_opacity = MOUSE_OPACITY_OPAQUE //Clicking anywhere on the turf is good enough
 	pass_flags = PASSTABLE | PASSGRILLE
 	max_integrity = 50
+	unbuckle_time = 5 SECONDS
 	var/energy = 0
 	var/obj/structure/spacevine_controller/master = null
 	var/list/mutations = list()

--- a/code/modules/mob/living/carbon/carbon_procs.dm
+++ b/code/modules/mob/living/carbon/carbon_procs.dm
@@ -805,7 +805,15 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 /mob/living/carbon/resist_buckle()
 	INVOKE_ASYNC(src, PROC_REF(resist_muzzle))
 	var/obj/item/I = get_restraining_item()
-	if(!I) // If there is nothing to restrain him then he is not restrained
+	var/time = 0
+	if(!istype(I)) // If there is nothing to restrain him then he is not restrained
+		if(isstructure(buckled))
+			var/obj/structure/struct = buckled
+			time = struct.unbuckle_time
+	else
+		time = I.breakouttime
+
+	if(time == 0)
 		buckled.user_unbuckle_mob(src, src)
 		return
 
@@ -813,7 +821,7 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 		to_chat(src, "<span class='notice'>You are already trying to unbuckle!</span>")
 		return
 	apply_status_effect(STATUS_EFFECT_UNBUCKLE)
-	var/time = I.breakouttime
+
 	visible_message("<span class='warning'>[src] attempts to unbuckle [p_themselves()]!</span>",
 				"<span class='notice'>You attempt to unbuckle yourself... (This will take around [time / 10] seconds and you need to stay still.)</span>")
 	if(!do_after(src, time, FALSE, src, extra_checks = list(CALLBACK(src, PROC_REF(buckle_check)))))

--- a/code/modules/mob/living/carbon/carbon_procs.dm
+++ b/code/modules/mob/living/carbon/carbon_procs.dm
@@ -806,12 +806,11 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 	INVOKE_ASYNC(src, PROC_REF(resist_muzzle))
 	var/obj/item/I = get_restraining_item()
 	var/time = 0
-	if(!istype(I)) // If there is nothing to restrain him then he is not restrained
-		if(isstructure(buckled))
-			var/obj/structure/struct = buckled
-			time = struct.unbuckle_time
-	else
+	if(istype(I))
 		time = I.breakouttime
+	else if(isstructure(buckled))
+		var/obj/structure/struct = buckled
+		time = struct.unbuckle_time
 
 	if(time == 0)
 		buckled.user_unbuckle_mob(src, src)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Gives kudzu a chance to buckle you to it based on how well-grown it is. Unbuckling from kudzu takes five seconds per plant.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Currently, it really only buckles on spreading, which is a little rough. This should provide a disincentive for bumrushing kudzu
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Ran into vines, got stuck.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Kudzu now has a chance to buckle you when crossing it, and takes a bit of time to unbuckle yourself from.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
