### PR TITLE
IV bags injection stops if target gets hit

### DIFF
--- a/code/modules/reagents/reagent_containers/iv_bag.dm
+++ b/code/modules/reagents/reagent_containers/iv_bag.dm
@@ -41,11 +41,18 @@
 	..()
 	update_icon(UPDATE_OVERLAYS)
 
+/obj/item/reagent_containers/iv_bag/proc/on_target_hit(mob/target)
+	SIGNAL_HANDLER
+	visible_message("<span class='danger'>The IV bag's needle pops out of [injection_target]'s arm!</span>")
+	end_processing()
+
 /obj/item/reagent_containers/iv_bag/proc/begin_processing(mob/target)
 	injection_target = target
+	RegisterSignals(injection_target, list(COMSIG_ITEM_ATTACK, COMSIG_ATOM_BULLET_ACT, COMSIG_ATOM_HULK_ATTACK), PROC_REF(on_target_hit))
 	START_PROCESSING(SSobj, src)
 
 /obj/item/reagent_containers/iv_bag/proc/end_processing()
+	UnregisterSignal(injection_target, list(COMSIG_ITEM_ATTACK, COMSIG_ATOM_BULLET_ACT, COMSIG_ATOM_HULK_ATTACK))
 	injection_target = null
 	STOP_PROCESSING(SSobj, src)
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

If target gets hit by an item, a bullet or a hulk, then all IV bags will stop injecting into a target.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Reduces powergame value of IV bags with huge amount of chems.

It was either restrict it by only using from hands, turf and IV bag structure, OR allow for funny chems outside of combat.

## Testing
<!-- How did you test the PR, if at all? -->

Telescopic baton and disabler removes injections

## Changelog
:cl:
tweak: If IV bag's injection target is hit by an item (ie telescopic baton), a bullet (ie disabler hit) or by a hulk, then the injection will stop.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
