### PR TITLE
fix: VV list display with values that are zero

### DIFF
--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -517,7 +517,7 @@
 				var/val
 				if(IS_NORMAL_LIST(L) && !isnum(key))
 					val = L[key]
-				if(!val)
+				if(isnull(val))
 					val = key
 					key = i
 
@@ -952,7 +952,7 @@
 					message_admins("<span class='notice'>[key_name(usr)] has added [amount] units of [chosen_id] to \the [A]</span>")
 
 	else if(href_list["editreagents"])
-		if(!check_rights(R_DEBUG|R_ADMIN))	
+		if(!check_rights(R_DEBUG|R_ADMIN))
 			return
 
 		var/atom/A = locateUID(href_list["editreagents"])


### PR DESCRIPTION
## What Does This PR Do
This PR fixes VV incorrectly displaying lists when the lists contain values that are zero.
## Why It's Good For The Game
Inscrutable variable inspection bad.
## Images of changes
Before:

![2024_05_24__18_18_49__Paradise Station 13](https://github.com/ParadiseSS13/Paradise/assets/59303604/1d1ecf69-5f69-467b-a4ba-e13f3843011c)

After:

![2024_05_24__18_10_04__Paradise Station 13](https://github.com/ParadiseSS13/Paradise/assets/59303604/613ff9ca-a963-45a6-b463-582099d4b035)


## Testing
Created some lists, cached them in GLOB.string_assoc_lists, inspected them.

## Changelog
NPFC
