### PR TITLE
Fixes Null origin tech on Lost Nanotrasen Research Documents

### DIFF
--- a/code/game/objects/items/salvage.dm
+++ b/code/game/objects/items/salvage.dm
@@ -54,7 +54,8 @@
 
 /obj/item/salvage/ruin/nanotrasen/Initialize(mapload)
 	. = ..()
-	origin_tech = pick(list("combat=5", "materials=5", "engineering=5", "biotech=5", "power=5", "data=5"))
+	origin_tech = pick(list("combat=5", "materials=5", "engineering=5", "biotech=5", "powerstorage=5", "data=5"))
+
 /obj/item/salvage/ruin/carp
 	name = "carp scales"
 	desc = "A collection of scales shed from a corrupted space carp. Their culinary potential could mean untold riches for Nanotrasen."

--- a/code/game/objects/items/salvage.dm
+++ b/code/game/objects/items/salvage.dm
@@ -54,7 +54,7 @@
 
 /obj/item/salvage/ruin/nanotrasen/Initialize(mapload)
 	. = ..()
-	origin_tech = pick(list("combat=5", "materials=5", "engineering=5", "biotech=5", "powerstorage=5", "data=5"))
+	origin_tech = pick("combat=5", "materials=5", "engineering=5", "biotech=5", "powerstorage=5", "programming=5")
 
 /obj/item/salvage/ruin/carp
 	name = "carp scales"


### PR DESCRIPTION
## What Does This PR Do
Fixes #25768. Gives the correct tech type for tech origin on lost nanotrasen research documents

## Why It's Good For The Game
Null research bad

## Testing
Compiled. Threw a bunch of notes in the analyser. No more nulls.

## Changelog
:cl:
tweak: Tweaked a few things
/:cl: