### PR TITLE
Fix blood pack crate runtimes when ordering through cargo shuttle

### DIFF
--- a/code/modules/reagents/reagent_containers/iv_bag.dm
+++ b/code/modules/reagents/reagent_containers/iv_bag.dm
@@ -52,9 +52,10 @@
 	START_PROCESSING(SSobj, src)
 
 /obj/item/reagent_containers/iv_bag/proc/end_processing()
-	REMOVE_TRAIT(injection_target, TRAIT_HAS_IV_BAG, UID())
-	UnregisterSignal(injection_target, COMSIG_PARENT_EXAMINE)
-	injection_target = null
+	if(injection_target)
+		REMOVE_TRAIT(injection_target, TRAIT_HAS_IV_BAG, UID())
+		UnregisterSignal(injection_target, COMSIG_PARENT_EXAMINE)
+		injection_target = null
 	STOP_PROCESSING(SSobj, src)
 
 /obj/item/reagent_containers/iv_bag/process()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
#25805 added a status trait removal on `iv_bag/proc/end_processing()` that causes each IV bag in a blood crate to runtime when `Destroy()` is called in the instance that they do not have an `injection_target`. This most commonly happens when ordered through the cargo shuttle
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Runtime log spam bad.
## Testing
<!-- How did you test the PR, if at all? -->
Ordered a crate. Sent it back. Didn't runtime. 


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
