### PR TITLE
Improves interactions with display cases.

### DIFF
--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -61,7 +61,7 @@
 		if(!open)
 			. += "<span class='notice'>The ID lock is active, you need to swipe an ID to open it.</span>"
 		else if((broken || open) && showpiece)
-			. += "<span class='notice'>\A [showpiece] is held up by a holo-field. You can take [showpiece] out[broken ? "." : ", or lock [src] with an ID"].</span>"
+			. += "<span class='notice'>[showpiece] is held in a loose low gravity suspension field. You can take [showpiece] out[broken ? "." : ", or lock [src] with an ID"].</span>"
 
 	if(alert)
 		. += "<span class='notice'>It is hooked up with an anti-theft system.</span>"

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -234,7 +234,7 @@
 /obj/structure/displaycase_chassis/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/airlock_electronics))
 		to_chat(user, "<span class='notice'>You start installing the electronics into [src]...</span>")
-		playsound(loc, I.usesound, 50, 1)
+		playsound(loc, I.usesound, 50, TRUE)
 		if(do_after(user, 30, target = src))
 			var/obj/item/airlock_electronics/new_electronics = I
 			if(user.drop_item() && !new_electronics.is_installed)

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -74,7 +74,6 @@
 	if(emagged)
 		. += "<span class='warning'>The ID lock has been shorted out.</span>"
 
-
 /obj/structure/displaycase/proc/dump(mob/user)
 	if(showpiece)
 		if(!user || !user.put_in_hands(showpiece))
@@ -138,7 +137,7 @@
 			to_chat(user, "<span class='warning'>[src] is broken, the ID lock won't do anything.</span>")
 			return
 		if(allowed(user) || emagged)
-			to_chat(user, "<span class='notice'>You use [I] to [open ? "close":"open"] [src].</span>")
+			to_chat(user, "<span class='notice'>You use [I] to [open ? "close" : "open"] [src].</span>")
 			toggle_lock()
 		else
 			to_chat(user, "<span class='warning'>Access denied.</span>")

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -61,9 +61,7 @@
 		if(!open)
 			. += "<span class='notice'>The ID lock is active, you need to swipe an ID to open it.</span>"
 		else if((broken || open) && showpiece)
-			. += "<span class='notice'>[showpiece] is held up by a holo-field. You can deactivate the field with an open hand.</span>"
-		else if(open)
-			. += "<span class='notice'>You can close the case by swiping your ID.</span>"
+			. += "<span class='notice'>\A [showpiece] is held up by a holo-field. You can take [showpiece] out[broken ? "." : ", or lock [src] with an ID"].</span>"
 
 	if(alert)
 		. += "<span class='notice'>It is hooked up with an anti-theft system.</span>"
@@ -127,6 +125,9 @@
 
 /obj/structure/displaycase/attackby(obj/item/I, mob/user, params)
 	if(I.GetID())
+		if(!openable)
+			to_chat(user, "<span class='warning'>There is no ID scanner, looks like this one is sealed shut.</span>")
+			return
 		if(broken)
 			to_chat(user, "<span class='warning'>[src] is broken, the ID lock won't do anything.</span>")
 			return

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -15,10 +15,16 @@
 	var/alert = FALSE
 	/// If this is currently unlocked
 	var/open = FALSE
+	/// If false, this can never be opened, and the item inside should be inaccessible. Good for showcases.
 	var/openable = TRUE
+	/// The electronics currently installed in this showpiece.
 	var/obj/item/airlock_electronics/electronics
-	var/start_showpiece_type = null //add type for items on display
-	var/list/start_showpieces = list() //Takes sublists in the form of list("type" = /obj/item/bikehorn, "trophy_message" = "henk")
+	/// The type that should be instantiated to fill the showpiece.
+	var/start_showpiece_type
+	/// A list of random items that could possibly fill the case, as well as a flavor message for them.
+	/// Takes sublists in the form of list("type" = /obj/item/bikehorn, "trophy_message" = "henk")
+	var/list/start_showpieces = list()
+	/// A flavor message to show with this item.
 	var/trophy_message = ""
 
 /obj/structure/displaycase/Initialize(mapload)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds much better feedback for interacting with and examining display cases.
Clicking on an open display case will now try to put the item into your hands if possible, or drop the item onto the ground if it can't.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
I've personally been noob-trapped by these before; it's not always clear how you're supposed to interact with this item, which is especially annoying for something that frequently holds onto a high-value item.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Busted up a few cases, and checked them out.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Display cases are now a bit more informative on examine and interaction.
tweak: Items removed from display cases will now be placed into your hand.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
