### PR TITLE
grammar: fix malf apc board removal message

### DIFF
--- a/code/modules/power/apc/apc_construction.dm
+++ b/code/modules/power/apc/apc_construction.dm
@@ -42,7 +42,7 @@
 						return
 					else if(malfhack) // AI hacks board, not APC's frame
 						user.visible_message(\
-							"[user.name] has discarded strangely the programmed APC electronics from [name]!",
+							"[user.name] has discarded the strangely programmed APC electronics from [name]!",
 							"<span class='notice'>You discarded the strangely programmed board.</span>")
 						malfai = null
 						malfhack = FALSE


### PR DESCRIPTION
## What Does This PR Do
This PR fixes the wording of the description for removing malf boards from APCs.
## Why It's Good For The Game
Bad grammar bad
## Testing
Proofread message.
## Changelog
:cl:
spellcheck: Fixed the description for removing malf boards from APCs.
/:cl:
