### PR TITLE
AI eyes with relay speech effects the AI with voice of god if the ai eye has relay speech

### DIFF
--- a/code/modules/surgery/organs/vocal_cords.dm
+++ b/code/modules/surgery/organs/vocal_cords.dm
@@ -167,9 +167,9 @@ GLOBAL_DATUM_INIT(multispin_words, /regex, regex("like a record baby"))
 				if(H.check_ear_prot() >= HEARING_PROTECTION_TOTAL)
 					continue
 			if(istype(L, /mob/camera/aiEye))
-				var/mob/camera/aiEye/AEAIO = L
-				if(AEAIO.relay_speech && AEAIO.ai)
-					listeners += AEAIO.ai
+				var/mob/camera/aiEye/ai_eye = L
+				if(ai_eye.relay_speech && ai_eye.ai)
+					listeners += ai_eye.ai
 			else
 				listeners += L
 

--- a/code/modules/surgery/organs/vocal_cords.dm
+++ b/code/modules/surgery/organs/vocal_cords.dm
@@ -166,7 +166,12 @@ GLOBAL_DATUM_INIT(multispin_words, /regex, regex("like a record baby"))
 				var/mob/living/carbon/human/H = L
 				if(H.check_ear_prot() >= HEARING_PROTECTION_TOTAL)
 					continue
-			listeners += L
+			if(istype(L, /mob/camera/aiEye))
+				var/mob/camera/aiEye/AEAIO = L
+				if(AEAIO.relay_speech && AEAIO.ai)
+					listeners += AEAIO.ai
+			else
+				listeners += L
 
 	if(!length(listeners))
 		next_command = world.time + cooldown_none


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

AI eyes (and other camera eyes) no longer runtime when VOG is used near them, breaking VOG

Instead, if it is a normal camera eye, nothing happens.

If it is a ai camera eye that has the "hear from it's camera" function, it instead will be affected as well by the VOG! Fun for the whole family!

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Runtimes bad.
Funny niche interactions good!

## Testing
<!-- How did you test the PR, if at all? -->

Used vog, no runtime, ai unaffected.
Used VOG with relay speach, AI affected.

## Changelog
:cl:
tweak: AI eyes with relay speech effects the AI with voice of god if the ai eye has relay speech
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
