### PR TITLE
Fixes Cash Purchases Breaking the Merch Vendor

### DIFF
--- a/code/game/machinery/merch_vendor.dm
+++ b/code/game/machinery/merch_vendor.dm
@@ -52,7 +52,7 @@
 	return TRUE
 
 /obj/machinery/economy/merch/proc/attempt_transaction(datum/merch_item/merch, mob/user)
-	if(cash_stored >= merch.cost)
+	if(cash_transaction >= merch.cost)
 		if(pay_with_cash(merch.cost, "Purchase of [merch.name]", name, user, account_database.vendor_account))
 			give_change(user)
 			return TRUE


### PR DESCRIPTION
## What Does This PR Do
Edits an if statement in the Merch Vendor to check for cash inserted for a current transaction instead of the cash stored inside the vendor.
Fixes #25581

## Why It's Good For The Game
Merch Vendor shouldn't disallow card purchases because of a bug

## Testing
Ran & Compiled Code
Spawned in as QM, purchased an item with my card, inserted cash and bought an item with cash, once all cash was removed from the machine I purchased an item again with my card. I was unable to replicate the bug with the current fix.

## Changelog
:cl:
fix: Cash Purchases no longer break the Merch Vendor
/:cl:
