### PR TITLE
Moving pulled objects as a borg checks if the turf is adjacent to you.

### DIFF
--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -362,6 +362,9 @@
 		return
 	if(!Process_Spacemove(get_dir(pulling.loc, A)))
 		return
+	var/target_turf = get_step(pulling, get_dir(pulling.loc, A)) //Make sure the turf we are trying to pull to is adjacent to the user.
+	if(!src.Adjacent(target_turf))
+		return
 	if(ismob(pulling))
 		var/mob/M = pulling
 		var/atom/movable/t = M.pulling

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -362,8 +362,8 @@
 		return
 	if(!Process_Spacemove(get_dir(pulling.loc, A)))
 		return
-	var/target_turf = get_step(pulling, get_dir(pulling.loc, A)) //Make sure the turf we are trying to pull to is adjacent to the user.
-	if(!src.Adjacent(target_turf))
+	var/target_turf = get_step(pulling, get_dir(pulling.loc, A))
+	if(!src.Adjacent(target_turf)) //Make sure the turf we are trying to pull to is adjacent to the user.
 		return
 	if(ismob(pulling))
 		var/mob/M = pulling

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -363,7 +363,7 @@
 	if(!Process_Spacemove(get_dir(pulling.loc, A)))
 		return
 	var/target_turf = get_step(pulling, get_dir(pulling.loc, A))
-	if(!src.Adjacent(target_turf)) //Make sure the turf we are trying to pull to is adjacent to the user.
+	if(!Adjacent(target_turf)) //Make sure the turf we are trying to pull to is adjacent to the user.
 		return
 	if(ismob(pulling))
 		var/mob/M = pulling


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
When you move a pulled object by clicking on a tile without a module selected as a borg, you can no longer move an objects two tiles away from you. Also fixes a similar issue with telekinesis.
Fixes: #25112
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
You should not be able to push things beyond your reach.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Be a human, try to move and pull stuff around, works just fine
Be a cyborg, try to move something beyond my reach, I can't, everything else works just fine.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Cyborgs can no longer move pulled objects two tiles away from them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
