### PR TITLE
Makes mind swapping instant

### DIFF
--- a/code/datums/spells/mind_transfer.dm
+++ b/code/datums/spells/mind_transfer.dm
@@ -84,4 +84,3 @@ Also, you never added distance checking after target is selected. I've went ahea
 		for(var/mob/living/L in range(3, new_or_formal_wizard))
 			L.SetSilence(15 SECONDS)
 
-

--- a/code/datums/spells/mind_transfer.dm
+++ b/code/datums/spells/mind_transfer.dm
@@ -6,7 +6,7 @@
 	base_cooldown = 600
 	clothes_req = FALSE
 	invocation = "GIN'YU CAPAN"
-	invocation_type = "whisper"  // shh
+	invocation_type = "none"  // shh
 	selection_activated_message = "<span class='notice'>You prepare to transfer your mind. Click on a target to cast the spell.</span>"
 	selection_deactivated_message = "<span class='notice'>You decide that your current form is good enough.</span>"
 	cooldown_min = 200 //100 deciseconds reduction per rank

--- a/code/datums/spells/mind_transfer.dm
+++ b/code/datums/spells/mind_transfer.dm
@@ -6,7 +6,7 @@
 	base_cooldown = 600
 	clothes_req = FALSE
 	invocation = "GIN'YU CAPAN"
-	invocation_type = "whisper"
+	invocation_type = "none"  // shh
 	selection_activated_message = "<span class='notice'>You prepare to transfer your mind. Click on a target to cast the spell.</span>"
 	selection_deactivated_message = "<span class='notice'>You decide that your current form is good enough.</span>"
 	cooldown_min = 200 //100 deciseconds reduction per rank

--- a/code/datums/spells/mind_transfer.dm
+++ b/code/datums/spells/mind_transfer.dm
@@ -6,7 +6,7 @@
 	base_cooldown = 600
 	clothes_req = FALSE
 	invocation = "GIN'YU CAPAN"
-	invocation_type = "none"  // shh
+	invocation_type = "whisper"  // shh
 	selection_activated_message = "<span class='notice'>You prepare to transfer your mind. Click on a target to cast the spell.</span>"
 	selection_deactivated_message = "<span class='notice'>You decide that your current form is good enough.</span>"
 	cooldown_min = 200 //100 deciseconds reduction per rank
@@ -21,6 +21,8 @@
 	T.allowed_type = /mob/living
 	T.range = 3
 	T.click_radius = 0
+	// you can use it on yourself as a fake-out
+	T.include_user = TRUE
 	return T
 
 /datum/spell/mind_transfer/valid_target(mob/living/target, mob/user)
@@ -39,42 +41,43 @@ Also, you never added distance checking after target is selected. I've went ahea
 		to_chat(user, "<span class='warning'>You're killing yourself! You can't concentrate enough to do this!</span>")
 		return
 
-	if(target.mind.special_role in protected_roles)
-		to_chat(user, "Their mind is resisting your spell.")
+	if(target.mind.special_role in protected_roles && target != user)
+		to_chat(user, "<span class='danger'>Their mind is resisting your spell.</span>")
 		return
 
 	if(issilicon(target))
-		to_chat(user, "You feel this enslaved being is just as dead as its cold, hard exoskeleton.")
+		to_chat(user, "<span class='warning'>You feel this enslaved being is just as dead as its cold, hard exoskeleton.</span>")
 		return
 
 	var/mob/living/victim = target//The target of the spell whos body will be transferred to.
 	var/mob/living/caster = user//The wizard/whomever doing the body transferring.
 
-	//MIND TRANSFER BEGIN
-	if(length(caster.mind.special_verbs))//If the caster had any special verbs, remove them from the mob verb list.
-		for(var/V in caster.mind.special_verbs)//Since the caster is using an object spell system, this is mostly moot.
-			remove_verb(caster, V) //But a safety nontheless.
+	if(victim != caster)
+		//MIND TRANSFER BEGIN
+		if(length(caster.mind.special_verbs))//If the caster had any special verbs, remove them from the mob verb list.
+			for(var/V in caster.mind.special_verbs)//Since the caster is using an object spell system, this is mostly moot.
+				remove_verb(caster, V) //But a safety nontheless.
 
-	if(length(victim.mind.special_verbs))//Now remove all of the victim's verbs.
-		for(var/V in victim.mind.special_verbs)
-			remove_verb(victim, V)
+		if(length(victim.mind.special_verbs))//Now remove all of the victim's verbs.
+			for(var/V in victim.mind.special_verbs)
+				remove_verb(victim, V)
 
-	var/mob/dead/observer/ghost = victim.ghostize(0)
-	caster.mind.transfer_to(victim)
+		var/mob/dead/observer/ghost = victim.ghostize(0)
+		caster.mind.transfer_to(victim)
 
-	if(length(victim.mind.special_verbs))//To add all the special verbs for the original caster.
-		for(var/V in caster.mind.special_verbs)//Not too important but could come into play.
-			add_verb(caster, V)
+		if(length(victim.mind.special_verbs))//To add all the special verbs for the original caster.
+			for(var/V in caster.mind.special_verbs)//Not too important but could come into play.
+				add_verb(caster, V)
 
-	ghost.mind.transfer_to(caster)
-	if(ghost.key)
-		GLOB.non_respawnable_keys -= ghost.ckey
-		caster.key = ghost.key	//have to transfer the key since the mind was not active
-	qdel(ghost)
+		ghost.mind.transfer_to(caster)
+		if(ghost.key)
+			GLOB.non_respawnable_keys -= ghost.ckey
+			caster.key = ghost.key	//have to transfer the key since the mind was not active
+		qdel(ghost)
 
-	if(length(caster.mind.special_verbs))//If they had any special verbs, we add them here.
-		for(var/V in caster.mind.special_verbs)
-			add_verb(caster, V)
+		if(length(caster.mind.special_verbs))//If they had any special verbs, we add them here.
+			for(var/V in caster.mind.special_verbs)
+				add_verb(caster, V)
 	//MIND TRANSFER END
 
 	for(var/mob/new_or_formal_wizard in list(victim, caster))

--- a/code/datums/spells/mind_transfer.dm
+++ b/code/datums/spells/mind_transfer.dm
@@ -14,11 +14,12 @@
 	var/paralysis_amount_caster = 40 SECONDS //how much the caster is paralysed for after the spell
 	var/paralysis_amount_victim = 40 SECONDS //how much the victim is paralysed for after the spell
 	action_icon_state = "mindswap"
+	sound = 'sound/magic/mindswap.ogg'
 
 /datum/spell/mind_transfer/create_new_targeting()
 	var/datum/spell_targeting/click/T = new()
 	T.allowed_type = /mob/living
-	T.range = 1
+	T.range = 3
 	T.click_radius = 0
 	return T
 
@@ -76,6 +77,8 @@ Also, you never added distance checking after target is selected. I've went ahea
 			add_verb(caster, V)
 	//MIND TRANSFER END
 
-	//Here we paralyze both mobs and knock them out for a time.
-	caster.Paralyse(paralysis_amount_caster)
-	victim.Paralyse(paralysis_amount_victim)
+	for(var/mob/new_or_formal_wizard in list(victim, caster))
+		for(var/mob/living/L in range(3, new_or_formal_wizard))
+			L.SetSilence(15 SECONDS)
+
+


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes mindswap happen instantly, unleashing a loud sound and silencing everyone in a range around both the target. Who can themselves be up to 3 tiles away. This also removes the hardstun, so you can start running instantly.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
In a gamemode where many people will be running at each other at once, we need to keep the meta info on things as low as possible. After the wizard loudly yells I AM USING THE MINDSWAP SPELL and two people are stuck jittering on the floor, the wizard is pretty much dead if they aren't careful about it, or if there is at least one other person who can take that 10 second stun to beat the shit out of you.


Let's make it faster :trollface:
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
swapped minds with myself once or twice. effects worked as intended.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Mindswap is now instant at range 3. It now doesn't stun, but it silences folks around in a range and plays an obvious sound.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
