### PR TITLE
Tweak: Converting into cult also purge all holy water from body

### DIFF
--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -356,7 +356,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 
 		H.uncuff()
 		H.Silence(6 SECONDS) //Prevent "HALP MAINT CULT" before you realise you're converted
-		if(H.reagents && H.reagents.has_reagent("holywater"))
+		if(H.reagents?.has_reagent("holywater"))
 			H.reagents.del_reagent("holywater") // Also prevent fill stomach with holy water and "forgot" about it after converting
 
 		var/obj/item/melee/cultblade/dagger/D = new(get_turf(src))

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -356,6 +356,8 @@ structure_check() searches for nearby cultist structures required for the invoca
 
 		H.uncuff()
 		H.Silence(6 SECONDS) //Prevent "HALP MAINT CULT" before you realise you're converted
+		if(H.reagents && H.reagents.has_reagent("holywater"))
+			H.reagents.del_reagent("holywater") // Also prevent fill stomach with holy water and "forgot" about it after converting
 
 		var/obj/item/melee/cultblade/dagger/D = new(get_turf(src))
 		if(H.equip_to_slot_if_possible(D, SLOT_HUD_IN_BACKPACK, FALSE, TRUE))


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Clear holywater from new body during converting process

## Why It's Good For The Game
some CLEVER AS F..REAKING ENSTEIN players fill their stomach with holy water and go fight to the cult, KNOWING they are not be converted. And then accidentaly "forgot" about 300 liters of cursed liquid into their bodyes after converting.
i need to fix that

## Images of changes
![image](https://github.com/ParadiseSS13/Paradise/assets/114731039/76ad2c23-7edb-485a-84d7-263a409478a7)

## Testing
copypasta from cult dagger

## Changelog
:cl:
tweak: Converting into cult also purge all holy water from body
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
