### PR TITLE
Removes an Evil Corner Window From the Luxury Survival Pod

### DIFF
--- a/_maps/map_files/templates/shelter_2.dmm
+++ b/_maps/map_files/templates/shelter_2.dmm
@@ -94,12 +94,6 @@
 	},
 /turf/simulated/floor/carpet/black,
 /area/survivalpod)
-"q" = (
-/obj/structure/window/reinforced/survival_pod{
-	dir = 9
-	},
-/turf/simulated/floor/carpet/black,
-/area/survivalpod)
 "r" = (
 /turf/simulated/floor/carpet/black,
 /area/survivalpod)
@@ -233,7 +227,7 @@ a
 n
 o
 p
-q
+r
 r
 a
 "}

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -18,10 +18,13 @@
 	var/reinf = FALSE
 	var/heat_resistance = 800
 	var/decon_speed = null
+	/// If set to TRUE, the window is a full-tile window, otherwise it is a directional window.
 	var/fulltile = FALSE
 	var/shardtype = /obj/item/shard
 	var/glass_decal = /obj/effect/decal/cleanable/glass
+	/// The material that drops when the window is dismantled.
 	var/glass_type = /obj/item/stack/sheet/glass
+	/// How much material drops when the window is dismantled.
 	var/glass_amount = 1
 	var/mutable_appearance/crack_overlay
 	var/real_explosion_block	//ignore this, just use explosion_block


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Removes a corner window from the luxury survival pod that blocked movement despite not visibly blocking anything.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Blocking bad. The window is tiny and I don't recall any place where corner windows are used, so no one will bat an eye at this.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://github.com/ParadiseSS13/Paradise/assets/143041327/1456fc25-fa07-495e-980b-fd8fd7e075ad)
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
There was no window.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Removed an evil window from the luxury capsule.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
