### PR TITLE
Made RCD code more efficient.

### DIFF
--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -266,7 +266,7 @@
 	if(!length(possible_actions))
 		possible_actions = list()
 		for(var/action_type in subtypesof(/datum/rcd_act))
-			possible_actions += action_type
+			possible_actions += new action_type()
 
 	spark_system = new /datum/effect_system/spark_spread
 	spark_system.set_up(5, 0, src)
@@ -572,8 +572,7 @@
 	if(!is_type_in_list(A, allowed_targets))
 		return FALSE
 
-	for(var/act_type in possible_actions)
-		var/datum/rcd_act/act = new act_type
+	for(var/datum/rcd_act/act in possible_actions)
 		if(act.can_act(A, src))
 			. = act.try_act(A, src, user)
 			update_icon(UPDATE_OVERLAYS)


### PR DESCRIPTION
## What Does This PR Do
The change that GDN *actually* asked for on #25062: initializing the RCD action types only once.

## Why It's Good For The Game
It doesn't runtime this time.

## Testing
Built and deconstructed wall, airlock, window, and plating. LGTM

## Changelog
NPFC, for real this time.