### PR TITLE
Reverse Wheel of Fortune tarot card now no longer spawns wallmeds or Donksoft vendors

### DIFF
--- a/code/game/gamemodes/wizard/magic_tarot.dm
+++ b/code/game/gamemodes/wizard/magic_tarot.dm
@@ -391,7 +391,7 @@
 /datum/tarot/wheel_of_fortune/activate(mob/living/target)
 	var/list/static/bad_vendors = typesof(/obj/machinery/economy/vending/liberationstation)\
 								+ typesof(/obj/machinery/economy/vending/toyliberationstation)\
-								+ typesof(/obj/machinery/economy/vending/wallmed) //Futureproofing in case we add more subtypes of disallowed vendors
+								+ typesof(/obj/machinery/economy/vending/wallmed) // Future proofing in case we add more subtypes of disallowed vendors
 	var/turf/target_turf = get_turf(target)
 	var/vendorpath = pick(subtypesof(/obj/machinery/economy/vending) - bad_vendors)
 	new vendorpath(target_turf)

--- a/code/game/gamemodes/wizard/magic_tarot.dm
+++ b/code/game/gamemodes/wizard/magic_tarot.dm
@@ -389,11 +389,9 @@
 	card_icon = "wheel_of_fortune"
 
 /datum/tarot/wheel_of_fortune/activate(mob/living/target)
-	var/list/static/bad_vendors = list(
-		/obj/machinery/economy/vending/liberationstation,
-		/obj/machinery/economy/vending/toyliberationstation,
-		/obj/machinery/economy/vending/wallmed
-	)
+	var/list/static/bad_vendors = typesof(/obj/machinery/economy/vending/liberationstation)\
+								+ typesof(/obj/machinery/economy/vending/toyliberationstation)\
+								+ typesof(/obj/machinery/economy/vending/wallmed) //Futureproofing in case we add more subtypes of disallowed vendors
 	var/turf/target_turf = get_turf(target)
 	var/vendorpath = pick(subtypesof(/obj/machinery/economy/vending) - bad_vendors)
 	new vendorpath(target_turf)

--- a/code/game/objects/structures/crates_lockers/closets/statue.dm
+++ b/code/game/objects/structures/crates_lockers/closets/statue.dm
@@ -120,7 +120,7 @@
 
 /obj/structure/closet/statue/indestructible
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
-	timer = 240 SECONDS_TO_LIFE_CYCLES
+	timer = 120 SECONDS_TO_LIFE_CYCLES
 
 /obj/structure/closet/statue/indestructible/ex_act(severity)
 	return //No delimbing them

--- a/code/game/objects/structures/crates_lockers/closets/statue.dm
+++ b/code/game/objects/structures/crates_lockers/closets/statue.dm
@@ -120,7 +120,7 @@
 
 /obj/structure/closet/statue/indestructible
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
-	timer = 120 SECONDS_TO_LIFE_CYCLES
+	timer = 240 SECONDS_TO_LIFE_CYCLES
 
 /obj/structure/closet/statue/indestructible/ex_act(severity)
 	return //No delimbing them


### PR DESCRIPTION
## What Does This PR Do
Reverse Wheel of Fortune tarot card now no longer spawns disallowed vendor types.
Once #25461 is merged, fixes #25450.

## Why It's Good For The Game
Magical artifacts working as intended is good.

## Testing
There are 6 disallowed subtypes of vendors: Liberation Station, Syndicate Donksoft Toy Vendor, secured Syndicate Donksoft Toy Vendor, Emergency Nanomed, Syndicate Emergency Nanomed, and finally Survival Pod Emergency Nanomed.

I put in a breakpoint during testing to tell me the length of the blacklist `message_admin(bad_vendors)` and this is the result, which concurs with the amount of vendors we want to blacklist.

![Screenshot (769)](https://github.com/ParadiseSS13/Paradise/assets/108938550/75f65741-bb2a-4fdb-8ce1-84f980d72841)

Then spawned 142 vendors with Reverse Wheel of Fortune, which should be significant enough despite the RNG. Not a single disallowed vendors in the test.

![Screenshot (770)](https://github.com/ParadiseSS13/Paradise/assets/108938550/9e646a52-d3ec-4d08-bc71-5c703c07fc50)

## Changelog
:cl:
fix: Reverse Wheel of Fortune tarot card now no longer spawns disallowed vendors
/:cl: