### PR TITLE
Adds firecrackers and decoy grenades

### DIFF
--- a/code/game/objects/items/weapons/grenades/firecracker.dm
+++ b/code/game/objects/items/weapons/grenades/firecracker.dm
@@ -1,0 +1,64 @@
+/obj/item/grenade/firecracker
+	name = "fire-cracker"
+	desc = "A firework that's great at making a lot of noise."
+	det_time = 2 SECONDS
+	/// The effect that will be randomly played at intervals.
+	var/sound_effect = 'sound/weapons/gunshots/gunshot_strong.ogg'
+	/// The minimum number of times it will fire.
+	var/min_pops = 5
+	/// The maximum number of times it fires.
+	var/max_pops = 20
+	/// How long, at least, we'll end up between pops.
+	var/min_time_between_pops = 5 DECISECONDS
+	/// The longest possible length between fires.
+	var/max_time_between_pops = 20 DECISECONDS
+
+
+/obj/item/grenade/firecracker/prime()
+	. = ..()
+	playsound(src, 'sound/effects/smoke.ogg', 50, TRUE, -3)
+	INVOKE_ASYNC(src, PROC_REF(start_popping), TRUE)
+
+/obj/item/grenade/firecracker/proc/start_popping(del_after = FALSE)
+	for(var/i in 0 to rand(min_pops, max_pops))
+		playsound(src, sound_effect, 100, TRUE)
+		sleep(rand(min_time_between_pops, max_time_between_pops))
+	if(del_after)
+		qdel(src)
+
+/obj/item/grenade/firecracker/decoy
+	name = "decoy grenade"
+	desc = "A grenade capable of imitating many different sounds."
+
+	var/list/possible_sounds = list(
+		"revolver" = 'sound/weapons/gunshots/gunshot_strong.ogg',
+		"armblade" = 'sound/weapons/armblade.ogg',
+		"laser" = 'sound/weapons/laser.ogg',
+		"sniper" = 'sound/weapons/gunshots/gunshot_sniper.ogg',
+		"pistol" = 'sound/weapons/gunshots/gunshot_pistol.ogg'
+	)
+
+	var/selected_sound = "revolver"
+
+/obj/item/grenade/firecracker/decoy/Initialize(mapload)
+	. = ..()
+	selected_sound = possible_sounds[1]
+
+/obj/item/grenade/firecracker/decoy/examine(mob/user)
+	. = ..()
+	if(!user.Adjacent(src))
+		return
+	. += "<span class='notice'>[src] will sound like \a [selected_sound].</span>"
+	. += "<span class='notice'>Alt-Click to change the imitated sound.</span>"
+
+/obj/item/grenade/firecracker/decoy/AltClick(mob/user)
+	. = ..()
+	var/selected = tgui_input_list(user, "Choose the decoy sound.", items = possible_sounds)
+	sound_effect = possible_sounds[selected] || sound_effect
+	to_chat(user, "<span class='notice'>[src] will now sound like \a [selected_sound].</span>")
+
+/obj/item/grenade/firecracker/decoy/AltShiftClick(mob/user)
+	. = ..()
+	min_time_between_pops = tgui_input_number(user, "Select the minimum time between pops (in 1/10s of a second).", "Minimum time", min_time_between_pops, 50, 2)
+	max_time_between_pops = tgui_input_number(user, "Select the maximum time between pops (in 1/10s of a second).", "Maximum time", max_time_between_pops, 50, 2)
+

--- a/paradise.dme
+++ b/paradise.dme
@@ -1201,6 +1201,7 @@
 #include "code\game\objects\items\weapons\grenades\confetti.dm"
 #include "code\game\objects\items\weapons\grenades\custom_grenades.dm"
 #include "code\game\objects\items\weapons\grenades\emgrenade.dm"
+#include "code\game\objects\items\weapons\grenades\firecracker.dm"
 #include "code\game\objects\items\weapons\grenades\flashbang.dm"
 #include "code\game\objects\items\weapons\grenades\frag.dm"
 #include "code\game\objects\items\weapons\grenades\ghettobomb.dm"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds firecrackers and decoy grenades, which are able to imitate some weapon sounds.
Firecrackers sound like a .357 revolver, and fire occasionally before disappearing.
Decoy grenades can be alt-clicked to change the sound within a pre-configured set of sound effects:
- .357 revolver
- Armblades
- Lasers
- Sniper sound
- Stetchkin pistol
- Blobs
- Spider bites
...and maybe more, feel free to recommend them.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
I think being able to create decoys to throw people off your tail is neat. I envision decoy grenades as being a syndicate item, and firecrackers being a publicly available noisemaker that people can use to goof off with.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Loaded in, tried configuring the sound effects, threw the grenades.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
add: New noisemakers: Firecrackers, and decoy grenades.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
