### PR TITLE
Makes high levels of infection less likely to kill you instantly

### DIFF
--- a/code/__DEFINES/misc_defines.dm
+++ b/code/__DEFINES/misc_defines.dm
@@ -33,6 +33,7 @@
 #define INFECTION_LEVEL_ONE		100
 #define INFECTION_LEVEL_TWO		500
 #define INFECTION_LEVEL_THREE	1000
+#define INFECTION_LEVEL_FOUR	1500
 
 // Damage above this value must be repaired with surgery.
 #define ROBOLIMB_SELF_REPAIR_CAP 60

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -489,7 +489,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 				"[src] feels like it's burning from the inside out!",
 				"[src] seems to be turning a nasty color.",
 			)
-			to_chat(user, "<span class='danger'>[pick(messages)]</span>")
+			to_chat(owner, "<span class='danger'>[pick(messages)]</span>")
 
 	if(germ_level >= INFECTION_LEVEL_THREE)
 		if(vital)

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -482,7 +482,34 @@ Note that amputating the affected organ does in fact remove the infection from t
 				if(parent.germ_level < INFECTION_LEVEL_ONE * 2 || prob(30))
 					parent.germ_level++
 
+		if(prob(5))
+			var/list/messages = list(
+				"You feel something uncomfortable in [src].",
+				"A sharp pain seems to spread out from [src].",
+				"[src] feels like it's burning from the inside out!",
+				"[src] seems to be turning a nasty color.",
+			)
+			to_chat(user, "<span class='danger'>[pick(messages)]</span>")
+
 	if(germ_level >= INFECTION_LEVEL_THREE)
+		if(vital)
+			var/list/messages = list(
+				"[src] oozes with pus!",
+				"[src] starts to go numb.",
+				"[src] feels dreadful, it feels like you're dying!"
+			)
+			// kill them fast, but don't drop them dead.
+			if(prob(5))
+				to_chat(owner, "<span class='userdanger'>[pick(messages)]</span>")
+			owner.adjustToxLoss(5)
+		else
+			necrotize()
+			owner.adjustToxLoss(1)
+
+		germ_level++
+
+	if(germ_level >= INFECTION_LEVEL_FOUR)
+		// we warned you
 		necrotize()
 		germ_level++
 		owner.adjustToxLoss(1)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes higher levels of infection, particularly in the context of burn wounds, a bit less deadly. Germs will now not outright kill your vital limbs at level three, and will instead start to deal heavy toxin damage. Once they reach a new level four, they will still kill your vital limbs, but you should have a bit more of an idea of what's coming down the pipeline rather than just dropping dead.
Also adds a little bit of feedback as you start to creep up in infection levels.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Dropping dead because your chest suddenly died sucks. At least if you quickly decline, it feels a bit less random.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
VVed my chest to have large amounts of germs, and then waited until I saw the eepy disk.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: High levels of germs in vital external organs will now deal heavy toxic damage first, which should be much more likely to kill you before you drop dead from a dead organ.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
