### PR TITLE
Fix stale bot closing stale-exempt issues and PRs

### DIFF
--- a/.github/workflows/label_stale.yml
+++ b/.github/workflows/label_stale.yml
@@ -19,6 +19,6 @@ jobs:
           days-before-issue-stale: 60
           days-before-close: 7
           days-before-issue-close: 14
-          exempt-issue-labels: '"Stale Exempt"'
-          exempt-pr-labels: '"Stale Exempt", "-Status: Awaiting approval", "-Status: Awaiting Merge", "-Status: Awaiting type assignment"'
-          any-of-issue-labels: '"Need Verification", "Cannot Reproduce", "Not A Bug", "(99% Sure) Not A Bug"'
+          exempt-issue-labels: 'Stale Exempt'
+          exempt-pr-labels: 'Stale Exempt, -Status: Awaiting approval, -Status: Awaiting Merge, -Status: Awaiting type assignment'
+          any-of-issue-labels: 'Need Verification, Cannot Reproduce, Not A Bug, (99% Sure) Not A Bug'


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
- Removed quotes around labels in the stale bot config

I am certain that quotes aren't supported, as no one mentioned them in the issue https://github.com/actions/stale/issues/98. They are not handled in code, either
https://github.com/actions/stale/blob/3f3b0175e8c66fb49b9a6d5a0cd1f8436d4c3ab6/src/functions/words-to-list.ts#L17

Furthermore, stale bot closing #25071 despite being stale exempt is further proof of this
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Stop closing stale-exempt PRs like #25071
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Unable to
<!-- How did you test the PR, if at all? -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
