### PR TITLE
Caps the number of thrown object impact sounds at 20/tick (400/second).

### DIFF
--- a/code/controllers/subsystem/SSthrowing.dm
+++ b/code/controllers/subsystem/SSthrowing.dm
@@ -57,7 +57,7 @@ SUBSYSTEM_DEF(throwing)
 
 	currentrun = null
 
-/datum/controller/subsystem/throwing/proc/playsound_capped(atom/source, soundin, vol as num, vary, extrarange as num, falloff_exponent = SOUND_FALLOFF_EXPONENT, frequency = null, channel = 0, pressure_affected = TRUE, ignore_walls = TRUE, falloff_distance = SOUND_DEFAULT_FALLOFF_DISTANCE, use_reverb = TRUE)
+/datum/controller/subsystem/throwing/proc/playsound_capped(atom/source, soundin, vol, vary, extrarange, falloff_exponent = SOUND_FALLOFF_EXPONENT, frequency, channel = 0, pressure_affected = TRUE, ignore_walls = TRUE, falloff_distance = SOUND_DEFAULT_FALLOFF_DISTANCE, use_reverb = TRUE)
 	if(impact_sounds < impact_sounds_cap)
 		impact_sounds++
 		playsound(source, soundin, vol, vary, extrarange, falloff_exponent, frequency, channel, pressure_affected, ignore_walls, falloff_distance, use_reverb)

--- a/code/controllers/subsystem/SSthrowing.dm
+++ b/code/controllers/subsystem/SSthrowing.dm
@@ -13,6 +13,15 @@ SUBSYSTEM_DEF(throwing)
 	var/list/currentrun
 	var/list/processing = list()
 
+	/// How many throw impact sounds have happened this tick.
+	var/impact_sounds = 0
+	/// How many throw impact sounds we allow per tick.
+	var/impact_sounds_cap = 20
+	/// How many sounds we've skipped due to hitting the per-tick cap.
+	var/skipped_sounds = 0
+	/// How many sounds there were last tick.
+	var/last_impact_sounds = 0
+
 /datum/controller/subsystem/throwing/get_stat_details()
 	return "P:[length(processing)]"
 
@@ -25,6 +34,8 @@ SUBSYSTEM_DEF(throwing)
 /datum/controller/subsystem/throwing/fire(resumed = 0)
 	if(!resumed)
 		src.currentrun = processing.Copy()
+		last_impact_sounds = impact_sounds
+		impact_sounds = 0
 
 	//cache for sanic speed (lists are references anyways)
 	var/list/currentrun = src.currentrun
@@ -45,6 +56,13 @@ SUBSYSTEM_DEF(throwing)
 			return
 
 	currentrun = null
+
+/datum/controller/subsystem/throwing/proc/playsound_capped(atom/source, soundin, vol as num, vary, extrarange as num, falloff_exponent = SOUND_FALLOFF_EXPONENT, frequency = null, channel = 0, pressure_affected = TRUE, ignore_walls = TRUE, falloff_distance = SOUND_DEFAULT_FALLOFF_DISTANCE, use_reverb = TRUE)
+	if(impact_sounds < impact_sounds_cap)
+		impact_sounds++
+		playsound(source, soundin, vol, vary, extrarange, falloff_exponent, frequency, channel, pressure_affected, ignore_walls, falloff_distance, use_reverb)
+	else
+		skipped_sounds++
 
 /datum/thrownthing
 	var/atom/movable/thrownthing

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -650,16 +650,16 @@ GLOBAL_DATUM_INIT(welding_sparks, /mutable_appearance, mutable_appearance('icons
 			var/volume = get_volume_by_throwforce_and_or_w_class()
 			if(throwforce > 0)
 				if(mob_throw_hit_sound)
-					playsound(hit_atom, mob_throw_hit_sound, volume, TRUE, -1)
+					SSthrowing.playsound_capped(hit_atom, mob_throw_hit_sound, volume, TRUE, -1)
 				else if(hitsound)
-					playsound(hit_atom, hitsound, volume, TRUE, -1)
+					SSthrowing.playsound_capped(hit_atom, hitsound, volume, TRUE, -1)
 				else
-					playsound(hit_atom, 'sound/weapons/genhit.ogg', volume, TRUE, -1)
+					SSthrowing.playsound_capped(hit_atom, 'sound/weapons/genhit.ogg', volume, TRUE, -1)
 			else
-				playsound(hit_atom, 'sound/weapons/throwtap.ogg', volume, TRUE, -1)
+				SSthrowing.playsound_capped(hit_atom, 'sound/weapons/throwtap.ogg', volume, TRUE, -1)
 
 		else
-			playsound(src, drop_sound, YEET_SOUND_VOLUME, ignore_walls = FALSE)
+			SSthrowing.playsound_capped(src, drop_sound, YEET_SOUND_VOLUME, ignore_walls = FALSE)
 		return hit_atom.hitby(src, 0, itempush, throwingdatum = throwingdatum)
 
 /obj/item/throw_at(atom/target, range, speed, mob/thrower, spin = 1, diagonals_first = 0, datum/callback/callback, force, dodgeable)


### PR DESCRIPTION
## What Does This PR Do
Caps the number of thrown object impact sounds at 20/tick (400/second).

## Why It's Good For The Game
With the uncapped singularity pull that Qwerty is looking at, singularities end up throwing a lot of items around, and causing a ton of overtime in playsound as a result. This cuts that overtime by about 75%, and I, at least, can't hear a difference.

## Testing
Spawned a singularity on the supermatter and gave it enough energy to start growing. Much clanging was heard as it wandered the station.

## Changelog
:cl:
sounddel: Thrown object impact sounds are now capped at 20/tick (400/second) for performance reasons. You are quite unlikely to notice this, but it's technically possible.
/:cl: