### PR TITLE
Cultists no longer instantly get red-eyes/halo when converted

### DIFF
--- a/code/modules/antagonists/cult/team_cult.dm
+++ b/code/modules/antagonists/cult/team_cult.dm
@@ -28,6 +28,9 @@ RESTRICT_TYPE(/datum/team/cult)
 	// Disables the station-wide announcements, unused except for admin editing.
 	var/no_announcements = FALSE
 
+	/// Boolean that prevents all_members_timer from being called multiple times
+	var/is_in_transition = FALSE
+
 /datum/team/cult/create_team(list/starting_members)
 	cult_threshold_check() // Set this ALWAYS before any check_cult_size check, or
 	. = ..()
@@ -145,6 +148,9 @@ RESTRICT_TYPE(/datum/team/cult)
 	INVOKE_ASYNC(src, PROC_REF(remove_member), deleting_cultist.mind)
 
 /datum/team/cult/proc/check_cult_size()
+	if(is_in_transition)
+		return
+
 	if(!ascend_percent)
 		stack_trace("[src]'s check_cult_size was called before cult_threshold_check, which leads to weird logic! This should be fixed ASAP.")
 		cult_threshold_check()
@@ -165,36 +171,36 @@ RESTRICT_TYPE(/datum/team/cult)
 		cult_ascend()
 
 /datum/team/cult/proc/cult_rise()
-	cult_risen = TRUE
+	is_in_transition = TRUE
 	for(var/datum/mind/M in members)
 		if(!ishuman(M.current))
 			continue
 		SEND_SOUND(M.current, sound('sound/hallucinations/i_see_you2.ogg'))
 		to_chat(M.current, "<span class='cultlarge'>The veil weakens as your cult grows, your eyes begin to glow...</span>")
 
-	addtimer(CALLBACK(src, PROC_REF(all_members_timer), TYPE_PROC_REF(/datum/antagonist/cultist, rise)), 20 SECONDS)
+	addtimer(CALLBACK(src, PROC_REF(all_members_timer), TYPE_PROC_REF(/datum/antagonist/cultist, rise), VARSET_CALLBACK(src, cult_risen, TRUE)), 20 SECONDS)
 
 /datum/team/cult/proc/cult_ascend()
-	cult_ascendant = TRUE
+	is_in_transition = TRUE
 	for(var/datum/mind/M in members)
 		if(!ishuman(M.current))
 			continue
 		SEND_SOUND(M.current, sound('sound/hallucinations/im_here1.ogg'))
 		to_chat(M.current, "<span class='cultlarge'>Your cult is ascendant and the red harvest approaches - you cannot hide your true nature for much longer!</span>")
 
-	addtimer(CALLBACK(src, PROC_REF(all_members_timer), TYPE_PROC_REF(/datum/antagonist/cultist, ascend)), 20 SECONDS)
+	addtimer(CALLBACK(src, PROC_REF(all_members_timer), TYPE_PROC_REF(/datum/antagonist/cultist, ascend), VARSET_CALLBACK(src, cult_ascendant, TRUE)), 20 SECONDS)
 	if(!no_announcements)
 		GLOB.major_announcement.Announce("Picking up extradimensional activity related to the Cult of [GET_CULT_DATA(entity_name, "Nar'Sie")] from your station. Data suggests that about [ascend_percent * 100]% of the station has been converted. Security staff are authorized to use lethal force freely against cultists. Non-security staff should be prepared to defend themselves and their work areas from hostile cultists. Self defense permits non-security staff to use lethal force as a last resort, but non-security staff should be defending their work areas, not hunting down cultists. Dead crewmembers must be revived and deconverted once the situation is under control.", "Central Command Higher Dimensional Affairs", 'sound/AI/commandreport.ogg')
 
 /datum/team/cult/proc/cult_fall()
-	cult_ascendant = FALSE
+	is_in_transition = TRUE
 	for(var/datum/mind/M in members)
 		if(!ishuman(M.current))
 			continue
 		SEND_SOUND(M.current, sound('sound/hallucinations/wail.ogg'))
 		to_chat(M.current, "<span class='cultlarge'>The veil repairs itself, your power grows weaker...</span>")
 
-	addtimer(CALLBACK(src, PROC_REF(all_members_timer), TYPE_PROC_REF(/datum/antagonist/cultist, descend)), 20 SECONDS)
+	addtimer(CALLBACK(src, PROC_REF(all_members_timer), TYPE_PROC_REF(/datum/antagonist/cultist, descend), VARSET_CALLBACK(src, cult_ascendant, FALSE)), 20 SECONDS)
 	if(!no_announcements)
 		GLOB.major_announcement.Announce("Paranormal activity has returned to minimal levels. \
 									Security staff should minimize lethal force against cultists, using non-lethals where possible. \
@@ -209,13 +215,18 @@ RESTRICT_TYPE(/datum/team/cult)
  * Created so that we don't make 1000 timers, and I'm too lazy to make a proc for all of these.
  * Used in callbacks for some *magic bullshit*.
  */
-/datum/team/cult/proc/all_members_timer(proc_ref_to_call)
+/datum/team/cult/proc/all_members_timer(cultist_proc_ref, datum/callback/varset_callback)
+	if(istype(varset_callback))
+		varset_callback.Invoke()
+
 	for(var/datum/mind/M in members)
 		if(!ishuman(M.current))
 			continue
 		var/datum/antagonist/cultist/cultist = M.has_antag_datum(/datum/antagonist/cultist)
 		if(cultist)
-			call(cultist, proc_ref_to_call)() // yes this is a type proc ref passed by a callback, i know its deranged
+			call(cultist, cultist_proc_ref)() // yes this is a type proc ref passed by a callback, i know its deranged
+
+	is_in_transition = FALSE
 
 /datum/team/cult/proc/is_convertable_to_cult(datum/mind/mind)
 	if(!mind)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Any new converts do not gain halos/red eyes until ALL of the cult gains them.

Also, cults can no longer ascend while they are rising, but this should basically never happen.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Makes more sense than new converts instantly getting halos / red eyes while the rest of the cult has to wait 20 seconds. Looks wonky when one cultist has a halo and the rest don't.

## Testing
<!-- How did you test the PR, if at all? -->
3 Skrells sitting near the bridge, C-U-L-T-I-N-G
![image](https://github.com/ParadiseSS13/Paradise/assets/91113370/1b2ec5b1-d5df-4396-b153-b607f310752b)


## Changelog
:cl:
fix: Cultists no longer instantly get red-eyes/halo when converted
tweak: Cults can no longer ascend while they are rising.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
