### PR TITLE
Converts Nutrition alert to hud element

### DIFF
--- a/code/__DEFINES/hud_locations.dm
+++ b/code/__DEFINES/hud_locations.dm
@@ -77,11 +77,11 @@
 #define ui_borg_lanugage_menu "EAST-2:26,SOUTH+1:7"
 
 //Upper-middle right (alerts)
-#define ui_alert1 "EAST-1:28,CENTER+5:27"
-#define ui_alert2 "EAST-1:28,CENTER+4:25"
-#define ui_alert3 "EAST-1:28,CENTER+3:23"
-#define ui_alert4 "EAST-1:28,CENTER+2:21"
-#define ui_alert5 "EAST-1:28,CENTER+1:19"
+#define ui_nutrition "EAST-1:28,CENTER+5:27"
+#define ui_alert1 "EAST-1:28,CENTER+4:25"
+#define ui_alert2 "EAST-1:28,CENTER+3:23"
+#define ui_alert3 "EAST-1:28,CENTER+2:21"
+#define ui_alert4 "EAST-1:28,CENTER+1:19"
 
 
 //Gun buttons
@@ -102,7 +102,6 @@
 #define ui_alien_nightvision "EAST-1:28,CENTER+2:25"
 
 //Middle right (status indicators)
-#define ui_nutrition "EAST-1:28,CENTER-3:11"
 #define ui_temp "EAST-1:28,CENTER-2:13"
 #define ui_healthdoll "EAST-1:28,CENTER-1:15"
 #define ui_health "EAST-1:28,CENTER:17"

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -793,9 +793,7 @@ so as to remain in compliance with the most up-to-date laws."
 			if(3)
 				. = ui_alert3
 			if(4)
-				. = ui_alert4
-			if(5)
-				. = ui_alert5 // Right now there's 5 slots
+				. = ui_alert4 // Right now there's 4 slots
 			else
 				. = ""
 		alert.screen_loc = .

--- a/code/_onclick/hud/hud_datum.dm
+++ b/code/_onclick/hud/hud_datum.dm
@@ -131,6 +131,7 @@
 	mymob.healths = null
 	mymob.healthdoll = null
 	mymob.pullin = null
+	mymob.nutrition_display = null
 
 	//clear the rest of our reload_fullscreen
 	lingchemdisplay = null

--- a/code/_onclick/hud/human_hud.dm
+++ b/code/_onclick/hud/human_hud.dm
@@ -335,6 +335,9 @@
 	mymob.healthdoll = new()
 	infodisplay += mymob.healthdoll
 
+	mymob.nutrition_display = new()
+	infodisplay += mymob.nutrition_display
+
 	mymob.pullin = new /atom/movable/screen/pull()
 	mymob.pullin.icon = ui_style
 	mymob.pullin.hud = src

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -552,6 +552,12 @@
 		var/mob/living/carbon/H = usr
 		H.check_self_for_injuries()
 
+/atom/movable/screen/nutrition
+	name = "nutrition"
+	icon = 'icons/mob/screen_hunger.dmi'
+	icon_state = null
+	screen_loc = ui_nutrition
+
 /atom/movable/screen/component_button
 	var/atom/movable/screen/parent
 

--- a/code/modules/antagonists/vampire/vamp_datum.dm
+++ b/code/modules/antagonists/vampire/vamp_datum.dm
@@ -84,7 +84,6 @@ RESTRICT_TYPE(/datum/antagonist/vampire)
 	var/datum/hud/hud = mob_override.hud_used
 	if(hud?.vampire_blood_display)
 		hud.remove_vampire_hud()
-	mob_override.dna?.species.hunger_type = initial(mob_override.dna.species.hunger_type)
 	mob_override.dna?.species.hunger_icon = initial(mob_override.dna.species.hunger_icon)
 	owner.current.alpha = 255
 	REMOVE_TRAITS_IN(owner.current, "vampire")
@@ -354,7 +353,6 @@ RESTRICT_TYPE(/datum/antagonist/vampire)
 		owner.som = new()
 		owner.som.masters += owner
 
-	mob_override.dna?.species.hunger_type = "vampire"
 	mob_override.dna?.species.hunger_icon = 'icons/mob/screen_hunger_vampire.dmi'
 	check_vampire_upgrade(FALSE)
 

--- a/code/modules/mob/living/carbon/human/human_life.dm
+++ b/code/modules/mob/living/carbon/human/human_life.dm
@@ -669,28 +669,26 @@
 
 #undef BODYPART_PAIN_REDUCTION
 
-/mob/living/carbon/human/proc/handle_nutrition_alerts() //This is a terrible abuse of the alert system; something like this should be a HUD element
-	if(HAS_TRAIT(src, TRAIT_NOHUNGER))
+/mob/living/carbon/human/proc/handle_nutrition_alerts()
+	if(!nutrition_display)
 		return
-	var/new_hunger
+	if(HAS_TRAIT(src, TRAIT_NOHUNGER))
+		nutrition_display.icon_state = null
+		return
+	nutrition_display.icon = dna.species.hunger_icon
 	switch(nutrition)
 		if(NUTRITION_LEVEL_FULL to INFINITY)
-			new_hunger = "fat"
+			nutrition_display.icon_state = "fat"
 		if(NUTRITION_LEVEL_WELL_FED to NUTRITION_LEVEL_FULL)
-			new_hunger = "full"
+			nutrition_display.icon_state = "full"
 		if(NUTRITION_LEVEL_FED to NUTRITION_LEVEL_WELL_FED)
-			new_hunger = "well_fed"
+			nutrition_display.icon_state = "well_fed"
 		if(NUTRITION_LEVEL_HUNGRY to NUTRITION_LEVEL_FED)
-			new_hunger = "fed"
+			nutrition_display.icon_state = "fed"
 		if(NUTRITION_LEVEL_STARVING to NUTRITION_LEVEL_HUNGRY)
-			new_hunger = "hungry"
+			nutrition_display.icon_state = "hungry"
 		else
-			new_hunger = "starving"
-	if(dna.species.hunger_type)
-		new_hunger += "/[dna.species.hunger_type]"
-	if(dna.species.hunger_level != new_hunger)
-		dna.species.hunger_level = new_hunger
-		throw_alert("nutrition", "/atom/movable/screen/alert/hunger/[new_hunger]", icon_override = dna.species.hunger_icon)
+			nutrition_display.icon_state = "starving"
 
 /mob/living/carbon/human/handle_random_events()
 	// Puke if toxloss is too high

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -48,8 +48,6 @@
 	var/hunger_drain = HUNGER_FACTOR
 	var/taste_sensitivity = TASTE_SENSITIVITY_NORMAL //the most widely used factor; humans use a different one
 	var/hunger_icon = 'icons/mob/screen_hunger.dmi'
-	var/hunger_type
-	var/hunger_level
 
 	var/siemens_coeff = 1 //base electrocution coefficient
 

--- a/code/modules/mob/living/carbon/human/species/machine.dm
+++ b/code/modules/mob/living/carbon/human/species/machine.dm
@@ -44,7 +44,6 @@
 	butt_sprite = "machine"
 
 	hunger_icon = 'icons/mob/screen_hunger_machine.dmi'
-	hunger_type = "machine"
 
 	has_organ = list(
 		"brain" = /obj/item/organ/internal/brain/mmi_holder/posibrain,

--- a/code/modules/mob/mob_vars.dm
+++ b/code/modules/mob/mob_vars.dm
@@ -27,6 +27,7 @@
 	*/
 	var/atom/movable/screen/leap_icon = null
 	var/atom/movable/screen/healthdoll/healthdoll = null
+	var/atom/movable/screen/nutrition/nutrition_display = null
 
 	var/use_me = TRUE //Allows all mobs to use the me verb by default, will have to manually specify they cannot
 	var/damageoverlaytemp = 0


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Replaces first alert slot to nutrition hud element. That's basically it.

"Animation" of the alert will be discarded, but it's a minor inconvenience.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Since it's always an alert, why not make it just a hud element?

Also it's required for downstream to not mess up with ui order.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

![Screenshot_1](https://github.com/ParadiseSS13/Paradise/assets/31931237/68eab081-5f7f-4570-b735-5b7b23c2732f)


## Testing
<!-- How did you test the PR, if at all? -->

Tested with:
- Human
- Machine
- Vampire
- Abductor