### PR TITLE
Fix undestrictible armor from attachable armor

### DIFF
--- a/code/game/objects/items/stacks/sheets/leather.dm
+++ b/code/game/objects/items/stacks/sheets/leather.dm
@@ -214,7 +214,7 @@ GLOBAL_LIST_INIT(sinew_recipes, list (
 				to_chat(user, "<span class='notice'>You dont have enough [src] for this!</span>")
 				return
 			D.hides++
-			D.armor = D.armor.setRating(melee_value = min(D.armor.getRating(MELEE) + 25, 115))
+			D.armor = D.armor.setRating(melee_value = min(D.armor.getRating(MELEE) + 10, 70))
 			D.armor = D.armor.setRating(bullet_value = min(D.armor.getRating(BULLET) + 7, 60))
 			D.armor = D.armor.setRating(laser_value = min(D.armor.getRating(LASER) + 7, 60))
 			to_chat(user, "<span class='info'>You strengthen [target], improving its resistance against attacks.</span>")
@@ -258,7 +258,7 @@ GLOBAL_LIST_INIT(sinew_recipes, list (
 				return
 			use(1)
 			D.plates++
-			D.armor = D.armor.setRating(melee_value = min(D.armor.getRating(MELEE) + 10, 70))
+			D.armor = D.armor.setRating(melee_value = min(D.armor.getRating(MELEE) + 7, 60))
 			D.armor = D.armor.setRating(bullet_value = min(D.armor.getRating(BULLET) + 4, 50))
 			D.armor = D.armor.setRating(laser_value = min(D.armor.getRating(LASER) + 4, 50))
 			to_chat(user, "<span class='info'>You strengthen [target], improving its resistance against attacks.</span>")
@@ -294,7 +294,7 @@ GLOBAL_LIST_INIT(sinew_recipes, list (
 			D.drake_hides++
 			D.max_integrity += 50
 			D.obj_integrity += 50
-			D.armor = D.armor.setRating(melee_value = min(D.armor.getRating(MELEE) + 45, 175)) // 77.7% melee armor maximum
+			D.armor = D.armor.setRating(melee_value = min(D.armor.getRating(MELEE) + 13, 80))
 			D.armor = D.armor.setRating(bullet_value = min(D.armor.getRating(BULLET) + 7, 60))
 			D.armor = D.armor.setRating(laser_value = min(D.armor.getRating(LASER) + 7, 60))
 			to_chat(user, "<span class='info'>You strengthen [target], improving its resistance against attacks.</span>")

--- a/code/game/objects/items/stacks/sheets/leather.dm
+++ b/code/game/objects/items/stacks/sheets/leather.dm
@@ -204,7 +204,6 @@ GLOBAL_LIST_INIT(sinew_recipes, list (
 				return
 			C.armor = current_armor.setRating(melee_value = min(current_armor.getRating(MELEE) + 15, 75))
 			to_chat(user, "<span class='info'>You strengthen [target], improving its resistance against melee attacks.</span>")
-			use(1)
 		else
 			to_chat(user, "<span class='warning'>You can't improve [C] any further!</span>")
 	else if(istype(target, /obj/mecha/working/ripley))
@@ -256,7 +255,6 @@ GLOBAL_LIST_INIT(sinew_recipes, list (
 			if(!use(1))
 				to_chat(user, "<span class='notice'>You dont have enough [src] for this!</span>")
 				return
-			use(1)
 			D.plates++
 			D.armor = D.armor.setRating(melee_value = min(D.armor.getRating(MELEE) + 7, 60))
 			D.armor = D.armor.setRating(bullet_value = min(D.armor.getRating(BULLET) + 4, 50))
@@ -287,10 +285,9 @@ GLOBAL_LIST_INIT(sinew_recipes, list (
 	if(istype(target, /obj/mecha/working/ripley))
 		var/obj/mecha/working/ripley/D = target
 		if(D.drake_hides < DRAKE_HIDES_COVERED_FULL && !D.hides && !D.plates)
-			if(!use(1))
+			if(!use(3))
 				to_chat(user, "<span class='notice'>You dont have enough [src] for this!</span>")
 				return
-			use(1)
 			D.drake_hides++
 			D.max_integrity += 50
 			D.obj_integrity += 50


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes https://github.com/ParadiseSS13/Paradise/pull/25231 armor value, because i though there is human armor here. Now i fully understand and do proper armor this time. Dragon hide gain 79%, goliath 70%, metal plate is 51%. Like somewhat intended at first.

## Why It's Good For The Game
Invinsible mech is fun but salty to up against

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Tested, damage is takes good.

## Changelog
:cl:
fix: Fix armor value on attachable armor for Ripleys, make them destructible now
tweak: Now dragon hide need 9 sheets to make dragon ripley, as intended before.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
