### PR TITLE
Narsie no longer sacrifices their own cultists

### DIFF
--- a/code/modules/mob/living/carbon/human/human_mob.dm
+++ b/code/modules/mob/living/carbon/human/human_mob.dm
@@ -1463,7 +1463,7 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 	rad_act(current_size * 3)
 
 /mob/living/carbon/human/narsie_act()
-	if(iswizard(src) && IS_CULTIST(src)) //Wizard cultists are immune to narsie because it would prematurely end the wiz round that's about to end by the automated shuttle call anyway
+	if(iswizard(src) || IS_CULTIST(src)) // Wizards are immune to the magic. Cultists also don't get transformed.
 		return
 	..()
 

--- a/code/modules/power/engines/singularity/narsie.dm
+++ b/code/modules/power/engines/singularity/narsie.dm
@@ -112,7 +112,6 @@
 	return
 
 /obj/singularity/narsie/proc/pickcultist() //Narsie rewards his cultists with being devoured first, then picks a ghost to follow. --NEO
-	var/list/cultists = list()
 	var/list/noncultists = list()
 	for(var/mob/living/carbon/food in GLOB.alive_mob_list) //we don't care about constructs or cult-Ians or whatever. cult-monkeys are fair game i guess
 		var/turf/pos = get_turf(food)
@@ -121,18 +120,12 @@
 		if(pos.z != src.z)
 			continue
 
-		if(IS_CULTIST(food))
-			cultists += food
-		else
+		if(!IS_CULTIST(food))
 			noncultists += food
 
-		if(length(cultists)) //cultists get higher priority
-			acquire(pick(cultists))
-			return
-
-		if(length(noncultists))
-			acquire(pick(noncultists))
-			return
+	if(length(noncultists))
+		acquire(pick(noncultists))
+		return
 
 	//no living humans, follow a ghost instead.
 	for(var/mob/dead/observer/ghost in GLOB.player_list)
@@ -141,10 +134,9 @@
 		var/turf/pos = get_turf(ghost)
 		if(pos.z != src.z)
 			continue
-		cultists += ghost
-	if(length(cultists))
-		acquire(pick(cultists))
-		return
+		noncultists += ghost
+	if(length(noncultists))
+		acquire(pick(noncultists))
 
 
 /obj/singularity/narsie/proc/acquire(mob/food)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
When narsie is spawned in, cultists will no longer be turned into harvesters by them.
They also won't be targetted by them when narsie is active but thats been broken for years

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Cultists are more powerful than harvesters and it doesn't actually feel like a *reward* to be turned into one. Every time narsie is summoned, all of the cultists struggle and run to get off the rune so they don't get gibbed.

## Testing
<!-- How did you test the PR, if at all? -->
Compiles. Spawned Narsie on top of myself as a cultist. Didn't get gibbed and transformed into a harvester

## Changelog
:cl:
tweak: Cultists will no longer be turned into harvesters by Nar'Sie
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
