### PR TITLE
fixes some locate checks being in world

### DIFF
--- a/code/game/gamemodes/nuclear/pinpointer.dm
+++ b/code/game/gamemodes/nuclear/pinpointer.dm
@@ -96,15 +96,15 @@
 
 /obj/item/pinpointer/proc/scandisk()
 	if(!the_disk)
-		the_disk = locate()
+		the_disk = locate() in GLOB.poi_list
 
 /obj/item/pinpointer/proc/scanbomb()
 	if(!syndicate)
 		if(!the_bomb)
-			the_bomb = locate()
+			the_bomb = locate() in GLOB.poi_list
 	else
 		if(!the_s_bomb)
-			the_s_bomb = locate()
+			the_s_bomb = locate() in GLOB.poi_list
 
 /obj/item/pinpointer/proc/point_at_target(atom/target)
 	if(!target)

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -65,8 +65,7 @@
 	return FALSE
 
 /datum/spellbook_entry/proc/Refund(mob/living/carbon/human/user, obj/item/spellbook/book) //return point value or -1 for failure
-	var/area/wizard_station/A = locate()
-	if(!(user in A.contents))
+	if(!istype(get_area(user), /area/wizard_station))
 		to_chat(user, "<span class='warning'>You can only refund spells at the wizard lair.</span>")
 		return -1
 	if(!S) //This happens when the spell's source is from another spellbook, from loadouts, or adminery, this create a new template temporary spell

--- a/code/modules/events/blob/overmind.dm
+++ b/code/modules/events/blob/overmind.dm
@@ -116,7 +116,7 @@
 		status_tab_data[++status_tab_data.len] = list("Power Stored:", "[blob_points]/[max_blob_points]")
 
 /mob/camera/blob/Move(NewLoc, Dir = 0)
-	var/obj/structure/blob/B = locate() in range("3x3", NewLoc)
+	var/obj/structure/blob/B = locate() in range(3, NewLoc)
 	if(B)
 		loc = NewLoc
 	else


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
fixes some locate checks being in world. if locate has no second arg it just defaults to in world

## Why It's Good For The Game
performance

## Testing
refunded a spell and used a pinpointer
## Changelog
🆑
tweak: blob camera controls no longer lock you to a 3 by 3 box, instead checking if a blob tile is in a radius of 3 tiles from the camera
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
