### PR TITLE
refactor: remove unused /turf/proc/reachableAdjacentTurfs

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -581,26 +581,6 @@
 /turf/AllowDrop()
 	return TRUE
 
-/**
- * Returns adjacent turfs to this turf that are reachable, in all cardinal directions
- *
- * Arguments:
- * * caller: The movable, if one exists, being used for mobility checks to see what tiles it can reach
- * * ID: An ID card that decides if we can gain access to doors that would otherwise block a turf
- * * simulated_only: Do we only worry about turfs with simulated atmos, most notably things that aren't space?
- * * no_id: When true, doors with public access will count as impassible
-*/
-/turf/proc/reachableAdjacentTurfs(caller, ID, simulated_only, no_id = FALSE)
-	var/static/space_type_cache = typecacheof(/turf/space)
-	. = list()
-
-	for(var/iter_dir in GLOB.cardinal)
-		var/turf/turf_to_check = get_step(src, iter_dir)
-		if(!turf_to_check || (simulated_only && space_type_cache[turf_to_check.type]))
-			continue
-		if(turf_to_check.density || LinkBlockedWithAccess(turf_to_check, caller, ID, no_id = no_id))
-			continue
-		. += turf_to_check
 
 // Makes an image of up to 20 things on a turf + the turf
 /turf/proc/photograph(limit = 20)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -581,7 +581,6 @@
 /turf/AllowDrop()
 	return TRUE
 
-
 // Makes an image of up to 20 things on a turf + the turf
 /turf/proc/photograph(limit = 20)
 	var/image/I = new()


### PR DESCRIPTION
## What Does This PR Do
This PR removes the unused `/turf/proc/reachableAdjacentTurfs`. It was last used before the initial JPS port, so it's been completely superseded by the new pathfinding features. 
## Why It's Good For The Game
Dead code bad.
## Testing
Compiled.
## Changelog
NPFC