### PR TITLE
tube stations can be skipped by holding direction key

### DIFF
--- a/_maps/map_files/stations/boxstation.dmm
+++ b/_maps/map_files/stations/boxstation.dmm
@@ -52294,12 +52294,6 @@
 	icon_state = "vault"
 	},
 /area/station/engineering/gravitygenerator)
-"dCJ" = (
-/obj/structure/transit_tube/cap{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/station/turret_protected/aisat/interior)
 "dCM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -57663,9 +57657,11 @@
 	layer = 4;
 	pixel_y = 32
 	},
-/obj/structure/transit_tube/station,
 /obj/structure/transit_tube_pod{
 	dir = 4
+	},
+/obj/structure/transit_tube/station/reverse/flipped{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -64029,9 +64025,6 @@
 /obj/machinery/firealarm{
 	name = "north bump";
 	pixel_y = 24
-	},
-/obj/structure/transit_tube/cap{
-	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -72410,11 +72403,11 @@
 /turf/simulated/floor/plasteel,
 /area/station/supply/storage)
 "nrh" = (
-/obj/structure/transit_tube/station,
 /obj/structure/transit_tube_pod{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/structure/transit_tube/station/reverse,
 /turf/simulated/floor/plating,
 /area/station/turret_protected/aisat/interior)
 "nrD" = (
@@ -131932,7 +131925,7 @@ aab
 aaa
 cQp
 wza
-dCJ
+dnW
 dnv
 dnW
 diz

--- a/_maps/map_files/stations/deltastation.dmm
+++ b/_maps/map_files/stations/deltastation.dmm
@@ -87524,9 +87524,6 @@
 /area/station/maintenance/starboard)
 "rjL" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/transit_tube/cap{
-	dir = 8
-	},
 /obj/item/radio/intercom{
 	name = "south bump";
 	pixel_y = -28
@@ -97315,9 +97312,7 @@
 /obj/machinery/ai_status_display{
 	pixel_y = -32
 	},
-/obj/structure/transit_tube/station{
-	dir = 1
-	},
+/obj/structure/transit_tube/station/reverse/flipped,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "vault"

--- a/_maps/map_files/stations/metastation.dmm
+++ b/_maps/map_files/stations/metastation.dmm
@@ -19452,9 +19452,11 @@
 /turf/simulated/floor/wood,
 /area/station/command/office/captain/bedroom)
 "bsI" = (
-/obj/structure/transit_tube/station,
 /obj/structure/sign/securearea{
 	pixel_y = 32
+	},
+/obj/structure/transit_tube/station/reverse/flipped{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -53831,9 +53833,6 @@
 	},
 /area/station/medical/virology)
 "hkm" = (
-/obj/structure/transit_tube/cap{
-	dir = 4
-	},
 /obj/machinery/status_display{
 	layer = 4;
 	pixel_y = 32

--- a/code/game/objects/structures/transit_tubes/station.dm
+++ b/code/game/objects/structures/transit_tubes/station.dm
@@ -50,14 +50,15 @@
 /obj/structure/transit_tube/station/should_stop_pod(obj/structure/transit_tube_pod/pod, from_dir)
 	for(var/atom/atom in pod.contents)
 		var/client/client = CLIENT_FROM_VAR(atom)
-		if(client)
-			var/datum/input_data/input_data = client.input_data
-			for(var/held_key in input_data.keys_held)
-				if(held_key in client.movement_kb_dirs)
-					var/held_dir = client.movement_kb_dirs[held_key]
-					// if they're holding a different direction down,
-					// stop to let them get out/change direction
-					return held_dir != from_dir
+		if(!client)
+			return
+
+		for(var/held_key in client.input_data.keys_held)
+			if(held_key in client.movement_kb_dirs)
+				var/held_dir = client.movement_kb_dirs[held_key]
+				// if they're holding a different direction down,
+				// stop to let them get out/change direction
+				return held_dir != from_dir
 
 	return TRUE
 

--- a/code/game/objects/structures/transit_tubes/station.dm
+++ b/code/game/objects/structures/transit_tubes/station.dm
@@ -55,12 +55,9 @@
 			for(var/held_key in input_data.keys_held)
 				if(held_key in client.movement_kb_dirs)
 					var/held_dir = client.movement_kb_dirs[held_key]
-					if(held_dir == from_dir)
-						return FALSE
-					else
-						// if they're holding a different direction down,
-						// stop to let them get out/change direction
-						return TRUE
+					// if they're holding a different direction down,
+					// stop to let them get out/change direction
+					return held_dir != from_dir
 
 	return TRUE
 

--- a/code/game/objects/structures/transit_tubes/station.dm
+++ b/code/game/objects/structures/transit_tubes/station.dm
@@ -33,6 +33,11 @@
 	STOP_PROCESSING(SSobj, src)
 	return ..()
 
+/obj/structure/transit_tube/station/examine(mob/user)
+	. = ..()
+	. += "<span class='notice'>While in transit, hold the directional key matching the pod's direction to skip a station.</span>"
+	. += "<span class='notice'>While at a station, press a directional key to quickly leave the station in that direction.</span>"
+
 /obj/structure/transit_tube/station/init_tube_dirs()
 	// Tube station directions are simply 90 to either side of
 	//  the exit.

--- a/code/game/objects/structures/transit_tubes/station.dm
+++ b/code/game/objects/structures/transit_tubes/station.dm
@@ -47,7 +47,21 @@
 			tube_dirs = list(NORTH, SOUTH)
 	boarding_dir = reverse_direction(dir)
 
-/obj/structure/transit_tube/station/should_stop_pod(pod, from_dir)
+/obj/structure/transit_tube/station/should_stop_pod(obj/structure/transit_tube_pod/pod, from_dir)
+	for(var/atom/atom in pod.contents)
+		var/client/client = CLIENT_FROM_VAR(atom)
+		if(client)
+			var/datum/input_data/input_data = client.input_data
+			for(var/held_key in input_data.keys_held)
+				if(held_key in client.movement_kb_dirs)
+					var/held_dir = client.movement_kb_dirs[held_key]
+					if(held_dir == from_dir)
+						return FALSE
+					else
+						// if they're holding a different direction down,
+						// stop to let them get out/change direction
+						return TRUE
+
 	return TRUE
 
 /obj/structure/transit_tube/station/Bumped(mob/living/L)
@@ -187,6 +201,9 @@
 	reverse_launch = TRUE
 	uninstalled_type = /obj/structure/transit_tube_construction/terminus
 
+/obj/structure/transit_tube/station/reverse/should_stop_pod(obj/structure/transit_tube_pod/pod, from_dir)
+	return TRUE
+
 /obj/structure/transit_tube/station/reverse/init_tube_dirs()
 	tube_dirs = list(turn(dir, -90))
 	boarding_dir = reverse_direction(dir)
@@ -259,6 +276,9 @@
 	icon_state = "open_terminusdispenser0"
 	base_icon_state = "terminusdispenser0"
 	uninstalled_type = /obj/structure/transit_tube_construction/terminus/dispenser
+
+/obj/structure/transit_tube/station/dispenser/reverse/should_stop_pod(obj/structure/transit_tube_pod/pod, from_dir)
+	return TRUE
 
 /obj/structure/transit_tube/station/dispenser/reverse/init_tube_dirs()
 	tube_dirs = list(turn(dir, -90))

--- a/code/game/objects/structures/transit_tubes/transit_tube.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube.dm
@@ -58,7 +58,7 @@
 			return
 
 // Called to check if a pod should stop upon entering this tube.
-/obj/structure/transit_tube/proc/should_stop_pod(pod, from_dir)
+/obj/structure/transit_tube/proc/should_stop_pod(obj/structure/transit_tube_pod/pod, from_dir)
 	return FALSE
 
 // Called when a pod stops in this tube section.
@@ -274,18 +274,3 @@
 			tube_dirs = list(EAST, NORTHWEST, SOUTHWEST)
 		if(WEST)
 			tube_dirs = list(WEST, SOUTHEAST, NORTHEAST)
-
-
-// cosmetic "cap" for tubes. Note that tubes can't enter this.
-/obj/structure/transit_tube/cap
-	icon_state = "cap"
-
-/obj/structure/transit_tube/cap/init_tube_dirs()
-	tube_dirs = list(turn(dir, 180))  // back the way we came
-
-/obj/structure/transit_tube/cap/has_entrance(from_dir)
-	return FALSE
-
-/obj/structure/transit_tube/cap/create_tube_overlay()
-	// cap sprites already have overlays
-	return


### PR DESCRIPTION
## What Does This PR Do
This PR allows transit tube pod riders to skip stations altogether by holding down the directional key of the direction they're traveling. It also finally removes the tube endcaps that exist on maps, since they already can't be built by the RPD and would have made this logic more confusing.
## Why It's Good For The Game
It was already possible to cut short the delay of sitting at a station, or go in the reverse direction, by pressing a directional key while stopped at a station. This makes the delay even faster by eliminating it.
## Images of changes

https://github.com/ParadiseSS13/Paradise/assets/59303604/363dbbc2-e5aa-4282-b788-24c2c3b9f8fa

## Testing
See above.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Transit tube stations may now be skipped by holding down the key in the direction of travel.
del: Transit tube end caps have been removed from remaining maps.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
