### PR TITLE
Fixes a runtime with loader modsuits dropping crates

### DIFF
--- a/code/modules/mod/modules/modules_supply.dm
+++ b/code/modules/mod/modules/modules_supply.dm
@@ -88,9 +88,7 @@
 
 /// Checks if the target crate has already been dropped by another on_select_use call
 /obj/item/mod/module/clamp/proc/should_cancel_drop()
-	if(length(stored_crates))
-		return FALSE
-	return TRUE
+	return !length(stored_crates)
 
 /obj/item/mod/module/clamp/loader
 	name = "MOD loader hydraulic clamp module"

--- a/code/modules/mod/modules/modules_supply.dm
+++ b/code/modules/mod/modules/modules_supply.dm
@@ -58,7 +58,7 @@
 		if(target_turf.density)
 			return
 		playsound(src, 'sound/mecha/hydraulic.ogg', 25, TRUE)
-		if(!do_after(mod.wearer, load_time, target = target))
+		if(!do_after(mod.wearer, load_time, target = target, extra_checks = list(CALLBACK(src, TYPE_PROC_REF(/obj/item/mod/module/clamp, should_cancel_drop)))))
 			return
 		if(target_turf.density)
 			return
@@ -83,6 +83,12 @@
 		if(mob.mob_size < MOB_SIZE_HUMAN)
 			continue
 		to_chat(mod.wearer, "<span class='warning'>Too heavy!</span>")
+		return FALSE
+	return TRUE
+
+/// Checks if the target crate has already been dropped by another on_select_use call
+/obj/item/mod/module/clamp/proc/should_cancel_drop()
+	if(length(stored_crates))
 		return FALSE
 	return TRUE
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
When crates are loaded, the clamp module's `on_select_use` will attempt to drop a crate from the `stored_crates` list at a target turf after a `do_after()` timer. This works great until the user has attempted to drop more crates than they have remaining. This leads to the situation where there is a single entry left in `stored_crates` and more than one `on_select_use()` calls awaiting the completion of the `do_after()`. After the most recent drop completes, `stored_crates` is now empty, and the remaining `on_select_use()` calls will attempt to `pop()` from the empty list, which leads to a runtime.

This adds a callback check to the `extra_check` parameter of the `do_after()` that will cancel the timer if `stored_crates` empties before it completes.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
This doesn't really affect gameplay much but having a progress bar complete and then nothing happen is kind of weird.

## Testing
<!-- How did you test the PR, if at all? -->

https://github.com/ParadiseSS13/Paradise/assets/98280110/f8271689-2193-49d3-a6b2-3e06073a2fb3


## Changelog
:cl:
fix: Fixes a runtime when a loader modsuit attempts to drop more crates than it has stored.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
