### PR TITLE
Adds 3 new traitor bundles

### DIFF
--- a/code/game/objects/items/devices/radio/beacon.dm
+++ b/code/game/objects/items/devices/radio/beacon.dm
@@ -57,7 +57,7 @@
 		user.drop_item()
 		qdel(src)
 
-/obj/item/radio/beacon/syndicate/bundle/
+/obj/item/radio/beacon/syndicate/bundle
 	name = "suspicious beacon"
 	desc = "A label on it reads: <i>Activate to select a bundle</i>."
 	var/list/static/bundles = list(
@@ -73,7 +73,10 @@
 		"Sniper" = /obj/item/storage/box/syndie_kit/bundle/professional,
 		"Grenadier" = /obj/item/storage/box/syndie_kit/bundle/grenadier,
 		"Augmented" = /obj/item/storage/box/syndie_kit/bundle/metroid,
-		"Ocelot" = /obj/item/storage/box/syndie_kit/bundle/ocelot)
+		"Ocelot" = /obj/item/storage/box/syndie_kit/bundle/ocelot,
+		"Nuclear Wannabe" = /obj/item/storage/box/syndie_kit/bundle/operative,
+		"Big Spender" = /obj/item/storage/box/syndie_kit/bundle/rich,
+		"Maintenance Collector" = /obj/item/storage/box/syndie_kit/bundle/maint_loot)
 	var/list/selected = list()
 	var/list/unselected = list()
 

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -636,6 +636,24 @@
 	untrackable = TRUE
 	access = list(ACCESS_SYNDICATE, ACCESS_SYNDICATE_LEADER, ACCESS_SYNDICATE_COMMAND, ACCESS_EXTERNAL_AIRLOCKS)
 
+// like /obj/item/card/id/syndicate, but you can only swipe access, not change your identity, its also trackable
+/obj/item/card/id/syndi_scan_only
+	name = "Syndicate Operative's ID card (Operative)"
+	rank = "Operative"
+	assignment = "Operative"
+	registered_name = "Syndicate Operative"
+	access = list(ACCESS_SYNDICATE)
+
+/obj/item/card/id/syndi_scan_only/afterattack(obj/item/O, mob/user, proximity)
+	if(!proximity)
+		return
+	if(istype(O, /obj/item/card/id))
+		var/obj/item/card/id/I = O
+		if(isliving(user) && user.mind)
+			if(user.mind.special_role)
+				to_chat(user, "<span class='notice'>The card's microscanners activate as you pass it over [I], copying its access.</span>")
+				access |= I.access //Don't copy access if user isn't an antag -- to prevent metagaming
+
 /obj/item/card/id/captains_spare
 	name = "captain's spare ID"
 	desc = "The spare ID of the captain."

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -254,6 +254,8 @@
 		/obj/item/clothing/shoes/laceup, // 0 TC
 		/obj/item/clothing/glasses/monocle, // 0 TC
 		/obj/item/clothing/gloves/color/white, // 0 TC
+		/obj/item/clothing/head/that, // 0 TC
+		/obj/item/storage/secure/briefcase, // 0 TC
 		/// syndie briefcase has 600 credits for 5 TC.
 		/obj/item/stack/spacecash/c10000,
 		/obj/item/stack/spacecash/c10000,

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -178,7 +178,7 @@
 /// 133TC + Tactical Grenadier Belt
 /obj/item/storage/box/syndie_kit/bundle/grenadier
 	name = "Grenade Bundle"
-	desc = "A variety of grenades and pyrotechnics to ensure you can blast your way through any situation. "
+	desc = "A variety of grenades and pyrotechnics to ensure you can blast your way through any situation."
 	items = list(
 		/obj/item/storage/belt/grenade/tactical, // Contains 2 Frag and EMP grenades, 5 C4 Explosives, 5 Smoke and Gluon grenades and 1 Minibomb grenade ~20TC Estimate
 		/obj/item/storage/box/syndie_kit/stechkin, // 20TC
@@ -226,6 +226,69 @@
 		/obj/item/clothing/head/beret, // 0 TC
 		/obj/item/clothing/gloves/combat, // 0 TC
 		/obj/item/clothing/shoes/combat) // 0 TC
+
+// 175 TC
+/obj/item/storage/box/syndie_kit/bundle/operative
+	name = "\"Operative\" Bundle"
+	desc = "Glory to the Syndicate! Only the essentials for destroying Nanotrasen in this important kit."
+	items = list(
+		/obj/item/mod/control/pre_equipped/traitor, // 30TC
+		/obj/item/card/id/syndi_scan_only, // ~2TC?
+		/obj/item/encryptionkey/syndicate, // 10tc
+		/obj/item/melee/energy/sword/saber/red, // 40tc
+		/obj/item/shield/energy, // 40tc
+		/obj/item/pinpointer/advpinpointer, // 20tc, get dat fuckin disk
+		/obj/item/storage/belt/military, // 10tc
+		/obj/item/grenade/plastic/c4, // 5tc
+		/obj/item/bio_chip_implanter/proto_adrenalin, // 18tc
+		/obj/item/toy/figure/crew/syndie, // 0tc
+		/obj/item/clothing/under/syndicate // 0tc
+	)
+
+// 250 TC worth of credits
+/obj/item/storage/box/syndie_kit/bundle/rich
+	name = "Big Spender Bundle"
+	desc = "It's money. I don't need to explain more."
+	items = list(
+		/obj/item/clothing/under/suit/really_black, // 0 TC
+		/obj/item/clothing/shoes/laceup, // 0 TC
+		/obj/item/clothing/glasses/monocle, // 0 TC
+		/obj/item/clothing/gloves/color/white, // 0 TC
+		/// syndie briefcase has 600 credits for 5 TC.
+		/obj/item/stack/spacecash/c10000,
+		/obj/item/stack/spacecash/c10000,
+		/obj/item/stack/spacecash/c10000
+	)
+
+// 211 TC of maint loot, higher than other bundles because it doesn't combo well
+/obj/item/storage/box/syndie_kit/bundle/maint_loot
+	name = "Maintenance Loot Bundle"
+	desc = "One of our interns found all of this lying in a Nanotrasen Maintenance tunnels. Reduce, Reuse, Recycle!"
+	items = list(
+		/obj/item/storage/bag/plasticbag, // 1 TC
+		/obj/item/grenade/clown_grenade, // 15 TC
+		/obj/item/seeds/ambrosia/cruciatus, // 5 TC
+		/obj/item/gun/projectile/automatic/pistol, // 20 TC
+		/obj/item/ammo_box/magazine/m10mm, // 3 TC
+		/obj/item/soap/syndie, // 5 TC
+		/obj/item/suppressor, // 5 TC
+		/obj/item/clothing/under/chameleon, // 3 TC
+		/obj/item/clothing/shoes/chameleon/noslip, // 10 TC
+		/obj/item/clothing/mask/chameleon/voice_change, // 10 TC
+		/obj/item/dnascrambler, // 7 TC
+		/obj/item/storage/backpack/satchel_flat, // 10 TC
+		/obj/item/storage/toolbox/syndicate, // 5 TC
+		/obj/item/storage/backpack/duffel/syndie/med/surgery, // 10 TC
+		/obj/item/storage/belt/military/traitor, // 10 TC
+		/obj/item/storage/box/syndie_kit/space, // 20 TC
+		/obj/item/multitool/ai_detect, // 5 TC
+		/obj/item/bio_chip_implanter/storage, // 40 TC
+		/obj/item/deck/cards/syndicate, // 2 TC
+		/obj/item/storage/secure/briefcase/syndie, // 5 TC
+		/obj/item/storage/fancy/cigarettes/cigpack_syndicate, // 7 TC
+		/obj/item/clothing/suit/jacket/syndicatebomber, // 3 TC
+		/obj/item/melee/knuckleduster/syndie, // 10 TC
+	)
 
 /obj/item/storage/box/syndie_kit/bundle/populate_contents()
 	for(var/obj/item/item as anything in items)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->Adds 3 new traitor bundles
- Nuclear Wannabe - Declare your allegiance to the syndicate with this bundle, for traitors wanting to get dat fuckin disk!
    - Worth 175 TC
    - Pre-Equipped Blood-red Modsuit
    - Syndicate Operative ID (Scans Access like an Agent ID, but does nothing else)
    - Syndi Headset Key
    - Esword
    - Energy shield
    - Advanced Pinpointer
    - Military belt (the red kind)
    - 1 block of C4
    - Proto-adrenals
    - Nuclear Operative action figure
    - REAL tactical turtleneck jumpsuit
- Big Spender - Show off your lavish lifestyle, with 250 TC worth of credits. (Subject to change)
    - Worth 250 TC
    - 1 fancy outfit
    - 30000 credits
- Maintenance Collector - Tired of looting maints? Have one of our interns do it for you! (Subject to Change)
    - 211 TC of maint loot, higher than most bundles but it doesn't combo well
    - Plastic Bag
    - Clown Grenade
    - Ambrosia Cruciatus seeds
    - Stetchkin
    - Stetchkin magazine
    - Syndicate Soap
    - Suppressor
    - Chameleon Jumpsuit
    - Noslips
    - Voice-changing chameleon mask
    - DNA Scrambler
    - Smuggler's satchel
    - Syndicate Toolbox
    - FULL Syndicate Surgery Duffel bag (including hydro and straight jacket)
    - Traitor Toolbelt
    - Black and Red softsuit
    - AI Detector
    - Storage Implant
    - Syndicards
    - Briefcase of Cash (600 credits)
    - syndi-smokes
    - Syndicate bomber jacket
    - Syndi Knuckleduster

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
More options for bundles is good, especially ones that are specifically tailored towards a specific playstyle (like going for the disk, or bribing with money), and that isn't just a 6th "I'm a spy, an agent, I'm 007!" type of stealth kit

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![image](https://github.com/ParadiseSS13/Paradise/assets/91113370/c74a7c02-6f0c-4c9a-a28d-cad9c1531637)
![image](https://github.com/ParadiseSS13/Paradise/assets/91113370/65617bb9-8e19-438e-8890-d60780eb7964)
![image](https://github.com/ParadiseSS13/Paradise/assets/91113370/7bf4810c-4d98-4d61-a777-fd6d43536d3b)
![image](https://github.com/ParadiseSS13/Paradise/assets/91113370/58f7e01b-e069-4f3f-98bb-92e781428138)


## Testing
<!-- How did you test the PR, if at all? -->
See Above. Spawned them in manually and through the beacon.

## Changelog
:cl:
add: Adds 3 new traitor bundles: Nuclear Wannabe, Big Spender, and Maintenance Collector
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
