### PR TITLE
Preventing creating two-brain bodies.

### DIFF
--- a/code/modules/surgery/limb_reattach.dm
+++ b/code/modules/surgery/limb_reattach.dm
@@ -91,6 +91,7 @@
 
 /datum/surgery_step/limb/attach/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 
+	var/obj/item/organ/external/E = tool
 	if(target.get_organ(E.limb_name))
 		// This catches attaching an arm to a missing hand while the arm is still there
 		to_chat(user, "<span class='warning'>[target] already has an [E.name]!</span>")

--- a/code/modules/surgery/limb_reattach.dm
+++ b/code/modules/surgery/limb_reattach.dm
@@ -91,7 +91,6 @@
 
 /datum/surgery_step/limb/attach/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 
-	var/obj/item/organ/external/E = tool
 	if(target.get_organ(E.limb_name))
 		// This catches attaching an arm to a missing hand while the arm is still there
 		to_chat(user, "<span class='warning'>[target] already has an [E.name]!</span>")
@@ -111,7 +110,7 @@
 	if(!target.bodyparts_by_name[E.parent_organ])
 		to_chat(user, "<span class='warning'>[target] doesn't have a [parse_zone(E.parent_organ)] to attach the [E.name] to!</span>")
 		return SURGERY_BEGINSTEP_ABORT
-	if(length(E.search_contents_for(/obj/item/organ/internal/brain)) && target.get_int_organ(/obj/item/organ/internal/brain))
+	if(length(E.search_contents_for(/obj/item/organ/internal/brain)) && (target.get_int_organ(/obj/item/organ/internal/brain) || IS_CHANGELING(target)))
 		to_chat(user, "<span class='warning'>Both [target] and [E.name] contain a brain, and [target] can't have two brains!</span>")
 		return SURGERY_BEGINSTEP_ABORT
 

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -423,6 +423,10 @@
 		to_chat(user, "<span class='warning'> [target] already has [I].</span>")
 		return SURGERY_BEGINSTEP_SKIP
 
+	if(istype(tool, /obj/item/organ/internal/brain) && target.get_int_organ(/obj/item/organ/internal/brain))
+		to_chat(user, "<span class='warning'>[target] can't have two brains!</span>")
+		return SURGERY_BEGINSTEP_SKIP
+
 	if(affected)
 		user.visible_message(
 			"[user] starts transplanting [tool] into [target]'s [affected.name].",

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -423,7 +423,7 @@
 		to_chat(user, "<span class='warning'> [target] already has [I].</span>")
 		return SURGERY_BEGINSTEP_SKIP
 
-	if(istype(tool, /obj/item/organ/internal/brain) && target.get_int_organ(/obj/item/organ/internal/brain))
+	if(istype(tool, /obj/item/organ/internal/brain) && (target.get_int_organ(/obj/item/organ/internal/brain) || IS_CHANGELING(target))
 		to_chat(user, "<span class='warning'>[target] can't have two brains!</span>")
 		return SURGERY_BEGINSTEP_SKIP
 

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -423,7 +423,7 @@
 		to_chat(user, "<span class='warning'> [target] already has [I].</span>")
 		return SURGERY_BEGINSTEP_SKIP
 
-	if(istype(tool, /obj/item/organ/internal/brain) && (target.get_int_organ(/obj/item/organ/internal/brain) || IS_CHANGELING(target))
+	if(istype(tool, /obj/item/organ/internal/brain) && (target.get_int_organ(/obj/item/organ/internal/brain) || IS_CHANGELING(target)))
 		to_chat(user, "<span class='warning'>[target] can't have two brains!</span>")
 		return SURGERY_BEGINSTEP_SKIP
 

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -553,12 +553,12 @@
 	allowed_tools = list(/obj/item/mmi = 100)
 
 /datum/surgery_step/robotics/manipulate_robotic_organs/install_mmi/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	if(!ismachineperson(target))
-		to_chat(user, "<span class='notice'> You can't install MMI in that body.</span>")
+	if(target.get_int_organ(/obj/item/organ/internal/brain))
+		to_chat(user, "<span class='warning'>[target] can't have two brains!</span>")
 		return SURGERY_BEGINSTEP_SKIP
 
 	if(target_zone != BODY_ZONE_CHEST)
-		to_chat(user, "<span class='notice'> You must target the chest cavity.</span>")
+		to_chat(user, "<span class='notice'>You must target the chest cavity.</span>")
 		return SURGERY_BEGINSTEP_SKIP
 
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -553,7 +553,7 @@
 	allowed_tools = list(/obj/item/mmi = 100)
 
 /datum/surgery_step/robotics/manipulate_robotic_organs/install_mmi/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	if(target.get_int_organ(/obj/item/organ/internal/brain))
+	if(target.get_int_organ(/obj/item/organ/internal/brain) || IS_CHANGELING(target))
 		to_chat(user, "<span class='warning'>[target] can't have two brains!</span>")
 		return SURGERY_BEGINSTEP_SKIP
 

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -553,9 +553,12 @@
 	allowed_tools = list(/obj/item/mmi = 100)
 
 /datum/surgery_step/robotics/manipulate_robotic_organs/install_mmi/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	if(!ismachineperson(target))
+		to_chat(user, "<span class='notice'> You can't install MMI in that body.</span>")
+		return SURGERY_BEGINSTEP_SKIP
+
 	if(target_zone != BODY_ZONE_CHEST)
 		to_chat(user, "<span class='notice'> You must target the chest cavity.</span>")
-
 		return SURGERY_BEGINSTEP_SKIP
 
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
This PR prevents players from making two-brain bodies. It will block surgery if target is changeling(they dont need brain to revive) or if target already has brain.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Two-brain bodies is bad. It causes bugs including one player being permanently dead with no chance to be revived. We dont need two-brain bodies.

## Testing
<!-- How did you test the PR, if at all? -->
Compiled, tried various surgery.

## Changelog
:cl:
fix: You can no longer put brain or MMI into a body that already has a brain or a player.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
