### PR TITLE
Update the TGUI conflict merge resolution to properly commit rebuilt bundles

### DIFF
--- a/tgui/bin/tgui
+++ b/tgui/bin/tgui
@@ -137,15 +137,22 @@ task-merge-bundle() {
   local file_other="${4}"
   local conflict_marker_size="${5}"
   echo "----------------------"
-  echo "tgui: rebuilding a conflicted tgui bundle, ${file_path}"
-  task-install
-  task-webpack --mode=production
-  echo "tgui: replacing conflicted bundle with newly compiled bundle"
-  cd ../
+  echo "tgui: prepping to replace a conflicted bundle"
   cat $file_path > $file_current
+  task-rebuild-conflicted-bundle &
   exit 0
 }
 
+task-rebuild-conflicted-bundle() {
+  echo "----------------------"
+  echo "tgui: rebuilding a conflicted tgui bundle, ${file_path}"
+  task-install
+  task-webpack --mode=production
+  echo "tgui: committing new bundle"
+  echo "----------------------"
+	git commit -am "TGUI Bundle Rebuild"
+  exit 0
+}
 
 ## Main
 ## --------------------------------------------------------
@@ -230,6 +237,13 @@ if [[ ${1} == '--tgui-polyfill' ]]; then
   shift 1
   task-install
   task-polyfill "${@}"
+  exit 0
+fi
+
+## Rebuild without checking
+if [[ ${1} == '--build-only' ]]; then
+  task-install
+  task-webpack --mode=production
   exit 0
 fi
 

--- a/tgui/bin/tgui
+++ b/tgui/bin/tgui
@@ -125,17 +125,14 @@ task-install-git-hooks() {
   git_root="$(git rev-parse --show-toplevel)"
   git_base_dir="${base_dir/${git_root}/.}"
   git config --replace-all merge.tgui-merge-bundle.driver \
-    "${git_base_dir}/bin/tgui --merge=bundle %P %O %A %B %L"
+    "${git_base_dir}/bin/tgui --merge=bundle %P %A"
   echo "tgui: Merge drivers have been successfully installed!"
 }
 
 ## Bundle merge driver
 task-merge-bundle() {
   local file_path="${1}"
-  local file_ancestor="${2}"
-  local file_current="${3}"
-  local file_other="${4}"
-  local conflict_marker_size="${5}"
+  local file_current="${2}"
   echo "----------------------"
   echo "tgui: prepping to replace a conflicted bundle"
   cat $file_path > $file_current
@@ -149,7 +146,6 @@ task-rebuild-conflicted-bundle() {
   task-install
   task-webpack --mode=production
   echo "tgui: committing new bundle"
-  echo "----------------------"
 	git commit -am "TGUI Bundle Rebuild"
   exit 0
 }
@@ -237,13 +233,6 @@ if [[ ${1} == '--tgui-polyfill' ]]; then
   shift 1
   task-install
   task-polyfill "${@}"
-  exit 0
-fi
-
-## Rebuild without checking
-if [[ ${1} == '--build-only' ]]; then
-  task-install
-  task-webpack --mode=production
   exit 0
 fi
 

--- a/tgui/bin/tgui_.ps1
+++ b/tgui/bin/tgui_.ps1
@@ -107,7 +107,7 @@ function task-validate-build {
 ## Installs merge drivers and git hooks
 function task-install-git-hooks () {
     Set-Location $global:basedir
-    git config --replace-all merge.tgui-merge-bundle.driver "tgui/bin/tgui --merge=bundle %P %O %A %B %L"
+    git config --replace-all merge.tgui-merge-bundle.driver "tgui/bin/tgui --merge=bundle %P %A"
     Write-Output "tgui: Merge drivers have been successfully installed!"
 }
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Changes the behaviour of the merge conflict resolution for TGUI bundles, allowing the rebuilt bundles to be committed using a separate commit.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
The current merge driver fails to actually use the right files when rebuilding, leading to the bundle being behind. This PR makes the TGUI build task async so it sorts itself out following the conflict resolution step.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
I can't test this locally using the workflow, so lets do it live!
(it works fine with local conflict resolutions, I just don't know how the workflow for !merge_upstream will work)
<!-- How did you test the PR, if at all? -->