### PR TITLE
Makes Mail Crates destructible with crowbars + Ups plastic output from mail crates.

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -553,7 +553,7 @@
 	icon_opened = "mailopen"
 	icon_closed = "mailsealed"
 	material_drop = /obj/item/stack/sheet/plastic
-	material_drop_amount = 4
+	material_drop_amount = 10
 	var/list/possible_contents = list(/obj/item/envelope/security,
 										/obj/item/envelope/science,
 										/obj/item/envelope/supply,
@@ -569,6 +569,18 @@
 	for(var/i in 1 to rand(5, 10))
 		var/item = pick(possible_contents)
 		new item(src)
+
+/obj/structure/closet/crate/mail/crowbar_act(mob/living/user, obj/item/I)
+	. = TRUE
+	new /obj/item/stack/sheet/plastic(loc, 10)(src)
+	var/turf/T = get_turf(src)
+	for(var/O in contents)
+		var/atom/movable/A = O
+		A.forceMove(T)
+	user.visible_message("<span class='notice'>[user] pries [src] open.</span>", \
+						"<span class='notice'>You pry open [src].</span>", \
+						"<span class='notice'>You hear cracking plastic.</span>")
+	qdel(src)
 
 /obj/structure/closet/crate/tape/populate_contents()
 	if(prob(10))

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -572,7 +572,7 @@
 
 /obj/structure/closet/crate/mail/crowbar_act(mob/living/user, obj/item/I)
 	. = TRUE
-	new /obj/item/stack/sheet/plastic(loc, 10)(src)
+	new /obj/item/stack/sheet/plastic(loc, 10)
 	var/turf/T = get_turf(src)
 	for(var/O in contents)
 		var/atom/movable/A = O


### PR DESCRIPTION
## What Does This PR Do
Mail Crates can now have a crowbar applied to them to make them drop ten plastic, and destroying a mail crate will now drop ten plastic.

## Why It's Good For The Game
After playing a good amount of cargo since we PRed in mail, I've come to the conclusion that how we implemented it is clunky, and leaves cargo  stuffed with mail crates and plastic they can't make much use out of. Plastic crates are no longer >>>stocks tier in terms of generating cargo revenue so I think some QOL wouldn't go amiss.

## Testing
I applied a crowbar and got ten plastic. I broke it with a knuckleduster and got ten plastic.

## Changelog
:cl:
tweak: Mail Crates now drop more plastic when destroyed.
tweak: Mail Crates can be dismantled with a crowbar.
/:cl: