### PR TITLE
Fixes empty gaseous decomposition plant procs runtiming

### DIFF
--- a/code/game/objects/effects/effect_system/effects_chem_smoke.dm
+++ b/code/game/objects/effects/effect_system/effects_chem_smoke.dm
@@ -141,9 +141,10 @@
 		if(iscarbon(A))
 			mobs_to_smoke += A
 
-	var/percentage_to_add
-	if(length(mobs_to_smoke))
-		percentage_to_add = chemholder.reagents.total_volume / length(mobs_to_smoke)
+	if(!length(mobs_to_smoke))
+		return
+
+	var/percentage_to_add = chemholder.reagents.total_volume / length(mobs_to_smoke)
 
 	for(var/mob/living/carbon/smoker as anything in mobs_to_smoke)
 		if(smoker.can_breathe_gas())

--- a/code/game/objects/effects/effect_system/effects_chem_smoke.dm
+++ b/code/game/objects/effects/effect_system/effects_chem_smoke.dm
@@ -141,7 +141,9 @@
 		if(iscarbon(A))
 			mobs_to_smoke += A
 
-	var/percentage_to_add = chemholder.reagents.total_volume / length(mobs_to_smoke)
+	var/percentage_to_add
+	if(length(mobs_to_smoke))
+		percentage_to_add = chemholder.reagents.total_volume / length(mobs_to_smoke)
 
 	for(var/mob/living/carbon/smoker as anything in mobs_to_smoke)
 		if(smoker.can_breathe_gas())


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes a runtime that would happen if no mob was hit with plant chem smoke
Mostly affected mass spreading of acid and stuff
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
This should work
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


## Testing
It compiled
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Smoke now properly spreads when it doesn't hit a mob
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
