### PR TITLE
Contort body now autodisables on death

### DIFF
--- a/code/modules/antagonists/changeling/powers/contort_body.dm
+++ b/code/modules/antagonists/changeling/powers/contort_body.dm
@@ -9,6 +9,9 @@
 
 /datum/action/changeling/contort_body/Remove(mob/M)
 	REMOVE_TRAIT(M, TRAIT_CONTORTED_BODY, CHANGELING_TRAIT)
+	UnregisterSignal(user, COMSIG_MOB_DEATH)
+	if(IS_HORIZONTAL(user))
+		user.layer = initial(user.layer)
 	..()
 
 /datum/action/changeling/contort_body/sting_action(mob/living/user)

--- a/code/modules/antagonists/changeling/powers/contort_body.dm
+++ b/code/modules/antagonists/changeling/powers/contort_body.dm
@@ -13,12 +13,14 @@
 
 /datum/action/changeling/contort_body/sting_action(mob/living/user)
 	if(HAS_TRAIT_FROM(user, TRAIT_CONTORTED_BODY, CHANGELING_TRAIT))
+		UnregisterSignal(user, COMSIG_MOB_DEATH)
 		REMOVE_TRAIT(user, TRAIT_CONTORTED_BODY, CHANGELING_TRAIT)
 		to_chat(user, "<span class='notice'>Our body stiffens and returns to form.</span>")
 		if(IS_HORIZONTAL(user))
 			user.layer = initial(user.layer)
 	else
 		ADD_TRAIT(user, TRAIT_CONTORTED_BODY, CHANGELING_TRAIT)
+		RegisterSignal(user, COMSIG_MOB_DEATH, PROC_REF(sting_action))
 		to_chat(user, "<span class='notice'>We contort our form to allow us to fit in and under things we normally wouldn't be able to.</span>")
 		if(IS_HORIZONTAL(user))
 			user.layer = TURF_LAYER + 0.2


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Reopens #24755 with the requested changes
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
> This is a stealth ability. It is a toggle, yes. However, if you have it on and are killed by Security who DONT know you are a Changeling, they can see you fall under things (i.e. body bags in execution) and then SPRINT to gib you.

> This is very fucking cringe. To quote the Heads of Staff when we asked for clarification:

> "I just...Thats so **gamey**", "Its like the shooting everyone on station with nerf dart guns to see if they had sleeping carp"

>Now, to counter - you COULD also do this test theoretically with Cling Eye Upgrade (the classic Flash Test). This, however, requires you to be alive for it and you can usually see it coming. One is an active check that you can react to and the other is one that you cant do anything about since youre dead.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Bought contort body
Killed myself
Went above the chair layer I was previously under, and couldn't be pulled under tables anymore
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Contort body now autodisables on death
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
