### PR TITLE
Botany light sourses can now be turned off

### DIFF
--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -205,9 +205,7 @@
 
 	add_attack_logs(user, target, "[what_done] ([reagent_str] | [genes_str])")
 
-/obj/item/food/snacks/grown/extinguish_light(force = FALSE)
-	if(!force)
-		return
+/obj/item/food/snacks/grown/extinguish_light(force)
 	if(seed.get_gene(/datum/plant_gene/trait/glow/shadow))
 		return
 	set_light(0)

--- a/code/modules/hydroponics/hydroponics_tray.dm
+++ b/code/modules/hydroponics/hydroponics_tray.dm
@@ -315,6 +315,11 @@
 
 	update_icon()
 
+/obj/machinery/hydroponics/extinguish_light(force)
+	if(!force)
+		return
+	set_light(0)
+
 /obj/machinery/hydroponics/update_overlays()
 	. = ..()
 	if(self_sustaining && !istype(src, /obj/machinery/hydroponics/soil))


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Allows the ability to extinguish light of weak strength to extinguish vegetables with the light gene, and strong level to extinguish hydroponics with light sources

## Why It's Good For The Game
Considering what spam potential the hydroponics department has, the lack of a way to put out their lights makes the shadow demon very dependent on one particular nerd rather than the efforts of the entire station, which doesn't fit the concept of a major antagonist.

Now vegetables with the light gene can be extinguished with a touch, like xenobiology cores or flashlights.

The hydroponic trays can now be extinguished. Before this was the only entity in the game that could not be extinguished at all.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![image](https://github.com/ParadiseSS13/Paradise/assets/114731039/97e16c88-4edd-476f-ada0-d64f1eb791e3)
![image](https://github.com/ParadiseSS13/Paradise/assets/114731039/a7e676c8-edab-4e01-aeca-0395b2265aa0)


## Testing
do code, do smooth

## Changelog
:cl:
fix: Botany Gaia trays can now be turned off like other sourse of lights.
tweak: Shadow demon can now turn off vegetables with the light gene with a touch, like xenobiology cores or flashlights.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
