### PR TITLE
Makes xenos not runtime on pierrots/wizarditis

### DIFF
--- a/code/datums/diseases/pierrot_throat.dm
+++ b/code/datums/diseases/pierrot_throat.dm
@@ -42,6 +42,9 @@
 	// Semi-permanent clown mask while in last stage of infection
 	if(locate(/obj/item/clothing/mask/gas/clown_hat) in H)
 		return
+	if(!istype(H)) // Xenos don't have masks. They can still feel silly though
+		return
+
 	if(!H.has_organ_for_slot(SLOT_HUD_WEAR_MASK) || !H.canUnEquip(H.get_item_by_slot(SLOT_HUD_WEAR_MASK)))
 		return
 

--- a/code/datums/diseases/wizarditis.dm
+++ b/code/datums/diseases/wizarditis.dm
@@ -58,6 +58,8 @@
 
 /datum/disease/wizarditis/proc/spawn_wizard_clothes()
 	var/mob/living/carbon/human/H = affected_mob
+	if(!istype(H))
+		return // Woe, wizard xeno upon ye
 
 	// Which slots can we replace?
 	var/list/eligible_slot_IDs = new


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes xenos runtiming because they don't have mask slots
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
These runtiming is very annoying
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Look at my sons, they are very sick
![image](https://github.com/ParadiseSS13/Paradise/assets/108773801/339d5624-612f-4aa1-935e-71bae2adfb87)

<!-- How did you test the PR, if at all? -->

## Changelog
NPFC

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
