### PR TITLE
Reduce ghost window highlight spam, part 2

### DIFF
--- a/code/modules/events/event.dm
+++ b/code/modules/events/event.dm
@@ -197,7 +197,7 @@
 //Only called once.
 /datum/event/proc/announce_to_ghosts(atom/atom_of_interest)
 	if(atom_of_interest)
-		notify_ghosts("[name] has an object of interest: [atom_of_interest]!", title = "Something's Interesting!", source = atom_of_interest, action = NOTIFY_FOLLOW)
+		notify_ghosts("[name] has an object of interest: [atom_of_interest]!", title = "Something's Interesting!", source = atom_of_interest, flashwindow = FALSE, action = NOTIFY_FOLLOW)
 
 /// Override this to make a custom fake announcement that differs from the normal announcement.
 /// Used for false alarms.

--- a/code/modules/events/tear.dm
+++ b/code/modules/events/tear.dm
@@ -26,7 +26,7 @@
 
 		// Give ghosts some time to jump there before it begins.
 		var/image/alert_overlay = image('icons/mob/animal.dmi', notify_image)
-		notify_ghosts("\A [src] is about to open in [get_area(T)].", title = notify_title, source = T, alert_overlay = alert_overlay, action = NOTIFY_FOLLOW)
+		notify_ghosts("\A [src] is about to open in [get_area(T)].", title = notify_title, source = T, alert_overlay = alert_overlay, flashwindow = FALSE, action = NOTIFY_FOLLOW)
 		addtimer(CALLBACK(src, PROC_REF(spawn_tear), T), 4 SECONDS)
 
 		// Energy overload; we mess with machines as an early warning and for extra spookiness.

--- a/code/modules/power/engines/singularity/singularity.dm
+++ b/code/modules/power/engines/singularity/singularity.dm
@@ -453,7 +453,6 @@
 		ghost_sound = 'sound/machines/warning-buzzer.ogg',
 		source = src,
 		action = NOTIFY_FOLLOW,
-		flashwindow = FALSE,
 		title = "IT'S LOOSE",
 		alert_overlay = image(icon='icons/obj/singularity.dmi', icon_state="singularity_s1")
 	)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes the ss13 window no longer flash yellow to ghosts for the following events: anomaly, dimensional tear. 
Makes the ss13 window flash yellow to ghosts for singoloose.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
These events already have loud voice announcements, which should cause you to alt tab if you're interested in them. No need for the window to also flash yellow. 
Singolooses are something ghosts are usually pretty interested in, so it can flash the window. 
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
It compiled.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Reduced events highlighting the game window for ghosts. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
