### PR TITLE
Hide runes from the AI better

### DIFF
--- a/code/__DEFINES/sight.dm
+++ b/code/__DEFINES/sight.dm
@@ -7,10 +7,12 @@
 
 #define SEE_INVISIBLE_LIVING_AI 24
 
+// Normal cult runes
+#define INVISIBILITY_RUNES 25
 #define SEE_INVISIBLE_LIVING 25
 
 // Hidden cult runes
-#define INVISIBILITY_HIDDEN_RUNES  30
+#define INVISIBILITY_HIDDEN_RUNES 30
 #define SEE_INVISIBLE_HIDDEN_RUNES 30
 
 #define SEE_INVISIBLE_LEVEL_ONE 35	//Used by some stuff in code. It's really poorly organized.

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -670,6 +670,8 @@
 
 //Update the screentip to reflect what we're hovering over
 /atom/movable/MouseEntered(location, control, params)
+	if(invisibility > usr.see_invisible)
+		return
 	var/datum/hud/active_hud = usr.hud_used // Don't nullcheck this stuff, if it breaks we wanna know it breaks
 	var/screentip_mode = usr.client.prefs.screentip_mode
 	if(screentip_mode == 0 || (flags & NO_SCREENTIPS))

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -26,7 +26,7 @@ To draw a rune, use a ritual dagger.
 	mouse_opacity = MOUSE_OPACITY_OPAQUE // So that runes aren't so hard to click
 	var/visibility = 0
 	var/view_range = 7
-	invisibility = 25
+	invisibility = INVISIBILITY_RUNES
 	layer = SIGIL_LAYER
 	color = COLOR_BLOOD_BASE
 

--- a/code/game/objects/effects/temporary_visuals/cult_visuals.dm
+++ b/code/game/objects/effects/temporary_visuals/cult_visuals.dm
@@ -51,6 +51,7 @@
 	icon_state = "space"
 	duration = 600
 	layer = ABOVE_OBJ_LAYER
+	invisibility = INVISIBILITY_RUNES
 
 /obj/effect/temp_visual/emp/cult
 	name = "cult emp sparks"
@@ -65,6 +66,7 @@
 	icon_state = "runeouter"
 	alpha = 0
 	var/turnedness = 179 //179 turns counterclockwise, 181 turns clockwise
+	invisibility = INVISIBILITY_RUNES
 
 /obj/effect/temp_visual/cult/rune_spawn/Initialize(mapload, set_duration, set_color)
 	if(isnum(set_duration))

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -615,6 +615,8 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 	DEFAULT_QUEUE_OR_CALL_VERB(VERB_CALLBACK(src, PROC_REF(run_examinate), A))
 
 /mob/proc/run_examinate(atom/A)
+	if(A.invisibility > see_invisible)
+		A = get_turf(A)
 	if(!has_vision(information_only = TRUE) && !isobserver(src))
 		to_chat(src, chat_box_regular("<span class='notice'>Something is there but you can't see it.</span>"), MESSAGE_TYPE_INFO, confidential = TRUE)
 		return TRUE


### PR DESCRIPTION
## What Does This PR Do
Invisible objects now have added safeguards to prevent tooltips and examine from people who can't see them. In theory, these shouldn't be necessary, but in practice...
The teleport portal effect is now invisible to the AI. They can, however, still see the red glow that it comes with.

## Why It's Good For The Game
AI shouldn't see what AI can't see.

## Testing
I tested what I could, but since I can't reproduce the original behavior of being able to hover over a rune or examine it, I can't confirm that the fix worked.

## Changelog
:cl:
fix: Cult runes are better hidden from the AI now.
/:cl: