### PR TITLE
Fix planetary_atmos working correctly only for lavaland + use defines for lavaland atmos

### DIFF
--- a/code/__DEFINES/atmospherics_defines.dm
+++ b/code/__DEFINES/atmospherics_defines.dm
@@ -142,6 +142,8 @@
 //LAVALAND
 #define LAVALAND_EQUIPMENT_EFFECT_PRESSURE 50 //what pressure you have to be under to increase the effect of equipment meant for lavaland
 #define LAVALAND_TEMPERATURE 500
+#define LAVALAND_OXYGEN 8
+#define LAVALAND_NITROGEN 14
 
 // Reactions
 #define N2O_DECOMPOSITION_MIN_ENERGY		1400

--- a/code/__DEFINES/atmospherics_defines.dm
+++ b/code/__DEFINES/atmospherics_defines.dm
@@ -141,6 +141,7 @@
 
 //LAVALAND
 #define LAVALAND_EQUIPMENT_EFFECT_PRESSURE 50 //what pressure you have to be under to increase the effect of equipment meant for lavaland
+#define LAVALAND_TEMPERATURE 500
 
 // Reactions
 #define N2O_DECOMPOSITION_MIN_ENERGY		1400

--- a/code/game/turfs/simulated/floor/asteroid_floors.dm
+++ b/code/game/turfs/simulated/floor/asteroid_floors.dm
@@ -148,14 +148,14 @@
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface
 	oxygen = 8
 	nitrogen = 14
-	temperature = 500
+	temperature = LAVALAND_TEMPERATURE
 	planetary_atmos = TRUE
 	baseturf = /turf/simulated/floor/lava/mapping_lava
 
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface_hard
 	oxygen = 8
 	nitrogen = 14
-	temperature = 500
+	temperature = LAVALAND_TEMPERATURE
 	planetary_atmos = TRUE
 	color = COLOR_FLOOR_HARD_ROCK
 	baseturf = /turf/simulated/floor/lava/lava_land_surface
@@ -201,7 +201,7 @@ GLOBAL_LIST_INIT(megafauna_spawn_list, list(/mob/living/simple_animal/hostile/me
 	turf_type = /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface
 	oxygen = 8
 	nitrogen = 14
-	temperature = 500
+	temperature = LAVALAND_TEMPERATURE
 
 /// subtype for producing a tunnel with given data
 /turf/simulated/floor/plating/asteroid/airless/cave/volcanic/has_data

--- a/code/game/turfs/simulated/floor/asteroid_floors.dm
+++ b/code/game/turfs/simulated/floor/asteroid_floors.dm
@@ -146,15 +146,15 @@
 ///////Surface. The surface is warm, but survivable without a suit. Internals are required. The floors break to chasms, which drop you into the underground.
 
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface
-	oxygen = 8
-	nitrogen = 14
+	oxygen = LAVALAND_OXYGEN
+	nitrogen = LAVALAND_NITROGEN
 	temperature = LAVALAND_TEMPERATURE
 	planetary_atmos = TRUE
 	baseturf = /turf/simulated/floor/lava/mapping_lava
 
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface_hard
-	oxygen = 8
-	nitrogen = 14
+	oxygen = LAVALAND_OXYGEN
+	nitrogen = LAVALAND_NITROGEN
 	temperature = LAVALAND_TEMPERATURE
 	planetary_atmos = TRUE
 	color = COLOR_FLOOR_HARD_ROCK
@@ -199,8 +199,8 @@ GLOBAL_LIST_INIT(megafauna_spawn_list, list(/mob/living/simple_animal/hostile/me
 
 	data_having_type = /turf/simulated/floor/plating/asteroid/airless/cave/volcanic/has_data
 	turf_type = /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface
-	oxygen = 8
-	nitrogen = 14
+	oxygen = LAVALAND_OXYGEN
+	nitrogen = LAVALAND_NITROGEN
 	temperature = LAVALAND_TEMPERATURE
 
 /// subtype for producing a tunnel with given data

--- a/code/game/turfs/simulated/floor/chasm.dm
+++ b/code/game/turfs/simulated/floor/chasm.dm
@@ -175,7 +175,7 @@
 /turf/simulated/floor/chasm/straight_down/lava_land_surface
 	oxygen = 8
 	nitrogen = 14
-	temperature = 500
+	temperature = LAVALAND_TEMPERATURE
 	planetary_atmos = TRUE
 	baseturf = /turf/simulated/floor/chasm/straight_down/lava_land_surface //Chasms should not turn into lava
 	light_range = 2

--- a/code/game/turfs/simulated/floor/chasm.dm
+++ b/code/game/turfs/simulated/floor/chasm.dm
@@ -173,8 +173,8 @@
 	drop_z = z - 1
 
 /turf/simulated/floor/chasm/straight_down/lava_land_surface
-	oxygen = 8
-	nitrogen = 14
+	oxygen = LAVALAND_OXYGEN
+	nitrogen = LAVALAND_NITROGEN
 	temperature = LAVALAND_TEMPERATURE
 	planetary_atmos = TRUE
 	baseturf = /turf/simulated/floor/chasm/straight_down/lava_land_surface //Chasms should not turn into lava

--- a/code/game/turfs/simulated/floor/fancy_floor.dm
+++ b/code/game/turfs/simulated/floor/fancy_floor.dm
@@ -53,8 +53,8 @@
 	temperature = 180
 
 /turf/simulated/floor/wood/lavaland_air
-	nitrogen = 14
-	oxygen = 8
+	nitrogen = LAVALAND_NITROGEN
+	oxygen = LAVALAND_OXYGEN
 	temperature = LAVALAND_TEMPERATURE
 
 // Grass

--- a/code/game/turfs/simulated/floor/fancy_floor.dm
+++ b/code/game/turfs/simulated/floor/fancy_floor.dm
@@ -17,7 +17,7 @@
 	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
 		return
 	remove_tile(user, FALSE, FALSE)
-	
+
 /turf/simulated/floor/wood/get_broken_states()
 	return list("wood-broken", "wood-broken2", "wood-broken3", "wood-broken4", "wood-broken5", "wood-broken6", "wood-broken7")
 
@@ -55,7 +55,7 @@
 /turf/simulated/floor/wood/lavaland_air
 	nitrogen = 14
 	oxygen = 8
-	temperature = 500
+	temperature = LAVALAND_TEMPERATURE
 
 // Grass
 /turf/simulated/floor/grass

--- a/code/game/turfs/simulated/floor/indestructible.dm
+++ b/code/game/turfs/simulated/floor/indestructible.dm
@@ -44,8 +44,8 @@
 	icon = 'icons/turf/floors.dmi'
 	icon_state = "necro1"
 	baseturf = /turf/simulated/floor/indestructible/necropolis
-	oxygen = 8
-	nitrogen = 14
+	oxygen = LAVALAND_OXYGEN
+	nitrogen = LAVALAND_NITROGEN
 	temperature = LAVALAND_TEMPERATURE
 	planetary_atmos = TRUE
 	footstep = FOOTSTEP_LAVA
@@ -69,8 +69,8 @@
 	icon = 'icons/turf/floors/boss_floors.dmi'
 	icon_state = "boss"
 	baseturf = /turf/simulated/floor/indestructible/boss
-	oxygen = 8
-	nitrogen = 14
+	oxygen = LAVALAND_OXYGEN
+	nitrogen = LAVALAND_NITROGEN
 	temperature = LAVALAND_TEMPERATURE
 	planetary_atmos = TRUE
 
@@ -83,8 +83,8 @@
 	name = "floor"
 	icon = 'icons/turf/floors/hierophant_floor.dmi'
 	icon_state = "floor"
-	oxygen = 8
-	nitrogen = 14
+	oxygen = LAVALAND_OXYGEN
+	nitrogen = LAVALAND_NITROGEN
 	temperature = LAVALAND_TEMPERATURE
 	planetary_atmos = TRUE
 	smoothing_flags = SMOOTH_CORNERS

--- a/code/game/turfs/simulated/floor/indestructible.dm
+++ b/code/game/turfs/simulated/floor/indestructible.dm
@@ -46,7 +46,7 @@
 	baseturf = /turf/simulated/floor/indestructible/necropolis
 	oxygen = 8
 	nitrogen = 14
-	temperature = 500
+	temperature = LAVALAND_TEMPERATURE
 	planetary_atmos = TRUE
 	footstep = FOOTSTEP_LAVA
 	barefootstep = FOOTSTEP_LAVA
@@ -71,7 +71,7 @@
 	baseturf = /turf/simulated/floor/indestructible/boss
 	oxygen = 8
 	nitrogen = 14
-	temperature = 500
+	temperature = LAVALAND_TEMPERATURE
 	planetary_atmos = TRUE
 
 /turf/simulated/floor/indestructible/boss/air
@@ -85,7 +85,7 @@
 	icon_state = "floor"
 	oxygen = 8
 	nitrogen = 14
-	temperature = 500
+	temperature = LAVALAND_TEMPERATURE
 	planetary_atmos = TRUE
 	smoothing_flags = SMOOTH_CORNERS
 

--- a/code/game/turfs/simulated/floor/lava.dm
+++ b/code/game/turfs/simulated/floor/lava.dm
@@ -161,8 +161,8 @@
 
 /turf/simulated/floor/lava/lava_land_surface
 	temperature = LAVALAND_TEMPERATURE
-	oxygen = 8
-	nitrogen = 14
+	oxygen = LAVALAND_OXYGEN
+	nitrogen = LAVALAND_NITROGEN
 	planetary_atmos = TRUE
 	baseturf = /turf/simulated/floor/chasm/straight_down/lava_land_surface
 
@@ -257,8 +257,8 @@
 	base_icon_state = "mappinglava"
 	baseturf = /turf/simulated/floor/lava/mapping_lava
 	temperature = LAVALAND_TEMPERATURE
-	oxygen = 8
-	nitrogen = 14
+	oxygen = LAVALAND_OXYGEN
+	nitrogen = LAVALAND_NITROGEN
 	planetary_atmos = TRUE
 
 

--- a/code/game/turfs/simulated/floor/lava.dm
+++ b/code/game/turfs/simulated/floor/lava.dm
@@ -160,7 +160,7 @@
 	return
 
 /turf/simulated/floor/lava/lava_land_surface
-	temperature = 500
+	temperature = LAVALAND_TEMPERATURE
 	oxygen = 8
 	nitrogen = 14
 	planetary_atmos = TRUE
@@ -256,7 +256,7 @@
 	icon_state = "mappinglava"
 	base_icon_state = "mappinglava"
 	baseturf = /turf/simulated/floor/lava/mapping_lava
-	temperature = 500
+	temperature = LAVALAND_TEMPERATURE
 	oxygen = 8
 	nitrogen = 14
 	planetary_atmos = TRUE

--- a/code/game/turfs/simulated/floor/mineral_floors.dm
+++ b/code/game/turfs/simulated/floor/mineral_floors.dm
@@ -287,6 +287,6 @@
 	return //unburnable
 
 /turf/simulated/floor/plating/abductor/lavaland_air
-	temperature = 500
+	temperature = LAVALAND_TEMPERATURE
 	oxygen = 8
 	nitrogen = 14

--- a/code/game/turfs/simulated/floor/mineral_floors.dm
+++ b/code/game/turfs/simulated/floor/mineral_floors.dm
@@ -288,5 +288,5 @@
 
 /turf/simulated/floor/plating/abductor/lavaland_air
 	temperature = LAVALAND_TEMPERATURE
-	oxygen = 8
-	nitrogen = 14
+	oxygen = LAVALAND_OXYGEN
+	nitrogen = LAVALAND_NITROGEN

--- a/code/game/turfs/simulated/floor/misc_floor.dm
+++ b/code/game/turfs/simulated/floor/misc_floor.dm
@@ -4,7 +4,7 @@
 	smoothing_flags = NONE
 
 /turf/simulated/floor/vault/lavaland_air
-	temperature = 500
+	temperature = LAVALAND_TEMPERATURE
 	oxygen = 8
 	nitrogen = 14
 	planetary_atmos = TRUE
@@ -148,7 +148,7 @@
 /turf/simulated/floor/noslip/lavaland
 	oxygen = 8
 	nitrogen = 14
-	temperature = 500
+	temperature = LAVALAND_TEMPERATURE
 	planetary_atmos = TRUE
 
 /turf/simulated/floor/lubed
@@ -236,7 +236,7 @@
 /turf/simulated/floor/clockwork/lavaland_air
 	nitrogen = 14
 	oxygen = 8
-	temperature = 500
+	temperature = LAVALAND_TEMPERATURE
 
 /turf/simulated/floor/catwalk
 	name = "catwalk"

--- a/code/game/turfs/simulated/floor/misc_floor.dm
+++ b/code/game/turfs/simulated/floor/misc_floor.dm
@@ -5,8 +5,8 @@
 
 /turf/simulated/floor/vault/lavaland_air
 	temperature = LAVALAND_TEMPERATURE
-	oxygen = 8
-	nitrogen = 14
+	oxygen = LAVALAND_OXYGEN
+	nitrogen = LAVALAND_NITROGEN
 	planetary_atmos = TRUE
 	baseturf = /turf/simulated/floor/chasm/straight_down/lava_land_surface
 
@@ -146,8 +146,8 @@
 	return
 
 /turf/simulated/floor/noslip/lavaland
-	oxygen = 8
-	nitrogen = 14
+	oxygen = LAVALAND_OXYGEN
+	nitrogen = LAVALAND_NITROGEN
 	temperature = LAVALAND_TEMPERATURE
 	planetary_atmos = TRUE
 
@@ -234,8 +234,8 @@
 	uses_overlay = FALSE
 
 /turf/simulated/floor/clockwork/lavaland_air
-	nitrogen = 14
-	oxygen = 8
+	nitrogen = LAVALAND_NITROGEN
+	oxygen = LAVALAND_OXYGEN
 	temperature = LAVALAND_TEMPERATURE
 
 /turf/simulated/floor/catwalk

--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -170,7 +170,7 @@
 	name = "plating"
 
 /turf/simulated/floor/plating/lavaland_air
-	temperature = 500
+	temperature = LAVALAND_TEMPERATURE
 	oxygen = 8
 	nitrogen = 14
 
@@ -255,7 +255,7 @@
 /turf/simulated/floor/engine/cult/lavaland_air
 	nitrogen = 14
 	oxygen = 8
-	temperature = 500
+	temperature = LAVALAND_TEMPERATURE
 
 //air filled floors; used in atmos pressure chambers
 

--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -171,8 +171,8 @@
 
 /turf/simulated/floor/plating/lavaland_air
 	temperature = LAVALAND_TEMPERATURE
-	oxygen = 8
-	nitrogen = 14
+	oxygen = LAVALAND_OXYGEN
+	nitrogen = LAVALAND_NITROGEN
 
 /turf/simulated/floor/engine
 	name = "reinforced floor"
@@ -253,8 +253,8 @@
 	return
 
 /turf/simulated/floor/engine/cult/lavaland_air
-	nitrogen = 14
-	oxygen = 8
+	nitrogen = LAVALAND_NITROGEN
+	oxygen = LAVALAND_OXYGEN
 	temperature = LAVALAND_TEMPERATURE
 
 //air filled floors; used in atmos pressure chambers

--- a/code/game/turfs/simulated/minerals.dm
+++ b/code/game/turfs/simulated/minerals.dm
@@ -281,7 +281,7 @@
 	baseturf = /turf/simulated/floor/lava/mapping_lava
 	oxygen = 8
 	nitrogen = 14
-	temperature = 500
+	temperature = LAVALAND_TEMPERATURE
 	defer_change = 1
 	mineralSpawnChanceList = list(
 		/turf/simulated/mineral/uranium/volcanic = 35, /turf/simulated/mineral/diamond/volcanic = 30, /turf/simulated/mineral/gold/volcanic = 45, /turf/simulated/mineral/titanium/volcanic = 45,
@@ -301,7 +301,7 @@
 	baseturf = /turf/simulated/floor/lava/mapping_lava
 	oxygen = 8
 	nitrogen = 14
-	temperature = 500
+	temperature = LAVALAND_TEMPERATURE
 	defer_change = 1
 
 	mineralChance = 10
@@ -330,7 +330,7 @@
 	baseturf = /turf/simulated/floor/lava/mapping_lava
 	oxygen = 8
 	nitrogen = 14
-	temperature = 500
+	temperature = LAVALAND_TEMPERATURE
 	defer_change = 1
 	mineralSpawnChanceList = list(
 		/turf/simulated/mineral/uranium/volcanic = 3, /turf/simulated/mineral/diamond/volcanic = 1, /turf/simulated/mineral/gold/volcanic = 8, /turf/simulated/mineral/titanium/volcanic = 8,
@@ -350,7 +350,7 @@
 	baseturf = /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface
 	oxygen = 8
 	nitrogen = 14
-	temperature = 500
+	temperature = LAVALAND_TEMPERATURE
 	defer_change = 1
 
 /turf/simulated/mineral/uranium
@@ -365,7 +365,7 @@
 	baseturf = /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface
 	oxygen = 8
 	nitrogen = 14
-	temperature = 500
+	temperature = LAVALAND_TEMPERATURE
 	defer_change = 1
 
 /turf/simulated/mineral/diamond
@@ -380,7 +380,7 @@
 	baseturf = /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface
 	oxygen = 8
 	nitrogen = 14
-	temperature = 500
+	temperature = LAVALAND_TEMPERATURE
 	defer_change = 1
 
 /turf/simulated/mineral/gold
@@ -395,7 +395,7 @@
 	baseturf = /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface
 	oxygen = 8
 	nitrogen = 14
-	temperature = 500
+	temperature = LAVALAND_TEMPERATURE
 	defer_change = 1
 
 /turf/simulated/mineral/silver
@@ -410,7 +410,7 @@
 	baseturf = /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface
 	oxygen = 8
 	nitrogen = 14
-	temperature = 500
+	temperature = LAVALAND_TEMPERATURE
 	defer_change = 1
 
 /turf/simulated/mineral/titanium
@@ -425,7 +425,7 @@
 	baseturf = /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface
 	oxygen = 8
 	nitrogen = 14
-	temperature = 500
+	temperature = LAVALAND_TEMPERATURE
 	defer_change = 1
 
 /turf/simulated/mineral/plasma
@@ -440,7 +440,7 @@
 	baseturf = /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface
 	oxygen = 8
 	nitrogen = 14
-	temperature = 500
+	temperature = LAVALAND_TEMPERATURE
 	defer_change = 1
 
 /turf/simulated/mineral/clown
@@ -456,7 +456,7 @@
 	baseturf = /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface
 	oxygen = 8
 	nitrogen = 14
-	temperature = 500
+	temperature = LAVALAND_TEMPERATURE
 	defer_change = 1
 
 /turf/simulated/mineral/mime
@@ -471,7 +471,7 @@
 	baseturf = /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface
 	oxygen = 8
 	nitrogen = 14
-	temperature = 500
+	temperature = LAVALAND_TEMPERATURE
 	defer_change = 1
 
 /turf/simulated/mineral/bscrystal
@@ -487,7 +487,7 @@
 	baseturf = /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface
 	oxygen = 8
 	nitrogen = 14
-	temperature = 500
+	temperature = LAVALAND_TEMPERATURE
 	defer_change = 1
 
 /turf/simulated/mineral/volcanic
@@ -496,7 +496,7 @@
 	baseturf = /turf/simulated/floor/plating/asteroid/basalt
 	oxygen = 8
 	nitrogen = 14
-	temperature = 500
+	temperature = LAVALAND_TEMPERATURE
 
 /turf/simulated/mineral/volcanic/lava_land_surface
 	environment_type = "basalt"
@@ -611,7 +611,7 @@
 	baseturf = /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface
 	oxygen = 8
 	nitrogen = 14
-	temperature = 500
+	temperature = LAVALAND_TEMPERATURE
 	defer_change = 1
 
 #undef GIBTONITE_UNSTRUCK

--- a/code/game/turfs/simulated/minerals.dm
+++ b/code/game/turfs/simulated/minerals.dm
@@ -279,8 +279,8 @@
 	environment_type = "basalt"
 	turf_type = /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface
 	baseturf = /turf/simulated/floor/lava/mapping_lava
-	oxygen = 8
-	nitrogen = 14
+	oxygen = LAVALAND_OXYGEN
+	nitrogen = LAVALAND_NITROGEN
 	temperature = LAVALAND_TEMPERATURE
 	defer_change = 1
 	mineralSpawnChanceList = list(
@@ -299,8 +299,8 @@
 	environment_type = "basalt"
 	turf_type = /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface
 	baseturf = /turf/simulated/floor/lava/mapping_lava
-	oxygen = 8
-	nitrogen = 14
+	oxygen = LAVALAND_OXYGEN
+	nitrogen = LAVALAND_NITROGEN
 	temperature = LAVALAND_TEMPERATURE
 	defer_change = 1
 
@@ -328,8 +328,8 @@
 	environment_type = "basalt"
 	turf_type = /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface
 	baseturf = /turf/simulated/floor/lava/mapping_lava
-	oxygen = 8
-	nitrogen = 14
+	oxygen = LAVALAND_OXYGEN
+	nitrogen = LAVALAND_NITROGEN
 	temperature = LAVALAND_TEMPERATURE
 	defer_change = 1
 	mineralSpawnChanceList = list(
@@ -348,8 +348,8 @@
 	environment_type = "basalt"
 	turf_type = /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface
 	baseturf = /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface
-	oxygen = 8
-	nitrogen = 14
+	oxygen = LAVALAND_OXYGEN
+	nitrogen = LAVALAND_NITROGEN
 	temperature = LAVALAND_TEMPERATURE
 	defer_change = 1
 
@@ -363,8 +363,8 @@
 	environment_type = "basalt"
 	turf_type = /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface
 	baseturf = /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface
-	oxygen = 8
-	nitrogen = 14
+	oxygen = LAVALAND_OXYGEN
+	nitrogen = LAVALAND_NITROGEN
 	temperature = LAVALAND_TEMPERATURE
 	defer_change = 1
 
@@ -378,8 +378,8 @@
 	environment_type = "basalt"
 	turf_type = /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface
 	baseturf = /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface
-	oxygen = 8
-	nitrogen = 14
+	oxygen = LAVALAND_OXYGEN
+	nitrogen = LAVALAND_NITROGEN
 	temperature = LAVALAND_TEMPERATURE
 	defer_change = 1
 
@@ -393,8 +393,8 @@
 	environment_type = "basalt"
 	turf_type = /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface
 	baseturf = /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface
-	oxygen = 8
-	nitrogen = 14
+	oxygen = LAVALAND_OXYGEN
+	nitrogen = LAVALAND_NITROGEN
 	temperature = LAVALAND_TEMPERATURE
 	defer_change = 1
 
@@ -408,8 +408,8 @@
 	environment_type = "basalt"
 	turf_type = /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface
 	baseturf = /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface
-	oxygen = 8
-	nitrogen = 14
+	oxygen = LAVALAND_OXYGEN
+	nitrogen = LAVALAND_NITROGEN
 	temperature = LAVALAND_TEMPERATURE
 	defer_change = 1
 
@@ -423,8 +423,8 @@
 	environment_type = "basalt"
 	turf_type = /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface
 	baseturf = /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface
-	oxygen = 8
-	nitrogen = 14
+	oxygen = LAVALAND_OXYGEN
+	nitrogen = LAVALAND_NITROGEN
 	temperature = LAVALAND_TEMPERATURE
 	defer_change = 1
 
@@ -438,8 +438,8 @@
 	environment_type = "basalt"
 	turf_type = /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface
 	baseturf = /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface
-	oxygen = 8
-	nitrogen = 14
+	oxygen = LAVALAND_OXYGEN
+	nitrogen = LAVALAND_NITROGEN
 	temperature = LAVALAND_TEMPERATURE
 	defer_change = 1
 
@@ -454,8 +454,8 @@
 	environment_type = "basalt"
 	turf_type = /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface
 	baseturf = /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface
-	oxygen = 8
-	nitrogen = 14
+	oxygen = LAVALAND_OXYGEN
+	nitrogen = LAVALAND_NITROGEN
 	temperature = LAVALAND_TEMPERATURE
 	defer_change = 1
 
@@ -469,8 +469,8 @@
 	environment_type = "basalt"
 	turf_type = /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface
 	baseturf = /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface
-	oxygen = 8
-	nitrogen = 14
+	oxygen = LAVALAND_OXYGEN
+	nitrogen = LAVALAND_NITROGEN
 	temperature = LAVALAND_TEMPERATURE
 	defer_change = 1
 
@@ -485,8 +485,8 @@
 	environment_type = "basalt"
 	turf_type = /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface
 	baseturf = /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface
-	oxygen = 8
-	nitrogen = 14
+	oxygen = LAVALAND_OXYGEN
+	nitrogen = LAVALAND_NITROGEN
 	temperature = LAVALAND_TEMPERATURE
 	defer_change = 1
 
@@ -494,8 +494,8 @@
 	environment_type = "basalt"
 	turf_type = /turf/simulated/floor/plating/asteroid/basalt
 	baseturf = /turf/simulated/floor/plating/asteroid/basalt
-	oxygen = 8
-	nitrogen = 14
+	oxygen = LAVALAND_OXYGEN
+	nitrogen = LAVALAND_NITROGEN
 	temperature = LAVALAND_TEMPERATURE
 
 /turf/simulated/mineral/volcanic/lava_land_surface
@@ -609,8 +609,8 @@
 	environment_type = "basalt"
 	turf_type = /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface
 	baseturf = /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface
-	oxygen = 8
-	nitrogen = 14
+	oxygen = LAVALAND_OXYGEN
+	nitrogen = LAVALAND_NITROGEN
 	temperature = LAVALAND_TEMPERATURE
 	defer_change = 1
 

--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -203,7 +203,7 @@
 		G.toxins = toxins
 		G.sleeping_agent = sleeping_agent
 		G.agent_b = agent_b
-		G.temperature = temperature
+		G.temperature = initial(temperature) // Temperature is modified at runtime; we only care about the turf's initial temperature
 		G.archive()
 		if(!air.compare(G))
 			if(!our_excited_group)

--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -195,8 +195,6 @@
 				if(our_excited_group)
 					last_share_check()
 
-#define LAVALAND_TEMPERATURE 500
-
 	if(planetary_atmos) //share our air with the "atmosphere" "above" the turf
 		var/datum/gas_mixture/G = new
 		G.oxygen = oxygen
@@ -205,7 +203,7 @@
 		G.toxins = toxins
 		G.sleeping_agent = sleeping_agent
 		G.agent_b = agent_b
-		G.temperature = LAVALAND_TEMPERATURE // Temperature is modified at runtime; we only care about the turf's initial temperature
+		G.temperature = temperature
 		G.archive()
 		if(!air.compare(G))
 			if(!our_excited_group)
@@ -214,8 +212,6 @@
 				our_excited_group = excited_group
 			air.share(G, adjacent_turfs_length)
 			last_share_check()
-
-#undef LAVALAND_TEMPERATURE
 
 	air.react()
 

--- a/code/modules/awaymissions/mission_code/beach.dm
+++ b/code/modules/awaymissions/mission_code/beach.dm
@@ -114,8 +114,8 @@
 		linkedcontroller.decalinpool += A
 
 /turf/simulated/floor/beach/away/water/lavaland_air
-	nitrogen = 14
-	oxygen = 8
+	nitrogen = LAVALAND_NITROGEN
+	oxygen = LAVALAND_OXYGEN
 	temperature = LAVALAND_TEMPERATURE
 	planetary_atmos = TRUE
 

--- a/code/modules/awaymissions/mission_code/beach.dm
+++ b/code/modules/awaymissions/mission_code/beach.dm
@@ -116,7 +116,7 @@
 /turf/simulated/floor/beach/away/water/lavaland_air
 	nitrogen = 14
 	oxygen = 8
-	temperature = 500
+	temperature = LAVALAND_TEMPERATURE
 	planetary_atmos = TRUE
 
 /// for boundary "walls"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

When `planetary_atmos` is `TRUE`, it will take turf's initial temperature value instead of hardcoded lavaland's temperature

Use defines

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

planetary_atmos can be used not only in Lavaland

## Testing
<!-- How did you test the PR, if at all? -->

Accidentaly start a plasmafire on lavaland with toxin canister, atmos normalized