### PR TITLE
Click cooldown modifiers affect full auto component the same as every other gun

### DIFF
--- a/code/datums/components/fullauto.dm
+++ b/code/datums/components/fullauto.dm
@@ -262,6 +262,9 @@
 		current_windup_reduction = (current_windup_reduction + round(autofire_shot_delay * windup_autofire_reduction_multiplier))
 		timerid = addtimer(CALLBACK(src, PROC_REF(windup_reset), FALSE), windup_spindown, TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_STOPPABLE)
 
+	if(shooter.next_move_modifier) //DNA vault, mephemdrone, bluespace slowness debuff.
+		next_delay = round(next_delay * shooter.next_move_modifier, SSprojectiles.wait)
+
 	COOLDOWN_START(src, next_shot_cd, next_delay)
 
 	if(SEND_SIGNAL(parent, COMSIG_AUTOFIRE_SHOT, target, shooter, allow_akimbo, mouse_parameters) & COMPONENT_AUTOFIRE_SHOT_SUCCESS)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Any gun with full auto, now respects click cooldown modifiers, like the rest of the guns in the game.
This is consistant with TG and the double tap trait reducing full auto cooldown there as well.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Consistency is good. The QOL of full auto, should not make mechanics that increase your click speed (or decrease it), not affect the weapon. TG does the same thing with the double tap trait. Yes, it is not the most realistic thing in the world, but in real life taking drugs doesn't make you make after images, and in real life bluespace doesn't slow you down.

## Testing
<!-- How did you test the PR, if at all? -->

Fired a full auto gun set to 0.5 seconds.
Halfed my click speed.
Fired at 0.25 seconds

## Changelog
:cl:
tweak: Click cooldown modifiers affect full auto component the same as every other gun
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
