### PR TITLE
Bring `respawn_enabled` back to config

### DIFF
--- a/code/controllers/configuration/sections/general_configuration.dm
+++ b/code/controllers/configuration/sections/general_configuration.dm
@@ -18,7 +18,7 @@
 	var/allow_antag_hud = TRUE
 	/// Forbid players from rejoining if they use AntagHUD?
 	var/restrict_antag_hud_rejoin = TRUE
-	/// Enable respanws by default?
+	/// Enable respawns by default?
 	var/respawn_enabled = FALSE
 	/// Enable CID randomiser buster?
 	var/enabled_cid_randomiser_buster = FALSE
@@ -94,6 +94,7 @@
 	CONFIG_LOAD_BOOL(allow_antag_hud, data["allow_antag_hud"])
 	CONFIG_LOAD_BOOL(restrict_antag_hud_rejoin, data["restrict_antag_hud_rejoin"])
 	CONFIG_LOAD_BOOL(enabled_cid_randomiser_buster, data["enable_cid_randomiser_buster"])
+	CONFIG_LOAD_BOOL(respawn_enabled, data["respawn_enabled"])
 	CONFIG_LOAD_BOOL(forbid_singulo_possession, data["prevent_admin_singlo_possession"])
 	CONFIG_LOAD_BOOL(popup_admin_pm, data["popup_admin_pm"])
 	CONFIG_LOAD_BOOL(allow_holidays, data["allow_holidays"])

--- a/config/example/config.toml
+++ b/config/example/config.toml
@@ -283,6 +283,8 @@ guest_ban = true
 allow_antag_hud = true
 # Forbid players from rejoining if they use antag hud
 restrict_antag_hud_rejoin = true
+# Do we want to allow player respawns?
+respawn_enabled = false
 # Enable/disable the buster for the CID randomiser DLL
 enable_cid_randomiser_buster = false
 # Prevent admins from possessing the singularity


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Reverts configurable option that has been removed from config in #24060.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Besides the fact that this change was really unrelated, it will cause problems on our ss220 server, because this value can no longer be changed in the config without reverting this code. It would be great to keep this value configurable so that we don't have to create another conflict in the codebase. Thank you in advance.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Reverts existed code.
<!-- How did you test the PR, if at all? -->

## Changelog
NPFC

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
