### PR TITLE
Fixes vampires ending up with negative blood

### DIFF
--- a/code/datums/spell_handler/vampire.dm
+++ b/code/datums/spell_handler/vampire.dm
@@ -36,8 +36,8 @@
 		return
 
 	var/datum/antagonist/vampire/vampire = user.mind.has_antag_datum(/datum/antagonist/vampire)
-
-	vampire.bloodusable -= calculate_blood_cost(vampire)
+	var/blood_cost = calculate_blood_cost(vampire)
+	vampire.bloodusable = clamp(vampire.bloodusable - blood_cost, 0, vampire.bloodusable)
 
 /datum/spell_handler/vampire/proc/calculate_blood_cost(datum/antagonist/vampire/vampire)
 	var/blood_cost_modifier = 1 + vampire.nullified / 100

--- a/code/datums/spell_handler/vampire.dm
+++ b/code/datums/spell_handler/vampire.dm
@@ -37,7 +37,7 @@
 
 	var/datum/antagonist/vampire/vampire = user.mind.has_antag_datum(/datum/antagonist/vampire)
 	var/blood_cost = calculate_blood_cost(vampire)
-	vampire.bloodusable = clamp(vampire.bloodusable - blood_cost, 0, vampire.bloodusable)
+	vampire.subtract_usable_blood(blood_cost)
 
 /datum/spell_handler/vampire/proc/calculate_blood_cost(datum/antagonist/vampire/vampire)
 	var/blood_cost_modifier = 1 + vampire.nullified / 100

--- a/code/modules/antagonists/vampire/vamp_datum.dm
+++ b/code/modules/antagonists/vampire/vamp_datum.dm
@@ -228,7 +228,7 @@ RESTRICT_TYPE(/datum/antagonist/vampire)
 			return
 	if(bloodusable >= 10)	//burn through your blood to tank the light for a little while
 		to_chat(owner.current, "<span class='warning'>The starlight saps your strength!</span>")
-		bloodusable -= 10
+		subtract_usable_blood(10)
 		vamp_burn(10)
 	else		//You're in trouble, get out of the sun NOW
 		to_chat(owner.current, "<span class='userdanger'>Your body is turning to ash, get out of the light now!</span>")
@@ -278,6 +278,13 @@ RESTRICT_TYPE(/datum/antagonist/vampire)
 	REMOVE_TRAIT(owner.current, TRAIT_GOTTAGONOTSOFAST, VAMPIRE_TRAIT)
 	owner.current.alpha = 204 // 255 * 0.80
 
+/**
+ * Handles unique drain ID checks and increases vampire's total and usable blood by blood_amount. Checks for ability upgrades.
+ *
+ * Arguments:
+ ** C: victim [/mob/living/carbon] that is being drained form.
+ ** blood_amount: amount of blood to add to vampire's usable and total pools.
+ */
 /datum/antagonist/vampire/proc/adjust_blood(mob/living/carbon/C, blood_amount = 0)
 	if(C)
 		var/unique_suck_id = C.UID()
@@ -292,6 +299,15 @@ RESTRICT_TYPE(/datum/antagonist/vampire)
 	for(var/datum/spell/S in powers)
 		if(S.action)
 			S.action.UpdateButtons()
+
+/**
+ * Safely subtract vampire's bloodusable. Clamped between 0 and bloodtotal.
+ *
+ * Arguments:
+ ** blood_amount: amount of blood to subtract.
+ */
+/datum/antagonist/vampire/proc/subtract_usable_blood(blood_amount)
+	bloodusable = clamp(bloodusable - blood_amount, 0, bloodtotal)
 
 /datum/antagonist/vampire/proc/vamp_burn(burn_chance)
 	if(prob(burn_chance) && owner.current.health >= 50)

--- a/code/modules/antagonists/vampire/vampire_powers/dantalion_powers.dm
+++ b/code/modules/antagonists/vampire/vampire_powers/dantalion_powers.dm
@@ -33,7 +33,7 @@
 			handle_enthrall(user, target)
 			var/datum/spell_handler/vampire/V = custom_handler
 			var/blood_cost = V.calculate_blood_cost(vampire)
-			vampire.bloodusable = clamp(vampire.bloodusable - blood_cost, 0, vampire.bloodusable) //we take the blood after enthralling, not before
+			vampire.subtract_usable_blood(blood_cost) //we take the blood after enthralling, not before
 	else
 		revert_cast(user)
 		to_chat(user, "<span class='warning'>You or your target moved.</span>")

--- a/code/modules/antagonists/vampire/vampire_powers/dantalion_powers.dm
+++ b/code/modules/antagonists/vampire/vampire_powers/dantalion_powers.dm
@@ -33,7 +33,7 @@
 			handle_enthrall(user, target)
 			var/datum/spell_handler/vampire/V = custom_handler
 			var/blood_cost = V.calculate_blood_cost(vampire)
-			vampire.bloodusable -= blood_cost //we take the blood after enthralling, not before
+			vampire.bloodusable = clamp(vampire.bloodusable - blood_cost, 0, vampire.bloodusable) //we take the blood after enthralling, not before
 	else
 		revert_cast(user)
 		to_chat(user, "<span class='warning'>You or your target moved.</span>")

--- a/code/modules/antagonists/vampire/vampire_powers/hemomancer_powers.dm
+++ b/code/modules/antagonists/vampire/vampire_powers/hemomancer_powers.dm
@@ -199,7 +199,7 @@
 	var/datum/spell_handler/vampire/V = custom_handler
 	var/datum/antagonist/vampire/vampire = user.mind.has_antag_datum(/datum/antagonist/vampire)
 	var/blood_cost = V.calculate_blood_cost(vampire)
-	vampire.bloodusable = clamp(vampire.bloodusable - blood_cost, 0, vampire.bloodusable)
+	vampire.subtract_usable_blood(blood_cost)
 	start_turf = null
 	should_recharge_after_cast = FALSE
 

--- a/code/modules/antagonists/vampire/vampire_powers/hemomancer_powers.dm
+++ b/code/modules/antagonists/vampire/vampire_powers/hemomancer_powers.dm
@@ -199,7 +199,7 @@
 	var/datum/spell_handler/vampire/V = custom_handler
 	var/datum/antagonist/vampire/vampire = user.mind.has_antag_datum(/datum/antagonist/vampire)
 	var/blood_cost = V.calculate_blood_cost(vampire)
-	vampire.bloodusable -= blood_cost
+	vampire.bloodusable = clamp(vampire.bloodusable - blood_cost, 0, vampire.bloodusable)
 	start_turf = null
 	should_recharge_after_cast = FALSE
 

--- a/code/modules/antagonists/vampire/vampire_powers/umbrae_powers.dm
+++ b/code/modules/antagonists/vampire/vampire_powers/umbrae_powers.dm
@@ -181,7 +181,7 @@
 	var/datum/spell_handler/vampire/V = custom_handler
 	var/datum/antagonist/vampire/vampire = user.mind.has_antag_datum(/datum/antagonist/vampire)
 	var/blood_cost = V.calculate_blood_cost(vampire)
-	vampire.bloodusable = clamp(vampire.bloodusable - blood_cost, 0, vampire.bloodusable)// Vampires get a coupon if they have less than the normal blood cost
+	vampire.subtract_usable_blood(blood_cost)// Vampires get a coupon if they have less than the normal blood cost
 
 /proc/shadow_to_animation(turf/start_turf, turf/end_turf, mob/user)
 	var/x_difference = end_turf.x - start_turf.x


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Adds proc to handle subtracting from usable blood pool that clamps between 0 and blood total and replaces all manual subtractions from bloodusable with it. This proc should be used to safely spend blood when not handing it off to spend_spell_cost. 
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
This bug breaks using zero cost abilities and is not supposed to happen.
## Testing
<!-- How did you test the PR, if at all? -->
Before
![image](https://github.com/ParadiseSS13/Paradise/assets/98280110/9ea72221-bac7-4255-84ef-b279486f44f0)

After
![image](https://github.com/ParadiseSS13/Paradise/assets/98280110/ece071b0-57ca-4851-ba83-54e20ea60f65)

## Changelog
:cl: Chuga
fix: Vampires can longer get stuck with negative blood after being fed holy water.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
