### PR TITLE
[s] maint drones no longer can endlessly ghost and respawn

### DIFF
--- a/code/modules/mob/dead/observer/observer_base.dm
+++ b/code/modules/mob/dead/observer/observer_base.dm
@@ -238,7 +238,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		return
 
 	if(HAS_TRAIT(M, TRAIT_RESPAWNABLE))
-		if(isdrone(M))
+		if(isdrone(M))//We do not punish maint drones for leaving early, *but* we don't want them ghosting, finding damage, respawning / rentering over and over.
 			var/mob/dead/observer/ghost = ghostize(0)	// 0 parameter stops them re-entering their body
 			ghost.timeofdeath = world.time	// Because the living mob won't have a time of death and we want the respawn timer to work properly.
 			return

--- a/code/modules/mob/dead/observer/observer_base.dm
+++ b/code/modules/mob/dead/observer/observer_base.dm
@@ -238,6 +238,10 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		return
 
 	if(HAS_TRAIT(M, TRAIT_RESPAWNABLE))
+		if(isdrone(M))
+			var/mob/dead/observer/ghost = ghostize(0)	// 0 parameter stops them re-entering their body
+			ghost.timeofdeath = world.time	// Because the living mob won't have a time of death and we want the respawn timer to work properly.
+			return
 		ghostize(1)
 		return
 	if(P)

--- a/code/modules/mob/dead/observer/observer_base.dm
+++ b/code/modules/mob/dead/observer/observer_base.dm
@@ -239,10 +239,10 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 	if(HAS_TRAIT(M, TRAIT_RESPAWNABLE))
 		if(isdrone(M))//We do not punish maint drones for leaving early, *but* we don't want them ghosting, finding damage, respawning / rentering over and over.
-			var/mob/dead/observer/ghost = ghostize(0)	// 0 parameter stops them re-entering their body
+			var/mob/dead/observer/ghost = ghostize(FALSE)	// FALSE parameter stops them re-entering their body
 			ghost.timeofdeath = world.time	// Because the living mob won't have a time of death and we want the respawn timer to work properly.
 			return
-		ghostize(1)
+		ghostize(TRUE)
 		return
 	if(P)
 		if(TOO_EARLY_TO_GHOST)
@@ -271,11 +271,11 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 	if(warningmsg)
 		// Not respawnable
-		var/mob/dead/observer/ghost = ghostize(0)	// 0 parameter stops them re-entering their body
+		var/mob/dead/observer/ghost = ghostize(FALSE)	// FALSE parameter stops them re-entering their body
 		ghost.timeofdeath = world.time	// Because the living mob won't have a time of death and we want the respawn timer to work properly.
 	else
 		// Respawnable
-		ghostize(1)
+		ghostize(TRUE)
 
 	// If mob in cryopod, despawn mob
 	if(P)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Maint drones no longer can renter the drone when ghosting from it and get the 10 minute mob spawner respawn timer

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

We let maint drones ghost easier, as we wanted it as a chiller low impact role you could leave whenever. We did not however want them able to ghost, look around the station for potential damages or other issues, and re-enter body

## Testing
<!-- How did you test the PR, if at all? -->
Ghosted as a maint drone, kept respawnability, but could not instantly re-enter my body or respawn from the drone factory.

## Changelog
:cl:
fix: maint drones no longer can endlessly ghost and respawn
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
