### PR TITLE
Decreases Spikethrower's cost to 50TC

### DIFF
--- a/code/datums/uplink_items/uplink_traitor.dm
+++ b/code/datums/uplink_items/uplink_traitor.dm
@@ -351,7 +351,7 @@
 	desc = "An energy based weapon that launches high velocity plasma spikes. These spikes hit with enough force to knock the target down and leave a nasty wound."
 	reference = "STG"
 	item = /obj/item/gun/energy/spikethrower
-	cost = 60
+	cost = 50
 	species = list("Vox")
 	surplus = 0
 


### PR DESCRIPTION
## What Does This PR Do
Title.

## Why It's Good For The Game
While the spikethrower is an interesting and powerful weapon, it is unfortunately a bit overpriced compared to contemporaries such as the Power Fist and Chainsaw. This should make it picked a bit more.

## Testing
N/A, one number change

## Changelog
:cl:
tweak: Spikethrower now costs 50TC
/:cl: