### PR TITLE
ghost bar members are now cleared more hastily

### DIFF
--- a/code/modules/ruins/ghost_bar.dm
+++ b/code/modules/ruins/ghost_bar.dm
@@ -1,3 +1,4 @@
+GLOBAL_LIST_EMPTY(occupants_by_key)
 /obj/effect/mob_spawn/human/alive/ghost_bar
 	name = "ghastly rejuvenator"
 	mob_name = "ghost bar occupant"
@@ -55,7 +56,7 @@
 		equip_item(H, /obj/item/clothing/under/color/random, SLOT_HUD_JUMPSUIT)
 	if(!H.shoes)
 		equip_item(H, /obj/item/clothing/shoes/black, SLOT_HUD_SHOES)
-	equip_item(H, /obj/item/stack/spacecash/c1000, SLOT_HUD_LEFT_STORE)
+	equip_item(H, /obj/item/stack/spacecash/c100, SLOT_HUD_LEFT_STORE)
 
 	var/obj/item/card/id/syndicate/our_id = equip_item(H, /obj/item/card/id/syndicate/ghost_bar, SLOT_HUD_WEAR_ID)
 	our_id.assignment = assignedrole
@@ -83,12 +84,20 @@
 		implant.insert(H)
 	log_game("[ckey] has entered the ghost bar")
 	playsound(src, 'sound/machines/wooden_closet_open.ogg', 50)
+	var/mob/old_mob = GLOB.occupants_by_key["[H.ckey]"]
+	if(old_mob)
+		qdel(old_mob)
+	GLOB.occupants_by_key["[H.ckey]"] = H
+	RegisterSignal(H, COMSIG_PARENT_QDELETING, PROC_REF(clear_references_to_owner))
 
 /obj/effect/mob_spawn/human/alive/ghost_bar/proc/equip_item(mob/living/carbon/human/H, path, slot)
 	var/obj/item/I = new path(H)
 	H.equip_or_collect(I, slot, TRUE)
 	H.speaks_ooc = TRUE
 	return I
+
+/obj/effect/mob_spawn/human/alive/ghost_bar/proc/clear_references_to_owner(mob/mob_to_obliterate)
+	GLOB.occupants_by_key -= mob_to_obliterate.ckey
 
 /obj/structure/ghost_bar_cryopod
 	name = "returning sarcophagus"

--- a/code/modules/ruins/ghost_bar.dm
+++ b/code/modules/ruins/ghost_bar.dm
@@ -97,6 +97,7 @@ GLOBAL_LIST_EMPTY(occupants_by_key)
 	return I
 
 /obj/effect/mob_spawn/human/alive/ghost_bar/proc/clear_references_to_owner(mob/mob_to_obliterate)
+	SIGNAL_HANDLER  // COMSIG_PARENT_QDELETING
 	GLOB.occupants_by_key -= mob_to_obliterate.ckey
 
 /obj/structure/ghost_bar_cryopod

--- a/code/modules/ruins/ghost_bar.dm
+++ b/code/modules/ruins/ghost_bar.dm
@@ -56,7 +56,7 @@ GLOBAL_LIST_EMPTY(occupants_by_key)
 		equip_item(H, /obj/item/clothing/under/color/random, SLOT_HUD_JUMPSUIT)
 	if(!H.shoes)
 		equip_item(H, /obj/item/clothing/shoes/black, SLOT_HUD_SHOES)
-	equip_item(H, /obj/item/stack/spacecash/c100, SLOT_HUD_LEFT_STORE)
+	equip_item(H, /obj/item/stack/spacecash/c1000, SLOT_HUD_LEFT_STORE)
 
 	var/obj/item/card/id/syndicate/our_id = equip_item(H, /obj/item/card/id/syndicate/ghost_bar, SLOT_HUD_WEAR_ID)
 	our_id.assignment = assignedrole

--- a/code/modules/ruins/ghost_bar.dm
+++ b/code/modules/ruins/ghost_bar.dm
@@ -1,4 +1,5 @@
 GLOBAL_LIST_EMPTY(occupants_by_key)
+
 /obj/effect/mob_spawn/human/alive/ghost_bar
 	name = "ghastly rejuvenator"
 	mob_name = "ghost bar occupant"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
ghost bar members are now cleared more hastily. You'll now have your previous mob cleared if you rejoin the bar

## Why It's Good For The Game
bugfix

## Testing
did it in game

## Changelog
:cl:
fix: Ghost bar members are now cleared when rejoining the bar with a character already in the bar
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
