### PR TITLE
Enhances the Farragus Smoking Experience

### DIFF
--- a/_maps/map_files/stations/cerestation.dmm
+++ b/_maps/map_files/stations/cerestation.dmm
@@ -6159,7 +6159,7 @@
 "aOn" = (
 /obj/machinery/economy/vending/cigarette,
 /turf/simulated/floor/plasteel,
-/area/station/medical/medbay)
+/area/station/hallway/primary/starboard/south)
 "aOu" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -125164,7 +125164,7 @@ njR
 ciG
 gPL
 pQN
-ftr
+pQN
 clq
 cGd
 xPU
@@ -145140,7 +145140,7 @@ rNa
 blC
 bmT
 aOn
-cKk
+vXn
 voS
 cKk
 jVQ

--- a/_maps/map_files/stations/cerestation.dmm
+++ b/_maps/map_files/stations/cerestation.dmm
@@ -6156,6 +6156,10 @@
 	icon_state = "darkbrown"
 	},
 /area/station/supply/office)
+"aOn" = (
+/obj/machinery/economy/vending/cigarette,
+/turf/simulated/floor/plasteel,
+/area/station/medical/medbay)
 "aOu" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -7392,6 +7396,7 @@
 	network = list("SS13","QM")
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/landmark/start/assistant,
 /turf/simulated/floor/plasteel{
 	icon_state = "browncorner"
 	},
@@ -10137,6 +10142,10 @@
 /obj/item/storage/fancy/donut_box,
 /turf/simulated/floor/carpet/black,
 /area/station/command/office/captain)
+"bjP" = (
+/obj/machinery/economy/vending/cigarette,
+/turf/simulated/floor/plating,
+/area/station/hallway/primary/central/west)
 "bjT" = (
 /obj/structure/table/wood,
 /obj/item/camera_film,
@@ -28667,10 +28676,7 @@
 	},
 /area/station/public/quantum/cargo)
 "cXc" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/landmark/start/assistant,
+/obj/machinery/economy/vending/cigarette,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "browncorner"
@@ -34943,6 +34949,29 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/prison/cell_block/A)
+"dSH" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "purplecorner"
+	},
+/area/station/hallway/primary/aft/east)
 "dSI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -37635,7 +37664,7 @@
 /turf/simulated/floor/plating,
 /area/station/public/quantum/service)
 "eQt" = (
-/obj/item/kirbyplants/plant21,
+/obj/machinery/economy/vending/cigarette,
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
@@ -47875,21 +47904,6 @@
 /obj/item/pickaxe,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/fore/west)
-"ipe" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "bluecorner"
-	},
-/area/station/hallway/primary/starboard/south)
 "ipr" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -55384,6 +55398,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -61052,6 +61069,10 @@
 	slowdown = -0.3
 	},
 /area/station/hallway/spacebridge/comeng)
+"mnA" = (
+/obj/machinery/economy/vending/cigarette,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/aft/east)
 "mnL" = (
 /obj/structure/disposalpipe/junction/reversed{
 	dir = 4
@@ -72264,7 +72285,7 @@
 	},
 /area/station/service/chapel/office)
 "pSr" = (
-/obj/item/kirbyplants,
+/obj/machinery/economy/vending/cigarette,
 /turf/simulated/floor/plasteel,
 /area/station/public/fitness)
 "pSE" = (
@@ -73522,6 +73543,10 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central/east)
+"qkR" = (
+/obj/machinery/economy/vending/cigarette,
+/turf/simulated/floor/wood,
+/area/station/maintenance/starboard)
 "qkS" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -79584,6 +79609,13 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/gravitygenerator)
+"slZ" = (
+/obj/machinery/economy/vending/cigarette,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkblue"
+	},
+/area/station/command/bridge)
 "smf" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -80681,6 +80713,13 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/public/arcade)
+"sCQ" = (
+/obj/machinery/economy/vending/cigarette,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkredcorners"
+	},
+/area/station/security/brig)
 "sCT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/sign/directions/engineering{
@@ -82759,6 +82798,7 @@
 	dir = 4;
 	color = "#954535"
 	},
+/obj/machinery/economy/vending/cigarette,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "redcorner"
@@ -91840,6 +91880,7 @@
 /area/station/maintenance/port2)
 "vZN" = (
 /obj/machinery/light,
+/obj/item/kirbyplants,
 /turf/simulated/floor/plasteel,
 /area/station/public/fitness)
 "wac" = (
@@ -116247,7 +116288,7 @@ aom
 nFH
 sZS
 afd
-yfX
+sCQ
 bqV
 dpu
 mng
@@ -124862,10 +124903,10 @@ xFM
 ful
 wpc
 ful
-igd
+dSH
 ciG
-vni
-pQN
+gPL
+mnA
 pQN
 nta
 cGd
@@ -125123,7 +125164,7 @@ njR
 ciG
 gPL
 pQN
-tnj
+ftr
 clq
 cGd
 xPU
@@ -125380,7 +125421,7 @@ rMW
 ciG
 gPL
 pQN
-jRl
+tnj
 kmp
 cGd
 pAi
@@ -125637,7 +125678,7 @@ dUO
 ciG
 gPL
 pQN
-gtV
+jRl
 awZ
 cGd
 isf
@@ -125894,7 +125935,7 @@ aeG
 ciG
 gPL
 pQN
-fqM
+gtV
 vru
 cGd
 dzs
@@ -126151,7 +126192,7 @@ jkh
 ciG
 nWY
 pQN
-wsR
+fqM
 awZ
 cGd
 cGd
@@ -128647,7 +128688,7 @@ wWC
 aXR
 aZK
 aZK
-aZK
+bjP
 jjf
 oZE
 cIA
@@ -131171,7 +131212,7 @@ aVS
 aVS
 aVS
 aVS
-xLP
+slZ
 tkv
 fPE
 suI
@@ -144584,7 +144625,7 @@ rni
 vuM
 seO
 bxN
-ipe
+bxN
 tjS
 tHE
 bxN
@@ -144841,7 +144882,7 @@ rnv
 bmS
 bmS
 bmS
-vXn
+bmS
 oGF
 gOh
 oGF
@@ -145098,7 +145139,7 @@ rnW
 rNa
 blC
 bmT
-cKk
+aOn
 cKk
 voS
 cKk
@@ -156176,7 +156217,7 @@ hPG
 itf
 itf
 itf
-jsE
+qkR
 jsE
 gvx
 pep


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
The Galactic Tobacco Federation has lobbied for YOUR interests as an enjoyer of our many products. Whether it's the smooth flavour of an Uplift, the dominant sensation of a Robust Gold, or the complex sophistication of an Embellished Enigma, we know you wish to be able to access your favourite brand without hassle.

And so, Nanotrasen has bowed to our demands and installed TEN brand new ShadyCigs Deluxe vendors to the NSS Farragus. These have been spaced out across the asteroids to ensure you don't have to run too far to reach them, because we know that for some reason (completely unrelated to the consumption of tobacco products) you just seem to run out of breath a lot faster than you used to.

And remember, don't listen to the reports, smoke today!
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
There are only 6 cigarette machines across the WHOLE Farragus (one of which is just for the Captain (based TBH)). For comparison, Cyberiad has 13 of them.

Now Farragus has 16. No more shall you be denied convenient access to tobacco products.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
Science hallway.
![image](https://github.com/ParadiseSS13/Paradise/assets/143041327/f2a2573f-b533-4e94-b5e7-612d699b631b)
Science breakroom.
![image](https://github.com/ParadiseSS13/Paradise/assets/143041327/4680235b-bfdb-4992-9c5c-461f987dc5de)
Dorms.
![image](https://github.com/ParadiseSS13/Paradise/assets/143041327/fe5549e1-dc48-4eeb-8443-4a8e85ffdb2e)
Security hallway.
![image](https://github.com/ParadiseSS13/Paradise/assets/143041327/3f2191b2-1595-4a9f-957b-7d399210fa20)
Brig.
![image](https://github.com/ParadiseSS13/Paradise/assets/143041327/b1a80c3d-b07f-48b1-9758-15a60c8820af)
Bridge.
![image](https://github.com/ParadiseSS13/Paradise/assets/143041327/20b41c7c-205a-4ad0-b770-5af16d32f0e0)
Cargo.
![image](https://github.com/ParadiseSS13/Paradise/assets/143041327/763f7507-63ea-4ac3-b58a-a2bb20144fca)
Engineering hallway (in maint like all the other public vendors there).
![image](https://github.com/ParadiseSS13/Paradise/assets/143041327/87f9289e-839e-4093-9ce3-0f81fa233933)
Medical hallway.
![image](https://github.com/ParadiseSS13/Paradise/assets/143041327/bc99f8f5-0a49-45f0-8b37-a4ffedb10862)
Old maintbar.
![image](https://github.com/ParadiseSS13/Paradise/assets/143041327/8a7c13ad-9d01-4ced-a014-b885ef8a7b3f)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
It compiled.
There were more vendors.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Added TEN new cigarette vendors to Farragus.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
