### PR TITLE
Fix Chemistry goals

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -3,7 +3,7 @@
 	id = "medicine"
 	taste_description = "bitterness"
 	harmless = TRUE
-	goal_department = "Medbay"
+	goal_department = "Chemistry"
 
 /datum/reagent/medicine/on_mob_life(mob/living/M)
 	current_cycle++


### PR DESCRIPTION
## What Does This PR Do
Makes Chemistry goals work again.

## Why It's Good For The Game
Bugs are bad.

## Testing
Successfully received both Chemistry goal types.

## Changelog
:cl:
fix: Chemistry goals can generate correctly again.
/:cl: