### PR TITLE
bluespace spellblade and modsuit teleporter module work better

### DIFF
--- a/code/game/objects/items/weapons/melee/melee_misc.dm
+++ b/code/game/objects/items/weapons/melee/melee_misc.dm
@@ -296,7 +296,9 @@
 	if(!.)
 		return
 	var/turf/user_turf = get_turf(user)
-	if(!(target in view(7, user_turf))) // no camera shenangians
+	if(get_dist(user_turf, get_turf(target)) > 9) //blocks cameras without blocking xray or thermals
+		return
+	if(!((target in view(9, user)) || user.sight & SEE_MOBS))
 		return
 	var/list/turfs = list()
 	for(var/turf/T in orange(1, get_turf(target)))

--- a/code/game/objects/items/weapons/melee/melee_misc.dm
+++ b/code/game/objects/items/weapons/melee/melee_misc.dm
@@ -296,9 +296,9 @@
 	if(!.)
 		return
 	var/turf/user_turf = get_turf(user)
-	if(get_dist(user_turf, get_turf(target)) > 7) //blocks cameras without blocking xray or thermals
+	if(get_dist(user_turf, get_turf(target)) > 9) //blocks cameras without blocking xray or thermals
 		return
-	if(!((target in view(7, user)) || user.sight & SEE_MOBS))
+	if(!((target in view(9, user)) || user.sight & SEE_MOBS))
 		return
 	var/list/turfs = list()
 	for(var/turf/T in orange(1, get_turf(target)))

--- a/code/game/objects/items/weapons/melee/melee_misc.dm
+++ b/code/game/objects/items/weapons/melee/melee_misc.dm
@@ -296,9 +296,9 @@
 	if(!.)
 		return
 	var/turf/user_turf = get_turf(user)
-	if(get_dist(user_turf, get_turf(target)) > 9) //blocks cameras without blocking xray or thermals
+	if(get_dist(user_turf, get_turf(target)) > 7) //blocks cameras without blocking xray or thermals
 		return
-	if(!((target in view(9, user)) || user.sight & SEE_MOBS))
+	if(!((target in view(7, user)) || user.sight & SEE_MOBS))
 		return
 	var/list/turfs = list()
 	for(var/turf/T in orange(1, get_turf(target)))

--- a/code/modules/mod/modules/modules_science.dm
+++ b/code/modules/mod/modules/modules_science.dm
@@ -77,7 +77,7 @@
 	if(!.)
 		return
 	var/turf/target_turf = get_turf(target)
-	if(!istype(target_turf) || target_turf.density || !(target_turf in view(9, mod.wearer))) //No. No camera bug shenanigins.
+	if(!istype(target_turf) || target_turf.density || !((target in view(9, mod.wearer)) || mod.wearer.sight & SEE_TURFS) || (get_dist(target_turf, get_turf(mod.wearer)) > 9)) //No. No camera bug shenanigins.
 		return
 	var/matrix/pre_matrix = matrix()
 	pre_matrix.Scale(4, 0.25)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Bluespace spellblade can now work with thermals or xray vision, allowing a wizard who spent points on say, smoke, or the scrying orb, to not get ripped off. It's magic, it works.

The teleporter module for modsuits that requires a bluespace core, now works with mesons or xray. You spent a core on this instead of a phason, it should work through walls.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

A magic spellblade a wizard can buy should work through walls with xray or thermals.

A teleportation module that you took over a phason should bloody work through walls. I intended this, but uh, checks to prevent camera teleporting to AI core made it a pain.

## Testing
<!-- How did you test the PR, if at all? -->
Smacking skrells through walls with xray and thermals.
Teleporting through walls with mesons and xray.

## Changelog
:cl:
tweak: Bluespace spellblade works with thermals or xray now.
tweak: The modsuit teleporter module that requires an anomaly core, works with mesons or xray now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
