### PR TITLE
Multitools can now be used to find APCs

### DIFF
--- a/code/game/objects/items/tools/multitool.dm
+++ b/code/game/objects/items/tools/multitool.dm
@@ -57,9 +57,9 @@
 		to_chat(user, "<span class='warning'>No APC detected.</span>")
 		return
 	if(get_turf(src) == get_turf(apc)) // we're standing on top of it
-		to_chat(user, "<span class='notice'>APC detected 0 units [dir2text(apc.dir)].</span>")
+		to_chat(user, "<span class='notice'>APC detected 0 meters [dir2text(apc.dir)].</span>")
 		return
-	to_chat(user, "<span class='notice'>APC detected [get_dist(src, apc)] units [dir2text(get_dir(src, apc))].</span>")
+	to_chat(user, "<span class='notice'>APC detected [get_dist(src, apc)] meters [dir2text(get_dir(src, apc))].</span>")
 
 // Syndicate device disguised as a multitool; it will turn red when an AI camera is nearby.
 /obj/item/multitool/ai_detect

--- a/code/game/objects/items/tools/multitool.dm
+++ b/code/game/objects/items/tools/multitool.dm
@@ -59,7 +59,7 @@
 	if(get_turf(src) == get_turf(apc)) // we're standing on top of it
 		to_chat(user, "<span class='notice'>APC detected 0 meters [dir2text(apc.dir)].</span>")
 		return
-	to_chat(user, "<span class='notice'>APC detected [get_dist(src, apc)] meters [dir2text(get_dir(src, apc))].</span>")
+	to_chat(user, "<span class='notice'>APC detected [get_dist(src, apc)] meter\s [dir2text(get_dir(src, apc))].</span>")
 
 // Syndicate device disguised as a multitool; it will turn red when an AI camera is nearby.
 /obj/item/multitool/ai_detect

--- a/code/game/objects/items/tools/multitool.dm
+++ b/code/game/objects/items/tools/multitool.dm
@@ -29,6 +29,8 @@
 	var/obj/machinery/buffer // TODO - Make this a soft ref to tie into whats below
 	/// Soft-ref for linked stuff. This should be used over the above var.
 	var/buffer_uid
+	/// Cooldown for detecting APCs
+	COOLDOWN_DECLARE(cd_apc_scan)
 
 /obj/item/multitool/multitool_check_buffer(user, silent = FALSE)
 	return TRUE
@@ -44,6 +46,20 @@
 /obj/item/multitool/Destroy()
 	buffer = null
 	return ..()
+
+/obj/item/multitool/attack_self(mob/user)
+	if(!COOLDOWN_FINISHED(src, cd_apc_scan))
+		return
+	COOLDOWN_START(src, cd_apc_scan, 1.5 SECONDS)
+	var/area/local_area = get_area(src)
+	var/obj/machinery/power/apc/apc = local_area?.get_apc()
+	if(!apc)
+		to_chat(user, "<span class='warning'>No APC detected.</span>")
+		return
+	if(get_turf(src) == get_turf(apc)) // we're standing on top of it
+		to_chat(user, "<span class='notice'>APC detected 0 units [dir2text(apc.dir)].</span>")
+		return
+	to_chat(user, "<span class='notice'>APC detected [get_dist(src, apc)] units [dir2text(get_dir(src, apc))].</span>")
 
 // Syndicate device disguised as a multitool; it will turn red when an AI camera is nearby.
 /obj/item/multitool/ai_detect


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Multitools can now be used to find APCs.
Press Z (aka attack_self) in hand to use it.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Makes it easier for newbie and veteran engi players help find where that freakin broken APC is in the room without looking at the .dmm files

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![image](https://github.com/ParadiseSS13/Paradise/assets/91113370/01015d9c-15e7-4bd1-bf48-a55e5a015dbf)

## Testing
<!-- How did you test the PR, if at all? -->
See above

## Changelog
:cl:
add: Multitools can now be used in-hand to find a room's APC
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
