### PR TITLE
CLEANBOT: You can area lock without access

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/cleanbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/cleanbot.dm
@@ -228,7 +228,7 @@
 /mob/living/simple_animal/bot/cleanbot/ui_act(action, params)
 	if(..())
 		return
-	if(topic_denied(usr))
+	if(action != "area" && topic_denied(usr))
 		to_chat(usr, "<span class='warning'>[src]'s interface is not responding!</span>")
 		return
 	add_fingerprint(usr)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

You can now area lock the cleanbot without unlocking it first

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

Do you want a cleanbot in your area?
You do not have access? Well you can wait for your department head, or robotics to visit you
Or you can jsut grab the bot from hallway, and area lock it as intended

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

![FDLXgC5glS](https://github.com/ParadiseSS13/Paradise/assets/66401072/374e7a97-b4f8-4efc-b01c-05585f8cf1ed)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing

Compiles
Loaded and tested, ghost + crew

<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Cleanbot no longer requires unlocking to lock area
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
