### PR TITLE
Adds emoji to admin dsay

### DIFF
--- a/code/modules/admin/verbs/deadsay.dm
+++ b/code/modules/admin/verbs/deadsay.dm
@@ -31,8 +31,7 @@
 	if(check_rights(R_ADMIN, 0))
 		stafftype = "ADMIN"
 
-	msg = sanitize(copytext_char(msg, 1, MAX_MESSAGE_LEN))
-	msg = emoji_parse(copytext_char(sanitize(msg), 1, MAX_MESSAGE_LEN))
+	msg = emoji_parse(sanitize(copytext_char(msg, 1, MAX_MESSAGE_LEN)))
 	log_admin("[key_name(src)] : [msg]")
 
 	if(!msg)

--- a/code/modules/admin/verbs/deadsay.dm
+++ b/code/modules/admin/verbs/deadsay.dm
@@ -32,6 +32,7 @@
 		stafftype = "ADMIN"
 
 	msg = sanitize(copytext_char(msg, 1, MAX_MESSAGE_LEN))
+	msg = emoji_parse(copytext_char(sanitize(msg), 1, MAX_MESSAGE_LEN))
 	log_admin("[key_name(src)] : [msg]")
 
 	if(!msg)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds emoji support to admin dsay. Seems this was missed in #25012 
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
![image](https://github.com/ParadiseSS13/Paradise/assets/89928798/5ebc9760-e0da-4f57-92c5-21b760a66a13)

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://github.com/ParadiseSS13/Paradise/assets/89928798/7d3c4814-3dfa-465c-ad25-832bd1a0216a)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
![image](https://github.com/ParadiseSS13/Paradise/assets/89928798/16556a47-93c2-42d4-a04b-7c5bf381d356)

<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
add: Admins can now use emoji through the dsay verb.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
