### PR TITLE
Adds single indestructible plating to syndie researcher bomb site

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/syndie_space_base.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/syndie_space_base.dmm
@@ -569,8 +569,8 @@
 	},
 /area/ruin/unpowered/syndicate_space_base/main)
 "dl" = (
-/obj/effect/turf_decal/stripes/box,
-/turf/simulated/floor/engine,
+/obj/effect/turf_decal/stripes,
+/turf/simulated/floor/indestructible,
 /area/ruin/unpowered/syndicate_space_base/toxtest)
 "do" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal,


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #25841

## Why It's Good For The Game
Syndie researchers should be able to test multiple bombs without having to space walk.

## Testing
Blew up the syndicate research bomb site. Plating was still there for bombs to land on.

## Changelog
:cl:
fix: Added an indestructable plating to syndie test site
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
