### PR TITLE
Adds hydroponic HUD implant

### DIFF
--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -480,6 +480,17 @@
 	build_path = /obj/item/organ/internal/cyberimp/eyes/hud/medical
 	category = list("Medical")
 
+/datum/design/cyberimp_hydroponics_hud
+	name = "Hydroponic HUD Implant"
+	desc = "These cybernetic eye implants will display a hydroponics HUD over everything you see. Wiggle eyes to control."
+	id = "ci-hydrohud"
+	req_tech = list("materials" = 5, "programming" = 4, "biotech" = 4, "magnets" = 3)
+	build_type = PROTOLATHE | MECHFAB
+	construction_time = 50
+	materials = list(MAT_METAL = 600, MAT_GLASS = 600, MAT_SILVER = 700, MAT_GOLD = 500)
+	build_path = /obj/item/organ/internal/cyberimp/eyes/hud/hydroponic
+	category = list("Medical")
+
 /datum/design/cyberimp_security_hud
 	name = "Security HUD Implant"
 	desc = "These cybernetic eyes will display a security HUD over everything you see. Wiggle eyes to control."

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -486,7 +486,7 @@
 	id = "ci-hydrohud"
 	req_tech = list("materials" = 5, "programming" = 4, "biotech" = 4, "magnets" = 3)
 	build_type = PROTOLATHE | MECHFAB
-	construction_time = 50
+	construction_time = 5 SECONDS
 	materials = list(MAT_METAL = 600, MAT_GLASS = 600, MAT_SILVER = 700, MAT_GOLD = 500)
 	build_path = /obj/item/organ/internal/cyberimp/eyes/hud/hydroponic
 	category = list("Medical")

--- a/code/modules/surgery/organs/augments_eyes.dm
+++ b/code/modules/surgery/organs/augments_eyes.dm
@@ -65,7 +65,15 @@
 /obj/item/organ/internal/cyberimp/eyes/hud/jani
 	name = "Janitor HUD implant"
 	desc = "These cybernetic eye implants will display a filth HUD over everything you see."
-	implant_color = "#AF00AF"
+	implant_color = "#DFBE00" // Every other eye implant was the color of the HUD
 	origin_tech = "materials=4;engineering=4;biotech=4"
 	aug_message = "You scan for filth spots around you..."
 	HUD_type = DATA_HUD_JANITOR
+
+/obj/item/organ/internal/cyberimp/eyes/hud/hydroponic
+	name = "Hydroponic HUD implant"
+	desc = "These cybernetic eye implants will display a botanical HUD over everything you see."
+	implant_color = "#4850D5"
+	origin_tech = "materials=4;magnets=4;biotech=4"
+	aug_message = "You scan for non-plastic plants around you..."
+	HUD_type = DATA_HUD_HYDROPONIC

--- a/code/modules/surgery/organs/augments_eyes.dm
+++ b/code/modules/surgery/organs/augments_eyes.dm
@@ -65,7 +65,7 @@
 /obj/item/organ/internal/cyberimp/eyes/hud/jani
 	name = "Janitor HUD implant"
 	desc = "These cybernetic eye implants will display a filth HUD over everything you see."
-	implant_color = "#DFBE00" // Every other eye implant was the color of the HUD
+	implant_color = "#DFBE00"
 	origin_tech = "materials=4;engineering=4;biotech=4"
 	aug_message = "You scan for filth spots around you..."
 	HUD_type = DATA_HUD_JANITOR


### PR DESCRIPTION
Created a hydroponic HUD implant to match the medical, security, diagnostic, and janitorial implants.

## What Does This PR Do
Adds a hydroponic HUD implant option in order to mirror the medical, security, janitorial, and diagnostic HUD implants. 

## Why It's Good For The Game
Allows farmers to keep up with janitors in unnecessary cybernetic augmentation arms races.

## Testing
Leveled up required technologies at R&D desk, printed hydroponic HUD implant. Implanted in humanized monkey, possessed humanized monkey, verified that monkey could see hydroponic HUD meters. Removed implant from humanized monkey, verified that monkey could no longer see hydroponic HUD meters. Verified that hydroponic HUD implant and worn medical HUD stacked successfully. Verified that hydroponic HUD implant and worn hydroponic HUD did not interfere with each other.

## Changelog
:cl:
add: Added new hydroponic HUD implant
tweak: Changed color of janitorial HUD implant to match color of worn HUD, as all other HUD implants had
/:cl: