### PR TITLE
Adds advanced_bullet_dodge_chance, for admin / mob use. Applies it to space combat drones

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -6,6 +6,8 @@
 	faction += "\ref[src]"
 	determine_move_and_pull_forces()
 	GLOB.mob_living_list += src
+	if(advanced_bullet_dodge_chance)
+		RegisterSignal(src, COMSIG_ATOM_PREHIT, PROC_REF(advanced_bullet_dodge))
 
 // Used to determine the forces dependend on the mob size
 // Will only change the force if the force was not set in the mob type itself
@@ -51,6 +53,7 @@
 	QDEL_NULL(middleClickOverride)
 	if(mind?.current == src)
 		mind.current = null
+	UnregisterSignal(src, COMSIG_ATOM_PREHIT)
 	return ..()
 
 /mob/living/ghostize(can_reenter_corpse = 1)
@@ -1068,6 +1071,9 @@
 			update_transform()
 		if("lighting_alpha")
 			sync_lighting_plane_alpha()
+		if("advanced_bullet_dodge_chance")
+			UnregisterSignal(src, COMSIG_ATOM_PREHIT)
+			RegisterSignal(src, COMSIG_ATOM_PREHIT, PROC_REF(advanced_bullet_dodge))
 
 /mob/living/throw_at(atom/target, range, speed, mob/thrower, spin, diagonals_first, datum/callback/callback, force, dodgeable, block_movement)
 	stop_pulling()

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -71,10 +71,10 @@
 	var/list/potential_first_directions = list(NORTH, SOUTH, EAST, WEST)
 	potential_first_directions -= dir_to_avoid
 	step(source, pick(potential_first_directions))
-	//Chance to dodge multiple shotgun spreads, but not likely. Mainly: Infinite loop prevention from admins setting it to 100 and doing something stupid.
-	//If you want to set your dodge chance to 100 on a subtype, no issue: Just make sure the subtype does not step in a direction, otherwise you'll have the mob move a large distance to dodge rubbershot.
+	// Chance to dodge multiple shotgun spreads, but not likely. Mainly: Infinite loop prevention from admins setting it to 100 and doing something stupid.
+	// If you want to set your dodge chance to 100 on a subtype, no issue: Just make sure the subtype does not step in a direction, otherwise you'll have the mob move a large distance to dodge rubbershot.
 	if(prob(50))
-		addtimer(VARSET_CALLBACK(src, advanced_bullet_dodge_chance, advanced_bullet_dodge_chance), 0.25 SECONDS) //Returns fast enough for multiple laser shots.
+		addtimer(VARSET_CALLBACK(src, advanced_bullet_dodge_chance, advanced_bullet_dodge_chance), 0.25 SECONDS) // Returns fast enough for multiple laser shots.
 		advanced_bullet_dodge_chance = 0
 	return ATOM_PREHIT_FAILURE
 

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -51,6 +51,33 @@
 			check_projectile_dismemberment(P, def_zone)
 	return P.on_hit(src, armor, def_zone)
 
+/// Tries to dodge incoming bullets if we aren't disabled for any reasons. Advised to overide with advanced effects, this is as basic example admins can apply.
+/mob/living/proc/advanced_bullet_dodge(mob/living/source, obj/item/projectile/hitting_projectile)
+	SIGNAL_HANDLER
+
+	if(HAS_TRAIT(source, TRAIT_IMMOBILIZED))
+		return NONE
+	if(source.stat != CONSCIOUS)
+		return NONE
+	if(!prob(advanced_bullet_dodge_chance))
+		return NONE
+
+	source.visible_message(
+		"<span class='danger'>[source] [pick("dodges","jumps out of the way of","evades","dives out of the way of")] [hitting_projectile]!</span>",
+		"<span class='userdanger'>You evade [hitting_projectile]!</span>",
+	)
+	playsound(source, pick('sound/weapons/bulletflyby.ogg', 'sound/weapons/bulletflyby2.ogg', 'sound/weapons/bulletflyby3.ogg'), 75, TRUE)
+	var/dir_to_avoid = angle2dir_cardinal(hitting_projectile.Angle)
+	var/list/potential_first_directions = list(NORTH, SOUTH, EAST, WEST)
+	potential_first_directions -= dir_to_avoid
+	step(source, pick(potential_first_directions))
+	//Chance to dodge multiple shotgun spreads, but not likely. Mainly: Infinite loop prevention from admins setting it to 100 and doing something stupid.
+	//If you want to set your dodge chance to 100 on a subtype, no issue: Just make sure the subtype does not step in a direction, otherwise you'll have the mob move a large distance to dodge rubbershot.
+	if(prob(50))
+		addtimer(VARSET_CALLBACK(src, advanced_bullet_dodge_chance, advanced_bullet_dodge_chance), 0.25 SECONDS) //Returns fast enough for multiple laser shots.
+		advanced_bullet_dodge_chance = 0
+	return ATOM_PREHIT_FAILURE
+
 /mob/living/proc/check_projectile_dismemberment(obj/item/projectile/P, def_zone)
 	return 0
 

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -100,6 +100,9 @@
 	/// Famous last words -- if succumbing, what the user's last words were
 	var/last_words
 
+	///This variable is the chance for a mob to automatically dodge a bullet. Useful for admins, and applied to some mobs by default, such as the malfunctioning drone mobs.
+	var/advanced_bullet_dodge_chance = 0
+
 	/*
 	Taste Vars
 	*/

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/combat_drone.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/combat_drone.dm
@@ -30,6 +30,7 @@
 	faction = list("malf_drone")
 	deathmessage = "suddenly breaks apart."
 	del_on_death = TRUE
+	advanced_bullet_dodge_chance = 15 // This will be adjusted when active, vs deactivated. Randomises on hit if it is zero.
 	var/passive_mode = TRUE // if true, don't target anything.
 
 /mob/living/simple_animal/hostile/malf_drone/Initialize(mapload)
@@ -69,6 +70,8 @@
 	do_sparks(3, 1, src)
 	passive_mode = FALSE
 	update_icons()
+	if(!advanced_bullet_dodge_chance)
+		advanced_bullet_dodge_chance = rand(15, 30)
 	. = ..() // this will handle finding a target if there is a valid one nearby
 
 /mob/living/simple_animal/hostile/malf_drone/Life(seconds, times_fired)
@@ -83,11 +86,37 @@
 		passive_mode = !passive_mode
 		if(passive_mode)
 			visible_message("<span class='notice'>[src] retracts several targetting vanes.</span>")
+			advanced_bullet_dodge_chance = 0
 			if(target)
 				LoseTarget()
 		else
 			visible_message("<span class='warning'>[src] suddenly lights up, and additional targetting vanes slide into place.</span>")
+			advanced_bullet_dodge_chance = rand(15, 30)
 		update_icons()
+
+///We overide the basic effect, as malfunctioning drones are in space, and use jets to dodge. Also lets us do cool effects.
+/mob/living/simple_animal/hostile/malf_drone/advanced_bullet_dodge(mob/living/source, obj/item/projectile/hitting_projectile)
+	if(HAS_TRAIT(source, TRAIT_IMMOBILIZED))
+		return NONE
+	if(source.stat != CONSCIOUS)
+		return NONE
+	if(!prob(advanced_bullet_dodge_chance))
+		return NONE
+
+	source.visible_message(
+		"<span class='danger'>[source]'s jets [pick("boost", "propell", "pulse", "flare up and move", "shudders and pushes")] it out'[hitting_projectile]'s way!</span>",
+		"<span class='userdanger'>You evade [hitting_projectile]!</span>",
+	)
+	playsound(source, pick('sound/weapons/bulletflyby.ogg', 'sound/weapons/bulletflyby2.ogg', 'sound/weapons/bulletflyby3.ogg', 'sound/effects/refill.ogg'), 75, TRUE)
+	var/dir_to_avoid = angle2dir_cardinal(hitting_projectile.Angle)
+	var/list/potential_first_directions = list(NORTH, SOUTH, EAST, WEST)
+	potential_first_directions -= dir_to_avoid
+	new /obj/effect/temp_visual/decoy/fading(source.loc, source)
+	step(source, pick(potential_first_directions))
+	if(prob(50))
+		addtimer(VARSET_CALLBACK(source, advanced_bullet_dodge_chance, advanced_bullet_dodge_chance), 0.25 SECONDS)
+		advanced_bullet_dodge_chance = 0
+	return ATOM_PREHIT_FAILURE
 
 /mob/living/simple_animal/hostile/malf_drone/emp_act(severity)
 	adjustHealth(100 / severity) // takes the same damage as a mining drone from emp

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/combat_drone.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/combat_drone.dm
@@ -94,7 +94,7 @@
 			advanced_bullet_dodge_chance = 25
 		update_icons()
 
-///We overide the basic effect, as malfunctioning drones are in space, and use jets to dodge. Also lets us do cool effects.
+/// We overide the basic effect, as malfunctioning drones are in space, and use jets to dodge. Also lets us do cool effects.
 /mob/living/simple_animal/hostile/malf_drone/advanced_bullet_dodge(mob/living/source, obj/item/projectile/hitting_projectile)
 	if(HAS_TRAIT(source, TRAIT_IMMOBILIZED))
 		return NONE
@@ -104,7 +104,7 @@
 		return NONE
 
 	source.visible_message(
-		"<span class='danger'>[source]'s jets [pick("boost", "propell", "pulse", "flare up and move", "shudders and pushes")] it out'[hitting_projectile]'s way!</span>",
+		"<span class='danger'>[source]'s jets [pick("boosts", "propels", "pulses", "flares up and moves", "shudders and pushes")] it out of '[hitting_projectile]'s way!</span>",
 		"<span class='userdanger'>You evade [hitting_projectile]!</span>",
 	)
 	playsound(source, pick('sound/weapons/bulletflyby.ogg', 'sound/weapons/bulletflyby2.ogg', 'sound/weapons/bulletflyby3.ogg', 'sound/effects/refill.ogg'), 75, TRUE)

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/combat_drone.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/combat_drone.dm
@@ -30,7 +30,7 @@
 	faction = list("malf_drone")
 	deathmessage = "suddenly breaks apart."
 	del_on_death = TRUE
-	advanced_bullet_dodge_chance = 15 // This will be adjusted when active, vs deactivated. Randomises on hit if it is zero.
+	advanced_bullet_dodge_chance = 25 // This will be adjusted when active, vs deactivated. Randomises on hit if it is zero.
 	var/passive_mode = TRUE // if true, don't target anything.
 
 /mob/living/simple_animal/hostile/malf_drone/Initialize(mapload)
@@ -71,7 +71,7 @@
 	passive_mode = FALSE
 	update_icons()
 	if(!advanced_bullet_dodge_chance)
-		advanced_bullet_dodge_chance = rand(15, 30)
+		advanced_bullet_dodge_chance = 25
 	. = ..() // this will handle finding a target if there is a valid one nearby
 
 /mob/living/simple_animal/hostile/malf_drone/Life(seconds, times_fired)
@@ -91,7 +91,7 @@
 				LoseTarget()
 		else
 			visible_message("<span class='warning'>[src] suddenly lights up, and additional targetting vanes slide into place.</span>")
-			advanced_bullet_dodge_chance = rand(15, 30)
+			advanced_bullet_dodge_chance = 25
 		update_icons()
 
 ///We overide the basic effect, as malfunctioning drones are in space, and use jets to dodge. Also lets us do cool effects.


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Adds advanced_bullet_dodge_chance, for admin / mob use

This variable is used for a percent chance signal on mobs, for them to attempt to dodge and step out of a way of a bullet. Ideally to make up for simple mobs not dodging much when running up to someone unlike an actual person, but also for use by admins to make a mob tankier.

Used with a subtype of the proc for malfunctioning combat drones, with an updated text / effect for flavour, as well to show it off.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

A system to help mobs dodge bullets could be useful. This system is easy to apply, and can be overiden to function in many ways. Could have them leap farther. Could have them phase out of reality if it is a bluespace thing. Could make them dodge and return fire! Many options, signal based.

Applicable by admins, if they want to make something beefier, with protections to keep them from breaking the game.

Makes combat drones a slight bit more of a threat, with their inate 25% chance to dodge a hit in space. Still predictable, and often move in a straight line, but a little harder.

## Testing
<!-- How did you test the PR, if at all? -->

Var edited a cyborg to have it, dodged as expected.
Shot at a malf drone, watched it dodge bullets as expected

## Changelog
:cl:
tweak: Malfunctioning drones that are not in passive mode will have a chance to dodge incoming projectiles.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
