### PR TITLE
Antagbanned people can join the ghost bar

### DIFF
--- a/code/modules/awaymissions/mob_spawn.dm
+++ b/code/modules/awaymissions/mob_spawn.dm
@@ -39,6 +39,8 @@
 	var/ghost_usable = TRUE
 	var/offstation_role = TRUE // If set to true, the role of the user's mind will be set to offstation
 	var/death_cooldown = 0 // How long you have to wait after dying before using it again, in deciseconds. People that join as observers are not included.
+	///If antagbanned people are prevented from using it, only false for the ghost bar spawner.
+	var/restrict_antagban = TRUE
 
 /obj/effect/mob_spawn/attack_ghost(mob/user)
 	if(!valid_to_spawn(user))
@@ -84,7 +86,7 @@
 	if(!uses && !permanent)
 		to_chat(user, "<span class='warning'>This spawner is out of charges!</span>")
 		return FALSE
-	if(jobban_isbanned(user, banType) || jobban_isbanned(user, ROLE_SYNDICATE))
+	if((jobban_isbanned(user, banType) || (jobban_isbanned(user, ROLE_SYNDICATE) && restrict_antagban)))
 		to_chat(user, "<span class='warning'>You are jobanned!</span>")
 		return FALSE
 	if(!HAS_TRAIT(user, TRAIT_RESPAWNABLE))

--- a/code/modules/awaymissions/mob_spawn.dm
+++ b/code/modules/awaymissions/mob_spawn.dm
@@ -86,7 +86,7 @@
 	if(!uses && !permanent)
 		to_chat(user, "<span class='warning'>This spawner is out of charges!</span>")
 		return FALSE
-	if((jobban_isbanned(user, banType) || (jobban_isbanned(user, ROLE_SYNDICATE) && restrict_antagban)))
+	if((jobban_isbanned(user, banType) || (restrict_antagban && jobban_isbanned(user, ROLE_SYNDICATE))))
 		to_chat(user, "<span class='warning'>You are jobanned!</span>")
 		return FALSE
 	if(!HAS_TRAIT(user, TRAIT_RESPAWNABLE))

--- a/code/modules/ruins/ghost_bar.dm
+++ b/code/modules/ruins/ghost_bar.dm
@@ -11,6 +11,7 @@ GLOBAL_LIST_EMPTY(occupants_by_key)
 	flavour_text = "You are a ghost bar occupant. You've gotten sick of being dead and decided to meet up with some of your fellow haunting brothers. Take a seat, grab a beer, and chat it out."
 	assignedrole = "Ghost Bar Occupant"
 	death_cooldown = 1 MINUTES
+	restrict_antagban = FALSE
 
 /obj/effect/mob_spawn/human/alive/ghost_bar/create(ckey, flavour = TRUE, name, mob/user = usr) // So divorced from the normal proc it's just being overriden
 	var/datum/character_save/save_to_load


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Allows antagbanned players to use the ghastly rejuvinator in the ghost bar. Fixes #25868
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Antagbanned players are supposed to not be able to be ghostroles so they can't mess with other players, but ghost bar players have no way to interact with the main station.
## Testing
<!-- How did you test the PR, if at all? -->
Used breakpoints to make sure the spawner logic didn't change how it currently works, but unfortunately without a database set up I cannot actually test if you can use the rejuvinator while jobbanned.
## Changelog
:cl:
fix: People with antagbans can join the ghost bar
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
