### PR TITLE
refactor: remove unused var in medicine.dm

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -914,7 +914,6 @@
 					return
 
 				if(!M.suiciding && !HAS_TRAIT(M, TRAIT_HUSK) && !HAS_TRAIT(M, TRAIT_BADDNA))
-					var/time_dead = world.time - M.timeofdeath
 					M.visible_message("<span class='warning'>[M] seems to rise from the dead!</span>")
 					M.adjustCloneLoss(50)
 					M.setOxyLoss(0)


### PR DESCRIPTION
## What Does This PR Do
Removes an unused var.
## Why It's Good For The Game
Unused vars bad.
## Testing
Compiled.
## Changelog
NPFC