### PR TITLE
[FIX] Cyborg Zipties Will Not be Consumed When Making Wired Rods

### DIFF
--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -39,12 +39,9 @@ GLOBAL_LIST_INIT(rod_recipes, list (
 	usesound = 'sound/items/deconstruct.ogg'
 	merge_type = /obj/item/stack/rods
 
-
-
 /obj/item/stack/rods/examine(mob/user)
 	. = ..()
 	. += "<span class='notice'>Using rods on a floor plating will install a reinforced floor. You can make reinforced glass by combining rods and normal glass sheets.</span>"
-
 
 /obj/item/stack/rods/cyborg
 	energy_type = /datum/robot_storage/energy/rods
@@ -76,9 +73,11 @@ GLOBAL_LIST_INIT(rod_recipes, list (
 	if(get_amount() < 2)
 		to_chat(user, "<span class='warning'>You need at least two rods to do this!</span>")
 		return
+
 	. = TRUE
 	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
 		return
+
 	var/obj/item/stack/sheet/metal/new_item = new(drop_location())
 	if(new_item.get_amount() <= 0)
 		// stack was moved into another one on the pile

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -26,7 +26,7 @@
 	/// Sound made when cuffing someone.
 	var/cuffsound = 'sound/weapons/handcuffs.ogg'
 	/// Trash item generated when cuffs are broken (for disposable cuffs).
-	var/trashtype = null
+	var/trashtype
 	/// If set to TRUE, people with the TRAIT_CLUMSY won't cuff themselves when trying to cuff others.
 	var/ignoresClumsy = FALSE
 

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -224,6 +224,10 @@
 //////////////////////////////
 /obj/item/restraints/handcuffs/cable/attackby(obj/item/I, mob/user as mob, params)
 	..()
+	// Don't allow borgs to send their their ziptie module to the shadow realm.
+	if(istype(src, /obj/item/restraints/handcuffs/cable/zipties/cyborg))
+		return
+
 	if(istype(I, /obj/item/stack/rods))
 		var/obj/item/stack/rods/R = I
 		if(!R.use(1))
@@ -235,8 +239,6 @@
 			user.unEquip(src)
 		user.put_in_hands(W)
 		to_chat(user, "<span class='notice'>You wrap the cable restraint around the top of the rod.</span>")
-		if(istype(src, /obj/item/restraints/handcuffs/cable/zipties/cyborg))
-			return
 		qdel(src)
 		return
 
@@ -245,10 +247,10 @@
 		if(M.amount < 6)
 			to_chat(user, "<span class='warning'>You need at least six metal sheets to make good enough weights!</span>")
 			return
+
 		to_chat(user, "<span class='notice'>You begin to apply [I] to [src]...</span>")
-		if(do_after(user, 35 * M.toolspeed, target = src))
+		if(M.use(6) && do_after(user, 35 * M.toolspeed, target = src))
 			var/obj/item/restraints/legcuffs/bola/S = new /obj/item/restraints/legcuffs/bola
-			M.use(6)
 			user.put_in_hands(S)
 			to_chat(user, "<span class='notice'>You make some weights out of [I] and tie them to [src].</span>")
 			if(!remove_item_from_storage(user))

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -233,9 +233,10 @@
 		if(!R.use(1))
 			to_chat(user, "<span class='warning'>[R.amount > 1 ? "These rods" : "This rod"] somehow can't be used for crafting!</span>")
 			return
-
+		if(!user.unEquip(src))
+			return
 		var/obj/item/wirerod/W = new /obj/item/wirerod(get_turf(src))
-		if(user.unEquip(src) || !remove_item_from_storage(user))
+		if(!remove_item_from_storage(user))
 			user.put_in_hands(W)
 		to_chat(user, "<span class='notice'>You wrap the cable restraint around the top of the rod.</span>")
 		qdel(src)
@@ -248,12 +249,13 @@
 			return
 
 		to_chat(user, "<span class='notice'>You begin to apply [I] to [src]...</span>")
-		if(M.use(6) && do_after(user, 3.5 SECONDS * M.toolspeed, target = src))
+		if(do_after(user, 3.5 SECONDS * M.toolspeed, target = src))
+			if(!M.use(6) || !user.unEquip(src))
+				return
 			var/obj/item/restraints/legcuffs/bola/S = new /obj/item/restraints/legcuffs/bola(get_turf(src))
-			user.put_in_hands(S)
 			to_chat(user, "<span class='notice'>You make some weights out of [I] and tie them to [src].</span>")
 			if(!remove_item_from_storage(user))
-				user.unEquip(src)
+				user.put_in_hands(S)
 			qdel(src)
 		return
 

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -235,10 +235,8 @@
 			return
 
 		var/obj/item/wirerod/W = new /obj/item/wirerod
-		if(user.unEquip(src) || remove_item_from_storage(user))
+		if(user.unEquip(src) || !remove_item_from_storage(user))
 			user.put_in_hands(W)
-		else
-			W.forceMove(src.loc)
 		to_chat(user, "<span class='notice'>You wrap the cable restraint around the top of the rod.</span>")
 		qdel(src)
 		return

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -227,7 +227,7 @@
 	if(istype(I, /obj/item/stack/rods))
 		var/obj/item/stack/rods/R = I
 		if(!R.use(1))
-			to_chat(user, "<span class='warning'>You need one rod to make a wired rod!</span>")
+			to_chat(user, "<span class='warning'>[R.amount > 1 ? "These rods" : "This rod"] somehow can't be used for crafting!</span>")
 			return
 
 		var/obj/item/wirerod/W = new /obj/item/wirerod

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -235,9 +235,10 @@
 			return
 
 		var/obj/item/wirerod/W = new /obj/item/wirerod
-		if(!remove_item_from_storage(user))
-			user.unEquip(src)
-		user.put_in_hands(W)
+		if(user.unEquip(src) || remove_item_from_storage(user))
+			user.put_in_hands(W)
+		else
+			W.forceMove(src.loc)
 		to_chat(user, "<span class='notice'>You wrap the cable restraint around the top of the rod.</span>")
 		qdel(src)
 		return

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -3,7 +3,9 @@
 	desc = "Should not exist. Report me to a(n) coder/admin!"
 	icon = 'icons/obj/restraints.dmi'
 	var/cuffed_state = "handcuff"
-
+//////////////////////////////
+// MARK: HANDCUFFS
+//////////////////////////////
 /obj/item/restraints/handcuffs
 	name = "handcuffs"
 	desc = "Use this to keep prisoners in line."
@@ -20,9 +22,11 @@
 	origin_tech = "engineering=3;combat=3"
 	breakouttime = 1 MINUTES
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, RAD = 0, FIRE = 50, ACID = 50)
+	/// Sound made when cuffing someone.
 	var/cuffsound = 'sound/weapons/handcuffs.ogg'
-	// Icon state for cuffed overlay on a mob
-	var/trashtype = null //For disposable cuffs
+	/// Trash item generated when cuffs are broken (for disposable cuffs).
+	var/trashtype = null
+	/// If set to TRUE, people with the TRAIT_CLUMSY won't cuff themselves when trying to cuff others.
 	var/ignoresClumsy = FALSE
 
 /obj/item/restraints/handcuffs/attack(mob/living/carbon/C, mob/user)
@@ -88,6 +92,21 @@
 		target.update_handcuffed()
 		return
 
+//////////////////////////////
+// MARK: CUFF SKINS
+//////////////////////////////
+/obj/item/restraints/handcuffs/alien
+	icon_state = "handcuffAlien"
+
+/obj/item/restraints/handcuffs/pinkcuffs
+	name = "fluffy pink handcuffs"
+	desc = "Use this to keep prisoners in line, they are really itchy."
+	icon_state = "pinkcuffs"
+	cuffed_state = "pinkcuff"
+
+//////////////////////////////
+// MARK: SINEW CUFFS
+//////////////////////////////
 /obj/item/restraints/handcuffs/sinew
 	name = "sinew restraints"
 	desc = "A pair of restraints fashioned from long strands of flesh."
@@ -98,6 +117,9 @@
 	breakouttime = 30 SECONDS
 	cuffsound = 'sound/weapons/cablecuff.ogg'
 
+//////////////////////////////
+// MARK: CABLE CUFFS
+//////////////////////////////
 /obj/item/restraints/handcuffs/cable
 	name = "cable restraints"
 	desc = "Looks like some cables tied together. Could be used to tie something up."
@@ -152,46 +174,9 @@
 	color = pick(COLOR_RED, COLOR_BLUE, COLOR_GREEN, COLOR_PINK, COLOR_YELLOW, COLOR_CYAN)
 	return color
 
-/obj/item/restraints/handcuffs/alien
-	icon_state = "handcuffAlien"
-
-/obj/item/restraints/handcuffs/pinkcuffs
-	name = "fluffy pink handcuffs"
-	desc = "Use this to keep prisoners in line, they are really itchy."
-	icon_state = "pinkcuffs"
-	cuffed_state = "pinkcuff"
-
-/obj/item/restraints/handcuffs/cable/attackby(obj/item/I, mob/user as mob, params)
-	..()
-	if(istype(I, /obj/item/stack/rods))
-		var/obj/item/stack/rods/R = I
-		if(R.use(1))
-			var/obj/item/wirerod/W = new /obj/item/wirerod
-			if(!remove_item_from_storage(user))
-				user.unEquip(src)
-			user.put_in_hands(W)
-			to_chat(user, "<span class='notice'>You wrap the cable restraint around the top of the rod.</span>")
-			qdel(src)
-		else
-			to_chat(user, "<span class='warning'>You need one rod to make a wired rod!</span>")
-	else if(istype(I, /obj/item/stack/sheet/metal))
-		var/obj/item/stack/sheet/metal/M = I
-		if(M.amount < 6)
-			to_chat(user, "<span class='warning'>You need at least six metal sheets to make good enough weights!</span>")
-			return
-		to_chat(user, "<span class='notice'>You begin to apply [I] to [src]...</span>")
-		if(do_after(user, 35 * M.toolspeed, target = src))
-			var/obj/item/restraints/legcuffs/bola/S = new /obj/item/restraints/legcuffs/bola
-			M.use(6)
-			user.put_in_hands(S)
-			to_chat(user, "<span class='notice'>You make some weights out of [I] and tie them to [src].</span>")
-			if(!remove_item_from_storage(user))
-				user.unEquip(src)
-			qdel(src)
-	else if(istype(I, /obj/item/toy/crayon))
-		var/obj/item/toy/crayon/C = I
-		cable_color(C.colourName)
-
+//////////////////////////////
+// MARK: ZIPTIES
+//////////////////////////////
 /obj/item/restraints/handcuffs/cable/zipties
 	name = "zipties"
 	desc = "Plastic, disposable zipties that can be used to restrain temporarily but are destroyed after use."
@@ -218,6 +203,9 @@
 /obj/item/restraints/handcuffs/cable/zipties/used/attack()
 	return
 
+//////////////////////////////
+// MARK: TWIMSTS
+//////////////////////////////
 /obj/item/restraints/handcuffs/twimsts
 	name = "twimsts cuffs"
 	desc = "Liquorice twist candy made into cable cuffs, tasty but it can't actually hold anyone."
@@ -229,3 +217,44 @@
 	throwforce = 0
 	breakouttime = 0
 	cuffsound = 'sound/weapons/cablecuff.ogg'
+
+//////////////////////////////
+// MARK: CRAFTING
+//////////////////////////////
+/obj/item/restraints/handcuffs/cable/attackby(obj/item/I, mob/user as mob, params)
+	..()
+	if(istype(I, /obj/item/stack/rods))
+		var/obj/item/stack/rods/R = I
+		if(!R.use(1))
+			to_chat(user, "<span class='warning'>You need one rod to make a wired rod!</span>")
+			return
+
+			var/obj/item/wirerod/W = new /obj/item/wirerod
+			if(!remove_item_from_storage(user))
+				user.unEquip(src)
+			user.put_in_hands(W)
+			to_chat(user, "<span class='notice'>You wrap the cable restraint around the top of the rod.</span>")
+			if(istype(src, /obj/item/restraints/handcuffs/cable/zipties/cyborg))
+				return
+			qdel(src)
+			return
+
+	if(istype(I, /obj/item/stack/sheet/metal))
+		var/obj/item/stack/sheet/metal/M = I
+		if(M.amount < 6)
+			to_chat(user, "<span class='warning'>You need at least six metal sheets to make good enough weights!</span>")
+			return
+		to_chat(user, "<span class='notice'>You begin to apply [I] to [src]...</span>")
+		if(do_after(user, 35 * M.toolspeed, target = src))
+			var/obj/item/restraints/legcuffs/bola/S = new /obj/item/restraints/legcuffs/bola
+			M.use(6)
+			user.put_in_hands(S)
+			to_chat(user, "<span class='notice'>You make some weights out of [I] and tie them to [src].</span>")
+			if(!remove_item_from_storage(user))
+				user.unEquip(src)
+			qdel(src)
+		return
+
+	if(istype(I, /obj/item/toy/crayon))
+		var/obj/item/toy/crayon/C = I
+		cable_color(C.colourName)

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -229,15 +229,15 @@
 			to_chat(user, "<span class='warning'>You need one rod to make a wired rod!</span>")
 			return
 
-			var/obj/item/wirerod/W = new /obj/item/wirerod
-			if(!remove_item_from_storage(user))
-				user.unEquip(src)
-			user.put_in_hands(W)
-			to_chat(user, "<span class='notice'>You wrap the cable restraint around the top of the rod.</span>")
-			if(istype(src, /obj/item/restraints/handcuffs/cable/zipties/cyborg))
-				return
-			qdel(src)
+		var/obj/item/wirerod/W = new /obj/item/wirerod
+		if(!remove_item_from_storage(user))
+			user.unEquip(src)
+		user.put_in_hands(W)
+		to_chat(user, "<span class='notice'>You wrap the cable restraint around the top of the rod.</span>")
+		if(istype(src, /obj/item/restraints/handcuffs/cable/zipties/cyborg))
 			return
+		qdel(src)
+		return
 
 	if(istype(I, /obj/item/stack/sheet/metal))
 		var/obj/item/stack/sheet/metal/M = I

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -3,6 +3,7 @@
 	desc = "Should not exist. Report me to a(n) coder/admin!"
 	icon = 'icons/obj/restraints.dmi'
 	var/cuffed_state = "handcuff"
+
 //////////////////////////////
 // MARK: HANDCUFFS
 //////////////////////////////

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -222,7 +222,7 @@
 //////////////////////////////
 // MARK: CRAFTING
 //////////////////////////////
-/obj/item/restraints/handcuffs/cable/attackby(obj/item/I, mob/user as mob, params)
+/obj/item/restraints/handcuffs/cable/attackby(obj/item/I, mob/user, params)
 	..()
 	// Don't allow borgs to send their their ziptie module to the shadow realm.
 	if(istype(src, /obj/item/restraints/handcuffs/cable/zipties/cyborg))
@@ -234,7 +234,7 @@
 			to_chat(user, "<span class='warning'>[R.amount > 1 ? "These rods" : "This rod"] somehow can't be used for crafting!</span>")
 			return
 
-		var/obj/item/wirerod/W = new /obj/item/wirerod
+		var/obj/item/wirerod/W = new /obj/item/wirerod(get_turf(src))
 		if(user.unEquip(src) || !remove_item_from_storage(user))
 			user.put_in_hands(W)
 		to_chat(user, "<span class='notice'>You wrap the cable restraint around the top of the rod.</span>")
@@ -248,8 +248,8 @@
 			return
 
 		to_chat(user, "<span class='notice'>You begin to apply [I] to [src]...</span>")
-		if(M.use(6) && do_after(user, 35 * M.toolspeed, target = src))
-			var/obj/item/restraints/legcuffs/bola/S = new /obj/item/restraints/legcuffs/bola
+		if(M.use(6) && do_after(user, 3.5 SECONDS * M.toolspeed, target = src))
+			var/obj/item/restraints/legcuffs/bola/S = new /obj/item/restraints/legcuffs/bola(get_turf(src))
 			user.put_in_hands(S)
 			to_chat(user, "<span class='notice'>You make some weights out of [I] and tie them to [src].</span>")
 			if(!remove_item_from_storage(user))


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #22238.

Tiny cleanup of code.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Fix good.

Code nicer.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Compiled.
Cannot make wired rods as borg.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Borg zipties cannot be used to make wired rods.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
