### PR TITLE
Cleans up duplicate var definitions

### DIFF
--- a/code/datums/spells/mimic.dm
+++ b/code/datums/spells/mimic.dm
@@ -3,7 +3,6 @@
 	desc =  "Learn a new form to mimic or become one of your known forms"
 	clothes_req = FALSE
 	base_cooldown = 3 SECONDS
-	action_icon_state = "genetic_morph"
 	selection_activated_message = "<span class='sinister'>Click on a target to remember it's form. Click on yourself to change form.</span>"
 	create_attack_logs = FALSE
 	action_icon_state = "morph_mimic"

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -439,10 +439,9 @@
 				return
 
 /atom/movable/screen/alert/status_effect/regenerative_core
-	name = "Reinforcing Tendrils"
+	name = "Regenerative Core Tendrils"
 	desc = "You can move faster than your broken body could normally handle!"
 	icon_state = "regenerative_core"
-	name = "Regenerative Core Tendrils"
 
 /datum/status_effect/regenerative_core
 	id = "Regenerative Core"

--- a/code/game/jobs/job/security_jobs.dm
+++ b/code/game/jobs/job/security_jobs.dm
@@ -127,7 +127,6 @@
 	selection_color = "#ffeeee"
 	alt_titles = list("Forensic Technician")
 	access = list(ACCESS_SECURITY, ACCESS_SEC_DOORS, ACCESS_BRIG, ACCESS_FORENSICS_LOCKERS, ACCESS_MORGUE, ACCESS_MAINT_TUNNELS, ACCESS_COURT, ACCESS_WEAPONS)
-	alt_titles = list("Forensic Technician")
 	minimal_player_age = 14
 	exp_map = list(EXP_TYPE_CREW = 600)
 	blacklisted_disabilities = list(DISABILITY_FLAG_BLIND, DISABILITY_FLAG_DEAF, DISABILITY_FLAG_MUTE, DISABILITY_FLAG_DIZZY)

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -43,7 +43,6 @@
 	icon_state = "donutbox"
 	storage_slots = 6
 	can_hold = list(/obj/item/food/snacks/donut)
-	icon_type = "donut"
 	foldable = /obj/item/stack/sheet/cardboard
 	foldable_amt = 1
 

--- a/code/game/objects/structures/holosigns.dm
+++ b/code/game/objects/structures/holosigns.dm
@@ -79,7 +79,6 @@
 	density = FALSE
 	layer = ABOVE_MOB_LAYER
 	anchored = TRUE
-	layer = ABOVE_MOB_LAYER
 	alpha = 150
 	flags_2 = RAD_PROTECT_CONTENTS_2 | RAD_NO_CONTAMINATE_2
 	rad_insulation = RAD_LIGHT_INSULATION

--- a/code/game/objects/structures/lavaland/billboard.dm
+++ b/code/game/objects/structures/lavaland/billboard.dm
@@ -11,7 +11,6 @@
 	armor = list(MELEE = 20, BULLET = 20, LASER = 20, ENERGY = 100, BOMB = 0, RAD = 0, FIRE = 50, ACID = 50)
 	resistance_flags = LAVA_PROOF | FIRE_PROOF
 	layer = EDGED_TURF_LAYER
-	resistance_flags = FIRE_PROOF
 	blocks_emissive = FALSE
 	var/static/list/billboard_overlay = list("chasmland", "incompatible", "feed", "warm", "adventure", "plasmaland", "gate", "gate2", "ufo", "notfriendly", "gps", "service", "protection", "diamonds", "step", "paradise", "hell")
 

--- a/code/game/turfs/space/space_turf.dm
+++ b/code/game/turfs/space/space_turf.dm
@@ -16,7 +16,6 @@
 	var/destination_z
 	var/destination_x
 	var/destination_y
-	plane = PLANE_SPACE
 
 /turf/space/Initialize(mapload)
 	SHOULD_CALL_PARENT(FALSE)

--- a/code/modules/clothing/head/job_hats.dm
+++ b/code/modules/clothing/head/job_hats.dm
@@ -2,10 +2,9 @@
 //Bartender
 /obj/item/clothing/head/chefhat
 	name = "chef's hat"
-	desc = "It's a hat used by chefs to keep hair out of your food. Judging by the food in the mess, they don't work."
+	desc = "The commander in chef's head wear."
 	icon_state = "chef"
 	item_state = "chef"
-	desc = "The commander in chef's head wear."
 	strip_delay = 10
 	put_on_delay = 10
 	dog_fashion = /datum/dog_fashion/head/chef

--- a/code/modules/clothing/masks/misc_masks.dm
+++ b/code/modules/clothing/masks/misc_masks.dm
@@ -416,7 +416,6 @@
 		"Drask" = 'icons/mob/clothing/species/drask/mask.dmi'
 		)
 	actions_types = list(/datum/action/item_action/adjust)
-	can_toggle = TRUE
 
 /obj/item/clothing/mask/bandana/attack_self(mob/user)
 	adjustmask(user)

--- a/code/modules/clothing/spacesuits/ert_hardsuits.dm
+++ b/code/modules/clothing/spacesuits/ert_hardsuits.dm
@@ -57,7 +57,6 @@
 	icon_state = "ert_commander"
 	item_state = "suit-command"
 	w_class = WEIGHT_CLASS_NORMAL
-	allowed = list(/obj/item/gun,/obj/item/ammo_box,/obj/item/ammo_casing,/obj/item/melee/baton,/obj/item/melee/energy/sword/saber,/obj/item/restraints/handcuffs,/obj/item/tank/internals)
 	armor = list(MELEE = 40, BULLET = 15, LASER = 20, ENERGY = 5, BOMB = 15, RAD = 50, FIRE = 200, ACID = 200)
 	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/t_scanner, /obj/item/rcd, /obj/item/crowbar, \
 	/obj/item/screwdriver, /obj/item/weldingtool, /obj/item/wirecutters, /obj/item/wrench, /obj/item/multitool, \

--- a/code/modules/clothing/spacesuits/syndi.dm
+++ b/code/modules/clothing/spacesuits/syndi.dm
@@ -1,10 +1,9 @@
 //Regular syndicate space suit
 /obj/item/clothing/head/helmet/space/syndicate
 	name = "red space helmet"
-	desc = "Top secret Spess Helmet."
+	desc = "Has a tag on it: Totally not property of a hostile corporation, honest!"
 	icon_state = "syndicate"
 	item_state = "syndicate"
-	desc = "Has a tag on it: Totally not property of a hostile corporation, honest!"
 	armor = list(MELEE = 35, BULLET = 50, LASER = 20, ENERGY = 10, BOMB = 20, RAD = 20, FIRE = 200, ACID = 285)
 	sprite_sheets = list(
 		"Grey" = 'icons/mob/clothing/species/grey/helmet.dmi',

--- a/code/modules/clothing/under/costumes.dm
+++ b/code/modules/clothing/under/costumes.dm
@@ -173,7 +173,6 @@
 	name = "tourist outfit"
 	desc = "A light blue shirt with brown shorts. Feels oddly spooky."
 	icon_state = "tourist"
-	icon_state = "tourist"
 	item_color = "tourist"
 
 /obj/item/clothing/under/costume/singery

--- a/code/modules/hydroponics/grown/nettle.dm
+++ b/code/modules/hydroponics/grown/nettle.dm
@@ -32,10 +32,9 @@
 /obj/item/grown/nettle
 	name = "nettle"
 	desc = "It's probably <B>not</B> wise to touch it with bare hands..."
-	icon = 'icons/obj/items.dmi'
+	icon = 'icons/obj/weapons/melee.dmi'
 	lefthand_file = 'icons/mob/inhands/weapons_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons_righthand.dmi'
-	icon = 'icons/obj/weapons/melee.dmi'
 	icon_state = "nettle"
 	damtype = "fire"
 	force = 15

--- a/code/modules/mining/equipment/explorer_gear.dm
+++ b/code/modules/mining/equipment/explorer_gear.dm
@@ -109,7 +109,6 @@
 	gas_transfer_coefficient = 0.90
 	permeability_coefficient = 0.50
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
-	allowed = list(/obj/item/flashlight,/obj/item/tank/internals/emergency_oxygen,/obj/item/extinguisher)
 	slowdown = 1
 	armor = list(MELEE = 10, BULLET = 5, LASER = 10, ENERGY = 5, BOMB = 50, RAD = 10, FIRE = 50, ACID = 50)
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT|HIDETAIL

--- a/code/modules/mining/lavaland/loot/colossus_loot.dm
+++ b/code/modules/mining/lavaland/loot/colossus_loot.dm
@@ -258,7 +258,6 @@
 	response_help = "waves away"
 	response_disarm = "brushes aside"
 	response_harm = "disrupts"
-	speak_emote = list("oscillates")
 	maxHealth = 2
 	health = 2
 	harm_intent_damage = 1
@@ -277,7 +276,6 @@
 	universal_understand = TRUE
 	del_on_death = TRUE
 	unsuitable_atmos_damage = 0
-	flying = TRUE
 	minbodytemp = 0
 	maxbodytemp = 1500
 	environment_smash = 0

--- a/code/modules/mob/living/brain/MMI.dm
+++ b/code/modules/mob/living/brain/MMI.dm
@@ -5,7 +5,6 @@
 	icon = 'icons/obj/assemblies.dmi'
 	icon_state = "mmi_empty"
 	w_class = WEIGHT_CLASS_NORMAL
-	origin_tech = "biotech=3"
 	origin_tech = "biotech=2;programming=3;engineering=2"
 
 	//Revised. Brainmob is now contained directly within object of transfer. MMI in this case.

--- a/code/modules/mob/living/carbon/human/human_emote.dm
+++ b/code/modules/mob/living/carbon/human/human_emote.dm
@@ -39,7 +39,6 @@
 
 /datum/emote/living/carbon/human/clap
 	key = "clap"
-	key = "clap"
 	key_third_person = "claps"
 	message = "claps."
 	message_mime = "claps silently."

--- a/code/modules/mob/living/living_emote.dm
+++ b/code/modules/mob/living/living_emote.dm
@@ -73,7 +73,6 @@
 	muzzle_ignore = TRUE // makes sure that sound is played upon death
 	bypass_unintentional_cooldown = TRUE  // again, this absolutely MUST play when a user dies, if it can.
 	message = "seizes up and falls limp, their eyes dead and lifeless..."
-	message_alien = "seizes up and falls limp, their eyes dead and lifeless..."
 	message_robot = "shudders violently for a moment before falling still, its eyes slowly darkening."
 	message_AI = "screeches, its screen flickering as its systems slowly halt."
 	message_alien = "lets out a waning guttural screech, green blood bubbling from its maw..."

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -589,7 +589,6 @@ Difficulty: Hard
 	maxHealth = 1
 	alpha = 127.5
 	crusher_loot = null
-	loot = null
 	medal_type = null
 	score_type = null
 	deathmessage = "Explodes into a pool of blood!"

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
@@ -48,7 +48,6 @@ Difficulty: Medium
 	enraged_loot = /obj/item/disk/fauna_research/legion
 	vision_range = 13
 	elimination = TRUE
-	appearance_flags = 0
 	mouse_opacity = MOUSE_OPACITY_ICON
 	stat_attack = UNCONSCIOUS // Overriden from /tg/ - otherwise Legion starts chasing its minions
 	appearance_flags = 512

--- a/code/modules/mob/living/simple_animal/hostile/mining/basilisk.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/basilisk.dm
@@ -28,7 +28,6 @@
 	a_intent = INTENT_HARM
 	speak_emote = list("chitters")
 	attack_sound = 'sound/weapons/bladeslice.ogg'
-	vision_range = 2
 	aggro_vision_range = 9
 	turns_per_move = 5
 	gold_core_spawnable = HOSTILE_SPAWN

--- a/code/modules/mob/living/simple_animal/hostile/mining/goliath.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/goliath.dm
@@ -15,7 +15,6 @@
 	ranged_cooldown_time = 120
 	friendly = "wails at"
 	speak_emote = list("bellows")
-	vision_range = 4
 	speed = 3
 	maxHealth = 300
 	health = 300

--- a/code/modules/mob/living/simple_animal/hostile/netherworld.dm
+++ b/code/modules/mob/living/simple_animal/hostile/netherworld.dm
@@ -11,7 +11,6 @@
 	melee_damage_upper = 50
 	attacktext = "chomps"
 	attack_sound = 'sound/weapons/bladeslice.ogg'
-	faction = list("creature")
 	speak_emote = list("screams")
 	gold_core_spawnable = HOSTILE_SPAWN
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/clown.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/clown.dm
@@ -6,7 +6,6 @@
 	icon_living = "clown"
 	icon_dead = "clown_dead"
 	icon_gib = "clown_gib"
-	speak_chance = 0
 	mob_biotypes = MOB_ORGANIC | MOB_HUMANOID
 	turns_per_move = 5
 	response_help = "pokes the"

--- a/code/modules/mob/living/simple_animal/shade.dm
+++ b/code/modules/mob/living/simple_animal/shade.dm
@@ -22,7 +22,6 @@
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	speed = -1
 	stop_automated_movement = TRUE
-	status_flags = 0
 	pull_force = 0
 	see_invisible = SEE_INVISIBLE_HIDDEN_RUNES
 	universal_speak = TRUE

--- a/code/modules/mob/living/simple_animal/slime/slime_mob.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime_mob.dm
@@ -25,7 +25,6 @@
 	maxHealth = 150
 	health = 150
 	healable = FALSE
-	gender = NEUTER
 
 	see_in_dark = 8
 

--- a/code/modules/mod/mod_control.dm
+++ b/code/modules/mod/mod_control.dm
@@ -8,7 +8,6 @@
 /obj/item/mod/control
 	name = "MOD control unit"
 	desc = "The control unit of a Modular Outerwear Device, a powered suit that protects against various environments."
-	icon_state = "standard-control"
 	icon_state = "mod_control"
 	item_state = "mod_control"
 	base_icon_state = "control"

--- a/code/modules/mod/modules/modules_antag.dm
+++ b/code/modules/mod/modules/modules_antag.dm
@@ -331,7 +331,6 @@
 	icon_state = "cloak_ninja"
 	bumpoff = FALSE
 	stealth_alpha = 10
-	cooldown_time = 5 SECONDS
 	active_power_cost = DEFAULT_CHARGE_DRAIN
 	use_power_cost = DEFAULT_CHARGE_DRAIN * 5
 	cooldown_time = 3 SECONDS

--- a/code/modules/power/cables/cable_coil.dm
+++ b/code/modules/power/cables/cable_coil.dm
@@ -11,7 +11,7 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list (new/datum/stack_recipe/cable_restrain
 	singular_name = "cable"
 	icon = 'icons/obj/power.dmi'
 	icon_state = "coil"
-	item_state = "coil_red"
+	item_state = "coil"
 	belt_icon = "cable_coil"
 	amount = MAXCOIL
 	max_amount = MAXCOIL
@@ -24,7 +24,6 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list (new/datum/stack_recipe/cable_restrain
 	materials = list(MAT_METAL = 15, MAT_GLASS = 10)
 	flags = CONDUCT
 	slot_flags = SLOT_FLAG_BELT
-	item_state = "coil"
 	attack_verb = list("whipped", "lashed", "disciplined", "flogged")
 	usesound = 'sound/items/deconstruct.ogg'
 	toolspeed = 1

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -119,7 +119,6 @@
 	muzzle_type = /obj/effect/projectile/muzzle/pulse
 	tracer_type = /obj/effect/projectile/tracer/pulse
 	impact_type = /obj/effect/projectile/impact/pulse
-	impact_effect_type = null
 	hitscan_light_intensity = 3
 	hitscan_light_range = 0.75
 	hitscan_light_color_override = LIGHT_COLOR_DARKBLUE

--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -472,7 +472,6 @@
 	drink_icon ="beerglass"
 	drink_name = "Beer glass"
 	drink_desc = "A freezing pint of beer"
-	taste_description = "beer"
 	taste_description = "piss water"
 
 /datum/reagent/beer2/on_mob_life(mob/living/M)

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -201,7 +201,6 @@
 	return 1
 
 /obj/docking_port/mobile
-	icon_state = "mobile"
 	name = "shuttle"
 	icon_state = "pinonclose"
 

--- a/code/modules/surgery/organs/organ_datums/lung_datum.dm
+++ b/code/modules/surgery/organs/organ_datums/lung_datum.dm
@@ -353,10 +353,6 @@
 
 /datum/organ/lungs/ashwalker
 	safe_oxygen_min = 4 // 4x as efficient as regular Unathi, can comfortably breathe on lavaland
-	heat_level_1_threshold = 505
-	heat_level_2_threshold = 540
-	heat_level_3_threshold = 600
-
 	cold_level_1_threshold = 280
 	cold_level_2_threshold = 220
 	cold_level_3_threshold = 140


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Removes duplicate definitions of overridden vars throughout the codebase. These were found using a regex from coderbus.

`^(?!\/\/)\/?\S+\/\w+(?:\s*\/\/.*)?$(?:\n+^\s*?[^\s\/].*$)*?\n+\t(\w+\b)\s*=.*$\n+(?:^\s*?[^\s\/].*$\n+)*?\t\1\b`
This thing looks like it came straight from Satan's ass crack, but I will break it down for anybody interested.

```
^               match must begin from start of line
(?!\/\/)        negative lookahead: don't match double slashes (comments) after the end of the main expression

\/?             optionally match beginning of type path (/)
\S+             exclude any amount of whitespace at the beginning or second character of the line
\/\w+           match a whole word after the last /

(?:\s*\/\/.*)?  optionally match, but don't capture, any amount of white space, then //, and all text for the rest of the line
$               end of the line

(?:             non-capturing group
    \n+         match any amount newlines after the first line
    ^           start of the line
    \s*?        match as few whitespace characters as possible (probably tabs) - these are the indented variable definitions
    [^\s\/]     do not match any whitespace and do not match any /
    .*$         then, match any character except for line breaks until the end of the line is hit
)               end group. this ensures we are not hitting any var/ declarations - only overrides. 

*?              match as few of the preceding group as possible
\n+\t           then, match any amount of newlines which are then followed by a single tab character

(\w+\b)         capture group: any amount of letters followed by a boundary. example:
                |------|     capture group 1 now holds the name of the variable
                some_var = ...
                        ^^
\s*=            match any amount of whitespace characters and then an equals sign
.*$             afterwards, match anything until the end of the line is hit
\n+             then, match any amount of newlines

(?:             non-capturing group
    ^           from the start of the line, match the following
    \s*?        match as few whitespace characters as possible
    [^\s\/]     exclude any whitespace characters or slashes immediately after the above
    .*$         match everything afterwards until the end of the line is hit
    \n+         then match as many newlines as possible
)               end of group
*?              match as few of this group as possible

\t\1\b          match a single tab, followed by the variable name (\1 is the previously mentioned capture group 1) followed by a word boundary

If this matches, we have found a repeat definition of a variable.
```

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Code cleanup. 
## Testing
<!-- How did you test the PR, if at all? -->
It compiles and launches. I made sure to keep the definitions the same as they are on live. There should be no change in functionality. Please double check that I didn't miss something, though.


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
