### PR TITLE
Gives singularity engines a slight nudge towards the station

### DIFF
--- a/code/modules/power/engines/singularity/singularity.dm
+++ b/code/modules/power/engines/singularity/singularity.dm
@@ -343,9 +343,9 @@
 	if(force_move)
 		movement_dir = force_move
 	if(target && prob(20))
-		movement_dir = get_dir(src,target) //moves to a random spot on the map
+		movement_dir = get_dir(src, target) //moves to a random spot on the map
 	if(beacon_target && prob(60))
-		movement_dir = get_dir(src,target) //moves to a singulo beacon, if there is one
+		movement_dir = get_dir(src, target) //moves to a singulo beacon, if there is one
 
 	step(src, movement_dir)
 

--- a/code/modules/power/engines/singularity/singularity.dm
+++ b/code/modules/power/engines/singularity/singularity.dm
@@ -21,14 +21,16 @@
 	move_resist = INFINITY	//no, you don't get to push the singulo. Not even you OP wizard gateway statues
 	var/consume_range = 0 //How many tiles out do we eat
 	var/event_chance = 15 //Prob for event each tick
-	var/target = null //Its target. Moves slowly towards this.
-	var/beacon_target = null //Syndicate singularity beacon. Moves fast towards this.
 	var/last_failed_movement = 0//Will not move in the same dir if it couldnt before, will help with the getting stuck on fields thing
 	var/last_warning
 	var/consumedSupermatter = FALSE //If the singularity has eaten a supermatter shard and can go to stage six
 	var/warps_projectiles = TRUE
 	var/obj/effect/warp_effect/supermatter/warp
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF | FREEZE_PROOF
+	/// The target of the singularity. It will wander slowly towards this, and pick another target once it reaches it.
+	var/target = null
+	/// If there is a syndicate beacon, the singularity will move quickly towards it.
+	var/beacon_target = null
 	/// Whether or not we've pinged ghosts
 	var/isnt_shutting_down = FALSE
 	/// Init list that has all the areas that we can possibly move to, to reduce processing impact

--- a/code/modules/power/engines/singularity/singularity.dm
+++ b/code/modules/power/engines/singularity/singularity.dm
@@ -22,7 +22,7 @@
 	var/consume_range = 0 //How many tiles out do we eat
 	var/event_chance = 15 //Prob for event each tick
 	var/target = null //Its target. Moves slowly towards this.
-	var/becaon_target = null //Syndicate singularity beacon. Moves fast towards this.
+	var/beacon_target = null //Syndicate singularity beacon. Moves fast towards this.
 	var/last_failed_movement = 0//Will not move in the same dir if it couldnt before, will help with the getting stuck on fields thing
 	var/last_warning
 	var/consumedSupermatter = FALSE //If the singularity has eaten a supermatter shard and can go to stage six
@@ -48,7 +48,7 @@
 	GLOB.singularities += src
 	for(var/obj/machinery/power/singularity_beacon/singubeacon in GLOB.machines)
 		if(singubeacon.active)
-			becaon_target = singubeacon
+			beacon_target = singubeacon
 			break
 	all_possible_areas = findUnrestrictedEventArea()
 
@@ -344,7 +344,7 @@
 		movement_dir = force_move
 	if(target && prob(20))
 		movement_dir = get_dir(src,target) //moves to a random spot on the map
-	if(becaon_target && prob(60))
+	if(beacon_target && prob(60))
 		movement_dir = get_dir(src,target) //moves to a singulo beacon, if there is one
 
 	step(src, movement_dir)

--- a/code/modules/power/engines/tesla/energy_ball.dm
+++ b/code/modules/power/engines/tesla/energy_ball.dm
@@ -39,8 +39,6 @@
 	var/movement_dir
 	/// Variable that defines whether it has a field generator close enough
 	var/has_close_field = FALSE
-	/// Init list that has all the areas that we can possibly move to, to reduce processing impact
-	var/list/all_possible_areas = list()
 	/// How many tiles do we move per movement step?
 	var/steps_per_move = 8
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Gives the singularity engine a 20% chance to move towards the station instead of in a random direction.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Singularity engines are currently significantly less deadly than the tesla engines, despite not appearing roundstart on any map. 
In the rare circumstance that engineering specifically orders one from cargo and the even rarer circumstance that it gets loose (and then doesn't get GOATed), it tends to float away into deep space half the time, or eat a part of engineering at worst, which is a little anti-climactic for something that immediately gets the shuttle called.

This will make it slowly drift towards a random part of the station, to make it roughly on par in danger to the tesla engine. Mass is attracted to mass, after all, and the station is the heaviest thing around. 

## Testing
<!-- How did you test the PR, if at all? -->
Watched the Lord float around.
Made sure singularity beacons worked.
Made sure the tesla still worked.

## Changelog
:cl:
tweak: The singularity engine will now slowly drift towards the station
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
