### PR TITLE
cere: remove inner carp spawns and secure storage bats

### DIFF
--- a/_maps/map_files/stations/cerestation.dmm
+++ b/_maps/map_files/stations/cerestation.dmm
@@ -36168,13 +36168,6 @@
 /turf/simulated/wall,
 /area/station/science/robotics)
 "equ" = (
-/obj/effect/spawner/grouped_spawner{
-	group_id = "tunnelbats";
-	max_per_spawner = 1;
-	name = "bat spawner";
-	path_to_spawn = /mob/living/simple_animal/hostile/scarybat;
-	total_amount = 20
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -123786,7 +123779,7 @@ lzH
 rNK
 rNK
 rNK
-dcv
+rNK
 rNK
 rNK
 lzH
@@ -124323,7 +124316,7 @@ rNK
 rNK
 rNK
 rNK
-dcv
+rNK
 rNK
 rNK
 rNK
@@ -125027,7 +125020,7 @@ rNK
 rNK
 rNK
 rNK
-dcv
+rNK
 rNK
 rNK
 rNK
@@ -131519,7 +131512,7 @@ xbO
 xbO
 rNK
 rNK
-dcv
+rNK
 rNK
 rNK
 rNK
@@ -135886,7 +135879,7 @@ rNK
 rNK
 rNK
 rNK
-dcv
+rNK
 rNK
 rNK
 knD
@@ -140734,7 +140727,7 @@ rNK
 rNK
 rNK
 rNK
-dcv
+rNK
 rNK
 rNK
 rNK
@@ -141232,7 +141225,7 @@ lzH
 rNK
 rNK
 rNK
-dcv
+rNK
 rNK
 lzH
 euP


### PR DESCRIPTION
## What Does This PR Do
This PR removes all the carp spawners from the inner ring of Cere space, as well as the space bats spawner inside engineering secure storage.
## Why It's Good For The Game
While massive carp migrations destroying every space bridge is very funny, fixing them exhaustively is time-consuming and hinders traversing the station in a way that other maps aren't affected by. The space bats inside secure storage are a little mean and keeping them out of departments, confining them to maints, makes more sense.
## Images of changes
See MDB.
## Testing
Visual inspection.
## Changelog
:cl:
tweak: Farragus: Space carp will no longer spawn in the space between asteroids.
tweak: Farragus: Space bats will no longer spawn in Engineering Secure Storage.
/:cl: