### PR TITLE
Adds an admin message and logging for 'Crew Traitor' smite

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2162,6 +2162,7 @@
 					to_chat(new_traitor_mind.current, "<b>Goal: <span class='danger'>KILL [H.real_name]</span>, currently in [get_area(H.loc)]</b>")
 					new_traitor_mind.add_antag_datum(T)
 					message_admins("[key_name_admin(new_traitor_mind)] was chosen to be the traitor for a smite!")
+					log_admin("[key_name(new_traitor_mind)] was made into a traitor to hunt [key_name(H)] for 'Crew Traitor' smite.")
 				else
 					to_chat(usr, "<span class='warning'>ERROR: Unable to find any valid candidate to send after [H].</span>")
 					return

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2149,18 +2149,19 @@
 						if(ismindshielded(player.current))
 							possible_traitors -= player
 				if(length(possible_traitors))
-					var/datum/mind/newtraitormind = pick(possible_traitors)
+					var/datum/mind/new_traitor_mind = pick(possible_traitors)
 
 					var/datum/objective/assassinate/kill_objective = new()
 					kill_objective.target = H.mind
 					kill_objective.explanation_text = "Assassinate [H.mind.name], the [H.mind.assigned_role]"
-					newtraitormind.add_mind_objective(kill_objective)
+					new_traitor_mind.add_mind_objective(kill_objective)
 
 					var/datum/antagonist/traitor/T = new()
 					T.give_objectives = FALSE
-					to_chat(newtraitormind.current, "<span class='danger'>ATTENTION:</span> It is time to pay your debt to the Syndicate...")
-					to_chat(newtraitormind.current, "<b>Goal: <span class='danger'>KILL [H.real_name]</span>, currently in [get_area(H.loc)]</b>")
-					newtraitormind.add_antag_datum(T)
+					to_chat(new_traitor_mind.current, "<span class='danger'>ATTENTION:</span> It is time to pay your debt to the Syndicate...")
+					to_chat(new_traitor_mind.current, "<b>Goal: <span class='danger'>KILL [H.real_name]</span>, currently in [get_area(H.loc)]</b>")
+					new_traitor_mind.add_antag_datum(T)
+					message_admins("[key_name_admin(new_traitor_mind)] was chosen to be the traitor for a smite!")
 				else
 					to_chat(usr, "<span class='warning'>ERROR: Unable to find any valid candidate to send after [H].</span>")
 					return


### PR DESCRIPTION
## What Does This PR Do
This PR adds additional logging to game log and an admin message for the 'Crew Traitor' player smite. 
Additionally, this PR cleans up the name of a variable used in this smite.

## Why It's Good For The Game
The message lets admins know who was made a traitor to hunt the target of the smite.
The logging keeps track of the results of the admin action.

## Images of changes
![dreamseeker_SP7dY88M08](https://github.com/ParadiseSS13/Paradise/assets/116982774/e7fdc037-ed9f-4e73-917d-6fff727d18d5)
![notepad++_IleMIsbhqR](https://github.com/ParadiseSS13/Paradise/assets/116982774/70ea2a87-992f-40c9-8a35-4d3972186d63)

## Testing
Started an instance with two clients.
Used one client to smite the the player on the other.
Observed admin message and checked the game log for proper behavior.

## Changelog
NPFC
