### PR TITLE
Removes ID-locking from cloning console

### DIFF
--- a/code/game/machinery/clonepod.dm
+++ b/code/game/machinery/clonepod.dm
@@ -57,11 +57,11 @@
 /obj/machinery/clonepod
 	anchored = TRUE
 	name = "cloning pod"
-	desc = "An electronically-lockable pod for growing organic tissue."
+	desc = "A pod for growing organic tissue."
 	density = TRUE
 	icon = 'icons/obj/cloning.dmi'
 	icon_state = "pod_idle"
-
+	req_access = list(ACCESS_MEDICAL)
 	//So that chemicals can be loaded into the pod.
 	container_type = OPENCONTAINER
 	/// The linked cloning console.
@@ -80,9 +80,6 @@
 	var/desc_flavor = "It doesn't seem to be doing anything right now."
 	/// The countdown.
 	var/obj/effect/countdown/clonepod/countdown
-	/// Whether or not the interface is locked.
-	var/locked = TRUE
-	req_access = list(ACCESS_MEDICAL)
 
 	/// The speed at which we clone. Each processing cycle will advance clone_progress by this amount.
 	var/speed_modifier = 1
@@ -165,7 +162,6 @@
 /obj/machinery/clonepod/examine(mob/user)
 	. = ..()
 	. += "<span class='notice'>[desc_flavor]</span>"
-	. += "<span class='notice'>[src] is currently [locked ? "locked" : "unlocked"], and can be [locked ? "unlocked" : "locked"] by swiping an ID with medical access on it.</span>"
 
 /obj/machinery/clonepod/RefreshParts()
 	speed_modifier = 0 //Since we have multiple manipulators, which affect this modifier, we reset here so we can just use += later
@@ -571,11 +567,8 @@
 			to_chat(user, "<span class='warning'>Access denied.</span>")
 			return
 
-		switch(tgui_alert(user, "Change access restrictions or perform an emergency ejection of [src]?", "Cloning pod", list("Change access", "Emergency ejection")))
-			if("Change access")
-				locked = !locked
-				to_chat(user, "<span class='notice'>Access restriction is now [locked ? "enabled" : "disabled"].</span>")
-			if("Emergency ejection")
+		switch(tgui_alert(user, "Perform an emergency ejection of [src]?", "Cloning pod", list("Yes", "No")))
+			if("Yes")
 				eject_clone(TRUE) // GET OUT
 				to_chat(user, "<span class='warning'>You force [src] to eject its clone!</span>")
 		return
@@ -643,12 +636,6 @@
 //TGUI
 /obj/machinery/clonepod/ui_interact(mob/user, datum/tgui/ui = null)
 	if(stat & (NOPOWER|BROKEN))
-		return
-
-	if(!allowed(user) && locked && !isobserver(user))
-		to_chat(user, "<span class='warning'>Access denied.</span>")
-		if(ui)
-			ui.close()
 		return
 
 	ui = SStgui.try_update_ui(user, src, ui)

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -95,16 +95,6 @@
 
 	ui_interact(user)
 
-/obj/machinery/computer/cloning/emag_act(mob/user)
-	. = ..()
-	if(!emagged)
-		emagged = TRUE
-		to_chat(user, "<span class='notice'>You short out the ID scanner on [src].</span>")
-	else
-		to_chat(user, "<span class='warning'>[src]'s ID scanner is already broken!</span>")
-
-	return TRUE
-
 /obj/machinery/computer/cloning/proc/generate_healthy_data(datum/cloning_data/patient_data)
 	var/datum/cloning_data/desired_data = new
 
@@ -140,12 +130,6 @@
 
 /obj/machinery/computer/cloning/ui_interact(mob/user, datum/tgui/ui = null)
 	if(stat & (NOPOWER|BROKEN))
-		return
-
-	if(!allowed(user) && !isobserver(user))
-		to_chat(user, "<span class='warning'>Access denied.</span>")
-		if(ui)
-			ui.close()
 		return
 
 	var/datum/asset/simple/cloning/assets = get_asset_datum(/datum/asset/simple/cloning)

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -7,7 +7,6 @@
 	icon_keyboard = "med_key"
 	icon_screen = "dna"
 	circuit = /obj/item/circuitboard/cloning
-	req_access = list(ACCESS_MEDICAL)
 
 	/// The currently-selected cloning pod.
 	var/obj/machinery/clonepod/selected_pod
@@ -21,8 +20,6 @@
 	var/feedback
 	/// The desired outcome of the cloning process.
 	var/datum/cloning_data/desired_data
-	/// Whether the ID lock is on or off
-	var/locked = TRUE
 
 	COOLDOWN_DECLARE(scancooldown)
 
@@ -49,18 +46,7 @@
 			P.console = null
 	return ..()
 
-/obj/machinery/computer/cloning/examine(mob/user)
-	. = ..()
-	. += "<span class='notice'>[src] is currently [locked ? "locked" : "unlocked"], and can be [locked ? "unlocked" : "locked"] by swiping an ID with medical access on it.</span>"
-
 /obj/machinery/computer/cloning/attackby(obj/item/I, mob/user, params)
-	if(istype(I, /obj/item/card/id) || istype(I, /obj/item/pda))
-		if(allowed(user))
-			locked = !locked
-			to_chat(user, "<span class='notice'>Access restriction is now [locked ? "enabled" : "disabled"].</span>")
-		else
-			to_chat(user, "<span class='warning'>Access denied.</span>")
-		return
 
 	if(!ismultitool(I))
 		return ..()
@@ -156,7 +142,7 @@
 	if(stat & (NOPOWER|BROKEN))
 		return
 
-	if(!allowed(user) && locked && !isobserver(user))
+	if(!allowed(user) && !isobserver(user))
 		to_chat(user, "<span class='warning'>Access denied.</span>")
 		if(ui)
 			ui.close()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
- The cloning console is no longer able to be ID locked, similar to how it operated prior to the rework. This means that anybody can access it.
-  The cloning pod itself retains a medical access level requirement for force ejecting patients, but accessing it no longer requires a medical ID.
- Removes unimplemented emag_act on the console.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Hard locking cloning equipment to doctors was an interesting experiment, but I don't believe that it has had a positive effect on the game. I believe that other crew members should be able to step in and assist medbay in their operations when help is needed. An access lock on the single most important part of medbay's role is an immovable barrier to this.
## Testing
<!-- How did you test the PR, if at all? -->
Made sure ghost interaction and ID things didn't break.
## Changelog
:cl:
tweak: Cloning equipment is no longer ID-locked to medical personnel.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
