### PR TITLE
derails the acid peel train, acid peels no longer fit in trash bags

### DIFF
--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -39,7 +39,7 @@
 	storage_slots = 30
 	max_combined_w_class = 30
 	can_hold = list() // any
-	cant_hold = list(/obj/item/disk/nuclear)
+	cant_hold = list(/obj/item/disk/nuclear, /obj/item/grown/bananapeel/traitorpeel)
 
 /obj/item/storage/bag/trash/proc/update_weight()
 	if(!length(contents))


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

You can no longer place acid peels in a trashbag.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

It's one thing when you have a bunch of peels in the locker, as it is telegraphed, and can be stolen from you.
When you instantly drop all the peels at once from the trashbag, then pick them up after the person slips, that is much less engaging, and less fair to deal with.
I would prefer to stop this before it becomes more of a pattern, so we'll stop the train here.

## Testing
<!-- How did you test the PR, if at all? -->

Picked up non peels acid peels, worked, tried to pick up acid peels, failed..

## Changelog
:cl:
tweak: Acid peels no longer fit in trash bags
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
