### PR TITLE
Fixes a bug with admin keybinds occasionally not working

### DIFF
--- a/code/datums/keybindings/admin_keybinds.dm
+++ b/code/datums/keybindings/admin_keybinds.dm
@@ -4,7 +4,7 @@
 	var/rights
 
 /datum/keybinding/admin/can_use(client/C, mob/M)
-	if(rights && !check_rights(rights, FALSE))
+	if(rights && !check_rights(rights, FALSE, M))
 		return FALSE
 	return !isnull(C.holder) && ..()
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes a bug that seems to have been around for a while, but has only really surfaced while working with https://github.com/ParadiseSS13/Paradise/pull/24855. Without it, you can sometimes get stuck without your F7 or F3 keybinds. Since it's kind of a wider-ranging bug, I figured I'd pull it out into its own issue.
`check_rights()` with no mob passed defaults to `usr`, which can sometimes not be what we expect it to be, particularly when hopping between bodies and ghosts.

Thanks to Tourte for poking me about this bug until I got around to fixing it.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
While it should be easy enough to get yourself out of this kinda broken state (pressing F12), admins shouldn't have to fumble to check player panels when observing.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


## Testing
Loaded in, was able to open player panel while observing and did not observe the weird behavior I had seen before.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Fixes a bug where some keybindings (particularly some admin ones) would sometimes stop working when in certain states.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
