### PR TITLE
Buffs Deathsquad - inventory revision and implants

### DIFF
--- a/code/datums/outfits/outfit_admin.dm
+++ b/code/datums/outfits/outfit_admin.dm
@@ -276,7 +276,7 @@
 	gloves = /obj/item/clothing/gloves/combat
 	uniform = /obj/item/clothing/under/rank/centcom/deathsquad
 	shoes = /obj/item/clothing/shoes/magboots/elite
-	glasses = /obj/item/clothing/glasses/thermal
+	glasses = /obj/item/clothing/glasses/hud/security/night
 	mask = /obj/item/clothing/mask/gas/sechailer/swat
 	l_pocket = /obj/item/tank/internals/emergency_oxygen/double
 	r_pocket = /obj/item/reagent_containers/hypospray/combat/nanites
@@ -285,12 +285,21 @@
 	suit_store = /obj/item/gun/energy/pulse
 
 	backpack_contents = list(
-		/obj/item/storage/box/flashbangs,
+		/obj/item/storage/box/smoke_grenades,
+		/obj/item/ammo_box/a357,
+		/obj/item/ammo_box/a357,
 		/obj/item/ammo_box/a357,
 		/obj/item/flashlight/seclite,
-		/obj/item/grenade/plastic/c4/x4,
+		/obj/item/grenade/barrier,
 		/obj/item/melee/energy/sword/saber,
-		/obj/item/shield/energy,
+		/obj/item/shield/energy
+	)
+
+	cybernetic_implants = list(
+		/obj/item/organ/internal/eyes/cybernetic/thermals/hardened,
+		/obj/item/organ/internal/cyberimp/brain/anti_stam/hardened,
+		/obj/item/organ/internal/cyberimp/chest/nutriment/plus/hardened,
+		/obj/item/organ/internal/cyberimp/chest/reviver/hardened
 	)
 
 	bio_chips = list(

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -1011,10 +1011,10 @@
 	new /obj/item/flashlight/flare(src)
 	new /obj/item/crowbar/small(src)
 	new /obj/item/kitchen/knife/combat(src)
+	new /obj/item/grenade/plastic/c4/x4(src)
 	new /obj/item/reagent_containers/patch/synthflesh(src)
 	new /obj/item/reagent_containers/hypospray/autoinjector/survival(src)
-	new /obj/item/ammo_box/a357(src)
-	new /obj/item/ammo_box/a357(src)
+	new /obj/item/tank/internals/emergency_oxygen/engi(src)
 
 /obj/item/storage/box/soviet
 	name = "boxed survival kit"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR aims to improve the life and logic of Deathsquad existence.
1. I added sechuds with nightvision so they can recognise friends & foes better, especially when [this PR](https://github.com/ParadiseSS13/Paradise/pull/25743) will be merged.
2. I replaced flashbangs with smoke grenades, because Deathsquad don't really need non-lethal force. Smoke grenades will better outplay with thermal vision.
3. I replaced X4 with barrier grenade, and put X4 into "emergency" box, because why you ever want to use X4 when you had pulse rifle.
4. I added cybernetic implants to them, because Gamma ERT have it, so why they don't?
5. I added one extended-capacity oxygen tank to their emergency box, because you could litterally just lose yours, and that's it.

## Why It's Good For The Game
Deathsquad has some of the strongest weapons and armor in the game right now, but they are absolutely worthless against non-lethal force (and starvation, lol).

## Images of changes
![image](https://github.com/ParadiseSS13/Paradise/assets/20109643/1903c772-7b19-4f1b-9d8d-49ba605bb384)

## Testing
Tested on my local

## Changelog
:cl:
tweak: Deathsquad is now implanted with the most advanced technologies the NT has, and they've also had their inventory revised
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
