### PR TITLE
Fixes an Oversight with Spray Paint Cans

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -303,6 +303,7 @@
 	name = "\improper Nanotrasen-brand Rapid Paint Applicator"
 	desc = "A metallic container containing spray paint."
 	icon_state = "spraycan_cap"
+	slot_flags = SLOT_FLAG_BELT
 	var/capped = TRUE
 	instant = TRUE
 	validSurfaces = list(/turf/simulated/floor,/turf/simulated/wall)


### PR DESCRIPTION
## What Does This PR Do
Fixes https://github.com/ParadiseSS13/Paradise/issues/20221 - an oversight that allows players to store spray paint cans behind their ears.

## Why It's Good For The Game
It's silly, but a little too silly.

## Testing
Tried to put a spray can in the ear slots, was not able to.

## Changelog
:cl:
fix: Fixed an oversight where spray cans could be equipped in ear slots
/:cl: