### PR TITLE
box: handful of disposals fixes

### DIFF
--- a/_maps/map_files/stations/boxstation.dmm
+++ b/_maps/map_files/stations/boxstation.dmm
@@ -23510,9 +23510,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel,
 /area/station/command/bridge)
 "btF" = (
@@ -65402,6 +65399,24 @@
 /obj/structure/falsewall,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/aft)
+"jTk" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/central/sw)
 "jTq" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -89785,9 +89800,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
@@ -121416,7 +121428,7 @@ iLY
 bZc
 bSi
 cdU
-cok
+jTk
 shN
 qcM
 mNf


### PR DESCRIPTION
## What Does This PR Do
This PR removes floating disposals pipes on Box bridge and reconnect's Blueshield's disposal chute to the pipe network.
## Why It's Good For The Game
Disposals should work, pipes shouldn't just vibe.
## Images of changes
![2024_06_20__09_33_21__paradise dme  boxstation dmm  - StrongDMM](https://github.com/ParadiseSS13/Paradise/assets/59303604/5a65719e-060e-4748-a4d5-d0daba78b49d)
![2024_06_20__09_33_31__paradise dme  boxstation dmm  - StrongDMM](https://github.com/ParadiseSS13/Paradise/assets/59303604/4c4ce9d9-607d-42cd-83d3-c82e2fb0eddb)
![2024_06_20__09_34_50__paradise dme  boxstation dmm  - StrongDMM](https://github.com/ParadiseSS13/Paradise/assets/59303604/5b97cfc5-f930-4177-b25d-43f50ebe08a8)


## Testing
Spawned in, threw thing in BS's disposal, ensured it arrived in Disposals.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Cyberiad: Blueshield's disposals chute is properly connected to the pipe network.
fix: Cyberiad: Disconnected disposals pipes on bridge have been removed.
/:cl: