### PR TITLE
RCD now build floor on chasms instead of wall

### DIFF
--- a/code/game/mecha/equipment/tools/work_tools.dm
+++ b/code/game/mecha/equipment/tools/work_tools.dm
@@ -254,19 +254,12 @@
 					qdel(target)
 					playsound(target, usesound, 50, 1)
 		if(MECH_RCD_MODE_WALL_OR_FLOOR)
-			if(isspaceturf(target))
+			if(isspaceturf(target) || ischasm(target))
 				var/turf/space/S = target
 				occupant_message("Building Floor...")
 				if(do_after_cooldown(S))
 					S.ChangeTurf(/turf/simulated/floor/plating)
 					playsound(S, usesound, 50, 1)
-					chassis.spark_system.start()
-			if(ischasm(target))
-				var/turf/simulated/floor/chasm/C = target
-				occupant_message("Building Floor...")
-				if(do_after_cooldown(C))
-					C.ChangeTurf(/turf/simulated/floor/plating)
-					playsound(C, usesound, 50, 1)
 					chassis.spark_system.start()
 			else if(isfloorturf(target))
 				var/turf/simulated/floor/F = target

--- a/code/game/mecha/equipment/tools/work_tools.dm
+++ b/code/game/mecha/equipment/tools/work_tools.dm
@@ -261,6 +261,13 @@
 					S.ChangeTurf(/turf/simulated/floor/plating)
 					playsound(S, usesound, 50, 1)
 					chassis.spark_system.start()
+			if(ischasm(target))
+				var/turf/simulated/floor/chasm/C = target
+				occupant_message("Building Floor...")
+				if(do_after_cooldown(C))
+					C.ChangeTurf(/turf/simulated/floor/plating)
+					playsound(C, usesound, 50, 1)
+					chassis.spark_system.start()
 			else if(isfloorturf(target))
 				var/turf/simulated/floor/F = target
 				occupant_message("Building Wall...")


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Changes mech RCD ability to build a floor instead of a wall on chasm tiles. 

## Why It's Good For The Game
Makes it easier to try and deal with chasms that turn lavaland into a real torture that is no fun to play. Also a little tightens the logic, because the wall should be placed on the floor, and the base of this "floor" is a giant hole in the middle of nowhere.

## Images of changes
![image](https://github.com/ParadiseSS13/Paradise/assets/114731039/fbd7eb8b-d137-4283-9898-99a29dcad876)


## Testing
copypasta spaceturf, change into chasm, all work perfectly

## Changelog
:cl:
tweak: Mecha RCD now build floor on chasms instead of walls.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
