### PR TITLE
Vetus Speculator now tell you what type he is

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/ancient_robot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/ancient_robot.dm
@@ -105,19 +105,19 @@ Difficulty: Hard
 	mode = pick(BLUESPACE, GRAV, PYRO, FLUX, VORTEX, CRYO) //picks one of the 6 cores
 	switch(mode)
 		if(BLUESPACE)
-			desc += "It emits sparks of blue energy."
+			desc += " It emits sparks of blue energy."
 		if(GRAV)
-			desc += "Gravity seems to distort around it."
+			desc += " Gravity seems to distort around it."
 		if(PYRO)
-			desc += "You see flames burning around it."
+			desc += " You see flames burning around it."
 		if(FLUX) // Main attack is shock, so flux makes it stronger
 			melee_damage_lower = 25
 			melee_damage_upper = 25
-			desc += "It seems to overflow with energy."
+			desc += " It seems to overflow with energy."
 		if(VORTEX)
-			desc += "You see space bend and distort around it."
+			desc += " You see space bend and distort around it."
 		if(CRYO)
-			desc += "The air surrounding it is cold and listless."
+			desc += " The air surrounding it is cold and listless."
 	body_shield()
 	add_overlay("[mode]")
 	add_overlay("eyes")

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/ancient_robot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/ancient_robot.dm
@@ -117,7 +117,7 @@ Difficulty: Hard
 		if(VORTEX)
 			desc += "You see space bend and distort around it."
 		if(CRYO)
-			desc += "The air surrounding it cold and listless."
+			desc += "The air surrounding it is cold and listless."
 	body_shield()
 	add_overlay("[mode]")
 	add_overlay("eyes")

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/ancient_robot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/ancient_robot.dm
@@ -103,9 +103,21 @@ Difficulty: Hard
 	BL = new /mob/living/simple_animal/hostile/ancient_robot_leg(loc, src, BOTTOM_LEFT)
 	beam = new /obj/effect/abstract(loc)
 	mode = pick(BLUESPACE, GRAV, PYRO, FLUX, VORTEX, CRYO) //picks one of the 6 cores
-	if(mode == FLUX) // Main attack is shock, so flux makes it stronger
-		melee_damage_lower = 25
-		melee_damage_upper = 25
+	switch(mode)
+		if(BLUESPACE)
+			desc += "It emits sparks of blue energy."
+		if(GRAV)
+			desc += "There's a distorted gravity around him"
+		if(PYRO)
+			desc += "You see the flames around him"
+		if(FLUX) // Main attack is shock, so flux makes it stronger
+			melee_damage_lower = 25
+			melee_damage_upper = 25
+			desc += "He looks overflowing with energy"
+		if(VORTEX)
+			desc += "You can see the strong wind around him"
+		if(CRYO)
+			desc += "The air around him is cold. How?"
 	body_shield()
 	add_overlay("[mode]")
 	add_overlay("eyes")

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/ancient_robot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/ancient_robot.dm
@@ -107,17 +107,17 @@ Difficulty: Hard
 		if(BLUESPACE)
 			desc += "It emits sparks of blue energy."
 		if(GRAV)
-			desc += "There's a distorted gravity around him"
+			desc += "Gravity seems to distort around it."
 		if(PYRO)
-			desc += "You see the flames around him"
+			desc += "You see flames burning around it."
 		if(FLUX) // Main attack is shock, so flux makes it stronger
 			melee_damage_lower = 25
 			melee_damage_upper = 25
-			desc += "He looks overflowing with energy"
+			desc += "It seems to overflow with energy."
 		if(VORTEX)
-			desc += "You can see the strong wind around him"
+			desc += "You see space bend and distort around it."
 		if(CRYO)
-			desc += "The air around him is cold. How?"
+			desc += "The air surrounding it cold and listless."
 	body_shield()
 	add_overlay("[mode]")
 	add_overlay("eyes")


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Now when you examine Vetus, you can see a postscript telling you the type of its core.

## Why It's Good For The Game
Sometimes Vetus' appearance is not obvious, especially to people with color blindness, so being able to understand the core type by inspection can be a lifesaver, as each core type should ideally have different equipment, such as magboots vs cryo, fire protection for fire type, and so on.

## Images of changes
Cryo core example. Now air cold around him 
![image](https://github.com/ParadiseSS13/Paradise/assets/114731039/9cea200c-f092-4622-b59a-271daad0e53b)


## Testing
do code, try again, do correct

## Changelog
:cl:
tweak: Examination of Vetus now tells us its core type
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
