### PR TITLE
Berets no longer make other hats invisible on borgs

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -366,6 +366,7 @@
 /obj/item/clothing/head
 	name = "head"
 	icon = 'icons/obj/clothing/hats.dmi'
+	icon_override = 'icons/mob/clothing/head.dmi'
 	body_parts_covered = HEAD
 	slot_flags = SLOT_FLAG_HEAD
 	var/HUDType = null


### PR DESCRIPTION
## What Does This PR Do
I didn't think about borg hats when splitting the dmis
When equipping the beret, the icon_override value was set to the beret (or softcap) file
When equipping an item that used the basic hat item, the icon_override was never reset so it would continue attempting to look for the icons in the beret/softcap file.

This PR adds a line of code to set the icon_override value back to the OG file when equipping any hat that uses the basic item.

Fixes https://github.com/ParadiseSS13/Paradise/issues/25718

## Why It's Good For The Game
Bugs bad

## Images of changes
![image](https://github.com/ParadiseSS13/Paradise/assets/25437893/e30ad9bc-8f8b-40c3-ba28-62ceb84845c3)


## Testing
Put beret on borg, swap it for other hats
Put beret/other hats on myself, swap species with magic mirror to ensure all items still work

## Changelog
:cl:
fix: Borg hats no longer go invisible after equipping a beret
/:cl:
