### PR TITLE
More craftable first aid kits!

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -686,6 +686,8 @@ GLOBAL_LIST_INIT(plastic_recipes, list(
 		new /datum/stack_recipe("toxin first aid kit", /obj/item/storage/firstaid/toxin, 4),
 		new /datum/stack_recipe("oxygen deprivation first aid kit", /obj/item/storage/firstaid/o2, 4),
 		new /datum/stack_recipe("advanced first-aid kit", /obj/item/storage/firstaid/adv, 4),
+		new /datum/stack_recipe("machine repair kit", /obj/item/storage/firstaid/machine, 4),
+		new /datum/stack_recipe("aquatic starter kit", /obj/item/storage/firstaid/aquatic_kit, 4),
 		)),
 	new /datum/stack_recipe("pill bottle", /obj/item/storage/pill_bottle),
 	new /datum/stack_recipe("IV bag", /obj/item/reagent_containers/iv_bag, 2),

--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -910,6 +910,16 @@
 	pathtools = list(/obj/item/reagent_containers/glass/rag = 1) //need something to paint with it
 	category = CAT_MISC
 
+/datum/crafting_recipe/tactical_medkit
+	name = "Tactical First-Aid Kit"
+	result = list(/obj/item/storage/firstaid/tactical/empty)
+	time = 40
+	reqs = list(/datum/reagent/paint/blue = 10,
+				/datum/reagent/paint/black = 30,
+				/obj/item/storage/firstaid = 1)
+	pathtools = list(/obj/item/reagent_containers/glass/rag = 1)
+	category = CAT_MISC
+
 /datum/crafting_recipe/snowman
 	name = "Snowman"
 	result = list(/obj/structure/snowman/built)


### PR DESCRIPTION
## What Does This PR Do
This adds the aquatic starter kit and the machine repair kit to the list of craftable medkit from plastic.
It also adds a special craft, similar to the fake syndi toolbox, to make empty tactical medkits using blue paint and black paint.

## Why It's Good For The Game
Less impossible to get/remake items
More medibot customization :D

## Testing
Made sure all medkits could be made through their correct means
Made sure the tactical medkit was the EMPTY one... Totally didn't forget this the first time I added it

## Changelog
:cl:
add: Added a recipe for tactical medkit using blue and black paint and a first aid kit
add: Added recipes for the aquatic starter kit and the machine repair kit using plastic
/:cl: