### PR TITLE
tarot card improvements / fixes

### DIFF
--- a/code/datums/spells/construct_spells.dm
+++ b/code/datums/spells/construct_spells.dm
@@ -69,6 +69,9 @@
 
 	summon_type = list(/obj/item/soulstone/anybody/purified)
 
+/datum/spell/aoe/conjure/build/soulstone/any
+	summon_type = list(/obj/item/soulstone/anybody)
+
 /datum/spell/aoe/conjure/build/pylon
 	name = "Cult Pylon"
 	desc = "This spell uses dark magic to craft an unholy beacon. Heals cultists, and makes a handy light source."

--- a/code/game/gamemodes/wizard/magic_tarot.dm
+++ b/code/game/gamemodes/wizard/magic_tarot.dm
@@ -173,9 +173,13 @@
 	. += "<span class='hierophant'>Alt-Shift-Click to flip the card over.</span>"
 
 /obj/item/magic_tarot_card/attack_self(mob/user)
-	if(our_tarot)
-		INVOKE_ASYNC(our_tarot, TYPE_PROC_REF(/datum/tarot, activate), user)
 	poof()
+	if(face_down)
+		flip()
+	if(our_tarot)
+		pre_activate(user)
+		return
+	qdel(src)
 
 /obj/item/magic_tarot_card/throw_at(atom/target, range, speed, mob/thrower, spin, diagonals_first, datum/callback/callback, force, dodgeable)
 	if(face_down)
@@ -184,9 +188,11 @@
 
 /obj/item/magic_tarot_card/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	. = ..()
-	if(isliving(hit_atom) && our_tarot)
-		INVOKE_ASYNC(our_tarot, TYPE_PROC_REF(/datum/tarot, activate), hit_atom)
 	poof()
+	if(isliving(hit_atom) && our_tarot)
+		pre_activate(hit_atom)
+		return
+	qdel(src)
 
 /obj/item/magic_tarot_card/AltShiftClick(mob/user)
 	flip()
@@ -203,12 +209,37 @@
 
 /obj/item/magic_tarot_card/proc/poof()
 	new /obj/effect/temp_visual/revenant(get_turf(src))
-	qdel(src)
 
 /obj/item/magic_tarot_card/proc/dust()
 	visible_message("<span class='danger'>[src] disintegrates into dust!</span>")
 	new /obj/effect/temp_visual/revenant(get_turf(src))
 	qdel(src)
+
+/obj/item/magic_tarot_card/proc/pre_activate(mob/user)
+	forceMove(user)
+	var/obj/effect/temp_visual/tarot_preview/draft = new /obj/effect/temp_visual/tarot_preview(user, our_tarot.card_icon)
+	user.vis_contents += draft
+	user.visible_message("<span class='hierophant'>[user] holds up [src]!</span>")
+	addtimer(CALLBACK(our_tarot, TYPE_PROC_REF(/datum/tarot, activate), user), 0.5 SECONDS)
+	QDEL_IN(src, 0.6 SECONDS)
+
+/obj/effect/temp_visual/tarot_preview
+	name = "a tarot card"
+	icon = 'icons/obj/playing_cards.dmi'
+	icon_state = "tarot_the_unknown"
+	pixel_y = 20
+	duration = 1.5 SECONDS
+
+/obj/effect/temp_visual/tarot_preview/Initialize(atom/mapload, new_icon_state)
+	. = ..()
+	if(new_icon_state)
+		icon_state = "tarot_[new_icon_state]"
+	var/new_filter = isnull(get_filter("ray"))
+	ray_filter_helper(1, 40,"#fcf3dc", 6, 20)
+	if(new_filter)
+		animate(get_filter("ray"), alpha = 0, offset = 10, time = duration, loop = -1)
+		animate(offset = 0, time = duration)
+
 
 /datum/tarot
 	/// Name used for the card
@@ -572,7 +603,7 @@
 		return
 	var/mob/living/carbon/human/H = target
 	for(var/obj/item/I in H)
-		if(istype(/obj/item/bio_chip, I))
+		if(istype(I, /obj/item/bio_chip))
 			continue
 		H.unEquip(I)
 

--- a/code/game/gamemodes/wizard/magic_tarot.dm
+++ b/code/game/gamemodes/wizard/magic_tarot.dm
@@ -240,7 +240,6 @@
 		animate(get_filter("ray"), alpha = 0, offset = 10, time = duration, loop = -1)
 		animate(offset = 0, time = duration)
 
-
 /datum/tarot
 	/// Name used for the card
 	var/name = "XXII - The Unknown."

--- a/code/game/gamemodes/wizard/soulstone.dm
+++ b/code/game/gamemodes/wizard/soulstone.dm
@@ -389,13 +389,17 @@
 /mob/living/simple_animal/hostile/construct/proc/init_construct(mob/living/simple_animal/shade/shade, obj/item/soulstone/SS, obj/structure/constructshell/shell)
 	if(shade.mind)
 		shade.mind.transfer_to(src)
+	if(SS.usability)
+		// Replace regular soulstone summoning with anyuse soulstones
+		if(is_type_in_list(/datum/spell/aoe/conjure/build/soulstone, mob_spell_list))
+			RemoveSpell(/datum/spell/aoe/conjure/build/soulstone)
+			AddSpell(new /datum/spell/aoe/conjure/build/soulstone/any)
 	if(SS.purified)
 		make_holy()
 		// Replace regular soulstone summoning with purified soulstones
 		if(is_type_in_list(/datum/spell/aoe/conjure/build/soulstone, mob_spell_list))
 			RemoveSpell(/datum/spell/aoe/conjure/build/soulstone)
 			AddSpell(new /datum/spell/aoe/conjure/build/soulstone/holy)
-
 	else if(mind.has_antag_datum(/datum/antagonist/cultist)) // Re-grant cult actions, lost in the transfer
 		var/datum/action/innate/cult/comm/CC = new
 		var/datum/action/innate/cult/check_progress/D = new


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Tarot cards show which card was used / over someones head for 1.5 seconds, activating after half a second. You can't stop the effect, but better telegraphs it / gives perhaps a moment to disarm them before they teleport away!
Anyuse soulstone constructs produce anyuse soulstones.
the reverse fool card no longer removes biochips due to a bug



## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

A better tell what happened with a tarot card is good.
Anyuse soulstone armies working again is good.
The reverse fool card not demindshielding officers or deleting traitor adrenals is good

## Testing
<!-- How did you test the PR, if at all? -->

Used cards, used reverse fool, etc

## Changelog
:cl:
tweak: Anyuse soulstone constructs can make anyuse soulstones (again?)
tweak: Tarot cards now show over the affected persons head when used for 1.5 seconds, activating after a 0.5 second delay.
fix: Reverse fool no longer removes mindshields
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
