### PR TITLE
Add Variety of Food secondary goal, small tweaks.

### DIFF
--- a/code/__DEFINES/food_defines.dm
+++ b/code/__DEFINES/food_defines.dm
@@ -1,5 +1,13 @@
-// Used for secondary goals.
+/// Used for secondary goals.
+/// TOO easy, not accepted for variety goals.
 #define FOOD_GOAL_SKIP 0
+/// Easy food, ask for a lot for single goals.
 #define FOOD_GOAL_EASY 1
+/// Normal food, ask for a middling amount for single goals.
 #define FOOD_GOAL_NORMAL 2
+/// Hard reagent, ask for a little for single goals.
 #define FOOD_GOAL_HARD 3
+/// TOO hard, accepted for variety goals, but never used for single goals.
+#define FOOD_GOAL_EXCESSIVE 4
+/// Same as FOOD_GOAL_EXCESSIVE, just different name to indicate that there's another version of this food that's used in variety goals.
+#define FOOD_GOAL_DUPLICATE FOOD_GOAL_EXCESSIVE

--- a/code/__DEFINES/reagents_defines.dm
+++ b/code/__DEFINES/reagents_defines.dm
@@ -34,7 +34,13 @@
 #define BLOOD_TYPE_FAKE_BLOOD	"Vh Null"
 
 /// Used for secondary goals.
+/// TOO easy, not accepted for variety goals.
 #define REAGENT_GOAL_SKIP 0
+/// Easy reagent, ask for a lot for single goals.
 #define REAGENT_GOAL_EASY 1
+/// Normal reagent, ask for a middling amount for single goals.
 #define REAGENT_GOAL_NORMAL 2
+/// Hard reagent, ask for a little for single goals.
 #define REAGENT_GOAL_HARD 3
+/// TOO hard, accepted for variety goals, but never used for single goals.
+#define REAGENT_GOAL_EXCESSIVE 4

--- a/code/controllers/subsystem/SSeconomy.dm
+++ b/code/controllers/subsystem/SSeconomy.dm
@@ -68,6 +68,7 @@ SUBSYSTEM_DEF(economy)
 	var/credits_per_easy_food_goal = 300
 	var/credits_per_normal_food_goal = 450
 	var/credits_per_hard_food_goal = 600
+	var/credits_per_variety_food_goal = 450
 	var/credits_per_ripley_goal = 600
 	var/credits_per_kudzu_goal = 600
 	/// credits lost for sending unsecured cargo

--- a/code/modules/food_and_drinks/food/foods/baked_goods.dm
+++ b/code/modules/food_and_drinks/food/foods/baked_goods.dm
@@ -16,6 +16,7 @@
 	filling_color = "#FFD675"
 	list_reagents = list("nutriment" = 20, "oculine" = 10, "vitamin" = 5)
 	tastes = list("cake" = 5, "sweetness" = 2, "carrot" = 1)
+	goal_difficulty = FOOD_GOAL_DUPLICATE
 
 /obj/item/food/snacks/carrotcakeslice
 	name = "carrot cake slice"
@@ -39,6 +40,7 @@
 	bitesize = 3
 	list_reagents = list("protein" = 10, "nutriment" = 10, "mannitol" = 10, "vitamin" = 5)
 	tastes = list("cake" = 5, "sweetness" = 2, "brains" = 1)
+	goal_difficulty = FOOD_GOAL_DUPLICATE
 
 /obj/item/food/snacks/braincakeslice
 	name = "brain cake slice"
@@ -61,6 +63,7 @@
 	bitesize = 3
 	list_reagents = list("nutriment" = 20, "vitamin" = 5)
 	tastes = list("cake" = 4, "cream cheese" = 3)
+	goal_difficulty = FOOD_GOAL_DUPLICATE
 
 /obj/item/food/snacks/cheesecakeslice
 	name = "cheese cake slice"
@@ -83,6 +86,7 @@
 	filling_color = "#F7EDD5"
 	list_reagents = list("nutriment" = 20, "vitamin" = 5)
 	tastes = list("cake" = 5, "vanilla" = 1, "sweetness" = 2)
+	goal_difficulty = FOOD_GOAL_DUPLICATE
 
 /obj/item/food/snacks/plaincakeslice
 	name = "vanilla cake slice"
@@ -105,6 +109,7 @@
 	filling_color = "#FADA8E"
 	list_reagents = list("nutriment" = 20, "vitamin" = 5)
 	tastes = list("cake" = 5, "sweetness" = 2, "oranges" = 2)
+	goal_difficulty = FOOD_GOAL_DUPLICATE
 
 /obj/item/food/snacks/orangecakeslice
 	name = "orange cake slice"
@@ -127,6 +132,7 @@
 	filling_color = "#FADA8E"
 	list_reagents = list("nutriment" = 20, "vitamin" = 5)
 	tastes = list("cake" = 5, "sweetness" = 2, "banana" = 2)
+	goal_difficulty = FOOD_GOAL_DUPLICATE
 
 /obj/item/food/snacks/bananacakeslice
 	name = "banana cake slice"
@@ -149,6 +155,7 @@
 	filling_color = "#CBFA8E"
 	list_reagents = list("nutriment" = 20, "vitamin" = 5)
 	tastes = list("cake" = 5, "sweetness" = 2, "unbearable sourness" = 2)
+	goal_difficulty = FOOD_GOAL_DUPLICATE
 
 /obj/item/food/snacks/limecakeslice
 	name = "lime cake slice"
@@ -171,6 +178,7 @@
 	filling_color = "#FAFA8E"
 	list_reagents = list("nutriment" = 20, "vitamin" = 5)
 	tastes = list("cake" = 5, "sweetness" = 2, "sourness" = 2)
+	goal_difficulty = FOOD_GOAL_DUPLICATE
 
 /obj/item/food/snacks/lemoncakeslice
 	name = "lemon cake slice"
@@ -193,6 +201,7 @@
 	filling_color = "#805930"
 	list_reagents = list("nutriment" = 20, "vitamin" = 5)
 	tastes = list("cake" = 5, "sweetness" = 1, "chocolate" = 4)
+	goal_difficulty = FOOD_GOAL_DUPLICATE
 
 /obj/item/food/snacks/chocolatecakeslice
 	name = "chocolate cake slice"
@@ -215,6 +224,7 @@
 	bitesize = 3
 	list_reagents = list("nutriment" = 20, "sprinkles" = 10, "vitamin" = 5)
 	tastes = list("cake" = 5, "sweetness" = 1)
+	goal_difficulty = FOOD_GOAL_DUPLICATE
 
 /obj/item/food/snacks/birthdaycakeslice
 	name = "birthday cake slice"
@@ -237,6 +247,7 @@
 	filling_color = "#EBF5B8"
 	list_reagents = list("nutriment" = 20, "vitamin" = 5)
 	tastes = list("cake" = 5, "sweetness" = 1, "apple" = 1)
+	goal_difficulty = FOOD_GOAL_DUPLICATE
 
 /obj/item/food/snacks/applecakeslice
 	name = "apple cake slice"
@@ -369,6 +380,7 @@
 	filling_color = "#43DE18"
 	list_reagents = list("nutriment" = 10, "vitamin" = 2)
 	tastes = list("pie" = 1, "meat" = 1, "acid" = 1)
+	goal_difficulty = FOOD_GOAL_EXCESSIVE
 
 
 /obj/item/food/snacks/applepie

--- a/code/modules/food_and_drinks/food/foods/bread.dm
+++ b/code/modules/food_and_drinks/food/foods/bread.dm
@@ -13,6 +13,7 @@
 	filling_color = "#FF7575"
 	list_reagents = list("protein" = 20, "nutriment" = 10, "vitamin" = 5)
 	tastes = list("bread" = 10, "meat" = 10)
+	goal_difficulty = FOOD_GOAL_DUPLICATE
 
 /obj/item/food/snacks/meatbreadslice
 	name = "meatbread slice"
@@ -32,6 +33,7 @@
 	filling_color = "#8AFF75"
 	list_reagents = list("protein" = 20, "nutriment" = 10, "vitamin" = 5)
 	tastes = list("bread" = 10, "acid" = 10)
+	goal_difficulty = FOOD_GOAL_DUPLICATE
 
 /obj/item/food/snacks/xenomeatbreadslice
 	name = "xenomeatbread slice"
@@ -39,6 +41,7 @@
 	icon = 'icons/obj/food/burgerbread.dmi'
 	icon_state = "xenobreadslice"
 	filling_color = "#8AFF75"
+	goal_difficulty = FOOD_GOAL_EXCESSIVE
 
 /obj/item/food/snacks/sliceable/spidermeatbread
 	name = "spider meat loaf"
@@ -49,6 +52,7 @@
 	slices_num = 5
 	list_reagents = list("protein" = 20, "nutriment" = 10, "toxin" = 15, "vitamin" = 5)
 	tastes = list("bread" = 10, "cobwebs" = 5)
+	goal_difficulty = FOOD_GOAL_DUPLICATE
 
 /obj/item/food/snacks/spidermeatbreadslice
 	name = "spider meat bread slice"
@@ -57,6 +61,7 @@
 	icon_state = "spidermeatslice"
 	tastes = list("bread" = 10, "cobwebs" = 5)
 	list_reagents = list("toxin" = 2)
+	goal_difficulty = FOOD_GOAL_EXCESSIVE
 
 /obj/item/food/snacks/sliceable/bananabread
 	name = "banana-nut bread"
@@ -68,6 +73,7 @@
 	filling_color = "#EDE5AD"
 	list_reagents = list("banana" = 20, "nutriment" = 20)
 	tastes = list("bread" = 10, "banana" = 5)
+	goal_difficulty = FOOD_GOAL_DUPLICATE
 
 /obj/item/food/snacks/bananabreadslice
 	name = "banana-nut bread slice"
@@ -88,6 +94,7 @@
 	filling_color = "#F7FFE0"
 	list_reagents = list("nutriment" = 20, "vitamin" = 5)
 	tastes = list("bread" = 10, "tofu" = 10)
+	goal_difficulty = FOOD_GOAL_DUPLICATE
 
 /obj/item/food/snacks/tofubreadslice
 	name = "tofubread slice"
@@ -107,6 +114,7 @@
 	filling_color = "#FFE396"
 	list_reagents = list("nutriment" = 10)
 	tastes = list("bread" = 1)
+	goal_difficulty = FOOD_GOAL_DUPLICATE
 
 /obj/item/food/snacks/breadslice
 	name = "bread slice"
@@ -128,6 +136,7 @@
 	filling_color = "#FFF896"
 	list_reagents = list("nutriment" = 20, "vitamin" = 5)
 	tastes = list("bread" = 10, "cheese" = 10)
+	goal_difficulty = FOOD_GOAL_DUPLICATE
 
 /obj/item/food/snacks/creamcheesebreadslice
 	name = "cream cheese bread slice"
@@ -149,6 +158,7 @@
 	filling_color = "#6F0000"
 	list_reagents = list("nutriment" = 20, "vitamin" = 5)
 	tastes = list("heresy" = 10, "banana" = 10)
+	goal_difficulty = FOOD_GOAL_DUPLICATE
 
 /obj/item/food/snacks/banarnarbreadslice
 	name = "banarnarbread slice"
@@ -225,6 +235,7 @@
 	bitesize = 3
 	list_reagents = list("nutriment" = 3)
 	tastes = list("toast" = 1)
+	goal_difficulty = FOOD_GOAL_EXCESSIVE
 
 /obj/item/food/snacks/jelliedtoast
 	name = "jellied toast"

--- a/code/modules/food_and_drinks/food/foods/candy.dm
+++ b/code/modules/food_and_drinks/food/foods/candy.dm
@@ -125,6 +125,7 @@
 	filling_color = "#FFFFFF"
 	bitesize = 4
 	list_reagents = list("sugar" = 15)
+	goal_difficulty = FOOD_GOAL_DUPLICATE
 
 /obj/item/food/snacks/candy/candybar
 	name = "candy"
@@ -155,6 +156,7 @@
 	filling_color = "#FFFFFF"
 	bitesize = 3
 	list_reagents = list("sugar" = 10)
+	goal_difficulty = FOOD_GOAL_DUPLICATE
 
 /obj/item/food/snacks/candy/gummyworm
 	name = "gummy worm"
@@ -163,6 +165,7 @@
 	filling_color = "#FFFFFF"
 	bitesize = 3
 	list_reagents = list("sugar" = 10)
+	goal_difficulty = FOOD_GOAL_DUPLICATE
 
 /obj/item/food/snacks/candy/jellybean
 	name = "jelly bean"
@@ -171,6 +174,7 @@
 	filling_color = "#FFFFFF"
 	bitesize = 3
 	list_reagents = list("sugar" = 10)
+	goal_difficulty = FOOD_GOAL_DUPLICATE
 
 /obj/item/food/snacks/candy/jawbreaker
 	name = "jawbreaker"

--- a/code/modules/food_and_drinks/food/foods/frozen.dm
+++ b/code/modules/food_and_drinks/food/foods/frozen.dm
@@ -21,6 +21,7 @@
 	bitesize = 3
 	list_reagents = list("nutriment" = 20, "sugar" = 5, "vitamin" = 5, "banana" = 15)
 	tastes = list("cake" = 5, "sweetness" = 2, "banana" = 1, "sad clowns" = 1, "ice-cream" = 1)
+	goal_difficulty = FOOD_GOAL_EXCESSIVE
 
 /obj/item/food/snacks/frozen/clowncakeslice
 	name = "clown cake slice"
@@ -155,6 +156,7 @@
 	trash = /obj/item/reagent_containers/drinks/sillycup
 	list_reagents = list("water" = 10, "ice" = 5)
 	tastes = list("cold water" = 1)
+	goal_difficulty = FOOD_GOAL_DUPLICATE
 
 /obj/item/food/snacks/frozen/snowcone/apple
 	name = "apple snowcone"

--- a/code/modules/food_and_drinks/food/foods/meat.dm
+++ b/code/modules/food_and_drinks/food/foods/meat.dm
@@ -273,6 +273,7 @@
 	bitesize = 4
 	list_reagents = list("nutriment" = 6)
 	tastes = list("cobwebs" = 1, "the colour green" = 1)
+	goal_difficulty = FOOD_GOAL_EXCESSIVE
 
 /obj/item/food/snacks/boiledspiderleg
 	name = "boiled spider leg"
@@ -283,6 +284,7 @@
 	bitesize = 3
 	list_reagents = list("nutriment" = 3, "capsaicin" = 2)
 	tastes = list("cobwebs" = 1, "hot peppers" = 1)
+	goal_difficulty = FOOD_GOAL_EXCESSIVE
 
 /obj/item/food/snacks/wingfangchu
 	name = "wing fang chu"
@@ -293,6 +295,7 @@
 	filling_color = "#43DE18"
 	list_reagents = list("nutriment" = 6, "soysauce" = 5, "vitamin" = 2)
 	tastes = list("soy" = 1)
+	goal_difficulty = FOOD_GOAL_EXCESSIVE
 
 /obj/item/food/snacks/goliath_steak
 	name = "goliath steak"
@@ -303,6 +306,7 @@
 	trash = null
 	list_reagents = list("protein" = 6, "vitamin" = 2)
 	tastes = list("meat" = 1)
+	goal_difficulty = FOOD_GOAL_EXCESSIVE
 
 /obj/item/food/snacks/fried_vox
 	name = "Kentucky Fried Vox"
@@ -312,6 +316,7 @@
 	trash = /obj/item/trash/fried_vox
 	list_reagents = list("nutriment" = 3, "protein" = 5)
 	tastes = list("quills" = 1, "the shoal" = 1)
+	goal_difficulty = FOOD_GOAL_EXCESSIVE
 
 //////////////////////
 //		Cubes		//
@@ -542,6 +547,7 @@
 	slices_num = 6
 	list_reagents = list("protein" = 24, "nutriment" = 18, "vitamin" = 5)
 	tastes = list("turkey" = 2, "stuffing" = 2)
+	goal_difficulty = FOOD_GOAL_DUPLICATE
 
 /obj/item/food/snacks/turkeyslice
 	name = "turkey serving"

--- a/code/modules/food_and_drinks/food/foods/misc_food.dm
+++ b/code/modules/food_and_drinks/food/foods/misc_food.dm
@@ -277,6 +277,7 @@
 	bitesize = 3
 	list_reagents = list("slimejelly" = 5)
 	tastes = list("jelly" = 1)
+	goal_difficulty = FOOD_GOAL_EXCESSIVE
 
 /obj/item/food/snacks/popcorn
 	name = "popcorn"

--- a/code/modules/food_and_drinks/food/foods/pizza.dm
+++ b/code/modules/food_and_drinks/food/foods/pizza.dm
@@ -16,6 +16,7 @@
 	icon_state = "margheritapizza"
 	slice_path = /obj/item/food/snacks/margheritapizzaslice
 	list_reagents = list("nutriment" = 30, "tomatojuice" = 6, "vitamin" = 5)
+	goal_difficulty = FOOD_GOAL_DUPLICATE
 
 /obj/item/food/snacks/margheritapizzaslice
 	name = "margherita slice"
@@ -34,6 +35,7 @@
 	slice_path = /obj/item/food/snacks/meatpizzaslice
 	list_reagents = list("protein" = 30, "tomatojuice" = 6, "vitamin" = 8)
 	tastes = list("crust" = 1, "cheese" = 1, "meat" = 1)
+	goal_difficulty = FOOD_GOAL_DUPLICATE
 
 /obj/item/food/snacks/meatpizzaslice
 	name = "meat pizza slice"
@@ -52,6 +54,7 @@
 	slice_path = /obj/item/food/snacks/mushroompizzaslice
 	list_reagents = list("plantmatter" = 30, "vitamin" = 5)
 	tastes = list("crust" = 1, "cheese" = 1, "mushroom" = 1)
+	goal_difficulty = FOOD_GOAL_DUPLICATE
 
 /obj/item/food/snacks/mushroompizzaslice
 	name = "mushroom pizza slice"
@@ -70,6 +73,7 @@
 	slice_path = /obj/item/food/snacks/vegetablepizzaslice
 	list_reagents = list("plantmatter" = 25, "tomatojuice" = 6, "oculine" = 12, "vitamin" = 5)
 	tastes = list("crust" = 1, "tomato" = 1, "carrot" = 1, "vegetables" = 1)
+	goal_difficulty = FOOD_GOAL_DUPLICATE
 
 /obj/item/food/snacks/vegetablepizzaslice
 	name = "vegetable pizza slice"
@@ -88,6 +92,7 @@
 	slice_path = /obj/item/food/snacks/hawaiianpizzaslice
 	list_reagents = list("protein" = 15, "tomatojuice" = 6, "plantmatter" = 20, "pineapplejuice" = 6, "vitamin" = 5)
 	tastes = list("crust" = 1, "cheese" = 1, "pineapple" = 1)
+	goal_difficulty = FOOD_GOAL_DUPLICATE
 
 /obj/item/food/snacks/hawaiianpizzaslice
 	name = "hawaiian pizza slice"
@@ -107,6 +112,7 @@
 	list_reagents = list("nutriment" = 40, "vitamin" = 5) //More nutriment because carbs, but it's not any more vitaminicious
 	filling_color = "#ffe45d"
 	tastes = list("crust" = 1, "cheese" = 2, "pasta" = 1)
+	goal_difficulty = FOOD_GOAL_DUPLICATE
 
 /obj/item/food/snacks/macpizzaslice
 	name = "mac 'n' cheese pizza slice"
@@ -126,6 +132,7 @@
 	list_reagents = list("protein" = 30, "tomatojuice" = 6, "vitamin" = 8)
 	filling_color = "#ffe45d"
 	tastes = list("cheese" = 3, "pepperoni" = 3, "grease" = 1)
+	goal_difficulty = FOOD_GOAL_DUPLICATE
 
 /obj/item/food/snacks/pepperonipizzaslice
 	name = "pepperoni pizza slice"
@@ -143,6 +150,7 @@
 	icon_state = "cheesepizza"
 	slice_path = /obj/item/food/snacks/cheesepizzaslice
 	list_reagents = list("nutriment" = 40, "tomatojuice" = 6, "vitamin" = 5)
+	goal_difficulty = FOOD_GOAL_DUPLICATE
 
 /obj/item/food/snacks/cheesepizzaslice
 	name = "cheese pizza slice"
@@ -161,6 +169,7 @@
 	slice_path = /obj/item/food/snacks/donkpocketpizzaslice
 	list_reagents = list("nutriment" = 35, "tomatojuice" = 6, "vitamin" = 2, "weak_omnizine" = 6)
 	tastes = list("crust" = 1, "meat" = 1, "laziness" = 1)
+	goal_difficulty = FOOD_GOAL_DUPLICATE
 
 /obj/item/food/snacks/donkpocketpizzaslice
 	name = "donk-pocket pizza slice"
@@ -179,6 +188,7 @@
 	slice_path = /obj/item/food/snacks/dankpizzaslice
 	list_reagents = list("nutriment" = 30, "tomatojuice" = 6, "vitamin" = 5, "cbd" = 6, "thc" = 6)
 	tastes = list("crust" = 1, "cheese" = 1, "special herbs" = 2)
+	goal_difficulty = FOOD_GOAL_DUPLICATE
 
 /obj/item/food/snacks/dankpizzaslice
 	name = "dank pizza slice"
@@ -197,6 +207,7 @@
 	slice_path = /obj/item/food/snacks/firecrackerpizzaslice
 	list_reagents = list("nutriment" = 30, "vitamin" = 5, "capsaicin" = 12)
 	tastes = list("crust" = 1, "cheese" = 1, "HOTNESS" = 1)
+	goal_difficulty = FOOD_GOAL_DUPLICATE
 
 /obj/item/food/snacks/firecrackerpizzaslice
 	name = "firecracker pizza slice"
@@ -215,6 +226,7 @@
 	slice_path = /obj/item/food/snacks/pestopizzaslice
 	list_reagents = list("nutriment" = 30, "tomatojuice" = 12, "vitamin" = 5, "wasabi" = 12)
 	tastes = list("tomato" = 1, "cheese" = 1, "wasabi" = 1)
+	goal_difficulty = FOOD_GOAL_DUPLICATE
 
 /obj/item/food/snacks/pestopizzaslice
 	name = "\"pesto\" pizza slice"
@@ -233,6 +245,7 @@
 	slice_path = /obj/item/food/snacks/garlicpizzaslice
 	list_reagents = list("plantmatter" = 30, "vitamin" = 5, "garlic" = 12)
 	tastes = list("crust" = 1, "cheese" = 1, "garlic" = 1)
+	goal_difficulty = FOOD_GOAL_DUPLICATE
 
 /obj/item/food/snacks/garlicpizzaslice
 	name = "garlic pizza slice"

--- a/code/modules/food_and_drinks/food/foods/sandwiches.dm
+++ b/code/modules/food_and_drinks/food/foods/sandwiches.dm
@@ -29,6 +29,7 @@
 	bitesize = 3
 	list_reagents = list("nutriment" = 6, "prions" = 10, "vitamin" = 1)
 	tastes = list("bun" = 4, "brains" = 2)
+	goal_difficulty = FOOD_GOAL_EXCESSIVE
 
 /obj/item/food/snacks/burger/ghost
 	name = "ghost burger"
@@ -38,6 +39,7 @@
 	bitesize = 3
 	list_reagents = list("nutriment" = 6, "vitamin" = 1)
 	tastes = list("bun" = 4, "ectoplasm" = 2)
+	goal_difficulty = FOOD_GOAL_EXCESSIVE
 
 /obj/item/food/snacks/human
 	var/hname = ""
@@ -93,6 +95,7 @@
 	bitesize = 3
 	list_reagents = list("nutriment" = 6, "vitamin" = 1)
 	tastes = list("bun" = 4, "acid" = 4)
+	goal_difficulty = FOOD_GOAL_EXCESSIVE
 
 /obj/item/food/snacks/burger/clown
 	name = "clown burger"
@@ -102,6 +105,7 @@
 	bitesize = 3
 	list_reagents = list("nutriment" = 6, "vitamin" = 1)
 	tastes = list("bun" = 4, "banana" = 1, "magic" = 2)
+	goal_difficulty = FOOD_GOAL_EXCESSIVE
 
 /obj/item/food/snacks/burger/mime
 	name = "mime burger"
@@ -111,6 +115,7 @@
 	bitesize = 3
 	list_reagents = list("nutriment" = 6, "vitamin" = 1)
 	tastes = list("bun" = 4, "silence" = 2)
+	goal_difficulty = FOOD_GOAL_EXCESSIVE
 
 /obj/item/food/snacks/burger/baseball
 	name = "home run baseball burger"
@@ -120,6 +125,7 @@
 	bitesize = 3
 	list_reagents = list("nutriment" = 6, "vitamin" = 1)
 	tastes = list("bun" = 4, "a homerun" = 3)
+	goal_difficulty = FOOD_GOAL_EXCESSIVE
 
 /obj/item/food/snacks/burger/spell
 	name = "spell burger"
@@ -129,6 +135,7 @@
 	bitesize = 3
 	list_reagents = list("nutriment" = 6, "vitamin" = 1)
 	tastes = list("bun" = 4, "magic" = 2)
+	goal_difficulty = FOOD_GOAL_EXCESSIVE
 
 /obj/item/food/snacks/burger/bigbite
 	name = "BigBite burger"
@@ -148,6 +155,7 @@
 	bitesize = 7
 	list_reagents = list("nutriment" = 40, "vitamin" = 5)
 	tastes = list("bun" = 4, "meat" = 2, "cheese" = 2, "type two diabetes" = 10)
+	goal_difficulty = FOOD_GOAL_HARD
 
 /obj/item/food/snacks/burger/crazy
 	name = "crazy hamburger"
@@ -157,6 +165,7 @@
 	bitesize = 3
 	list_reagents = list("nutriment" = 10, "vitamin" = 2, "capsaicin" = 3, "condensedcapsaicin" = 2)
 	tastes = list("bun" = 2, "meat" = 4, "cheese" = 2, "beef soaked in chili" = 3, "a smoking flare" = 2)
+	goal_difficulty = FOOD_GOAL_EXCESSIVE
 
 /obj/item/food/snacks/burger/ppatty/white
 	name = "white pretty patty"
@@ -285,6 +294,7 @@
 	bitesize = 3
 	list_reagents = list("nutriment" = 3, "protein" = 6, "vitamin" = 2)
 	tastes = list("bun" = 1, "meat" = 1, "salmon" = 1)
+	goal_difficulty = FOOD_GOAL_EXCESSIVE
 
 /obj/item/food/snacks/burger/fivealarm
 	name = "five alarm burger"
@@ -393,6 +403,7 @@
 	icon_state = "notasandwich"
 	list_reagents = list("nutriment" = 6, "vitamin" = 6)
 	tastes = list("nothing suspicious" = 1)
+	goal_difficulty = FOOD_GOAL_EXCESSIVE
 
 /obj/item/food/snacks/wrap
 	name = "egg wrap"

--- a/code/modules/food_and_drinks/food/foods/sandwiches.dm
+++ b/code/modules/food_and_drinks/food/foods/sandwiches.dm
@@ -29,7 +29,6 @@
 	bitesize = 3
 	list_reagents = list("nutriment" = 6, "prions" = 10, "vitamin" = 1)
 	tastes = list("bun" = 4, "brains" = 2)
-	goal_difficulty = FOOD_GOAL_EXCESSIVE
 
 /obj/item/food/snacks/burger/ghost
 	name = "ghost burger"

--- a/code/modules/food_and_drinks/food/foods/seafood.dm
+++ b/code/modules/food_and_drinks/food/foods/seafood.dm
@@ -149,6 +149,7 @@
 	bitesize = 3
 	list_reagents = list("nutriment" = 8)
 	tastes = list("shrimp" = 1, "rice" = 1, "seaweed" = 1)
+	goal_difficulty = FOOD_GOAL_DUPLICATE
 
 /obj/item/food/snacks/sushi_Ebi
 	name = "ebi sushi"
@@ -170,6 +171,7 @@
 	bitesize = 3
 	list_reagents = list("nutriment" = 8, "protein" = 4)
 	tastes = list("salmon roe" = 1, "rice" = 1, "seaweed" = 1)
+	goal_difficulty = FOOD_GOAL_DUPLICATE
 
 /obj/item/food/snacks/sushi_Ikura
 	name = "ikura sushi"
@@ -191,6 +193,7 @@
 	bitesize = 3
 	list_reagents = list("nutriment" = 8)
 	tastes = list("raw salmon" = 1, "rice" = 1, "seaweed" = 1)
+	goal_difficulty = FOOD_GOAL_DUPLICATE
 
 /obj/item/food/snacks/sushi_Sake
 	name = "sake sushi"
@@ -212,6 +215,7 @@
 	bitesize = 3
 	list_reagents = list("nutriment" = 8)
 	tastes = list("smoked salmon" = 1, "rice" = 1, "seaweed" = 1)
+	goal_difficulty = FOOD_GOAL_DUPLICATE
 
 /obj/item/food/snacks/sushi_SmokedSalmon
 	name = "smoked salmon sushi"
@@ -233,6 +237,7 @@
 	bitesize = 3
 	list_reagents = list("nutriment" = 8)
 	tastes = list("egg" = 1, "rice" = 1, "seaweed" = 1)
+	goal_difficulty = FOOD_GOAL_DUPLICATE
 
 /obj/item/food/snacks/sushi_Tamago
 	name = "tamago sushi"
@@ -254,6 +259,7 @@
 	bitesize = 3
 	list_reagents = list("nutriment" = 8)
 	tastes = list("fried tofu" = 1, "rice" = 1, "seaweed" = 1)
+	goal_difficulty = FOOD_GOAL_DUPLICATE
 
 /obj/item/food/snacks/sushi_Inari
 	name = "inari sushi"
@@ -275,6 +281,7 @@
 	bitesize = 3
 	list_reagents = list("nutriment" = 8, "protein" = 4)
 	tastes = list("goldfish roe" = 1, "rice" = 1, "seaweed" = 1)
+	goal_difficulty = FOOD_GOAL_DUPLICATE
 
 /obj/item/food/snacks/sushi_Masago
 	name = "masago sushi"
@@ -296,6 +303,7 @@
 	bitesize = 3
 	list_reagents = list("nutriment" = 8, "protein" = 4)
 	tastes = list("shark roe" = 1, "rice" = 1, "seaweed" = 1)
+	goal_difficulty = FOOD_GOAL_DUPLICATE
 
 /obj/item/food/snacks/sushi_Tobiko
 	name = "tobiko sushi"
@@ -317,6 +325,7 @@
 	bitesize = 3
 	list_reagents = list("nutriment" = 8, "protein" = 4)
 	tastes = list("shark roe" = 1, "rice" = 1, "egg" = 1, "seaweed" = 1)
+	goal_difficulty = FOOD_GOAL_DUPLICATE
 
 /obj/item/food/snacks/sushi_TobikoEgg
 	name = "tobiko and egg sushi"
@@ -338,6 +347,7 @@
 	bitesize = 3
 	list_reagents = list("nutriment" = 8)
 	tastes = list("catfish" = 1, "rice" = 1, "seaweed" = 1)
+	goal_difficulty = FOOD_GOAL_DUPLICATE
 
 /obj/item/food/snacks/sushi_Tai
 	name = "tai sushi"

--- a/code/modules/food_and_drinks/food/foods/soups.dm
+++ b/code/modules/food_and_drinks/food/foods/soups.dm
@@ -47,6 +47,7 @@
 	filling_color = "#C4FBFF"
 	list_reagents = list("nutriment" = 4, "banana" = 5, "water" = 5, "vitamin" = 8)
 	tastes = list("a bad joke" = 1)
+	goal_difficulty = FOOD_GOAL_EXCESSIVE
 
 /obj/item/food/snacks/soup/vegetablesoup
 	name = "vegetable soup"
@@ -317,3 +318,4 @@
 	filling_color = "#FF3C00"
 	list_reagents = list("nutriment" = 5, "tomatojuice" = 2, "protein" = 2)
 	tastes = list("tomato" = 1, "chili" = 1, "meat" = 1, "sad clowns" = 4)
+	goal_difficulty = FOOD_GOAL_EXCESSIVE

--- a/code/modules/food_and_drinks/food_base.dm
+++ b/code/modules/food_and_drinks/food_base.dm
@@ -29,9 +29,9 @@
 	var/temperature_min = 0 // To limit the temperature of a reagent container can attain when exposed to heat/cold
 	var/temperature_max = 10000
 
-	// How difficult is this food for the kitchen to make?
-	// Affects the quantity of food that is requested by CC.
-	var/goal_difficulty = REAGENT_GOAL_SKIP
+	/// How difficult is this food for the kitchen to make?
+	/// Affects the quantity of food that is requested by CC.
+	var/goal_difficulty = FOOD_GOAL_SKIP
 
 /obj/item/food/Initialize(mapload)
 	. = ..()

--- a/code/modules/reagents/chemistry/reagents/alcohol.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol.dm
@@ -163,7 +163,7 @@
 	drink_name = "Glass of Mojito"
 	drink_desc = "Fresh from Spesscuba."
 	taste_description = "mojito"
-	goal_difficulty = REAGENT_GOAL_EASY
+	goal_difficulty = REAGENT_GOAL_NORMAL
 
 /datum/reagent/consumable/ethanol/vodka
 	name = "Vodka"
@@ -776,7 +776,7 @@
 	drink_name = "Demons Blood"
 	drink_desc = "Just looking at this thing makes the hair at the back of your neck stand up."
 	taste_description = "<span class='warning'>evil</span>"
-	goal_difficulty = REAGENT_GOAL_EASY
+	goal_difficulty = REAGENT_GOAL_HARD
 
 /datum/reagent/consumable/ethanol/vodkatonic
 	name = "Vodka and Tonic"
@@ -1529,7 +1529,7 @@
 	drink_desc = "A sawed-off cola bottle filled with Fernet Cola. You can hear cuarteto music coming from the inside."
 	taste_description = "low class heaven"
 	remove_nutrition = 1
-	goal_difficulty = REAGENT_GOAL_EASY
+	goal_difficulty = REAGENT_GOAL_EXCESSIVE
 
 /datum/reagent/consumable/ethanol/gimlet
 	name = "Gimlet"
@@ -1553,7 +1553,7 @@
 	drink_name = "Sidecar"
 	drink_desc = "You can smell the citrus from here!"
 	taste_description = "smooth cognac and tart citrus"
-	goal_difficulty = REAGENT_GOAL_HARD
+	goal_difficulty = REAGENT_GOAL_EASY
 
 /datum/reagent/consumable/ethanol/whiskey_sour
 	name = "Whiskey Sour"
@@ -1577,7 +1577,7 @@
 	drink_name = "Mint Julep"
 	drink_desc = "A dainty glass of whiskey and mint on the rocks. Perfect for summer!"
 	taste_description = "sweet and cooling mint"
-	goal_difficulty = REAGENT_GOAL_EASY
+	goal_difficulty = REAGENT_GOAL_NORMAL
 
 /datum/reagent/consumable/ethanol/pina_colada
 	name = "Pina Colada"

--- a/code/modules/reagents/chemistry/reagents/drugs.dm
+++ b/code/modules/reagents/chemistry/reagents/drugs.dm
@@ -453,7 +453,7 @@
 	taste_description = "WAAAAGH"
 	var/bonus_damage = 2
 	goal_department = "Science"
-	goal_difficulty = REAGENT_GOAL_HARD
+	goal_difficulty = REAGENT_GOAL_EXCESSIVE
 
 /datum/reagent/bath_salts/on_mob_add(mob/living/L)
 	if(ishuman(L))

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -296,8 +296,8 @@
 
 	var/msg = "<center>---[station_time_timestamp()]---</center><br>"
 
-	var/list/credit_changes = new
-	var/list/department_messages = new
+	var/list/credit_changes = list()
+	var/list/department_messages = list()
 	for(var/datum/economy/line_item/item in manifest.line_items)
 		if(!credit_changes[item.account])
 			credit_changes[item.account] = 0
@@ -329,7 +329,7 @@
 			GLOB.station_money_database.charge_account(account, -credit_changes[account], "Supply Shuttle Fine", "Central Command Supply Master", allow_overdraft = TRUE, supress_log = FALSE)
 
 	for(var/department in department_messages)
-		var/list/rc_message = new
+		var/list/rc_message = list()
 		for(var/message_piece in department_messages[department])
 			var/count = ""
 			if(department_messages[department][message_piece] > 1)
@@ -810,7 +810,6 @@
 	var/credits
 	var/reason
 	var/zero_is_good = FALSE
-
 
 #undef MAX_CRATE_DELIVERY
 

--- a/code/modules/station_goals/secondary/botany/kudzu_goal.dm
+++ b/code/modules/station_goals/secondary/botany/kudzu_goal.dm
@@ -86,6 +86,6 @@
 	if(sent < needed)
 		return
 
-	three_way_reward(manifest, "Hydroponics", GLOB.station_money_database.get_account_by_department(DEPARTMENT_SERVICE), SSeconomy.credits_per_kudzu_goal,  "Secondary goal complete: [needed] samples of kudzu seeds.")
+	three_way_reward(manifest, "Hydroponics", GLOB.station_money_database.get_account_by_department(DEPARTMENT_SERVICE), SSeconomy.credits_per_kudzu_goal, "Secondary goal complete: [needed] samples of kudzu seeds.")
 
 	return TRUE

--- a/code/modules/station_goals/secondary/botany/kudzu_goal.dm
+++ b/code/modules/station_goals/secondary/botany/kudzu_goal.dm
@@ -65,6 +65,7 @@
 		item.account = GLOB.station_money_database.get_account_by_department(DEPARTMENT_SERVICE)
 		item.credits = 0
 		item.reason = "[AM] does not have the right traits."
+		item.requests_console_department = "Hydroponics"
 		manifest.line_items += item
 		return COMSIG_CARGO_SELL_WRONG
 
@@ -79,27 +80,12 @@
 		update_item.credits = 0
 		update_item.zero_is_good = TRUE
 		update_item.reason = "Received [sent_this_shipment] useful samples of kudzu seeds."
+		update_item.requests_console_department = "Hydroponics"
 		manifest.line_items += update_item
 
 	if(sent < needed)
 		return
 
-	var/datum/economy/line_item/supply_item = new
-	supply_item.account = SSeconomy.cargo_account
-	supply_item.credits = SSeconomy.credits_per_kudzu_goal / 3
-	supply_item.reason = "Secondary goal complete: [needed] samples of kudzu seeds."
-	manifest.line_items += supply_item
-
-	var/datum/economy/line_item/department_item = new
-	department_item.account = GLOB.station_money_database.get_account_by_department(DEPARTMENT_SERVICE)
-	department_item.credits = SSeconomy.credits_per_kudzu_goal / 3
-	department_item.reason = "Secondary goal complete: [needed] samples of kudzu seeds."
-	manifest.line_items += department_item
-
-	var/datum/economy/line_item/personal_item = new
-	personal_item.account = personal_account || department_item.account
-	personal_item.credits = SSeconomy.credits_per_kudzu_goal / 3
-	personal_item.reason = "Secondary goal complete: [needed] samples of kudzu seeds."
-	manifest.line_items += personal_item
+	three_way_reward(manifest, "Hydroponics", GLOB.station_money_database.get_account_by_department(DEPARTMENT_SERVICE), SSeconomy.credits_per_kudzu_goal,  "Secondary goal complete: [needed] samples of kudzu seeds.")
 
 	return TRUE

--- a/code/modules/station_goals/secondary/kitchen/random_bulk_food.dm
+++ b/code/modules/station_goals/secondary/kitchen/random_bulk_food.dm
@@ -13,6 +13,8 @@
 		var/obj/item/food/snacks/candidate = S
 		if(initial(candidate.goal_difficulty) == FOOD_GOAL_SKIP)
 			continue
+		if(initial(candidate.goal_difficulty) == FOOD_GOAL_EXCESSIVE)
+			continue
 		valid_food += candidate
 
 	if(!valid_food)
@@ -83,6 +85,7 @@
 		update_item.credits = 0
 		update_item.zero_is_good = TRUE
 		update_item.reason = "Received [sent_this_shipment] servings of [initial(food_type.name)]."
+		update_item.requests_console_department = "Kitchen"
 		manifest.line_items += update_item
 
 	if(sent < needed)

--- a/code/modules/station_goals/secondary/kitchen/variety_food.dm
+++ b/code/modules/station_goals/secondary/kitchen/variety_food.dm
@@ -50,7 +50,7 @@
 	copy.generic_name_plural = generic_name_plural
 	return copy
 
-/datum/secondary_goal_progress/variety_food/update(/obj/item/food/food, datum/economy/cargo_shuttle_manifest/manifest = null)
+/datum/secondary_goal_progress/variety_food/update(obj/item/food/food, datum/economy/cargo_shuttle_manifest/manifest = null)
 	// Not in a matching personal crate? Ignore.
 	if(!check_personal_crate(food))
 		return

--- a/code/modules/station_goals/secondary/kitchen/variety_food.dm
+++ b/code/modules/station_goals/secondary/kitchen/variety_food.dm
@@ -1,13 +1,13 @@
 /datum/station_goal/secondary/variety_food
 	name = "Variety of Food"
 	progress_type = /datum/secondary_goal_progress/variety_food
+	department = "Kitchen"
+	abstract = FALSE
 	var/different_types = 10
 	var/amount_per = 3
 	var/department_account
 	var/generic_name_plural = "dishes"
 	var/reward
-	department = "Kitchen"
-	abstract = FALSE
 
 /datum/station_goal/secondary/variety_food/randomize_params()
 	..()

--- a/code/modules/station_goals/secondary/kitchen/variety_food.dm
+++ b/code/modules/station_goals/secondary/kitchen/variety_food.dm
@@ -19,7 +19,6 @@
 	..()
 	admin_desc = "[amount_per] units of [different_types] [generic_name_plural]"
 
-
 /datum/secondary_goal_progress/variety_food
 	var/list/foods_sent = list()
 	var/department
@@ -51,16 +50,14 @@
 	copy.generic_name_plural = generic_name_plural
 	return copy
 
-/datum/secondary_goal_progress/variety_food/update(atom/movable/AM, datum/economy/cargo_shuttle_manifest/manifest = null)
+/datum/secondary_goal_progress/variety_food/update(/obj/item/food/food, datum/economy/cargo_shuttle_manifest/manifest = null)
 	// Not in a matching personal crate? Ignore.
-	if(!check_personal_crate(AM))
+	if(!check_personal_crate(food))
 		return
 
 	// Not food? Ignore.
-	if(!istype(AM, /obj/item/food))
+	if(!istype(food))
 		return
-
-	var/obj/item/food/food = AM
 
 	// No easy foods allowed.
 	if(food.goal_difficulty == FOOD_GOAL_SKIP)
@@ -94,9 +91,8 @@
 	if(!manifest)
 		return COMSIG_CARGO_SELL_PRIORITY
 	SSblackbox.record_feedback("nested tally", "secondary goals", 1, list(goal_name, "valid foods"))
-	var/obj/item/food/food_type = food.type
-	SSblackbox.record_feedback("nested tally", "secondary goals", 1, list(goal_name, "foods", initial(food_type.name)))
-	var/datum/economy/line_item/item = new
+	SSblackbox.record_feedback("nested tally", "secondary goals", 1, list(goal_name, "foods", initial(food.name)))
+	var/datum/economy/line_item/item = new()
 	item.account = department_account
 	item.credits = 0
 	item.reason = "Received [initial(food.name)]."

--- a/code/modules/station_goals/secondary/kitchen/variety_food.dm
+++ b/code/modules/station_goals/secondary/kitchen/variety_food.dm
@@ -1,0 +1,119 @@
+/datum/station_goal/secondary/variety_food
+	name = "Variety of Food"
+	progress_type = /datum/secondary_goal_progress/variety_food
+	var/different_types = 10
+	var/amount_per = 3
+	var/department_account
+	var/generic_name_plural = "dishes"
+	var/reward
+	department = "Kitchen"
+	abstract = FALSE
+
+/datum/station_goal/secondary/variety_food/randomize_params()
+	..()
+	department_account = GLOB.station_money_database.get_account_by_department(DEPARTMENT_SERVICE)
+	report_message = "We're holding a fundraising banquet, and we need a suitable spread of food for it. Send us at least [amount_per] servings of [different_types] different dishes."
+
+/datum/station_goal/secondary/variety_food/Initialize(requester_account)
+	reward = SSeconomy.credits_per_variety_food_goal
+	..()
+	admin_desc = "[amount_per] units of [different_types] [generic_name_plural]"
+
+
+/datum/secondary_goal_progress/variety_food
+	var/list/foods_sent = list()
+	var/department
+	var/needed
+	var/amount_per
+	var/department_account
+	var/reward
+	var/generic_name_plural
+
+/datum/secondary_goal_progress/variety_food/configure(datum/station_goal/secondary/variety_food/goal)
+	..()
+	department = goal.department
+	needed = goal.different_types
+	amount_per = goal.amount_per
+	department_account = goal.department_account
+	reward = goal.reward
+	generic_name_plural = goal.generic_name_plural
+
+/datum/secondary_goal_progress/variety_food/Copy()
+	var/datum/secondary_goal_progress/variety_food/copy = ..()
+	copy.foods_sent = foods_sent.Copy()
+	copy.department = department
+	copy.needed = needed
+	copy.amount_per = amount_per
+	// These ones aren't really needed in the intended use case, they're
+	// just here in case someone uses this method somewhere else.
+	copy.department_account = department_account
+	copy.reward = reward
+	copy.generic_name_plural = generic_name_plural
+	return copy
+
+/datum/secondary_goal_progress/variety_food/update(atom/movable/AM, datum/economy/cargo_shuttle_manifest/manifest = null)
+	// Not in a matching personal crate? Ignore.
+	if(!check_personal_crate(AM))
+		return
+
+	// Not food? Ignore.
+	if(!istype(AM, /obj/item/food))
+		return
+
+	var/obj/item/food/food = AM
+
+	// No easy foods allowed.
+	if(food.goal_difficulty == FOOD_GOAL_SKIP)
+		if(!manifest)
+			return COMSIG_CARGO_SELL_WRONG
+		SSblackbox.record_feedback("nested tally", "secondary goals", 1, list(goal_name, "boring foods"))
+		var/datum/economy/line_item/item = new
+		item.account = department_account
+		item.credits = 0
+		item.reason = "We don't need [food.name]. Send something better."
+		item.requests_console_department = "Kitchen"
+		manifest.line_items += item
+		return COMSIG_CARGO_SELL_WRONG
+
+	if(foods_sent[food.type] >= amount_per)
+		if(!manifest)
+			return COMSIG_CARGO_SELL_WRONG
+		SSblackbox.record_feedback("nested tally", "secondary goals", 1, list(goal_name, "repeat foods"))
+		var/datum/economy/line_item/item = new
+		item.account = department_account
+		item.credits = 0
+		item.reason = "You already sent us enough [food.name]."
+		item.requests_console_department = "Kitchen"
+		manifest.line_items += item
+		return COMSIG_CARGO_SELL_WRONG
+
+	if(!foods_sent[food.type])
+		foods_sent[food.type] = 0
+	foods_sent[food.type]++
+
+	if(!manifest)
+		return COMSIG_CARGO_SELL_PRIORITY
+	SSblackbox.record_feedback("nested tally", "secondary goals", 1, list(goal_name, "valid foods"))
+	var/obj/item/food/food_type = food.type
+	SSblackbox.record_feedback("nested tally", "secondary goals", 1, list(goal_name, "foods", initial(food_type.name)))
+	var/datum/economy/line_item/item = new
+	item.account = department_account
+	item.credits = 0
+	item.reason = "Received [initial(food.name)]."
+	item.zero_is_good = TRUE
+	item.requests_console_department = "Kitchen"
+	manifest.line_items += item
+	return COMSIG_CARGO_SELL_PRIORITY
+
+/datum/secondary_goal_progress/variety_food/check_complete(datum/economy/cargo_shuttle_manifest/manifest)
+	var/list/complete_foods = 0
+	for(var/food_type in foods_sent)
+		if(foods_sent[food_type] >= amount_per)
+			complete_foods++
+			SSblackbox.record_feedback("nested tally", "secondary goals", 1, list(goal_name, "complete foods"))
+
+	if(complete_foods < needed)
+		return FALSE
+
+	three_way_reward(manifest, department, department_account, reward, "Secondary goal complete: [needed] different [generic_name_plural].")
+	return TRUE

--- a/code/modules/station_goals/secondary/kitchen/variety_food.dm
+++ b/code/modules/station_goals/secondary/kitchen/variety_food.dm
@@ -3,7 +3,9 @@
 	progress_type = /datum/secondary_goal_progress/variety_food
 	department = "Kitchen"
 	abstract = FALSE
+	/// How many different types of food are needed.
 	var/different_types = 10
+	/// How many of each food type are needed.
 	var/amount_per = 3
 	var/department_account
 	var/generic_name_plural = "dishes"

--- a/code/modules/station_goals/secondary/kitchen/variety_food.dm
+++ b/code/modules/station_goals/secondary/kitchen/variety_food.dm
@@ -106,7 +106,7 @@
 	return COMSIG_CARGO_SELL_PRIORITY
 
 /datum/secondary_goal_progress/variety_food/check_complete(datum/economy/cargo_shuttle_manifest/manifest)
-	var/list/complete_foods = 0
+	var/complete_foods = 0
 	for(var/food_type in foods_sent)
 		if(foods_sent[food_type] >= amount_per)
 			complete_foods++

--- a/code/modules/station_goals/secondary/random_bulk_reagent.dm
+++ b/code/modules/station_goals/secondary/random_bulk_reagent.dm
@@ -17,6 +17,10 @@
 		if(initial(candidate.goal_department) != department)
 			continue
 		if(initial(candidate.goal_difficulty) == REAGENT_GOAL_SKIP)
+			// Too easy, don't want.
+			continue
+		if(initial(candidate.goal_difficulty) == REAGENT_GOAL_EXCESSIVE)
+			// Too hard, don't ask for.
 			continue
 		valid_reagents += candidate
 
@@ -89,6 +93,7 @@
 	item.account = department_account
 	item.credits = 0
 	item.reason = "Received [amount] units of [initial(reagent_type.name)]."
+	item.requests_console_department = department
 	item.zero_is_good = TRUE
 	manifest.line_items += item
 

--- a/code/modules/station_goals/secondary/science/random_ripley.dm
+++ b/code/modules/station_goals/secondary/science/random_ripley.dm
@@ -71,8 +71,8 @@
 		extra_item.account = SSeconomy.cargo_account
 		extra_item.credits = SSeconomy.credits_per_mech
 		extra_item.reason = "We already got the mech we needed, but we'll take this one at the usual price."
+		extra_item.requests_console_department = "Robotics"
 		manifest.line_items += extra_item
-		send_requests_console_message(extra_item.reason, "Central Command", "Robotics", "Stamped with the Central Command rubber stamp.", null, RQ_NORMALPRIORITY)
 		return COMSIG_CARGO_SELL_PRIORITY | COMSIG_CARGO_IS_SECURED
 
 	var/remaining_needs = modules.Copy()
@@ -90,9 +90,9 @@
 			var/datum/economy/line_item/wrong_item = new
 			wrong_item.account = SSeconomy.cargo_account
 			wrong_item.credits = SSeconomy.credits_per_mech
-			wrong_item.reason = "That's not the equipment we needed, but it's still a mech"
+			wrong_item.reason = "That's not the equipment we needed, but it's still a mech, so we'll take it at the usual price."
+			wrong_item.requests_console_department = "Robotics"
 			manifest.line_items += wrong_item
-			send_requests_console_message(wrong_item.reason + ", so we sent the usual amount to your supply account.", "Central Command", "Robotics", "Stamped with the Central Command rubber stamp.", null, RQ_NORMALPRIORITY)
 		return COMSIG_CARGO_SELL_PRIORITY | COMSIG_CARGO_IS_SECURED
 
 	sent = TRUE

--- a/code/modules/station_goals/secondary/secondary_goal_tracker.dm
+++ b/code/modules/station_goals/secondary/secondary_goal_tracker.dm
@@ -120,6 +120,6 @@
 	personal_item.account = personal_account || department_account
 	personal_item.credits = reward / 3
 	personal_item.reason = message
+	personal_item.requests_console_department = department
 	manifest.line_items += personal_item
 
-	send_requests_console_message(message, "Central Command", department, "Stamped with the Central Command rubber stamp.", null, RQ_NORMALPRIORITY)

--- a/code/modules/station_goals/secondary/variety_reagent.dm
+++ b/code/modules/station_goals/secondary/variety_reagent.dm
@@ -73,8 +73,8 @@
 		item.account = department_account
 		item.credits = 0
 		item.reason = "That [reagent.name] seems to be mixed with something else. Send it by itself, please."
+		item.requests_console_department = department
 		manifest.line_items += item
-		send_requests_console_message(item.reason, "Central Command", department, "Stamped with the Central Command rubber stamp.", null, RQ_NORMALPRIORITY)
 		return COMSIG_CARGO_SELL_WRONG
 
 	// No easy reagents allowed.
@@ -86,8 +86,8 @@
 		item.account = department_account
 		item.credits = 0
 		item.reason = "We don't need [reagent.name]. Send something better."
+		item.requests_console_department = department
 		manifest.line_items += item
-		send_requests_console_message(item.reason, "Central Command", department, "Stamped with the Central Command rubber stamp.", null, RQ_NORMALPRIORITY)
 		return COMSIG_CARGO_SELL_WRONG
 		
 	// Make sure there's enough.
@@ -99,8 +99,8 @@
 		item.account = department_account
 		item.credits = 0
 		item.reason = "That batch of [reagent.name] was too small; send at least [amount_per] units."
+		item.requests_console_department = department
 		manifest.line_items += item
-		send_requests_console_message(item.reason, "Central Command", department, "Stamped with the Central Command rubber stamp.", null, RQ_NORMALPRIORITY)
 		return COMSIG_CARGO_SELL_WRONG
 
 	if(reagents_sent[reagent.id])
@@ -111,8 +111,8 @@
 		item.account = department_account
 		item.credits = 0
 		item.reason = "You already sent us [reagent.name]."
+		item.requests_console_department = department
 		manifest.line_items += item
-		send_requests_console_message(item.reason, "Central Command", department, "Stamped with the Central Command rubber stamp.", null, RQ_NORMALPRIORITY)
 		return COMSIG_CARGO_SELL_WRONG
 
 	reagents_sent[reagent.id] = TRUE
@@ -125,9 +125,9 @@
 	item.account = department_account
 	item.credits = 0
 	item.reason = "Received [initial(reagent.name)]."
+	item.requests_console_department = department
 	item.zero_is_good = TRUE
 	manifest.line_items += item
-	send_requests_console_message(item.reason, "Central Command", department, "Stamped with the Central Command rubber stamp.", null, RQ_NORMALPRIORITY)
 	return COMSIG_CARGO_SELL_PRIORITY
 
 /datum/secondary_goal_progress/variety_reagent/check_complete(datum/economy/cargo_shuttle_manifest/manifest)

--- a/paradise.dme
+++ b/paradise.dme
@@ -2733,6 +2733,7 @@
 #include "code\modules\station_goals\secondary\botany\kudzu_goal.dm"
 #include "code\modules\station_goals\secondary\kitchen\random_bulk_condiment.dm"
 #include "code\modules\station_goals\secondary\kitchen\random_bulk_food.dm"
+#include "code\modules\station_goals\secondary\kitchen\variety_food.dm"
 #include "code\modules\station_goals\secondary\medical\random_bulk_medicine.dm"
 #include "code\modules\station_goals\secondary\medical\variety_medicine.dm"
 #include "code\modules\station_goals\secondary\science\random_bulk_chemical.dm"


### PR DESCRIPTION
## What Does This PR Do
Adds a new secondary goal: Variety of Food, for the Kitchen.
More foods are now labelled with new difficulty categories that exempt them from specific food goals, but allow them in Variety of Food if the chef wants to send them..
A few reagent difficulties have been tweaked, including using a similar exemption mechanism.
Request console messages from the supply shuttle are now batched together, and duplicates are compressed.

## Why It's Good For The Game
More secondary goal variety is nice.
Better food/reagent labelling makes for better goals.
Less request console spam is good.

## Testing
Completed variety of food, saw less request console spam.

## Changelog
:cl:
add: New secondary goal for Kitchen: Variety of Food.
tweak: A few reagents have been tweaked to more fitting secondary goal difficulties.
tweak: Secondary Goals will no longer spam request consoles with multiple messages when the supply shuttle reaches CC.
/:cl: