### PR TITLE
Proto adrenalin price changes and one use adrenalin

### DIFF
--- a/code/datums/uplink_items/uplink_general.dm
+++ b/code/datums/uplink_items/uplink_general.dm
@@ -817,7 +817,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/bio_chips/basic_adrenal
 	name = "Basic-Adrenal Bio-chip"
-	desc = "A single-use bio-chip injected into the body and later activated manually to inject a chemical cocktail. This one has a worse healing effect than regular adrenaline. It can be activated up to 1 time for 3/4 of the effect of the original."
+	desc = "A single-use bio-chip injected into the body and later activated manually to inject a chemical cocktail. This one has a worse healing effect than regular adrenaline. It can be activated once for 3/4 of the effect of the original."
 	reference = "BAI"
 	item = /obj/item/bio_chip_implanter/basic_adrenalin
 	cost = 20

--- a/code/datums/uplink_items/uplink_general.dm
+++ b/code/datums/uplink_items/uplink_general.dm
@@ -808,19 +808,27 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/bio_chip_implanter/traitor
 	cost = 50
 
-/datum/uplink_item/bio_chips/proto_adrenal
-	name = "Proto-Adrenal Bio-chip"
-	desc = "A old prototype of the Adrenalin implant, that grants the user 4 seconds of antistun, getting them back on their feet instantly once, but nothing more. Speed and healing sold seperately."
-	reference = "PAI"
-	item = /obj/item/bio_chip_implanter/proto_adrenalin
-	cost = 18
-
 /datum/uplink_item/bio_chips/adrenal
 	name = "Adrenal Bio-chip"
 	desc = "A bio-chip injected into the body, and later activated manually to inject a chemical cocktail, which has a mild healing effect along with removing and reducing the time of all stuns and increasing movement speed. Can be activated up to 3 times."
 	reference = "AI"
 	item = /obj/item/bio_chip_implanter/adrenalin
 	cost = 40
+
+/datum/uplink_item/bio_chips/basic_adrenal
+	name = "Basic-Adrenal Bio-chip"
+	desc = "A single-use bio-chip injected into the body and later activated manually to inject a chemical cocktail. This one has a worse healing effect than regular adrenaline. It can be activated up to 1 time for 3/4 of the effect of the original."
+	reference = "BAI"
+	item = /obj/item/bio_chip_implanter/basic_adrenalin
+	cost = 20
+	can_discount = FALSE
+
+/datum/uplink_item/bio_chips/proto_adrenal
+	name = "Proto-Adrenal Bio-chip"
+	desc = "A old prototype of the Adrenalin implant, that grants the user 4 seconds of antistun, getting them back on their feet instantly once, but nothing more. Speed and healing sold seperately."
+	reference = "PAI"
+	item = /obj/item/bio_chip_implanter/proto_adrenalin
+	cost = 10
 
 /datum/uplink_item/bio_chips/stealthimplant
 	name = "Stealth Bio-chip"

--- a/code/game/objects/items/weapons/bio_chips/bio_chip_adrenalin.dm
+++ b/code/game/objects/items/weapons/bio_chips/bio_chip_adrenalin.dm
@@ -33,6 +33,41 @@
 	desc = "A glass case containing an adrenaline bio-chip."
 	implant_type = /obj/item/bio_chip/adrenalin
 
+/obj/item/bio_chip/basic_adrenalin
+	name = "basic adrenal bio-chip"
+	desc = "Removes all stuns and knockdowns."
+	icon_state = "adrenal"
+	origin_tech = "materials=2;biotech=4;combat=3;syndicate=3"
+	uses = 1
+	implant_data = /datum/implant_fluff/basic_adrenalin
+	implant_state = "implant-syndicate"
+
+/obj/item/bio_chip/basic_adrenalin/activate()
+	uses--
+	to_chat(imp_in, "<span class='notice'>You feel a sudden surge of energy!</span>")
+	imp_in.SetStunned(0)
+	imp_in.SetWeakened(0)
+	imp_in.SetKnockDown(0)
+	imp_in.SetParalysis(0)
+	imp_in.adjustStaminaLoss(-75)
+	imp_in.stand_up(TRUE)
+	SEND_SIGNAL(imp_in, COMSIG_LIVING_CLEAR_STUNS)
+
+	imp_in.reagents.add_reagent("synaptizine", 7.5)
+	imp_in.reagents.add_reagent("weak_omnizine", 7.5)
+	imp_in.reagents.add_reagent("stimulative_agent", 7.5)
+	if(!uses)
+		qdel(src)
+
+/obj/item/bio_chip_implanter/basic_adrenalin
+	name = "bio-chip implanter (basic adrenalin)"
+	implant_type = /obj/item/bio_chip/basic_adrenalin
+
+/obj/item/bio_chip_case/basic_adrenalin
+	name = "bio-chip case - 'Basic Adrenaline'"
+	desc = "A glass case containing an smaller than normal adrenaline bio-chip."
+	implant_type = /obj/item/bio_chip/basic_adrenalin
+
 /obj/item/bio_chip/proto_adrenalin
 	name = "proto-adrenal bio-chip"
 	desc = "Removes all stuns and knockdowns."

--- a/code/game/objects/items/weapons/bio_chips/bio_chip_fluff.dm
+++ b/code/game/objects/items/weapons/bio_chips/bio_chip_fluff.dm
@@ -22,6 +22,12 @@
 	notes = "One of Cybersun Industries oldest and simplest implants, even in its simplicity it is rumoured to be one of Cybersun Industries best-selling products."
 	function = "Subjects injected with this bio-chip can activate an injection of medical cocktails that removes stuns, increases speed, and has mild healing effects."
 
+/datum/implant_fluff/basic_adrenalin
+	name = "Cybersun Industries RX-1 Adrenaline Bio-chip"
+	life = "Five days or after 1 use."
+	notes = "One of Cybersun Industries oldest implants, made smaller because of popular demand, because of the manufacturing cost and the smaller size. Then, more inferior products were used in the implant to decrease the price."
+	function = "Subjects injected with this bio-chip can activate an injection of medical cocktails that removes stuns, increases speed, and has mild healing effects."
+
 /datum/implant_fluff/proto_adrenaline
 	name = "Cybersun Industries FX-1 Proto-Adrenaline Bio-chip"
 	life = "Destroyed after 1 use."


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Normal Proto adrenalin price change to 10 TC
Changed the position of the adrenalin to be based on cost
Made a one-use adrenalin, that can't be discounted, with 3/4 the stim agent, synaptinzine, and weak omnizine instead of normal omnizine for the price of 20TC
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Adrenaline has always been in a very weird spot regarding price. The original idea for the proto-adrenaline was to ensure that vampires and changelings were not instantly meta'ed to death since it did not have any speed to the stims. 
However, with the price of proto-adrenaline and its basic use, it was hard to justify it against the proto-freedom implant, which cost the same.
Instead, a new item called basic adrenaline, priced at 20TC will replace proto-adrenalin in the price range. It does not have much healing, so if you get noticed with this, you might have a harder time escaping than the original when they start to lethal you.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![image](https://github.com/ParadiseSS13/Paradise/assets/154929127/a6b87702-fcd6-4887-ae2e-aca7fc2f4f35)

## Testing
<!-- How did you test the PR, if at all? -->
I bought all the adrenaline in a package
I then bought them individually
I injected two basic stimulants and used them twice
I then used the two other adrenaline and used them


## Changelog
:cl:
add: Basic adrenalin for 20 TC
tweak: Changed the price of the proto adrenalin to 10 TC
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
