### PR TITLE
Shuttle Lore Tweaks

### DIFF
--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -131,7 +131,7 @@
 /datum/map_template/shuttle/emergency/lance
 	suffix = "lance"
 	name = "NAV Lance"
-	description = "Based on a rejected design by an overager member of Nanotrasen Asset Protection, the NAV Lance is designed to tactically slam into destroyed stations, \
+	description = "Based on a rejected design by an over-eager member of Nanotrasen Asset Protection, the NAV Lance is designed to tactically slam into destroyed stations, \
 	dispatching threats and saving crew at the same time! \
 	Be careful to stay out of its path. Comes with a beacon to choose where it docks!"
 	admin_notes = "WARNING: This shuttle is designed to crash into the station. It has turrets, similar to the raven. Place down the beacon please. Once the shuttle is loaded, it cannot be unloaded."

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -39,8 +39,8 @@
 
 /datum/map_template/shuttle/emergency/bar
 	suffix = "bar"
-	name = "Emergency Escape Bar"
-	description = "Features include a bathroom, a quality lounge for the heads, and a \
+	name = "NTTV Charon (B)"
+	description = "A modification of the standard shuttle featuring a bathroom, quality lounge for the heads, and a \
 		small gambling table."
 
 
@@ -50,14 +50,14 @@
 
 /datum/map_template/shuttle/emergency/dept
 	suffix = "dept"
-	name = "Emergency shuttle (department)"
-	description = "Features include: areas for each department, and a small bar."
+	name = "NTTV Charon (D)"
+	description = "A modified Charon-class shuttle featuring areas for each department, and a small bar."
 	admin_notes = "Designed to reduce chaos. Each dept requires dept access."
 
 /datum/map_template/shuttle/emergency/military
 	suffix = "mil"
-	name = "Emergency shuttle (military)"
-	description = "Troop transport with point defense turrets."
+	name = "NTTV Charon (M)"
+	description = "A militarized Charon-class shuttle hull featuring defense turrets and minimal crew comforts."
 	admin_notes = "Designed to ensure a safe evacuation during xeno outbreaks."
 
 

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -131,7 +131,7 @@
 /datum/map_template/shuttle/emergency/lance
 	suffix = "lance"
 	name = "NAV Lance"
-	description = "Based on a rejected design by an overager member of Nanotrasen Asset Protection, the NTAV Lance is designed to tactically slam into destroyed stations, \
+	description = "Based on a rejected design by an overager member of Nanotrasen Asset Protection, the NAV Lance is designed to tactically slam into destroyed stations, \
 	dispatching threats and saving crew at the same time! \
 	Be careful to stay out of its path. Comes with a beacon to choose where it docks!"
 	admin_notes = "WARNING: This shuttle is designed to crash into the station. It has turrets, similar to the raven. Place down the beacon please. Once the shuttle is loaded, it cannot be unloaded."

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -56,7 +56,7 @@
 
 /datum/map_template/shuttle/emergency/military
 	suffix = "mil"
-	name = "NTTV Charon (M)"
+	name = "NTTV Charon (Militarized)"
 	description = "A militarized Charon-class shuttle hull featuring defense turrets and minimal crew comforts."
 	admin_notes = "Designed to ensure a safe evacuation during xeno outbreaks."
 

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -39,7 +39,7 @@
 
 /datum/map_template/shuttle/emergency/bar
 	suffix = "bar"
-	name = "NTTV Charon (Bar)"
+	name = "NTV Charon (Bar)"
 	description = "A modification of the standard shuttle featuring a bathroom, quality lounge for the heads, and a \
 		small gambling table."
 
@@ -50,20 +50,20 @@
 
 /datum/map_template/shuttle/emergency/dept
 	suffix = "dept"
-	name = "NTTV Charon (Departmental)"
+	name = "NTV Charon (Departmental)"
 	description = "A modified Charon-class shuttle featuring areas for each department, and a small bar."
 	admin_notes = "Designed to reduce chaos. Each dept requires dept access."
 
 /datum/map_template/shuttle/emergency/military
 	suffix = "mil"
-	name = "NTTV Charon (Militarized)"
+	name = "NTV Charon (Militarized)"
 	description = "A militarized Charon-class shuttle hull featuring defense turrets and minimal crew comforts."
 	admin_notes = "Designed to ensure a safe evacuation during xeno outbreaks."
 
 
 /datum/map_template/shuttle/emergency/clown
 	suffix = "clown"
-	name = "NTCV Snappop(tm)"
+	name = "NCV Snappop(tm)"
 	description = "Hey kids and grownups! Are you bored of DULL and TEDIOUS \
 		shuttle journeys after you're evacuating for probably BORING reasons. \
 		Well then order the Snappop(tm) today! We've got fun activities for \
@@ -116,7 +116,7 @@
 
 /datum/map_template/shuttle/emergency/raven
 	suffix = "raven"
-	name = "NTSV Raven"
+	name = "NSV Raven"
 	description = "The NTSV Raven is a former high-risk salvage frigate, now repurposed into an emergency escape shuttle. \
 	Once first to the scene to pick through warzones for valuable remains, it now serves as an excellent escape option for stations under heavy fire from outside forces. \
 	This escape shuttle boasts shields and numerous anti-personnel turrets guarding its perimeter to fend off meteors and enemy boarding attempts."
@@ -124,13 +124,13 @@
 
 /datum/map_template/shuttle/emergency/shadow
 	suffix = "shadow"
-	name = "NTRTV Shadow"
+	name = "NRTV Shadow"
 	description = "Guaranteed to get you somewhere FAST. Featuring a supercharged plasma-injection burn drive, this bad boy will put more distance between you and certain death than any other!"
 	admin_notes = "The aft of the ship has a plasma tank that starts ignited. May get released by crew. The plasma windows next to the engine heaters will also erupt into flame, and also risk getting released by crew."
 
 /datum/map_template/shuttle/emergency/lance
 	suffix = "lance"
-	name = "NTAV Lance"
+	name = "NAV Lance"
 	description = "Based on a rejected design by an overager member of Nanotrasen Asset Protection, the NTAV Lance is designed to tactically slam into destroyed stations, \
 	dispatching threats and saving crew at the same time! \
 	Be careful to stay out of its path. Comes with a beacon to choose where it docks!"
@@ -184,17 +184,17 @@
 
 /datum/map_template/shuttle/admin/hospital
 	suffix = "hospital"
-	name = "NTHV Asclepius"
+	name = "NHV Asclepius"
 	description = "Nanostrasen Hospital ship, for medical assistance during disasters."
 
 /datum/map_template/shuttle/admin/admin
 	suffix = "admin"
-	name = "NTTV Argos"
+	name = "NTV Argos"
 	description = "Default Admin ship. An older ship used for special operations."
 
 /datum/map_template/shuttle/admin/armory
 	suffix = "armory"
-	name = "NTRV Sparta"
+	name = "NRV Sparta"
 	description = "Armory Shuttle, with plenty of guns to hand out and some general supplies."
 
 /datum/map_template/shuttle/admin/skipjack

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -50,7 +50,7 @@
 
 /datum/map_template/shuttle/emergency/dept
 	suffix = "dept"
-	name = "NTTV Charon (D)"
+	name = "NTTV Charon (Departmental)"
 	description = "A modified Charon-class shuttle featuring areas for each department, and a small bar."
 	admin_notes = "Designed to reduce chaos. Each dept requires dept access."
 

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -39,7 +39,7 @@
 
 /datum/map_template/shuttle/emergency/bar
 	suffix = "bar"
-	name = "NTTV Charon (B)"
+	name = "NTTV Charon (Bar)"
 	description = "A modification of the standard shuttle featuring a bathroom, quality lounge for the heads, and a \
 		small gambling table."
 

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -63,7 +63,7 @@
 
 /datum/map_template/shuttle/emergency/clown
 	suffix = "clown"
-	name = "Snappop(tm)"
+	name = "NTCV Snappop(tm)"
 	description = "Hey kids and grownups! Are you bored of DULL and TEDIOUS \
 		shuttle journeys after you're evacuating for probably BORING reasons. \
 		Well then order the Snappop(tm) today! We've got fun activities for \
@@ -116,24 +116,24 @@
 
 /datum/map_template/shuttle/emergency/raven
 	suffix = "raven"
-	name = "CentCom Raven Cruiser"
-	description = "The CentCom Raven Cruiser is a former high-risk salvage vessel, now repurposed into an emergency escape shuttle. \
+	name = "NTSV Raven"
+	description = "The NTSV Raven is a former high-risk salvage frigate, now repurposed into an emergency escape shuttle. \
 	Once first to the scene to pick through warzones for valuable remains, it now serves as an excellent escape option for stations under heavy fire from outside forces. \
 	This escape shuttle boasts shields and numerous anti-personnel turrets guarding its perimeter to fend off meteors and enemy boarding attempts."
 	admin_notes = "Comes with turrets that will target simple mobs."
 
 /datum/map_template/shuttle/emergency/shadow
 	suffix = "shadow"
-	name = "The NTSS Shadow"
-	description = "Guaranteed to get you somewhere FAST. With a custom-built plasma engine, this bad boy will put more distance between you and certain danger than any other!"
+	name = "NTRTV Shadow"
+	description = "Guaranteed to get you somewhere FAST. Featuring a supercharged plasma-injection burn drive, this bad boy will put more distance between you and certain death than any other!"
 	admin_notes = "The aft of the ship has a plasma tank that starts ignited. May get released by crew. The plasma windows next to the engine heaters will also erupt into flame, and also risk getting released by crew."
 
 /datum/map_template/shuttle/emergency/lance
 	suffix = "lance"
-	name = "The Lance Crew Evacuation System"
-	description = "A brand new shuttle by Nanotrasen's finest in shuttle-engineering, it's designed to tactically slam into a destroyed station, \
+	name = "NTAV Lance"
+	description = "Based on a rejected design by an overager member of Nanotrasen Asset Protection, the NTAV Lance is designed to tactically slam into destroyed stations, \
 	dispatching threats and saving crew at the same time! \
-	Be careful to stay out of it's path. Comes with a beacon to choose where it docks!"
+	Be careful to stay out of its path. Comes with a beacon to choose where it docks!"
 	admin_notes = "WARNING: This shuttle is designed to crash into the station. It has turrets, similar to the raven. Place down the beacon please. Once the shuttle is loaded, it cannot be unloaded."
 
 /datum/map_template/shuttle/emergency/lance/preload()
@@ -184,17 +184,17 @@
 
 /datum/map_template/shuttle/admin/hospital
 	suffix = "hospital"
-	name = "NHV Asclepius"
+	name = "NTHV Asclepius"
 	description = "Nanostrasen Hospital ship, for medical assistance during disasters."
 
 /datum/map_template/shuttle/admin/admin
 	suffix = "admin"
-	name = "NTV Argos"
+	name = "NTTV Argos"
 	description = "Default Admin ship. An older ship used for special operations."
 
 /datum/map_template/shuttle/admin/armory
 	suffix = "armory"
-	name = "NRV Sparta"
+	name = "NTRV Sparta"
 	description = "Armory Shuttle, with plenty of guns to hand out and some general supplies."
 
 /datum/map_template/shuttle/admin/skipjack

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -117,7 +117,7 @@
 /datum/map_template/shuttle/emergency/raven
 	suffix = "raven"
 	name = "NSV Raven"
-	description = "The NTSV Raven is a former high-risk salvage frigate, now repurposed into an emergency escape shuttle. \
+	description = "The NSV Raven is a former high-risk salvage frigate, now repurposed into an emergency escape shuttle. \
 	Once first to the scene to pick through warzones for valuable remains, it now serves as an excellent escape option for stations under heavy fire from outside forces. \
 	This escape shuttle boasts shields and numerous anti-personnel turrets guarding its perimeter to fend off meteors and enemy boarding attempts."
 	admin_notes = "Comes with turrets that will target simple mobs."


### PR DESCRIPTION
## What Does This PR Do
Standardizes the naming schemes of most purchasable shuttles. Shuttle prefixes now use N followed by letters designating their function. I.e NTV Charon, or Nanotrasen Transport Vessel Charon.

Renames some shuttles which lacked a name.

Rewrote and grammar checked shuttle lore.

## Why It's Good For The Game
Consistency in naming schemes is good. Names for shuttles are neat. Lore is good.

## Testing
- Loaded in
- Checked shuttle section
- Names and desc are updated

## Changelog
:cl:
tweak: Rewrote shuttle lore
/:cl:
