### PR TITLE
Gives the bluesheild and NTR back their keycard authenticators on boxstation

### DIFF
--- a/_maps/map_files/stations/boxstation.dmm
+++ b/_maps/map_files/stations/boxstation.dmm
@@ -34147,6 +34147,9 @@
 /area/station/medical/medbay3)
 "chH" = (
 /obj/structure/closet/secure_closet/ntrep,
+/obj/machinery/keycard_auth{
+	pixel_y = -26
+	},
 /turf/simulated/floor/wood,
 /area/station/command/office/ntrep)
 "chI" = (
@@ -34340,6 +34343,9 @@
 /area/station/public/toilet/lockerroom)
 "ciD" = (
 /obj/structure/closet/secure_closet/blueshield,
+/obj/machinery/keycard_auth{
+	pixel_y = -26
+	},
 /turf/simulated/floor/wood,
 /area/station/command/office/blueshield)
 "ciE" = (
@@ -35183,6 +35189,13 @@
 	},
 /area/station/hallway/primary/aft/north)
 "clR" = (
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Blueshield";
+	departmentType = 5;
+	name = "Blueshield Requests Console";
+	pixel_x = -32
+	},
 /turf/simulated/floor/wood,
 /area/station/command/office/blueshield)
 "clT" = (
@@ -82874,16 +82887,6 @@
 /obj/effect/landmark/spawner/nukedisc_respawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
-"smS" = (
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Blueshield";
-	departmentType = 5;
-	name = "Blueshield Requests Console";
-	pixel_y = -30
-	},
-/turf/simulated/wall,
-/area/station/command/office/blueshield)
 "smW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
@@ -120391,7 +120394,7 @@ bTy
 cok
 cfi
 cgS
-smS
+cgS
 cgS
 coT
 coT


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Gives the keycard authenticators back to the NTR and BS on cyberiad, as well as moves the request console out of the wall, so you cant see it from maints
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Was missed in the explorer PR
## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![StrongDMM_GeKgV37Z8J](https://github.com/ParadiseSS13/Paradise/assets/96908085/fbec2758-c842-4f22-9771-2d54b4be4aa3)
![dreamseeker_KFaXjRfrE0](https://github.com/ParadiseSS13/Paradise/assets/96908085/b96d34c6-600a-43c1-ac67-9b7784537415)
![dreamseeker_iUvhgP9p4H](https://github.com/ParadiseSS13/Paradise/assets/96908085/00fa7b0e-42bd-43db-8bfd-54018b015055)

## Testing
<!-- How did you test the PR, if at all? -->
Compiles, checked in game if the request console was good
## Changelog
:cl:
add: Added keycard authentication tappers back to the NTR and BS office on cyberiad
tweak: Bluesheilds request console is no longer accessible via maintenance on cyberiad
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
