### PR TITLE
No more AI tracking Syndicate Researchers

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/syndie_space_base.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/syndie_space_base.dmm
@@ -937,7 +937,7 @@
 /area/ruin/unpowered/syndicate_space_base/testlab)
 "fo" = (
 /obj/effect/decal/cleanable/blood/old,
-/obj/effect/mob_spawn/human/corpse/skeleton,
+/obj/effect/decal/remains/human,
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/ruin/unpowered/syndicate_space_base/cave)
 "fp" = (

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -350,6 +350,7 @@
 	initial_access = list(ACCESS_SYNDICATE)
 	assignment = "Syndicate Researcher"
 	icon_state = "syndie"
+	untrackable = TRUE
 
 /obj/item/card/id/syndicate/New()
 	access = initial_access.Copy()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes the AI from being able to jump to the cameras around the syndicate research base by means of tracking the skeleton that spawns in the cave, or from tracking researchers. This is done by changing the skeleton to a pile of remains, and making Syndicate Researcher ID's untrackable similar to Agent IDs.

## Why It's Good For The Game
AI should not be spying on the syndicate.

## Testing
Spawned as researcher, walked to cave, spawned as AI, could not track researcher.

## Changelog
:cl:
tweak: Syndicate Researcher ID's are now untrackable to AI cameras.
tweak: Skeleton in Syndicate Research Lab Cave replaced with Remains decal.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
