### PR TITLE
You can no longer push people with riot shields (and other parry objects) on help intent

### DIFF
--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -596,12 +596,14 @@
 			H.physiology.brute_mod *= 0.8
 			H.physiology.burn_mod *= 0.8
 			H.physiology.stamina_mod *= 0.8
+		owner.status_flags &= ~CANPUSH
 		add_attack_logs(owner, owner, "gained chainsaw stun immunity", ATKLOG_ALL)
 		owner.add_stun_absorption("chainsaw", INFINITY, 4)
 		owner.playsound_local(get_turf(owner), 'sound/effects/singlebeat.ogg', 40, TRUE, use_reverb = FALSE)
 
 /datum/status_effect/chainsaw_slaying/on_remove()
 	add_attack_logs(owner, owner, "lost chainsaw stun immunity", ATKLOG_ALL)
+	owner.status_flags |= CANPUSH
 	if(islist(owner.stun_absorption) && owner.stun_absorption["chainsaw"])
 		owner.remove_stun_absorption("chainsaw")
 	if(ishuman(owner))

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -118,6 +118,8 @@
 	if(a_intent == INTENT_HELP) // Help intent doesn't mob swap a mob pulling a structure
 		if(isstructure(M.pulling) || isstructure(pulling))
 			return TRUE
+	//Let us check if the person has riot equipment. We should not move past them or push them, unless they are on *walk* intent. This is so officers batoning on help can't me moved past.
+	var/riot_equipment_used = (M.r_hand?.GetComponent(/datum/component/parry) || M.l_hand?.GetComponent(/datum/component/parry))
 
 	if(!M.buckled && !M.has_buckled_mobs())
 		var/mob_swap
@@ -125,7 +127,7 @@
 		if(length(M.grabbed_by) && a_intent == INTENT_GRAB)
 			mob_swap = TRUE
 		//restrained people act if they were on 'help' intent to prevent a person being pulled from being seperated from their puller
-		else if((M.restrained() || M.a_intent == INTENT_HELP) && (restrained() || a_intent == INTENT_HELP))
+		else if(((M.restrained() || M.a_intent == INTENT_HELP) && !(riot_equipment_used && M.m_intent == MOVE_INTENT_RUN)) && (restrained() || a_intent == INTENT_HELP))
 			mob_swap = TRUE
 		if(mob_swap)
 			//switch our position with M
@@ -156,7 +158,7 @@
 	if(!(M.status_flags & CANPUSH))
 		return TRUE
 	//anti-riot equipment is also anti-push
-	if(M.r_hand?.GetComponent(/datum/component/parry) || M.l_hand?.GetComponent(/datum/component/parry))
+	if(riot_equipment_used)
 		return TRUE
 
 //Called when we bump into an obj


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Riot shields (dswords, mirror shields, spellblades, anything with parry really) now, rather than blocking movement on any intent bar help, block movement on all intents, but allow people to push past on help walk intent.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

You may have noticed, riot shields block movement well, as they are supposed to, when the officer is beating you to death.
However, sometimes it fails? What happens?

What happens is we let people swap on help intent. This sucks for when officers are not trying to kill people, as it doesn't make sense that "I'm going to non lethally arrest this person, but I have to let me push me around when doing so"

This means that shields are no longer weaker on help intent, and are more useful even if you are not parrying.

Disarms / knockdowns still work as usual! (perhaps they should not, but another time for that)

Chainsaw users with the buff can not be pushed around now, since rng block should respect that as well

## Testing
<!-- How did you test the PR, if at all? -->

pushed into the skrell on diffrent intents on both sides.

## Changelog
:cl:
tweak: You can no longer push people with riot shields (and other parry objects) on help intent
tweak: Chainsaw users with the chainsaw buff can no longer be pushed past.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
