### PR TITLE
Adds Ctrl Shift Click to radio, fixes issue with uplink

### DIFF
--- a/code/game/objects/items/devices/radio/radio_objects.dm
+++ b/code/game/objects/items/devices/radio/radio_objects.dm
@@ -138,6 +138,14 @@ GLOBAL_LIST_EMPTY(deadsay_radio_systems)
 	to_chat(user, "<span class='notice'>You <b>[broadcasting ? "enable" : "disable"]</b> [src]'s hotmic!</span>")
 	add_fingerprint(user)
 
+/obj/item/radio/CtrlShiftClick(mob/user)
+	if(user.stat || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED) || !Adjacent(user) || !istype(user))
+		return
+
+	ToggleReception()
+	to_chat(user, "<span class='notice'>You <b>[listening ? "enable" : "disable"]</b> [src]'s speaker!</span>")
+	add_fingerprint(user)
+
 /obj/item/radio/ui_state(mob/user)
 	return GLOB.default_state
 
@@ -541,9 +549,15 @@ GLOBAL_LIST_EMPTY(deadsay_radio_systems)
 
 	return null
 
+/obj/item/radio/proc/show_examine_hotkeys()
+	. = list()
+	. += "<span class='notice'><b>Alt-Click</b> to toggle [src]'s hotmic!</span>"
+	. += "<span class='notice'><b>Ctrl-Shift-Click</b> to toggle [src]'s speaker!</span>"
+
 /obj/item/radio/examine(mob/user)
 	. = ..()
-	. += "<span class='notice'><b>Alt-Click</b> to toggle [src]'s hotmic!</span>"
+	. += show_examine_hotkeys()
+
 	if(in_range(src, user) || loc == user)
 		if(b_stat)
 			. += "<span class='notice'>\the [src] can be attached and modified!</span>"

--- a/code/game/objects/items/devices/radio/radio_objects.dm
+++ b/code/game/objects/items/devices/radio/radio_objects.dm
@@ -131,19 +131,19 @@ GLOBAL_LIST_EMPTY(deadsay_radio_systems)
 	ui_interact(user)
 
 /obj/item/radio/AltClick(mob/user)
-	if(user.stat || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED) || !Adjacent(user) || !istype(user))
+	if(!istype(user) || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED) || !Adjacent(user))
 		return
 
 	ToggleBroadcast()
-	to_chat(user, "<span class='notice'>You <b>[broadcasting ? "enable" : "disable"]</b> [src]'s hotmic!</span>")
+	to_chat(user, "<span class='notice'>You <b>[broadcasting ? "enable" : "disable"]</b> [src]'s hotmic.</span>")
 	add_fingerprint(user)
 
 /obj/item/radio/CtrlShiftClick(mob/user)
-	if(user.stat || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED) || !Adjacent(user) || !istype(user))
+	if(!istype(user) || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED) || !Adjacent(user))
 		return
 
 	ToggleReception()
-	to_chat(user, "<span class='notice'>You <b>[listening ? "enable" : "disable"]</b> [src]'s speaker!</span>")
+	to_chat(user, "<span class='notice'>You <b>[listening ? "enable" : "disable"]</b> [src]'s speaker.</span>")
 	add_fingerprint(user)
 
 /obj/item/radio/ui_state(mob/user)
@@ -551,8 +551,8 @@ GLOBAL_LIST_EMPTY(deadsay_radio_systems)
 
 /obj/item/radio/proc/show_examine_hotkeys()
 	. = list()
-	. += "<span class='notice'><b>Alt-Click</b> to toggle [src]'s hotmic!</span>"
-	. += "<span class='notice'><b>Ctrl-Shift-Click</b> to toggle [src]'s speaker!</span>"
+	. += "<span class='notice'><b>Alt-Click</b> to toggle [src]'s hotmic.</span>"
+	. += "<span class='notice'><b>Ctrl-Shift-Click</b> to toggle [src]'s speaker.</span>"
 
 /obj/item/radio/examine(mob/user)
 	. = ..()
@@ -563,6 +563,10 @@ GLOBAL_LIST_EMPTY(deadsay_radio_systems)
 			. += "<span class='notice'>\the [src] can be attached and modified!</span>"
 		else
 			. += "<span class='notice'>\the [src] can not be modified or attached!</span>"
+
+/obj/item/radio/examine_more(mob/user)
+	. = ..()
+	. += "<span class='notice'>You can transmit messages from [src] without the hotmic by using <b>:l</b> or <b>:r</b> whilst holding it in your left or right hand.</span>"
 
 /obj/item/radio/screwdriver_act(mob/user, obj/item/I)
 	. = TRUE

--- a/code/game/objects/items/devices/uplinks.dm
+++ b/code/game/objects/items/devices/uplinks.dm
@@ -405,6 +405,15 @@ GLOBAL_LIST_EMPTY(world_uplinks)
 	hidden_uplink = new(src)
 	icon_state = "radio"
 
+/obj/item/radio/uplink/AltClick()
+	return
+
+/obj/item/radio/uplink/CtrlShiftClick()
+	return
+
+/obj/item/radio/uplink/show_examine_hotkeys()
+	return list()
+
 /obj/item/radio/uplink/attack_self(mob/user as mob)
 	if(hidden_uplink)
 		hidden_uplink.trigger(user)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Re-opens [PR](https://github.com/ParadiseSS13/Paradise/pull/25554) 
We've been testing this change on our downstream for a while now before the Alt+Click update came out, and we found an issue where someone (accidentally or on purpose) presses Alt+Click on Uplinks and speaks into a public channel and no one realizes how it happens and complains about it. This PR fixes this issue and also adds Ctrl+Shift+Click for broadcasting, which has already been tested on our downstream and this update went well.

## Why It's Good For The Game
More functions, less bugs.

## Images of changes
![image](https://github.com/ParadiseSS13/Paradise/assets/20109643/903223c9-9acb-4fee-be45-f33c06275fcc)

## Testing
Tested in-game

## Changelog
:cl:
add: Added Ctrl+Shift+Click to broadcast for radio
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
