### PR TITLE
Dsword can now be purchased directly

### DIFF
--- a/code/datums/uplink_items/uplink_general.dm
+++ b/code/datums/uplink_items/uplink_general.dm
@@ -205,6 +205,13 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/melee/energy/sword/saber
 	cost = 40
 
+/datum/uplink_item/dangerous/dsword
+	name = "Double Energy Sword"
+	desc = "A double-bladed energy sword. More damaging than a standard energy sword, and automatically parries incoming energy weapons fire. Bulk discount applied."
+	reference = "DSRD"
+	item = /obj/item/dualsaber
+	cost = 60
+
 /datum/uplink_item/dangerous/powerfist
 	name = "Power Fist"
 	desc = "The power-fist is a metal gauntlet with a built-in piston-ram powered by an external gas supply. \


### PR DESCRIPTION
## What Does This PR Do
Title. Dsword can now be bought directly in the uplink at a 20TC bulk discount.

## Why It's Good For The Game
The dsword is really damn overpriced for a weapon that is debatably worse than the chainsaw, as you are forced to pay 80TC for the privilege of wielding it.

Hopefully this makes it used a bit more often.

## Testing
- loaded in
- checked uplink
- dsword

## Changelog
:cl:
tweak: Dsword can be bought in the uplink for 60TC
/:cl: