### PR TITLE
Having a sting prepared when you lose your changeling status no longer makes you unable to use middle click

### DIFF
--- a/code/modules/antagonists/changeling/datum_changeling.dm
+++ b/code/modules/antagonists/changeling/datum_changeling.dm
@@ -79,9 +79,9 @@
 
 /datum/antagonist/changeling/Destroy()
 	SSticker.mode.changelings -= owner
-	chosen_sting = null
 	QDEL_LIST_CONTENTS(acquired_powers)
 	STOP_PROCESSING(SSobj, src)
+	chosen_sting = null
 	return ..()
 
 /datum/antagonist/changeling/greet()

--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -12,17 +12,21 @@
 	click_override = new(CALLBACK(src, PROC_REF(try_to_sting)))
 
 /datum/action/changeling/sting/Destroy(force, ...)
-	if(cling.owner.current && cling.owner.current.middleClickOverride == click_override) // this is a very scuffed way of doing this honestly
-		cling.owner.current.middleClickOverride = null
 	QDEL_NULL(click_override)
 	if(cling.chosen_sting == src)
-		cling.chosen_sting = null
+		unset_sting()
 	return ..()
 
 /datum/action/changeling/sting/Trigger(left_click)
 	if(!cling.chosen_sting)
 		set_sting()
 	else
+		unset_sting()
+
+/datum/action/changeling/sting/Remove(mob/remove_from)
+	. = ..()
+	// Check that cling exists because in certain scenarios, it may have been deleted in Destroy() first.
+	if(cling?.chosen_sting == src)
 		unset_sting()
 
 /datum/action/changeling/sting/proc/set_sting()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
If you happen to have any changeling sting prepared, such as extract DNA sting, and you get de-changeling'd, you will no longer have that sting "stuck" in your middle click spot. You will be able to use middle click normally again.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Testing
1. Spawn in
2. Changeling myself
3. Prepare the Extract DNA sting
4. De-changeling myself
5. I can use middle click for pointing again
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
Fix: Having a sting prepared when you lose your changeling status no longer makes you unable to use middle click
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
