### PR TITLE
Lowering megafauna mouse_opacity

### DIFF
--- a/code/__DEFINES/_click.dm
+++ b/code/__DEFINES/_click.dm
@@ -41,5 +41,5 @@
 #define MOUSE_OPACITY_TRANSPARENT 0
 /// Objects will be clicked on if it is the topmost object and the pixel isn't transparent at the position of the mouse (default behavior for 99.99% of game objects)
 #define MOUSE_OPACITY_ICON 1
-/// Objects will be always be clicked on regardless of pixel transparency or other objects at that location (used in space vines, megafauna, storage containers)
+/// Objects will be always be clicked on regardless of pixel transparency or other objects at that location (used in space vines, storage containers)
 #define MOUSE_OPACITY_OPAQUE 2

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
@@ -27,7 +27,7 @@
 	mob_size = MOB_SIZE_LARGE
 	layer = LARGE_MOB_LAYER //Looks weird with them slipping under mineral walls and cameras and shit otherwise
 	flags_2 = IMMUNE_TO_SHUTTLECRUSH_2
-	mouse_opacity =  MOUSE_OPACITY_ICON
+	mouse_opacity = MOUSE_OPACITY_ICON
 	dodging = FALSE // This needs to be false until someone fixes megafauna pathing so they dont lag-switch teleport at you (09-15-2023)
 	var/list/crusher_loot
 	var/medal_type

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
@@ -27,7 +27,7 @@
 	mob_size = MOB_SIZE_LARGE
 	layer = LARGE_MOB_LAYER //Looks weird with them slipping under mineral walls and cameras and shit otherwise
 	flags_2 = IMMUNE_TO_SHUTTLECRUSH_2
-	mouse_opacity = MOUSE_OPACITY_OPAQUE // Easier to click on in melee, they're giant targets anyway
+	mouse_opacity =  MOUSE_OPACITY_ICON
 	dodging = FALSE // This needs to be false until someone fixes megafauna pathing so they dont lag-switch teleport at you (09-15-2023)
 	var/list/crusher_loot
 	var/medal_type


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Making megafauna mouse opacity stick to its icon than its size. That means that you will click megafauna only if you actually click its icon, not the 3x3 tile box which its icon size is.

I wonder why it even was used for such massive objects with big sprites as megafauna.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->If you ever played as megafauna on some events, you might have find that your icon is weird, its much bigger than it looks like, you nearly always attack yourself in melee. This setting was making it, your icon was basically 3x3 box, forget about visual. And also all mobs are hidden behind that 3x3 box because your layer is above them.

If there is an item or a mob behind the megafauna and you want to interact with it, you will fail because megafauna 3x3 box covers most in game objects.

This fix makes megafauna icon actaully its icon, not 3x3 tile box.

Megafauna sprites are big, clicking it on melee or range attacks is easy enough, its layer is ontop of most objects in game.

## Testing
<!-- How did you test the PR, if at all? -->
Compiled, clicked on fauna.

## Changelog
:cl:
tweak: Now you need to actually click on megafauna icon to attack it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
