### PR TITLE
Reduces glowshroom maturation. Keeps shadow shroom and glowcaps the s…

### DIFF
--- a/code/modules/hydroponics/grown/mushrooms.dm
+++ b/code/modules/hydroponics/grown/mushrooms.dm
@@ -225,7 +225,7 @@
 	product = /obj/item/food/snacks/grown/mushroom/glowshroom
 	lifespan = 100 //ten times that is the delay
 	endurance = 30
-	maturation = 15
+	maturation = 6
 	production = 1
 	yield = 3 //-> spread
 	potency = 30 //-> brightness
@@ -280,6 +280,7 @@
 	icon_harvest = "glowcap-harvest"
 	plantname = "Glowcaps"
 	product = /obj/item/food/snacks/grown/mushroom/glowshroom/glowcap
+	maturation = 15
 	genes = list(/datum/plant_gene/trait/glow/red, /datum/plant_gene/trait/cell_charge, /datum/plant_gene/trait/plant_type/fungal_metabolism)
 	mutatelist = list()
 	reagents_add = list("teslium" = 0.1, "nutriment" = 0.04)
@@ -332,6 +333,7 @@
 	icon_dead = "shadowshroom-dead"
 	plantname = "Shadowshrooms"
 	product = /obj/item/food/snacks/grown/mushroom/glowshroom/shadowshroom
+	maturation = 15
 	genes = list(/datum/plant_gene/trait/glow/shadow, /datum/plant_gene/trait/plant_type/fungal_metabolism)
 	mutatelist = list()
 	reagents_add = list("radium" = 0.2, "nutriment" = 0.04)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Lowers glowshroom maturation time to 6 from 15. glowcaps and shadow shrooms remain the same
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Botany is already quite slow, and now that they should no longer be getting a chem dispenser they are reliant on glowshrooms for mutagen production. A maturation time of 15 means 5 minutes and 20 seconds from planting to first harvest, which makes up a decent chunk of botany's setup during which there is not much to do except sit and wait.  Reducing the maturation time to 6 lowers that time to 1 minute and 20 seconds, which is more inline with other plants and should make for a much better experience.  
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


## Testing
Planted glowshrooms, glowcaps, and shadowshrooms. They mature as fast as they should.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: reduces glowshroom maturation time from 15 to 6
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
