### PR TITLE
Gargantua Blood Rush now removes bolas

### DIFF
--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -354,7 +354,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 				for(var/datum/disease/critical/crit in H.viruses) // cure all crit conditions
 					crit.cure()
 
-		H.uncuff()
+		H.clear_restraints()
 		H.Silence(6 SECONDS) //Prevent "HALP MAINT CULT" before you realise you're converted
 		if(H.reagents?.has_reagent("holywater"))
 			H.reagents.del_reagent("holywater") // Also prevent fill stomach with holy water and "forgot" about it after converting

--- a/code/game/gamemodes/miniantags/abduction/machinery/experiment.dm
+++ b/code/game/gamemodes/miniantags/abduction/machinery/experiment.dm
@@ -166,11 +166,11 @@
 	H.Sleeping(16 SECONDS)
 	if(console && console.pad && console.pad.teleport_target)
 		H.forceMove(console.pad.teleport_target)
-		H.uncuff()
+		H.clear_restraints()
 		return
 	//Area not chosen / It's not safe area - teleport to arrivals
 	H.forceMove(pick(GLOB.latejoin))
-	H.uncuff()
+	H.clear_restraints()
 	return
 
 /obj/machinery/abductor/experiment/attackby(obj/item/G, mob/user)

--- a/code/game/objects/items/weapons/bio_chips/bio_chip_freedom.dm
+++ b/code/game/objects/items/weapons/bio_chips/bio_chip_freedom.dm
@@ -14,7 +14,7 @@
 	to_chat(imp_in, "You feel a faint click.")
 	if(iscarbon(imp_in))
 		var/mob/living/carbon/C_imp_in = imp_in
-		C_imp_in.uncuff()
+		C_imp_in.clear_restraints()
 		for(var/obj/item/grab/G in C_imp_in.grabbed_by)
 			var/mob/living/carbon/M = G.assailant
 			C_imp_in.visible_message("<span class='warning'>[C_imp_in] suddenly shocks [M] from their wrists and slips out of their grab!</span>")

--- a/code/modules/antagonists/vampire/vampire_powers/gargantua_powers.dm
+++ b/code/modules/antagonists/vampire/vampire_powers/gargantua_powers.dm
@@ -92,18 +92,30 @@
 
 /datum/spell/vampire/self/blood_rush
 	name = "Blood Rush (30)"
-	desc = "Infuse yourself with blood magic to boost your movement speed."
+	desc = "Infuse yourself with blood magic to boost your movement speed and break out of leg restraints."
 	gain_desc = "You have gained the ability to temporarily move at high speeds."
 	base_cooldown = 30 SECONDS
 	required_blood = 30
 	action_icon_state = "blood_rush"
 
+/datum/spell/vampire/self/blood_rush/can_cast(mob/user, charge_check, show_message)
+	var/mob/living/L = user
+	if(L.IsWeakened())
+		to_chat(L, "<span class='warning'>You can't use this spell while incapacitated!</span>")
+		return FALSE
+	return ..()
+
 /datum/spell/vampire/self/blood_rush/cast(list/targets, mob/user)
 	var/mob/living/target = targets[1]
-	if(ishuman(target))
-		var/mob/living/carbon/human/H = target
-		to_chat(H, "<span class='notice'>You feel a rush of energy!</span>")
-		H.apply_status_effect(STATUS_EFFECT_BLOOD_RUSH)
+	if(!ishuman(target))
+		return
+
+	var/mob/living/carbon/human/H = target
+	to_chat(H, "<span class='notice'>You feel a rush of energy!</span>")
+
+	H.apply_status_effect(STATUS_EFFECT_BLOOD_RUSH)
+	H.clear_legcuffs(TRUE)
+	H.stand_up(TRUE)
 
 /datum/spell/fireball/demonic_grasp
 	name = "Demonic Grasp (20)"

--- a/code/modules/antagonists/vampire/vampire_powers/gargantua_powers.dm
+++ b/code/modules/antagonists/vampire/vampire_powers/gargantua_powers.dm
@@ -100,8 +100,9 @@
 
 /datum/spell/vampire/self/blood_rush/can_cast(mob/user, charge_check, show_message)
 	var/mob/living/L = user
-	if(L.IsWeakened())
-		to_chat(L, "<span class='warning'>You can't use this spell while incapacitated!</span>")
+	// they're not getting anything out of this spell if they're stunned or buckled anyways, so we might as well stop them from wasting the blood
+	if(L.IsWeakened() || L.buckled)
+		to_chat(L, "<span class='warning'>You can't cast this spell while incapacitated!</span>")
 		return FALSE
 	return ..()
 
@@ -115,6 +116,8 @@
 
 	H.apply_status_effect(STATUS_EFFECT_BLOOD_RUSH)
 	H.clear_legcuffs(TRUE)
+	// note that this doesn't cancel the baton knockdown timer
+	H.SetKnockDown(0)
 	H.stand_up(TRUE)
 
 /datum/spell/fireball/demonic_grasp

--- a/code/modules/mob/living/carbon/carbon_procs.dm
+++ b/code/modules/mob/living/carbon/carbon_procs.dm
@@ -1034,7 +1034,7 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 	return cleared_hands || cleared_legs
 
 /**
- * Removes a carbon's handcuffs, dropping them to the ground. Unbuckles if handcuffs were necessary for the buckle (pipe buckling, etc.)
+ * Removes a carbon's handcuffs, dropping them to the ground. Calls update_handcuffed(). Unbuckles if handcuffs were necessary for the buckle (pipe buckling, etc.)
  *
  * Arguments:
  * * show_message - if TRUE, will display a visible message when restraints are removed. FALSE by default.
@@ -1070,7 +1070,7 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 	return TRUE
 
 /**
- * Removes a carbon's legcuffs, dropping them to the ground.
+ * Removes a carbon's legcuffs, dropping them to the ground. Calls update_inv_legcuffed().
  *
  * Arguments:
  * * show_message - if TRUE, will display a visible message when restraints are removed. FALSE by default.

--- a/code/modules/mob/living/carbon/carbon_procs.dm
+++ b/code/modules/mob/living/carbon/carbon_procs.dm
@@ -1018,35 +1018,91 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 				legcuffed,
 				back,
 				wear_mask)
+/**
+ * Clears a carbon mob's handcuffs and legcuffs, dropping them to the ground.
+ *
+ * Arguments:
+ * * show_message - if TRUE, will display a visible message when restraints are removed. FALSE by default.
+ *
+ * Returns:
+ * * TRUE if handcuffs or legcuffs were removed, FALSE otherwise
+ */
+/mob/living/carbon/proc/clear_restraints(show_message = FALSE)
+	var/cleared_hands = clear_handcuffs(show_message)
+	var/cleared_legs = clear_legcuffs(show_message)
 
-/mob/living/carbon/proc/uncuff()
-	if(handcuffed)
-		var/obj/item/W = handcuffed
-		handcuffed = null
-		if(buckled && buckled.buckle_requires_restraints)
-			buckled.unbuckle_mob(src)
-		update_handcuffed()
-		if(client)
-			client.screen -= W
-		if(W)
-			W.forceMove(drop_location())
-			W.dropped(src)
-			if(W)
-				W.layer = initial(W.layer)
-				W.plane = initial(W.plane)
-	if(legcuffed)
-		var/obj/item/W = legcuffed
-		legcuffed = null
-		toggle_move_intent()
-		update_inv_legcuffed()
-		if(client)
-			client.screen -= W
-		if(W)
-			W.forceMove(drop_location())
-			W.dropped(src)
-			if(W)
-				W.layer = initial(W.layer)
-				W.plane = initial(W.plane)
+	return cleared_hands || cleared_legs
+
+/**
+ * Removes a carbon's handcuffs, dropping them to the ground. Unbuckles if handcuffs were necessary for the buckle (pipe buckling, etc.)
+ *
+ * Arguments:
+ * * show_message - if TRUE, will display a visible message when restraints are removed. FALSE by default.
+ *
+ * Returns:
+ * * TRUE if handcuffs existed and were successfully removed, FALSE otherwise
+ */
+/mob/living/carbon/proc/clear_handcuffs(show_message = FALSE)
+	if(!handcuffed)
+		return FALSE
+
+	var/obj/item/W = handcuffed
+	if(isnull(W))
+		return FALSE
+
+	handcuffed = null
+	if(buckled && buckled.buckle_requires_restraints)
+		buckled.unbuckle_mob(src)
+	update_handcuffed()
+
+	if(client)
+		client.screen -= W
+
+	if(show_message)
+		visible_message("<span class='warning'>[src] slips out of [W]!</span>")
+
+	W.forceMove(drop_location())
+	W.dropped(src)
+	if(W)
+		W.layer = initial(W.layer)
+		W.plane = initial(W.plane)
+
+	return TRUE
+
+/**
+ * Removes a carbon's legcuffs, dropping them to the ground.
+ *
+ * Arguments:
+ * * show_message - if TRUE, will display a visible message when restraints are removed. FALSE by default.
+ *
+ * Returns:
+ * * TRUE if legcuffs existed and were successfully removed, FALSE otherwise
+ */
+/mob/living/carbon/proc/clear_legcuffs(show_message = FALSE)
+	if(!legcuffed)
+		return FALSE
+
+	var/obj/item/W = legcuffed
+	if(isnull(W))
+		return FALSE
+
+	legcuffed = null
+	toggle_move_intent()
+	update_inv_legcuffed()
+
+	if(client)
+		client.screen -= W
+
+	if(show_message)
+		visible_message("<span class='warning'>[W] falls off of [src]!</span>")
+
+	W.forceMove(drop_location())
+	W.dropped(src)
+	if(W)
+		W.layer = initial(W.layer)
+		W.plane = initial(W.plane)
+
+	return TRUE
 
 
 /mob/living/carbon/proc/slip(description, knockdown, tilesSlipped, walkSafely, slipAny, slipVerb = "slip")

--- a/code/modules/mob/living/carbon/carbon_procs.dm
+++ b/code/modules/mob/living/carbon/carbon_procs.dm
@@ -1028,10 +1028,8 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
  * * TRUE if handcuffs or legcuffs were removed, FALSE otherwise
  */
 /mob/living/carbon/proc/clear_restraints(show_message = FALSE)
-	var/cleared_hands = clear_handcuffs(show_message)
-	var/cleared_legs = clear_legcuffs(show_message)
-
-	return cleared_hands || cleared_legs
+	. = clear_handcuffs(show_message)
+	. |= clear_legcuffs(show_message)
 
 /**
  * Removes a carbon's handcuffs, dropping them to the ground. Calls update_handcuffed(). Unbuckles if handcuffs were necessary for the buckle (pipe buckling, etc.)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
- Slightly refactors `/mob/living/carbon/proc/uncuff()`
  - Renames the proc to `clear_restraints()`
  - Splits clearing handcuffs and legcuffs into separate procs.
  - These procs now have a return value of either `TRUE` or `FALSE` depending on whether or not the respective item existed and was removed.
  - All three procs now have the argument `show_message` (defaults to`FALSE`), which when `TRUE` will display a `visible_message` about the restraint being removed.

Gameplay changes:
- Blood Rush cannot be activated when the vampire is stamcritted, stunned, or buckled. This means that you will not waste blood when you can't benefit from the speed.
- Blood Rush now clears knockdowns, instantly stands the vampire up, and removes any legcuffs (bolas, beartraps).

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
The removal of Shadowstep left Gargantua as the only Vampire subclass without some kind of teleport escape ability. Stomp and Blood Rush are supposed to take Shadowstep's place, but they have a fatal flaw: you can't use them while you're bola'd, unlike a teleport. This PR brings Gargantua up to a rough parity with other subclasses.
## Testing
<!-- How did you test the PR, if at all? -->
Made sure the refactor didn't break freedoms or cuff removal and that the ability didn't do anything weird.
## Changelog
:cl:
tweak: The Gargantua Vampire Blood Rush ability now removes bolas and clears knockdowns when the user is not buckled.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
