### PR TITLE
brain can understand itself yay

### DIFF
--- a/code/modules/mob/living/brain/living_brain.dm
+++ b/code/modules/mob/living/brain/living_brain.dm
@@ -18,14 +18,16 @@
 	return ..()
 
 /mob/living/brain/say_understands(other)//Goddamn is this hackish, but this say code is so odd
-	if(!ismob(other))
-		return ..()
 	if(issilicon(other))
 		return istype(container, /obj/item/mmi)
 	if(ishuman(other))
 		return TRUE
 	if(isslime(other))
 		return TRUE
+	if(isbrain(other))
+		return TRUE
+
+	return ..()
 
 /mob/living/brain/ex_act() //you cant blow up brainmobs because it makes transfer_to() freak out when borgs blow up.
 	return


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Fixes https://github.com/ParadiseSS13/Paradise/issues/25641
Brain can now understand itself, how cool.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Speaking with asterisks while everyone else can hear what you're saying is silly.

## Testing
<!-- How did you test the PR, if at all? -->
Compiled, became robotic brain, talked
![image](https://github.com/ParadiseSS13/Paradise/assets/61080616/2299c8a9-d1a7-4ef8-88c0-0f439dfba1aa)

## Changelog
:cl:
fix: Robobrain can now understand itself speech yay
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
