### PR TITLE
More medkits ! With the correct branch this time!

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -686,6 +686,8 @@ GLOBAL_LIST_INIT(plastic_recipes, list(
 		new /datum/stack_recipe("toxin first aid kit", /obj/item/storage/firstaid/toxin, 4),
 		new /datum/stack_recipe("oxygen deprivation first aid kit", /obj/item/storage/firstaid/o2, 4),
 		new /datum/stack_recipe("advanced first-aid kit", /obj/item/storage/firstaid/adv, 4),
+		new /datum/stack_recipe("machine repair kit", /obj/item/storage/firstaid/machine, 4),
+		new /datum/stack_recipe("aquatic starter kit", /obj/item/storage/firstaid/aquatic_kit, 4),
 		)),
 	new /datum/stack_recipe("pill bottle", /obj/item/storage/pill_bottle),
 	new /datum/stack_recipe("IV bag", /obj/item/reagent_containers/iv_bag, 2),

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -219,6 +219,7 @@
 	name = "ert first-aid kit"
 	icon_state = "bezerk"
 	desc = "A medical kit used by Nanotrasen emergency response team personnel."
+	med_bot_skin = "bezerk"
 
 /obj/item/storage/firstaid/ert/populate_contents()
 	new /obj/item/healthanalyzer/advanced(src)
@@ -243,6 +244,15 @@
 	new /obj/item/stack/medical/ointment/advanced(src)
 	new /obj/item/storage/pill_bottle/ert_amber(src)
 	new /obj/item/storage/pill_bottle/patch_pack/ert_amber(src)
+
+/obj/item/storage/firstaid/fake_tactical
+	name = "tactical first-aid kit"
+	icon_state = "bezerk"
+	desc = "I hope you've got insurance. The paint is still wet."
+	med_bot_skin = "bezerk"
+
+/obj/item/storage/firstaid/fake_tactical/populate_contents()
+	return
 
 /*
  * Pill Bottles

--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -910,6 +910,16 @@
 	pathtools = list(/obj/item/reagent_containers/glass/rag = 1) //need something to paint with it
 	category = CAT_MISC
 
+/datum/crafting_recipe/tactical_medkit
+	name = "Tactical First-Aid Kit"
+	result = list(/obj/item/storage/firstaid/tactical/empty)
+	time = 40
+	reqs = list(/datum/reagent/paint/blue = 10,
+				/datum/reagent/paint/black = 30,
+				/obj/item/storage/firstaid = 1)
+	pathtools = list(/obj/item/reagent_containers/glass/rag = 1)
+	category = CAT_MISC
+
 /datum/crafting_recipe/snowman
 	name = "Snowman"
 	result = list(/obj/structure/snowman/built)

--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -910,9 +910,9 @@
 	pathtools = list(/obj/item/reagent_containers/glass/rag = 1) //need something to paint with it
 	category = CAT_MISC
 
-/datum/crafting_recipe/tactical_medkit
+/datum/crafting_recipe/fake_tactical_medkit
 	name = "Tactical First-Aid Kit"
-	result = list(/obj/item/storage/firstaid/tactical/empty)
+	result = list(/obj/item/storage/firstaid/fake_tactical)
 	time = 40
 	reqs = list(/datum/reagent/paint/blue = 10,
 				/datum/reagent/paint/black = 30,


### PR DESCRIPTION
## What Does This PR Do
This adds the aquatic starter kit and the machine repair kit to the list of craftable medkit from plastic.
It also adds a special craft, similar to the fake syndi toolbox, to make empty tactical medkits using blue paint and black paint.

## Why It's Good For The Game
Less impossible to get/remake items
More medibot customization :D

## Testing
Made sure all medkits could be made through their correct means
~~Made sure the tactical medkit was the EMPTY one... Totally didn't forget this the first time I added it~~
Made sure the tactical medkit was the new fake variant.
Also made sure the medibot made from the fake variant used the right chems and healed crewmembers.

## Changelog
:cl:
add: Added a recipe for tactical medkit using blue and black paint and a first aid kit
add: Added recipes for the aquatic starter kit and the machine repair kit using plastic
/:cl: