### PR TITLE
Fixes runtime in sticky component Destroy()

### DIFF
--- a/code/datums/components/sticky.dm
+++ b/code/datums/components/sticky.dm
@@ -15,10 +15,12 @@
 
 /datum/component/sticky/Destroy(force, silent)
 	// we dont want the falling off visible message if this component is getting destroyed because parent is getting destroyed
-	if(!QDELETED(parent) && isitem(parent) && attached_to)
-		var/obj/item/I = parent
-		I.visible_message("<span class='notice'>[parent] falls off of [attached_to].</span>")
-	pick_up(parent)
+	if(attached_to)
+		if(!QDELETED(parent) && isitem(parent))
+			var/obj/item/I = parent
+			I.visible_message("<span class='notice'>[parent] falls off of [attached_to].</span>")
+		pick_up(parent)
+
 	move_to_the_thing(parent, get_turf(parent))
 	return ..()
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
If an item with the sticky component was deleted without being attached to something, it would attempt to call `pick_up()` in the component `Destroy()` and runtime. This makes it not do that.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Runtime bad

## Testing
<!-- How did you test the PR, if at all? -->
Didn't runtime when qdel'd without an `attached_to` (lying on the ground)

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
