### PR TITLE
Fix random emote pitch

### DIFF
--- a/code/datums/emote.dm
+++ b/code/datums/emote.dm
@@ -280,7 +280,7 @@
 /datum/emote/proc/alter_emote_pitch(mob/user)
 	if(HAS_TRAIT(user, TRAIT_I_WANT_BRAINS))
 		return 0.7
-	return 1
+	return
 
 /**
  * Send an emote to runechat for all (listening) users in the vicinity.

--- a/code/datums/emote.dm
+++ b/code/datums/emote.dm
@@ -273,14 +273,14 @@
 	if(age_based && ishuman(user))
 		var/mob/living/carbon/human/H = user
 		// Vary needs to be true as otherwise frequency changes get ignored deep within playsound_local :(
-		playsound(user.loc, sound_path, sound_volume, TRUE, frequency = H.get_age_pitch(H.dna.species.max_age) * alter_emote_pitch(user))
+		playsound(user.loc, sound_path, sound_volume, vary = TRUE, frequency = H.get_age_pitch(H.dna.species.max_age) * alter_emote_pitch(user))
 	else
-		playsound(user.loc, sound_path, sound_volume, TRUE, frequency = alter_emote_pitch(user))
+		playsound(user.loc, sound_path, sound_volume, vary = TRUE, frequency = alter_emote_pitch(user))
 
 /datum/emote/proc/alter_emote_pitch(mob/user)
 	if(HAS_TRAIT(user, TRAIT_I_WANT_BRAINS))
 		return 0.7
-	return
+	return 1
 
 /**
  * Send an emote to runechat for all (listening) users in the vicinity.

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -93,7 +93,7 @@ falloff_distance - Distance at which falloff begins. Sound is at peak volume (in
 	S.volume = vol
 
 	if(vary)
-		if(frequency)
+		if(frequency || frequency != 1)
 			S.frequency = frequency
 		else
 			S.frequency = get_rand_frequency()

--- a/code/modules/mob/living/carbon/human/human_mob.dm
+++ b/code/modules/mob/living/carbon/human/human_mob.dm
@@ -1728,7 +1728,7 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 	return ..()
 
 /mob/living/carbon/human/proc/get_age_pitch(species_pitch = 85)
-	return 1.0 + 0.5 * ((species_pitch * 0.35) - age) / (0.94 * species_pitch)
+	return get_rand_frequency() * (1.0 + 0.5 * ((species_pitch * 0.35) - age) / (0.94 * species_pitch))
 
 /mob/living/carbon/human/get_access()
 	. = ..()


### PR DESCRIPTION
## What Does This PR Do
Fixes random emote pitch, generally, just removes 1 number
Cause if frequency is not null, random pitch will not be applied

## Why It's Good For The Game
*scream

## Images of changes
*screaming with different pitch

## Testing
https://github.com/ParadiseSS13/Paradise/assets/69762909/2f8699b8-665c-4e60-a0f1-541a82e19775


## Changelog
:cl:
fix: Some emote sounds returns his random pitch
/:cl:

