### PR TITLE
Fixing emagged RCS not teleporting crates

### DIFF
--- a/code/modules/telesci/rcs.dm
+++ b/code/modules/telesci/rcs.dm
@@ -79,21 +79,18 @@
 /**
   * Returns a random location in a z level
   *
-  * Defaults to Z level 1, with a 50% chance of being a different one.
-  * Z levels 1 to 4 are excluded from the alternatives.
+  * Defaults to station Z level, with a 50% chance of being a different one.
+  * Alternatives are space z levels with ruins.
   * Coordinates are constrained within 50-200 x & y.
   */
 /obj/item/rcs/proc/random_coords()
-	var/Z = 1 // Z level
+	var/Z = level_name_to_num(MAIN_STATION)
 	// Random Coordinates
 	var/rand_x = rand(50, 200)
 	var/rand_y = rand(50, 200)
 
 	if(prob(50)) // 50% chance of being a different Z level
-		var/list/z_levels = GLOB.space_manager.levels_by_name.Copy()
-		z_levels.Cut(1, 5) // Remove the first four z levels from the list (Station, CC, Lavaland, Gateway)
-		Z = pick(z_levels) // Pick a z level
-		Z = z_levels.Find(Z) + 4 // And get the corresponding number + 4
+		Z = pick(levels_by_trait(SPAWN_RUINS))
 
 	return locate(rand_x, rand_y, Z)
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
fixes https://github.com/ParadiseSS13/Paradise/issues/25647
selecting unknown on RCS no longer selected centcom turfs and no longer fails to teleport

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
bugs bad

## Testing
<!-- How did you test the PR, if at all? -->
compiled, teleported

## Changelog
:cl:
fix: Emagged RCS no longer fails to teleport crates when selecting Unknown option.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
