### PR TITLE
Don't try to calculate sound falloff at or below the minimum distance.

### DIFF
--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -106,7 +106,7 @@ falloff_distance - Distance at which falloff begins. Sound is at peak volume (in
 
 		distance *= distance_multiplier
 
-		if(max_distance) //If theres no max_distance we're not a 3D sound, so no falloff.
+		if(max_distance && distance > falloff_distance) //If theres no max_distance we're not a 3D sound, so no falloff.
 			S.volume -= (max(distance - falloff_distance, 0) ** (1 / falloff_exponent)) / ((max(max_distance, distance) - falloff_distance) ** (1 / falloff_exponent)) * S.volume
 			//https://www.desmos.com/calculator/sqdfl8ipgf
 


### PR DESCRIPTION
## What Does This PR Do
Fixes an old bug imported from TG by #15608, where we try to calculate sound falloff at or below the minimum falloff distance.

## Why It's Good For The Game
Bugs bad.

## Testing
It compiles.

## Changelog
:cl:
fix: Fixed a bug that could cause sounds to not play or play too loudly at close range.
/:cl: