### PR TITLE
Fixes advanced_bullet_dodge mobs sometimes leaving ghost projectiles on death

### DIFF
--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -67,10 +67,6 @@
 		"<span class='userdanger'>You evade [hitting_projectile]!</span>",
 	)
 	playsound(source, pick('sound/weapons/bulletflyby.ogg', 'sound/weapons/bulletflyby2.ogg', 'sound/weapons/bulletflyby3.ogg'), 75, TRUE)
-	var/dir_to_avoid = angle2dir_cardinal(hitting_projectile.Angle)
-	var/list/potential_first_directions = list(NORTH, SOUTH, EAST, WEST)
-	potential_first_directions -= dir_to_avoid
-	step(source, pick(potential_first_directions))
 	// Chance to dodge multiple shotgun spreads, but not likely. Mainly: Infinite loop prevention from admins setting it to 100 and doing something stupid.
 	// If you want to set your dodge chance to 100 on a subtype, no issue: Just make sure the subtype does not step in a direction, otherwise you'll have the mob move a large distance to dodge rubbershot.
 	if(prob(50))

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/combat_drone.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/combat_drone.dm
@@ -108,11 +108,6 @@
 		"<span class='userdanger'>You evade [hitting_projectile]!</span>",
 	)
 	playsound(source, pick('sound/weapons/bulletflyby.ogg', 'sound/weapons/bulletflyby2.ogg', 'sound/weapons/bulletflyby3.ogg', 'sound/effects/refill.ogg'), 75, TRUE)
-	var/dir_to_avoid = angle2dir_cardinal(hitting_projectile.Angle)
-	var/list/potential_first_directions = list(NORTH, SOUTH, EAST, WEST)
-	potential_first_directions -= dir_to_avoid
-	new /obj/effect/temp_visual/decoy/fading(source.loc, source)
-	step(source, pick(potential_first_directions))
 	if(prob(50))
 		addtimer(VARSET_CALLBACK(source, advanced_bullet_dodge_chance, advanced_bullet_dodge_chance), 0.25 SECONDS)
 		advanced_bullet_dodge_chance = 0


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Makes the mobs not step when dodging, this seems to cause issues when they step and die, leaving a ghost undeletable projectile.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Ghost projectiles are bad.

## Testing
<!-- How did you test the PR, if at all? -->

Shot at mobs with this variable a whole bunch, no ghost projectiles were created.

## Changelog
:cl:
fix: Fixes advanced_bullet_dodge mobs sometimes leaving ghost projectiles on death
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
