### PR TITLE
Reduce the chance of getting no changes to a stat when mutating plants.

### DIFF
--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -135,16 +135,23 @@
 		add_random_traits(1, 1)
 
 /obj/item/seeds/proc/mutate_stat(stat, level, mutation_size)
+	// 505 chance to do nothing to each stat even if mutation level is nonzero.
 	if(level <= 0 || prob(50))
 		return
 
 	var/mod = 0
+	// Roll for a bit of change every 10 mutation level.
 	while(level > 10)
 		mod += rand(0, mutation_size)
 		level -= 10
+	// And a partial chance if there's any mutation level left over.
 	if(level > 0 && prob(level * 10))
 		mod += rand(0, mutation_size)
 
+	// Ensure we change it at least a bit if we passed the initial prob(50).
+	mod = max(1, mod)
+
+	// 50% chance of going either way.
 	if(prob(50))
 		mod = -mod
 

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -135,7 +135,7 @@
 		add_random_traits(1, 1)
 
 /obj/item/seeds/proc/mutate_stat(stat, level, mutation_size)
-	// 505 chance to do nothing to each stat even if mutation level is nonzero.
+	// 50% chance to do nothing to each stat even if mutation level is nonzero.
 	if(level <= 0 || prob(50))
 		return
 


### PR DESCRIPTION
## What Does This PR Do
Reduce the chance of getting no changes to a stat when mutating plants.

## Why It's Good For The Game
It was supposed to be 50%, but ended up as more like 75% in some situations.

## Testing
Did a round of mutation selections, got less non-changes.

## Changelog
:cl:
fix: Corrected an oversight that made the chance of some plant stats mutating lower than intended.
/:cl: