### PR TITLE
Hivelord cores now fix bones / burn wounds / ib in space, ruins, and depot

### DIFF
--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -449,6 +449,11 @@
 	duration = 1 MINUTES
 	status_type = STATUS_EFFECT_REPLACE
 	alert_type = /atom/movable/screen/alert/status_effect/regenerative_core
+	var/regen_type_applied
+
+/datum/status_effect/regenerative_core/on_creation(mob/living/new_owner, incoming_type)
+	regen_type_applied = incoming_type
+	return ..()
 
 /datum/status_effect/regenerative_core/on_apply()
 	ADD_TRAIT(owner, TRAIT_IGNOREDAMAGESLOWDOWN, id)
@@ -458,13 +463,24 @@
 	if(ishuman(owner))
 		var/mob/living/carbon/human/H = owner
 		H.bodytemperature = H.dna.species.body_temperature
-		if(is_mining_level(H.z) || istype(get_area(H), /area/ruin/space/bubblegum_arena))
-			for(var/obj/item/organ/external/E in H.bodyparts)
-				E.fix_internal_bleeding()
-				E.fix_burn_wound()
-				E.mend_fracture()
-		else
-			to_chat(owner, "<span class='warning'>...But the core was weakened, it is not close enough to the rest of the legions of the necropolis.</span>")
+		if(regen_type_applied == "Legion")
+			if(is_mining_level(H.z) || istype(get_area(H), /area/ruin/space/bubblegum_arena))
+				for(var/obj/item/organ/external/E in H.bodyparts)
+					E.fix_internal_bleeding()
+					E.fix_burn_wound()
+					E.mend_fracture()
+			else
+				to_chat(owner, "<span class='warning'>...But the core was weakened, it is not close enough to the rest of the legions of the necropolis.</span>")
+			return TRUE
+		if(regen_type_applied == "Hivelord")
+			var/area/A = get_area(H)
+			if(isspaceturf(get_turf(H)) || isspacearea(A) || istype(A, /area/syndicate_depot) || istype(A, /area/ruin/space) || istype(A, /area/shuttle))
+				for(var/obj/item/organ/external/E in H.bodyparts)
+					E.fix_internal_bleeding()
+					E.fix_burn_wound()
+					E.mend_fracture()
+			else
+				to_chat(owner, "<span class='warning'>...But the core was weakened, it is not close enough to the stars to absorb solar radiation...</span>")
 	else
 		owner.bodytemperature = BODYTEMP_NORMAL
 	return TRUE

--- a/code/modules/mining/equipment/regenerative_core.dm
+++ b/code/modules/mining/equipment/regenerative_core.dm
@@ -29,6 +29,8 @@
 	actions_types = list(/datum/action/item_action/organ_action/use)
 	var/inert = 0
 	var/preserved = 0
+	///Is this a hivelord or legion core?
+	var/core_type = "Hivelord"
 
 /obj/item/organ/internal/regenerative_core/Initialize(mapload)
 	. = ..()
@@ -84,7 +86,7 @@
 			else
 				to_chat(user, "<span class='notice'>You start to smear [src] on yourself. Disgusting tendrils hold you together and allow you to keep moving, but for how long?</span>")
 				SSblackbox.record_feedback("nested tally", "hivelord_core", 1, list("[type]", "used", "self"))
-			H.apply_status_effect(STATUS_EFFECT_REGENERATIVE_CORE)
+			H.apply_status_effect(STATUS_EFFECT_REGENERATIVE_CORE, core_type)
 			user.drop_item()
 			qdel(src)
 
@@ -115,6 +117,7 @@
 /obj/item/organ/internal/regenerative_core/legion
 	desc = "A strange rock that crackles with power. It can be used to heal completely, but it will rapidly decay into uselessness."
 	icon_state = "legion_soul"
+	core_type = "Legion"
 
 /obj/item/organ/internal/regenerative_core/legion/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Hivelord cores, from the hivelord simplemob, heal IB, broken bones, burnwounds, in space, space ruins, shuttles, and depot.

They do not heal on station, lavaland, or  other non ruin or shuttle areas.

Legion cores still only heal on lavaland (or the bubblegum arena)

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Much like legion cores only heal on lavaland, we make these bad boys only heal in space, where they should be used.

Yes, this will be a bit strong, but it is what they are for! If they are in the middle of the station, they won't be able to do it.

If people (balance) want, I can make it not work at all on the station zlvl due to gravity generator radiation or something (outside of being implanted as usual)

## Testing
<!-- How did you test the PR, if at all? -->
Used the cores in space, in shuttles, on lavaland, with the various types. Double checking depot quickly as we speak

## Changelog
:cl:
tweak: Hivelord cores now fix bones / burn wounds / ib in space, ruins, and depot
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
