### PR TITLE
[TM FIRST] RUSTG ~~3.2.0-P~~ Temporarily on 3.1.0-P

### DIFF
--- a/_build_dependencies.sh
+++ b/_build_dependencies.sh
@@ -14,4 +14,4 @@ export STABLE_BYOND_MINOR=1633
 # Python version for mapmerge and other tools
 export PYTHON_VERSION=3.11.6
 # RUSTG version
-export RUSTG_VERSION=v3.2.0-P
+export RUSTG_VERSION=v3.1.0-P

--- a/_build_dependencies.sh
+++ b/_build_dependencies.sh
@@ -14,4 +14,4 @@ export STABLE_BYOND_MINOR=1633
 # Python version for mapmerge and other tools
 export PYTHON_VERSION=3.11.6
 # RUSTG version
-export RUSTG_VERSION=v3.0.0-P
+export RUSTG_VERSION=v3.2.0-P

--- a/code/__DEFINES/_versions.dm
+++ b/code/__DEFINES/_versions.dm
@@ -1,2 +1,2 @@
 /// Version of RUST-G that this codebase wants
-#define RUST_G_VERSION "3.0.0-P"
+#define RUST_G_VERSION "3.2.0-P"

--- a/code/__DEFINES/_versions.dm
+++ b/code/__DEFINES/_versions.dm
@@ -1,2 +1,2 @@
 /// Version of RUST-G that this codebase wants
-#define RUST_G_VERSION "3.2.0-P"
+#define RUST_G_VERSION "3.1.0-P"

--- a/code/__DEFINES/rust_g.dm
+++ b/code/__DEFINES/rust_g.dm
@@ -203,66 +203,6 @@
 /proc/rustg_create_async_http_client() return RUSTG_CALL(RUST_G, "start_http_client")()
 /proc/rustg_close_async_http_client() return RUSTG_CALL(RUST_G, "shutdown_http_client")()
 
-/// Generates a spritesheet at: [file_path][spritesheet_name]_[size_id].png
-/// The resulting spritesheet arranges icons in a random order, with the position being denoted in the "sprites" return value.
-/// All icons have the same y coordinate, and their x coordinate is equal to `icon_width * position`.
-///
-/// hash_icons is a boolean (0 or 1), and determines if the generator will spend time creating hashes for the output field dmi_hashes.
-/// These hashes can be heplful for 'smart' caching (see rustg_iconforge_cache_valid), but require extra computation.
-///
-/// Spritesheet will contain all sprites listed within "sprites".
-/// "sprites" format:
-/// list(
-///     "sprite_name" = list( // <--- this list is a [SPRITE_OBJECT]
-///         icon_file = 'icons/path_to/an_icon.dmi',
-///         icon_state = "some_icon_state",
-///         dir = SOUTH,
-///         frame = 1,
-///         transform = list([TRANSFORM_OBJECT], ...)
-///     ),
-///     ...,
-/// )
-/// TRANSFORM_OBJECT format:
-/// list("type" = RUSTG_ICONFORGE_BLEND_COLOR, "color" = "#ff0000", "blend_mode" = ICON_MULTIPLY)
-/// list("type" = RUSTG_ICONFORGE_BLEND_ICON, "icon" = [SPRITE_OBJECT], "blend_mode" = ICON_OVERLAY)
-/// list("type" = RUSTG_ICONFORGE_SCALE, "width" = 32, "height" = 32)
-/// list("type" = RUSTG_ICONFORGE_CROP, "x1" = 1, "y1" = 1, "x2" = 32, "y2" = 32) // (BYOND icons index from 1,1 to the upper bound, inclusive)
-///
-/// Returns a SpritesheetResult as JSON, containing fields:
-/// list(
-///     "sizes" = list("32x32", "64x64", ...),
-///     "sprites" = list("sprite_name" = list("size_id" = "32x32", "position" = 0), ...),
-///     "dmi_hashes" = list("icons/path_to/an_icon.dmi" = "d6325c5b4304fb03", ...),
-///     "sprites_hash" = "a2015e5ff403fb5c", // This is the xxh64 hash of the INPUT field "sprites".
-///     "error" = "[A string, empty if there were no errors.]"
-/// )
-/// In the case of an unrecoverable panic from within Rust, this function ONLY returns a string containing the error.
-#define rustg_iconforge_generate(file_path, spritesheet_name, sprites, hash_icons) RUSTG_CALL(RUST_G, "iconforge_generate")(file_path, spritesheet_name, sprites, "[hash_icons]")
-/// Returns a job_id for use with rustg_iconforge_check()
-#define rustg_iconforge_generate_async(file_path, spritesheet_name, sprites, hash_icons) RUSTG_CALL(RUST_G, "iconforge_generate_async")(file_path, spritesheet_name, sprites, "[hash_icons]")
-/// Returns the status of an async job_id, or its result if it is completed. See RUSTG_JOB DEFINEs.
-#define rustg_iconforge_check(job_id) RUSTG_CALL(RUST_G, "iconforge_check")("[job_id]")
-/// Clears all cached DMIs and images, freeing up memory.
-/// This should be used after spritesheets are done being generated.
-#define rustg_iconforge_cleanup RUSTG_CALL(RUST_G, "iconforge_cleanup")
-/// Takes in a set of hashes, generate inputs, and DMI filepaths, and compares them to determine cache validity.
-/// input_hash: xxh64 hash of "sprites" from the cache.
-/// dmi_hashes: xxh64 hashes of the DMIs in a spritesheet, given by `rustg_iconforge_generate` with `hash_icons` enabled. From the cache.
-/// sprites: The new input that will be passed to rustg_iconforge_generate().
-/// Returns a CacheResult with the following structure: list(
-///     "result": "1" (if cache is valid) or "0" (if cache is invalid)
-///     "fail_reason": "" (emtpy string if valid, otherwise a string containing the invalidation reason or an error with ERROR: prefixed.)
-/// )
-/// In the case of an unrecoverable panic from within Rust, this function ONLY returns a string containing the error.
-#define rustg_iconforge_cache_valid(input_hash, dmi_hashes, sprites) RUSTG_CALL(RUST_G, "iconforge_cache_valid")(input_hash, dmi_hashes, sprites)
-/// Returns a job_id for use with rustg_iconforge_check()
-#define rustg_iconforge_cache_valid_async(input_hash, dmi_hashes, sprites) RUSTG_CALL(RUST_G, "iconforge_cache_valid_async")(input_hash, dmi_hashes, sprites)
-
-#define RUSTG_ICONFORGE_BLEND_COLOR "BlendColor"
-#define RUSTG_ICONFORGE_BLEND_ICON "BlendIcon"
-#define RUSTG_ICONFORGE_CROP "Crop"
-#define RUSTG_ICONFORGE_SCALE "Scale"
-
 // Jobs Defines //
 
 #define RUSTG_JOB_NO_RESULTS_YET "NO RESULTS YET"

--- a/code/__DEFINES/rust_g.dm
+++ b/code/__DEFINES/rust_g.dm
@@ -19,14 +19,14 @@
 /* This comment bypasses grep checks */ /var/__rust_g
 
 /proc/__detect_rust_g()
-	if(world.system_type == UNIX)
-		if(fexists("./librust_g.so"))
+	if (world.system_type == UNIX)
+		if (fexists("./librust_g.so"))
 			// No need for LD_LIBRARY_PATH badness.
 			return __rust_g = "./librust_g.so"
-		else if(fexists("./rust_g"))
+		else if (fexists("./rust_g"))
 			// Old dumb filename.
 			return __rust_g = "./rust_g"
-		else if(fexists("[world.GetConfig("env", "HOME")]/.byond/bin/rust_g"))
+		else if (fexists("[world.GetConfig("env", "HOME")]/.byond/bin/rust_g"))
 			// Old dumb filename in `~/.byond/bin`.
 			return __rust_g = "rust_g"
 		else
@@ -144,7 +144,7 @@
 // File Operations //
 
 #define rustg_file_read(fname) RUSTG_CALL(RUST_G, "file_read")(fname)
-#define rustg_file_exists(fname) RUSTG_CALL(RUST_G, "file_exists")(fname)
+#define rustg_file_exists(fname) (RUSTG_CALL(RUST_G, "file_exists")(fname) == "true")
 #define rustg_file_write(text, fname) RUSTG_CALL(RUST_G, "file_write")(text, fname)
 #define rustg_file_append(text, fname) RUSTG_CALL(RUST_G, "file_append")(text, fname)
 #define rustg_file_get_line_count(fname) text2num(RUSTG_CALL(RUST_G, "file_get_line_count")(fname))
@@ -157,7 +157,13 @@
 
 // Git Operations //
 
+/// Returns the git hash of the given revision, ex. "HEAD".
 #define rustg_git_revparse(rev) RUSTG_CALL(RUST_G, "rg_git_revparse")(rev)
+
+/**
+ * Returns the date of the given revision in the format YYYY-MM-DD.
+ * Returns null if the revision is invalid.
+ */
 #define rustg_git_commit_date(rev) RUSTG_CALL(RUST_G, "rg_git_commit_date")(rev)
 
 // Hashing Functions //
@@ -173,6 +179,11 @@
 #define RUSTG_HASH_SHA512 "sha512"
 #define RUSTG_HASH_XXH64 "xxh64"
 #define RUSTG_HASH_BASE64 "base64"
