### PR TITLE
Fixes a misleading lavaland area name

### DIFF
--- a/code/game/area/areas/mining_areas.dm
+++ b/code/game/area/areas/mining_areas.dm
@@ -195,4 +195,3 @@
 	icon_state = "danger"
 
 /area/lavaland/surface/outdoors/explored
-	name = "Lavaland Labor Camp"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes an area's name used in winter biodome and clown ruin. These aren't where labor camp is.

## Why It's Good For The Game

People in these areas shouldn't be shown as if they were inside labor camp in gps.

## Testing
Yes

## Changelog
:cl:
fix: fixed a lavaland area name.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
