### PR TITLE
Fixes runtime with out of bounds hitscan projectiles

### DIFF
--- a/code/modules/projectiles/projectile_base.dm
+++ b/code/modules/projectiles/projectile_base.dm
@@ -341,6 +341,8 @@
 		trajectory.increment(trajectory_multiplier)
 		var/turf/T = trajectory.return_turf()
 		if(!istype(T))
+			// if we've gone off of the map, we need to step back once so that hitscanning projectiles have a valid end turf
+			trajectory.increment(-trajectory_multiplier)
 			qdel(src)
 			return
 		if(T.z != loc.z)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Fixes longstanding bug with the ported TG hitscan projectile system. Hitscan projectiles delete either through their `range` counter reaching 0, hitting a target, or if the turf their `trajectory` has just crossed into is invalid. When near the edge of the map, the last option happens frequently. 

Before deleting itself, the hitscan projectile performs the calculations necessary for the line visuals. `trajectory`'s turf is passed into the `ending_atom` argument of `get_line` to return a list of turfs between the shooter and the point of termination. However, `trajectory`'s turf is by necessity `null` at this point. To fix this, we just decrement `trajectory` back to the `increment()`'s value so that it returns the last valid turf within map bounds.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
This is a bug, and as a wise man once said, "I'm from Buenos Aires and i say kill 'em all!" 

## Testing
<!-- How did you test the PR, if at all? -->
I shot at the edge of the map a bunch of times and it didn't runtime so it seems good to me.


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
