### PR TITLE
fix: null check during morph eat

### DIFF
--- a/code/game/gamemodes/miniantags/morph/morph.dm
+++ b/code/game/gamemodes/miniantags/morph/morph.dm
@@ -113,7 +113,7 @@
 			var/obj/item/clothing/under/U = H.w_uniform
 			U.turn_sensors_off()
 
-		A.pulledby.stop_pulling()
+		A.pulledby?.stop_pulling()
 		A.extinguish_light()
 		A.forceMove(src)
 		var/food_value = calc_food_gained(A)


### PR DESCRIPTION
## What Does This PR Do
This PR fixes a runtime preventing morphs from eating dead bodies.
## Why It's Good For The Game
Bugs bad
## Testing
Ensured I could eat a dead body.
## Changelog
:cl:
fix: Morphs should no longer fail to eat dead bodies.
/:cl: