### PR TITLE
Adds a copy button to fill build mode

### DIFF
--- a/code/modules/buildmode/submodes/fill.dm
+++ b/code/modules/buildmode/submodes/fill.dm
@@ -9,6 +9,7 @@
 	to_chat(user, "<span class='notice'>Left Mouse Button on turf/obj/mob      = Select corner</span>")
 	to_chat(user, "<span class='notice'>Left Mouse Button + Alt on turf/obj/mob = Delete region</span>")
 	to_chat(user, "<span class='notice'>Right Mouse Button on buildmode button = Select object type</span>")
+	to_chat(user, "<span class='notice'>Left Mouse Button + alt on turf/obj    = Copy object type")
 	to_chat(user, "<span class='notice'>***********************************************************</span>")
 
 /datum/buildmode_mode/fill/change_settings(mob/user)
@@ -26,6 +27,15 @@
 	deselect_region()
 
 /datum/buildmode_mode/fill/handle_click(mob/user, params, obj/object)
+	var/list/pa = params2list(params)
+	var/alt_click = pa.Find("alt")
+	var/left_click = pa.Find("left")
+	if(left_click && alt_click)
+		if(isturf(object) || isobj(object) || ismob(object))
+			objholder = object.type
+			to_chat(user, "<span class='notice'>[initial(object.name)] ([object.type]) selected.</span>")
+		else
+			to_chat(user, "<span class='notice'>[initial(object.name)] is not a turf, object, or mob! Please select again.</span>")
 	if(isnull(objholder))
 		to_chat(user, "<span class='warning'>Select an object type first.</span>")
 		deselect_region()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
When in buildmode's fill module, you can alt-click to copy something as the fill target.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Makes working with fill mode a bit easier.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
![image](https://github.com/ParadiseSS13/Paradise/assets/89928798/802d6b12-6660-49eb-9608-748388016551)

<!-- How did you test the PR, if at all? -->

## Changelog
NPFC

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
