### PR TITLE
Allow new lines in IC notes again

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -719,7 +719,7 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 	set category = "IC"
 
 	msg = copytext(msg, 1, MAX_MESSAGE_LEN)
-	msg = sanitize(msg, list("\n" = "<BR>"))
+	msg = sanitize_simple(html_encode(msg), list("\n" = "<br>"))
 
 	var/combined = length(memory + msg)
 	if(mind && (combined < MAX_PAPER_MESSAGE_LEN))


### PR DESCRIPTION
## What Does This PR Do
#24876 accidentally broke newlines in IC notes. This fixes them.

## Why It's Good For The Game
Putting newlines in your own memory is useful.\

## Testing
It compiled.

## Changelog
:cl:
fix: Newlines work in IC notes again.
/:cl: