### PR TITLE
Fixes z-level dragging and smoothes space drift

### DIFF
--- a/code/__HELPERS/trait_helpers.dm
+++ b/code/__HELPERS/trait_helpers.dm
@@ -276,6 +276,10 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 ///e.g. a storage container or a modsuit.
 #define TRAIT_ADJACENCY_TRANSPARENT "adjacency_transparent"
 
+//****** ATOM/MOVABLE TRAITS *****//
+/// A trait for determining if a atom/movable is currently crossing into another z-level by using of /turf/space z-level "destination-xyz" transfers
+#define TRAIT_CURRENTLY_Z_MOVING "currently_z_moving" // please dont adminbus this
+
 //
 // common trait sources
 #define TRAIT_GENERIC "generic"

--- a/code/controllers/subsystem/SSspacedrift.dm
+++ b/code/controllers/subsystem/SSspacedrift.dm
@@ -53,7 +53,7 @@ SUBSYSTEM_DEF(spacedrift)
 		var/old_dir = AM.dir
 		var/old_loc = AM.loc
 		AM.inertia_moving = TRUE
-		step(AM, AM.inertia_dir)
+		AM.Move(get_step(AM, AM.inertia_dir), AM.inertia_dir, AM.inertia_move_delay)
 		AM.inertia_moving = FALSE
 		AM.inertia_next_move = world.time + AM.inertia_move_delay
 		if(AM.loc == old_loc)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Fixes #13574.

You can now drag people/objects across z-levels again.
Objects/people undergoing spacedrift will now have a smooth animation, instead of a janky one.

Also fucking finally removes the sleep(0) from /turf/space/entered because its fuckin useless. No need to wait. One step closer to `forceMove` being able to be a non-sleeping proc

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Removes scuffedness, adds smoothness

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

https://github.com/ParadiseSS13/Paradise/assets/91113370/b3d74089-0923-4ef5-909a-3cf66c7a14c5

## Testing
<!-- How did you test the PR, if at all? -->
See above

## Changelog
:cl:
fix: You can now drag things across z-level boundaries again
tweak: Space drifting is now smoother
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
