### PR TITLE
Fixes SSdcs element ID hashing

### DIFF
--- a/code/controllers/subsystem/processing/SSdcs.dm
+++ b/code/controllers/subsystem/processing/SSdcs.dm
@@ -32,24 +32,32 @@ PROCESSING_SUBSYSTEM_DEF(dcs)
 	**/
 /datum/controller/subsystem/processing/dcs/proc/GetIdFromArguments(list/arguments)
 	var/datum/element/eletype = arguments[1]
-	var/list/fullid = list("[eletype]")
-	var/list/named_arguments = list()
-	for(var/i in initial(eletype.id_arg_index) to length(arguments))
+	var/list/fullid = list(eletype)
+	var/list/named_arguments
+	for(var/i in initial(eletype.id_arg_index) to (initial(eletype.id_arg_index) || length(arguments)))
 		var/key = arguments[i]
-		var/value
-		if(istext(key))
-			value = arguments[key]
-		if(!(istext(key) || isnum(key)))
-			key = "\ref[key]"
-		key = "[key]" // Key is stringified so numbers dont break things
-		if(!isnull(value))
-			if(!(istext(value) || isnum(value)))
-				value = "\ref[value]"
-			named_arguments["[key]"] = value
-		else
-			fullid += "[key]"
 
-	if(length(named_arguments))
-		named_arguments = sortList(named_arguments)
+		if(istext(key))
+			var/value = arguments[key]
+			if(isnull(value))
+				fullid += key
+			else
+				if(!istext(value) && !isnum(value))
+					value = text_ref(value)
+
+				if(!named_arguments)
+					named_arguments = list()
+
+				named_arguments[key] = value
+			continue
+
+		if(isnum(key))
+			fullid += key
+		else
+			fullid += text_ref(key)
+
+	if(named_arguments)
+		sortTim(named_arguments, GLOBAL_PROC_REF(cmp_text_asc))
 		fullid += named_arguments
+
 	return list2params(fullid)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Updates `GetIdFromArguments()` with its most recent TG iteration to make it work properly. This proc is used for generating IDs for elements with ELEMENT_BESPOKE (see dcs_flags.dm for what this does). 
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
I noticed ELEMENT_BESPOKE elements not generating properly while working on #25527. There aren't many things that use bespoke elements right now, but having it working is required for said PR.

## Testing
<!-- How did you test the PR, if at all? -->
It launches and runs. I can't test this much on a fresh master branch because there aren't many things to test. This did, however, fix the issues I was experiencing with element generation in #25527 and was tested pretty thoroughly with a new element type then.


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
