### PR TITLE
Radio Hotmic Noise + Alt Click Toggle

### DIFF
--- a/code/__DEFINES/misc_defines.dm
+++ b/code/__DEFINES/misc_defines.dm
@@ -396,7 +396,6 @@
 #define INVESTIGATE_RENAME "renames"
 
 #define INVESTIGATE_BOMB "bombs"
-
 #define INVESTIGATE_HOTMIC "hotmic"
 
 // The SQL version required by this version of the code

--- a/code/__DEFINES/misc_defines.dm
+++ b/code/__DEFINES/misc_defines.dm
@@ -397,6 +397,8 @@
 
 #define INVESTIGATE_BOMB "bombs"
 
+#define INVESTIGATE_HOTMIC "hotmic"
+
 // The SQL version required by this version of the code
 #define SQL_VERSION 55
 

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -174,6 +174,11 @@
 	else
 		return ..()
 
+/obj/item/radio/intercom/AltClick(mob/user)
+	. = ..()
+	if(broadcasting)
+		investigate_log("had its hotmic toggled on via hotkey by [key_name(user)].", INVESTIGATE_HOTMIC) ///Allows us to track who spams all these on if they do.
+
 /obj/item/radio/intercom/crowbar_act(mob/user, obj/item/I)
 	if(buildstage != 1)
 		return
@@ -245,7 +250,7 @@
 		underlays += emissive_appearance(icon, "intercom_lightmask")
 
 /obj/item/radio/intercom/proc/update_operating_status(on = TRUE)
-	if(!loc) // We init a few radios in nullspace to prevent them from needing power. 
+	if(!loc) // We init a few radios in nullspace to prevent them from needing power.
 		return
 	var/area/current_area = get_area(src)
 	if(on)

--- a/code/game/objects/items/devices/radio/radio_objects.dm
+++ b/code/game/objects/items/devices/radio/radio_objects.dm
@@ -261,7 +261,7 @@ GLOBAL_LIST_EMPTY(deadsay_radio_systems)
 /obj/item/radio/proc/ToggleBroadcast()
 	broadcasting = !broadcasting && !(wires.is_cut(WIRE_RADIO_TRANSMIT) || wires.is_cut(WIRE_RADIO_SIGNAL))
 	if(broadcasting)
-		playsound(src, 'sound/items/radio_common.ogg', rand(4, 16) * 5, SOUND_RANGE_SET(3) )
+		playsound(src, 'sound/items/radio_common.ogg', rand(4, 16) * 5, SOUND_RANGE_SET(3))
 
 /obj/item/radio/proc/isBroadcasting()
 	if(broadcasting)

--- a/code/game/objects/items/devices/radio/radio_objects.dm
+++ b/code/game/objects/items/devices/radio/radio_objects.dm
@@ -263,9 +263,6 @@ GLOBAL_LIST_EMPTY(deadsay_radio_systems)
 	if(broadcasting)
 		playsound(src, 'sound/items/radio_common.ogg', rand(4, 16) * 5, SOUND_RANGE_SET(3))
 
-/obj/item/radio/proc/is_broadcasting()
-	return broadcasting
-
 /obj/item/radio/proc/ToggleReception()
 	listening = !listening && !(wires.is_cut(WIRE_RADIO_RECEIVER) || wires.is_cut(WIRE_RADIO_SIGNAL))
 

--- a/code/game/objects/items/devices/radio/radio_objects.dm
+++ b/code/game/objects/items/devices/radio/radio_objects.dm
@@ -576,6 +576,7 @@ GLOBAL_LIST_EMPTY(deadsay_radio_systems)
 
 /obj/item/radio/examine(mob/user)
 	. = ..()
+	. += "<span class='notice'><b>Alt-Click</b> to toggle [src]'s hotmic!</span>"
 	if(in_range(src, user) || loc == user)
 		if(b_stat)
 			. += "<span class='notice'>\the [src] can be attached and modified!</span>"

--- a/code/game/objects/items/devices/radio/radio_objects.dm
+++ b/code/game/objects/items/devices/radio/radio_objects.dm
@@ -131,6 +131,14 @@ GLOBAL_LIST_EMPTY(deadsay_radio_systems)
 		return
 	ui_interact(user)
 
+/obj/item/radio/AltClick(mob/user)
+	if(user.stat || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED) || !Adjacent(user) || !istype(user))
+		return
+
+	ToggleBroadcast()
+	to_chat(user, "<span class='notice'>You <b>[isBroadcasting() ? "enable" : "disable"]</b> [src]'s hotmic!</span>")
+	add_fingerprint(user)
+
 /obj/item/radio/ui_state(mob/user)
 	return GLOB.default_state
 
@@ -252,6 +260,13 @@ GLOBAL_LIST_EMPTY(deadsay_radio_systems)
 
 /obj/item/radio/proc/ToggleBroadcast()
 	broadcasting = !broadcasting && !(wires.is_cut(WIRE_RADIO_TRANSMIT) || wires.is_cut(WIRE_RADIO_SIGNAL))
+	if(broadcasting)
+		playsound(src, 'sound/items/radio_common.ogg', rand(4, 16) * 5, SOUND_RANGE_SET(3) )
+
+/obj/item/radio/proc/isBroadcasting()
+	if(broadcasting)
+		return TRUE
+	return FALSE
 
 /obj/item/radio/proc/ToggleReception()
 	listening = !listening && !(wires.is_cut(WIRE_RADIO_RECEIVER) || wires.is_cut(WIRE_RADIO_SIGNAL))

--- a/code/game/objects/items/devices/radio/radio_objects.dm
+++ b/code/game/objects/items/devices/radio/radio_objects.dm
@@ -136,7 +136,7 @@ GLOBAL_LIST_EMPTY(deadsay_radio_systems)
 		return
 
 	ToggleBroadcast()
-	to_chat(user, "<span class='notice'>You <b>[isBroadcasting() ? "enable" : "disable"]</b> [src]'s hotmic!</span>")
+	to_chat(user, "<span class='notice'>You <b>[broadcasting ? "enable" : "disable"]</b> [src]'s hotmic!</span>")
 	add_fingerprint(user)
 
 /obj/item/radio/ui_state(mob/user)
@@ -263,10 +263,8 @@ GLOBAL_LIST_EMPTY(deadsay_radio_systems)
 	if(broadcasting)
 		playsound(src, 'sound/items/radio_common.ogg', rand(4, 16) * 5, SOUND_RANGE_SET(3))
 
-/obj/item/radio/proc/isBroadcasting()
-	if(broadcasting)
-		return TRUE
-	return FALSE
+/obj/item/radio/proc/is_broadcasting()
+	return broadcasting
 
 /obj/item/radio/proc/ToggleReception()
 	listening = !listening && !(wires.is_cut(WIRE_RADIO_RECEIVER) || wires.is_cut(WIRE_RADIO_SIGNAL))


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds the radio transmit noise when a Radio hotmic is toggled on.
Allows you to toggle a radio's hotmic via Alt Click
Adds logging to prevent mass enabling of hotmics because people are stupid.

## Why It's Good For The Game
QoL upgrade for Handheld Radios mostly.

Also gives a heads up if someone activates a hotmic nearby.

Logging is due to people being stupid a lot of the time.

## Testing
Testing a buncha radios on local, seems to work.

## Changelog
:cl:
tweak: Radio hotmics can now be enabled via Alt Click + make a transmit noise on activation.
add: Added logging for hotkey hotmic enabling to prevent spam.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
