### PR TITLE
Gives plasma golems their suicide ignite back

### DIFF
--- a/code/modules/mob/living/carbon/human/species/unathi.dm
+++ b/code/modules/mob/living/carbon/human/species/unathi.dm
@@ -57,15 +57,15 @@
 
 /datum/species/unathi/on_species_gain(mob/living/carbon/human/H)
 	..()
-	var/datum/action/innate/ignite/fire = new()
+	var/datum/action/innate/unathi_ignite/fire = new()
 	fire.Grant(H)
 
 /datum/species/unathi/on_species_loss(mob/living/carbon/human/H)
 	..()
-	for(var/datum/action/innate/ignite/fire in H.actions)
+	for(var/datum/action/innate/unathi_ignite/fire in H.actions)
 		fire.Remove(H)
 
-/datum/action/innate/ignite
+/datum/action/innate/unathi_ignite
 	name = "Ignite"
 	desc = "A fire forms in your mouth, fierce enough to... light a cigarette. Requires you to drink welding fuel beforehand."
 	icon_icon = 'icons/obj/cigarettes.dmi'
@@ -75,7 +75,7 @@
 	var/welding_fuel_used = 3 //one sip, with less strict timing
 	check_flags = AB_CHECK_HANDS_BLOCKED
 
-/datum/action/innate/ignite/Activate()
+/datum/action/innate/unathi_ignite/Activate()
 	var/mob/living/carbon/human/user = owner
 	if(world.time <= cooldown)
 		to_chat(user, "<span class='warning'>Your throat hurts too much to do it right now. Wait [round((cooldown - world.time) / 10)] seconds and try again.</span>")
@@ -94,7 +94,6 @@
 			to_chat(user, "<span class='warning'>You don't have any free hands.</span>")
 	else
 		to_chat(user, "<span class='warning'>You need to drink welding fuel first.</span>")
-
 
 /datum/species/unathi/handle_death(gibbed, mob/living/carbon/human/H)
 	H.stop_tail_wagging()
@@ -127,14 +126,14 @@
 
 /datum/species/unathi/ashwalker/on_species_gain(mob/living/carbon/human/H)
 	..()
-	for(var/datum/action/innate/ignite/fire in H.actions)
+	for(var/datum/action/innate/unathi_ignite/fire in H.actions)
 		fire.Remove(H)
-	var/datum/action/innate/ignite/ash_walker/fire = new()
+	var/datum/action/innate/unathi_ignite/ash_walker/fire = new()
 	fire.Grant(H)
 
 /datum/species/unathi/ashwalker/on_species_loss(mob/living/carbon/human/H)
 	..()
-	for(var/datum/action/innate/ignite/ash_walker/fire in H.actions)
+	for(var/datum/action/innate/unathi_ignite/ash_walker/fire in H.actions)
 		fire.Remove(H)
 
 /datum/species/unathi/ashwalker/movement_delay(mob/living/carbon/human/H)
@@ -143,7 +142,7 @@
 	if(!is_mining_level(our_turf.z))
 		. -= speed_mod
 
-/datum/action/innate/ignite/ash_walker
+/datum/action/innate/unathi_ignite/ash_walker
 	desc = "You form a fire in your mouth, fierce enough to... light a cigarette."
 	cooldown_duration = 3 MINUTES
 	welding_fuel_used = 0 // Ash walkers dont need welding fuel to use ignite


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Gives plasma golems their self ignite ability back by removing the duplicate definition
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
The unathi breathing fire PR was a stealth removal by accident
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Had ignite as an unathi, which worked properly
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Fixed plasma golems not being able to ignite themselves
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
