### PR TITLE
Trade Shuttle Console Fix + Standardization

### DIFF
--- a/_maps/map_files/generic/centcomm.dmm
+++ b/_maps/map_files/generic/centcomm.dmm
@@ -5868,7 +5868,7 @@
 	dwidth = 4;
 	height = 11;
 	id = "trade_sol_base";
-	name = "docking bay 2 at Jupiter Station";
+	name = "docking bay at Trading Satellite";
 	width = 9
 	},
 /obj/structure/fans/tiny,

--- a/code/game/area/centcom_areas.dm
+++ b/code/game/area/centcom_areas.dm
@@ -135,7 +135,7 @@
 	dynamic_lighting = DYNAMIC_LIGHTING_DISABLED
 
 /area/trader_station/sol
-	name = "Jupiter Station 6"
+	name = "Trading Satellite"
 
 /area/ghost_bar
 	name = "Ghost Bar"

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -953,6 +953,7 @@
 /obj/machinery/computer/shuttle/trade
 	name = "Freighter Console"
 	resistance_flags = INDESTRUCTIBLE
+	flags = NODECONSTRUCT
 
 /obj/machinery/computer/shuttle/trade/sol
 	req_access = list(ACCESS_TRADE_SOL)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes issue #25459 

Also makes the trading dock the "Trading Satellite", to make the different trader types not all dock at Jupiter Station.

## Why It's Good For The Game
Bugs bad. Mismatches bad. Fixes good. 

## Testing
Spawned in, tried to deconstruct the console. Traveled to and from the cyberiad and the trading station.

## Changelog
:cl:
tweak: Changed "Jupiter Station" to "Trading Satellite"
fix: Fixed trader console being deconstructable
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
