### PR TITLE
[FIX] Security level changes no longer force depowered lights on.

### DIFF
--- a/code/modules/power/lights.dm
+++ b/code/modules/power/lights.dm
@@ -292,7 +292,7 @@
 /obj/machinery/light/proc/on_security_level_update(datum/source, previous_level_number, new_level_number)
 	SIGNAL_HANDLER
 
-	if(status != LIGHT_OK)
+	if(status != LIGHT_OK || !has_power())
 		return
 
 	if(new_level_number >= SEC_LEVEL_EPSILON)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
When the security level is increased it no longer forces lights that don't have any power to magically turn on again.
(Note that when the security level goes to EPSILON the lights will still turn red, even if they don't have any power.)

Fixes: #24592
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
It's a bit silly if you put in a lot of work to disable APCs to turn off the lights, only for all lights to magically turn back on when the alert level changes
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Depower all APCs.
Change the alert level.
The lights no longer turn on.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Security level changes no longer force depowered lights on.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
