### PR TITLE
Humans now instantly fall asleep at -100 HP, rather than after an (up to) 2 second delay

### DIFF
--- a/code/modules/mob/living/carbon/carbon_update_status.dm
+++ b/code/modules/mob/living/carbon/carbon_update_status.dm
@@ -6,7 +6,7 @@
 			death()
 			create_debug_log("died of damage, trigger reason: [reason]")
 			return
-		if(HAS_TRAIT(src, TRAIT_KNOCKEDOUT) || (check_death_method() && getOxyLoss() > 50) || HAS_TRAIT(src, TRAIT_FAKEDEATH) || health < HEALTH_THRESHOLD_KNOCKOUT && check_death_method())
+		if(HAS_TRAIT(src, TRAIT_KNOCKEDOUT) || (check_death_method() && getOxyLoss() > 50) || HAS_TRAIT(src, TRAIT_FAKEDEATH) || health < HEALTH_THRESHOLD_KNOCKOUT && check_death_method() || health <= HEALTH_THRESHOLD_DEAD)
 			if(stat == CONSCIOUS)
 				KnockOut()
 				create_debug_log("fell unconscious, trigger reason: [reason]")


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

People now instantly fall asleep the moment they hit -100 HP, rather than an up 2 second delay.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

357 / melee biohazards / other high alpha weapons without stamina damage suffer from 2 issues: limb damage cap, and the 2 second before knockout period.

This PR addresses the second issue, where a person rapidly dropped into crit would get 2-3 more shots off, even if they were 50 damage past the sleep point, making stamina crit weapons prefered as they could not shoot back / instantly went down from stamina.

Outside of these weapons, the only major change is if you are not stamina crit, as if you are in crit normally for a while, you'll randomly be knockdowned or stunned or slept from crit, likely leading to no diffrence felt there. This just makes the bigger hitting things, or pure melee biohazards, not suffer as much from finishing people off. Stamina based attacks unaffected.

## Testing
<!-- How did you test the PR, if at all? -->

Delt 200 damage to a drask.
Instantly fell asleep, rather than after 0 - 2 seconds.

## Changelog
:cl:
tweak: Humans now instantly fall asleep at -100 HP, rather than after an (up to) 2 second delay
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
