### PR TITLE
Replaces ERT Synthflesh with Survival Medipen

### DIFF
--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -973,7 +973,6 @@
 /obj/item/storage/box/responseteam
 	name = "boxed survival kit"
 	icon_state = "ert_box"
-	storage_slots = 8
 
 /obj/item/storage/box/responseteam/populate_contents()
 	new /obj/item/clothing/mask/breath(src)
@@ -982,8 +981,7 @@
 	new /obj/item/flashlight/flare(src)
 	new /obj/item/kitchen/knife/combat(src)
 	new /obj/item/radio/centcom(src)
-	new /obj/item/reagent_containers/patch/synthflesh(src)
-	new /obj/item/reagent_containers/hypospray/autoinjector/epinephrine(src)
+	new /obj/item/reagent_containers/hypospray/autoinjector/survival(src)
 
 /obj/item/storage/box/deathsquad
 	name = "boxed death kit"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Removes Synthflesh Patch and Epinepherine Autoinjector from ERT Survival Box.
Gives ERT Survival Box the survival medipen (same one as mining gets, and crew on deluxe box shift).
Now that the ERT Box no longer starts with 8 items, makes it only store 7 items, like god intended.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

The synthflesh patch is pretty shit ever since we made patches slowly put reagents inside of you instead of doing an on-touch reaction. Also, if Nanotrasen gives these to all their employees on deluxe emergency box shifts, then by god they can at least give it to their well equipped response teams.
This means that while response team members won't all be equipped like medics (except the medics), they at least won't spawn with practically zero healing and might have a chance to survive an ambush before they can raid the medbay to get basic healing supplies.

## Testing
<!-- How did you test the PR, if at all? -->
Yeah it's fine.
I got an odd-ass error from a file this PR didn't touch, but as this PR didn't touch that it shouldn't cause any issues that weren't already there?
Game still loaded fine, boxes were correct, so I dunno.

## Changelog
:cl:
tweak: Response team members get a Survival Medipen instead of an Epi Auto and a Synthflesh Patch
tweak: Response Team emergency boxes now only store 7 items
/:cl:

Also yes I did bully at least one member of the balance team before making this balance change.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
