### PR TITLE
bluespace belt fits handheld defibs now

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -781,7 +781,8 @@
 		/obj/item/weldingtool,
 		/obj/item/wirecutters,
 		/obj/item/wrench,
-		/obj/item/multitool
+		/obj/item/multitool,
+		/obj/item/handheld_defibrillator
 		)
 
 /obj/item/storage/belt/bluespace/owlman


### PR DESCRIPTION
## What Does This PR Do
This PR adds the handheld defibrillator (yellow one used to restart hearts) to the list of exception of the bluespace belt, allowing it to fit inside.

## Why It's Good For The Game
the bluespace belt is research-locked between fairly high levels and is supposed to be an upgrade to *most* belts, but it cannot hold the handheld defibrillator like the medical one can, which is a big downgrade from the medical one, since most medical doctors will have atleast one (if not two) handheld defibs on their belt.

## Testing
Threw a bunch of handheld defibrillators in a bluespace belts, worked
Tried to throw a bunch of other normal-sized objects, like stunbatons, didn't work

## Changelog
:cl:
tweak: The bluespace belt has been upgraded to be able to hold handheld defibrillators now
/:cl:
