### PR TITLE
Adds wikipage to zombie antag datum + minor fix

### DIFF
--- a/code/datums/diseases/zombie_virus.dm
+++ b/code/datums/diseases/zombie_virus.dm
@@ -31,11 +31,13 @@
 	if(!..())
 		return FALSE
 	if(HAS_TRAIT(affected_mob, TRAIT_I_WANT_BRAINS) || affected_mob.mind?.has_antag_datum(/datum/antagonist/zombie))
+		SSticker.mode.zombie_infected -= affected_mob
 		if(affected_mob.reagents.has_reagent("zombiecure4"))
 			return
 		handle_rot(TRUE)
 		stage = 7
 		return FALSE
+	SSticker.mode.zombie_infected |= affected_mob
 	switch(stage)
 		if(1) // cured by lvl 1 cure
 			if(prob(4))

--- a/code/datums/diseases/zombie_virus.dm
+++ b/code/datums/diseases/zombie_virus.dm
@@ -31,6 +31,8 @@
 	if(!..())
 		return FALSE
 	if(HAS_TRAIT(affected_mob, TRAIT_I_WANT_BRAINS) || affected_mob.mind?.has_antag_datum(/datum/antagonist/zombie))
+		if(affected_mob.reagents.has_reagent("zombiecure4"))
+			return
 		handle_rot(TRUE)
 		stage = 7
 		return FALSE

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -90,6 +90,11 @@
 	/// A list of all the minds that have the ERT special role
 	var/list/datum/mind/ert = list()
 
+	/// A list of all minds that are zombies
+	var/list/datum/mind/zombies = list()
+	/// A list of all minds that are infected with the zombie virus, but aren't zombies yet
+	var/list/datum/mind/zombie_infected = list()
+
 /datum/game_mode/proc/announce() //to be calles when round starts
 	to_chat(world, "<B>Notice</B>: [src] did not define announce()")
 

--- a/code/game/objects/items/weapons/manuals.dm
+++ b/code/game/objects/items/weapons/manuals.dm
@@ -543,7 +543,7 @@
 							<li>Chlorine Trifluoride</li>
 							<li>Sorium</li>
 							<li>"????" Reagent</li>
-							<li>A	ranesp</li>
+							<li>Aranesp</li>
 						</ul>
 					</li>
 				</ul>

--- a/code/modules/admin/player_panel.dm
+++ b/code/modules/admin/player_panel.dm
@@ -470,6 +470,12 @@
 		if(length(SSticker.mode.eventmiscs))
 			dat += check_role_table("Event Roles", SSticker.mode.eventmiscs)
 
+		if(length(SSticker.mode.zombies))
+			dat += check_role_table("Zombies", SSticker.mode.zombies)
+
+		if(length(SSticker.mode.zombie_infected))
+			dat += check_role_table_mob("Pre-zombie infected", SSticker.mode.zombie_infected)
+
 		if(length(GLOB.ts_spiderlist))
 			var/list/spider_minds = list()
 			for(var/mob/living/simple_animal/hostile/poison/terror_spider/S in GLOB.ts_spiderlist)
@@ -528,4 +534,11 @@
 		"}
 
 	txt += "</tr>"
+	return txt
+
+/datum/admins/proc/check_role_table_mob(name, list/members, show_objectives=1)
+	var/txt = "<br><table cellspacing=5><tr><td><b>[name]</b></td><td></td></tr>"
+	for(var/mob/M in members)
+		txt += check_role_table_row(M, show_objectives)
+	txt += "</table>"
 	return txt

--- a/code/modules/antagonists/zombie/datum_zombie.dm
+++ b/code/modules/antagonists/zombie/datum_zombie.dm
@@ -28,6 +28,12 @@ RESTRICT_TYPE(/datum/antagonist/zombie)
 	owner.RemoveSpell(/datum/spell/zombie_claws)
 	return ..()
 
+/datum/antagonist/zombie/add_owner_to_gamemode()
+	SSticker.mode.zombies |= owner
+
+/datum/antagonist/zombie/remove_owner_from_gamemode()
+	SSticker.mode.zombies -= owner
+
 /datum/antagonist/zombie/greet()
 	var/list/messages = list()
 	. = messages

--- a/code/modules/antagonists/zombie/datum_zombie.dm
+++ b/code/modules/antagonists/zombie/datum_zombie.dm
@@ -7,6 +7,7 @@ RESTRICT_TYPE(/datum/antagonist/zombie)
 	special_role = SPECIAL_ROLE_ZOMBIE
 	clown_gain_text = "B-Braaaaaains... Honk..."
 	clown_removal_text = "You feel funnier again."
+	wiki_page_name = "Zombie"
 	var/list/old_languages = list() // someone make this better to prevent langs changing if species changes while zombie somehow
 	var/static/list/zombie_traits = list(TRAIT_LANGUAGE_LOCKED, TRAIT_GOTTAGOSLOW, TRAIT_ABSTRACT_HANDS, TRAIT_SLOW_GRABBER)
 	var/datum/unarmed_attack/claws/claw_attack


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Adds wikipage to zombies now that they have a page. Fixes some bad spacing in the zombie manual too.
Fixes zombies being incurable because of an oversight... oops.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Wiki good

## Testing
<!-- How did you test the PR, if at all? -->
![image](https://github.com/ParadiseSS13/Paradise/assets/91113370/cad8600a-e76c-483b-b935-b25db17cca1a)


## Changelog
:cl:
fix: Zombies' now get their wikipage linked to when you become a zombie
fix: Zombies can be fully cured now. Oops.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
