### PR TITLE
Add few ways to heal clone damage as Traitor and Vampire

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -661,10 +661,9 @@
 			dreamer.adjustToxLoss(-1)
 			dreamer.adjustOxyLoss(-1)
 			dreamer.adjustCloneLoss(-0.5)
-			if(dreamer.HasDisease(/datum/disease/critical/heart_failure))
-				if(prob(25))
-					for(var/datum/disease/critical/heart_failure/HF in dreamer.viruses)
-						HF.cure()
+			if(dreamer.HasDisease(/datum/disease/critical/heart_failure) && prob(25))
+				for(var/datum/disease/critical/heart_failure/HF in dreamer.viruses)
+					HF.cure()
 	dreamer.handle_dreams()
 	dreamer.adjustStaminaLoss(-10)
 	var/comfort = 1

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -659,6 +659,12 @@
 			dreamer.adjustBruteLoss(-1, FALSE)
 			dreamer.adjustFireLoss(-1, FALSE)
 			dreamer.adjustToxLoss(-1)
+			dreamer.adjustOxyLoss(-1)
+			dreamer.adjustCloneLoss(-0.5)
+			if(dreamer.HasDisease(/datum/disease/critical/heart_failure))
+				if(prob(25))
+					for(var/datum/disease/critical/heart_failure/HF in dreamer.viruses)
+						HF.cure()
 	dreamer.handle_dreams()
 	dreamer.adjustStaminaLoss(-10)
 	var/comfort = 1

--- a/code/game/gamemodes/miniantags/guardian/types/healer.dm
+++ b/code/game/gamemodes/miniantags/guardian/types/healer.dm
@@ -69,6 +69,7 @@
 				C.adjustFireLoss(-5, robotic=1)
 				C.adjustOxyLoss(-5)
 				C.adjustToxLoss(-5)
+				C.adjustCloneLoss(-1)
 				heal_cooldown = world.time + 1.5 SECONDS
 				if(C == summoner)
 					med_hud_set_health()

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -1559,6 +1559,7 @@
 						HF.cure() //Won't fix a stopped heart, but it will sure fix a critical one. Shock is not fixed as healing will fix it
 					for(var/obj/item/organ/O as anything in (H.internal_organs + H.bodyparts))
 						O.germ_level = 0
+					update_flags |= M.adjustCloneLoss(-4 * REAGENTS_EFFECT_MULTIPLIER, FALSE) // 60 clone one-use heal for 10 TC seems fair
 				if(M.health < 40)
 					update_flags |= M.adjustOxyLoss(-5 * REAGENTS_EFFECT_MULTIPLIER, FALSE)
 					update_flags |= M.adjustToxLoss(-1 * REAGENTS_EFFECT_MULTIPLIER, FALSE)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
- Sleeping in coffin as Vampire now heal your clone loss and allow to heal from crit, curing oxy damage and heart failure, making coffin a canonically good thing to use as vampire. I never believed that fool, who told me after few seconds on sun you will be permanently injured for the rest of your eternal life.
- Holoparasite healer now heal you from ALL possible damage in the game, adding heal 1 clone per tap. This is slow, but clone damage is intended to be hard damage to heal.
- Nanocalcium injector now heal you 60 clone damage. Cheap one-use version of holopara. For 10 TC being possible not goes into medbay seems fair.

## Why It's Good For The Game
Right now decloner is impossibly powerful weapon, deals permanent damage which can be healed once you give up and go to medbay, where always patrolling one or two sec, who with your previous damage is always salty situation nearly impossible to solve. 
Now vampires can use their coffin, who already heal toxins, to cure their wounds after REALLY TIGHT and long sleep. This is risky, but this is fully free medicine.
For traitors, they can now heal their clone damage, invest 10 TC for panacea injector, or invest 60 TC to nearly useless in battle medic helper, who can handle every possible trauma in the game. All purchases besides their power are very specific, traitor must save TC for extra heal or fully relate on second player, both of this is challenging to play.

## Images of changes
https://www.youtube.com/watch?v=q61tUDCItXo

## Testing
add numbers where they belong to be, tested, all work

## Changelog
:cl:
tweak: Heal in coffin as vampire now slowly heal clone damage and cure heart failure, allowing to sleep in crit and not die from cringe.
tweak: Nanocalcium injector for 10 TC now heal overall 60 clone damage
tweak: Holoparasite healer now heal 1 clone damage per tap. Slow, but honest work.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
