### PR TITLE
Adds/ports the AI Triumvirate station trait. (triple ai mode as a VERY rare trait)

### DIFF
--- a/code/__HELPERS/trait_helpers.dm
+++ b/code/__HELPERS/trait_helpers.dm
@@ -386,6 +386,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define STATION_TRAIT_FORESTED "station_trait_forested"
 #define STATION_TRAIT_VENDING_SHORTAGE "station_trait_vending_shortage"
 #define STATION_TRAIT_MESSY "station_trait_messy"
+#define STATION_TRAIT_TRIAI "station_trait_triai"
 
 //***** TURF TRAITS *****//
 /// Removes slowdown while walking on these tiles.

--- a/code/controllers/subsystem/SSticker.dm
+++ b/code/controllers/subsystem/SSticker.dm
@@ -284,6 +284,12 @@ SUBSYSTEM_DEF(ticker)
 	Master.SetRunLevel(RUNLEVEL_GAME)
 
 	// Generate the list of empty playable AI cores in the world
+	if(HAS_TRAIT(SSstation, STATION_TRAIT_TRIAI))
+		for(var/obj/effect/landmark/tripai in GLOB.landmarks_list)
+			if(tripai.name == "tripai")
+				if(locate(/mob/living) in get_turf(tripai))
+					continue
+				GLOB.empty_playable_ai_cores += new /obj/structure/AIcore/deactivated(get_turf(tripai))
 	for(var/obj/effect/landmark/start/ai/A in GLOB.landmarks_list)
 		if(locate(/mob/living) in get_turf(A))
 			continue

--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -64,3 +64,19 @@
 /datum/station_trait/hangover/revert()
 	. = ..()
 	SSjobs.drunken_spawning = FALSE
+
+/datum/station_trait/triple_ai
+	name = "AI Triumvirate"
+	trait_type = STATION_TRAIT_NEUTRAL
+	weight = 1
+	show_in_report = TRUE
+	report_message = "As part of Operation Magi, your station has been instated with three Nanotrasen Artificial Intelligence models. Try not to break them."
+	trait_to_give = STATION_TRAIT_TRIAI
+
+/datum/station_trait/triple_ai/New()
+	. = ..()
+	SSticker.triai = TRUE
+
+/datum/station_trait/triple_ai/revert()
+	. = ..()
+	SSticker.triai = FALSE

--- a/code/modules/admin/verbs/tripAI.dm
+++ b/code/modules/admin/verbs/tripAI.dm
@@ -1,22 +1,26 @@
 /client/proc/triple_ai()
-	set category = "Event"
-	set name = "Create AI Triumvirate"
+    set category = "Event"
+    set name = "Create AI Triumvirate"
 
-	if(SSticker.current_state > GAME_STATE_PREGAME)
-		to_chat(usr, "This option is currently only usable during pregame. This may change at a later date.")
-		return
+    if(SSticker.current_state > GAME_STATE_PREGAME)
+        to_chat(usr, "This option is currently only usable during pregame. This may change at a later date.")
+        return
 
-	if(SSjobs && SSticker)
-		var/datum/job/job = SSjobs.GetJob("AI")
-		if(!job)
-			to_chat(usr, "Unable to locate the AI job")
-			return
-		if(SSticker.triai)
-			SSticker.triai = 0
-			to_chat(usr, "Only one AI will be spawned at round start.")
-			message_admins("<span class='notice'>[key_name_admin(usr)] has toggled off triple AIs at round start.</span>", 1)
-		else
-			SSticker.triai = 1
-			to_chat(usr, "There will be an AI Triumvirate at round start.")
-			message_admins("<span class='notice'>[key_name_admin(usr)] has toggled on triple AIs at round start.</span>", 1)
-	return
+    if(SSjobs && SSticker)
+        var/datum/job/job = SSjobs.GetJob("AI")
+        if(!job)
+            to_chat(usr, "Unable to locate the AI job")
+            return
+        if(HAS_TRAIT(SSstation, STATION_TRAIT_TRIAI))
+            to_chat(usr, "<span class='danger'>The triple AI station trait is activated. If you wished to turn on this mode, it is already enabled. If you wish to disable it, revert the trait in Modify Station Traits.</span>")
+            return
+
+        if(SSticker.triai)
+            SSticker.triai = FALSE
+            to_chat(usr, "Only one AI will be spawned at round start.")
+            message_admins("<span class='notice'>[key_name_admin(usr)] has toggled off triple AIs at round start.</span>", 1)
+        else
+            SSticker.triai = TRUE
+            to_chat(usr, "There will be an AI Triumvirate at round start.")
+            message_admins("<span class='notice'>[key_name_admin(usr)] has toggled on triple AIs at round start.</span>", 1)
+    return


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Ported/Heavily inspired from https://github.com/tgstation/tgstation/pull/79995
Adds the triple ai mode to the possible station traits. Allowing very rarely, to be a total of three AI cores in the ai sat.
Also makes it so if the triple ai mode event/trait is active, it spawns all three cores over just spawning one for each person upto three that has ai on.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Triple ai is a very interesting concept thats rarely ever seen, having three ai cores with unique players controlling each one, allowing for faster door openings, better security call outs, and most importantly, very interesting subversion possibilities. 
Imagine the chaos that'd unfold if three ais all got hacked laws to aid in a shuttle hijack? 

Since this trait is VERY VERY. rare(as rare as death rattles. i honestly cant remember the last time i've seen this event happen!), i cant see it being that big of a problem, and when it is, it'll be few and far between. 


Its worth noting, that each ai gets unique laws, whether or not they might conflict, or conform to one another is upto the whims of rng.

It appears in my 10 borg sample size it seems to equally dishes the borgs out to be to each ai, so one ai wont get all the borgs.(unknown if this applies to roundstart, it /should/)
Also due to the mapping(that im not touching in this pr) some maps will have some.. lesser defended core locations, and some more so. It'll be upto the luck of the draw who gets where!
## Testing
<!-- How did you test the PR, if at all? -->
Painfully, checked if three cores spawned when the trait/event was active, and if one spawned while it was inactive.
Seems to all work fine.

## Changelog
:cl: Qwertytoforty, 1080p Cat
add: Added AI Triumvirate station trait. Very rarely will the ai sat be stocked with three entire ai cores.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
