### PR TITLE
Informs Deathsquad that the bomb has been armed during Epsilon Alert.

### DIFF
--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -55,6 +55,8 @@ GLOBAL_VAR(bomb_set)
 	var/core_stage = NUKE_CORE_EVERYTHING_FINE
 	///How many sheets of various metals we need to fix it
 	var/sheets_to_fix = 5
+	///Bombs Internal Radio
+	var/obj/item/radio/radio
 
 /obj/machinery/nuclearbomb/syndicate
 	is_syndicate = TRUE
@@ -74,6 +76,10 @@ GLOBAL_VAR(bomb_set)
 	core = new /obj/item/nuke_core/plutonium(src)
 	STOP_PROCESSING(SSobj, core) //Let us not irradiate the vault by default.
 	update_icon(UPDATE_OVERLAYS)
+	radio = new(src)
+	radio.listening = FALSE
+	radio.follow_target = src
+	radio.config(list("Special Ops" = 0))
 
 /obj/machinery/nuclearbomb/Destroy()
 	SStgui.close_uis(wires)
@@ -507,6 +513,8 @@ GLOBAL_VAR(bomb_set)
 					if(!is_syndicate && SSsecurity_level.get_current_level_as_number() != SEC_LEVEL_EPSILON)
 						SSsecurity_level.set_level(SEC_LEVEL_DELTA)
 					GLOB.bomb_set = TRUE // There can still be issues with this resetting when there are multiple bombs. Not a big deal though for Nuke
+					if(SSsecurity_level.get_current_level_as_number() == SEC_LEVEL_EPSILON)
+						radio.autosay("<span class='reallybig'>The Nuclear Bomb has been armed, retreat from the station immediately!</span>", name, "Special Ops")
 				else
 					GLOB.bomb_set = TRUE
 			else

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -85,6 +85,7 @@ GLOBAL_VAR(bomb_set)
 	SStgui.close_uis(wires)
 	QDEL_NULL(wires)
 	QDEL_NULL(core)
+	QDEL_NULL(radio)
 	GLOB.poi_list.Remove(src)
 	return ..()
 


### PR DESCRIPTION


<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Informs the Deathsquad over the radio that the nuke has been armed, since the station no longer goes into Delta when the station is on Epsilon. This probably should have been added with the other PR but I didnt think of it until my other PR was approved!

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
The deathsquad should know the bomb is armed so they can leave if they so want to.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

![Screenshot 2024-04-23 012743](https://github.com/ParadiseSS13/Paradise/assets/13879982/8d14edde-6448-4ae0-8033-80c21a6f57e0)


## Testing
<!-- How did you test the PR, if at all? -->
Set security level to Epsilon and armed the nuke and saw the new message.

## Changelog
:cl:
tweak: Deathsquad members are now informed over the Special Ops channel that the nuke has been armed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
