### PR TITLE
Buffs Capitalist Chef

### DIFF
--- a/_maps/map_files/stations/boxstation.dmm
+++ b/_maps/map_files/stations/boxstation.dmm
@@ -22169,6 +22169,7 @@
 "bpG" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/bucket,
+/obj/item/wrench,
 /obj/item/reagent_containers/glass/bucket,
 /turf/simulated/floor/plasteel{
 	icon_state = "hydrofloor"
@@ -23277,7 +23278,6 @@
 /obj/item/reagent_containers/condiment/enzyme{
 	layer = 5
 	},
-/obj/item/stack/packageWrap,
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
@@ -23285,7 +23285,7 @@
 "bsT" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/sop_service,
-/obj/item/eftpos/register,
+/obj/item/stack/packageWrap,
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
@@ -40729,22 +40729,25 @@
 	},
 /area/station/supply/miningdock)
 "cEU" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/fancy/donut_box,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/classic/normal{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/windoor/autoname{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/service/kitchen{
 	dir = 1
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id_tag = "kitchenhall";
 	name = "Kitchen Shutters";
 	dir = 2
+	},
+/obj/item/eftpos/register{
+	dir = 1;
+	pixel_y = 5
+	},
+/obj/structure/table/reinforced,
+/obj/effect/mapping_helpers/airlock/windoor/autoname{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/service/kitchen{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
@@ -54530,6 +54533,30 @@
 	icon_state = "grimy"
 	},
 /area/station/hallway/secondary/entry/lounge)
+"eDk" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/classic/normal{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/windoor/autoname{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/service/kitchen{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id_tag = "kitchenbar";
+	name = "Kitchen Shutters"
+	},
+/obj/item/eftpos/register{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/station/service/kitchen)
 "eDs" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -86048,6 +86075,28 @@
 	},
 /turf/simulated/floor/noslip,
 /area/station/engineering/control)
+"tRp" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/classic/reversed{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/windoor/autoname{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/service/kitchen{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id_tag = "kitchenhall";
+	name = "Kitchen Shutters";
+	dir = 2
+	},
+/obj/item/storage/fancy/donut_box,
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/station/service/kitchen)
 "tRs" = (
 /obj/machinery/door/airlock/maintenance{
 	locked = 1
@@ -131938,7 +131987,7 @@ hEW
 wmU
 hEW
 wmU
-hEW
+eDk
 gxs
 bdT
 bdT
@@ -133996,7 +134045,7 @@ buv
 bof
 bof
 bof
-hrA
+tRp
 bzf
 nuq
 uZL

--- a/_maps/map_files/stations/boxstation.dmm
+++ b/_maps/map_files/stations/boxstation.dmm
@@ -22169,7 +22169,6 @@
 "bpG" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/bucket,
-/obj/item/wrench,
 /obj/item/reagent_containers/glass/bucket,
 /turf/simulated/floor/plasteel{
 	icon_state = "hydrofloor"
@@ -23286,6 +23285,7 @@
 /obj/structure/table,
 /obj/item/book/manual/wiki/sop_service,
 /obj/item/stack/packageWrap,
+/obj/item/eftpos/register,
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
@@ -40738,10 +40738,6 @@
 	name = "Kitchen Shutters";
 	dir = 2
 	},
-/obj/item/eftpos/register{
-	dir = 1;
-	pixel_y = 5
-	},
 /obj/structure/table/reinforced,
 /obj/effect/mapping_helpers/airlock/windoor/autoname{
 	dir = 1
@@ -54533,30 +54529,6 @@
 	icon_state = "grimy"
 	},
 /area/station/hallway/secondary/entry/lounge)
-"eDk" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/classic/normal{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/windoor/autoname{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/service/kitchen{
-	dir = 4
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 8;
-	id_tag = "kitchenbar";
-	name = "Kitchen Shutters"
-	},
-/obj/item/eftpos/register{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/station/service/kitchen)
 "eDs" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -72304,6 +72276,16 @@
 	icon_state = "blackcorner"
 	},
 /area/station/security/permabrig)
+"nlp" = (
+/obj/structure/table,
+/obj/item/eftpos/register{
+	dir = 4
+	},
+/obj/item/wrench,
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/station/service/kitchen)
 "nlK" = (
 /obj/machinery/light{
 	dir = 8
@@ -131987,7 +131969,7 @@ hEW
 wmU
 hEW
 wmU
-eDk
+hEW
 gxs
 bdT
 bdT
@@ -132240,7 +132222,7 @@ biU
 boN
 bdT
 bmh
-bof
+nlp
 bpL
 bof
 bof

--- a/_maps/map_files/stations/cerestation.dmm
+++ b/_maps/map_files/stations/cerestation.dmm
@@ -42964,9 +42964,6 @@
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
-/obj/item/eftpos/register{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/station/service/kitchen)
 "gMb" = (
@@ -50940,6 +50937,7 @@
 /obj/structure/table,
 /obj/item/eftpos,
 /obj/effect/spawner/random_spawners/dirt_often,
+/obj/item/eftpos/register,
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
@@ -75098,6 +75096,9 @@
 	pixel_y = -24
 	},
 /obj/structure/table/reinforced,
+/obj/item/eftpos/register{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
@@ -87051,21 +87052,6 @@
 	icon_state = "redyellowfull"
 	},
 /area/station/service/bar)
-"uHk" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 1;
-	id_tag = "kitchen2"
-	},
-/obj/machinery/door/window/classic/normal,
-/obj/effect/mapping_helpers/airlock/windoor/autoname,
-/obj/effect/mapping_helpers/airlock/windoor/access/any/service/kitchen,
-/obj/item/eftpos/register,
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/station/service/kitchen)
 "uHx" = (
 /turf/simulated/mineral/ancient,
 /area/station/supply/miningdock)
@@ -119427,7 +119413,7 @@ vaT
 qoN
 onO
 bjr
-uHk
+mgI
 mrt
 juY
 mrt

--- a/_maps/map_files/stations/cerestation.dmm
+++ b/_maps/map_files/stations/cerestation.dmm
@@ -42595,7 +42595,7 @@
 /area/station/medical/morgue)
 "gGj" = (
 /obj/structure/table,
-/obj/item/kitchen/knife,
+/obj/item/wrench,
 /turf/simulated/floor/plasteel/freezer,
 /area/station/service/kitchen)
 "gGB" = (
@@ -42964,6 +42964,9 @@
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
+/obj/item/eftpos/register{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/service/kitchen)
 "gMb" = (
@@ -50935,7 +50938,6 @@
 /area/station/service/library)
 "jlp" = (
 /obj/structure/table,
-/obj/item/eftpos/register,
 /obj/item/eftpos,
 /obj/effect/spawner/random_spawners/dirt_often,
 /turf/simulated/floor/plasteel{
@@ -75096,7 +75098,6 @@
 	pixel_y = -24
 	},
 /obj/structure/table/reinforced,
-/obj/item/eftpos/register,
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
@@ -87050,6 +87051,21 @@
 	icon_state = "redyellowfull"
 	},
 /area/station/service/bar)
+"uHk" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	id_tag = "kitchen2"
+	},
+/obj/machinery/door/window/classic/normal,
+/obj/effect/mapping_helpers/airlock/windoor/autoname,
+/obj/effect/mapping_helpers/airlock/windoor/access/any/service/kitchen,
+/obj/item/eftpos/register,
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/station/service/kitchen)
 "uHx" = (
 /turf/simulated/mineral/ancient,
 /area/station/supply/miningdock)
@@ -119411,7 +119427,7 @@ vaT
 qoN
 onO
 bjr
-mgI
+uHk
 mrt
 juY
 mrt

--- a/_maps/map_files/stations/deltastation.dmm
+++ b/_maps/map_files/stations/deltastation.dmm
@@ -18074,6 +18074,7 @@
 /obj/item/hand_labeler,
 /obj/item/book/manual/wiki/chef_recipes,
 /obj/effect/turf_decal/delivery/hollow,
+/obj/item/wrench,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -19257,6 +19258,9 @@
 /obj/machinery/door/window/reinforced/reversed{
 	dir = 8;
 	name = "kitchen ingredient storage"
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/service/kitchen{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/station/service/kitchen)
@@ -20781,12 +20785,8 @@
 /turf/simulated/floor/plasteel,
 /area/station/service/kitchen)
 "blo" = (
-/obj/item/clipboard,
 /obj/item/toy/figure/crew/chef,
 /obj/effect/turf_decal/delivery/hollow,
-/obj/item/eftpos/register{
-	dir = 1
-	},
 /obj/structure/table,
 /turf/simulated/floor/plasteel,
 /area/station/service/kitchen)
@@ -70926,6 +70926,28 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/west)
+"hhu" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/windoor/autoname{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/service/kitchen{
+	dir = 8
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id_tag = "kitchenhall";
+	name = "Kitchen Shutters"
+	},
+/obj/item/eftpos/register{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/service/kitchen)
 "hhz" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable{
@@ -73764,7 +73786,6 @@
 /area/station/hallway/secondary/entry/west)
 "iUZ" = (
 /obj/structure/table/reinforced,
-/obj/item/reagent_containers/condiment/peppermill,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window,
 /obj/effect/mapping_helpers/airlock/windoor/autoname,
@@ -73775,6 +73796,7 @@
 	name = "Kitchen Shutters";
 	dir = 1
 	},
+/obj/item/eftpos/register,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
@@ -81016,8 +81038,6 @@
 /obj/machinery/door/window,
 /obj/effect/mapping_helpers/airlock/windoor/autoname,
 /obj/effect/mapping_helpers/airlock/windoor/access/any/service/kitchen,
-/obj/item/reagent_containers/drinks/britcup,
-/obj/item/reagent_containers/condiment/saltshaker,
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/delivery,
 /obj/structure/table/reinforced,
@@ -83338,6 +83358,13 @@
 	id_tag = "kitchenbar";
 	name = "Kitchen Shutters";
 	dir = 1
+	},
+/obj/item/reagent_containers/condiment/peppermill,
+/obj/item/reagent_containers/condiment/saltshaker{
+	pixel_x = 8
+	},
+/obj/item/reagent_containers/drinks/britcup{
+	pixel_x = -9
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
@@ -138967,7 +138994,7 @@ aYZ
 rVB
 pzT
 pzT
-pzT
+hhu
 aYZ
 bna
 rnb

--- a/_maps/map_files/stations/deltastation.dmm
+++ b/_maps/map_files/stations/deltastation.dmm
@@ -19294,6 +19294,7 @@
 /obj/item/reagent_containers/condiment/flour,
 /obj/effect/turf_decal/delivery/hollow,
 /obj/structure/table,
+/obj/item/food/snacks/dough,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -19329,10 +19330,10 @@
 	},
 /area/station/hallway/primary/fore/east)
 "bhQ" = (
-/obj/item/food/snacks/dough,
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/turf_decal/delivery/hollow,
 /obj/structure/table,
+/obj/item/kitchen/rollingpin,
 /turf/simulated/floor/plasteel{
 	icon_state = "redfull"
 	},
@@ -19340,7 +19341,13 @@
 "bhR" = (
 /obj/effect/turf_decal/delivery/hollow,
 /obj/structure/table,
-/obj/item/food/snacks/mint,
+/obj/item/food/snacks/mint{
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/condiment/saltshaker{
+	pixel_x = 7
+	},
+/obj/item/reagent_containers/condiment/peppermill,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -20785,9 +20792,17 @@
 /turf/simulated/floor/plasteel,
 /area/station/service/kitchen)
 "blo" = (
-/obj/item/toy/figure/crew/chef,
+/obj/item/toy/figure/crew/chef{
+	pixel_x = -1;
+	pixel_y = 3
+	},
 /obj/effect/turf_decal/delivery/hollow,
 /obj/structure/table,
+/obj/item/clothing/suit/chef,
+/obj/item/kitchen/knife{
+	pixel_x = -9;
+	pixel_y = 5
+	},
 /turf/simulated/floor/plasteel,
 /area/station/service/kitchen)
 "blq" = (
@@ -21586,10 +21601,11 @@
 /turf/simulated/wall,
 /area/station/service/kitchen)
 "bnc" = (
-/obj/item/clothing/suit/chef,
-/obj/item/kitchen/rollingpin,
 /obj/effect/turf_decal/delivery/hollow,
 /obj/structure/table,
+/obj/item/eftpos/register{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel,
 /area/station/service/kitchen)
 "bnd" = (
@@ -21606,11 +21622,11 @@
 /turf/simulated/wall,
 /area/station/supply/lobby)
 "bne" = (
-/obj/item/reagent_containers/condiment/saltshaker,
-/obj/item/reagent_containers/condiment/peppermill,
-/obj/item/kitchen/knife,
 /obj/effect/turf_decal/delivery,
 /obj/structure/table,
+/obj/item/eftpos/register{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel,
 /area/station/service/kitchen)
 "bnf" = (
@@ -70926,28 +70942,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/west)
-"hhu" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/windoor/autoname{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/service/kitchen{
-	dir = 8
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id_tag = "kitchenhall";
-	name = "Kitchen Shutters"
-	},
-/obj/item/eftpos/register{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/station/service/kitchen)
 "hhz" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable{
@@ -73796,7 +73790,6 @@
 	name = "Kitchen Shutters";
 	dir = 1
 	},
-/obj/item/eftpos/register,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
@@ -138994,7 +138987,7 @@ aYZ
 rVB
 pzT
 pzT
-hhu
+pzT
 aYZ
 bna
 rnb

--- a/_maps/map_files/stations/metastation.dmm
+++ b/_maps/map_files/stations/metastation.dmm
@@ -25512,7 +25512,6 @@
 /obj/item/reagent_containers/condiment/peppermill{
 	pixel_x = 3
 	},
-/obj/item/eftpos/register,
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
@@ -48952,6 +48951,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/item/eftpos/register,
 /obj/item/wrench,
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"

--- a/_maps/map_files/stations/metastation.dmm
+++ b/_maps/map_files/stations/metastation.dmm
@@ -25512,6 +25512,7 @@
 /obj/item/reagent_containers/condiment/peppermill{
 	pixel_x = 3
 	},
+/obj/item/eftpos/register,
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
@@ -48951,9 +48952,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/item/eftpos/register{
-	dir = 8
-	},
+/obj/item/wrench,
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Every station kitchen has enough points of sale to equip all serving counters.

Every station kitchen is now equipped with a wrench.

Removes a superfluous knife from Farragus' kitchen.

Removes a seemingly useless clipboard from Delta's kitchen.

Adds a table to Box's kitchen to hold the second point of sale.

Minor repositioning of some items.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Currently, 2 of the 4 maps don't have enough points of sale to equip both serving counters. This requires capitalist chefs to direct people to whichever serving counter is being used rather than being able to use both, improving the customer service experience for the rest of the crew.

The wrench allows chefs to unanchor and reanchor the points of sale immediately at round start, either to set them up, or to allow communist chefs to throw them into disposals to free up table space.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![image](https://github.com/ParadiseSS13/Paradise/assets/143041327/de139376-b640-4552-9224-95b4323ba42f)
![image](https://github.com/ParadiseSS13/Paradise/assets/143041327/e9c03fbf-0f83-4937-9c1d-32757240d715)
![image](https://github.com/ParadiseSS13/Paradise/assets/143041327/1b51cc64-1810-478d-af8b-309688a5ecdf)
![image](https://github.com/ParadiseSS13/Paradise/assets/143041327/9eebfc63-065c-4c97-b515-16cb92b0fd44)

## Testing
It compiled.
Points of sale were there.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
add: Adds an extra point of sale to Box and Delta.
add: Adds a wrench to Box, Delta, Meta, and Cere.
add: Adds a single table to Box kitchen.
tweak: Rearranges some items in the kitchen.
del: Removes a superflous knife from Farragus' kitchen.
del: Removes a useless clipboard from Delta's kitchen.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
