### PR TITLE
Gives more HUD options for the Captain and gives the Blueshield a crew monitor.

### DIFF
--- a/code/game/objects/items/weapons/storage/garment.dm
+++ b/code/game/objects/items/weapons/storage/garment.dm
@@ -46,6 +46,8 @@
 	new /obj/item/clothing/shoes/brown(src)
 	new /obj/item/clothing/shoes/laceup(src)
 	new /obj/item/clothing/glasses/sunglasses(src)
+	new /obj/item/clothing/glasses/hud/security/sunglasses(src)
+	new /obj/item/clothing/glasses/hud/health/sunglasses(src)
 
 /obj/item/storage/bag/garment/head_of_personnel
 	name = "head of personnel's garment bag"

--- a/code/game/objects/structures/crates_lockers/closets/secure/security_lockers.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security_lockers.dm
@@ -140,6 +140,7 @@
 	new /obj/item/storage/belt/security/full(src)
 	new /obj/item/clothing/accessory/holster(src)
 	new /obj/item/storage/bag/garment/blueshield(src)
+	new /obj/item/sensor_device(src)
 
 /obj/structure/closet/secure_closet/ntrep
 	name = "\improper Nanotrasen Representative's locker"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds both the security and medical sunglasses to the Captain's garment.
Adds a handheld monitor inside the Blueshield's closet.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Usually Captains have to ask security/medical to get one or even craft one if they desire, doesn't make sense for them to not have both available. Same situation applies for the Blueshield, which usually has to grab a crew monitor from medical.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Joined in the test server and grabbed said items.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:Pedroca
add: Captain's garment now has both the medical/security sunglasses.
add: Blueshield's locker now starts with a handheld crew monitor

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
