### PR TITLE
Adds a rod smite

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2062,6 +2062,7 @@
 			ptypes += "Shamebrero"
 			ptypes += "Nugget"
 			ptypes += "Bread"
+			ptypes += "Rod"
 		var/punishment = input(owner, "How would you like to smite [M]?", "Its good to be baaaad...", "") as null|anything in ptypes
 		if(!(punishment in ptypes))
 			return
@@ -2185,7 +2186,6 @@
 				to_chat(H, "<span class='danger'>You feel as if your limbs are being ripped from your body!</span>")
 				addtimer(CALLBACK(H, TYPE_PROC_REF(/mob/living/carbon/human, make_nugget)), 6 SECONDS)
 				logmsg = "nugget"
-
 			if("Bread")
 				var/mob/living/simple_animal/shade/sword/bread/breadshade = new(H.loc)
 				var/bready = pick(/obj/item/food/snacks/customizable/cook/bread, /obj/item/food/snacks/sliceable/meatbread, /obj/item/food/snacks/sliceable/xenomeatbread, /obj/item/food/snacks/sliceable/spidermeatbread, /obj/item/food/snacks/sliceable/bananabread, /obj/item/food/snacks/sliceable/tofubread, /obj/item/food/snacks/sliceable/bread, /obj/item/food/snacks/sliceable/creamcheesebread, /obj/item/food/snacks/sliceable/banarnarbread, /obj/item/food/snacks/flatbread, /obj/item/food/snacks/baguette)
@@ -2196,6 +2196,13 @@
 				qdel(H)
 				logmsg = "baked"
 				to_chat(breadshade, "<span class='warning'>Get bready for combat, you've been baked into a piece of bread! Before you break down and rye thinking that your life is over, people are after you waiting for a snack! If you'd rather not be toast, lunge away from any hungry crew else you bite the crust. At the yeast you may survive a little longer...</span>")
+			if("Rod")
+
+				var/starting_turf_x = M.x + rand(10, 15) * pick(1, -1)
+				var/starting_turf_y = M.y + rand(10, 15) * pick(1, -1)
+				var/turf/start = locate(starting_turf_x, starting_turf_y, M.z)
+
+				new /obj/effect/immovablerod/smite(start, M)
 		if(logmsg)
 			log_admin("[key_name(owner)] smited [key_name(M)] with: [logmsg]")
 			message_admins("[key_name_admin(owner)] smited [key_name_admin(M)] with: [logmsg]")

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -20,7 +20,7 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	new /obj/effect/immovablerod/event(startT, endT)
 
 /obj/effect/immovablerod
-	name = "Immovable Rod"
+	name = "\improper Immovable Rod"
 	desc = "What the fuck is that?"
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "immrod"
@@ -81,13 +81,13 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 
 	if(isturf(clong) || isobj(clong))
 		if(clong.density)
-			clong.ex_act(2)
+			clong.ex_act(EXPLODE_HEAVY)
 
 	else if(ismob(clong))
 		if(ishuman(clong))
 			var/mob/living/carbon/human/H = clong
-			H.visible_message("<span class='danger'>[H.name] is penetrated by an immovable rod!</span>" ,
-				"<span class='userdanger'>The rod penetrates you!</span>" ,
+			H.visible_message("<span class='danger'>[H.name] is penetrated by an immovable rod!</span>",
+				"<span class='userdanger'>The rod penetrates you!</span>",
 				"<span class ='danger'>You hear a CLANG!</span>")
 			H.adjustBruteLoss(160)
 		if(clong.density || prob(10))
@@ -114,7 +114,6 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 /obj/effect/immovablerod/smite
 	/// The target that we're gonna aim for between start and end
 	var/obj/effect/portal/exit
-	var/floor_rip_chance = 40
 
 /obj/effect/immovablerod/smite/New(atom/_start, atom/_end)
 	new /obj/effect/portal(start, lifespan = 2 SECONDS)
@@ -123,10 +122,6 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 /obj/effect/immovablerod/smite/Move()
 	var/atom/oldloc = loc
 	. = ..()
-	if(prob(floor_rip_chance))
-		var/turf/simulated/floor/T = get_turf(oldloc)
-		if(istype(T))
-			T.ex_act(EXPLODE_HEAVY)
 	if(get_turf(src) == get_turf(end))
 		// our exit condition: get outta there kowalski
 		var/target_turf = get_ranged_target_turf(src, dir, rand(1, 10))

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -28,23 +28,28 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	density = TRUE
 	anchored = TRUE
 	var/z_original = 0
-	var/destination
 	var/notify = TRUE
 	var/move_delay = 1
+	var/atom/start
+	var/atom/end
 
-/obj/effect/immovablerod/New(atom/start, atom/end, delay)
+/obj/effect/immovablerod/New(atom/_start, atom/_end, delay)
 	. = ..()
+	start = _start
+	end = _end
 	loc = start
 	z_original = z
-	destination = end
 	move_delay = delay
 	if(notify)
 		notify_ghosts("\A [src] is inbound!",
 				enter_link="<a href=byond://?src=[UID()];follow=1>(Click to follow)</a>",
 				source = src, action = NOTIFY_FOLLOW)
 	GLOB.poi_list |= src
+	head_towards_dest()
+
+/obj/effect/immovablerod/proc/head_towards_dest()
 	if(end?.z == z_original)
-		walk_towards(src, destination, move_delay)
+		walk_towards(src, end, move_delay)
 
 /obj/effect/immovablerod/Topic(href, href_list)
 	if(href_list["follow"])
@@ -100,11 +105,38 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 		var/turf/simulated/floor/T = get_turf(oldloc)
 		if(istype(T))
 			T.ex_act(EXPLODE_HEAVY)
-	if(loc == destination)
+	if(loc == end)
 		qdel(src)
 
 /obj/effect/immovablerod/deadchat_plays(mode = DEADCHAT_DEMOCRACY_MODE, cooldown = 6 SECONDS)
 	return AddComponent(/datum/component/deadchat_control/immovable_rod, mode, list(), cooldown)
+
+/obj/effect/immovablerod/smite
+	/// The target that we're gonna aim for between start and end
+	var/obj/effect/portal/exit
+	var/floor_rip_chance = 40
+
+/obj/effect/immovablerod/smite/New(atom/_start, atom/_end)
+	new /obj/effect/portal(start, lifespan = 2 SECONDS)
+	return ..()
+
+/obj/effect/immovablerod/smite/Move()
+	var/atom/oldloc = loc
+	. = ..()
+	if(prob(floor_rip_chance))
+		var/turf/simulated/floor/T = get_turf(oldloc)
+		if(istype(T))
+			T.ex_act(EXPLODE_HEAVY)
+	if(get_turf(src) == get_turf(end))
+		// our exit condition: get outta there kowalski
+		var/target_turf = get_ranged_target_turf(src, dir, rand(1, 10))
+		start = loc
+		walk(src, 0)
+		exit = new /obj/effect/portal(target_turf, lifespan = 2 SECONDS)
+		walk_towards(src, exit, move_delay)
+	else if(locate(exit) in get_turf(src))
+		QDEL_NULL(exit)
+		qdel(src)
 
 /**
  * Rod will walk towards edge turf in the specified direction.
@@ -113,5 +145,5 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
  * * direction - The direction to walk the rod towards: NORTH, SOUTH, EAST, WEST.
  */
 /obj/effect/immovablerod/proc/walk_in_direction(direction)
-	destination = get_edge_target_turf(src, direction)
-	walk_towards(src, destination)
+	end = get_edge_target_turf(src, direction)
+	walk_towards(src, end, move_delay)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds a portable rod smite that spawns a rod from 10-20 tiles away from your target, swooping in and hitting them specifically, and then promptly disappearing before causing catastrophic harm.

This will still mess up the people standing around them, but it won't be full station destruction.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
More smites fun. I was inspired.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

https://github.com/ParadiseSS13/Paradise/assets/89928798/c9b42837-1764-42e0-9930-07afea8b98ca


<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing

See images


<!-- How did you test the PR, if at all? -->

NPFC :smirk: 
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
