### PR TITLE
Halfs the probability for scaling drug downsides. Makes mephedrone less harsh on ipcs

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drugs.dm
+++ b/code/modules/reagents/chemistry/reagents/drugs.dm
@@ -190,7 +190,7 @@
 		M.emote(pick("twitch", "twitch_s", "grumble", "laugh"))
 	if(prob(8))
 		M.emote(pick("laugh", "giggle"))
-	if(prob(5 * DRAWBACK_CHANCE_MODIFIER(recent_consumption)))
+	if(prob(2.5 * DRAWBACK_CHANCE_MODIFIER(recent_consumption)))
 		to_chat(M, "<span class='notice'>You feel warm.</span>") // fever, gets worse with volume
 		M.bodytemperature += 30 * DRAWBACK_CHANCE_MODIFIER(recent_consumption * 2)
 		M.Confused(1 SECONDS * DRAWBACK_CHANCE_MODIFIER(recent_consumption * 2)) //let us see how this feels
@@ -398,7 +398,7 @@
 	update_flags |= M.adjustStaminaLoss(-30, FALSE)
 	M.SetSleeping(0)
 	M.SetDrowsy(0)
-	if(prob(10 * DRAWBACK_CHANCE_MODIFIER(recent_consumption)))
+	if(prob(5 * DRAWBACK_CHANCE_MODIFIER(recent_consumption)))
 		update_flags |= M.adjustBrainLoss(10, FALSE)
 		M.adjust_nutrition(-25)
 	return ..() | update_flags
@@ -596,8 +596,8 @@
 	// you can take 7 disabler shots (30 base * 0.5 stam mod = 15 stam damage each, 7 shots to 105 which is stamina crit. but you can heal 6 in 3 cycles) before going down.
 	// Strong combined with another drug, but frankly I could do meth crank hydro for a better mix. Will be interesting with batons?
 	update_flags |= M.adjustStaminaLoss(-2, FALSE)
-	if(prob(10 * DRAWBACK_CHANCE_MODIFIER(recent_consumption)))
-		update_flags |= M.adjustToxLoss(4, FALSE) //This does toxin damage. This kills any chem mixes, which could be considered a good thing, but it is a drug that MUST be combined with other drugs. I want to turn this down, but someone will just iv drip a certian bar drink
+	if(prob(3 * DRAWBACK_CHANCE_MODIFIER(recent_consumption)))
+		update_flags |= M.adjustToxLoss(4, FALSE) //This does toxin damage. This kills any chem mixes, which could be considered a good thing, but it is a drug that MUST be combined with other drugs.
 	if(prob(5))
 		M.emote(pick("twitch", "shake", "tremble","quiver", "twitch_s"))
 	if(prob(8))
@@ -1163,7 +1163,7 @@
 	update_flags |= M.adjustStaminaLoss(-40, FALSE)
 	M.SetSleeping(0)
 	M.SetDrowsy(0)
-	if(prob(12 * DRAWBACK_CHANCE_MODIFIER(recent_consumption))) // slightly higher prob than meth due to the no nutrition thing
+	if(prob(6 * DRAWBACK_CHANCE_MODIFIER(recent_consumption))) // slightly higher prob than meth due to the no nutrition thing
 		update_flags |= M.adjustBrainLoss(10, FALSE)
 
 	var/high_message = pick("You feel your servos whir!", "You feel like you need to go faster.", "You feel like you were just overclocked!")
@@ -1230,7 +1230,7 @@
 		if(prob(10))
 			high_message = "0100011101001111010101000101010001000001010001110100111101000110010000010101001101010100!"
 		to_chat(M, "<span class='notice'>[high_message]</span>")
-	if(prob(5 * DRAWBACK_CHANCE_MODIFIER(recent_consumption)))
+	if(prob(2.5 * DRAWBACK_CHANCE_MODIFIER(recent_consumption)))
 		to_chat(M, "<span class='notice'>Your circuits overheat!</span>") // synth fever
 		M.bodytemperature += 30 * DRAWBACK_CHANCE_MODIFIER(recent_consumption * 2)
 		M.Confused(1 SECONDS * DRAWBACK_CHANCE_MODIFIER(recent_consumption * 2))

--- a/code/modules/reagents/chemistry/reagents/drugs.dm
+++ b/code/modules/reagents/chemistry/reagents/drugs.dm
@@ -398,7 +398,7 @@
 	update_flags |= M.adjustStaminaLoss(-30, FALSE)
 	M.SetSleeping(0)
 	M.SetDrowsy(0)
-	if(prob(5 * DRAWBACK_CHANCE_MODIFIER(recent_consumption)))
+	if(prob(6 * DRAWBACK_CHANCE_MODIFIER(recent_consumption)))
 		update_flags |= M.adjustBrainLoss(10, FALSE)
 		M.adjust_nutrition(-25)
 	return ..() | update_flags
@@ -828,8 +828,9 @@
 
 // Mephedrone.
 
-#define CONSTANT_DOSE_SAFE_LIMIT 60
-#define CONSTANT_DOSE_DEATH_LIMIT 600
+// These defines are in CYCLES
+#define CONSTANT_DOSE_SAFE_LIMIT 30
+#define CONSTANT_DOSE_DEATH_LIMIT 300
 
 #define MEPHEDRONE_SCREEN_FILTER "mephedrone_screen_filter"
 #define MEPHEDRONE_SCREEN_BLUR "mephedrone_screen_blur"
@@ -850,12 +851,10 @@
 	metabolization_rate = 0.375 * REAGENTS_METABOLISM
 	overdose_threshold = 15
 	addiction_chance = 3
-	addiction_threshold = 15
+	addiction_threshold = 20 //High chance so higher threshold
 	shock_reduction = 40 // Slight shock reduction to assist with damage / disablers
 	allowed_overdose_process = TRUE
 	process_flags = ORGANIC | SYNTHETIC
-	/// How much time has the drug been in them?
-	var/constant_dose_time = 0
 	/// Keeps track of how many chemicals we are delaying the changeling by.
 	var/changeling_chemical_tracker = 0
 	goal_department = "Science"
@@ -906,28 +905,28 @@
 		cling.chem_recharge_slowdown -= changeling_chemical_tracker
 		changeling_chemical_tracker = 0
 
-	if(constant_dose_time < CONSTANT_DOSE_SAFE_LIMIT) // Anything less than this and you'll come out fiiiine, aside from a big hit of stamina damage
+	if(current_cycle < CONSTANT_DOSE_SAFE_LIMIT) // Anything less than this and you'll come out fiiiine, aside from a big hit of stamina damage
 		L.visible_message(
 			"<span class='danger'>[L] suddenly slows from their inhuman speeds, coming back with a wicked nosebleed!</span>",
 			"<span class='danger'>You suddenly slow back to normal, a stream of blood gushing from your nose!</span>")
-		L.adjustStaminaLoss(constant_dose_time)
+		L.adjustStaminaLoss(current_cycle * 2)
 	else // Much longer than that however, and you're not gonna have a good day
 		L.visible_message(
 			"<span class='danger'>[L] suddenly snaps back from their inhumans speeds, coughing up a spray of blood!</span>",
 			"<span class='danger'>As you snap back to normal speed you cough up a worrying amount of blood. You feel like you've just been run over by a power loader.</span>")
 		L.custom_emote(EMOTE_VISIBLE, "coughs up blood!")
 		L.bleed(25)
-		L.apply_damage(max(constant_dose_time / 3, 60), STAMINA)
-		L.KnockDown((constant_dose_time / 15) SECONDS) // a minute is a 4 second knockdown, 2 is 8, etc
-		if(!HAS_TRAIT(L, TRAIT_MEPHEDRONE_ADAPTED) || constant_dose_time >= CONSTANT_DOSE_DEATH_LIMIT) //If you are going infinite with mito and you run out, you deserve this even with an implant
+		L.apply_damage(max(current_cycle * 2 / 3, 60), STAMINA)
+		L.KnockDown((current_cycle * 2 / 15) SECONDS) // a minute is a 4 second knockdown, 2 is 8, etc
+		if(!HAS_TRAIT(L, TRAIT_MEPHEDRONE_ADAPTED) || current_cycle >= CONSTANT_DOSE_DEATH_LIMIT) //If you are going infinite with mito and you run out, you deserve this even with an implant
 			if(ishuman(L))
 				var/mob/living/carbon/human/H = L
 				var/datum/organ/heart/datum_heart = H.get_int_organ_datum(ORGAN_DATUM_HEART)
 				if(datum_heart)
 					var/obj/item/organ/internal/our_heart = datum_heart.linked_organ
-					our_heart.receive_damage(0.15 * constant_dose_time, TRUE) // Basically you might die. Especially if you are a slime.
+					our_heart.receive_damage(0.15 * current_cycle * 2, TRUE) // Basically you might die. Especially if you are a slime.
 				else
-					handle_heartless(L, 0.15 * constant_dose_time)
+					handle_heartless(L, 0.15 * current_cycle * 2)
 
 
 	if(!L.hud_used)
@@ -994,8 +993,6 @@
 
 /datum/reagent/mephedrone/on_mob_life(mob/living/carbon/L)
 	. = ..()
-
-	constant_dose_time += 2
 
 	if(ishuman(L))
 		var/heart_damage = 0.1
@@ -1083,17 +1080,17 @@
 	update_flags |= L.adjustToxLoss(1 * REAGENTS_EFFECT_MULTIPLIER, FALSE)
 	return ..() | update_flags
 
-//This proc is for IPCS, skeletons, golems, and people with corazone. IPCS are treated lightly, power loss and brain damage.
-//IPC brain damage gets an increase with liquid solder, so it matters
+//This proc is for IPCS, skeletons, golems, and people with corazone. IPCS are treated lightly, power loss and brute on OD. Used to be brain damage but new brain damage is much deadlier and ipcs would fall asleep in the middle of using the drug
+//IPC brute damage scales over time. Endleslly running an OD on this will not work well. Theoretically they could run a low dose well, but over 10 minutes will make them explode on wear off.
 //Otherwise, the user hallucinates a bunch, and as well takes stamina damage. This will block passive stamina regen, and most likely require antistun drugs to use as well
 
 /datum/reagent/mephedrone/proc/handle_heartless(mob/living/carbon/L, damage_input)
 	if(ismachineperson(L))
-		L.adjust_nutrition(-damage_input * 7.5)
-		if(damage_input == 0.9) //This is the input from the OD
-			L.adjustBrainLoss(1.75)
-			if(L.reagents.has_reagent("liquid_solder"))
-				L.adjustBrainLoss(2.75)
+		if(damage_input >= 0.9) //This is the input from the OD
+			L.adjustBruteLoss((1 + (current_cycle * (damage_input + 0.1) / 100)), TRUE) //Yes, this means an IPC on this drug for 10+ minutes, that has it wear off, will instantly lego. That is funny.
+			L.adjust_nutrition(-damage_input * 3.75) // I don't think they should have to charge like twice in the middle of combat. Still will need to charge after however!
+		else
+			L.adjust_nutrition(-damage_input * 15)
 	else //Corazone or skeletons. We go hard on them.
 		L.Hallucinate(damage_input * 50 SECONDS)
 		L.apply_damage(damage_input * 3, STAMINA)

--- a/code/modules/reagents/chemistry/reagents/drugs.dm
+++ b/code/modules/reagents/chemistry/reagents/drugs.dm
@@ -398,7 +398,7 @@
 	update_flags |= M.adjustStaminaLoss(-30, FALSE)
 	M.SetSleeping(0)
 	M.SetDrowsy(0)
-	if(prob(6 * DRAWBACK_CHANCE_MODIFIER(recent_consumption)))
+	if(prob(7 * DRAWBACK_CHANCE_MODIFIER(recent_consumption)))
 		update_flags |= M.adjustBrainLoss(10, FALSE)
 		M.adjust_nutrition(-25)
 	return ..() | update_flags


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

All drugs (bar meth) have had their scaling drug downside chance halfed. This means downsides happen at half the probability now, requiring twice the drugs to reach the same downside level.
Consumption decay rate remains the same, so fully recovering from the really heavy downsides by extention if you now reach it, takes twice as long.
Meth is adjusted to 70% rather than 50%. This with luck will have people try some other drugs, while also still making meth less harsh.
Arsnep had it's toxin damage lowered since it really has to be combined with another drug to work well.
Mephedrone no longer does enough brain damage to ipcs to make them fall asleep in combat.
Instead, it does scaling brute damage when overdosing. It's power use has been tweaked to not drain an IPC out of power in the middle of an overdose. They still will need to charge after an overdose. Yes, this makes mephedrone very strong on an IPC, but it is however, an IPC. They will die to other means.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

About half a year ago, in #22170 , we fixed scaling drug downsides not working right. I did say that  if it was too harsh after being fixed, drugs would be adjusted.

Half a year later, chemical use is back to all meth, and even then, meth users are dropping brain death quite fast, especially with the newer brain damage downsides.

The drug scaling system is great, it just is too fast. Halfing it should allow for drugs to be used a bit longer, while still punishing overuse. Meth reduced only by 30% should still help, but also perhaps encourage experimenting with other drugs.

IPCS should actually be able to use mephedrone reasonably now

## Testing
<!-- How did you test the PR, if at all? -->

fiddled with numbers untill I was happy with mephedrone and other drugs when experimenting with them.
Starved a bunch of ipcs to death in the process.

## Changelog
:cl:
tweak: Halfs the probability for scaling drug downsides. Meth is only reduced by 30%. In other words, it takes using the drug twice as long to get the downsides.
tweak: IPCS no longer fall asleep when oding mephedrone from the heavy brain damage, or keel over and die from their battery depleting halfway through the overdose. 
tweak: Arsnep toxin damage reduced.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
