### PR TITLE
Removed a bunch of unnecessary work from atmos machinery.

### DIFF
--- a/code/modules/atmospherics/machinery/components/binary_devices/binary_atmos_base.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/binary_atmos_base.dm
@@ -153,7 +153,3 @@
 		to_release.merge(air2.remove(shared_loss))
 		T.assume_air(to_release)
 		air_update_turf(1)
-
-/obj/machinery/atmospherics/binary/process_atmos()
-	..()
-	return parent1 && parent2

--- a/code/modules/atmospherics/machinery/components/binary_devices/passive_gate.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/passive_gate.dm
@@ -39,7 +39,6 @@
 		add_underlay(T, node2, dir)
 
 /obj/machinery/atmospherics/binary/passive_gate/process_atmos()
-	..()
 	if(!on)
 		return 0
 

--- a/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
@@ -72,7 +72,6 @@ Thus, the two variables affect pump operation are set in New():
 		add_underlay(T, node2, dir)
 
 /obj/machinery/atmospherics/binary/pump/process_atmos()
-	..()
 	if((stat & (NOPOWER|BROKEN)) || !on)
 		return 0
 

--- a/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
@@ -68,7 +68,6 @@ Thus, the two variables affect pump operation are set in New():
 		add_underlay(T, node2, dir)
 
 /obj/machinery/atmospherics/binary/volume_pump/process_atmos()
-	..()
 	if((stat & (NOPOWER|BROKEN)) || !on)
 		return 0
 

--- a/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
@@ -94,7 +94,6 @@
 	update_icon()
 
 /obj/machinery/atmospherics/trinary/filter/process_atmos()
-	..()
 	if(!on)
 		return FALSE
 

--- a/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
@@ -79,7 +79,6 @@
 	air3.volume = 300
 
 /obj/machinery/atmospherics/trinary/mixer/process_atmos()
-	..()
 	if(!on)
 		return 0
 

--- a/code/modules/atmospherics/machinery/components/trinary_devices/trinary_base.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/trinary_base.dm
@@ -210,7 +210,3 @@
 		to_release.merge(air3.remove(shared_loss))
 		T.assume_air(to_release)
 		air_update_turf(1)
-
-/obj/machinery/atmospherics/trinary/process_atmos()
-	..()
-	return parent1 && parent2 && parent3

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -178,7 +178,6 @@
 	return TRUE
 
 /obj/machinery/atmospherics/unary/cryo_cell/process_atmos()
-	..()
 	if(!node || !on)
 		return
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/heat_exchanger.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/heat_exchanger.dm
@@ -29,7 +29,6 @@
 	..()
 
 /obj/machinery/atmospherics/unary/heat_exchanger/process_atmos()
-	..()
 	if(!partner)
 		return 0
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/outlet_injector.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/outlet_injector.dm
@@ -54,8 +54,6 @@ GLOBAL_LIST_EMPTY(air_injectors)
 	update_icon()
 
 /obj/machinery/atmospherics/unary/outlet_injector/process_atmos()
-	..()
-
 	injecting = FALSE
 
 	if(!on || stat & NOPOWER)

--- a/code/modules/atmospherics/machinery/components/unary_devices/oxygen_generator.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/oxygen_generator.dm
@@ -25,7 +25,6 @@
 	air_contents.volume = 50
 
 /obj/machinery/atmospherics/unary/oxygen_generator/process_atmos()
-	..()
 	if(!on)
 		return 0
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/passive_vent.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/passive_vent.dm
@@ -20,7 +20,6 @@
 	air_contents.volume = volume
 
 /obj/machinery/atmospherics/unary/passive_vent/process_atmos()
-	..()
 	if(!node)
 		return 0
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/portables_connector.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/portables_connector.dm
@@ -28,7 +28,6 @@
 		add_underlay(T, node, dir)
 
 /obj/machinery/atmospherics/unary/portables_connector/process_atmos()
-	..()
 	if(!connected_device)
 		return 0
 	parent.update = 1

--- a/code/modules/atmospherics/machinery/components/unary_devices/thermal_plate.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermal_plate.dm
@@ -18,8 +18,6 @@
 	icon_state = "[prefix]off"
 
 /obj/machinery/atmospherics/unary/thermal_plate/process_atmos()
-	..()
-
 	var/datum/gas_mixture/environment = loc.return_air()
 
 	//Get processable air sample and thermal info from environment

--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -93,7 +93,6 @@
 
 
 /obj/machinery/atmospherics/unary/thermomachine/process_atmos()
-	..()
 	if(!on)
 		return
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/unary_base.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/unary_base.dm
@@ -99,7 +99,3 @@
 		var/datum/gas_mixture/to_release = air_contents.remove(lost)
 		T.assume_air(to_release)
 		air_update_turf(1)
-
-/obj/machinery/atmospherics/unary/process_atmos()
-	..()
-	return parent

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -110,7 +110,6 @@
 	update_underlays()
 
 /obj/machinery/atmospherics/unary/vent_pump/process_atmos()
-	..()
 	if(stat & (NOPOWER|BROKEN))
 		return FALSE
 	var/turf/T = loc

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -100,8 +100,6 @@
 	check_turfs()
 
 /obj/machinery/atmospherics/unary/vent_scrubber/process_atmos()
-	..()
-
 	if(widenet)
 		check_turfs()
 

--- a/code/modules/atmospherics/machinery/other/meter.dm
+++ b/code/modules/atmospherics/machinery/other/meter.dm
@@ -27,15 +27,6 @@ GLOBAL_LIST_EMPTY(gas_meters)
 	return ..()
 
 /obj/machinery/atmospherics/meter/process_atmos()
-	if(!target || (stat & (BROKEN|NOPOWER)))
-		update_icon(UPDATE_ICON_STATE)
-		return
-
-	var/datum/gas_mixture/environment = target.return_air()
-	if(!environment)
-		update_icon(UPDATE_ICON_STATE)
-		return
-
 	update_icon(UPDATE_ICON_STATE)
 
 /obj/machinery/atmospherics/meter/update_icon_state()

--- a/code/modules/atmospherics/machinery/pipes/manifold.dm
+++ b/code/modules/atmospherics/machinery/pipes/manifold.dm
@@ -70,12 +70,6 @@
 /obj/machinery/atmospherics/pipe/manifold/pipeline_expansion()
 	return list(node1, node2, node3)
 
-/obj/machinery/atmospherics/pipe/manifold/process_atmos()
-	if(!parent)
-		..()
-	else
-		. = PROCESS_KILL
-
 /obj/machinery/atmospherics/pipe/manifold/Destroy()
 	. = ..()
 

--- a/code/modules/atmospherics/machinery/pipes/manifold4w.dm
+++ b/code/modules/atmospherics/machinery/pipes/manifold4w.dm
@@ -28,12 +28,6 @@
 /obj/machinery/atmospherics/pipe/manifold4w/pipeline_expansion()
 	return list(node1, node2, node3, node4)
 
-/obj/machinery/atmospherics/pipe/manifold4w/process_atmos()
-	if(!parent)
-		..()
-	else
-		. = PROCESS_KILL
-
 /obj/machinery/atmospherics/pipe/manifold4w/Destroy()
 	. = ..()
 

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -236,8 +236,6 @@ GLOBAL_DATUM_INIT(canister_icon_container, /datum/canister_icons, new())
 	if(stat & BROKEN)
 		return
 
-	..()
-
 	if(valve_open)
 		var/datum/gas_mixture/environment
 		if(holding_tank)

--- a/code/modules/atmospherics/machinery/portable/portable_pump.dm
+++ b/code/modules/atmospherics/machinery/portable/portable_pump.dm
@@ -52,7 +52,6 @@
 	..(severity)
 
 /obj/machinery/atmospherics/portable/pump/process_atmos()
-	..()
 	if(on)
 		var/datum/gas_mixture/environment
 		if(holding_tank)

--- a/code/modules/atmospherics/machinery/portable/scrubber.dm
+++ b/code/modules/atmospherics/machinery/portable/scrubber.dm
@@ -45,8 +45,6 @@
 		. += "scrubber-connector"
 
 /obj/machinery/atmospherics/portable/scrubber/process_atmos()
-	..()
-
 	if(!on)
 		return
 	scrub(loc)


### PR DESCRIPTION
## What Does This PR Do
Removes all unnecessary parent calls across atmos machinery's process_atmos, as well as redundant code from meters.

## Why It's Good For The Game
*whispers* It's free performance.

## Images of changes
With the server at rest, before:
![image](https://github.com/ParadiseSS13/Paradise/assets/98381/bb5b4a10-7205-4ed8-ae03-b76dbf866fde)
And after:
![image](https://github.com/ParadiseSS13/Paradise/assets/98381/47266df3-6a13-4459-8579-31f3ec50af02)

## Testing
Successfully started a stable CO2 SM with default piping.

## Changelog
NPFC