### PR TITLE
Mech jetpack allow walk on chasms

### DIFF
--- a/code/game/turfs/simulated/floor/chasm.dm
+++ b/code/game/turfs/simulated/floor/chasm.dm
@@ -144,6 +144,12 @@
 	//Make sure the item is still there after our sleep
 	if(!AM || QDELETED(AM))
 		return
+	if(ismecha(AM))
+		var/obj/mecha/M = AM
+		if(locate(/obj/item/mecha_parts/mecha_equipment/thrusters) in M.equipment)
+			if(M.use_power(100)) // cost a LOT to keep mech at fly in such gravitation
+				return
+
 	falling_atoms[AM] = TRUE
 	var/turf/T = locate(drop_x, drop_y, drop_z)
 	if(T)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Add automatical "hover mode" to mech jetpack, which prevent mech from falling into any type of chasm. Believe me, you DONT WANT IN ANY CASE turn that feature off.

## Why It's Good For The Game
People without dragon magic suffer from lava, and also die instantly in chasm. Firefighter is a special mech specifically for lavaland, designed as an all-terrain vehicle that ignores any obstacles in its path. But with the introduction of chasm generation as a replacement for lava, its main and essentially the only advantage is simply multiplied by zero. The mech`s Jetpack will now have a permanently active "hover mode" that protects it from falling into the chasm at the cost of enormous energy expenditure. It only works when walking on chasms, so you won't have to worry about extra consumption when digging normally.

## Images of changes
You have energy - you have life
![image](https://github.com/ParadiseSS13/Paradise/assets/114731039/7204689a-249b-489f-ae65-997216221b41)

You dont have energy - you are fall.
![image](https://github.com/ParadiseSS13/Paradise/assets/114731039/2e2671b5-9772-484e-94ce-007f0ebd8e37)


## Testing
Make double sure it dont work in cargo, only in equipment.

## Changelog
:cl:
tweak: Mech`s jetpack now prevent from falling into chasms. Cost A LOT(100 per tick) of energy to keep ya in fly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
