### PR TITLE
Restricts rubbershot's guaranteed knockdown range

### DIFF
--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -93,8 +93,8 @@
 	if(!ishuman(target))
 		return
 	var/mob/living/carbon/human/H = target
-	//
-	if((50 - range) < 5 && H.getStaminaLoss() >= 60)
+	// 50 - range gives approximate tile distance from user
+	if((50 - range) <= 5 && H.getStaminaLoss() >= 60)
 		H.KnockDown(8 SECONDS)
 
 /obj/item/projectile/bullet/pellet/assassination

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -93,7 +93,8 @@
 	if(!ishuman(target))
 		return
 	var/mob/living/carbon/human/H = target
-	if(H.getStaminaLoss() >= 60)
+	//
+	if((50 - range) < 5 && H.getStaminaLoss() >= 60)
 		H.KnockDown(8 SECONDS)
 
 /obj/item/projectile/bullet/pellet/assassination

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -93,8 +93,8 @@
 	if(!ishuman(target))
 		return
 	var/mob/living/carbon/human/H = target
-	// 50 - range gives approximate tile distance from user
-	if((50 - range) <= 5 && H.getStaminaLoss() >= 60)
+	// initial range - range gives approximate tile distance from user
+	if(initial(range) - range <= 5 && H.getStaminaLoss() >= 60)
 		H.KnockDown(8 SECONDS)
 
 /obj/item/projectile/bullet/pellet/assassination


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Prevents rubbershot pellets from triggering its guaranteed 8 second knockdown more than 5 tiles away. 

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Requested by Qwerty.
![image](https://github.com/ParadiseSS13/Paradise/assets/98280110/c880d5c5-7af0-4275-9e3e-4f9ed398ebf8)
At a range of >5 tiles, it's only possible to be hit by one or two pellets (at a high deflection angle). If the target has 59 stamina damage and is hit by this pellet, it will trigger a knockdown for 8 seconds. This behavior is a little bit silly for an ammunition that is intended to be employed at close range.

Note: this does not affect 99% of use cases for rubbershot, only the rare situations where the target has just enough stamina damage to get sent over the 60 damage threshold by a single pellet fired at extreme range. It is not possible to hit a target with more than one or two (out of ten) pellets over a distance of more than a few tiles because of its high spread.
## Testing
<!-- How did you test the PR, if at all? -->
Knocked down skrell from close range, and did not knock them down from farther away.
## Changelog
:cl:
tweak: Rubbershot knockdown range is now limited to 5 tiles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
