### PR TITLE
Fixes radios permanently breaking

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -200,13 +200,13 @@
 	. = list()
 	// Returns a list of mobs who can hear any of the radios
 	var/list/speaker_coverage = list()
-	for(var/obj/item/radio/R as anything in radios)
+	for(var/obj/item/radio/R in radios)
 		var/obj/item/radio/borg/BR = R
 		if(istype(BR) && BR.myborg)
 			if(!BR.myborg.is_component_functioning("radio"))
 				continue //No power.
 
-		for(var/mob/listener as anything in R.listeners)
+		for(var/mob/listener in R.listeners)
 			speaker_coverage |= listener
 		
 		if(ismob(R.loc))


### PR DESCRIPTION
## What Does This PR Do
After any ghost that was listening to radios is fully deleted, all radios will break, permanently.

This fixes that.

## Why It's Good For The Game
; help maints

## Testing
Triggered the bug. Didn't happen.

## Changelog
:cl:
fix: Radios will no longer perma-break.
/:cl: