### PR TITLE
Wall Rechargers Cannot be Unwrenched.

### DIFF
--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -69,6 +69,8 @@
 	update_icon()
 
 /obj/machinery/recharger/crowbar_act(mob/user, obj/item/I)
+	if(istype(src, /obj/machinery/recharger/wallcharger))	// Do not disassemble wall rechargers. Can still unscrew for basic RPED upgrading.
+		return FALSE
 	if(panel_open && !charging && default_deconstruction_crowbar(user, I))
 		return TRUE
 
@@ -91,6 +93,8 @@
 
 /obj/machinery/recharger/wrench_act(mob/user, obj/item/I)
 	. = TRUE
+	if(istype(src, /obj/machinery/recharger/wallcharger))	// Unwrenching wall rechargers and dragging them off all kinds of cursed.
+		return
 	if(panel_open)
 		to_chat(user, "<span class='warning'>Close the maintenance panel first!</span>")
 		return

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -69,8 +69,6 @@
 	update_icon()
 
 /obj/machinery/recharger/crowbar_act(mob/user, obj/item/I)
-	if(istype(src, /obj/machinery/recharger/wallcharger))	// Do not disassemble wall rechargers. Can still unscrew for basic RPED upgrading.
-		return FALSE
 	if(panel_open && !charging && default_deconstruction_crowbar(user, I))
 		return TRUE
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
You can no longer unwrench a wall-mounted recharger to drag it around.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Dragging these things around is all kinds of cursed.

You can still disassemble them.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
I couldn't wrench the wall chargers.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: You cannot wrench a wall recharger.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
