### PR TITLE
Tweaks the Light Replacer

### DIFF
--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -74,10 +74,10 @@
 		if(uses >= max_uses)
 			to_chat(user, "<span class='warning'>[src] is full.</span>")
 			return
-		else if(G.use(decrement))
+
+		if(G.use(decrement))
 			AddUses(increment)
 			to_chat(user, "<span class='notice'>You insert a piece of glass into [src]. You have [uses] light\s remaining.</span>")
-			return
 		else
 			to_chat(user, "<span class='warning'>You need one sheet of glass to replace lights!</span>")
 		return
@@ -88,25 +88,26 @@
 			return
 		if(!user.unEquip(I))
 			return
-		AddUses(round(increment * 0.75))
+		AddUses(round(increment * 1)) // It literally contains the same amount of glass as a sheet.
 		to_chat(user, "<span class='notice'>You insert a shard of glass into [src]. You have [uses] light\s remaining.</span>")
 		qdel(I)
 		return
 
 	if(istype(I, /obj/item/light))
 		var/obj/item/light/L = I
-		if(L.status == 0) // LIGHT OKAY
-			if(uses < max_uses)
-				if(!user.unEquip(L))
-					return
-				AddUses(1)
-				qdel(L)
-		else
+		if(L.status == LIGHT_OK && uses < max_uses) // LIGHT OKAY
 			if(!user.unEquip(L))
 				return
-			to_chat(user, "<span class='notice'>You insert [L] into [src].</span>")
-			AddShards(1, user)
+			AddUses(1)
+			to_chat(user, "<span class='notice'>You insert [L] into [src]. You have [uses] light\s remaining.</span>")
 			qdel(L)
+			return
+
+		if(!user.unEquip(L))
+			return
+		to_chat(user, "<span class='notice'>You insert [L] into [src]. You have [uses] light\s remaining.</span>")
+		AddShards(1, user)
+		qdel(L)
 		return
 
 	if(isstorage(I))

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -78,7 +78,7 @@
 
 		if(G.use(decrement))
 			AddUses(increment)
-			to_chat(user, "<span class='notice'>You insert a piece of glass into [src]. You have [uses] light\s remaining.</span>")
+			to_chat(user, "<span class='notice'>You insert a some glass into [src]. You have [uses] light\s remaining.</span>")
 		else
 			to_chat(user, "<span class='warning'>You need one sheet of glass to replace lights!</span>")
 		return
@@ -106,8 +106,8 @@
 		if(!user.unEquip(L))
 			to_chat(user, "<span class='warning'>[L] is stuck to your hand!</span>")
 			return
-		to_chat(user, "<span class='notice'>You insert [L] into [src]. You have [uses] light\s remaining.</span>")
 		AddShards(1, user)
+		to_chat(user, "<span class='notice'>You insert [L] into [src]. You have [uses] light\s remaining.</span>")
 		qdel(L)
 		return
 

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -78,7 +78,7 @@
 
 		if(G.use(decrement))
 			AddUses(increment)
-			to_chat(user, "<span class='notice'>You insert a some glass into [src]. You have [uses] light\s remaining.</span>")
+			to_chat(user, "<span class='notice'>You insert some glass into [src]. You have [uses] light\s remaining.</span>")
 		else
 			to_chat(user, "<span class='warning'>You need one sheet of glass to replace lights!</span>")
 		return
@@ -231,17 +231,8 @@
 /obj/item/lightreplacer/afterattack(atom/target, mob/U, proximity)
 	. = ..()
 	if(isitem(target))
-		if(istype(target, /obj/item/shard))
-			attackby(target, U)
-			return
-
-		if(istype(target, /obj/item/light))
-			attackby(target, U)
-			return
-
-		if(istype(target, /obj/item/stack/sheet/glass))
-			attackby(target, U)
-			return
+		attackby(target, U)
+		return
 
 	if(!proximity && !bluespace_toggle)
 		return

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -95,19 +95,17 @@
 
 	if(istype(I, /obj/item/light))
 		var/obj/item/light/L = I
-		if(L.status == LIGHT_OK)
-			if(!user.unEquip(L))
-				return
-			AddUses(1)
-			to_chat(user, "<span class='notice'>You insert [L] into [src]. You have [uses] light\s remaining.</span>")
-			qdel(L)
-			return
-
 		if(!user.unEquip(L))
 			to_chat(user, "<span class='warning'>[L] is stuck to your hand!</span>")
 			return
-		AddShards(1, user)
-		to_chat(user, "<span class='notice'>You insert [L] into [src]. You have [uses] light\s remaining.</span>")
+
+		if(L.status == LIGHT_OK)
+			AddUses(1)
+			to_chat(user, "<span class='notice'>You insert [L] into [src]. You have [uses] light\s remaining.</span>")
+			qdel(L)
+		else
+			AddShards(1, user)
+			to_chat(user, "<span class='notice'>You insert [L] into [src]. You have [uses] light\s remaining.</span>")
 		qdel(L)
 		return
 

--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -66,11 +66,6 @@ GLOBAL_LIST_INIT(glass_recipes, list (
 	..()
 
 /obj/item/stack/sheet/glass/attackby(obj/item/W, mob/user, params)
-	..()
-	if(istype(W, /obj/item/lightreplacer))
-		W.attackby(src, user)
-		return
-
 	if(istype(W, /obj/item/stack/cable_coil))
 		var/obj/item/stack/cable_coil/CC = W
 		if(CC.get_amount() < 5)
@@ -94,6 +89,8 @@ GLOBAL_LIST_INIT(glass_recipes, list (
 		if(!G && !RG && replace)
 			user.put_in_hands(RG)
 		return
+	
+	return ..()
 
 //////////////////////////////
 // MARK: REINFORCED GLASS

--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -67,6 +67,10 @@ GLOBAL_LIST_INIT(glass_recipes, list (
 
 /obj/item/stack/sheet/glass/attackby(obj/item/W, mob/user, params)
 	..()
+	if(istype(W, /obj/item/lightreplacer))
+		W.attackby(src, user)
+		return
+
 	if(istype(W, /obj/item/stack/cable_coil))
 		var/obj/item/stack/cable_coil/CC = W
 		if(CC.get_amount() < 5)
@@ -76,7 +80,9 @@ GLOBAL_LIST_INIT(glass_recipes, list (
 		to_chat(user, "<span class='notice'>You attach wire to [src].</span>")
 		new /obj/item/stack/light_w(user.loc)
 		use(1)
-	else if(istype(W, /obj/item/stack/rods))
+		return
+
+	if(istype(W, /obj/item/stack/rods))
 		var/obj/item/stack/rods/V  = W
 		var/obj/item/stack/sheet/rglass/RG = new (user.loc)
 		RG.add_fingerprint(user)
@@ -87,8 +93,7 @@ GLOBAL_LIST_INIT(glass_recipes, list (
 		G.use(1)
 		if(!G && !RG && replace)
 			user.put_in_hands(RG)
-	else
-		return ..()
+		return
 
 //////////////////////////////
 // MARK: REINFORCED GLASS

--- a/code/game/objects/items/weapons/manuals.dm
+++ b/code/game/objects/items/weapons/manuals.dm
@@ -501,23 +501,16 @@
 				<b>Anti-Plague Sequence Beta</b>
 				<ul>
 					<li>1 unit of blood containing zombie plague cured by Anti-Plague Sequence Alpha</li>
-					<li>2 random chemicals from the list below, 1 unit of each (Unknown Random Recipe)
+					<li>3 random chemicals from the list below, 1 unit of each (Unknown Random Recipe)
 						<ul>
-							<li>Yellow Vomit</li>
-							<li>Jenkem</li>
-							<li>Charcoal</li>
-							<li>Egg</li>
 							<li>Saline-Glucose Solution</li>
 							<li>Toxin</li>
 							<li>Atropine</li>
 							<li>Lye</li>
-							<li>Sulphuric acid</li>
-							<li>Fluorosulfuric Acid</li>
 							<li>Soda Water</li>
-							<li>Surge</li>
-							<li>Ultra-Lube</li>
 							<li>Happiness</li>
 							<li>Morphine</li>
+							<li>Teporone</li>
 						</ul>
 					</li>
 				</ul>
@@ -528,21 +521,15 @@
 					<li>1 unit of blood containing an advanced virus with the <b>"Necrotizing Fasciitis"</b> symptom</li>
 					<li>3 random chemicals from the list below, 1 unit of each (Unknown Random Recipe)
 						<ul>
-							<li>Colorful Reagent</li>
-							<li>Bacchus' Blessing</li>
-							<li>Pentetic Acid</li>
-							<li>Teporone</li>
-							<li>Glyphosate</li>
-							<li>Lazarus Reagent</li>
-							<li>Omnizine</li>
-							<li>Sarin</li>
+							<li>Yellow Vomit</li>
+							<li>Jenkem</li>
+							<li>Charcoal</li>
+							<li>Egg</li>
+							<li>Sulphuric acid</li>
+							<li>Fluorosulfuric Acid</li>
+							<li>Surge</li>
+							<li>Ultra-Lube</li>
 							<li>Mitocholide</li>
-							<li>Fliptonium</li>
-							<li>Ants</li>
-							<li>Chlorine Trifluoride</li>
-							<li>Sorium</li>
-							<li>"????" Reagent</li>
-							<li>Aranesp</li>
 						</ul>
 					</li>
 				</ul>
@@ -553,14 +540,18 @@
 					<li>1 unit of blood containing an advanced virus with the <b>"Anti-Bodies Metabolism"</b> symptom</li>
 					<li>2 of the chemicals from the list below, 1 unit of each (Unknown Random Recipe)
 						<ul>
-							<li>Entropic Polypnium</li>
-							<li>Tinea Luxor</li>
-							<li>earthsblood</li>
-							<li>Bath Salts</li>
-							<li>Rezadone</li>
-							<li>Rotatium</li>
-							<li>Krokodil</li>
-							<li>Fliptonium</li>
+							<li>Colorful Reagent</li>
+							<li>Bacchus' Blessing</li>
+							<li>Pentetic Acid</li>
+							<li>Glyphosate</li>
+							<li>Lazarus Reagent</li>
+							<li>Omnizine</li>
+							<li>Sarin</li>
+							<li>Ants</li>
+							<li>Chlorine Trifluoride</li>
+							<li>Sorium</li>
+							<li>"????" Reagent</li>
+							<li>Aranesp</li>
 						</ul>
 					</li>
 				</ul>

--- a/code/game/objects/items/weapons/shards.dm
+++ b/code/game/objects/items/weapons/shards.dm
@@ -62,12 +62,6 @@
 			if(affecting.receive_damage(force * 0.5))
 				H.UpdateDamageIcon()
 
-/obj/item/shard/attackby(obj/item/I, mob/user, params)
-	if(istype(I, /obj/item/lightreplacer))
-		I.attackby(src, user)
-		return
-	return ..()
-
 /obj/item/shard/welder_act(mob/user, obj/item/I)
 	. = TRUE
 	if(!I.use_tool(src, user, volume = I.tool_volume))

--- a/code/modules/power/lights.dm
+++ b/code/modules/power/lights.dm
@@ -827,9 +827,8 @@
 	explosion(T, 0, 0, 2, 2)
 	qdel(src)
 
-
 /**
-  * # Light item
+  * MARK: Light item
   *
   * Parent type of light fittings (Light bulbs, light tubes)
   *
@@ -947,8 +946,12 @@
 
 
 // attack bulb/tube with object
-// if a syringe, can inject plasma to make it explode
+// if a syringe, can inject plasma to make it explode. Light replacers eat them.
 /obj/item/light/attackby(obj/item/I, mob/user, params)
+	if(istype(I, /obj/item/lightreplacer))
+		I.attackby(src, user)
+		return
+
 	if(istype(I, /obj/item/reagent_containers/syringe))
 		var/obj/item/reagent_containers/syringe/S = I
 

--- a/code/modules/power/lights.dm
+++ b/code/modules/power/lights.dm
@@ -948,10 +948,6 @@
 // attack bulb/tube with object
 // if a syringe, can inject plasma to make it explode. Light replacers eat them.
 /obj/item/light/attackby(obj/item/I, mob/user, params)
-	if(istype(I, /obj/item/lightreplacer))
-		I.attackby(src, user)
-		return
-
 	if(istype(I, /obj/item/reagent_containers/syringe))
 		var/obj/item/reagent_containers/syringe/S = I
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
The Light Replacer now eats glass sheets and lightbulbs when the user clicks on them rather than having to pick up the bulb/sheet and then insert it. This is how shards currently behave and brings them in line.

It now tells you how many fragments you have when you insert any kind of compatible item.

Shards now refill 1 full light rather than 0.75 of a light (it's literally the same amount of material, a welding tool can turn it into a sheet).
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
It's more convenient for human janitors.

Janiborgs are now able to actually use lightbulbs and sheets.

Conservation of mass has been achieved.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
I used my light replacer on shards and glass and lights and they worked.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak:  Light replacers can now eat glass and lightbulbs directly to refill.
tweak:  Shards will restore an entire lightbulb when eaten by the light replacer.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
