### PR TITLE
Pipe fix/tweak

### DIFF
--- a/code/game/objects/items/weapons/cigs.dm
+++ b/code/game/objects/items/weapons/cigs.dm
@@ -1,3 +1,5 @@
+#define REAGENT_TIME_RATIO 2.5
+
 /*
 CONTAINS:
 CIGARETTES
@@ -525,6 +527,7 @@ LIGHTERS ARE IN LIGHTERS.DM
 				return
 			O.reagents.trans_to(src, src.chem_volume)
 			to_chat(user, "<span class='notice'>You stuff the [O.name] into the pipe.</span>")
+			smoketime = max(src.reagents.total_volume * REAGENT_TIME_RATIO, smoketime)
 			qdel(O)
 		else
 			to_chat(user, "<span class='warning'>You need to dry this first!</span>")
@@ -544,7 +547,7 @@ LIGHTERS ARE IN LIGHTERS.DM
 	item_state = "cobpipeoff"
 	icon_on = "cobpipeon"  //Note - these are in masks.dmi
 	icon_off = "cobpipeoff"
-	smoketime = 400
+	smoketime = 0 //there is nothing to smoke initially
 	chem_volume = 160
 	list_reagents = list()
 
@@ -579,3 +582,5 @@ LIGHTERS ARE IN LIGHTERS.DM
 			to_chat(user, "<span class='warning'>You need to dry this first!</span>")
 	else
 		..()
+
+#undef REAGENT_TIME_RATIO

--- a/code/game/objects/items/weapons/cigs.dm
+++ b/code/game/objects/items/weapons/cigs.dm
@@ -502,7 +502,7 @@ LIGHTERS ARE IN LIGHTERS.DM
 		return
 	smoke()
 
-/obj/item/clothing/mask/cigarette/pipe/attack_self(mob/user) //Refills the pipe. Can be changed to an attackby later, if loose tobacco is added to vendors or something.
+/obj/item/clothing/mask/cigarette/pipe/attack_self(mob/user) //Extinguishes the pipe.
 	if(lit)
 		user.visible_message("<span class='notice'>[user] puts out [src].</span>")
 		lit = FALSE
@@ -510,17 +510,26 @@ LIGHTERS ARE IN LIGHTERS.DM
 		item_state = icon_off
 		STOP_PROCESSING(SSobj, src)
 		return
-	if(smoketime <= 0)
-		to_chat(user, "<span class='notice'>You refill the pipe with tobacco.</span>")
-		reagents.add_reagent("nicotine", chem_volume)
-		smoketime = initial(smoketime)
-		first_puff = TRUE
 
 /obj/item/clothing/mask/cigarette/pipe/try_light(obj/item/cigar, obj/item/lighting_item)
 	if(can_light_fancy(lighting_item))
 		return ..()
 
+//refill or light the pipe
 /obj/item/clothing/mask/cigarette/pipe/attackby(obj/item/I, mob/user, params)
+	if(istype(I, /obj/item/food/snacks/grown))
+		var/obj/item/food/snacks/grown/O = I
+		if(O.dry)
+			if(src.reagents.total_volume == src.reagents.maximum_volume)
+				to_chat(user, "<span class='warning'>[src] is full!</span>")
+				return
+			O.reagents.trans_to(src, src.chem_volume)
+			to_chat(user, "<span class='notice'>You stuff the [O.name] into the pipe.</span>")
+			qdel(O)
+		else
+			to_chat(user, "<span class='warning'>You need to dry this first!</span>")
+		return
+
 	if(!is_type_in_typecache(I, things_that_light))
 		return
 	if(can_light_fancy(I))
@@ -535,8 +544,9 @@ LIGHTERS ARE IN LIGHTERS.DM
 	item_state = "cobpipeoff"
 	icon_on = "cobpipeon"  //Note - these are in masks.dmi
 	icon_off = "cobpipeoff"
-	smoketime = 800
-	chem_volume = 40
+	smoketime = 400
+	chem_volume = 160
+	list_reagents = list()
 
 ///////////
 //ROLLING//


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Allows refilling of pipes using dried plants, removes their ability to conjure nicotine, applies the [May 22, 2015](https://github.com/ParadiseSS13/Paradise/commit/1c1eec321069b1b0bcf2474762db2026685a26c3) pipe tweak to cob pipes, and also created empty(corn has no nicotine).

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
The existing way of filling pipes is a place holder and there isn't any reason they shouldn't be consistent with cigarettes. And cob

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
<!-- How did you test the PR, if at all? -->
Filled pipes with dried plants. 
Made a Cobpipe and observed it was empty

## Changelog
:cl:
fix: Cobpipe is now consistent with normal pipes
tweak: pipes can now be filled with dried plants
tweak: Cobpipe is no longer full of nicotine when crafted
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
