### PR TITLE
Fix admin PMs not working from discord

### DIFF
--- a/code/modules/world_topic/adminmsg.dm
+++ b/code/modules/world_topic/adminmsg.dm
@@ -28,12 +28,12 @@
 	C.last_discord_pm_time = 0
 
 	SEND_SOUND(C, sound('sound/effects/adminhelp.ogg'))
-	to_chat(C, message, , MESSAGE_TYPE_ADMINPM)
+	to_chat(C, message, MESSAGE_TYPE_ADMINPM)
 
 	for(var/client/A in GLOB.admins)
 		// GLOB.admins includes anyone with a holder datum (mentors too). This makes sure only admins see ahelps
 		if(check_rights(R_ADMIN, FALSE, A.mob))
 			if(A != C)
-				to_chat(A, amessage, , MESSAGE_TYPE_ADMINPM)
+				to_chat(A, amessage, MESSAGE_TYPE_ADMINPM)
 
 	return json_encode(list("success" = "Message Successful"))


### PR DESCRIPTION
## What Does This PR Do
Fixes the adminPM from out of game showing as just the text `adminpm`.

## Why It's Good For The Game
Stuff should work

## Testing
None.

## Changelog
:cl: AffectedArc07
fix: Fixed out of game admin PMs not displaying properly
/:cl:
