### PR TITLE
fix avoiding powerfist antidrop

### DIFF
--- a/code/game/objects/items/weapons/powerfist.dm
+++ b/code/game/objects/items/weapons/powerfist.dm
@@ -31,7 +31,7 @@
 
 /obj/item/melee/powerfist/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/tank/internals))
-		if(!iscarbon(loc))
+		if(!iscarbon(loc) && user.get_active_hand())
 			to_chat(user, "<span class='warning'>You have to hold the powerfist in your hand!</span>")
 			return
 		if(!tank)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fix the case when you can load powerfist in inventory and can freely use it like a pocket knife. Pocket ultra-power-steam-giant knife.

## Why It's Good For The Game
fixing unintended interaction is good

## Images of changes
now it work as intended
![image](https://github.com/ParadiseSS13/Paradise/assets/114731039/5aade8b6-b149-4fa3-9a48-ad9a1ae24362)

## Testing
found the variable, added it to the code, check if it works.

## Changelog
:cl:
fix: You are now required to launch your power fist while holding it in your hands
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
