### PR TITLE
Partually reverts "Increases security of CC armory" by giving ert back the ability to goto the bar.

### DIFF
--- a/_maps/map_files/generic/centcomm.dmm
+++ b/_maps/map_files/generic/centcomm.dmm
@@ -13957,7 +13957,7 @@
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/specops)
 "Xo" = (
-/obj/machinery/door_control/no_emag{
+/obj/machinery/door_control/no_emag/no_cyborg{
 	desc = "A remote control switch to connect the ready room to the rest of Centcom.";
 	id = "SPECOPS";
 	name = "Nanotrasen Asset Protection Shutters";

--- a/_maps/map_files/generic/centcomm.dmm
+++ b/_maps/map_files/generic/centcomm.dmm
@@ -13957,11 +13957,12 @@
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/specops)
 "Xo" = (
-/obj/machinery/door_control/no_emag/no_cyborg{
+/obj/machinery/door_control/no_emag{
+	desc = "A remote control switch to connect the ready room to the rest of Centcom.";
+	id = "SPECOPS";
 	name = "Nanotrasen Asset Protection Shutters";
-	req_access_txt = "109";
 	pixel_y = -24;
-	id = "SPECOPS"
+	req_access_txt = "109"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;

--- a/_maps/map_files/generic/centcomm.dmm
+++ b/_maps/map_files/generic/centcomm.dmm
@@ -5170,7 +5170,7 @@
 	name = "Nanotrasen Asset Protection Shutters";
 	pixel_x = -8;
 	pixel_y = 30;
-	req_access_txt = "114"
+	req_access_txt = "109"
 	},
 /turf/simulated/floor/wood,
 /area/centcom/control)
@@ -13959,7 +13959,7 @@
 "Xo" = (
 /obj/machinery/door_control/no_emag/no_cyborg{
 	name = "Nanotrasen Asset Protection Shutters";
-	req_access_txt = "114";
+	req_access_txt = "109";
 	pixel_y = -24;
 	id = "SPECOPS"
 	},


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Swaps the "asset protection shutters" access requirement to "109" (specops access) that only ert+ get.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Ert being able to goto the bar after a "hard" day at the job ~~mainly eorg~~ shouldn't be restricted, the worst ert can do by going out here is killing Alice, but they'll likely be vaporized by admins for doing so
## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![dreamseeker_P2SSfQmVEe](https://github.com/ParadiseSS13/Paradise/assets/96908085/8d716afa-74e4-494c-acb5-158e7e391450)

## Testing
<!-- How did you test the PR, if at all? -->
See above
## Changelog
:cl:
tweak: ERT can go back to the bar in central command again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
