### PR TITLE
Fixes a small oversight with terror spiders and ghosts

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_ghost_interaction.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_ghost_interaction.dm
@@ -16,10 +16,6 @@
 	humanize_prompt += " Role: [spider_role_summary]"
 	if(user.ckey in GLOB.ts_ckey_blacklist)
 		error_on_humanize = "You are not able to control any terror spider this round."
-	else if(isobserver(user))
-		var/mob/dead/observer/O = user
-		if(!O.check_ahud_rejoin_eligibility())
-			error_on_humanize = "You have enabled antag HUD and are unable to re-enter the round."
 	else if(!ai_playercontrol_allowtype)
 		error_on_humanize = "This specific type of terror spider is not player-controllable."
 	else if(degenerate)
@@ -28,6 +24,10 @@
 		error_on_humanize = "Dead spiders are not player-controllable."
 	else if(!HAS_TRAIT(user, TRAIT_RESPAWNABLE))
 		error_on_humanize = "You are not able to rejoin the round."
+	else if(isobserver(user))
+		var/mob/dead/observer/O = user
+		if(!O.check_ahud_rejoin_eligibility())
+			error_on_humanize = "You have enabled antag HUD and are unable to re-enter the round."
 	if(jobban_isbanned(user, ROLE_SYNDICATE) || jobban_isbanned(user, ROLE_TSPIDER))
 		to_chat(user, "<span class='warning'>You are jobbanned from role of syndicate and/or terror spider.</span>")
 		return


### PR DESCRIPTION
## What Does This PR Do
This adjusts the logic in `humanize_spider` proc. It fixes an oversight with the order of conditional checks. 

## Why It's Good For The Game
It prevents ghosts from being able to control terror spiders that have been set to non-controllable by admins. 
It also ensures that some other checks are made first that would prevent a player from taking control of the terror spider.

## Testing
Tried to take control of a terror spider that has `ai_playercontrol_allowtype`  set to `0` as a ghost
Tried to take control of the terror spider that was dead as a ghost
Tested to make sure that Job Ban was still working properly

## Changelog
NPFC