### PR TITLE
de-capitalize the abductor surgery and toolset implant

### DIFF
--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -240,7 +240,7 @@
 	return FALSE
 
 /obj/item/organ/internal/cyberimp/arm/toolset_abductor
-	name = "Alien Toolset implant"
+	name = "alien toolset implant"
 	desc = "An alien toolset, designed to be installed on subject's arm."
 	origin_tech = "materials=5;engineering=5;plasmatech=5;powerstorage=4;abductor=3"
 	contents = newlist(/obj/item/screwdriver/abductor, /obj/item/wirecutters/abductor, /obj/item/crowbar/abductor, /obj/item/wrench/abductor, /obj/item/weldingtool/abductor, /obj/item/multitool/abductor)
@@ -262,7 +262,7 @@
 	parent_organ = "l_arm"
 
 /obj/item/organ/internal/cyberimp/arm/surgical_abductor
-	name = "Alien Surgical Toolset implant"
+	name = "alien surgical toolset implant"
 	desc = "An alien surgical toolset, designed to be installed on the subject's arm."
 	origin_tech = "materials=5;engineering=5;plasmatech=5;powerstorage=4;abductor=2"
 	contents = newlist(/obj/item/retractor/alien, /obj/item/hemostat/alien, /obj/item/cautery/alien, /obj/item/bonesetter/alien, /obj/item/scalpel/alien, /obj/item/circular_saw/alien, /obj/item/bonegel/alien, /obj/item/FixOVein/alien, /obj/item/surgicaldrill/alien)


### PR DESCRIPTION
## What Does This PR Do
De-capitalize the abductor surgery and toolset implant
Abductor Toolset implant --> abductor toolset implant
Abductor Surgery Toolset implant --> abductor surgery toolset implant

## Why It's Good For The Game
Fits in with the rest of the implants, so it's not an eyesore if you print multiple at once
Also makes it so pointing at the implant looks like "points to the abductor toolset implant" instead of "points to Abductor Toolset implant"

## Testing
launched a server, spawned both implant, no capital letters

## Changelog
NPFC