### PR TITLE
Adds Logging for Buckling

### DIFF
--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -142,10 +142,15 @@
 			M.visible_message("<span class='notice'>[M] buckles [M.p_themselves()] to [src].</span>",\
 				"<span class='notice'>You buckle yourself to [src].</span>",\
 				"<span class='italics'>You hear metal clanking.</span>")
+			M.create_log(ATTACK_LOG, "Buckles [M.p_themselves()] to [src]", M)
+			log_attack(M, M, "Buckles themselves to [src]")
 		else
 			M.visible_message("<span class='warning'>[user] buckles [M] to [src]!</span>",\
 				"<span class='warning'>[user] buckles you to [src]!</span>",\
 				"<span class='italics'>You hear metal clanking.</span>")
+			user.create_log(ATTACK_LOG, "[user] has buckled [M] to [src]", M)
+			M.create_log(DEFENSE_LOG, "[M] has been buckled by [user] to [src]", user)
+			log_attack(user, M, "Buckled to [src]")
 		M.pulledby?.stop_pulling()
 
 /atom/movable/proc/user_unbuckle_mob(mob/living/buckled_mob, mob/user)
@@ -155,10 +160,15 @@
 			M.visible_message("<span class='notice'>[user] unbuckles [M] from [src].</span>",\
 				"<span class='notice'>[user] unbuckles you from [src].</span>",\
 				"<span class='italics'>You hear metal clanking.</span>")
+			user.create_log(ATTACK_LOG, "[user] has unbuckled [M] from [src]", M)
+			M.create_log(DEFENSE_LOG, "[M] has been unbuckled by [user] from [src]", user)
+			log_attack(user, M, "Unbuckled from [src]")
 		else
 			M.visible_message("<span class='notice'>[M] unbuckles [M.p_themselves()] from [src].</span>",\
 				"<span class='notice'>You unbuckle yourself from [src].</span>",\
 				"<span class='italics'>You hear metal clanking.</span>")
+			M.create_log(ATTACK_LOG, "Unbuckles [M.p_themselves()] from [src]", M)
+			log_attack(M, M, "Unbuckles themselves from [src]")
 		add_fingerprint(user)
 	return M
 


### PR DESCRIPTION
## What Does This PR Do
This PR implements logging for Buckling. It includes the integration of logging features into both the in-game player logs and the game log. 

## Why It's Good For The Game
Logging is important to the administrative process. It helps to provide a better picture of events that have taken place during a round.

## Images of changes
![Oo1q6HWvAs](https://github.com/ParadiseSS13/Paradise/assets/116982774/8c2b1825-f601-46e3-8e8f-fc039cc7b02d)
![KJyUTvMjhz](https://github.com/ParadiseSS13/Paradise/assets/116982774/25b170bd-3202-48e3-a3f6-47e4e4b40eb0)
![Fleet_sNFGTBflzH](https://github.com/ParadiseSS13/Paradise/assets/116982774/1a29c406-36ab-4b38-9f2c-15b108e72cbb)

## Testing
Buckled a mob into a chair, then unbuckled it. 
Took control of a mob, buckled and then unbuckled it. 
Reviewed the logs for the intended updates.

## Changelog
NPFC
