### PR TITLE
improves singularity when loosed, by fixing it not eating anything. Deletes performance.

### DIFF
--- a/code/modules/power/engines/singularity/singularity.dm
+++ b/code/modules/power/engines/singularity/singularity.dm
@@ -306,8 +306,6 @@
 					X.singularity_pull(src, current_size)
 				else
 					consume(X)
-			if(TICK_CHECK)
-				return // You've eaten enough. Prevents weirdness like the singulo eating the containment on stage 2
 
 
 /obj/singularity/proc/consume(atom/A)

--- a/code/modules/power/engines/singularity/singularity.dm
+++ b/code/modules/power/engines/singularity/singularity.dm
@@ -307,7 +307,6 @@
 				else
 					consume(X)
 
-
 /obj/singularity/proc/consume(atom/A)
 	var/gain = A.singularity_act(current_size)
 	src.energy += gain


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Removes the tick_check check, which was used to try to stop the singulo from eating contaiment, we fixed propperly in   #25356
This stops a singularity from failing to suck anything in and being pityful destruction wise when the tick lag starts, as it would end the loop before pulling anything

### **Note**
This does make the singularity much less performant when **loosed**. When it is **contained** the singularity acts the same performance wise.
And frankly, I would rather a less performant singulo than one that doesn't work

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Singularity should pull and eat stuff when loosed, rather than just... move around, deleting only the turf it is on, vs everything near it being sucked in.

## Testing
<!-- How did you test the PR, if at all? -->

Loosed various singulos, did containmnent of one on delta, was performant, loosed it, higher tidi but actually working

## Changelog
:cl:
fix: Improves singularity when loosed not eating anything. Deletes performance.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
