### PR TITLE
fix: fix APC behavior in unpowered areas

### DIFF
--- a/code/game/machinery/cell_charger.dm
+++ b/code/game/machinery/cell_charger.dm
@@ -74,7 +74,7 @@
 			var/area/a = loc.loc // Gets our locations location, like a dream within a dream
 			if(!isarea(a))
 				return
-			if(!a.powernet.equipment_powered) // There's no APC in this area, don't try to cheat power!
+			if(!a.powernet.has_power(PW_CHANNEL_EQUIPMENT)) // There's no APC in this area, don't try to cheat power!
 				to_chat(user, "<span class='warning'>[src] blinks red as you try to insert the cell!</span>")
 				return
 			if(!user.drop_item())

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -49,7 +49,7 @@
 
 	//Checks to make sure he's not in space doing it, and that the area got proper power.
 	var/area/A = get_area(src)
-	if(!istype(A) || !A.powernet.equipment_powered)
+	if(!istype(A) || !A.powernet.has_power(PW_CHANNEL_EQUIPMENT))
 		to_chat(user, "<span class='warning'>[src] blinks red as you try to insert [G].</span>")
 		return
 

--- a/code/modules/power/apc/apc.dm
+++ b/code/modules/power/apc/apc.dm
@@ -166,17 +166,21 @@
 
 /obj/machinery/power/apc/Initialize(mapload)
 	. = ..()
+
+	var/area/A = get_area(src)
+
+	if(A.powernet && !A.powernet.powernet_apc)
+		A.powernet.powernet_apc = src
+
 	if(!mapload)
 		return
+
 	electronics_state = APC_ELECTRONICS_SECURED
 	// is starting with a power cell installed, create it and set its charge level
 	if(cell_type)
 		cell = new /obj/item/stock_parts/cell/upgraded(src)
 		cell.maxcharge = cell_type	// cell_type is maximum charge (old default was 1000 or 2500 (values one and two respectively)
 		cell.charge = start_charge * cell.maxcharge / 100 		// (convert percentage to actual value)
-
-	var/area/A = get_area(src)
-
 
 	//if area isn't specified use current
 	if(keep_preset_name)

--- a/code/modules/power/lights.dm
+++ b/code/modules/power/lights.dm
@@ -618,13 +618,13 @@
 // if a light is turned off, it won't activate emergency power
 /obj/machinery/light/proc/turned_off()
 	var/area/machine_area = get_area(src)
-	return !machine_area.lightswitch && machine_area.powernet.lighting_powered
+	return !machine_area.lightswitch && machine_area.powernet.has_power(PW_CHANNEL_LIGHTING)
 
 // returns whether this light has power
 // true if area has power and lightswitch is on
 /obj/machinery/light/has_power()
 	var/area/machine_area = get_area(src)
-	return machine_area.lightswitch && machine_area.powernet.lighting_powered
+	return machine_area.lightswitch && machine_area.powernet.has_power(PW_CHANNEL_LIGHTING)
 
 // attempts to set emergency lights
 /obj/machinery/light/proc/set_emergency_lights()
@@ -809,7 +809,7 @@
 /obj/machinery/light/power_change()
 	var/area/A = get_area(src)
 	if(A)
-		seton(A.lightswitch && A.powernet.lighting_powered)
+		seton(A.lightswitch && A.powernet.has_power(PW_CHANNEL_LIGHTING))
 
 // called when on fire
 

--- a/code/modules/power/powernets/local_powernet.dm
+++ b/code/modules/power/powernets/local_powernet.dm
@@ -105,7 +105,9 @@
 		return FALSE
 	if(power_flags & PW_ALWAYS_POWERED) //if this powernet is always powered, we always return TRUE
 		return TRUE
-	if(powernet_apc?.stat & (BROKEN|MAINT)) //no working apc, no power
+	if(!powernet_apc)
+		return FALSE
+	if(powernet_apc.stat & (BROKEN|MAINT)) //no working apc, no power
 		return FALSE
 
 	switch(channel)

--- a/code/modules/power/powernets/local_powernet.dm
+++ b/code/modules/power/powernets/local_powernet.dm
@@ -107,7 +107,7 @@
 		return TRUE
 	if(!powernet_apc)
 		return FALSE
-	if(powernet_apc.stat & (BROKEN|MAINT)) //no working apc, no power
+	if(powernet_apc.stat & (BROKEN|MAINT)) // no working apc, no power
 		return FALSE
 
 	switch(channel)


### PR DESCRIPTION
## What Does This PR Do
This PR sets powernets' APC when the APC is initialized. This wasn't getting set _anywhere_, even for station areas, but that wasn't noticeable because changes in power availability would cause power_change() calls for the affected powernet's machines. This means that machines installed in an unpowered area will be reliably powered when an APC is installed and charged.

This allows us to make it so that powernets without APCs qualify as having no power. This is meant to be the case but the proc in question skipped over ensuring the presence of an APC and went straight to checking whether the channels were enabled, which they are by default.

It also switches lights and chargers to using this proc so they can't avoid the check either. Again, this wasn't noticeable because when the APC runs out of charge it automatically sets the channels to off. 
## Why It's Good For The Game
Unpowered areas should be unpowered. Explorers' lives should be harder.
## Testing
Spawned an unpowered space ruin. Built a computer and autolathe on the ruin. Ensured they were unpowered. Installed a light frame and tube into an unpowered ruin. Ensured it was unpowered. Attached an APC frame to the wall, ensured emergency lighting activated. Finished building APC and added a cell, ensured that machine installed before APC now had power. Jumped to another ruin of the same type and area. Built an autolathe, ensured it didn't leech power from the other ruin. Built APC frames, ensured an APC could be installed in the second ruin, and only one could be installed. Spawned in on station, confirmed I didn't break everything.
## Changelog
:cl:
fix: Areas without APC now properly lack power.
fix: Machines built in areas without APC should now properly function when the APC is built and powered.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
