### PR TITLE
Crashing into stuff while leaping will actually work now.

### DIFF
--- a/code/game/dna/mutations/mutation_powers.dm
+++ b/code/game/dna/mutations/mutation_powers.dm
@@ -562,11 +562,13 @@
 	for(var/atom/movable/hit_thing in turf_to_check)
 		if(isliving(hit_thing))
 			var/mob/living/hit_mob = hit_thing
-			return hit_mob.density
+			if(hit_mob.density)
+				return hit_mob
 
 		if(isobj(hit_thing))
 			var/obj/hit_obj = hit_thing
-			return hit_obj.density
+			if(hit_obj.density)
+				return hit_obj
 
 	return FALSE
 


### PR DESCRIPTION
## What Does This PR Do
Fixes Leap leaving you bugged when you crash into something.

## Why It's Good For The Game
Flying is cool. Flying due to a bug, less cool.

## Testing
Crashed into a person. Fell to the ground.
Crashed into a window. Fell to the ground.

## Changelog
:cl:
fix: Leap will no longer leave you in a weird floating state if you crash into something.
/:cl: