### PR TITLE
Fix ppflowers (flora) generate missing icon

### DIFF
--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -237,7 +237,7 @@
 
 /obj/structure/flora/ausbushes/ppflowers/Initialize(mapload)
 	. = ..()
-	icon_state = "ppflowers_[rand(1, 4)]"
+	icon_state = "ppflowers_[rand(1, 3)]"
 
 /obj/structure/flora/ausbushes/sparsegrass
 	icon_state = "sparsegrass_1"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixed initialzie for ppflowers as they don't have a fourth icon, resulting in missing texture

![image](https://github.com/ParadiseSS13/Paradise/assets/20109643/78993413-fed8-414f-bf7b-95d9dbf8fe7c)

![image](https://github.com/ParadiseSS13/Paradise/assets/20109643/6af9cc4f-e2fb-4e39-8c4a-89d693d75883)

## Why It's Good For The Game
Who knows

## Images of changes
flwrs

![image](https://github.com/ParadiseSS13/Paradise/assets/20109643/643cd386-cc58-4478-9b0d-bd89f910c362)


## Testing
It's ok

## Changelog
:cl:
fix: Fix the lack of texture of some flora species
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
