### PR TITLE
Buffs Syndicate Bomb Size

### DIFF
--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -320,10 +320,10 @@
 	origin_tech = "syndicate=5;combat=6"
 	resistance_flags = FLAMMABLE //Burnable (but the casing isn't)
 	var/adminlog = null
-	var/range_heavy = 3
-	var/range_medium = 9
-	var/range_light = 17
-	var/range_flame = 17
+	var/range_heavy = 5
+	var/range_medium = 10
+	var/range_light = 20
+	var/range_flame = 20
 	var/admin_log = TRUE
 
 /obj/item/bombcore/ex_act(severity) //Little boom can chain a big boom
@@ -422,17 +422,10 @@
 	playsound(src.loc, 'sound/misc/sadtrombone.ogg', 50)
 	..()
 
-/obj/item/bombcore/large
-	name = "large bomb payload"
-	range_heavy = 5
-	range_medium = 10
-	range_light = 20
-	range_flame = 20
-
-/obj/item/bombcore/large/explosive_wall
+/obj/item/bombcore/explosive_wall
 	admin_log = FALSE
 
-/obj/item/bombcore/large/underwall
+/obj/item/bombcore/underwall
 	layer = ABOVE_OPEN_TURF_LAYER
 
 /obj/item/bombcore/miniature


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Raises the size of Syndie Bomb to maxcap, going from 3, 9, 17 size to 5, 10, 20.

Also removes the /large/ subtype of bomb, as it doesn't seem to be used anywhere, and the blast sizes would now be identical. I kept the subtypes of /large/ as a subtype of the regular bomb core now.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Hijack only and expensive to boot, there's not too much reason to use Syndicate Bombs when toxin bombs or even a little bit of effort with chemistry can yield maxcaps that are bigger and instantaneous (no loud beeping). Obviously there's the style factor, but that alone can't carry the beep-boom.

Sure, this will buff nukies with their ability to rapidly detonate the bomb, but it'll also probably result in them blowing themselves up more, so it balances out right?

## Testing
<!-- How did you test the PR, if at all? -->
It builds.
It launches.
It beeps.
It blows up.
It's the expected size.

## Changelog
:cl:
tweak: Syndicate Bombs now detonate in a larger radius
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
