### PR TITLE
Increase opening speed of jani keyring on repeated airlock use

### DIFF
--- a/code/game/objects/items/control_wand.dm
+++ b/code/game/objects/items/control_wand.dm
@@ -236,10 +236,10 @@
 	busy = TRUE
 	var/mob/living/carbon/human/H = user
 	if(H.mind.assigned_role == "Janitor" && last_airlock_uid == D.UID())
-		to_chat(user, "<span class='notice'>You recognise the [D] and look for the key you used...</span>")
+		to_chat(user, "<span class='notice'>You recognize [D] and look for the key you used...</span>")
 		hack_speed = 5 SECONDS
 	else
-		to_chat(user, "<span class='notice'>You fiddle with [src], trying different keys to open the [D]...</span>")
+		to_chat(user, "<span class='notice'>You fiddle with [src], trying different keys to open [D]...</span>")
 		if(H.mind.assigned_role != "Janitor")
 			hack_speed = rand(30, 60) SECONDS
 		else

--- a/code/game/objects/items/control_wand.dm
+++ b/code/game/objects/items/control_wand.dm
@@ -237,17 +237,14 @@
 	var/mob/living/carbon/human/H = user
 	if(H.mind.assigned_role == "Janitor" && last_airlock && last_airlock == D)
 		to_chat(user, "<span class='notice'>You recognise the [D] and look for the key you used...</span>")
-		playsound(src, 'sound/items/keyring_unlock.ogg', 50)
 		hack_speed = 5 SECONDS
 	else
 		to_chat(user, "<span class='notice'>You fiddle with [src], trying different keys to open the [D]...</span>")
-		playsound(src, 'sound/items/keyring_unlock.ogg', 50)
-
 		if(H.mind.assigned_role != "Janitor")
 			hack_speed = rand(30, 60) SECONDS
 		else
 			hack_speed = rand(5, 20) SECONDS
-
+	playsound(src, 'sound/items/keyring_unlock.ogg', 50)
 	if(do_after(user, hack_speed, target = D, progress = 0))
 		if(D.check_access(ID))
 			last_airlock = D

--- a/code/game/objects/items/control_wand.dm
+++ b/code/game/objects/items/control_wand.dm
@@ -210,6 +210,8 @@
 	var/cooldown = 0
 	/// How fast does the keyring open an airlock. It is not set here so that it can be set via the user's role.
 	var/hack_speed
+	/// Stores the last airlock opened, opens faster on repeated use
+	var/last_airlock
 	additional_access = list(ACCESS_MEDICAL, ACCESS_RESEARCH, ACCESS_CONSTRUCTION, ACCESS_MAILSORTING, ACCESS_CARGO, ACCESS_MINING, ACCESS_KITCHEN, ACCESS_BAR, ACCESS_JANITOR, ACCESS_CHAPEL_OFFICE)
 
 /obj/item/door_remote/janikeyring/examine(mob/user)
@@ -232,16 +234,23 @@
 		to_chat(user, "<span class='warning'>You are already using [src] on the [D]'s access panel!</span>")
 		return
 	busy = TRUE
-	to_chat(user, "<span class='notice'>You fiddle with [src], trying different keys to open the [D]...</span>")
-	playsound(src, 'sound/items/keyring_unlock.ogg', 50)
-
 	var/mob/living/carbon/human/H = user
-	if(H.mind.assigned_role != "Janitor")
-		hack_speed = rand(30, 60) SECONDS
+	if(H.mind.assigned_role == "Janitor" && last_airlock && last_airlock == D)
+		to_chat(user, "<span class='notice'>You recognise the [D] and look for the key you used...</span>")
+		playsound(src, 'sound/items/keyring_unlock.ogg', 50)
+		hack_speed = 5 SECONDS
 	else
-		hack_speed = rand(5, 20) SECONDS
+		to_chat(user, "<span class='notice'>You fiddle with [src], trying different keys to open the [D]...</span>")
+		playsound(src, 'sound/items/keyring_unlock.ogg', 50)
+
+		if(H.mind.assigned_role != "Janitor")
+			hack_speed = rand(30, 60) SECONDS
+		else
+			hack_speed = rand(5, 20) SECONDS
 
 	if(do_after(user, hack_speed, target = D, progress = 0))
+		if(D.check_access(ID))
+			last_airlock = D
 		. = ..()
 	busy = FALSE
 

--- a/code/game/objects/items/control_wand.dm
+++ b/code/game/objects/items/control_wand.dm
@@ -211,7 +211,7 @@
 	/// How fast does the keyring open an airlock. It is not set here so that it can be set via the user's role.
 	var/hack_speed
 	/// Stores the last airlock opened, opens faster on repeated use
-	var/last_airlock
+	var/last_airlock_uid
 	additional_access = list(ACCESS_MEDICAL, ACCESS_RESEARCH, ACCESS_CONSTRUCTION, ACCESS_MAILSORTING, ACCESS_CARGO, ACCESS_MINING, ACCESS_KITCHEN, ACCESS_BAR, ACCESS_JANITOR, ACCESS_CHAPEL_OFFICE)
 
 /obj/item/door_remote/janikeyring/examine(mob/user)
@@ -235,7 +235,7 @@
 		return
 	busy = TRUE
 	var/mob/living/carbon/human/H = user
-	if(H.mind.assigned_role == "Janitor" && last_airlock && last_airlock == D)
+	if(H.mind.assigned_role == "Janitor" && last_airlock_uid == D.UID())
 		to_chat(user, "<span class='notice'>You recognise the [D] and look for the key you used...</span>")
 		hack_speed = 5 SECONDS
 	else
@@ -247,7 +247,7 @@
 	playsound(src, 'sound/items/keyring_unlock.ogg', 50)
 	if(do_after(user, hack_speed, target = D, progress = 0))
 		if(D.check_access(ID))
-			last_airlock = D
+			last_airlock_uid = D.UID()
 		. = ..()
 	busy = FALSE
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

For janitors, using the janitor's keyring on the same airlock you last opened will open it in 5 seconds guaranteed
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Get in room, clean room, get out. Also makes sense you can recognise the airlock you just opened and get the key back quickly.
## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![image](https://github.com/ParadiseSS13/Paradise/assets/22121511/b603bfc3-f7aa-4e40-8fdb-af3987c18d17)

## Testing
<!-- How did you test the PR, if at all? -->
Tested the feature on both airlocks and windoors.

## Changelog
:cl:
tweak: Opening an airlock with the janitor's keyring will be faster if it's the same airlock you last opened.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
