### PR TITLE
Prevents using organ extractor to circumvent mephedrone heart damage

### DIFF
--- a/code/modules/surgery/organs/organ_extractor.dm
+++ b/code/modules/surgery/organs/organ_extractor.dm
@@ -141,7 +141,7 @@
 		replaced.remove(C)
 		replaced.forceMove(get_turf(src))
 		if(istype(storedorgan, /obj/item/organ/internal/heart) && ((/obj/item/organ/internal/cyberimp/brain/sensory_enhancer in C.internal_organs) || C.reagents.addiction_threshold_accumulated[/datum/reagent/mephedrone]))
-			storedorgan.damage = 40 //Damage the heart so you can't endlessly OD for cheap easily.
+			storedorgan.damage = 40 // Damage the heart so you can't endlessly OD for cheap easily.
 			to_chat(user, "<span class='warning'>CAUTION: Crystalized mephedrone has bounced off the drill into [storedorgan], causing internal damage!</span>")
 	storedorgan.insert(C)
 	playsound(get_turf(C), 'sound/weapons/circsawhit.ogg', 50, TRUE)

--- a/code/modules/surgery/organs/organ_extractor.dm
+++ b/code/modules/surgery/organs/organ_extractor.dm
@@ -140,6 +140,9 @@
 	if(replaced) //Lets not destroy someones brain fully by putting someone elses brain in that slot.
 		replaced.remove(C)
 		replaced.forceMove(get_turf(src))
+		if(istype(storedorgan, /obj/item/organ/internal/heart) && ((/obj/item/organ/internal/cyberimp/brain/sensory_enhancer in C.internal_organs) || C.reagents.addiction_threshold_accumulated[/datum/reagent/mephedrone]))
+			storedorgan.damage = 40 //Damage the heart so you can't endlessly OD for cheap easily.
+			to_chat(user, "<span class='warning'>CAUTION: Crystalized mephedrone has bounced off the drill into [storedorgan], causing internal damage!</span>")
 	storedorgan.insert(C)
 	playsound(get_turf(C), 'sound/weapons/circsawhit.ogg', 50, TRUE)
 	storedorgan = null


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Requested by Qwertytoforty

When implanting a harvested heart in somebody (or yourself) who either has a) a sensory enhancer implant or b) has accumulated any mephedrone addiction threshold (which decays with time), the extractor will now deal 40 damage to the stored heart before it is implanted into the target. 
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Mephedrone OD heart damage is intended to be controlled with mitocholide, nanocalcium, or other means. Using the organ extractor on morgue bodies or similarly accessible corpses allows the mephedrone user to instantly replenish their heart damage. 
## Testing
<!-- How did you test the PR, if at all? -->
Verified that it works with addiction threshold and a sensory computer installed.
## Changelog
:cl:
tweak: Prevents using organ extractor to circumvent mephedrone heart damage
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
