### PR TITLE
Expands the Cigarette Vendor Inventory

### DIFF
--- a/_maps/map_files/generic/centcomm.dmm
+++ b/_maps/map_files/generic/centcomm.dmm
@@ -6572,6 +6572,13 @@
 /obj/structure/flora/ausbushes/leafybush,
 /turf/simulated/floor/grass,
 /area/trader_station/sol)
+"wr" = (
+/obj/machinery/economy/vending/cigarette/beach/centcomm,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "green"
+	},
+/area/centcom/evac)
 "ws" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/reedbush,
@@ -47868,7 +47875,7 @@ OF
 Nu
 QG
 OF
-Nu
+wr
 Xl
 XC
 YO

--- a/_maps/map_files/generic/centcomm.dmm
+++ b/_maps/map_files/generic/centcomm.dmm
@@ -6572,13 +6572,6 @@
 /obj/structure/flora/ausbushes/leafybush,
 /turf/simulated/floor/grass,
 /area/trader_station/sol)
-"wr" = (
-/obj/machinery/economy/vending/cigarette/beach/centcomm,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "green"
-	},
-/area/centcom/evac)
 "ws" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/reedbush,
@@ -10679,7 +10672,7 @@
 	},
 /area/ghost_bar)
 "LH" = (
-/obj/machinery/economy/vending/cigarette/free,
+/obj/machinery/economy/vending/cigarette/beach/centcomm,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "green"
@@ -47875,7 +47868,7 @@ OF
 Nu
 QG
 OF
-wr
+Nu
 Xl
 XC
 YO

--- a/code/game/machinery/vendors/generic_vendors.dm
+++ b/code/game/machinery/vendors/generic_vendors.dm
@@ -1186,9 +1186,8 @@
 	icon_lightmask = "cigs"
 	category = VENDOR_TYPE_RECREATION
 	products = list(/obj/item/clothing/mask/cigarette/cigar = 2,
-					/obj/item/storage/fancy/cigarettes = 6,
 					/obj/item/storage/fancy/cigarettes/cigpack_carp = 6,
-					/obj/item/storage/fancy/cigarettes/dromedaryco = 6
+					/obj/item/storage/fancy/cigarettes/dromedaryco = 6,
 					/obj/item/storage/fancy/cigarettes/cigpack_random = 6,
 					/obj/item/storage/fancy/cigarettes/cigpack_midori = 6,
 					/obj/item/storage/fancy/cigarettes/cigpack_robust = 6,
@@ -1203,7 +1202,6 @@
 	contraband = list(/obj/item/storage/fancy/rollingpapers = 5)
 
 	prices = list(/obj/item/clothing/mask/cigarette/cigar = 100,
-				/obj/item/storage/fancy/cigarettes = 25,
 				/obj/item/storage/fancy/cigarettes/cigpack_carp = 25,
 				/obj/item/storage/fancy/cigarettes/dromedaryco = 25,
 				/obj/item/storage/fancy/cigarettes/cigpack_random = 80,
@@ -1227,7 +1225,6 @@
 // The Syndicate version doesn't sell Robust because that is a Nanotrasen-owned brand. It *does* have its special own-brand replacement.
 /obj/machinery/economy/vending/cigarette/syndicate
 	products = list(/obj/item/clothing/mask/cigarette/cigar = 6,
-				/obj/item/storage/fancy/cigarettes = 6,
 				/obj/item/storage/fancy/cigarettes/cigpack_carp = 6,
 				/obj/item/storage/fancy/cigarettes/dromedaryco = 6,
 				/obj/item/storage/fancy/cigarettes/cigpack_random = 6,
@@ -1237,7 +1234,7 @@
 				/obj/item/storage/fancy/cigarettes/cigpack_uplift = 6,
 				/obj/item/reagent_containers/patch/nicotine = 10,
 				/obj/item/storage/fancy/matches = 10,
-				/obj/item/lighter/zippo = 6
+				/obj/item/lighter/zippo = 6,
 				/obj/item/storage/fancy/rollingpapers = 5)
 
 	contraband = list()

--- a/code/game/machinery/vendors/generic_vendors.dm
+++ b/code/game/machinery/vendors/generic_vendors.dm
@@ -1186,6 +1186,7 @@
 	icon_lightmask = "cigs"
 	category = VENDOR_TYPE_RECREATION
 	products = list(/obj/item/clothing/mask/cigarette/cigar = 2,
+					/obj/item/storage/fancy/cigarettes = 6,
 					/obj/item/storage/fancy/cigarettes/cigpack_carp = 6,
 					/obj/item/storage/fancy/cigarettes/dromedaryco = 6,
 					/obj/item/storage/fancy/cigarettes/cigpack_random = 6,
@@ -1202,6 +1203,7 @@
 	contraband = list(/obj/item/storage/fancy/rollingpapers = 5)
 
 	prices = list(/obj/item/clothing/mask/cigarette/cigar = 100,
+				/obj/item/storage/fancy/cigarettes = 25,
 				/obj/item/storage/fancy/cigarettes/cigpack_carp = 25,
 				/obj/item/storage/fancy/cigarettes/dromedaryco = 25,
 				/obj/item/storage/fancy/cigarettes/cigpack_random = 80,
@@ -1225,6 +1227,7 @@
 // The Syndicate version doesn't sell Robust because that is a Nanotrasen-owned brand. It *does* have its special own-brand replacement.
 /obj/machinery/economy/vending/cigarette/syndicate
 	products = list(/obj/item/clothing/mask/cigarette/cigar = 6,
+				/obj/item/storage/fancy/cigarettes = 6,
 				/obj/item/storage/fancy/cigarettes/cigpack_carp = 6,
 				/obj/item/storage/fancy/cigarettes/dromedaryco = 6,
 				/obj/item/storage/fancy/cigarettes/cigpack_random = 6,

--- a/code/game/machinery/vendors/generic_vendors.dm
+++ b/code/game/machinery/vendors/generic_vendors.dm
@@ -1185,13 +1185,16 @@
 	icon_state = "cigs"
 	icon_lightmask = "cigs"
 	category = VENDOR_TYPE_RECREATION
-	products = list(/obj/item/storage/fancy/cigarettes/cigpack_robust = 6,
+	products = list(/obj/item/clothing/mask/cigarette/cigar = 2,
+					/obj/item/storage/fancy/cigarettes = 6,
 					/obj/item/storage/fancy/cigarettes/cigpack_carp = 6,
-					/obj/item/storage/fancy/cigarettes/cigpack_uplift = 6,
-					/obj/item/storage/fancy/cigarettes/cigpack_midori = 6,
+					/obj/item/storage/fancy/cigarettes/dromedaryco = 6
 					/obj/item/storage/fancy/cigarettes/cigpack_random = 6,
+					/obj/item/storage/fancy/cigarettes/cigpack_midori = 6,
+					/obj/item/storage/fancy/cigarettes/cigpack_robust = 6,
 					/obj/item/storage/fancy/cigarettes/cigpack_robustgold = 1,
-					/obj/item/clothing/mask/cigarette/cigar/havana = 2,
+					/obj/item/storage/fancy/cigarettes/cigpack_shadyjims = 6,
+					/obj/item/storage/fancy/cigarettes/cigpack_uplift = 6,
 					/obj/item/reagent_containers/patch/nicotine = 10,
 					/obj/item/storage/fancy/matches = 10,
 					/obj/item/lighter/random = 4,
@@ -1199,39 +1202,50 @@
 
 	contraband = list(/obj/item/storage/fancy/rollingpapers = 5)
 
-	prices = list(/obj/item/storage/fancy/cigarettes/cigpack_robust = 25,
+	prices = list(/obj/item/clothing/mask/cigarette/cigar = 100,
+				/obj/item/storage/fancy/cigarettes = 25,
 				/obj/item/storage/fancy/cigarettes/cigpack_carp = 25,
-				/obj/item/storage/fancy/cigarettes/cigpack_uplift = 35,
-				/obj/item/storage/fancy/cigarettes/cigpack_midori = 60,
+				/obj/item/storage/fancy/cigarettes/dromedaryco = 25,
 				/obj/item/storage/fancy/cigarettes/cigpack_random = 80,
+				/obj/item/storage/fancy/cigarettes/cigpack_midori = 60,
+				/obj/item/storage/fancy/cigarettes/cigpack_robust = 25,
 				/obj/item/storage/fancy/cigarettes/cigpack_robustgold = 120,
+				/obj/item/storage/fancy/cigarettes/cigpack_shadyjims = 50,
+				/obj/item/storage/fancy/cigarettes/cigpack_uplift = 35,
 				/obj/item/reagent_containers/patch/nicotine = 70,
 				/obj/item/storage/fancy/matches = 20,
 				/obj/item/lighter/random = 40,
 				/obj/item/lighter/zippo = 80,
 				/obj/item/storage/fancy/rollingpapers = 30,
-				/obj/item/clothing/mask/cigarette/cigar/havana = 80)
+)
 
 	refill_canister = /obj/item/vending_refill/cigarette
 
 /obj/machinery/economy/vending/cigarette/free
 	prices = list()
 
+// The Syndicate version doesn't sell Robust because that is a Nanotrasen-owned brand. It *does* have its special own-brand replacement.
 /obj/machinery/economy/vending/cigarette/syndicate
-	products = list(/obj/item/storage/fancy/cigarettes/cigpack_syndicate = 7,
-				/obj/item/storage/fancy/cigarettes/cigpack_uplift = 3,
-				/obj/item/storage/fancy/cigarettes/cigpack_robust = 2,
-				/obj/item/storage/fancy/cigarettes/cigpack_carp = 3,
-				/obj/item/storage/fancy/cigarettes/cigpack_midori = 1,
+	products = list(/obj/item/clothing/mask/cigarette/cigar = 6,
+				/obj/item/storage/fancy/cigarettes = 6,
+				/obj/item/storage/fancy/cigarettes/cigpack_carp = 6,
+				/obj/item/storage/fancy/cigarettes/dromedaryco = 6,
+				/obj/item/storage/fancy/cigarettes/cigpack_random = 6,
+				/obj/item/storage/fancy/cigarettes/cigpack_midori = 6,
+				/obj/item/storage/fancy/cigarettes/cigpack_shadyjims = 6,
+				/obj/item/storage/fancy/cigarettes/cigpack_syndicate = 10,
+				/obj/item/storage/fancy/cigarettes/cigpack_uplift = 6,
+				/obj/item/reagent_containers/patch/nicotine = 10,
 				/obj/item/storage/fancy/matches = 10,
+				/obj/item/lighter/zippo = 6
 				/obj/item/storage/fancy/rollingpapers = 5)
 
-	contraband = list(/obj/item/lighter/zippo = 4)
+	contraband = list()
 
 /obj/machinery/economy/vending/cigarette/syndicate/free
 	prices = list()
 
-/// Used in the lavaland_biodome_beach.dmm ruin
+/// Used in the lavaland_biodome_beach.dmm ruin. As the ultimate in smokable vending, it sells the widest range in the grestest quantity.
 /obj/machinery/economy/vending/cigarette/beach
 	name = "\improper ShadyCigs Ultra"
 	desc = "Now with extra premium products!"
@@ -1244,19 +1258,40 @@
 					"Dope will get you through times of no money better than money will get you through times of no dope!",
 					"It's good for you!")
 
-	products = list(/obj/item/storage/fancy/cigarettes = 5,
-				/obj/item/storage/fancy/cigarettes/cigpack_uplift = 3,
-				/obj/item/storage/fancy/cigarettes/cigpack_robust = 3,
-				/obj/item/storage/fancy/cigarettes/cigpack_carp = 3,
-				/obj/item/storage/fancy/cigarettes/cigpack_midori = 3,
-				/obj/item/storage/fancy/cigarettes/cigpack_robustgold = 1,
-				/obj/item/clothing/mask/cigarette/cigar/havana = 2,
+	products = list(/obj/item/clothing/mask/cigarette/cigar = 6,
+				/obj/item/clothing/mask/cigarette/cigar/cohiba = 6,
+				/obj/item/clothing/mask/cigarette/cigar/havana = 6,
+				/obj/item/storage/fancy/cigarettes = 10,
+				/obj/item/storage/fancy/cigarettes/cigpack_carp = 10,
+				/obj/item/storage/fancy/cigarettes/cigpack_random = 10,
+				/obj/item/storage/fancy/cigarettes/cigpack_midori = 10,
+				/obj/item/storage/fancy/cigarettes/cigpack_robust = 10,
+				/obj/item/storage/fancy/cigarettes/cigpack_robustgold = 10,
+				/obj/item/storage/fancy/cigarettes/cigpack_shadyjims = 10,
+				/obj/item/storage/fancy/cigarettes/cigpack_uplift = 10,
+				/obj/item/reagent_containers/patch/nicotine = 20,
 				/obj/item/storage/fancy/matches = 10,
-				/obj/item/lighter/zippo = 4,
-				/obj/item/storage/fancy/rollingpapers = 5)
+				/obj/item/lighter/zippo = 10,
+				/obj/item/storage/fancy/rollingpapers = 10)
 
 	contraband = list()
 	prices = list()
+
+// The finest cigs, available at centcomm for the crew to enjoy after a long, hard day of being brutalized.
+/obj/machinery/economy/vending/cigarette/beach/centcomm
+	slogan_list = list("Space cigs taste good like a cigarette should.",
+					"I'd rather toolbox than switch.",
+					"Smoke!",
+					"Don't believe the reports - smoke today!")
+
+	ads_list = list("Probably not bad for you!",
+					"Don't believe the scientists!",
+					"It's good for you!",
+					"Don't quit, buy more!",
+					"Smoke!",
+					"Nicotine heaven.",
+					"Best cigarettes since 2150.",
+					"Award-winning cigs.")
 
 /obj/machinery/economy/vending/wallmed
 	name = "\improper NanoMed"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds Dromedary Co. and Shady Jim's cigarettes to the ShadyCigs vendor. Cigpacks are now sorted alphabetically.

Replaced Premium Havana Cigars with basic Premium Cigars. Only the best of the best are supposed to have 'em! (also the price has been increased to 100 Cr).

Syndicate vendors are now better stocked, but do not carry Robust brand anymore, as the markings on the packets suggest it's an NT brand (which they wouldn't want for obvious reasons).

The ShadyCigs Ultra now carries all the cig and cigar types except for Syndicate cigarettes, and it carries a lot of them.

CentComm is now equipped with a ShadyCigs Ultra.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Dromedary Co. is another nicotine flavour, for the smoker's roleplay.

Shady Jims' is the smoking version of the weight loss shake and provides another way to not be fat on demand (at the cost of actually hurting you, cuz it contains 2 different poisons).

The Syndicate now has more consumer choice.

The ultimate smoking vendor now provides the ultimate (free) shopping experience.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Went to centcomm. Saw it had the new vendor.
Went to the station. Saw the new selection.
Went to the Syndicate Base. Saw the new selection.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Cigarette machines now sell basic Premium Cigars instead of Premium Havana Cigars.
tweak: The cigarette vendor now stocks Dromedary Co. and Shady Jim's cigarettes.
tweak: Syndicate cigarette vendors are now better stocked, but no longer carry Robust brand.
tweak: The ShadyCigs Ultra now sells all brands of cigar and cigarette (except for Syndicate cigarettes).
tweak: The free ShadyCigs machine outside the CentComm bar has been replaced with a ShadyCigs Ultra.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
