### PR TITLE
Adds Multi-antag hud, which shows multple antagonists on one person

### DIFF
--- a/code/datums/atom_hud.dm
+++ b/code/datums/atom_hud.dm
@@ -11,19 +11,19 @@ GLOBAL_LIST_INIT(huds, list(
 	DATA_HUD_DIAGNOSTIC_ADVANCED = new/datum/atom_hud/data/diagnostic/advanced(),
 	DATA_HUD_HYDROPONIC = new/datum/atom_hud/data/hydroponic(),
 	DATA_HUD_JANITOR = new/datum/atom_hud/data/janitor(),
-	ANTAG_HUD_CULT = new/datum/atom_hud/antag(),
-	ANTAG_HUD_REV = new/datum/atom_hud/antag(),
-	ANTAG_HUD_OPS = new/datum/atom_hud/antag(),
-	ANTAG_HUD_WIZ  = new/datum/atom_hud/antag(),
-	ANTAG_HUD_SHADOW  = new/datum/atom_hud/antag(),
-	ANTAG_HUD_TRAITOR = new/datum/atom_hud/antag/hidden(),
-	ANTAG_HUD_NINJA = new/datum/atom_hud/antag/hidden(),
-	ANTAG_HUD_CHANGELING = new/datum/atom_hud/antag/hidden(),
-	ANTAG_HUD_VAMPIRE = new/datum/atom_hud/antag/hidden(),
-	ANTAG_HUD_ABDUCTOR = new/datum/atom_hud/antag/hidden(),
+	ANTAG_HUD_CULT = new/datum/atom_hud/antag(ANTAG_HUD_CULT),
+	ANTAG_HUD_REV = new/datum/atom_hud/antag(ANTAG_HUD_REV),
+	ANTAG_HUD_OPS = new/datum/atom_hud/antag(ANTAG_HUD_OPS),
+	ANTAG_HUD_WIZ  = new/datum/atom_hud/antag(ANTAG_HUD_WIZ),
+	ANTAG_HUD_SHADOW  = new/datum/atom_hud/antag(ANTAG_HUD_SHADOW),
+	ANTAG_HUD_TRAITOR = new/datum/atom_hud/antag/hidden(ANTAG_HUD_TRAITOR),
+	ANTAG_HUD_NINJA = new/datum/atom_hud/antag/hidden(ANTAG_HUD_NINJA),
+	ANTAG_HUD_CHANGELING = new/datum/atom_hud/antag/hidden(ANTAG_HUD_CHANGELING),
+	ANTAG_HUD_VAMPIRE = new/datum/atom_hud/antag/hidden(ANTAG_HUD_VAMPIRE),
+	ANTAG_HUD_ABDUCTOR = new/datum/atom_hud/antag/hidden(ANTAG_HUD_ABDUCTOR),
 	DATA_HUD_ABDUCTOR = new/datum/atom_hud/abductor(),
-	ANTAG_HUD_EVENTMISC = new/datum/atom_hud/antag/hidden(),
-	ANTAG_HUD_BLOB = new/datum/atom_hud/antag/hidden()
+	ANTAG_HUD_EVENTMISC = new/datum/atom_hud/antag/hidden(ANTAG_HUD_EVENTMISC),
+	ANTAG_HUD_BLOB = new/datum/atom_hud/antag/hidden(ANTAG_HUD_BLOB)
 	))
 
 /datum/atom_hud

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -59,9 +59,9 @@
 	/// A lazy list of all teams the player is part of but doesnt have an antag role for, (i.e. a custom admin team)
 	var/list/teams
 
-	var/antag_hud_icon_state = null //this mind's ANTAG_HUD should have this icon_state
-	var/datum/atom_hud/antag/antag_hud = null //this mind's antag HUD
-	var/datum/mindslaves/som //stands for slave or master...hush..
+	var/datum/antag_hud_helper/antag_hud //this mind's antag HUD
+	var/datum/mindslaves/mindslave_master // We are a master of this group
+	var/datum/mindslaves/mindslave_slave // We are a slave to this group
 
 	var/isblessed = FALSE // is this person blessed by a chaplain?
 	var/num_blessed = 0 // for prayers
@@ -128,7 +128,6 @@
 	return out_ckey
 
 /datum/mind/proc/transfer_to(mob/living/new_character)
-	var/datum/atom_hud/antag/hud_to_transfer = antag_hud //we need this because leave_hud() will clear this list
 	var/mob/living/old_current = current
 	if(!istype(new_character))
 		stack_trace("transfer_to(): Some idiot has tried to transfer_to() a non mob/living mob.")
@@ -150,7 +149,7 @@
 	for(var/a in antag_datums)	//Makes sure all antag datums effects are applied in the new body
 		var/datum/antagonist/A = a
 		A.on_body_transfer(old_current, current)
-	transfer_antag_huds(hud_to_transfer)				//inherit the antag HUD
+	antag_hud?.transfer_antag_huds(old_current, current) // inherit the antag HUD
 	transfer_actions(new_character)
 	if(martial_art)
 		for(var/datum/martial_art/MA in known_martial_arts)

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -709,7 +709,7 @@
 	START_PROCESSING(SSfastprocess, src)
 	target_UIDs += owner.UID()
 	var/list/view_cache = view(7, owner)
-	for(var/datum/mind/M in owner.mind.som.serv)
+	for(var/datum/mind/M in owner.mind.mindslave_master.serv)
 		if(!M.has_antag_datum(/datum/antagonist/mindslave/thrall))
 			continue
 		if(!(M.current in view_cache))

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -574,14 +574,10 @@
 
 
 /datum/game_mode/proc/update_eventmisc_icons_added(datum/mind/mob_mind)
-	var/datum/atom_hud/antag/antaghud = GLOB.huds[ANTAG_HUD_EVENTMISC]
-	antaghud.join_hud(mob_mind.current)
-	set_antag_hud(mob_mind.current, "hudevent")
+	mob_mind.add_antag_hud(mob_mind.current, ANTAG_HUD_EVENTMISC, "hudevent")
 
 /datum/game_mode/proc/update_eventmisc_icons_removed(datum/mind/mob_mind)
-	var/datum/atom_hud/antag/antaghud = GLOB.huds[ANTAG_HUD_EVENTMISC]
-	antaghud.leave_hud(mob_mind.current)
-	set_antag_hud(mob_mind.current, null)
+	mob_mind.remove_antag_hud(mob_mind.current, ANTAG_HUD_EVENTMISC, "hudevent")
 
 /// Gets the value of all end of round stats through auto_declare and returns them
 /datum/game_mode/proc/get_end_of_round_antagonist_statistics()

--- a/code/game/gamemodes/miniantags/abduction/abduction.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction.dm
@@ -283,11 +283,7 @@
 		SSticker.mode.update_abductor_icons_removed(abductor_mind)
 
 /datum/game_mode/proc/update_abductor_icons_added(datum/mind/alien_mind)
-	var/datum/atom_hud/antag/hud = GLOB.huds[ANTAG_HUD_ABDUCTOR]
-	hud.join_hud(alien_mind.current)
-	set_antag_hud(alien_mind.current, ((alien_mind in abductors) ? "abductor" : "abductee"))
+	alien_mind.add_antag_hud(alien_mind.current, ANTAG_HUD_ABDUCTOR, ((alien_mind in abductors) ? "abductor" : "abductee"))
 
 /datum/game_mode/proc/update_abductor_icons_removed(datum/mind/alien_mind)
-	var/datum/atom_hud/antag/hud = GLOB.huds[ANTAG_HUD_ABDUCTOR]
-	hud.leave_hud(alien_mind.current)
-	set_antag_hud(alien_mind.current, null)
+	alien_mind.remove_antag_hud(alien_mind.current, ANTAG_HUD_ABDUCTOR, ((alien_mind in abductors) ? "abductor" : "abductee"))

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -76,14 +76,10 @@
 ////////////////////////////////////////////////////////////////////////////////////////
 
 /datum/game_mode/proc/update_synd_icons_added(datum/mind/synd_mind)
-	var/datum/atom_hud/antag/opshud = GLOB.huds[ANTAG_HUD_OPS]
-	opshud.join_hud(synd_mind.current)
-	set_antag_hud(synd_mind.current, "hudoperative")
+	synd_mind.add_antag_hud(synd_mind.current, ANTAG_HUD_OPS, "hudoperative")
 
 /datum/game_mode/proc/update_synd_icons_removed(datum/mind/synd_mind)
-	var/datum/atom_hud/antag/opshud = GLOB.huds[ANTAG_HUD_OPS]
-	opshud.leave_hud(synd_mind.current)
-	set_antag_hud(synd_mind.current, null)
+	synd_mind.remove_antag_hud(synd_mind.current, ANTAG_HUD_OPS, "hudoperative")
 
 ////////////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////////////

--- a/code/game/gamemodes/wizard/artefact.dm
+++ b/code/game/gamemodes/wizard/artefact.dm
@@ -783,9 +783,7 @@ GLOBAL_LIST_EMPTY(multiverse)
 	H.mind.assigned_role = SPECIAL_ROLE_WIZARD
 	H.mind.special_role = SPECIAL_ROLE_WIZARD
 
-	var/datum/atom_hud/antag/wizhud = GLOB.huds[ANTAG_HUD_WIZ]
-	wizhud.join_hud(H)
-	set_antag_hud(H, "apprentice")
+	H.mind.add_antag_hud(H, ANTAG_HUD_WIZ, "apprentice")
 
 	H.say("NYA!~")
 

--- a/code/game/jobs/job/syndicate_jobs.dm
+++ b/code/game/jobs/job/syndicate_jobs.dm
@@ -55,8 +55,6 @@
 	U.implant(H)
 	U.hidden_uplink.uses = 2500
 	H.faction += "syndicate"
-	var/datum/atom_hud/antag/opshud = GLOB.huds[ANTAG_HUD_OPS]
-	opshud.join_hud(H.mind.current)
 	H.mind.offstation_role = TRUE
-	set_antag_hud(H.mind.current, "hudoperative")
+	H.mind.add_antag_hud(H.mind.current, ANTAG_HUD_OPS, "hudoperative")
 	H.regenerate_icons()

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -3562,9 +3562,7 @@
 	if(killthem)
 		to_chat(hunter_mob, "<b>If you kill [H.p_them()], [H.p_they()] cannot be revived.</b>");
 	hunter_mob.mind.special_role = SPECIAL_ROLE_TRAITOR
-	var/datum/atom_hud/antag/tatorhud = GLOB.huds[ANTAG_HUD_TRAITOR]
-	tatorhud.join_hud(hunter_mob)
-	set_antag_hud(hunter_mob, "hudsyndicate")
+	hunter_mob.mind.add_antag_hud(hunter_mob, ANTAG_HUD_TRAITOR, "hudsyndicate")
 
 /proc/admin_jump_link(atom/target)
 	if(!target) return

--- a/code/modules/admin/verbs/infiltratorteam_syndicate.dm
+++ b/code/modules/admin/verbs/infiltratorteam_syndicate.dm
@@ -104,9 +104,8 @@ GLOBAL_VAR_INIT(sent_syndicate_infiltration_team, 0)
 		new_syndicate_infiltrator.mind.store_memory("<B>Mission:</B> [input] ")
 		new_syndicate_infiltrator.mind.store_memory("<B>Team Leader:</B> [team_leader] ")
 		new_syndicate_infiltrator.mind.store_memory("<B>Starting Equipment:</B> <BR>- Syndicate Headset ((.h for your radio))<BR>- Chameleon Jumpsuit ((right click to Change Color))<BR> - Agent ID card ((disguise as another job))<BR> - Uplink Bio-chip ((top left of screen)) <BR> - Dust Bio-chip ((destroys your body on death)) <BR> - Combat Gloves ((insulated, disguised as black gloves)) <BR> - Anything bought with your uplink bio-chip")
-		var/datum/atom_hud/antag/opshud = GLOB.huds[ANTAG_HUD_OPS]
-		opshud.join_hud(new_syndicate_infiltrator.mind.current)
-		set_antag_hud(new_syndicate_infiltrator.mind.current, "hudoperative")
+
+		new_syndicate_infiltrator.mind.add_antag_hud(new_syndicate_infiltrator.mind.current, ANTAG_HUD_OPS, "hudoperative")
 		new_syndicate_infiltrator.regenerate_icons()
 		num_spawned++
 		if(!teamsize)

--- a/code/modules/admin/verbs/striketeam_syndicate.dm
+++ b/code/modules/admin/verbs/striketeam_syndicate.dm
@@ -83,9 +83,8 @@ GLOBAL_VAR_INIT(sent_syndicate_strike_team, 0)
 
 		to_chat(new_syndicate_commando, "<span class='notice'>You are an Elite Syndicate [is_leader ? "<B>TEAM LEADER</B>" : "commando"] in the service of the Syndicate. \nYour current mission is: <span class='userdanger'>[input]</span></span>")
 		new_syndicate_commando.faction += "syndicate"
-		var/datum/atom_hud/antag/opshud = GLOB.huds[ANTAG_HUD_OPS]
-		opshud.join_hud(new_syndicate_commando.mind.current)
-		set_antag_hud(new_syndicate_commando.mind.current, "hudoperative")
+
+		new_syndicate_commando.mind.add_antag_hud(new_syndicate_commando.mind.current, ANTAG_HUD_OPS, "hudoperative")
 		new_syndicate_commando.regenerate_icons()
 		is_leader = FALSE
 		syndicate_commando_number--

--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -170,9 +170,7 @@ GLOBAL_LIST_EMPTY(antagonists)
  * * antag_mob - the mob to add the antag hud to.
  */
 /datum/antagonist/proc/add_antag_hud(mob/living/antag_mob)
-	var/datum/atom_hud/antag/hud = GLOB.huds[antag_hud_type]
-	hud.join_hud(antag_mob)
-	set_antag_hud(antag_mob, antag_hud_name)
+	antag_mob.mind.add_antag_hud(antag_mob, antag_hud_type, antag_hud_name)
 
 /**
  * Removes this datum's antag hud from `antag_mob`.
@@ -181,9 +179,7 @@ GLOBAL_LIST_EMPTY(antagonists)
  * * antag_mob - the mob to remove the antag hud from.
  */
 /datum/antagonist/proc/remove_antag_hud(mob/living/antag_mob)
-	var/datum/atom_hud/antag/hud = GLOB.huds[antag_hud_type]
-	hud.leave_hud(antag_mob)
-	set_antag_hud(antag_mob, null)
+	antag_mob.mind.remove_antag_hud(antag_mob, antag_hud_type, antag_hud_name)
 
 /**
  * Handles adding and removing the clumsy mutation from clown antags.

--- a/code/modules/antagonists/_common/antag_hud.dm
+++ b/code/modules/antagonists/_common/antag_hud.dm
@@ -1,20 +1,23 @@
 /datum/atom_hud/antag
 	hud_icons = list(SPECIALROLE_HUD)
 	var/self_visible = TRUE
+	var/key
 
 /datum/atom_hud/antag/hidden
 	self_visible = FALSE
 
-/datum/atom_hud/antag/proc/join_hud(mob/M, slave)
+/datum/atom_hud/antag/New(_key)
+	. = ..()
+	key = "[_key]"
+
+/datum/atom_hud/antag/proc/join_hud(mob/M)
 	//sees_hud should be set to 0 if the mob does not get to see it's own hud type.
 	if(!istype(M))
 		CRASH("join_hud(): [M] ([M.type]) is not a mob!")
-	if(M.mind.antag_hud && !slave) //note: please let this runtime if a mob has no mind, as mindless mobs shouldn't be getting antagged
-		M.mind.antag_hud.leave_hud(M)
 	add_to_hud(M)
 	if(self_visible)
 		add_hud_to(M)
-	M.mind.antag_hud = src
+	M.mind.antag_hud.antag_huds |= src
 
 /datum/atom_hud/antag/proc/leave_hud(mob/M)
 	if(!M)
@@ -23,28 +26,36 @@
 		CRASH("leave_hud(): [M] ([M.type]) is not a mob!")
 	remove_from_hud(M)
 	remove_hud_from(M)
-	if(M.mind)
-		M.mind.antag_hud = null
+	M.mind.antag_hud.antag_huds -= src
 
+/datum/atom_hud/antag/add_to_single_hud(mob/M, atom/A) //unsafe, no sanity apart from client
+	if(!M || !M.client || !A)
+		return
+	if(A.invisibility > M.see_invisible) // yee yee ass snowflake check for our yee yee ass snowflake huds
+		return
+	if(A.hud_list[SPECIALROLE_HUD] && A.hud_list[SPECIALROLE_HUD][key])
+		M.client.images |= A.hud_list[SPECIALROLE_HUD][key] // had to be copied to include `key`
 
-//GAME_MODE PROCS
-//called to set a mob's antag icon state
-/proc/set_antag_hud(mob/M, new_icon_state)
-	if(!istype(M))
-		CRASH("set_antag_hud(): [M] ([M.type]) is not a mob!")
-	var/image/holder = M.hud_list[SPECIALROLE_HUD]
-	if(holder)
-		holder.icon_state = new_icon_state
-	if(M.mind || new_icon_state) //in mindless mobs, only null is acceptable, otherwise we're antagging a mindless mob, meaning we should runtime
-		M.mind.antag_hud_icon_state = new_icon_state
+/datum/atom_hud/antag/remove_from_single_hud(mob/M, atom/A) //unsafe, no sanity apart from client
+	if(!M || !M.client || !A)
+		return
+	M.client.images -= A.hud_list[SPECIALROLE_HUD][key] // had to be copied to include `key`
 
-//MIND PROCS
-//these are called by mind.transfer_to()
-/datum/mind/proc/transfer_antag_huds(datum/atom_hud/antag/newhud)
-	leave_all_huds()
-	set_antag_hud(current, antag_hud_icon_state)
-	if(newhud)
-		newhud.join_hud(current)
+/datum/mind/proc/add_antag_hud(mob/M, hud_index, new_icon_state)
+	if(!antag_hud)
+		antag_hud = new(src)
+	var/datum/atom_hud/antag/hud = hud_index
+	if(!istype(hud, /datum/atom_hud/antag)) // I hate this but its required for mindslaves. Don't use this outside of mindslaves, always pass in the index.
+		hud = GLOB.huds[hud_index]
+	antag_hud.add_antag_hud(M, hud, new_icon_state)
+	hud.join_hud(M)
+
+/datum/mind/proc/remove_antag_hud(mob/M, hud_index, new_icon_state)
+	var/datum/atom_hud/antag/hud = GLOB.huds[hud_index]
+	antag_hud.remove_antag_hud(M, hud, new_icon_state)
+	hud.leave_hud(M)
+	if(!antag_hud.is_active())
+		qdel(antag_hud)
 
 /datum/mind/proc/leave_all_huds()
 	for(var/datum/atom_hud/antag/hud in GLOB.huds)
@@ -56,25 +67,117 @@
 			hud.remove_hud_from(current)
 
 
-///Master Servent Datum Sytems,Based on TG Gang system//
-
 /datum/mindslaves
 	var/name = "ERROR"
 	var/list/datum/mind/masters = list()
 	var/list/datum/mind/serv = list()
 	var/datum/atom_hud/antag/thrallhud
-	var/icontype
+	var/master_icon_state = "hudmaster"
 
-/datum/mindslaves/New(loc,mastername)
+/datum/mindslaves/New()
+	..()
+	thrallhud = new(src.UID())
 
-	name = mastername
-	thrallhud = new()
+/datum/mindslaves/Destroy(force, ...)
+	qdel(thrallhud)
+	return ..()
 
-/datum/mindslaves/proc/add_serv_hud(datum/mind/serv_mind, icon)
-	thrallhud.join_hud(serv_mind.current, 1)
-	icontype = "hud[icon]"
-	set_antag_hud(serv_mind.current, icontype)
+/datum/mindslaves/proc/add_master(datum/mind/_mind)
+	if(_mind.mindslave_master)
+		return FALSE
+	masters |= _mind
+	_mind.mindslave_master = src
+	_mind.add_antag_hud(_mind.current, thrallhud, master_icon_state)
+	return TRUE
 
-/datum/mindslaves/proc/leave_serv_hud(datum/mind/free_mind)
-	thrallhud.leave_hud(free_mind.current)
-	set_antag_hud(free_mind.current, null)
+/datum/mindslaves/proc/remove_master(datum/mind/_mind)
+	if(_mind.mindslave_master != src)
+		return FALSE
+	masters -= _mind
+	_mind.mindslave_master = null
+	_mind.remove_antag_hud(_mind.current, thrallhud, master_icon_state)
+	return TRUE
+
+
+/datum/mindslaves/proc/add_servant(datum/mind/_mind, icon_state)
+	if(_mind.mindslave_slave)
+		return FALSE
+	serv[_mind] = icon_state
+	_mind.mindslave_slave = src
+	_mind.add_antag_hud(_mind.current, thrallhud, icon_state)
+	return TRUE
+
+/datum/mindslaves/proc/remove_servant(datum/mind/_mind)
+	if(_mind.mindslave_slave != src)
+		return FALSE
+	_mind.remove_antag_hud(_mind.current, thrallhud, serv[_mind])
+	serv -= _mind
+	_mind.mindslave_slave = null
+	return TRUE
+
+
+#define ANTAG_HUD_HEIGHT_OFFSET -8
+
+/datum/antag_hud_helper
+	var/list/team_icon_states = list()
+	var/list/solo_icon_states = list()
+	var/list/icon_state_to_image = list()
+	var/list/datum/atom_hud/antag/antag_huds = list()
+	var/datum/mind/our_mind
+
+/datum/antag_hud_helper/New(datum/mind/mind)
+	. = ..()
+	our_mind = mind
+
+/datum/antag_hud_helper/proc/add_antag_hud(mob/M, datum/atom_hud/antag/hud, new_icon_state)
+	if(!istype(M))
+		CRASH("add_antag_hud(): [M] ([M.type]) is not a mob!")
+	if(hud.self_visible)
+		team_icon_states |= new_icon_state
+	else
+		solo_icon_states |= new_icon_state
+
+	var/image/I = image('icons/mob/hud/antaghud.dmi', M, new_icon_state)
+	I.appearance_flags = RESET_COLOR | RESET_TRANSFORM
+
+	M.hud_list[SPECIALROLE_HUD][hud.key] = I
+	icon_state_to_image[new_icon_state] = I
+	recalculate_images()
+
+/datum/antag_hud_helper/proc/remove_antag_hud(mob/M, datum/atom_hud/antag/hud, old_icon_state)
+	if(!istype(M))
+		CRASH("add_antag_hud(): [M] ([M.type]) is not a mob!")
+
+	M.hud_list[SPECIALROLE_HUD] -= hud.key
+	icon_state_to_image -= old_icon_state
+	team_icon_states -= old_icon_state
+	solo_icon_states -= old_icon_state
+	if(!length(solo_icon_states))
+		return
+	recalculate_images()
+
+/datum/antag_hud_helper/proc/transfer_antag_huds(mob/old_mob, mob/new_mob)
+	if(!istype(old_mob))
+		CRASH("transfer_antag_huds()'s old_mob: [old_mob] ([old_mob.type]) is not a mob!")
+	if(!istype(new_mob))
+		CRASH("transfer_antag_huds()'s new_mob: [new_mob] ([new_mob.type]) is not a mob!")
+	new_mob.hud_list[SPECIALROLE_HUD] = old_mob.hud_list[SPECIALROLE_HUD]
+	old_mob.hud_list[SPECIALROLE_HUD] = list()
+	var/list/temp_huds = antag_huds.Copy()
+	our_mind.leave_all_huds()
+	for(var/image/I as anything in new_mob.hud_list[SPECIALROLE_HUD])
+		I.loc = new_mob
+	for(var/datum/atom_hud/antag/swaphud in temp_huds)
+		swaphud.join_hud(new_mob)
+
+/datum/antag_hud_helper/proc/recalculate_images()
+	var/next_y = length(team_icon_states) ? ANTAG_HUD_HEIGHT_OFFSET : 0
+	for(var/icon_state in solo_icon_states)
+		var/image/I = icon_state_to_image[icon_state]
+		I.pixel_y = next_y
+		next_y += ANTAG_HUD_HEIGHT_OFFSET
+
+/datum/antag_hud_helper/proc/is_active()
+	return length(solo_icon_states) || length(team_icon_states)
+
+#undef ANTAG_HUD_HEIGHT_OFFSET

--- a/code/modules/antagonists/_common/antag_hud.dm
+++ b/code/modules/antagonists/_common/antag_hud.dm
@@ -165,7 +165,8 @@
 	old_mob.hud_list[SPECIALROLE_HUD] = list()
 	var/list/temp_huds = antag_huds.Copy()
 	our_mind.leave_all_huds()
-	for(var/image/I as anything in new_mob.hud_list[SPECIALROLE_HUD])
+	for(var/key as anything in new_mob.hud_list[SPECIALROLE_HUD])
+		var/image/I = new_mob.hud_list[SPECIALROLE_HUD][key]
 		I.loc = new_mob
 	for(var/datum/atom_hud/antag/swaphud in temp_huds)
 		swaphud.join_hud(new_mob)

--- a/code/modules/antagonists/traitor/datum_mindslave.dm
+++ b/code/modules/antagonists/traitor/datum_mindslave.dm
@@ -25,9 +25,7 @@ RESTRICT_TYPE(/datum/antagonist/mindslave)
 	..()
 
 /datum/antagonist/mindslave/Destroy(force, ...)
-	if(owner.som)
-		owner.som.serv -= owner
-		owner.som.leave_serv_hud(owner)
+	owner.mindslave_slave.remove_servant(owner)
 	// Remove the master reference but turn this into a string so it can still be used in /datum/antagonist/mindslave/farewell().
 	if(master.current)
 		master = "[master.current.real_name]"
@@ -36,18 +34,13 @@ RESTRICT_TYPE(/datum/antagonist/mindslave)
 	return ..()
 
 /datum/antagonist/mindslave/on_gain()
-	var/datum/mindslaves/slaved = master.som
+	var/datum/mindslaves/slaved = master.mindslave_master
 	if(!slaved) // If the master didn't already have this, we need to make a new mindslaves datum.
+		// if your master is a vampire and shit got here, this will probably be weird.
 		slaved = new
-		slaved.masters += master
-		master.som = slaved
+		slaved.add_master(master)
 
-	// Update our master's HUD to give him the "M" icon.
-	// Basically a copy and paste of what's in [/datum/antagonist/proc/add_antag_hud] in case the master doesn't have a traitor datum.
-	var/datum/atom_hud/antag/hud = GLOB.huds[antag_hud_type]
-	hud.join_hud(master.current)
-	set_antag_hud(master.current, "hudmaster")
-	slaved.add_serv_hud(master, "master")
+	slaved.add_servant(owner, antag_hud_name)
 	return ..()
 
 /datum/antagonist/mindslave/add_owner_to_gamemode()
@@ -65,26 +58,20 @@ RESTRICT_TYPE(/datum/antagonist/mindslave)
 	// Show them the custom greeting text if it exists.
 	if(greet_text)
 		return "<span class='biggerdanger'>[greet_text]</span>"
-	else // Default greeting text if nothing is given.
-		return "<span class='biggerdanger'><b>You are now completely loyal to [master.current.name]!</b> \
-							You must lay down your life to protect [master.current.p_them()] and assist in [master.current.p_their()] goals at any cost.</span>"
+	// Default greeting text if nothing is given.
+	return "<span class='biggerdanger'><b>You are now completely loyal to [master.current.name]!</b> \
+			You must lay down your life to protect [master.current.p_them()] and assist in [master.current.p_their()] goals at any cost.</span>"
 
 /datum/antagonist/mindslave/farewell()
 	if(owner && owner.current)
 		to_chat(owner.current, "<span class='biggerdanger'>You are no longer a mindslave of [master]!</span>")
 
-/datum/antagonist/mindslave/add_antag_hud(mob/living/antag_mob)
-	. = ..()
-	// Make the mindslave hud icon show to the mindslave.
-	var/datum/mindslaves/slaved = master.som
-	owner.som = slaved
-	slaved.serv += owner
-	slaved.add_serv_hud(owner, antag_hud_name)
+// /datum/antagonist/mindslave/add_antag_hud(mob/living/antag_mob)
+// 	. = ..()
+// 	// Make the mindslave hud icon show to the mindslave.
+// 	master.mindslave_master.add_servant(owner)
 
-/datum/antagonist/mindslave/remove_antag_hud(mob/living/antag_mob)
-	. = ..()
-	// Remove the mindslave antag hud from the mindslave.
-	var/datum/mindslaves/slaved = owner.som
-	slaved.serv -= owner
-	slaved.leave_serv_hud(owner)
-	owner.som = null
+// /datum/antagonist/mindslave/remove_antag_hud(mob/living/antag_mob)
+// 	. = ..()
+// 	// Remove the mindslave antag hud from the mindslave.
+// 	owner.mindslave_slave.remove_servant(owner)

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -16,16 +16,9 @@ RESTRICT_TYPE(/datum/antagonist/traitor)
 	var/give_codewords = TRUE
 	/// Should we give the traitor their uplink?
 	var/give_uplink = TRUE
+	var/datum/mindslaves/mindslave_datum
 	blurb_r = 200
 	blurb_a = 0.75
-
-/datum/antagonist/traitor/on_gain()
-	// Create this in case the traitor wants to mindslaves someone.
-	if(!owner.som)
-		owner.som = new /datum/mindslaves
-
-	owner.som.masters += owner
-	..()
 
 /datum/antagonist/traitor/apply_innate_effects(mob/living/mob_override)
 	. = ..()
@@ -52,12 +45,8 @@ RESTRICT_TYPE(/datum/antagonist/traitor)
 		QDEL_NULL(A.malf_picker)
 
 	// Leave the mindslave hud.
-	if(owner.som)
-		var/datum/mindslaves/slaved = owner.som
-		slaved.masters -= owner
-		slaved.serv -= owner
-		slaved.leave_serv_hud(owner)
-		owner.som = null
+	if(owner.mindslave_master)
+		owner.mindslave_master.remove_master(owner)
 
 	// Need to bring this functionality back to TGchat
 	// owner.current.client?.chatOutput?.clear_syndicate_codes()

--- a/code/modules/antagonists/vampire/vamp_datum.dm
+++ b/code/modules/antagonists/vampire/vamp_datum.dm
@@ -334,9 +334,6 @@ RESTRICT_TYPE(/datum/antagonist/vampire)
 
 /datum/antagonist/vampire/apply_innate_effects(mob/living/mob_override)
 	mob_override = ..()
-	if(!owner.som) //thralls and mindslaves
-		owner.som = new()
-		owner.som.masters += owner
 
 	mob_override.dna?.species.hunger_type = "vampire"
 	mob_override.dna?.species.hunger_icon = 'icons/mob/screen_hunger_vampire.dmi'

--- a/code/modules/antagonists/vampire/vampire_powers/dantalion_powers.dm
+++ b/code/modules/antagonists/vampire/vampire_powers/dantalion_powers.dm
@@ -42,7 +42,7 @@
 	. = FALSE
 	if(!C)
 		CRASH("target was null while trying to vampire enthrall, attacker is [user] [user.key] \ref[user]")
-	if(!user.mind.som)
+	if(!user.mind.mindslave_master)
 		CRASH("Dantalion Thrall datum ended up null.")
 	if(!ishuman(C))
 		to_chat(user, "<span class='warning'>You can only enthrall sentient humanoids!</span>")
@@ -52,7 +52,7 @@
 		return
 
 	var/datum/antagonist/vampire/V = user.mind.has_antag_datum(/datum/antagonist/vampire)
-	if(V.subclass.thrall_cap <= length(user.mind.som.serv))
+	if(V.subclass.thrall_cap <= length(user.mind.mindslave_master.serv))
 		to_chat(user, "<span class='warning'>You don't have enough power to enthrall any more people!</span>")
 		return
 	if(ismindshielded(C) || C.mind.has_antag_datum(/datum/antagonist/vampire) || IS_MINDSLAVE(C))
@@ -86,25 +86,13 @@
 	return
 
 /datum/spell_targeting/select_vampire_network/choose_targets(mob/user, datum/spell/spell, params, atom/clicked_atom) // Returns the vampire and their thralls. If user is a thrall then it will look up their master's network
-	var/list/mob/living/targets = list()
 	var/datum/antagonist/vampire/V = user.mind.has_antag_datum(/datum/antagonist/vampire) // if the user is a vampire
 
-	if(!V)
-		for(var/datum/mind/M in user.mind.som.masters) // if the user is a thrall
-			V = M.has_antag_datum(/datum/antagonist/vampire)
-			if(V)
-				break
-
-	if(!V)
-		return
-	if(!V.owner.som) // I hate som
+	var/datum/mindslaves/mindslave_datum = istype(V) ? user.mind.mindslave_master : user.mind.mindslave_slave
+	if(!mindslave_datum)
 		stack_trace("Dantalion Thrall datum ended up null.")
 		return
-
-	for(var/datum/mind/thrall in V.owner.som.serv)
-		targets += thrall.current
-	targets += V.owner.current
-	return targets
+	return mindslave_datum.masters | mindslave_datum.serv
 
 /datum/spell/vampire/thrall_commune/create_new_targeting()
 	var/datum/spell_targeting/select_vampire_network/T = new

--- a/code/modules/antagonists/vampire/vampire_powers/vampire_powers.dm
+++ b/code/modules/antagonists/vampire/vampire_powers/vampire_powers.dm
@@ -155,6 +155,9 @@
 	check_vampire_upgrade(announce)
 	if(log_choice)
 		SSblackbox.record_feedback("nested tally", "vampire_subclasses", 1, list("[new_subclass.name]"))
+	if(subclass_to_add == SUBCLASS_DANTALION) // did you know mindslaves are the worst thing ever
+		var/datum/mindslaves/the_thrallening = new /datum/mindslaves
+		the_thrallening.add_master(owner)
 
 /datum/spell/vampire/glare
 	name = "Glare"

--- a/code/modules/awaymissions/mission_code/ghost_role_spawners/golems.dm
+++ b/code/modules/awaymissions/mission_code/ghost_role_spawners/golems.dm
@@ -116,13 +116,12 @@
 			new_spawn.mind.store_memory("<b>[owner.real_name], your creator, is an antagonist.</b>")
 			to_chat(new_spawn, "<b>[owner.real_name], your creator, is an antagonist.</b>")
 			SSticker.mode.traitors.Add(new_spawn.mind)
-			var/datum/atom_hud/antag/hud = GLOB.huds[ANTAG_HUD_TRAITOR]
-			hud.join_hud(new_spawn)
-			set_antag_hud(new_spawn.mind.current, "hudmindslave")
 			if(locate(/datum/objective/hijack) in owner.mind.get_all_objectives())
 				new_spawn.mind.store_memory("<b>They must hijack the shuttle.</b>")
 				to_chat(new_spawn, "<b>They are tasked with hijacking the shuttle.</b>")
-				set_antag_hud(new_spawn.mind.current, "hudslavehijack")
+				new_spawn.mind.add_antag_hud(new_spawn.mind.current, ANTAG_HUD_TRAITOR, "hudslavehijack")
+			else
+				new_spawn.mind.add_antag_hud(new_spawn.mind.current, ANTAG_HUD_TRAITOR, "hudmindslave")
 		log_game("[key_name(new_spawn)] possessed a golem shell enslaved to [key_name(owner)].")
 		log_admin("[key_name(new_spawn)] possessed a golem shell enslaved to [key_name(owner)].")
 	if(ishuman(new_spawn))

--- a/code/modules/events/blob_spawn.dm
+++ b/code/modules/events/blob_spawn.dm
@@ -31,9 +31,7 @@
 	B.add_ventcrawl(vent)
 
 	// Mark it on antag HUD
-	var/datum/atom_hud/antag/antaghud = GLOB.huds[ANTAG_HUD_BLOB]
-	antaghud.join_hud(B.mind.current)
-	set_antag_hud(B.mind.current, "hudblob")
+	B.mind.add_antag_hud(B.mind.current, ANTAG_HUD_BLOB, "hudblob")
 
 	to_chat(B, "<span class='userdanger'>You are now a mouse, infected with blob spores. Find somewhere isolated... before you burst and become the blob! Use ventcrawl (alt-click on vents) to move around.</span>")
 	to_chat(B, "<span class='motd'>For more information, check the wiki page: ([GLOB.configuration.url.wiki_url]/index.php/Blob)</span>")

--- a/code/modules/mob/dead/observer/observer_base.dm
+++ b/code/modules/mob/dead/observer/observer_base.dm
@@ -171,18 +171,6 @@ GLOBAL_DATUM_INIT(ghost_crew_monitor, /datum/ui_module/crew_monitor/ghost, new)
 	return 1
 
 
-/*
-Transfer_mind is there to check if mob is being deleted/not going to have a body.
-Works together with spawning an observer, noted above.
-*/
-/mob/dead/proc/assess_targets(list/target_list, mob/dead/observer/U)
-	var/client/C = U.client
-	for(var/mob/living/carbon/human/target in target_list)
-		C.images += target.hud_list[SPECIALROLE_HUD]
-	for(var/mob/living/silicon/target in target_list)
-		C.images += target.hud_list[SPECIALROLE_HUD]
-	return 1
-
 /mob/proc/ghostize(flags = GHOST_CAN_REENTER, user_color, ghost_name)
 	if(key)
 		if(player_logged) //if they have disconnected we want to remove their SSD overlay

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -45,8 +45,6 @@
 /atom/proc/prepare_huds()
 	hud_list = list()
 	var/static/list/hud_dmis = list(
-		SPECIALROLE_HUD = 'icons/mob/hud/antaghud.dmi',
-
 		DIAG_TRACK_HUD = 'icons/mob/hud/diaghud.dmi',
 		DIAG_AIRLOCK_HUD = 'icons/mob/hud/diaghud.dmi',
 		DIAG_STAT_HUD = 'icons/mob/hud/diaghud.dmi',
@@ -74,6 +72,9 @@
 	)
 
 	for(var/hud in hud_possible)
+		if(hud == SPECIALROLE_HUD)
+			hud_list[SPECIALROLE_HUD] = list() // handled with /datum/antag_hud_helper
+			continue
 		var/use_this_dmi = hud_dmis[hud]
 		if(!use_this_dmi)
 			use_this_dmi = 'icons/mob/hud/hud_misc.dmi'


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Multiantag hud.

Posted early because theres so much shitcode and I need help 👍 

Also fucking fixes mindslaves. Shit code incarnate.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Makes it clear when a traitor has been converted to a rev or cultist, etc

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![image](https://github.com/ParadiseSS13/Paradise/assets/91113370/eb41631e-84ad-4652-be44-581fefea0487)

## Testing
<!-- How did you test the PR, if at all? -->
WIP

## Changelog
:cl:
add: Using antag-hud as a ghost will now show a list of antag statuses
fix: Nukies that use mindslaves no longer disappear from their teams
fix: Cultists that are auto-tot'd no longer appear as a non-cultist (if this ever even happens)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
