### PR TITLE
Gives all the marauder mechs a bluespace cell, since they're CC mechs and all.

### DIFF
--- a/code/game/mecha/combat/marauder.dm
+++ b/code/game/mecha/combat/marauder.dm
@@ -45,6 +45,9 @@
 	ME = new /obj/item/mecha_parts/mecha_equipment/thrusters
 	ME.attach(src)
 
+/obj/mecha/combat/marauder/add_cell()
+	cell = new /obj/item/stock_parts/cell/bluespace(src)
+
 /obj/mecha/combat/marauder/ares
 	name = "Ares"
 	desc = "Heavy-duty, combat exosuit, adapted from rejected early versions of the Marauder to serve as a biohazard containment exosuit. This model, albeit rare, can be found among civilian populations."
@@ -84,9 +87,6 @@
 	internal_damage_threshold = 20
 	force = 80
 	max_equip = 8
-
-/obj/mecha/combat/marauder/seraph/add_cell()
-	cell = new /obj/item/stock_parts/cell/bluespace(src)
 
 /obj/mecha/combat/marauder/seraph/loaded/Initialize(mapload)
 	. = ..()  //Let it equip whatever is needed.


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Gives the marauder, and their subtypes bluespace cells. So they dont runout of charge as often.
This includes the following exo suits

- The Marauder
- The Ares
- The Seraph
- And the Mauler

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
CC level(and syndicate) mechs shouldn't be running out of charge as quick as they do, i believe currently they have a super capacity cell, meaning they hardly have five minutes of fight in them before they go kaput and run outa charge.

## Testing
<!-- How did you test the PR, if at all? -->
Checked if the mechs had bluespace cells. they did.
## Changelog
:cl:
tweak: Central command has increased the budget for their exosuit program, and have given their standard issue exosuits higher capacity cells. As with the mauler, since the syndicate didn't want to be left out.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
