### PR TITLE
Few bugfixes for Shadow Demon

### DIFF
--- a/code/game/gamemodes/miniantags/demons/shadow_demon/shadow_demon.dm
+++ b/code/game/gamemodes/miniantags/demons/shadow_demon/shadow_demon.dm
@@ -6,7 +6,7 @@
 	icon_living = "shadow_demon"
 	move_resist = MOVE_FORCE_STRONG
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE // so they can tell where the darkness is
-	see_in_dark = 10
+	see_in_dark = 10 // lord of shadow must see through full screen darkness
 	loot = list(/obj/item/organ/internal/heart/demon/shadow)
 	death_sound = 'sound/shadowdemon/shadowdeath.ogg'
 	var/thrown_alert = FALSE

--- a/code/game/gamemodes/miniantags/demons/shadow_demon/shadow_demon.dm
+++ b/code/game/gamemodes/miniantags/demons/shadow_demon/shadow_demon.dm
@@ -6,7 +6,7 @@
 	icon_living = "shadow_demon"
 	move_resist = MOVE_FORCE_STRONG
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE // so they can tell where the darkness is
-	see_in_dark = 10 // lord of shadow must see through full screen darkness
+	see_in_dark = 10 // Below 10 `see_in_dark`, you'll not have full vision with fullscreen
 	loot = list(/obj/item/organ/internal/heart/demon/shadow)
 	death_sound = 'sound/shadowdemon/shadowdeath.ogg'
 	var/thrown_alert = FALSE

--- a/code/game/gamemodes/miniantags/demons/shadow_demon/shadow_demon.dm
+++ b/code/game/gamemodes/miniantags/demons/shadow_demon/shadow_demon.dm
@@ -6,6 +6,7 @@
 	icon_living = "shadow_demon"
 	move_resist = MOVE_FORCE_STRONG
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE // so they can tell where the darkness is
+	see_in_dark = 10
 	loot = list(/obj/item/organ/internal/heart/demon/shadow)
 	death_sound = 'sound/shadowdemon/shadowdeath.ogg'
 	var/thrown_alert = FALSE

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -94,7 +94,7 @@
 
 /obj/structure/closet/extinguish_light(force)
 	for(var/atom/A in contents)
-		A.extinguish_light()
+		A.extinguish_light(force)
 
 /obj/structure/closet/proc/open()
 	if(opened)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -92,6 +92,10 @@
 	if(throwing)
 		throwing.finalize(FALSE)
 
+/obj/structure/closet/extinguish_light(force)
+	for(var/atom/A in contents)
+		A.extinguish_light()
+
 /obj/structure/closet/proc/open()
 	if(opened)
 		return FALSE

--- a/code/modules/atmospherics/machinery/atmospherics.dm
+++ b/code/modules/atmospherics/machinery/atmospherics.dm
@@ -344,6 +344,10 @@ Pipelines + Other Objects -> Pipe network
 /obj/machinery/atmospherics/proc/can_crawl_through()
 	return TRUE
 
+/obj/machinery/atmospherics/extinguish_light(force)
+	set_light(0)
+	update_icon(UPDATE_OVERLAYS)
+
 /obj/machinery/atmospherics/proc/change_color(new_color)
 	//only pass valid pipe colors please ~otherwise your pipe will turn invisible
 	if(!pipe_color_check(new_color))


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
- All atmos machinery, expecially cryo pods, can now be turned off by shadow demon/shadowling vampire
- Lockers with flashlights inside now can be turned off
- Shadow demon now have full screen night vision, without black corners.

## Why It's Good For The Game
Few bugfixes for shadow boi, who struggle from another bug abuse. Also black corners for lord of shadow are bad.

## Images of changes
black corners i mentioned earlier
![image](https://github.com/ParadiseSS13/Paradise/assets/114731039/124ae1e0-7dc7-4d23-9f75-f8c1a69ad8fd)
cryo pods now can be turned off
![image](https://github.com/ParadiseSS13/Paradise/assets/114731039/683782d8-0b01-4ae9-8f2e-88beba94c171)

Locker interaction
![image](https://github.com/ParadiseSS13/Paradise/assets/114731039/ef7d09d2-0bc5-48b9-8ea9-80fbb0a08541)
![image](https://github.com/ParadiseSS13/Paradise/assets/114731039/fd753d46-51b5-41d4-ae7c-9d6add1465a5)



## Testing
write code, tested with presicion

## Changelog
:cl:
tweak: Shadow demon now have see_in_dark = 10, having night vision for entire screen.
fix: Cryo pods and flashlights in lockers now can be extinquished by shadow demon
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
