### PR TITLE
Refactors projectile ricochets

### DIFF
--- a/code/__DEFINES/directions.dm
+++ b/code/__DEFINES/directions.dm
@@ -28,3 +28,6 @@
 #define IS_DIR_DIAGONAL(dir) (dir & (dir - 1))
 /// returns TRUE if direction is cardinal and false if not
 #define IS_DIR_CARDINAL(dir) (!IS_DIR_DIAGONAL(dir))
+
+/// Inverse direction, taking into account UP|DOWN if necessary.
+#define REVERSE_DIR(dir) ( ((dir & 85) << 1) | ((dir & 170) >> 1) )

--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -63,12 +63,10 @@
 
 #define OVERLAY_QUEUED_2		(1<<12)
 
-#define CHECK_RICOCHET_2		(1<<13)
-
 /// should the contents of this atom be acted upon
-#define RAD_PROTECT_CONTENTS_2	(1<<14)
+#define RAD_PROTECT_CONTENTS_2		(1<<14)
 /// should this object be allowed to be contaminated
-#define RAD_NO_CONTAMINATE_2	(1<<15)
+#define RAD_NO_CONTAMINATE_2		(1<<15)
 /// Prevents shuttles from deleting the item
 #define IMMUNE_TO_SHUTTLECRUSH_2 	(1<<16)
 /// Prevents malf AI animate + overload ability
@@ -79,6 +77,12 @@
 #define RANDOM_BLOCKER_2			(1<<19)
 /// This flag allows for wearing of a belt item, even if you're not wearing a jumpsuit
 #define ALLOW_BELT_NO_JUMPSUIT_2	(1<<20)
+
+// /atom ricochet flags
+/// If the thing can reflect light (lasers/energy)
+#define RICOCHET_SHINY	(1<<0)
+/// If the thing can reflect matter (bullets/bomb shrapnel)
+#define RICOCHET_HARD 	(1<<1)
 
 //Reagent flags
 #define REAGENT_NOREACT			1

--- a/code/__HELPERS/icon_smoothing.dm
+++ b/code/__HELPERS/icon_smoothing.dm
@@ -362,7 +362,7 @@ DEFINE_BITFIELD(smoothing_junction, list(
 				icon_state = "[base_icon_state]-[smoothing_junction]-d"
 				if(!fixed_underlay && new_junction != .) // Mutable underlays?
 					var/junction_dir = reverse_ndir(smoothing_junction)
-					var/turned_adjacency = reverse_direction(junction_dir)
+					var/turned_adjacency = REVERSE_DIR(junction_dir)
 					var/turf/neighbor_turf = get_step(src, turned_adjacency & (NORTH|SOUTH))
 					var/mutable_appearance/underlay_appearance = mutable_appearance(layer = TURF_LAYER, plane = FLOOR_PLANE)
 					if(neighbor_turf && (!neighbor_turf.get_smooth_underlay_icon(underlay_appearance, src, turned_adjacency) || neighbor_turf.density)) //dense turfs are unwanted for underlays

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1143,25 +1143,6 @@ GLOBAL_LIST_INIT(can_embed_types, typecacheof(list(
 	if(is_type_in_typecache(W, GLOB.can_embed_types))
 		return TRUE
 
-/proc/reverse_direction(dir)
-	switch(dir)
-		if(NORTH)
-			return SOUTH
-		if(NORTHEAST)
-			return SOUTHWEST
-		if(EAST)
-			return WEST
-		if(SOUTHEAST)
-			return NORTHWEST
-		if(SOUTH)
-			return NORTH
-		if(SOUTHWEST)
-			return NORTHEAST
-		if(WEST)
-			return EAST
-		if(NORTHWEST)
-			return SOUTHEAST
-
 /*
 Checks if that loc and dir has a item on the wall
 */

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -4,6 +4,8 @@
 	var/level = 2
 	var/flags = NONE
 	var/flags_2 = NONE
+	/// how the atom should handle ricochet behavior
+	var/flags_ricochet = NONE
 	var/list/fingerprints
 	var/list/fingerprintshidden
 	var/fingerprintslast = null
@@ -106,6 +108,11 @@
 	var/list/viewing_alternate_appearances
 	/// Contains the world.time of when we start dragging something with our mouse. Used to prevent weird situations where you fail to click on something
 	var/drag_start = 0
+
+	///When a projectile tries to ricochet off this atom, the projectile ricochet chance is multiplied by this
+	var/receive_ricochet_chance_mod = 1
+	///When a projectile ricochets off this atom, it deals the normal damage * this modifier to this atom
+	var/receive_ricochet_damage_coeff = 0.33
 
 /atom/New(loc, ...)
 	SHOULD_CALL_PARENT(TRUE)
@@ -1121,8 +1128,20 @@ GLOBAL_LIST_EMPTY(blood_splatter_icons)
 /atom/proc/zap_act(power, zap_flags)
 	return
 
-/atom/proc/handle_ricochet(obj/item/projectile/P)
-	return
+/atom/proc/handle_ricochet(obj/item/projectile/ricocheting_projectile)
+	var/turf/p_turf = get_turf(ricocheting_projectile)
+	var/face_direction = get_dir(src, p_turf) || get_dir(src, ricocheting_projectile)
+	var/face_angle = dir2angle(face_direction)
+	var/incidence_s = GET_ANGLE_OF_INCIDENCE(face_angle, (ricocheting_projectile.Angle + 180))
+	var/a_incidence_s = abs(incidence_s)
+	if(a_incidence_s > 90 && a_incidence_s < 270)
+		return FALSE
+	if((ricocheting_projectile.flag in list(BULLET, BOMB)) && ricocheting_projectile.ricochet_incidence_leeway)
+		if((a_incidence_s < 90 && a_incidence_s < 90 - ricocheting_projectile.ricochet_incidence_leeway) || (a_incidence_s > 270 && a_incidence_s -270 > ricocheting_projectile.ricochet_incidence_leeway))
+			return FALSE
+	var/new_angle_s = SIMPLIFY_DEGREES(face_angle + incidence_s)
+	ricocheting_projectile.set_angle(new_angle_s)
+	return TRUE
 
 //This proc is called on the location of an atom when the atom is Destroy()'d
 /atom/proc/handle_atom_del(atom/A)

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -135,7 +135,7 @@
 /obj/machinery/door/window/unrestricted_side(mob/M)
 	var/mob_dir = get_dir(src, M)
 	if(mob_dir == 0) // If the mob is inside the tile
-		mob_dir = reverse_direction(dir) // Set it to the inside direction of the windoor
+		mob_dir = REVERSE_DIR(dir) // Set it to the inside direction of the windoor
 
 	return mob_dir & unres_sides
 

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -7,6 +7,8 @@
 	layer = BELOW_OBJ_LAYER
 	armor = list(melee = 25, bullet = 10, laser = 10, energy = 0, bomb = 0, rad = 0, fire = 50, acid = 70)
 	atom_say_verb = "beeps"
+	flags_ricochet = RICOCHET_HARD
+	receive_ricochet_chance_mod = 0.3
 	var/stat = 0
 
 	/// How is this machine currently passively consuming power?

--- a/code/game/objects/items/weapons/tanks/jetpack.dm
+++ b/code/game/objects/items/weapons/tanks/jetpack.dm
@@ -23,7 +23,7 @@
 
 /obj/item/tank/jetpack/on_mob_move(direction, mob/user)
 	if(on)
-		var/turf/T = get_step(src, reverse_direction(direction))
+		var/turf/T = get_step(src, REVERSE_DIR(direction))
 		if(!has_gravity(T))
 			new /obj/effect/particle_effect/ion_trails(T, direction)
 

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -316,3 +316,9 @@
 		C.Weaken(3 SECONDS)
 	else
 		C.KnockDown(3 SECONDS)
+
+/obj/handle_ricochet(obj/item/projectile/P)
+	. = ..()
+	if(. && receive_ricochet_damage_coeff)
+	 	// pass along receive_ricochet_damage_coeff damage to the structure for the ricochet
+		take_damage(P.damage * receive_ricochet_damage_coeff, P.damage_type, P.flag, 0, REVERSE_DIR(P.dir), P.armour_penetration_flat, P.armour_penetration_percentage)

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -3,6 +3,8 @@
 	pressure_resistance = 8
 	max_integrity = 300
 	face_while_pulling = TRUE
+	flags_ricochet = RICOCHET_HARD
+	receive_ricochet_chance_mod = 0.6
 	var/climbable
 	/// Determines if a structure adds the TRAIT_TURF_COVERED to its turf.
 	var/creates_cover = FALSE

--- a/code/game/objects/structures/transit_tubes/station.dm
+++ b/code/game/objects/structures/transit_tubes/station.dm
@@ -50,7 +50,7 @@
 			tube_dirs = list(NORTH, SOUTH)
 		if(WEST)
 			tube_dirs = list(NORTH, SOUTH)
-	boarding_dir = reverse_direction(dir)
+	boarding_dir = REVERSE_DIR(dir)
 
 /obj/structure/transit_tube/station/should_stop_pod(obj/structure/transit_tube_pod/pod, from_dir)
 	for(var/atom/atom in pod.contents)
@@ -209,7 +209,7 @@
 
 /obj/structure/transit_tube/station/reverse/init_tube_dirs()
 	tube_dirs = list(turn(dir, -90))
-	boarding_dir = reverse_direction(dir)
+	boarding_dir = REVERSE_DIR(dir)
 
 /obj/structure/transit_tube/station/reverse/flipped
 	icon_state = "closed_terminus1"
@@ -285,7 +285,7 @@
 
 /obj/structure/transit_tube/station/dispenser/reverse/init_tube_dirs()
 	tube_dirs = list(turn(dir, -90))
-	boarding_dir = reverse_direction(dir)
+	boarding_dir = REVERSE_DIR(dir)
 
 /obj/structure/transit_tube/station/dispenser/reverse/flipped
 	icon_state = "open_terminusdispenser1"

--- a/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
@@ -91,7 +91,7 @@
 
 	var/move_result = move_animation(current_move_anim_mode)
 	if(isnull(move_result))
-		if(isnull(current_tube) || (!(dir in current_tube.directions()) && !(reverse_direction(dir) in current_tube.directions())))
+		if(isnull(current_tube) || (!(dir in current_tube.directions()) && !(REVERSE_DIR(dir) in current_tube.directions())))
 			outside_tube()
 		return PROCESS_KILL
 

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -8,6 +8,8 @@
 	anchored = TRUE
 	flags = ON_BORDER
 	flags_2 = RAD_PROTECT_CONTENTS_2
+	flags_ricochet = RICOCHET_HARD
+	receive_ricochet_chance_mod = 0.5
 	can_be_unanchored = TRUE
 	max_integrity = 25
 	resistance_flags = ACID_PROOF

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -24,6 +24,7 @@
 	explosion_block = 1
 
 	flags_2 = RAD_PROTECT_CONTENTS_2 | RAD_NO_CONTAMINATE_2
+	flags_ricochet = RICOCHET_HARD
 	rad_insulation = RAD_MEDIUM_INSULATION
 
 	thermal_conductivity = WALL_HEAT_TRANSFER_COEFFICIENT
@@ -153,17 +154,6 @@
 		dismantle_wall()
 	else
 		update_icon()
-
-/turf/simulated/wall/handle_ricochet(obj/item/projectile/P)			//A huge pile of shitcode!
-	var/turf/p_turf = get_turf(P)
-	var/face_direction = get_dir(src, p_turf)
-	var/face_angle = dir2angle(face_direction)
-	var/incidence_s = GET_ANGLE_OF_INCIDENCE(face_angle, (P.Angle + 180))
-	if(abs(incidence_s) > 90 && abs(incidence_s) < 270)
-		return FALSE
-	var/new_angle_s = SIMPLIFY_DEGREES(face_angle + incidence_s)
-	P.set_angle(new_angle_s)
-	return TRUE
 
 /turf/simulated/wall/dismantle_wall(devastated = FALSE, explode = FALSE)
 	if(devastated)

--- a/code/game/turfs/simulated/walls_mineral.dm
+++ b/code/game/turfs/simulated/walls_mineral.dm
@@ -220,7 +220,7 @@
 	icon_state = "plastinum_wall-0"
 	base_icon_state = "plastinum_wall"
 	explosion_block = 3
-	flags_2 = CHECK_RICOCHET_2
+	flags_ricochet = RICOCHET_SHINY | RICOCHET_HARD
 	sheet_type = /obj/item/stack/sheet/mineral/titanium
 	smoothing_flags = SMOOTH_BITMASK | SMOOTH_DIAGONAL_CORNERS
 	smoothing_groups = list(SMOOTH_GROUP_TITANIUM_WALLS, SMOOTH_GROUP_WINDOW_FULLTILE_SHUTTLE)

--- a/code/game/turfs/space/space_turf.dm
+++ b/code/game/turfs/space/space_turf.dm
@@ -146,7 +146,7 @@
 			if(itercount > 100)
 				stack_trace("SPACE Z-TRANSIT ERROR: [A] encountered a possible infinite loop while traveling through z-levels.")
 				break
-			var/turf/target_turf = get_step(current_pull.pulledby.loc, reverse_direction(current_pull.pulledby.dir)) || current_pull.pulledby.loc
+			var/turf/target_turf = get_step(current_pull.pulledby.loc, REVERSE_DIR(current_pull.pulledby.dir)) || current_pull.pulledby.loc
 			ADD_TRAIT(current_pull, TRAIT_CURRENTLY_Z_MOVING, ROUNDSTART_TRAIT)
 			current_pull.forceMove(target_turf)
 			REMOVE_TRAIT(current_pull, TRAIT_CURRENTLY_Z_MOVING, ROUNDSTART_TRAIT)

--- a/code/modules/antagonists/vampire/vampire_powers/vampire_powers.dm
+++ b/code/modules/antagonists/vampire/vampire_powers/vampire_powers.dm
@@ -248,7 +248,7 @@
 	// - V - Attacker facing south
 	// - - -
 	// Victim at 135 or more degrees of where the victim is facing.
-	if(attacker_dir & reverse_direction(attacker_to_victim))
+	if(attacker_dir & REVERSE_DIR(attacker_to_victim))
 		return DEVIATION_FULL
 	// - - -
 	// # V # Attacker facing south

--- a/code/modules/events/blob/blob_structures/strong_blob.dm
+++ b/code/modules/events/blob/blob_structures/strong_blob.dm
@@ -61,16 +61,4 @@
 	brute_resist = 0.5
 	explosion_block = 2
 	point_return = 9
-	flags_2 = CHECK_RICOCHET_2
-
-/obj/structure/blob/shield/reflective/handle_ricochet(obj/item/projectile/P)
-	var/turf/p_turf = get_turf(P)
-	var/face_direction = get_dir(src, p_turf)
-	var/face_angle = dir2angle(face_direction)
-	var/incidence_s = GET_ANGLE_OF_INCIDENCE(face_angle, (P.Angle + 180))
-	if(abs(incidence_s) > 90 && abs(incidence_s) < 270)
-		return FALSE
-	var/new_angle_s = SIMPLIFY_DEGREES(face_angle + incidence_s)
-	P.set_angle(new_angle_s)
-	visible_message("<span class='warning'>[P] reflects off [src]!</span>")
-	return TRUE
+	flags_ricochet = RICOCHET_SHINY

--- a/code/modules/maze_generation/maze_generator.dm
+++ b/code/modules/maze_generation/maze_generator.dm
@@ -120,7 +120,7 @@
 
 			// On both tiles
 			for(var/obj/structure/window/reinforced/mazeglass/W in T3)
-				if(W.dir == reverse_direction(text2num(D)))
+				if(W.dir == REVERSE_DIR(text2num(D)))
 					qdel(W)
 
 			// Mark as visited

--- a/code/modules/maze_generation/maze_generator_blockwise.dm
+++ b/code/modules/maze_generation/maze_generator_blockwise.dm
@@ -68,7 +68,7 @@
 			var/turf/T3 = unvisited_neighbours["[D]"] // Pick random dir turf
 
 			// Remove the color between the two
-			var/turf/T4 = get_step(T3, reverse_direction(text2num(D)))
+			var/turf/T4 = get_step(T3, REVERSE_DIR(text2num(D)))
 			T4?.color = MAZEGEN_TURF_CELL
 
 			// Mark as visited

--- a/code/modules/mod/mod_control.dm
+++ b/code/modules/mod/mod_control.dm
@@ -244,7 +244,7 @@
 /obj/item/mod/control/on_mob_move(direction, mob/user)
 	if(!jetpack_active || !isturf(user.loc))
 		return
-	var/turf/T = get_step(src, reverse_direction(direction))
+	var/turf/T = get_step(src, REVERSE_DIR(direction))
 	if(!has_gravity(T))
 		new /obj/effect/particle_effect/ion_trails(T, direction)
 

--- a/code/modules/power/generators/treadmill.dm
+++ b/code/modules/power/generators/treadmill.dm
@@ -41,7 +41,7 @@
 	// if 2fast, throw the person, otherwise they just slide off, if there's reasonable speed at all
 	if(speed && A.move_resist < INFINITY)
 		var/dist = max(throw_dist * speed / MAX_SPEED, 1)
-		A.throw_at(get_distant_turf(get_turf(src), reverse_direction(dir), dist), A.throw_range, A.throw_speed, src, 1)
+		A.throw_at(get_distant_turf(get_turf(src), REVERSE_DIR(dir), dist), A.throw_range, A.throw_speed, src, 1)
 
 /obj/machinery/power/treadmill/process()
 	if(!anchored)

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -159,7 +159,7 @@
 				tempDir = EAST
 			if(NORTHWEST, SOUTHWEST)
 				tempDir = WEST
-		var/turf/tempLoc = get_step(src, reverse_direction(tempDir))
+		var/turf/tempLoc = get_step(src, REVERSE_DIR(tempDir))
 		if(isspaceturf(tempLoc))
 			to_chat(user, "<span class='warning'>You can't build a terminal on space.</span>")
 			return

--- a/code/modules/projectiles/projectile_base.dm
+++ b/code/modules/projectiles/projectile_base.dm
@@ -66,9 +66,6 @@
 	var/immolate = 0
 	var/dismemberment = 0 //The higher the number, the greater the bonus to dismembering. 0 will not dismember at all.
 	var/impact_effect_type //what type of impact effect to show when hitting something
-	var/ricochets = 0
-	var/ricochets_max = 2
-	var/ricochet_chance = 30
 
 	var/log_override = FALSE //whether print to admin attack logs or just keep it in the diary
 
@@ -113,6 +110,27 @@
 	var/impact_light_range = 2
 	var/impact_light_color_override
 	var/hitscan_duration = 0.3 SECONDS
+
+	/// how many times we've ricochet'd so far (instance variable, not a stat)
+	var/ricochets = 0
+	/// how many times we can ricochet max
+	var/ricochets_max = 0
+	/// how many times we have to ricochet min (unless we hit an atom we can ricochet off)
+	var/min_ricochets = 0
+	/// 0-100 (or more, I guess), the base chance of ricocheting, before being modified by the atom we shoot and our chance decay
+	var/ricochet_chance = 0
+	/// 0-1 (or more, I guess) multiplier, the ricochet_chance is modified by multiplying this after each ricochet
+	var/ricochet_decay_chance = 0.7
+	/// 0-1 (or more, I guess) multiplier, the projectile's damage is modified by multiplying this after each ricochet
+	var/ricochet_decay_damage = 0.7
+	/// On ricochet, if nonzero, we consider all mobs within this range of our projectile at the time of ricochet to home in on like Revolver Ocelot, as governed by ricochet_auto_aim_angle
+	var/ricochet_auto_aim_range = 0
+	/// On ricochet, if ricochet_auto_aim_range is nonzero, we'll consider any mobs within this range of the normal angle of incidence to home in on, higher = more auto aim
+	var/ricochet_auto_aim_angle = 30
+	/// the angle of impact must be within this many degrees of the struck surface, set to 0 to allow any angle
+	var/ricochet_incidence_leeway = 40
+	/// Can our ricochet autoaim hit our firer?
+	var/ricochet_shoots_firer = TRUE
 
 /obj/item/projectile/New()
 	return ..()
@@ -429,7 +447,21 @@
 
 
 /obj/item/projectile/proc/on_ricochet(atom/A)
-	return
+	if(!ricochet_auto_aim_angle || !ricochet_auto_aim_range)
+		return
+
+	var/mob/living/unlucky_sob
+	var/best_angle = ricochet_auto_aim_angle
+	for(var/mob/living/L in range(ricochet_auto_aim_range, src.loc))
+		if(L.stat == DEAD || !isInSight(src, L) || (!ricochet_shoots_firer && L == firer))
+			continue
+		var/our_angle = abs(closer_angle_difference(Angle, get_angle(src.loc, L.loc)))
+		if(our_angle < best_angle)
+			best_angle = our_angle
+			unlucky_sob = L
+
+	if(unlucky_sob)
+		set_angle(get_angle(src, unlucky_sob.loc))
 
 /obj/item/projectile/proc/check_ricochet()
 	if(prob(ricochet_chance))
@@ -437,8 +469,12 @@
 	return FALSE
 
 /obj/item/projectile/proc/check_ricochet_flag(atom/A)
-	if(A.flags_2 & CHECK_RICOCHET_2)
+	if((flag in list(ENERGY, LASER)) && (A.flags_ricochet & RICOCHET_SHINY))
 		return TRUE
+
+	if((flag in list(BOMB, BULLET)) && (A.flags_ricochet & RICOCHET_HARD))
+		return TRUE
+
 	return FALSE
 
 /obj/item/projectile/set_angle(new_angle)

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -417,7 +417,7 @@
 	playsound(human_owner, 'sound/goonstation/items/hypo.ogg', 80, TRUE)
 
 	var/obj/item/telegraph_vial = new /obj/item/qani_laaca_telegraph(get_turf(owner))
-	var/turf/turf_we_throw_at = get_edge_target_turf(owner, reverse_direction(owner.dir))
+	var/turf/turf_we_throw_at = get_edge_target_turf(owner, REVERSE_DIR(owner.dir))
 	telegraph_vial.throw_at(turf_we_throw_at, 5, 1)
 
 	// Safety net in case the injection amount doesn't get reset. Apparently it happened to someone in a round.

--- a/code/modules/unit_tests/map_tests.dm
+++ b/code/modules/unit_tests/map_tests.dm
@@ -137,7 +137,7 @@
 	if(!direction) // cable direction = 0, which means its a node
 		return TRUE
 	var/turf/potential_cable_turf = get_step(origin_turf, direction)
-	var/reversed_direction = reverse_direction(direction)
+	var/reversed_direction = REVERSE_DIR(direction)
 	for(var/obj/structure/cable/other_cable in potential_cable_turf.contents)
 		if(reversed_direction == other_cable.d1 || reversed_direction == other_cable.d2)
 			return TRUE


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
This is atomized from #25527. 

Defines `var/ricochet_flag`s on `/atom` and two bitflags for handling ricochet: `RICOCHET_SHINY` for laser reflects and `RICOCHET_HARD` for non-laser reflects. Moves `handle_ricochet()` to an `/atom` level proc because it was previously redefined verbatim for titanium walls and reflective blob tiles. Adds default ricochet vars and flags to `obj/machine` and `obj/structure` which can then be modified to add ricochets for any subtypes.

`/obj/item/projectile` has received a number of new variables (functionality is documented) related to ricochets. These are a stepping stone for #25527 and future features.

This was the original reason for #25550, which should be merged before this.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
This generalizes ricochets, removes duplicate code, and expands the system's functionality. 

## Testing
<!-- How did you test the PR, if at all? -->
This was tested to not do weird things previously, but more testing to make sure everything works properly is TODO.

NPFC

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
