### PR TITLE
Make some guns REAL auto

### DIFF
--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -74,10 +74,12 @@
 	weapon_weight = WEAPON_HEAVY
 	w_class = WEIGHT_CLASS_BULKY
 	ammo_type = list(/obj/item/ammo_casing/energy/disabler/smg)
-	burst_size = 2
-	fire_delay = 2.5
 	shaded_charge = TRUE
 	can_holster = FALSE
+
+/obj/item/gun/energy/disabler/smg/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/automatic_fire, 0.15 SECONDS, allow_akimbo = FALSE)
 
 /obj/item/gun/energy/disabler/cyborg
 	name = "cyborg disabler"

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -129,10 +129,6 @@
 	knife_x_offset = 25
 	knife_y_offset = 12
 
-/obj/item/gun/projectile/automatic/wt550/Initialize(mapload)
-	. = ..()
-	AddComponent(/datum/component/automatic_fire, 0.3 SECONDS)
-
 /obj/item/gun/projectile/automatic/wt550/update_icon_state()
 	icon_state = "wt550[magazine ? "-[CEILING(get_ammo(0)/4, 1)*4]" : ""]"
 	item_state = "wt550-[CEILING(get_ammo(0)/6.7, 1)]"

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -129,6 +129,10 @@
 	knife_x_offset = 25
 	knife_y_offset = 12
 
+/obj/item/gun/projectile/automatic/wt550/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/automatic_fire, 0.3 SECONDS)
+
 /obj/item/gun/projectile/automatic/wt550/update_icon_state()
 	icon_state = "wt550[magazine ? "-[CEILING(get_ammo(0)/4, 1)*4]" : ""]"
 	item_state = "wt550-[CEILING(get_ammo(0)/6.7, 1)]"
@@ -332,9 +336,14 @@
 	fire_sound = 'sound/weapons/gunshots/gunshot_lascarbine.ogg'
 	magin_sound = 'sound/weapons/gun_interactions/batrifle_magin.ogg'
 	magout_sound = 'sound/weapons/gun_interactions/batrifle_magout.ogg'
+	actions_types = list()
 	can_suppress = FALSE
-	burst_size = 2
+	burst_size = 1
 	execution_speed = 5 SECONDS
+
+/obj/item/gun/projectile/automatic/lasercarbine/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/automatic_fire, 0.15 SECONDS, allow_akimbo = FALSE)
 
 /obj/item/gun/projectile/automatic/lasercarbine/update_icon_state()
 	icon_state = "lasercarbine[magazine ? "-[CEILING(get_ammo(0)/5, 1)*5]" : ""]"

--- a/code/modules/projectiles/guns/projectile/saw.dm
+++ b/code/modules/projectiles/guns/projectile/saw.dm
@@ -13,8 +13,12 @@
 	magout_sound = 'sound/weapons/gun_interactions/lmg_magout.ogg'
 	var/cover_open = FALSE
 	can_suppress = FALSE
-	burst_size = 3
-	fire_delay = 1
+	burst_size = 1
+	spread = 7
+
+/obj/item/gun/projectile/automatic/l6_saw/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/automatic_fire, 0.2 SECONDS)
 
 /obj/item/gun/projectile/automatic/l6_saw/attack_self(mob/user)
 	cover_open = !cover_open

--- a/code/modules/projectiles/guns/projectile/saw.dm
+++ b/code/modules/projectiles/guns/projectile/saw.dm
@@ -12,6 +12,7 @@
 	magin_sound = 'sound/weapons/gun_interactions/lmg_magin.ogg'
 	magout_sound = 'sound/weapons/gun_interactions/lmg_magout.ogg'
 	var/cover_open = FALSE
+	actions_types = list()
 	can_suppress = FALSE
 	burst_size = 1
 	spread = 7


### PR DESCRIPTION
## What Does This PR Do
Makes IK-60 (RED ERT), Disabler SMG and L6-SAW full auto
Time to use new component
Rate of fire values were taken from TG

## Why It's Good For The Game
Full-Auto

## Images of changes
Record is laggy a little, potato PC
UPD. WT full-auto removed, but it still on video, ignore it

https://github.com/ParadiseSS13/Paradise/assets/69762909/58c327ce-dc99-464c-a488-a44817bcc650


## Testing
Above

## Changelog
:cl:
tweak: IK-60 (ERT), Disabler SMG and L6-SAW now real automatic guns (Have full-auto)
/:cl:

