### PR TITLE
the vox spikethrower no longer 2 shot bursts, and can be charged in a charger

### DIFF
--- a/code/modules/projectiles/guns/energy/special_eguns.dm
+++ b/code/modules/projectiles/guns/energy/special_eguns.dm
@@ -869,8 +869,6 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	fire_sound_text = "a strange noise"
 	can_suppress = 0
-	burst_size = 2 // burst has to be stored here
-	can_charge = FALSE
 	selfcharge = TRUE
 	charge_delay = 10
 	restricted_species = list(/datum/species/vox)
@@ -885,7 +883,6 @@
 	projectile_type = /obj/item/projectile/bullet/spike
 	muzzle_flash_effect = null
 	e_cost = 100
-	delay = 3 //and delay has to be stored here on energy guns
 	select_name = "spike"
 	fire_sound = 'sound/weapons/bladeslice.ogg'
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Makes the vox spikethrower less of a hassle to use, with 2 changes.

It no longer fires in a 2 shot burst, making it less likely that you waste a bullet each time you shoot it.

It can now be charged in a charger, so if you find a charger you can reload it, rather than waiting **20 seconds to reload 1 bullet**

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

The spikethrower is an interesting weapon, which suffers from a classic case of blowing away 20% of it's ammo each time you click with a bonus of a 20 second recharge per shot. If you miss, it will take you 40 seconds to get your ammo back. 
A 357 or ebow are both much more forgiving and generally work better, with the gimic of the vox spikethrower not working well if you don't have ammo for it.

This should keep ebow better for knocking down and recharging, and the 357 still better for dropping someone, but put the vox spikethrower as a weaker hybrid, with a strength if you can keep charging it.

## Testing
<!-- How did you test the PR, if at all? -->

shot it as a vox, then charged it.

## Changelog
:cl:
tweak: the vox spikethrower no longer 2 shot bursts, fires 1 shot at a time, and can be charged in a charger.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
