### PR TITLE
Nerfs gaseous decomposition

### DIFF
--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -444,7 +444,7 @@
 	dangerous = TRUE
 
 /datum/plant_gene/trait/smoke/on_squash(obj/item/food/snacks/grown/G, atom/target)
-	var/datum/effect_system/smoke_spread/chem/S = new
+	var/datum/effect_system/smoke_spread/chem/plant/S = new()
 	var/splat_location = get_turf(target)
 	var/smoke_amount = round(sqrt(G.seed.potency * 0.1), 1)
 	S.set_up(G.reagents, splat_location)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Nerfs gaseous decomposition to spread out it's chemicals over people, instead of fully duplicating chemicals
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Gaseous decompositions has been the target of removal attempts, this should give it something that doesn't make it the most OP trait in combat.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://github.com/ParadiseSS13/Paradise/assets/108773801/7d85d7a6-b691-4a85-852b-8f5cad064af2)

![image](https://github.com/ParadiseSS13/Paradise/assets/108773801/bde41af7-6a81-46c9-bf83-54d182ad16ed)

![image](https://github.com/ParadiseSS13/Paradise/assets/108773801/fccee1e4-984f-48d3-9f33-134f10dfe8b5)

Expected amount is somewhere around 1u of capsaicin and other things, which will most likely get metabolized out

![image](https://github.com/ParadiseSS13/Paradise/assets/108773801/5d37a078-683d-488f-8a32-413fed02bc55)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
See above
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Gaseous decomposition now spreads it's chemicals out instead of fully copying it to all mobs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
