### PR TITLE
Increases nanomed restocking unit cost

### DIFF
--- a/code/modules/supply/supply_packs/pack_medical.dm
+++ b/code/modules/supply/supply_packs/pack_medical.dm
@@ -112,7 +112,7 @@
 
 /datum/supply_packs/medical/vending
 	name = "Medical Vending Crate"
-	cost = 100
+	cost = 650
 	contains = list(/obj/item/vending_refill/medical,
 					/obj/item/vending_refill/wallmed)
 	containername = "medical vending crate"

--- a/code/modules/supply/supply_packs/pack_medical.dm
+++ b/code/modules/supply/supply_packs/pack_medical.dm
@@ -112,7 +112,7 @@
 
 /datum/supply_packs/medical/vending
 	name = "Medical Vending Crate"
-	cost = 650
+	cost = 400
 	contains = list(/obj/item/vending_refill/medical,
 					/obj/item/vending_refill/wallmed)
 	containername = "medical vending crate"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
This PR increases cost of nanomed restock unit in cargo from 100 credits to 400

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Having portable medbay with everything you need for 100 units sounds... powerful. We dont have all departments ordering nanomed just to have it(100 credits cmon) yet, but we better fix the price before it happens.

## Testing
<!-- How did you test the PR, if at all? -->
Compiled

## Changelog
:cl:
tweak: Nanomed restock unit now costs 400 credits.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
