### PR TITLE
Changelings now get an option to be revived by defibrillator when faking death

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -462,6 +462,10 @@
 	#define COMPONENT_BLOCK_DEFIB (1<<0)
 	/// If returned, don't even show the "failed" message, defer to the signal handler to do that.
 	#define COMPONENT_DEFIB_OVERRIDE (1<<1)
+	/// If returned, allow to revive through false death.
+	#define COMPONENT_DEFIB_FAKEDEATH_ACCEPTED (1<<2)
+	/// If returned, make the fake death look like a unresponsive ghost.
+	#define COMPONENT_DEFIB_FAKEDEATH_DENIED (1<<3)
 ///send from defibs on ressurection: (defibber, defib_item, ghost)
 #define COMSIG_LIVING_DEFIBBED "living_defibbed"
 ///from base of mob/living/revive() (full_heal, admin_revive)

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -879,7 +879,7 @@ so as to remain in compliance with the most up-to-date laws."
 	var/do_we_revive = FALSE
 	var/image/toggle_overlay
 
-/atom/movable/screen/alert/changeling_defib_revive/Initialize(mapload, parent_unit,)
+/atom/movable/screen/alert/changeling_defib_revive/Initialize(mapload, parent_unit)
 	. = ..()
 	var/image/defib_appearance = image(parent_unit)
 	defib_appearance.layer = FLOAT_LAYER
@@ -891,6 +891,8 @@ so as to remain in compliance with the most up-to-date laws."
 	RegisterSignal(owner, COMSIG_LIVING_DEFIBBED, PROC_REF(on_defib_revive))
 
 /atom/movable/screen/alert/changeling_defib_revive/Destroy()
+	if(owner)
+		UnregisterSignal(owner, COMSIG_LIVING_DEFIBBED)
 	if(toggle_overlay)
 		overlays -= toggle_overlay
 		qdel(toggle_overlay)

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -870,3 +870,56 @@ so as to remain in compliance with the most up-to-date laws."
 	if(!istype(usr))
 		return
 	living_owner.do_succumb(TRUE)
+
+/atom/movable/screen/alert/changeling_defib_revive
+	name = "Your heart is being defibrillated."
+	desc = "Click this status to be revived from fake death."
+	icon_state = "template"
+	timeout = 10 SECONDS
+	var/do_we_revive = FALSE
+	var/image/toggle_overlay
+
+/atom/movable/screen/alert/changeling_defib_revive/Initialize(mapload, parent_unit,)
+	. = ..()
+	var/image/defib_appearance = image(parent_unit)
+	defib_appearance.layer = FLOAT_LAYER
+	defib_appearance.plane = FLOAT_PLANE
+	overlays += defib_appearance
+
+/atom/movable/screen/alert/changeling_defib_revive/attach_owner(mob/new_owner)
+	. = ..()
+	RegisterSignal(owner, COMSIG_LIVING_DEFIBBED, PROC_REF(on_defib_revive))
+
+/atom/movable/screen/alert/changeling_defib_revive/Destroy()
+	if(toggle_overlay)
+		overlays -= toggle_overlay
+		qdel(toggle_overlay)
+	return ..()
+
+/atom/movable/screen/alert/changeling_defib_revive/Click()
+	if(!..())
+		return
+	do_we_revive = !do_we_revive
+	if(!toggle_overlay)
+		toggle_overlay = image('icons/mob/screen_gen.dmi', icon_state = "selector")
+		toggle_overlay.layer = FLOAT_LAYER
+		toggle_overlay.plane = FLOAT_PLANE + 2
+	if(do_we_revive)
+		overlays |= toggle_overlay
+	else
+		overlays -= toggle_overlay
+
+/atom/movable/screen/alert/changeling_defib_revive/proc/on_defib_revive()
+	. = COMPONENT_DEFIB_FAKEDEATH_DENIED
+	if(do_we_revive)
+		var/datum/antagonist/changeling/cling = owner.mind.has_antag_datum(/datum/antagonist/changeling)
+		cling.remove_specific_power(/datum/action/changeling/revive)
+		cling.regenerating = FALSE
+		var/heart_name = "heart"
+		if(iscarbon(owner))
+			var/mob/living/carbon/C = owner
+			var/datum/organ/heart/heart = C.get_int_organ_datum(ORGAN_DATUM_HEART)
+			heart_name = heart.linked_organ.name
+		to_chat(owner, "<span class='danger'>Electricity flows through our [heart_name]! We have been brought back to life and have stopped our regeneration.</span>")
+		. = COMPONENT_DEFIB_FAKEDEATH_ACCEPTED
+	owner.clear_alert("cling_defib")

--- a/code/datums/components/defibrillator.dm
+++ b/code/datums/components/defibrillator.dm
@@ -267,7 +267,7 @@
 			failure_message = "<span class='boldnotice'>[defib_ref] buzzes: Resuscitation failed - Patient's brain is unresponsive. Further attempts may succeed.</span>"
 		else if(signal_result & COMPONENT_DEFIB_FAKEDEATH_ACCEPTED)
 			// as much as I hate that this is here, it has to come after the `Patient is not in a valid state. Operation aborted.` check.
-			REMOVE_TRAIT(owner, TRAIT_FAKEDEATH, CHANGELING_TRAIT)
+			REMOVE_TRAIT(target, TRAIT_FAKEDEATH, CHANGELING_TRAIT)
 		else
 			failure_message = "<span class='boldnotice'>[defib_ref] buzzes: Resuscitation failed.</span>" // has a fakedeath like capulettium
 

--- a/code/datums/components/defibrillator.dm
+++ b/code/datums/components/defibrillator.dm
@@ -173,6 +173,11 @@
 		to_chat(ghost, "<span class='ghostalert'>Your heart is being defibrillated. Return to your body if you want to be revived!</span> (Verbs -> Ghost -> Re-enter corpse)")
 		window_flash(ghost.client)
 		SEND_SOUND(ghost, sound('sound/effects/genetics.ogg'))
+	else if(HAS_TRAIT_FROM(target, TRAIT_FAKEDEATH, CHANGELING_TRAIT))
+		to_chat(target, "<span class='ghostalert'>Your heart is being defibrillated. Click the defibrillator status to be revived!</span>")
+		window_flash(target.client)
+		SEND_SOUND(target, sound('sound/effects/genetics.ogg'))
+		target.throw_alert("cling_defib", /atom/movable/screen/alert/changeling_defib_revive, alert_args = list(parent, target))
 
 	if(!do_after(user, 3 SECONDS * speed_multiplier, target = target)) // Beginning to place the paddles on patient's chest to allow some time for people to move away to stop the process
 		busy = FALSE
@@ -238,37 +243,39 @@
 	playsound(get_turf(defib_ref), 'sound/machines/defib_zap.ogg', 50, 1, -1)
 	ghost = target.get_ghost(TRUE) // We have to double check whether the dead guy has entered their body during the above
 
-	var/defib_success = TRUE
-
 	// Run through some quick failure states after shocking.
 	var/time_dead = world.time - target.timeofdeath
 
+	var/failure_message
 	if(!target.is_revivable())
-		user.visible_message("<span class='boldnotice'>[defib_ref] buzzes: Resuscitation failed - Heart tissue damage beyond point of no return for defibrillation.</span>")
-		defib_success = FALSE
+		failure_message = "<span class='boldnotice'>[defib_ref] buzzes: Resuscitation failed - Heart tissue damage beyond point of no return for defibrillation.</span>"
 	else if(target.getBruteLoss() >= 180 || target.getFireLoss() >= 180)
-		user.visible_message("<span class='boldnotice'>[defib_ref] buzzes: Resuscitation failed - Severe tissue damage detected.</span>")
-		defib_success = FALSE
+		failure_message = "<span class='boldnotice'>[defib_ref] buzzes: Resuscitation failed - Severe tissue damage detected.</span>"
 	else if(HAS_TRAIT(target, TRAIT_HUSK))
-		user.visible_message("<span class='boldnotice'>[defib_ref] buzzes: Resuscitation failed - Subject is husked.</span>")
-		defib_success = FALSE
+		failure_message = "<span class='boldnotice'>[defib_ref] buzzes: Resuscitation failed - Subject is husked.</span>"
 	else if(target.blood_volume < BLOOD_VOLUME_SURVIVE)
-		user.visible_message("<span class='boldnotice'>[defib_ref] buzzes: Resuscitation failed - Patient blood volume critically low.</span>")
-		defib_success = FALSE
+		failure_message = "<span class='boldnotice'>[defib_ref] buzzes: Resuscitation failed - Patient blood volume critically low.</span>"
 	else if(!target.get_organ_slot("brain"))  // So things like headless clings don't get outed
-		user.visible_message("<span class='boldnotice'>[defib_ref] buzzes: Resuscitation failed - No brain detected within patient.</span>")
-		defib_success = FALSE
+		failure_message = "<span class='boldnotice'>[defib_ref] buzzes: Resuscitation failed - No brain detected within patient.</span>"
 	else if(ghost)
 		if(!ghost.can_reenter_corpse || target.suiciding) // DNR or AntagHUD
-			user.visible_message("<span class='boldnotice'>[defib_ref] buzzes: Resuscitation failed - No electrical brain activity detected.</span>")
+			failure_message = "<span class='boldnotice'>[defib_ref] buzzes: Resuscitation failed - No electrical brain activity detected.</span>"
 		else
-			user.visible_message("<span class='boldnotice'>[defib_ref] buzzes: Resuscitation failed - Patient's brain is unresponsive. Further attempts may succeed.</span>")
-		defib_success = FALSE
-	else if((signal_result & COMPONENT_BLOCK_DEFIB) || HAS_TRAIT(target, TRAIT_FAKEDEATH) || HAS_TRAIT(target, TRAIT_BADDNA) || target.suiciding)  // these are a bit more arbitrary
-		user.visible_message("<span class='boldnotice'>[defib_ref] buzzes: Resuscitation failed.</span>")
-		defib_success = FALSE
+			failure_message = "<span class='boldnotice'>[defib_ref] buzzes: Resuscitation failed - Patient's brain is unresponsive. Further attempts may succeed.</span>"
+	else if(HAS_TRAIT(target, TRAIT_FAKEDEATH))
+		if(signal_result & COMPONENT_DEFIB_FAKEDEATH_DENIED)
+			failure_message = "<span class='boldnotice'>[defib_ref] buzzes: Resuscitation failed - Patient's brain is unresponsive. Further attempts may succeed.</span>"
+		else if(signal_result & COMPONENT_DEFIB_FAKEDEATH_ACCEPTED)
+			// as much as I hate that this is here, it has to come after the `Patient is not in a valid state. Operation aborted.` check.
+			REMOVE_TRAIT(owner, TRAIT_FAKEDEATH, CHANGELING_TRAIT)
+		else
+			failure_message = "<span class='boldnotice'>[defib_ref] buzzes: Resuscitation failed.</span>" // has a fakedeath like capulettium
 
-	if(!defib_success)
+	else if((signal_result & COMPONENT_BLOCK_DEFIB) || HAS_TRAIT(target, TRAIT_BADDNA) || target.suiciding)  // these are a bit more arbitrary
+		failure_message = "<span class='boldnotice'>[defib_ref] buzzes: Resuscitation failed.</span>"
+
+	if(failure_message)
+		user.visible_message(failure_message)
 		playsound(get_turf(defib_ref), 'sound/machines/defib_failed.ogg', 50, 0)
 	else
 		// Heal each basic damage type by as much as we're under -100 health
@@ -313,7 +320,7 @@
 		target.med_hud_set_status()
 		add_attack_logs(user, target, "Revived with [defib_ref]")
 		SSblackbox.record_feedback("tally", "players_revived", 1, "defibrillator")
-	SEND_SIGNAL(parent, COMSIG_DEFIB_SHOCK_APPLIED, user, target, should_cause_harm, defib_success)
+	SEND_SIGNAL(parent, COMSIG_DEFIB_SHOCK_APPLIED, user, target, should_cause_harm, isnull(failure_message))
 	set_cooldown(cooldown)
 	busy = FALSE
 

--- a/code/modules/antagonists/changeling/changeling_power.dm
+++ b/code/modules/antagonists/changeling/changeling_power.dm
@@ -24,7 +24,7 @@
 	var/req_stat = CONSCIOUS
 	/// If this power is active or not. Used for toggleable abilities.
 	var/active = FALSE
-	/// If this power can be used while the changeling has the `TRAIT_FAKE_DEATH` trait.
+	/// If this power can be used while the changeling has the `TRAIT_FAKEDEATH` trait.
 	var/bypass_fake_death = FALSE
 
 /*

--- a/code/modules/antagonists/changeling/datum_changeling.dm
+++ b/code/modules/antagonists/changeling/datum_changeling.dm
@@ -278,6 +278,22 @@ RESTRICT_TYPE(/datum/antagonist/changeling)
 	power.on_purchase(changeling || owner.current, src)
 
 /**
+ * Removes all `power_type` abilities that the changeling has. Refunds the cost of the power from our genetic points.
+ *
+ * Arugments:
+ * * datum/action/changeling/power - the typepath power to remove from the changeling.
+ * * refund_cost - if we should refund genetic points when giving the power
+ */
+/datum/antagonist/changeling/proc/remove_specific_power(datum/action/changeling/power_type, refund_cost = TRUE)
+	for(var/datum/action/changeling/power in acquired_powers)
+		if(!istype(power, power_type))
+			continue
+		if(refund_cost)
+			genetic_points -= power.dna_cost
+		acquired_powers -= power
+		qdel(power)
+
+/**
  * Store the languages from the `new_languages` list into the `absorbed_languages` list. Teaches the changeling the new languages.
  *
  * Arguments:

--- a/code/modules/antagonists/changeling/powers/fakedeath.dm
+++ b/code/modules/antagonists/changeling/powers/fakedeath.dm
@@ -18,11 +18,14 @@
 	user.updatehealth("fakedeath sting")
 	cling.regenerating = TRUE
 
+	cling.remove_specific_power(/datum/action/changeling/revive)
 	addtimer(CALLBACK(src, PROC_REF(ready_to_regenerate), user), CHANGELING_FAKEDEATH_TIME)
 	SSblackbox.record_feedback("nested tally", "changeling_powers", 1, list("[name]"))
 	return TRUE
 
 /datum/action/changeling/fakedeath/proc/ready_to_regenerate(mob/user)
+	if(!HAS_TRAIT_FROM(user, TRAIT_FAKEDEATH, CHANGELING_TRAIT))
+		return
 	if(!QDELETED(user) && user.mind && cling?.acquired_powers)
 		to_chat(user, "<span class='notice'>We are ready to regenerate.</span>")
 		cling.give_power(new /datum/action/changeling/revive)

--- a/code/modules/antagonists/changeling/powers/revive.dm
+++ b/code/modules/antagonists/changeling/powers/revive.dm
@@ -11,7 +11,7 @@
 	if(HAS_TRAIT(user, TRAIT_UNREVIVABLE))
 		to_chat(user, "<span class='notice'>Something is preventing us from regenerating, we will need to revive at another point.</span>")
 		return FALSE
-	if(!HAS_TRAIT_FROM(target, TRAIT_FAKEDEATH, CHANGELING_TRAIT))
+	if(!HAS_TRAIT_FROM(user, TRAIT_FAKEDEATH, CHANGELING_TRAIT))
 		cling.acquired_powers -= src
 		Remove(user)
 		return

--- a/code/modules/antagonists/changeling/powers/revive.dm
+++ b/code/modules/antagonists/changeling/powers/revive.dm
@@ -11,6 +11,10 @@
 	if(HAS_TRAIT(user, TRAIT_UNREVIVABLE))
 		to_chat(user, "<span class='notice'>Something is preventing us from regenerating, we will need to revive at another point.</span>")
 		return FALSE
+	if(!HAS_TRAIT_FROM(target, TRAIT_FAKEDEATH, CHANGELING_TRAIT))
+		cling.acquired_powers -= src
+		Remove(user)
+		return
 	REMOVE_TRAIT(user, TRAIT_FAKEDEATH, CHANGELING_TRAIT)
 	for(var/obj/item/grab/G in user.grabbed_by)
 		var/mob/living/carbon/M = G.assailant


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
When a changeling is faking death, and they get defibrillated, they can now be revived like any normal dead person.

If the changeling accepts, it will appear like a normal defib happened, and the changeling loses all aheal/revive powers
If the changeling denies (doesn't click on the status) it will appear like the ghost isn't in the body
If its a non-changeling form of fake death, like capulettium, it will appear like it used to.

A white-box will appear around the status effect to indicate it has been accepted. It can be toggled for the 5-seconds while being defibbed, by default it is off.

Also adds more safeties to the cling Revive power to prevent it from being stacked or from being used while alive.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Its very awkward when a changeling is forced to revive or be cloned or just left in morgue because security is watching their body like a hawk because the defib failed for no clear reason. Helps against security meta-ing changelings.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![image](https://github.com/ParadiseSS13/Paradise/assets/91113370/c13f680b-d827-44ed-988f-c565ade754e6)


## Testing
<!-- How did you test the PR, if at all? -->
2 clients, revived myself a bunch.
I want to do more testing before undrafting.

## Changelog
:cl:
add: Changelings now get an option to be revived by defibrillator when faking death
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
