### PR TITLE
adds modular painter to maintenance drones

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -861,6 +861,7 @@
 		/obj/item/reagent_containers/spray/cleaner/drone,
 		/obj/item/soap,
 		/obj/item/t_scanner,
+		/obj/item/painter,
 		/obj/item/rpd,
 		/obj/item/analyzer,
 		/obj/item/stack/sheet/metal/cyborg/drone,


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
This PR gives the Maintenance drones the ability to use the floor painter module

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
This would allow maintenance drones to actually stay in maintenance working on their projects instead of wandering off and doing engineering things instead

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![image](https://github.com/ParadiseSS13/Paradise/assets/45021269/b1be3690-ec86-47cc-b52f-71654eb4277b)


## Testing
<!-- How did you test the PR, if at all? -->
had Spaghetti test it because for some reason I'm having trouble getting debug to launch anything and all the modules of the painter do seem to exist on the drone

## Changelog
:cl:
add: Added modular painter to maintenance drone

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
