### PR TITLE
[FIX] Glorious Communist Walls of USSP Station Now Fully Repel Capitalist Pigs!

### DIFF
--- a/code/game/turfs/simulated/walls_mineral.dm
+++ b/code/game/turfs/simulated/walls_mineral.dm
@@ -311,7 +311,7 @@
 	return
 
 /turf/simulated/wall/mineral/titanium/nodecon/try_destroy()
-    return
+	return
 
 /////////////////////Plastitanium walls/////////////////////
 

--- a/code/game/turfs/simulated/walls_mineral.dm
+++ b/code/game/turfs/simulated/walls_mineral.dm
@@ -1,6 +1,6 @@
 /turf/simulated/wall/mineral
 	name = "mineral wall"
-	desc = "This shouldn't exist"
+	desc = "If you can see this, please make an issue report on GitHub."
 	icon_state = ""
 	smoothing_flags = SMOOTH_BITMASK
 	canSmoothWith = null
@@ -309,6 +309,9 @@
 
 /turf/simulated/wall/mineral/titanium/nodecon/welder_act()
 	return
+
+/turf/simulated/wall/mineral/titanium/nodecon/try_destroy()
+    return
 
 /////////////////////Plastitanium walls/////////////////////
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Removes a structural flaw introduced by capitalist spies into the walls of the USSP's structures, which allowed certain capitalist mining tools to penetrate these otherwise completely impenetrable structures.

Puny diamond drills and sonic jackhammers of capitalist origin can no longer penetrate these bastions of socialism!
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Explorers shouldn't be able to casually skip the entire ruin and just rush to where the desirable loot is.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
I tried to use my capitalist tools on the wall, but my efforts were effortlessly repelled!
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Russian walls are now immune to diamond mining equipment.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
