### PR TITLE
Processing_unit is no longer dense - Fixes #25966

### DIFF
--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_althland_facility.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_althland_facility.dmm
@@ -915,8 +915,7 @@
 	},
 /obj/machinery/mineral/processing_unit_console{
 	pixel_y = -2;
-	pixel_x = -29;
-	density = 0
+	pixel_x = -29
 	},
 /turf/simulated/floor/plasteel/lavaland_air,
 /area/ruin/unpowered/althland_processing)

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_althland_facility.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_althland_facility.dmm
@@ -915,7 +915,8 @@
 	},
 /obj/machinery/mineral/processing_unit_console{
 	pixel_y = -2;
-	pixel_x = -29
+	pixel_x = -29;
+	density = 0
 	},
 /turf/simulated/floor/plasteel/lavaland_air,
 /area/ruin/unpowered/althland_processing)

--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -16,7 +16,7 @@
 	name = "production machine console"
 	icon = 'icons/obj/machines/mining_machines.dmi'
 	icon_state = "console"
-	density = TRUE
+	density = FALSE
 	anchored = TRUE
 	var/obj/machinery/mineral/processing_unit/machine = null
 	speed_process = TRUE


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Processing_unit is no longer dense!
Fixes #25966 
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
You can now access a blocked off part of the ruin.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Spawned in and walked into the blocked off area after fixing density.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: A console no longer blocks the way when exploring a certain lavaland ruin.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
