### PR TITLE
Changes AI tracking speed.

### DIFF
--- a/code/_onclick/ai_onclick.dm
+++ b/code/_onclick/ai_onclick.dm
@@ -18,7 +18,7 @@
 	if(control_disabled || stat) return
 
 	if(ismob(A))
-		ai_actual_track(A)
+		ai_actual_track(A, TRUE)
 	else
 		A.move_camera_by_click()
 

--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -120,7 +120,7 @@
 
 	to_chat(U, "<span class='notice'>Attempting to track [target.get_visible_name()]...</span>")
 	if(!doubleclick)
-		sleep(15) // Gives antags a brief window to get out of dodge before the eye of sauron decends upon them when someone yells ;HALP
+		sleep(1.5 SECONDS) // Gives antags a brief window to get out of dodge before the eye of sauron decends upon them when someone yells ;HALP
 	spawn(15) //give the AI a grace period to stop moving.
 		U.tracking = FALSE
 

--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -120,7 +120,7 @@
 
 	to_chat(U, "<span class='notice'>Attempting to track [target.get_visible_name()]...</span>")
 	if(!doubleclick)
-		sleep(5)
+		sleep(15)
 	spawn(15) //give the AI a grace period to stop moving.
 		U.tracking = FALSE
 

--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -120,7 +120,7 @@
 
 	to_chat(U, "<span class='notice'>Attempting to track [target.get_visible_name()]...</span>")
 	if(!doubleclick)
-		sleep(15)
+		sleep(15) // Gives antags a brief window to get out of dodge before the eye of sauron decends upon them when someone yells ;HALP
 	spawn(15) //give the AI a grace period to stop moving.
 		U.tracking = FALSE
 

--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -110,7 +110,7 @@
 	to_chat(src, "Follow camera mode [forced ? "terminated" : "ended"].")
 	cameraFollow = null
 
-/mob/living/silicon/ai/proc/ai_actual_track(mob/living/target, var/doubleclick = FALSE)
+/mob/living/silicon/ai/proc/ai_actual_track(mob/living/target, doubleclick = FALSE)
 	if(!istype(target))
 		return
 	var/mob/living/silicon/ai/U = usr

--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -110,7 +110,7 @@
 	to_chat(src, "Follow camera mode [forced ? "terminated" : "ended"].")
 	cameraFollow = null
 
-/mob/living/silicon/ai/proc/ai_actual_track(mob/living/target)
+/mob/living/silicon/ai/proc/ai_actual_track(mob/living/target, var/doubleclick = FALSE)
 	if(!istype(target))
 		return
 	var/mob/living/silicon/ai/U = usr
@@ -119,7 +119,8 @@
 	U.tracking = TRUE
 
 	to_chat(U, "<span class='notice'>Attempting to track [target.get_visible_name()]...</span>")
-	sleep(5)
+	if(!doubleclick)
+		sleep(5)
 	spawn(15) //give the AI a grace period to stop moving.
 		U.tracking = FALSE
 

--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -119,7 +119,7 @@
 	U.tracking = TRUE
 
 	to_chat(U, "<span class='notice'>Attempting to track [target.get_visible_name()]...</span>")
-	sleep(min(30, get_dist(target, U.eyeobj) / 4))
+	sleep(5)
 	spawn(15) //give the AI a grace period to stop moving.
 		U.tracking = FALSE
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Speeds up the time it takes to track a target by clicking their name in chat or using the search verb by up to 1.5 seconds for AIs. This was done ~~trough a massive performance refactor~~ by greatly reducing a sleep() in the proc. Tracking someone now always takes 1.5 seconds.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Tracking someone this way has always felt slow and clunky, especially when someone calls you to open a door and you have to sit there for literal seconds, waiting for the camera to finally jump to them. 

You could also theoretically exploit the delay between clicking on someone's name in chat and the time it takes to get the error message to locate a person even when the target is off cameras.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
<!-- How did you test the PR, if at all? -->
Tracked a monkey.

## Changelog
:cl:
tweak: Changed AI tracking speed from a dynamic time to a static 1.5 seconds.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
