### PR TITLE
Ammunition can no longer be discounted in the uplink

### DIFF
--- a/code/datums/uplink_items/uplink_general.dm
+++ b/code/datums/uplink_items/uplink_general.dm
@@ -61,9 +61,9 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	/// Description of the item in the uplink
 	var/desc = "Item Description"
 	/// Used for discounts. Any unique string will do.
-	var/reference = null
+	var/reference
 	/// What is spawned when we purchase this?
-	var/item = null
+	var/item
 	/// How many TC does this cost?
 	var/cost = 0
 	/// Is what we're spawning abstract?

--- a/code/datums/uplink_items/uplink_general.dm
+++ b/code/datums/uplink_items/uplink_general.dm
@@ -60,7 +60,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	var/category = "item category"
 	/// Description of the item in the uplink
 	var/desc = "Item Description"
-	/// Used for surplus crates
+	/// Used for surplus crates. Any unique string will do.
 	var/reference = null
 	/// What is spawned when we purchase this?
 	var/item = null

--- a/code/datums/uplink_items/uplink_general.dm
+++ b/code/datums/uplink_items/uplink_general.dm
@@ -8,7 +8,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	var/newreference = 1
 	if(!length(uplink_items))
 
-		var/list/last = list()
 		for(var/path in GLOB.uplink_items)
 
 			var/datum/uplink_item/I = new path
@@ -18,9 +17,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 				continue
 			if(length(I.excludefrom) && (U.uplink_type in I.excludefrom))
 				continue
-			if(I.last)
-				last += I
-				continue
 
 			if(!uplink_items[I.category])
 				uplink_items[I.category] = list()
@@ -28,12 +24,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			uplink_items[I.category] += I
 			if(I.limited_stock < 0 && I.can_discount && I.item && I.cost > 5)
 				sales_items += I
-
-		for(var/datum/uplink_item/I in last)
-			if(!uplink_items[I.category])
-				uplink_items[I.category] = list()
-
-			uplink_items[I.category] += I
 
 	for(var/i in 1 to 3)
 		var/datum/uplink_item/I = pick_n_take(sales_items)
@@ -61,30 +51,45 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 	return uplink_items
 
-// You can change the order of the list by putting datums before/after one another OR
-// you can use the last variable to make sure it appears last, well have the category appear last.
+// You can change the order of the list by putting datums before/after one another
 
 /datum/uplink_item
+	/// Name of the item in the uplink
 	var/name = "item name"
+	/// What category is the item listed under
 	var/category = "item category"
+	/// Description of the item in the uplink
 	var/desc = "Item Description"
+	/// Used for surplus crates
 	var/reference = null
+	/// What is spawned when we purchase this?
 	var/item = null
+	/// How many TC does this cost?
 	var/cost = 0
-	var/last = 0 // Appear last
+	/// Is what we're spawning abstract?
 	var/abstract = 0
-	var/list/uplinktypes = list() // Empty list means it is in all the uplink types. Otherwise place the uplink type here.
-	var/list/excludefrom = list() // Empty list does nothing. Place the name of uplink type you don't want this item to be available in here.
+	/// Empty list means it is in all the uplink types. Otherwise place the uplink type here.
+	var/list/uplinktypes = list()
+	/// Empty list does nothing. Place the name of uplink type you don't want this item to be available in here.
+	var/list/excludefrom = list()
+	/// Is this job locked?
 	var/list/job = null
 	/// This makes an item on the uplink only show up to the specified species
 	var/list/species = null
-	var/surplus = 100 //Chance of being included in the surplus crate (when pick() selects it)
+	/// Chance of being included in the surplus crate (when pick() selects it)
+	var/surplus = 100
+	/// Can this be sold at a discount?
 	var/can_discount = TRUE
-	var/limited_stock = -1 // Can you only buy so many? -1 allows for infinite purchases
-	var/hijack_only = FALSE //can this item be purchased only during hijackings?
+	/// Can you only buy so many? -1 allows for infinite purchases
+	var/limited_stock = -1
+	/// Can this item be purchased only during hijackings?
+	var/hijack_only = FALSE
+	/// Can you refund this in the uplink?
 	var/refundable = FALSE
-	var/refund_path = null // Alternative path for refunds, in case the item purchased isn't what is actually refunded (ie: holoparasites).
-	var/refund_amount // specified refund amount in case there needs to be a TC penalty for refunds.
+	/// Alternative path for refunds, in case the item purchased isn't what is actually refunded (ie: holoparasites).
+	var/refund_path = null
+	/// specified refund amount in case there needs to be a TC penalty for refunds.
+	var/refund_amount
 	/// Our special little snowflakes that have to be spawned in a different way than normal, like a surplus crate spawning a crate or contractor kits
 	var/uses_special_spawn = FALSE
 
@@ -241,9 +246,10 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 // Ammunition
 
-/datum/uplink_item/ammo
+/datum/uplink_item/ammo // Getting these in a discount or surplus is not a good time.
 	category = "Ammunition"
-	surplus = 40
+	surplus = 0
+	can_discount = FALSE
 
 /datum/uplink_item/ammo/pistol
 	name = "Stechkin - 10mm Magazine"
@@ -251,7 +257,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "10MM"
 	item = /obj/item/ammo_box/magazine/m10mm
 	cost = 3
-	surplus = 0 // Miserable
 
 /datum/uplink_item/ammo/pistolap
 	name = "Stechkin - 10mm Armour Piercing Magazine"
@@ -259,7 +264,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "10MMAP"
 	item = /obj/item/ammo_box/magazine/m10mm/ap
 	cost = 6
-	surplus = 0 // Miserable
 
 /datum/uplink_item/ammo/pistolfire
 	name = "Stechkin - 10mm Incendiary Magazine"
@@ -267,7 +271,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "10MMFIRE"
 	item = /obj/item/ammo_box/magazine/m10mm/fire
 	cost = 9
-	surplus = 0 // Miserable
 
 /datum/uplink_item/ammo/pistolhp
 	name = "Stechkin - 10mm Hollow Point Magazine"
@@ -275,7 +278,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "10MMHP"
 	item = /obj/item/ammo_box/magazine/m10mm/hp
 	cost = 7
-	surplus = 0 // Miserable
 
 /datum/uplink_item/ammo/revolver
 	name = ".357 Revolver - Speedloader"
@@ -283,7 +285,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "357"
 	item = /obj/item/ammo_box/a357
 	cost = 15
-	surplus = 0 // Miserable
 
 // STEALTHY WEAPONS
 
@@ -915,6 +916,8 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "SUIT"
 	item = /obj/item/clothing/suit/storage/iaa/blackjacket/armored
 	cost = 3
+
+// BUNDLES AND TELECRYSTALS
 
 /datum/uplink_item/bundles_TC
 	category = "Bundles and Telecrystals"

--- a/code/datums/uplink_items/uplink_general.dm
+++ b/code/datums/uplink_items/uplink_general.dm
@@ -60,7 +60,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	var/category = "item category"
 	/// Description of the item in the uplink
 	var/desc = "Item Description"
-	/// Used for surplus crates. Any unique string will do.
+	/// Used for discounts. Any unique string will do.
 	var/reference = null
 	/// What is spawned when we purchase this?
 	var/item = null

--- a/code/datums/uplink_items/uplink_general.dm
+++ b/code/datums/uplink_items/uplink_general.dm
@@ -164,14 +164,14 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 //	UPLINK ITEMS
 //
 */
-//Work in Progress, job specific antag tools
 
 //Discounts (dynamically filled above)
-
 /datum/uplink_item/discounts
 	category = "Discounted Gear"
 
-// DANGEROUS WEAPONS
+////////////////////////////////////////
+// MARK: DANGEROUS WEAPONS
+////////////////////////////////////////
 
 /datum/uplink_item/dangerous
 	category = "Highly Visible and Dangerous Weapons"
@@ -244,7 +244,9 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/grenade/turret
 	cost = 20
 
-// Ammunition
+////////////////////////////////////////
+// MARK: AMMUNITION
+////////////////////////////////////////
 
 /datum/uplink_item/ammo // Getting these in a discount or surplus is not a good time.
 	category = "Ammunition"
@@ -286,7 +288,9 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/ammo_box/a357
 	cost = 15
 
-// STEALTHY WEAPONS
+////////////////////////////////////////
+// MARK: STEALTHY WEAPONS
+////////////////////////////////////////
 
 /datum/uplink_item/stealthy_weapons
 	category = "Stealthy and Inconspicuous Weapons"
@@ -384,7 +388,9 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 10
 	can_discount = FALSE
 
-// GRENADES AND EXPLOSIVES
+////////////////////////////////////////
+// MARK: GRENADES AND EXPLOSIVES
+////////////////////////////////////////
 
 /datum/uplink_item/explosives
 	category = "Grenades and Explosives"
@@ -452,7 +458,9 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	if(HAS_TRAIT(SSstation, STATION_TRAIT_CYBERNETIC_REVOLUTION))
 		cost *= 3
 
-// STEALTHY TOOLS
+////////////////////////////////////////
+// MARK: STEALTHY TOOLS
+////////////////////////////////////////
 
 /datum/uplink_item/stealthy_tools
 	category = "Stealth and Camouflage Items"
@@ -570,7 +578,9 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/handheld_mirror
 	cost = 5
 
-// DEVICE AND TOOLS
+////////////////////////////////////////
+// MARK: DEVICES AND TOOLS
+////////////////////////////////////////
 
 /datum/uplink_item/device_tools
 	category = "Devices and Tools"
@@ -630,7 +640,75 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/organ_extractor
 	cost = 20
 
-//Space Suits and Hardsuits
+/datum/uplink_item/device_tools/binary
+	name = "Binary Translator Key"
+	desc = "A key, that when inserted into a radio headset, allows you to listen to and talk with artificial intelligences and cybernetic organisms in binary. To talk on the binary channel, type :+ before your radio message."
+	reference = "BITK"
+	item = /obj/item/encryptionkey/binary
+	cost = 25
+	surplus = 75
+
+/datum/uplink_item/device_tools/cipherkey
+	name = "Syndicate Encryption Key"
+	desc = "A key, that when inserted into a radio headset, allows you to listen to all station department channels as well as talk on an encrypted Syndicate channel."
+	reference = "SEK"
+	item = /obj/item/encryptionkey/syndicate
+	cost = 10 //Nowhere near as useful as the Binary Key!
+	surplus = 75
+
+/datum/uplink_item/device_tools/hacked_module
+	name = "Hacked AI Upload Module"
+	desc = "When used with an upload console, this module allows you to upload priority laws to an artificial intelligence. Be careful with their wording, as artificial intelligences may look for loopholes to exploit."
+	reference = "HAI"
+	item = /obj/item/aiModule/syndicate
+	cost = 15
+
+/datum/uplink_item/device_tools/powersink
+	name = "Power Sink"
+	desc = "When screwed to wiring attached to an electric grid, then activated, this large device places excessive load on the grid, causing a stationwide blackout. The sink cannot be carried because of its excessive size. Ordering this sends you a small beacon that will teleport the power sink to your location on activation."
+	reference = "PS"
+	item = /obj/item/radio/beacon/syndicate/power_sink
+	cost = 50
+
+/datum/uplink_item/device_tools/singularity_beacon
+	name = "Power Beacon"
+	desc = "When screwed to wiring attached to an electric grid and activated, this large device pulls any \
+			active gravitational singularities. This will not work when the engine is still \
+			in containment. Because of its size, it cannot be carried. Ordering this \
+			sends you a small beacon that will teleport the larger beacon to your location upon activation."
+	reference = "SNGB"
+	item = /obj/item/radio/beacon/syndicate
+	cost = 10
+	surplus = 0
+	hijack_only = TRUE //This is an item only useful for a hijack traitor, as such, it should only be available in those scenarios.
+	can_discount = FALSE
+
+/datum/uplink_item/device_tools/advpinpointer
+	name = "Advanced Pinpointer"
+	desc = "A pinpointer that tracks any specified coordinates, DNA string, high value item or the nuclear authentication disk."
+	reference = "ADVP"
+	item = /obj/item/pinpointer/advpinpointer
+	cost = 10
+	can_discount = FALSE
+
+/datum/uplink_item/device_tools/ai_detector
+	name = "Artificial Intelligence Detector" // changed name in case newfriends thought it detected disguised ai's
+	desc = "A functional multitool that turns red when it detects an artificial intelligence watching it or its holder. Knowing when an artificial intelligence is watching you is useful for knowing when to maintain cover."
+	reference = "AID"
+	item = /obj/item/multitool/ai_detect
+	cost = 5
+
+/datum/uplink_item/device_tools/jammer
+	name = "Radio Jammer"
+	desc = "When turned on this device will scramble any outgoing radio communications near you, making them hard to understand."
+	reference = "RJ"
+	item = /obj/item/jammer
+	cost = 20
+
+////////////////////////////////////////
+// MARK: SPACE SUITS AND HARDSUITS
+////////////////////////////////////////
+
 /datum/uplink_item/suits
 	category = "Space Suits and MODsuits"
 	surplus = 10 //I am setting this to 10 as there are a bunch of modsuit parts in here that should be weighted to 10. Suits and modsuits adjusted below.
@@ -713,73 +791,9 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 10
 	surplus = 10
 
-/datum/uplink_item/device_tools/binary
-	name = "Binary Translator Key"
-	desc = "A key, that when inserted into a radio headset, allows you to listen to and talk with artificial intelligences and cybernetic organisms in binary. To talk on the binary channel, type :+ before your radio message."
-	reference = "BITK"
-	item = /obj/item/encryptionkey/binary
-	cost = 25
-	surplus = 75
-
-/datum/uplink_item/device_tools/cipherkey
-	name = "Syndicate Encryption Key"
-	desc = "A key, that when inserted into a radio headset, allows you to listen to all station department channels as well as talk on an encrypted Syndicate channel."
-	reference = "SEK"
-	item = /obj/item/encryptionkey/syndicate
-	cost = 10 //Nowhere near as useful as the Binary Key!
-	surplus = 75
-
-/datum/uplink_item/device_tools/hacked_module
-	name = "Hacked AI Upload Module"
-	desc = "When used with an upload console, this module allows you to upload priority laws to an artificial intelligence. Be careful with their wording, as artificial intelligences may look for loopholes to exploit."
-	reference = "HAI"
-	item = /obj/item/aiModule/syndicate
-	cost = 15
-
-/datum/uplink_item/device_tools/powersink
-	name = "Power Sink"
-	desc = "When screwed to wiring attached to an electric grid, then activated, this large device places excessive load on the grid, causing a stationwide blackout. The sink cannot be carried because of its excessive size. Ordering this sends you a small beacon that will teleport the power sink to your location on activation."
-	reference = "PS"
-	item = /obj/item/radio/beacon/syndicate/power_sink
-	cost = 50
-
-/datum/uplink_item/device_tools/singularity_beacon
-	name = "Power Beacon"
-	desc = "When screwed to wiring attached to an electric grid and activated, this large device pulls any \
-			active gravitational singularities. This will not work when the engine is still \
-			in containment. Because of its size, it cannot be carried. Ordering this \
-			sends you a small beacon that will teleport the larger beacon to your location upon activation."
-	reference = "SNGB"
-	item = /obj/item/radio/beacon/syndicate
-	cost = 10
-	surplus = 0
-	hijack_only = TRUE //This is an item only useful for a hijack traitor, as such, it should only be available in those scenarios.
-	can_discount = FALSE
-
-/datum/uplink_item/device_tools/advpinpointer
-	name = "Advanced Pinpointer"
-	desc = "A pinpointer that tracks any specified coordinates, DNA string, high value item or the nuclear authentication disk."
-	reference = "ADVP"
-	item = /obj/item/pinpointer/advpinpointer
-	cost = 10
-	can_discount = FALSE
-
-/datum/uplink_item/device_tools/ai_detector
-	name = "Artificial Intelligence Detector" // changed name in case newfriends thought it detected disguised ai's
-	desc = "A functional multitool that turns red when it detects an artificial intelligence watching it or its holder. Knowing when an artificial intelligence is watching you is useful for knowing when to maintain cover."
-	reference = "AID"
-	item = /obj/item/multitool/ai_detect
-	cost = 5
-
-/datum/uplink_item/device_tools/jammer
-	name = "Radio Jammer"
-	desc = "When turned on this device will scramble any outgoing radio communications near you, making them hard to understand."
-	reference = "RJ"
-	item = /obj/item/jammer
-	cost = 20
-
-
-// IMPLANTS
+////////////////////////////////////////
+// MARK: IMPLANTS
+////////////////////////////////////////
 
 /datum/uplink_item/bio_chips
 	category = "Bio-chips"
@@ -834,7 +848,9 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/bio_chip_implanter/stealth
 	cost = 45
 
-// CYBERNETICS
+////////////////////////////////////////
+// MARK: CYBERNETICS
+////////////////////////////////////////
 
 /datum/uplink_item/cyber_implants
 	category = "Cybernetic Implants"
@@ -867,7 +883,9 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 20
 
 
-// POINTLESS BADASSERY
+////////////////////////////////////////
+// MARK: POINTLESS BADASSERY
+////////////////////////////////////////
 
 /datum/uplink_item/badass
 	category = "(Pointless) Badassery"
@@ -917,7 +935,9 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/clothing/suit/storage/iaa/blackjacket/armored
 	cost = 3
 
-// BUNDLES AND TELECRYSTALS
+////////////////////////////////////////
+// MARK: BUNDLES AND TELECRYSTALS
+////////////////////////////////////////
 
 /datum/uplink_item/bundles_TC
 	category = "Bundles and Telecrystals"

--- a/code/datums/uplink_items/uplink_general.dm
+++ b/code/datums/uplink_items/uplink_general.dm
@@ -248,9 +248,9 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 // MARK: AMMUNITION
 ////////////////////////////////////////
 
-/datum/uplink_item/ammo // Getting these in a discount or surplus is not a good time.
+/datum/uplink_item/ammo
 	category = "Ammunition"
-	surplus = 0
+	surplus = 0 // Getting these in a discount or surplus is not a good time.
 	can_discount = FALSE
 
 /datum/uplink_item/ammo/pistol

--- a/code/datums/uplink_items/uplink_general.dm
+++ b/code/datums/uplink_items/uplink_general.dm
@@ -386,7 +386,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "SKD"
 	item = /obj/item/melee/knuckleduster/syndie
 	cost = 10
-	can_discount = FALSE
 
 ////////////////////////////////////////
 // MARK: GRENADES AND EXPLOSIVES

--- a/code/datums/uplink_items/uplink_nuclear.dm
+++ b/code/datums/uplink_items/uplink_nuclear.dm
@@ -1,6 +1,8 @@
 // NUCLEAR AGENT ONLY GEAR
 
-// DANGEROUS WEAPONS
+////////////////////////////////////////
+// MARK: DANGEROUS WEAPONS
+////////////////////////////////////////
 
 /datum/uplink_item/dangerous/aps
 	name = "Stechkin APS Pistol"
@@ -89,7 +91,9 @@
 	uplinktypes = list(UPLINK_TYPE_NUCLEAR, UPLINK_TYPE_SST)
 	surplus = 0
 
-// SUPPORT AND MECHAS
+////////////////////////////////////////
+// MARK: SUPPORT AND MECHAS
+////////////////////////////////////////
 
 /datum/uplink_item/support
 	category = "Support and Mechanized Exosuits"
@@ -150,7 +154,9 @@
 	refund_path = /obj/item/antag_spawner/nuke_ops/borg_tele/saboteur
 	cost = 125
 
-// AMMUNITION
+////////////////////////////////////////
+// MARK: AMMUNITION
+////////////////////////////////////////
 
 /datum/uplink_item/ammo/aps
 	name = "Stechkin APS - 10mm Magazine"
@@ -337,9 +343,9 @@
 	uplinktypes = list(UPLINK_TYPE_NUCLEAR, UPLINK_TYPE_SST)
 	surplus = 0
 
-// STEALTHY WEAPONS
-
-// EXPLOSIVES
+////////////////////////////////////////
+// MARK: EXPLOSIVES
+////////////////////////////////////////
 
 /datum/uplink_item/explosives/c4bag
 	name = "Bag of C-4 explosives"
@@ -387,7 +393,15 @@
 	uplinktypes = list(UPLINK_TYPE_NUCLEAR, UPLINK_TYPE_SST)
 	surplus = 35
 
-// STEALTHY TOOLS
+////////////////////////////////////////
+// MARK: STEALTHY WEAPONS
+////////////////////////////////////////
+
+// There's no nukie only stealthy weapons right now, but if you want to add one, put it here.
+
+////////////////////////////////////////
+// MARK: STEALTHY TOOLS
+////////////////////////////////////////
 
 /datum/uplink_item/stealthy_tools/clownkit
 	name = "Honk Brand Infiltration Kit"
@@ -398,7 +412,9 @@
 	uplinktypes = list(UPLINK_TYPE_NUCLEAR, UPLINK_TYPE_SST)
 	surplus = 0
 
-// DEVICES AND TOOLS
+////////////////////////////////////////
+// MARK: DEVICES AND TOOLS
+////////////////////////////////////////
 
 /datum/uplink_item/device_tools/diamond_drill
 	name = "Amplifying Diamond Tipped Thermal Safe Drill"
@@ -486,7 +502,9 @@
 	cost = 75
 	uplinktypes = list(UPLINK_TYPE_NUCLEAR, UPLINK_TYPE_SST)
 
-// SPACE SUITS
+////////////////////////////////////////
+// MARK: SPACE SUITS
+////////////////////////////////////////
 
 /datum/uplink_item/suits/elite_nukie
 	name = "Elite Syndicate MODsuit"
@@ -509,7 +527,9 @@
 	excludefrom = list()
 	uplinktypes = list(UPLINK_TYPE_NUCLEAR, UPLINK_TYPE_SST)
 
-// IMPLANTS
+////////////////////////////////////////
+// MARK: IMPLANTS
+////////////////////////////////////////
 
 /datum/uplink_item/bio_chips/krav_implant
 	name = "Krav Maga Implant"
@@ -582,7 +602,9 @@
 	surplus = 0
 	uplinktypes = list(UPLINK_TYPE_NUCLEAR, UPLINK_TYPE_SST)
 
-// BUNDLES
+////////////////////////////////////////
+// MARK: BUNDLES
+////////////////////////////////////////
 
 /datum/uplink_item/bundles_TC/bulldog
 	name = "Bulldog Bundle"
@@ -628,10 +650,9 @@
 	cost = 90 // normally 115
 	uplinktypes = list(UPLINK_TYPE_NUCLEAR, UPLINK_TYPE_SST)
 
-
-// ---------------------------------
-// PRICES OVERRIDE FOR TRAITOR ITEMS
-// ---------------------------------
+////////////////////////////////////////
+// MARK: PRICES OVERRIDE FOR TRAITOR ITEMS
+////////////////////////////////////////
 
 /datum/uplink_item/stealthy_weapons/cqc/nuke
 	reference = "NCQC"
@@ -679,9 +700,9 @@
 	excludefrom = list()
 	uplinktypes = list(UPLINK_TYPE_NUCLEAR, UPLINK_TYPE_SST)
 
-// ---------------------------------
-// NUKIE ONLY POINTLESS BADASSERY
-// ---------------------------------
+////////////////////////////////////////
+// MARK: NUKIE ONLY POINTLESS BADASSERY
+////////////////////////////////////////
 
 /datum/uplink_item/badass/confettidrum
 	name = "Bulldog - 12g party Magazine"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes ammunition in the uplink not able to be discounted.
Makes the syndicate knuckleduster able to be a discounted - this seems like a leftover from when it was 5TC.
Also does a major cleanup of the uplink code.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Getting a 3TC, single use discount on a pistol magazine is not a great use of one (or more) of your 3 discount slots, and is very unlikely to make you change your plans. Even if you're planning on buying the gun anyways, you would probably still prefer a more meaningful discount on a stronger item. 
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Purchased a surplus crate to make sure I didn't mess up the code during my cleanup.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Ammunition can no longer be discounted in the uplink.
tweak: Syndicate knuckleduster can now be discounted in the uplink.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
