### PR TITLE
Remove some windows from Narsie shuttle

### DIFF
--- a/_maps/map_files/shuttles/emergency_narnar.dmm
+++ b/_maps/map_files/shuttles/emergency_narnar.dmm
@@ -215,15 +215,6 @@
 /obj/effect/decal/cleanable/blood/writing,
 /turf/simulated/floor/engine/cult,
 /area/shuttle/escape)
-"aJ" = (
-/obj/structure/closet/walllocker/emerglocker{
-	pixel_x = 28
-	},
-/obj/machinery/light/spot{
-	dir = 4
-	},
-/turf/simulated/floor/engine/cult,
-/area/shuttle/escape)
 "aK" = (
 /obj/effect/rune,
 /mob/living/simple_animal/hostile/construct/wraith,
@@ -266,12 +257,6 @@
 	},
 /obj/machinery/light/spot,
 /turf/simulated/floor/engine/cult,
-/area/shuttle/escape)
-"aU" = (
-/obj/effect/spawner/window/reinforced{
-	color = "red"
-	},
-/turf/space,
 /area/shuttle/escape)
 "aV" = (
 /mob/living/simple_animal/hostile/construct/harvester,
@@ -478,7 +463,7 @@ ab
 ac
 ay
 ac
-ac
+ab
 aj
 aF
 aH
@@ -538,7 +523,7 @@ aM
 aI
 aQ
 aF
-ac
+ab
 aa
 aa
 aa
@@ -564,7 +549,7 @@ aI
 aV
 aH
 aS
-aU
+ab
 ab
 ab
 ab
@@ -661,14 +646,14 @@ aj
 aA
 aj
 aj
-aj
-aJ
-aj
-aj
+bb
+aA
 aj
 aj
 aj
-ac
+aj
+aj
+ab
 aZ
 aZ
 aZ
@@ -693,7 +678,7 @@ ac
 ac
 ac
 ac
-ac
+ab
 ab
 ab
 ab

--- a/_maps/map_files/shuttles/emergency_narnar.dmm
+++ b/_maps/map_files/shuttles/emergency_narnar.dmm
@@ -152,9 +152,7 @@
 /turf/simulated/floor/engine/cult,
 /area/shuttle/escape)
 "aA" = (
-/obj/structure/closet/walllocker/emerglocker{
-	pixel_x = 28
-	},
+/obj/structure/closet/walllocker/emerglocker/north,
 /turf/simulated/floor/engine/cult,
 /area/shuttle/escape)
 "aB" = (
@@ -165,19 +163,9 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
-/turf/simulated/floor/engine/cult,
-/area/shuttle/escape)
-"aC" = (
 /obj/item/radio/intercom{
 	dir = 4;
-	pixel_x = 28
-	},
-/obj/effect/decal/remains/human{
-	desc = "This guy seemed to have died in terrible way! Half his remains are dust.";
-	name = "Human remains"
-	},
-/obj/structure/chair/comfy/shuttle{
-	dir = 8
+	pixel_y = -28
 	},
 /turf/simulated/floor/engine/cult,
 /area/shuttle/escape)
@@ -213,6 +201,15 @@
 /area/shuttle/escape)
 "aI" = (
 /obj/effect/decal/cleanable/blood/writing,
+/turf/simulated/floor/engine/cult,
+/area/shuttle/escape)
+"aJ" = (
+/obj/structure/closet/walllocker/emerglocker{
+	pixel_x = 28
+	},
+/obj/machinery/light/spot{
+	dir = 4
+	},
 /turf/simulated/floor/engine/cult,
 /area/shuttle/escape)
 "aK" = (
@@ -436,9 +433,9 @@ an
 ab
 au
 aj
-aC
+au
 ab
-aj
+aA
 aj
 aj
 aF
@@ -643,11 +640,11 @@ aa
 aa
 ab
 aj
-aA
 aj
 aj
-bb
-aA
+aj
+aj
+aJ
 aj
 aj
 aj
@@ -669,10 +666,10 @@ aa
 aa
 ab
 ab
-ab
 ac
-ab
-ab
+ac
+ac
+ac
 ab
 ac
 ac


### PR DESCRIPTION
## What Does This PR Do
Replaces some windows on narsie shuttle with walls, and add some new ones
Also replaces o2 wall locker closer to the shuttle entrance

## Why It's Good For The Game
A strange arrangement of windows, one of which had space underneath it
Plus those who really need an emergency locker will get to it in time.

## Images of changes
| Before | After |
| - | - |
| ![StrongDMM-2024-05-20 01 28 47](https://github.com/ParadiseSS13/Paradise/assets/69762909/18272a68-e0f5-4f15-bdc5-f2b64252ecb3) | ![StrongDMM-2024-05-20 01 36 19](https://github.com/ParadiseSS13/Paradise/assets/69762909/def1755f-723d-4207-81aa-a1bd0d11fe0c) |

## Testing
I'm sure it's fine

## Changelog
NPFC?
