### PR TITLE
Adds logging for thrall deconversions

### DIFF
--- a/code/modules/antagonists/vampire/vamp_thrall.dm
+++ b/code/modules/antagonists/vampire/vamp_thrall.dm
@@ -9,6 +9,7 @@ RESTRICT_TYPE(/datum/antagonist/mindslave/thrall)
 	SSticker.mode.vampire_enthralled += owner
 
 /datum/antagonist/mindslave/thrall/remove_owner_from_gamemode()
+	owner.current.create_log(CONVERSION_LOG, "Deconverted from thrall")
 	SSticker.mode.vampire_enthralled -= owner
 
 /datum/antagonist/mindslave/thrall/apply_innate_effects(mob/living/mob_override)

--- a/code/modules/reagents/chemistry/reagents/water.dm
+++ b/code/modules/reagents/chemistry/reagents/water.dm
@@ -284,7 +284,6 @@
 			M.SetJitter(0)
 			M.SetStuttering(0)
 			M.SetConfused(0)
-			M.mind.current.create_log(CONVERSION_LOG, "Deconverted from thrall")
 			return
 		if(IS_CULTIST(M))
 			var/datum/antagonist/cultist/cultist = IS_CULTIST(M)

--- a/code/modules/reagents/chemistry/reagents/water.dm
+++ b/code/modules/reagents/chemistry/reagents/water.dm
@@ -284,6 +284,7 @@
 			M.SetJitter(0)
 			M.SetStuttering(0)
 			M.SetConfused(0)
+			M.mind.current.create_log(CONVERSION_LOG, "Deconverted from thrall")
 			return
 		if(IS_CULTIST(M))
 			var/datum/antagonist/cultist/cultist = IS_CULTIST(M)


### PR DESCRIPTION
## What Does This PR Do
Adds logging for vampire thrall deconversions into player logs.

## Why It's Good For The Game
Helps admins keep track of in-game events. 

## Images of changes
![YlMKADVMpo](https://github.com/ParadiseSS13/Paradise/assets/116982774/1a350222-7131-40b9-b317-c910cc32a4dc)

## Testing
Converted a mob to a thrall, fed holy water, checked logs to confirm. 

## Changelog
NPFC
