### PR TITLE
Doubles all percentages for botany genes

### DIFF
--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -29,9 +29,6 @@
 	reagents_add = list("iron" = 0.5)
 	rarity = 20
 
-
-
-
 /obj/item/grown/log
 	seed = /obj/item/seeds/tower
 	name = "tower-cap log"

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -148,7 +148,7 @@
 	var/rate = 0.04
 
 /datum/plant_gene/reagent/get_name()
-	return "[name] production [rate*100]%"
+	return "[name] production [rate * 200]%" // Yes 200 is correct
 
 /datum/plant_gene/reagent/proc/set_reagent(reag_id)
 	reagent_id = reag_id


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Doubles all visible percentages for botany plants

This way, if you reach 100% reagent capacity, you will still get all types of reagents added to your plant, in their ratios.
This has no balance changes.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
On live, the percentages stop counting at 50%, and densified chemicals "unlocks" the full 100% of plant power. 
This is a dumb system.
This way we can have 100% plant power at roundstart, with a potential 200% total plant power with densified chems.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
It compiled
![image](https://github.com/ParadiseSS13/Paradise/assets/108773801/2441510a-24cc-41f9-af9b-28402f1c325c)
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: All visible plant reagent percentages have been doubled. Their reagent production stays the same
tweak: That reagent production is now 0.5u per % of reagents
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
