### PR TITLE
Lazarus Reagent Change and Formaldehyde Buff

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -923,12 +923,12 @@
 					M.adjustFireLoss(rand(0, 15))
 					if(ishuman(M))
 						var/mob/living/carbon/human/H = M
+						var/necrosis_prob = 15 * H.decaylevel
 						H.decaylevel = 0
-						var/necrosis_prob = 40 * min((20 MINUTES), max((time_dead - (1 MINUTES)), 0)) / ((20 MINUTES) - (1 MINUTES))
 						for(var/obj/item/organ/O in (H.bodyparts | H.internal_organs))
 							// Per non-vital body part:
-							// 0% chance of necrosis within 1 minute of death
-							// 40% chance of necrosis after 20 minutes of death
+							// 15% * H.decaylevel (1 to 4) 
+							// Min of 0%, Max of 60%
 							if(prob(necrosis_prob) && !O.is_robotic() && !O.vital)
 								// side effects may include: Organ failure
 								O.necrotize(FALSE)

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -923,8 +923,8 @@
 					M.adjustFireLoss(rand(0, 15))
 					if(ishuman(M))
 						var/mob/living/carbon/human/H = M
-						var/necrosis_prob = 15 * H.decaylevel
 						H.decaylevel = 0
+						var/necrosis_prob = 40 * min((20 MINUTES), max((time_dead - (1 MINUTES)), 0)) / ((20 MINUTES) - (1 MINUTES))
 						for(var/obj/item/organ/O in (H.bodyparts | H.internal_organs))
 							// Per non-vital body part:
 							// 0% chance of necrosis within 1 minute of death

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -923,8 +923,8 @@
 					M.adjustFireLoss(rand(0, 15))
 					if(ishuman(M))
 						var/mob/living/carbon/human/H = M
+						var/necrosis_prob = 15 * H.decaylevel
 						H.decaylevel = 0
-						var/necrosis_prob = 40 * min((20 MINUTES), max((time_dead - (1 MINUTES)), 0)) / ((20 MINUTES) - (1 MINUTES))
 						for(var/obj/item/organ/O in (H.bodyparts | H.internal_organs))
 							// Per non-vital body part:
 							// 0% chance of necrosis within 1 minute of death


### PR DESCRIPTION
## What Does This PR Do

This PR changes the medicines.dm file to change the necrosis probability from Lazarus reagent reviving. This is done by tying in the human carbon's decaylevel to the probability. This would mean that formaldehyde would not only just stop corpses from decaying into skeletons but also make lazarus revival much easier.

It changes one line. Buffs Lazarus directly. From being 40% max over 20 minutes. to...

Per (non-vital) Organ on revival:
[0] 0-10 minutes: 0% 
[1] 11-20 minutes: 15%
[2] 21-30 minutes: 30%
[3] 31-40 minutes: 45%

## Why It's Good For The Game
Improves alternative revival methods. Also gives less of an incentive to just clone immediately by vastly increasing the range of time before organ necrosis starts to make LR revival unviable. This also indirectly buffs formaldehyde and gives more of a reason to prevent corpse decay. This is especially useful for species that can't be cloned; (Vox [derogatory] and slime person)

## Testing
None done.

## Changelog
:cl:
tweak: Tweaked necrosis probability
/:cl:
