### PR TITLE
fix: ensure Lavaland tcomms is linked roundstart

### DIFF
--- a/code/game/machinery/tcomms/relay.dm
+++ b/code/game/machinery/tcomms/relay.dm
@@ -54,6 +54,11 @@
   */
 /obj/machinery/tcomms/relay/LateInitialize()
 	. = ..()
+
+	// It's also possible the relay's APC's Initialize was called after this one.
+	// Take the opportunity here to re-check the equipment channel.
+	power_change()
+
 	for(var/obj/machinery/tcomms/core/C in GLOB.tcomms_machines)
 		if(C.network_id == autolink_id)
 			AddLink(C)


### PR DESCRIPTION
## What Does This PR Do
This PR fixes the Lavaland tcomms relay to be properly registered to the core at roundstart. An APC's Initialize, as of #25642, is what links it to its powernet, and since the effective roundstart behavior for relays is to tell the core to refresh its z-levels after a power change, if that powernet doesn't exist, the core will think the relay doesn't have power. Since relays have a LateInitialize anyway, we do another power_change there to reflect if a powernet became available between Initialize and LateInitialize. Fixes #25722.
## Why It's Good For The Game
Bug fix good.
## Testing
Stepped through debugger at round initialize, confirmed with VV that core's available z-levels included Lavaland.
## Changelog
:cl:
fix: Lavaland's telecomms relay will now properly be linked to the station core at roundstart.
/:cl: