### PR TITLE
Prevent constructed AI laws from randomly becoming null.

### DIFF
--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -178,6 +178,8 @@
 					SSticker.mode.remove_revolutionary(brain.brainmob.mind, 1)
 
 				var/mob/living/silicon/ai/A = new /mob/living/silicon/ai(loc, laws, brain)
+				// Stop holding onto the laws so we don't qdel them and make the AI randomly lose its laws when GC gives up and hard deletes them.
+				laws = null
 				if(A) //if there's no brain, the mob is deleted and a structure/AIcore is created
 					A.rename_self("AI", 1)
 			SSblackbox.record_feedback("amount", "ais_created", 1)


### PR DESCRIPTION
## What Does This PR Do
Fixes #23696
The root cause here is that the laws were qdeleted by the AI core after being transferred to the AI mob, causing them to get hard-deleted at some time in the future, which would reset them to NT-Default once something triggered a sanity check.

## Why It's Good For The Game
Random law changes with zero notice suck.

## Testing
Constructed AIs before:
![image](https://github.com/ParadiseSS13/Paradise/assets/98381/a4001eb3-2d4b-476f-a491-1e7eb865e4ef)
And after:
![image](https://github.com/ParadiseSS13/Paradise/assets/98381/29607a2e-e65e-4426-8a40-7320f39235d8)

## Changelog
:cl:
fix: Fixed a bug that made all constructed AIs randomly reset to NT Default after an indeterminate amount of time, without informing them.
/:cl: