### PR TITLE
Fixes Chapel Requests Console on Farragus

### DIFF
--- a/_maps/map_files/stations/cerestation.dmm
+++ b/_maps/map_files/stations/cerestation.dmm
@@ -44321,11 +44321,6 @@
 /area/station/maintenance/storage)
 "hkr" = (
 /obj/item/kirbyplants,
-/obj/machinery/requests_console{
-	department = "Chapel";
-	departmentType = 2;
-	pixel_y = 30
-	},
 /turf/simulated/floor/carpet/black,
 /area/station/service/chapel)
 "hkt" = (
@@ -78175,6 +78170,14 @@
 	icon_state = "bluecorner"
 	},
 /area/station/hallway/primary/starboard/north)
+"rOy" = (
+/obj/machinery/requests_console{
+	department = "Chapel";
+	departmentType = 2;
+	pixel_y = 30
+	},
+/turf/simulated/floor/carpet/black,
+/area/station/service/chapel)
 "rOM" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Walkway"
@@ -112234,7 +112237,7 @@ aEe
 aEe
 vtY
 bZg
-nvU
+rOy
 xVY
 eZY
 nvU


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Puts the Chapel Requests Console on Cerestation back on the wall.

## Why It's Good For The Game
Requests consoles need walls. Bad mapping is bad.

## Images of changes
![image](https://github.com/ParadiseSS13/Paradise/assets/144391971/ad3d0607-5f32-4fa0-859f-f45cabcbafe7)

## Testing
Booted up. Map fix.

## Changelog
:cl:
fix: Put Farragus chapel request console back on the wall
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
