### PR TITLE
Fixes being unable to move objects out of your way when stuck.

### DIFF
--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -363,8 +363,8 @@
 	if(!Process_Spacemove(get_dir(pulling.loc, A)))
 		return
 	var/target_turf = get_step(pulling, get_dir(pulling.loc, A))
-	if(get_dist(target_turf, loc) > 1) //Make sure the turf we are trying to pull to is adjacent to the user. We do not use Adjacent() here because it checks if there are dense objects in the way, making it impossible to move an object to the side if we're blocked on both sides.
-		return
+	if(get_dist(target_turf, loc) > 1) // Make sure the turf we are trying to pull to is adjacent to the user.
+		return // We do not use Adjacent() here because it checks if there are dense objects in the way, making it impossible to move an object to the side if we're blocked on both sides.
 	if(ismob(pulling))
 		var/mob/M = pulling
 		var/atom/movable/t = M.pulling

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -363,7 +363,7 @@
 	if(!Process_Spacemove(get_dir(pulling.loc, A)))
 		return
 	var/target_turf = get_step(pulling, get_dir(pulling.loc, A))
-	if(get_dist(target_turf, loc) > 1) //Make sure the turf we are trying to pull to is adjacent to the user.
+	if(get_dist(target_turf, loc) > 1) //Make sure the turf we are trying to pull to is adjacent to the user. We do not use Adjacent() here because it checks if there are dense objects in the way, making it impossible to move an object to the side if we're blocked on both sides.
 		return
 	if(ismob(pulling))
 		var/mob/M = pulling

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -363,7 +363,7 @@
 	if(!Process_Spacemove(get_dir(pulling.loc, A)))
 		return
 	var/target_turf = get_step(pulling, get_dir(pulling.loc, A))
-	if(!Adjacent(target_turf)) //Make sure the turf we are trying to pull to is adjacent to the user.
+	if(get_dist(target_turf, loc) > 1) //Make sure the turf we are trying to pull to is adjacent to the user.
 		return
 	if(ismob(pulling))
 		var/mob/M = pulling


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes an unintended side effect from #25253 which made it impossible to move an object out of your way if you get blocked in by it.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Unintended change that makes it very easy to trap yourself on accident.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
Before:

https://github.com/ParadiseSS13/Paradise/assets/19361017/ac0d10c2-be8a-48b4-be3a-342bde9f0ec1


After:

https://github.com/ParadiseSS13/Paradise/assets/19361017/be9c2823-6f6f-46c2-92e6-fdc97530fd4d

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Get stuck between a bunch of lockers.
Move the locker out of the way
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: You can now move a dragged object out of the way again if it is trapping you.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
