### PR TITLE
Changelings can now absorb people they already have DNA of

### DIFF
--- a/code/modules/antagonists/changeling/datum_changeling.dm
+++ b/code/modules/antagonists/changeling/datum_changeling.dm
@@ -425,8 +425,7 @@ RESTRICT_TYPE(/datum/antagonist/changeling)
 		to_chat(user, "<span class='warning'>This creature does not have DNA!</span>")
 		return FALSE
 	if(get_dna(target.dna))
-		to_chat(user, "<span class='warning'>We already have this DNA in storage!</span>")
-		return FALSE
+		to_chat(user, "<span class='warning'>We already have this DNA in storage.</span>")
 	return TRUE
 
 /datum/antagonist/changeling/proc/on_death(mob/living/L, gibbed)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
can_absorb_dna() now only outputs a warning if the changeling already has the target DNA, instead of returning False, allowing absorption (and as a side effect, the DNA sting) to be performed on targets they already have DNA of.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Changelings are highly incentivized to get their objective's DNA as soon as possible - you never know when they might decide to hug the SM or eat xenomicrobes, or do anything else that permanently removes their DNA from the round. Absorption does much more than just give you DNA, so it makes no sense to block the entire ability over it.
All relevant code already has safeties against getting duplicates of the same DNA, so it seems that the only thing the check in can_absorb_dna() did was prevent wasting chemicals on repeated DNA stings.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->



## Testing
<!-- How did you test the PR, if at all? -->
Spawned in a Skrell, stung them with DNA sting couple of times, absorbed them, used Last Resort, egged from the same Skrell. Only got their DNA once in the process.
## Changelog
:cl:
tweak: DNA Sting and Absorb can now be used on targets whose DNA changeling already has
/:cl:
