### PR TITLE
Update Secondary Goals to accept reagents in fermenting barrels, etc..

### DIFF
--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -177,11 +177,11 @@
 			return CARGO_PREVENT_SHUTTLE
 		var/sellable = SEND_SIGNAL(src, COMSIG_CARGO_CHECK_SELL, AM)
 		manifest.items_to_sell[AM] = sellable
-		if(top_level && !(sellable & COMSIG_CARGO_IS_SECURED))
-			manifest.loose_cargo = TRUE
-		if(sellable & COMSIG_CARGO_SELL_PRIORITY)
-			if(top_level)
-				return CARGO_OK
+		if(top_level)
+			if(!AM.anchored && !(sellable & COMSIG_CARGO_IS_SECURED))
+				manifest.loose_cargo = TRUE
+			return CARGO_OK
+		if(found_priority || sellable & COMSIG_CARGO_SELL_PRIORITY)
 			return CARGO_HAS_PRIORITY
 
 	return CARGO_OK
@@ -220,9 +220,6 @@
 		if(E.is_cleanable())
 			return CARGO_OK
 
-	if(AM.anchored && !istype(AM, /obj/mecha/working))
-		return CARGO_SKIP_ATOM
-
 	return CARGO_OK
 
 
@@ -253,7 +250,7 @@
 			SSeconomy.sold_atoms += "[AM.name](mess)"
 			qdel_atoms += AM
 			continue
-		else if(!(sellable & COMSIG_CARGO_SELL_SKIP))
+		else if(!AM.anchored && !(sellable & COMSIG_CARGO_SELL_SKIP))
 			manifest.sent_trash = TRUE
 
 		rescue_atoms += AM
@@ -768,7 +765,7 @@
 
 /datum/economy/simple_seller/mechs/check_sell(obj/docking_port/mobile/supply/S, atom/movable/AM)
 	if(istype(AM, /obj/mecha/working))
-		return COMSIG_CARGO_SELL_NORMAL | COMSIG_CARGO_IS_SECURED
+		return COMSIG_CARGO_SELL_NORMAL
 
 
 // Skip mech parts to avoid complaining about them.

--- a/code/modules/station_goals/secondary/random_bulk_reagent.dm
+++ b/code/modules/station_goals/secondary/random_bulk_reagent.dm
@@ -67,16 +67,11 @@
 	return copy
 
 /datum/secondary_goal_progress/random_bulk_reagent/update(atom/movable/AM, datum/economy/cargo_shuttle_manifest/manifest = null)
-	// Not a reagent container? Ignore.
-	if(!istype(AM, /obj/item/reagent_containers))
-		return
-
 	// Not in a matching personal crate? Ignore.
 	if(!check_personal_crate(AM))
 		return
 
-	var/obj/item/reagent_containers/container = AM
-	var/amount = container.reagents?.get_reagent_amount(initial(reagent_type.id))
+	var/amount = AM.reagents?.get_reagent_amount(initial(reagent_type.id))
 	if(!amount)
 		return
 	sent += amount

--- a/code/modules/station_goals/secondary/science/random_ripley.dm
+++ b/code/modules/station_goals/secondary/science/random_ripley.dm
@@ -56,9 +56,8 @@
 	return copy
 
 /datum/secondary_goal_progress/random_ripley/update(atom/movable/AM, datum/economy/cargo_shuttle_manifest/manifest = null)
-	var/datum/component/label/goal/label = AM.GetComponent(/datum/component/label/goal)
 	// Not labelled for this goal? Ignore.
-	if(!istype(label) || label.label_name != goal_requester)
+	if(!check_personal_crate(AM))
 		return
 	if(!istype(AM, /obj/mecha/working/ripley))
 		return

--- a/code/modules/station_goals/secondary/secondary_goal_tracker.dm
+++ b/code/modules/station_goals/secondary/secondary_goal_tracker.dm
@@ -93,12 +93,16 @@
 	return FALSE
 
 /datum/secondary_goal_progress/proc/check_personal_crate(atom/movable/AM)
+	// Accept stuff that is properly labelled with a hand labeller.
+	var/datum/component/label/goal/label = AM.GetComponent(/datum/component/label/goal)
+	if(istype(label))
+		return !goal_requester || label.label_name == goal_requester
+
+	// Accept stuff in matching personal crates.
 	var/obj/structure/closet/crate/secure/personal/PC = get_atom_on_turf(AM, /obj/structure/closet/crate/secure/personal)
 	if(!istype(PC))
 		return FALSE
-	if(goal_requester && PC.registered_name != goal_requester)
-		return FALSE
-	return TRUE
+	return !goal_requester || PC.registered_name == goal_requester
 
 /datum/secondary_goal_progress/proc/three_way_reward(datum/economy/cargo_shuttle_manifest/manifest, department, department_account, reward, message)
 	SSblackbox.record_feedback("nested tally", "secondary goals", 1, list(goal_name, "payments made"))

--- a/code/modules/station_goals/secondary/variety_reagent.dm
+++ b/code/modules/station_goals/secondary/variety_reagent.dm
@@ -45,27 +45,22 @@
 	return copy
 
 /datum/secondary_goal_progress/variety_reagent/update(atom/movable/AM, datum/economy/cargo_shuttle_manifest/manifest = null)
-	// Not a reagent container? Ignore.
-	if(!istype(AM, /obj/item/reagent_containers))
-		return
-
 	// Not in a matching personal crate? Ignore.
 	if(!check_personal_crate(AM))
 		return
 
-	var/obj/item/reagent_containers/container = AM
 	// No reagents? Ignore.
-	if(!container.reagents.reagent_list)
+	if(!AM.reagents?.reagent_list)
 		return
 
-	var/datum/reagent/reagent = container.reagents?.get_master_reagent()
+	var/datum/reagent/reagent = AM.reagents.get_master_reagent()
 
 	// Make sure it's for our department.
 	if(!reagent || reagent.goal_department != department)
 		return
 
 	// Isolated reagents only, please.
-	if(length(container.reagents.reagent_list) != 1)
+	if(length(AM.reagents.reagent_list) != 1)
 		if(!manifest)
 			return COMSIG_CARGO_SELL_WRONG
 		SSblackbox.record_feedback("nested tally", "secondary goals", 1, list(goal_name, "mixed reagents"))


### PR DESCRIPTION
## What Does This PR Do
Update Secondary Goals to accept reagents in anything that contains reagents, notably fermenting barrels.

## Why It's Good For The Game
Ran into a bartender who thought this already worked.

## Testing
Sent reagents in fermenting barrels, got paid.

## Changelog
:cl:
tweak: Secondary Goals will now accept reagents in anything that contains reagents, notably fermenting barrels.
/:cl: