### PR TITLE
day 1 shadow tweaks

### DIFF
--- a/_maps/map_files/shuttles/emergency_shadow.dmm
+++ b/_maps/map_files/shuttles/emergency_shadow.dmm
@@ -34,11 +34,11 @@
 /turf/simulated/floor/plasteel/dark,
 /area/shuttle/escape)
 "bh" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/effect/turf_decal/stripes/red/line,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
 	},
+/obj/structure/window/plasmareinforced,
 /turf/simulated/floor/pod/dark,
 /area/shuttle/escape)
 "bD" = (
@@ -191,7 +191,7 @@
 /turf/simulated/floor/engine/airless,
 /area/shuttle/escape)
 "hm" = (
-/obj/machinery/door/firedoor/border_only{
+/obj/structure/window/plasmareinforced{
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/red/line{
@@ -301,7 +301,7 @@
 	},
 /area/shuttle/escape)
 "my" = (
-/obj/machinery/door/firedoor/border_only{
+/obj/structure/window/plasmareinforced{
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/red/line{
@@ -473,7 +473,7 @@
 /turf/simulated/floor/pod/dark,
 /area/shuttle/escape)
 "vw" = (
-/obj/machinery/door/firedoor/border_only{
+/obj/structure/window/plasmareinforced{
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/red/line{
@@ -518,7 +518,7 @@
 /turf/simulated/floor/pod/dark,
 /area/shuttle/escape)
 "wF" = (
-/obj/machinery/door/firedoor/border_only{
+/obj/structure/window/plasmareinforced{
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/red/line{
@@ -620,8 +620,8 @@
 	},
 /area/shuttle/escape)
 "Bu" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/effect/turf_decal/stripes/red/line,
+/obj/structure/window/plasmareinforced,
 /turf/simulated/floor/pod/dark,
 /area/shuttle/escape)
 "BB" = (
@@ -697,7 +697,7 @@
 /turf/simulated/floor/plasteel/dark,
 /area/shuttle/escape)
 "EM" = (
-/obj/machinery/door/firedoor/border_only{
+/obj/structure/window/plasmareinforced{
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/red/line{
@@ -875,7 +875,8 @@
 	dwidth = 16;
 	width = 41;
 	timid = 1;
-	height = 13
+	height = 13;
+	shuttle_speed_factor = 2
 	},
 /turf/simulated/floor/pod/dark,
 /area/shuttle/escape)
@@ -892,7 +893,7 @@
 /turf/simulated/floor/plasteel/dark,
 /area/shuttle/escape)
 "LA" = (
-/obj/machinery/door/firedoor/border_only{
+/obj/structure/window/plasmareinforced{
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/red/line{
@@ -1051,11 +1052,11 @@
 	},
 /area/shuttle/escape)
 "Sn" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/effect/turf_decal/stripes/red/line,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
 	},
+/obj/structure/window/plasmareinforced,
 /turf/simulated/floor/pod/dark,
 /area/shuttle/escape)
 "So" = (
@@ -1145,6 +1146,7 @@
 	name = "Engine Room"
 	},
 /obj/machinery/door/firedoor/heavy,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
 /turf/simulated/floor/plasteel/dark,
 /area/shuttle/escape)
 "WQ" = (
@@ -1231,7 +1233,7 @@
 /turf/simulated/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "Zq" = (
-/obj/machinery/door/firedoor/border_only{
+/obj/structure/window/plasmareinforced{
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/red/line{


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Engineering section is engineering / atmos locked, oops, sorry.
Directional firelocks replaced with directional reinforced plasmaglass, to make breaking it slightly harder, primarly for griefers.
Shuttle will be faster when admin forced, like a cargo order.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

engineering in shuttle being engineering locked is good.
Extra protection from grief is good.
Admin forced shuttle being fast is good.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
Attempted to open door as civilian, then engi, then atmos.
Called shuttle when admin ordered, faster.
Confirmed glass was there / anchored.

## Testing
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: NTSS shadow engineering section is engineering access locked.
tweak: NTSS shadow direcitonal firelocks removed, replaced with directional plasmaglass windows.
fix: Admin ordered NTSS shadow is faster as it should be.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
