### PR TITLE
Zombie changes #3

### DIFF
--- a/code/datums/components/zombie_regen.dm
+++ b/code/datums/components/zombie_regen.dm
@@ -20,7 +20,7 @@
 		healing_factor /= 3
 	if(zomboid.stat == DEAD)
 		healing_factor *= 2
-	zomboid.heal_overall_damage(healing_factor, healing_factor)
+	zomboid.heal_overall_damage(healing_factor, healing_factor, robotic = TRUE)
 	zomboid.adjustBrainLoss(-healing_factor)
 	if(zomboid.stat == DEAD && zomboid.getBruteLoss() <= 1 && zomboid.getFireLoss() <= 1 && (zomboid.timeofdeath + 15 SECONDS <= world.time))
 		var/datum/reagent/the_cure = zomboid.reagents.has_reagent("zombiecure4")
@@ -118,8 +118,8 @@
 /datum/component/zombie_regen/proc/mindless_hunger()
 	var/mob/living/carbon/human/zomboid = parent
 	var/list/targets = list()
-	for(var/mob/living/carbon/human/target in view(6, zomboid))
-		if(target.stat == CONSCIOUS && !HAS_TRAIT(target, TRAIT_I_WANT_BRAINS))
+	for(var/mob/living/target in view(6, zomboid))
+		if(target.stat == CONSCIOUS && target.client && !HAS_TRAIT(target, TRAIT_I_WANT_BRAINS))
 			targets |= target
 			if(zomboid.Adjacent(target))
 				break // we're just gonna hit em

--- a/code/datums/components/zombie_regen.dm
+++ b/code/datums/components/zombie_regen.dm
@@ -15,7 +15,7 @@
 	if(zomboid.suiciding)
 		return
 	var/turf/current_turf = get_turf(zomboid)
-	var/healing_factor = max(1, 6 * (1 - current_turf.get_lumcount()))
+	var/healing_factor = max(3, 8 * (1 - current_turf.get_lumcount()))
 	if(zomboid.reagents.has_reagent("zombiecure3"))
 		healing_factor /= 3
 	if(zomboid.stat == DEAD)

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -491,6 +491,14 @@ GLOBAL_LIST_EMPTY(crematoriums)
 		if(M.stat != DEAD)
 			M.emote("scream")
 
+		if(HAS_TRAIT(M, TRAIT_I_WANT_BRAINS))
+			if(istype(user))
+				add_attack_logs(user, M, "Burned with cremator (Zombie)")
+			M.adjustFireLoss(1000)
+			M.adjust_fire_stacks(20)
+			M.IgniteMob()
+			return
+
 		if(istype(user))
 			add_attack_logs(user, M, "Cremated")
 

--- a/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
@@ -245,6 +245,12 @@
 	var/offset = prob(50) ? -2 : 2
 	animate(src, pixel_x = pixel_x + offset, time = 0.2, loop = gibtime * 5) //start shaking
 
+	if(HAS_TRAIT(occupant, TRAIT_I_WANT_BRAINS))
+		if(istype(user))
+			add_attack_logs(user, M, "Crushed with gibber (Zombie)")
+		M.adjustBruteLoss(1000)
+		return
+
 	var/slab_name = occupant.name
 	var/slab_count = 6
 	var/slab_type = /obj/item/food/snacks/meat/human //gibber can only gib humans on paracode, no need to check meat type

--- a/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
@@ -247,8 +247,8 @@
 
 	if(HAS_TRAIT(occupant, TRAIT_I_WANT_BRAINS))
 		if(istype(user))
-			add_attack_logs(user, M, "Crushed with gibber (Zombie)")
-		M.adjustBruteLoss(1000)
+			add_attack_logs(user, occupant, "Crushed with gibber (Zombie)")
+		occupant.adjustBruteLoss(1000)
 		return
 
 	var/slab_name = occupant.name

--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -783,7 +783,7 @@
 	exclaim_verbs = list("yells")
 	colour = "zombie"
 	key = "zz" //doesn't matter, this is their default and only language
-	flags = RESTRICTED | NOLIBRARIAN
+	flags = RESTRICTED | NOLIBRARIAN | NOBABEL
 	syllables = list("Brains", "Brainssss", "Flesh", "Grrr", "Hnng", "Braaaains", "Braaiiiins")
 	english_names = TRUE
 

--- a/code/modules/mob/living/carbon/carbon_procs.dm
+++ b/code/modules/mob/living/carbon/carbon_procs.dm
@@ -810,6 +810,10 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 		var/obj/structure/struct = buckled
 		time = struct.unbuckle_time
 
+	if(HAS_TRAIT(src, TRAIT_I_WANT_BRAINS))
+		time /= 2
+		// Ctodo fix unbuckling since I think its broken for zombies
+
 	if(time == 0)
 		buckled.user_unbuckle_mob(src, src)
 		return

--- a/code/modules/mob/living/carbon/carbon_procs.dm
+++ b/code/modules/mob/living/carbon/carbon_procs.dm
@@ -811,7 +811,7 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 		time = struct.unbuckle_time
 
 	if(HAS_TRAIT(src, TRAIT_I_WANT_BRAINS))
-		time /= 2
+		time = 0
 		// Ctodo fix unbuckling since I think its broken for zombies
 
 	if(time == 0)

--- a/code/modules/reagents/chemistry/chemical_reaction.dm
+++ b/code/modules/reagents/chemistry/chemical_reaction.dm
@@ -36,7 +36,7 @@
 /datum/chemical_reaction/proc/last_can_react_check(datum/reagents/holder)
 	return TRUE
 
-/datum/chemical_reaction/proc/get_total_required_reagents()
+/datum/chemical_reaction/proc/get_total_required_reagents(datum/reagents/holder)
 	return length(required_reagents)
 
 /datum/chemical_reaction/proc/chemical_mob_spawn(datum/reagents/holder, amount_to_spawn, reaction_name, mob_class = HOSTILE_SPAWN, mob_faction = "chemicalsummon", random = TRUE, gold_core_spawn = FALSE)

--- a/code/modules/reagents/chemistry/chemical_reaction.dm
+++ b/code/modules/reagents/chemistry/chemical_reaction.dm
@@ -36,6 +36,9 @@
 /datum/chemical_reaction/proc/last_can_react_check(datum/reagents/holder)
 	return TRUE
 
+/datum/chemical_reaction/proc/get_total_required_reagents()
+	return length(required_reagents)
+
 /datum/chemical_reaction/proc/chemical_mob_spawn(datum/reagents/holder, amount_to_spawn, reaction_name, mob_class = HOSTILE_SPAWN, mob_faction = "chemicalsummon", random = TRUE, gold_core_spawn = FALSE)
 	if(holder && holder.my_atom)
 		var/atom/A = holder.my_atom

--- a/code/modules/reagents/chemistry/reagents/water.dm
+++ b/code/modules/reagents/chemistry/reagents/water.dm
@@ -159,13 +159,19 @@
 		for(var/datum/disease/advance/AD in mix2)
 			to_mix += AD
 
+		var/list/preserve = list()
+		for(var/D in data["viruses"])
+			if(!istype(D, /datum/disease/advance))
+				preserve += D
+		for(var/D in mix_data["viruses"])
+			if(!istype(D, /datum/disease/advance))
+				preserve += D
+
 		var/datum/disease/advance/AD = Advance_Mix(to_mix)
 		if(AD)
-			var/list/preserve = list(AD)
-			for(var/D in data["viruses"])
-				if(!istype(D, /datum/disease/advance))
-					preserve += D
-			data["viruses"] = preserve
+			preserve += AD
+
+		data["viruses"] = preserve
 
 /datum/reagent/blood/on_update(atom/A)
 	if(data["blood_color"])

--- a/code/modules/reagents/chemistry/reagents_holder.dm
+++ b/code/modules/reagents/chemistry/reagents_holder.dm
@@ -457,7 +457,7 @@
 					continue
 
 				var/datum/chemical_reaction/C = reaction
-				var/total_required_reagents = C.get_total_required_reagents()
+				var/total_required_reagents = C.get_total_required_reagents(src)
 				var/total_matching_reagents = 0
 				var/total_required_catalysts = length(C.required_catalysts)
 				var/total_matching_catalysts = 0

--- a/code/modules/reagents/chemistry/reagents_holder.dm
+++ b/code/modules/reagents/chemistry/reagents_holder.dm
@@ -457,7 +457,7 @@
 					continue
 
 				var/datum/chemical_reaction/C = reaction
-				var/total_required_reagents = get_total_required_reagents()
+				var/total_required_reagents = C.get_total_required_reagents()
 				var/total_matching_reagents = 0
 				var/total_required_catalysts = length(C.required_catalysts)
 				var/total_matching_catalysts = 0

--- a/code/modules/reagents/chemistry/reagents_holder.dm
+++ b/code/modules/reagents/chemistry/reagents_holder.dm
@@ -457,7 +457,7 @@
 					continue
 
 				var/datum/chemical_reaction/C = reaction
-				var/total_required_reagents = length(C.required_reagents)
+				var/total_required_reagents = get_total_required_reagents()
 				var/total_matching_reagents = 0
 				var/total_required_catalysts = length(C.required_catalysts)
 				var/total_matching_catalysts = 0
@@ -495,7 +495,7 @@
 				if(min_temp == 0)
 					min_temp = chem_temp
 
-				if(total_matching_reagents == total_required_reagents && total_matching_catalysts == total_required_catalysts && matching_container && matching_other && chem_temp <= max_temp && chem_temp >= min_temp)
+				if(total_matching_reagents >= total_required_reagents && total_matching_catalysts == total_required_catalysts && matching_container && matching_other && chem_temp <= max_temp && chem_temp >= min_temp)
 					if(!C.last_can_react_check(src))
 						continue
 					var/multiplier = min(multipliers)

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -506,7 +506,7 @@
 	/// The amount of reagents to pick from get_possible_cures()
 	var/amt_req_cures = 1
 	/// A virus symptom required to complete this chemical reaction
-	var/datum/symptom/required_symptom // ctodo make this lower the amount of required cures
+	var/datum/symptom/helpful_symptom // ctodo make this lower the amount of required cures
 
 /datum/chemical_reaction/zombie/New()
 	. = ..()
@@ -532,12 +532,12 @@
 
 /datum/chemical_reaction/zombie/get_total_required_reagents(datum/reagents/holder)
 	. = ..()
-	if(!required_symptom)
+	if(!helpful_symptom)
 		return
 
 	for(var/datum/disease/advance/advanced in blood.data["viruses"])
 		for(var/datum/symptom/symptom as anything in advanced.symptoms)
-			if(istype(symptom, required_symptom))
+			if(istype(symptom, helpful_symptom))
 				return 2 // if you have the symptom, it becomes much easier to make! (blood and 1 other random reagent)
 
 /datum/chemical_reaction/zombie/proc/get_possible_cures()
@@ -549,7 +549,7 @@
 	result = "zombiecure2"
 	cure_level = 2
 	amt_req_cures = 3
-	required_symptom = /datum/symptom/heal/metabolism
+	helpful_symptom = /datum/symptom/heal/metabolism
 
 /datum/chemical_reaction/zombie/second/get_possible_cures()
 	return list("salglu_solution", "toxin", "atropine", "lye", "sodawater", "happiness", "morphine", "teporone")
@@ -560,7 +560,7 @@
 	result = "zombiecure3"
 	cure_level = 3
 	amt_req_cures = 3
-	required_symptom = /datum/symptom/flesh_eating
+	helpful_symptom = /datum/symptom/flesh_eating
 
 /datum/chemical_reaction/zombie/third/get_possible_cures()
 	return list("vomit", "jenkem", "charcoal", "egg", "sacid", "facid", "surge", "ultralube", "mitocholide")

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -500,13 +500,13 @@
 	result = "zombiecure1"
 	result_amount = 1
 	required_reagents = list("blood" = 1, "diphenhydramine" = 1)
-	mix_message = "The mixture into a dark green paste."
+	mix_message = "The mixture turns into a thick paste."
 	/// The cure level of the reagent, level 4 cure requires level 3 cure, which requires level 2 cure, etc
 	var/cure_level = 1
 	/// The amount of reagents to pick from get_possible_cures()
 	var/amt_req_cures = 1
 	/// A virus symptom required to complete this chemical reaction
-	var/datum/symptom/required_symptom
+	var/datum/symptom/required_symptom // ctodo make this lower the amount of required cures
 
 /datum/chemical_reaction/zombie/New()
 	. = ..()
@@ -528,16 +528,17 @@
 	var/datum/disease/zombie/zomb = locate(/datum/disease/zombie) in blood.data["viruses"]
 	if(!zomb)
 		return FALSE
-	if(zomb.cure_stage + 1 > cure_level) // Virus has already been cured to this level
-		return FALSE
+	return zomb.cure_stage < cure_level
+
+/datum/chemical_reaction/zombie/get_total_required_reagents(datum/reagents/holder)
+	. = ..()
 	if(!required_symptom)
-		return TRUE
+		return
 
 	for(var/datum/disease/advance/advanced in blood.data["viruses"])
 		for(var/datum/symptom/symptom as anything in advanced.symptoms)
 			if(istype(symptom, required_symptom))
-				return TRUE
-	return FALSE
+				return 2 // if you have the symptom, it becomes much easier to make! (blood and 1 other random reagent)
 
 /datum/chemical_reaction/zombie/proc/get_possible_cures()
 	return list()
@@ -548,6 +549,7 @@
 	result = "zombiecure2"
 	cure_level = 2
 	amt_req_cures = 3
+	required_symptom = /datum/symptom/heal/metabolism
 
 /datum/chemical_reaction/zombie/second/get_possible_cures()
 	return list("salglu_solution", "toxin", "atropine", "lye", "sodawater", "happiness", "morphine", "teporone")
@@ -569,7 +571,6 @@
 	result = "zombiecure4"
 	cure_level = 4
 	amt_req_cures = 2
-	required_symptom = /datum/symptom/heal/metabolism
 
 /datum/chemical_reaction/zombie/four/get_possible_cures()
 	return list("colorful_reagent", "bacchus_blessing", "pen_acid", "glyphosate", "lazarus_reagent", "omnizine", "sarin", "ants", "clf3", "sorium", "????", "aranesp")

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -535,6 +535,10 @@
 	if(!helpful_symptom)
 		return
 
+	var/datum/reagent/blood/blood = locate(/datum/reagent/blood) in holder.reagent_list
+	if(!blood || !blood.data)
+		return
+
 	for(var/datum/disease/advance/advanced in blood.data["viruses"])
 		for(var/datum/symptom/symptom as anything in advanced.symptoms)
 			if(istype(symptom, helpful_symptom))

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -585,7 +585,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	if(limb_flags & CANNOT_DISMEMBER || !owner)
 		return
 
-	if(HAS_TRAIT(owner, TRAIT_I_WANT_BRAINS) && !clean)
+	if(HAS_TRAIT(owner, TRAIT_I_WANT_BRAINS) && !clean && !vital)
 		fracture()
 		return
 

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -585,7 +585,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	if(limb_flags & CANNOT_DISMEMBER || !owner)
 		return
 
-	if(HAS_TRAIT(owner, TRAIT_I_WANT_BRAINS) && !clean && !vital)
+	if(HAS_TRAIT(owner, TRAIT_I_WANT_BRAINS) && !clean && !istype(src, /obj/item/organ/external/head)) // ctodo make better
 		fracture()
 		return
 

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -585,7 +585,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	if(limb_flags & CANNOT_DISMEMBER || !owner)
 		return
 
-	if(HAS_TRAIT(owner, TRAIT_I_WANT_BRAINS) && !clean && !istype(src, /obj/item/organ/external/head)) // ctodo make better
+	if(HAS_TRAIT(owner, TRAIT_I_WANT_BRAINS) && !clean)
 		fracture()
 		return
 

--- a/code/modules/surgery/organs/subtypes/standard_organs.dm
+++ b/code/modules/surgery/organs/subtypes/standard_organs.dm
@@ -319,3 +319,9 @@
 		if(2)
 			owner?.AdjustConfused(40 SECONDS)
 	to_chat(owner, "<span class='userdanger'>Your [name] malfunctions, overloading your motor control!</span>")
+
+/obj/item/organ/external/head/droplimb(clean, disintegrate, ignore_children, nodamage)
+	if(HAS_TRAIT(owner, TRAIT_I_WANT_BRAINS)) // gonna have to work a bit harder to debrain a zombie
+		fracture()
+		return
+	return ..()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
- Buffs zombie healing from 1-6 to 3-8 for each damage type.
- Zombie healing now heals robotic parts
- Zombies now go after all living non-zombie players when in a mindless hunger, including borgs and simplemobs.
- Cremating a zombie will now do 1000 burn damage instead of destroying them
- Gibbers do the same, but with 1000 brute
- You can no longer cut off a zombie's head, even with surgery
- Zombies now break out of buckle-cuffs instantly, but still have their normal cuff time. This is because cuffing is way too strong.
- Cures now no longer need the virology symptoms, but having them makes making the cure much easier as it requires only 1/3 of the reagents

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->Zombie "balance", and less round removal.

## Testing
<!-- How did you test the PR, if at all? -->
Not tested yet

## Changelog
:cl:
tweak: Buffs zombie healing from 1-6 to 3-8 for each damage type.
tweak: Zombie healing now heals robotic parts
tweak: Zombies now go after all living non-zombie players when in a mindless hunger, including borgs and simplemobs.
tweak: Cremating a zombie will now do 1000 burn damage instead of destroying them
tweak: Gibbers do the same, but with 1000 brute
tweak: You can no longer cut off a zombie's head, even with surgery
tweak: Zombies now break out of buckle-cuffs instantly, but still have their normal cuff time. This is because cuffing is way too strong.
tweak: Cures now no longer need the virology symptoms, but having them makes making the cure much easier as it requires only 1/3 of the reagents
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
