### PR TITLE
Mecha Actions: Fixes #25828 and #25826

### DIFF
--- a/code/game/mecha/equipment/mecha_equipment.dm
+++ b/code/game/mecha/equipment/mecha_equipment.dm
@@ -128,6 +128,7 @@
 		if(chassis.selected == src)
 			chassis.selected = null
 		update_chassis_page()
+		src.remove_targeted_action()
 		chassis.log_message("[src] removed from equipment.")
 		chassis = null
 		set_ready_state(1)

--- a/code/game/mecha/mecha_actions.dm
+++ b/code/game/mecha/mecha_actions.dm
@@ -231,8 +231,8 @@
 	equipment = _equipment
 	icon_icon = equipment.icon
 	button_icon_state = equipment.icon_state
-	. = ..()
 	name = "Switch module to [equipment.name]"
+	. = ..()
 
 /datum/action/innate/mecha/select_module/Activate()
 	if(!owner || !chassis || chassis.occupant != owner)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #25828 and #25826

Action buttons now properly delete when an item is detached
Action buttons are now properly named before being applied

## Why It's Good For The Game
Bugs bad

## Testing
Made mechs. Added equipment. Dropped equipment.

## Changelog
:cl:
fix: Fixes naming of the final exosuit action button
fix: Fixes detached equipment not removing the action button
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
