### PR TITLE
ion scatter gets 2 more pellets and 5 degrees more spread

### DIFF
--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -101,10 +101,10 @@
 	desc = "An ion shotgun, that when fired gives the mecha a second of EMP shielding with the excess energy from the discharge."
 	icon_state = "mecha_ion"
 	origin_tech = "materials=4;combat=5;magnets=4"
-	energy_drain = 300 // This is per shot + 1x cost, so 1500 per shotgun shot
+	energy_drain = 215 // This is per shot + 1x cost, so ~1500 per shotgun shot
 	projectile = /obj/item/projectile/ion/weak
-	projectiles_per_shot = 4
-	variance = 35
+	projectiles_per_shot = 6
+	variance = 40
 	fire_sound = 'sound/weapons/ionrifle.ogg'
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/ion/action()

--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -246,8 +246,8 @@
 	name = "ion shell"
 	desc = "An advanced 12 gauge shell that fires a spread of ion bolts."
 	projectile_type = /obj/item/projectile/ion/weak
-	pellets = 4
-	variance = 35
+	pellets = 6
+	variance = 40
 	muzzle_flash_strength = MUZZLE_FLASH_STRENGTH_NORMAL
 	muzzle_flash_range = MUZZLE_FLASH_RANGE_NORMAL
 	muzzle_flash_color = LIGHT_COLOR_LIGHTBLUE


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
ion scatter gets 2 more pellets and 5 degrees more spread.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Over the years, I have inderectly nerfed ion scatter through fixes / tweaks, such as:
https://github.com/ParadiseSS13/Paradise/pull/23864 , mainly for the HOS gun, a weak ion should be a weak emp effect on the tile, not 50/50 for a heavy, and:
https://github.com/ParadiseSS13/Paradise/pull/18713, which fixed weak ion shots being stronger than normal ion shots.

These changes were good,but weak ion has certainly been left behind from them in power, especially when you have to manually craft the ammunition.

This should give the ion scatter a bit more strength against borgs / mechs, and keep up as a good AOE emp weapon.

Also applied to the mech ion scatter now

## Testing
<!-- How did you test the PR, if at all? -->
I shot the funny ammo

## Changelog
:cl:
tweak: Ion scatter shotgun shells gets 2 more pellets and 5 degrees more spread, compared to before
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