+
+/// Encode a given string into base64
+#define rustg_encode_base64(str) rustg_hash_string(RUSTG_HASH_BASE64, str)
+/// Decode a given base64 string
+#define rustg_decode_base64(str) RUSTG_CALL(RUST_G, "decode_base64")(str)
 
 #ifdef RUSTG_OVERRIDE_BUILTINS
 	#define md5(thing) (isfile(thing) ? rustg_hash_file(RUSTG_HASH_MD5, "[thing]") : rustg_hash_string(RUSTG_HASH_MD5, thing))
@@ -191,6 +202,66 @@
 #define rustg_http_check_request(req_id) RUSTG_CALL(RUST_G, "http_check_request")(req_id)
 /proc/rustg_create_async_http_client() return RUSTG_CALL(RUST_G, "start_http_client")()
 /proc/rustg_close_async_http_client() return RUSTG_CALL(RUST_G, "shutdown_http_client")()
+
+/// Generates a spritesheet at: [file_path][spritesheet_name]_[size_id].png
+/// The resulting spritesheet arranges icons in a random order, with the position being denoted in the "sprites" return value.
+/// All icons have the same y coordinate, and their x coordinate is equal to `icon_width * position`.
+///
+/// hash_icons is a boolean (0 or 1), and determines if the generator will spend time creating hashes for the output field dmi_hashes.
+/// These hashes can be heplful for 'smart' caching (see rustg_iconforge_cache_valid), but require extra computation.
+///
+/// Spritesheet will contain all sprites listed within "sprites".
+/// "sprites" format:
+/// list(
+///     "sprite_name" = list( // <--- this list is a [SPRITE_OBJECT]
+///         icon_file = 'icons/path_to/an_icon.dmi',
+///         icon_state = "some_icon_state",
+///         dir = SOUTH,
+///         frame = 1,
+///         transform = list([TRANSFORM_OBJECT], ...)
+///     ),
+///     ...,
+/// )
+/// TRANSFORM_OBJECT format:
+/// list("type" = RUSTG_ICONFORGE_BLEND_COLOR, "color" = "#ff0000", "blend_mode" = ICON_MULTIPLY)
+/// list("type" = RUSTG_ICONFORGE_BLEND_ICON, "icon" = [SPRITE_OBJECT], "blend_mode" = ICON_OVERLAY)
+/// list("type" = RUSTG_ICONFORGE_SCALE, "width" = 32, "height" = 32)
+/// list("type" = RUSTG_ICONFORGE_CROP, "x1" = 1, "y1" = 1, "x2" = 32, "y2" = 32) // (BYOND icons index from 1,1 to the upper bound, inclusive)
+///
+/// Returns a SpritesheetResult as JSON, containing fields:
+/// list(
+///     "sizes" = list("32x32", "64x64", ...),
+///     "sprites" = list("sprite_name" = list("size_id" = "32x32", "position" = 0), ...),
+///     "dmi_hashes" = list("icons/path_to/an_icon.dmi" = "d6325c5b4304fb03", ...),
+///     "sprites_hash" = "a2015e5ff403fb5c", // This is the xxh64 hash of the INPUT field "sprites".
+///     "error" = "[A string, empty if there were no errors.]"
+/// )
+/// In the case of an unrecoverable panic from within Rust, this function ONLY returns a string containing the error.
+#define rustg_iconforge_generate(file_path, spritesheet_name, sprites, hash_icons) RUSTG_CALL(RUST_G, "iconforge_generate")(file_path, spritesheet_name, sprites, "[hash_icons]")
+/// Returns a job_id for use with rustg_iconforge_check()
+#define rustg_iconforge_generate_async(file_path, spritesheet_name, sprites, hash_icons) RUSTG_CALL(RUST_G, "iconforge_generate_async")(file_path, spritesheet_name, sprites, "[hash_icons]")
+/// Returns the status of an async job_id, or its result if it is completed. See RUSTG_JOB DEFINEs.
+#define rustg_iconforge_check(job_id) RUSTG_CALL(RUST_G, "iconforge_check")("[job_id]")
+/// Clears all cached DMIs and images, freeing up memory.
+/// This should be used after spritesheets are done being generated.
+#define rustg_iconforge_cleanup RUSTG_CALL(RUST_G, "iconforge_cleanup")
+/// Takes in a set of hashes, generate inputs, and DMI filepaths, and compares them to determine cache validity.
+/// input_hash: xxh64 hash of "sprites" from the cache.
+/// dmi_hashes: xxh64 hashes of the DMIs in a spritesheet, given by `rustg_iconforge_generate` with `hash_icons` enabled. From the cache.
+/// sprites: The new input that will be passed to rustg_iconforge_generate().
+/// Returns a CacheResult with the following structure: list(
+///     "result": "1" (if cache is valid) or "0" (if cache is invalid)
+///     "fail_reason": "" (emtpy string if valid, otherwise a string containing the invalidation reason or an error with ERROR: prefixed.)
+/// )
+/// In the case of an unrecoverable panic from within Rust, this function ONLY returns a string containing the error.
+#define rustg_iconforge_cache_valid(input_hash, dmi_hashes, sprites) RUSTG_CALL(RUST_G, "iconforge_cache_valid")(input_hash, dmi_hashes, sprites)
+/// Returns a job_id for use with rustg_iconforge_check()
+#define rustg_iconforge_cache_valid_async(input_hash, dmi_hashes, sprites) RUSTG_CALL(RUST_G, "iconforge_cache_valid_async")(input_hash, dmi_hashes, sprites)
+
+#define RUSTG_ICONFORGE_BLEND_COLOR "BlendColor"
+#define RUSTG_ICONFORGE_BLEND_ICON "BlendIcon"
+#define RUSTG_ICONFORGE_CROP "Crop"
+#define RUSTG_ICONFORGE_SCALE "Scale"
 
 // Jobs Defines //
 
@@ -236,15 +307,15 @@
  */
 #define rustg_add_node_astar(json) RUSTG_CALL(RUST_G, "add_node_astar")(json)
 
-/**²
+/**
  * Remove every link to the node with unique_id. Replace that node by null
  */
-#define rustg_remove_node_astart(unique_id) RUSTG_CALL(RUST_G, "remove_node_astar")(unique_id)
+#define rustg_remove_node_astar(unique_id) RUSTG_CALL(RUST_G, "remove_node_astar")("[unique_id]")
 
 /**
  * Compute the shortest path between start_node and goal_node using A*. Heuristic used is simple geometric distance
  */
-#define rustg_generate_path_astar(start_node_id, goal_node_id) RUSTG_CALL(RUST_G, "generate_path_astar")(start_node_id, goal_node_id)
+#define rustg_generate_path_astar(start_node_id, goal_node_id) RUSTG_CALL(RUST_G, "generate_path_astar")("[start_node_id]", "[goal_node_id]")
 
 // Redis PubSub Operations //
 
@@ -324,7 +395,7 @@
 
 /proc/rustg_read_toml_file(path)
 	var/list/output = rustg_raw_read_toml_file(path)
-	if(output["success"])
+	if (output["success"])
 		return json_decode(output["content"])
 	else
 		CRASH(output["content"])
@@ -333,7 +404,7 @@
 
 /proc/rustg_toml_encode(value)
 	var/list/output = rustg_raw_toml_encode(value)
-	if(output["success"])
+	if (output["success"])
 		return output["content"]
 	else
 		CRASH(output["content"])

--- a/code/__DEFINES/rust_g.dm
+++ b/code/__DEFINES/rust_g.dm
@@ -19,14 +19,14 @@
 /* This comment bypasses grep checks */ /var/__rust_g
 
 /proc/__detect_rust_g()
-	if (world.system_type == UNIX)
-		if (fexists("./librust_g.so"))
+	if(world.system_type == UNIX)
+		if(fexists("./librust_g.so"))
 			// No need for LD_LIBRARY_PATH badness.
 			return __rust_g = "./librust_g.so"
-		else if (fexists("./rust_g"))
+		else if(fexists("./rust_g"))
 			// Old dumb filename.
 			return __rust_g = "./rust_g"
-		else if (fexists("[world.GetConfig("env", "HOME")]/.byond/bin/rust_g"))
+		else if(fexists("[world.GetConfig("env", "HOME")]/.byond/bin/rust_g"))
 			// Old dumb filename in `~/.byond/bin`.
 			return __rust_g = "rust_g"
 		else
@@ -395,7 +395,7 @@
 
 /proc/rustg_read_toml_file(path)
 	var/list/output = rustg_raw_read_toml_file(path)
-	if (output["success"])
+	if(output["success"])
 		return json_decode(output["content"])
 	else
 		CRASH(output["content"])
@@ -404,7 +404,7 @@
 
 /proc/rustg_toml_encode(value)
 	var/list/output = rustg_raw_toml_encode(value)
-	if (output["success"])
+	if(output["success"])
 		return output["content"]
 	else
 		CRASH(output["content"])


### PR DESCRIPTION
## What Does This PR Do
- Updates RUSTG to 3.2.0-P (`-P` is the Paradise modifications suffix)
- Preps us for massive changes in the future with IconForge (allows us to generate DMI spritesheets at lunacy speeds, even by my standards)

This also wont pass CI as I aint pushing the build until I know it works on live.

## Why It's Good For The Game
Updates good

## Testing
- Logs work
- SQL works
- Redis works
- Toasts work

## Changelog
NPFC