### PR TITLE
Botanists are no longer Gardeners and made Chemist matter in the Fungal Growth event.

### DIFF
--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -141,7 +141,7 @@ GLOBAL_LIST_EMPTY(event_last_fired)
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Mundane News", 		/datum/event/mundane_news, 		300),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Vermin Infestation",/datum/event/infestation, 		100,	list(ASSIGNMENT_JANITOR = 100)),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Sentience",			/datum/event/sentience,			50),
-		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Wallrot",			/datum/event/wallrot, 			0,		list(ASSIGNMENT_ENGINEER = 30, ASSIGNMENT_GARDENER = 50)),
+		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Wallrot",			/datum/event/wallrot, 			0,		list(ASSIGNMENT_ENGINEER = 30)),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Fungal Growth",		/datum/event/wallrot/fungus, 	50, 	list(ASSIGNMENT_CHEMIST = 50)),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Koi School",		/datum/event/carp_migration/koi,		80),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Camera Failure",	/datum/event/camera_failure,		100, list(ASSIGNMENT_ENGINEER = 10)),

--- a/code/modules/events/event_procs.dm
+++ b/code/modules/events/event_procs.dm
@@ -64,6 +64,7 @@
 	active_with_role["Cyborg"] = 0
 	active_with_role["Janitor"] = 0
 	active_with_role["Botanist"] = 0
+	active_with_role["Chemist"] = 0
 	active_with_role["Any"] = length(GLOB.player_list)
 
 	for(var/mob/M in GLOB.player_list)
@@ -104,6 +105,9 @@
 
 		if(M.mind.assigned_role == "Botanist")
 			active_with_role["Botanist"]++
+
+		if(M.mind.assigned_role == "Chemist")
+			active_with_role["Chemist"]++
 
 	return active_with_role
 


### PR DESCRIPTION
## What Does This PR Do
Removes "ASSIGNMENT_GARDENER" and fixes Chemists not affecting the weight of the Fungal Growth event.

## Why It's Good For The Game
It was meant to work this way.

## Testing
Spawned as a Chemist and saw that the Fungal Growth event weight raised in the Event Manager Panel.

## Changelog
:cl:
fix: Fixed the amount of Chemists on station not mattering when Fungal Growth is supposed to roll.
/:cl:
