### PR TITLE
Unwrenching a pressurized pipe you're standing on now flings you in a random direction

### DIFF
--- a/code/modules/atmospherics/machinery/atmospherics.dm
+++ b/code/modules/atmospherics/machinery/atmospherics.dm
@@ -260,6 +260,9 @@ Pipelines + Other Objects -> Pipe network
 		pressures = int_air.return_pressure() - env_air.return_pressure()
 
 	var/fuck_you_dir = get_dir(src, user)
+	if(!fuck_you_dir)
+		fuck_you_dir = pick(NORTH, NORTHEAST, EAST, SOUTHEAST, SOUTH, SOUTHWEST, WEST, NORTHWEST)
+
 	var/turf/general_direction = get_edge_target_turf(user, fuck_you_dir)
 	user.visible_message("<span class='danger'>[user] is sent flying by pressure!</span>","<span class='userdanger'>The pressure sends you flying!</span>")
 	//Values based on 2*ONE_ATMOS (the unsafe pressure), resulting in 20 range and 4 speed

--- a/code/modules/atmospherics/machinery/atmospherics.dm
+++ b/code/modules/atmospherics/machinery/atmospherics.dm
@@ -261,7 +261,7 @@ Pipelines + Other Objects -> Pipe network
 
 	var/fuck_you_dir = get_dir(src, user)
 	if(!fuck_you_dir)
-		fuck_you_dir = pick(NORTH, NORTHEAST, EAST, SOUTHEAST, SOUTH, SOUTHWEST, WEST, NORTHWEST)
+		fuck_you_dir = pick(GLOB.alldirs)
 
 	var/turf/general_direction = get_edge_target_turf(user, fuck_you_dir)
 	user.visible_message("<span class='danger'>[user] is sent flying by pressure!</span>","<span class='userdanger'>The pressure sends you flying!</span>")


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Tweaks unsafe pressurized pipe unwrenching so that standing ontop of the pipe, instead of making you do a flip, will instead fling you in a random direction.

## Why It's Good For The Game
Magboots are required to work with atmos pipes to prevent being tossed, unless you stand directly ontop of the pipe as it is currently. This makes it so that you need magboots even while standing on the unsafe pipe.

## Images of changes

https://github.com/ParadiseSS13/Paradise/assets/144391971/391249ff-a1b2-469d-a259-81dd6a49f5e3


## Testing
See above. Spawned as CE, made a pressure problem, did not follow OSHA.

## Changelog
:cl:
tweak: Pressurized pipes now fling you in a random direction when stood on and wrenched unsafely.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
