### PR TITLE
Fixes a Bug with Ore Box Deconstruction

### DIFF
--- a/code/modules/mining/satchel_ore_boxdm.dm
+++ b/code/modules/mining/satchel_ore_boxdm.dm
@@ -26,7 +26,7 @@
 
 /obj/structure/ore_box/crowbar_act(mob/living/user, obj/item/I)
 	. = TRUE
-	if(!I.use_tool(src, user, 5 SECONDS, I.tool_volume))
+	if(!I.use_tool(src, user, 5 SECONDS, volume = I.tool_volume))
 		return
 	user.visible_message("<span class='notice'>[user] pries [src] apart.</span>", "<span class='notice'>You pry apart [src].</span>", "<span class='italics'>You hear splitting wood.</span>")
 	deconstruct(TRUE, user)


### PR DESCRIPTION
## What Does This PR Do
Fixes https://github.com/ParadiseSS13/Paradise/issues/25544 - a bug within `crowbar_act` for ore boxes. 

## Why It's Good For The Game
Bug bad

## Testing
Spawned an ore box and used a crowbar on it.
Observed deconstruction of ore box.

## Changelog
:cl:
fix: Fixed an issue that would not allow for the deconstruction of the ore box with a crowbar
/:cl: