### PR TITLE
Spray paint no longer checks for eye protection, and rather if the eyes are covered or not.

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -330,6 +330,7 @@
 			update_icon()
 
 /obj/item/toy/crayon/spraycan/afterattack(atom/target, mob/user as mob, proximity)
+	. = ..()
 	if(!proximity)
 		return
 	if(capped)
@@ -338,23 +339,25 @@
 	if(istype(target, /obj/item/clothing/head/cardborg) || istype(target, /obj/item/clothing/suit/cardborg))	// Spraypainting your cardborg suit for more fashion options.
 		cardborg_recolor(target, user)
 		return
-	if(iscarbon(target))
-		var/mob/living/carbon/attackee = target
-		if(uses - 10 > 0)
-			uses = uses - 10
-			user.visible_message("<span class='danger'> [user] sprays [src] into the face of [target]!</span>")
-			if(ishuman(target))
-				var/mob/living/carbon/human/H = target
-				if(!attackee.is_eyes_covered()) // no eye protection? ARGH IT BURNS.
-					H.Confused(6 SECONDS)
-					H.KnockDown(6 SECONDS)
-					H.lip_style = "spray_face"
-					H.lip_color = colour
-					H.update_body()
-				H.EyeBlurry(6 SECONDS)
-				H.EyeBlind(2 SECONDS)
+	if(!ishuman(target))
+		return
+	var/mob/living/carbon/human/attackee = target
+	if(uses < 10)
+		to_chat(user, "<span class='warning'>Theres not enough paint left to have an effect!</span>")
+		return
+	uses = uses - 10
+	user.visible_message("<span class='danger'> [user] sprays [src] into the face of [target]!</span>")
+	if(!attackee.is_eyes_covered()) // eyes aren't covered? ARGH IT BURNS.
+		attackee.Confused(6 SECONDS)
+		attackee.KnockDown(6 SECONDS)
+	attackee.EyeBlurry(6 SECONDS)
+	attackee.EyeBlind(2 SECONDS)
+
+	attackee.lip_style = "spray_face"
+	attackee.lip_color = colour
+	attackee.update_body()
+
 	playsound(user, 'sound/effects/spray.ogg', 5, TRUE, 5)
-	..()
 
 /obj/item/toy/crayon/spraycan/update_icon_state()
 	icon_state = "spraycan[capped ? "_cap" : ""]"

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -339,21 +339,20 @@
 		cardborg_recolor(target, user)
 		return
 	if(iscarbon(target))
+		var/mob/living/carbon/attackee = target
 		if(uses - 10 > 0)
 			uses = uses - 10
-			var/mob/living/carbon/C = target
 			user.visible_message("<span class='danger'> [user] sprays [src] into the face of [target]!</span>")
-			if(C.client)
-				C.EyeBlurry(6 SECONDS)
-				C.EyeBlind(2 SECONDS)
-				if(ishuman(target))
-					var/mob/living/carbon/human/H = target
-					if(H.check_eye_prot() <= 0) // no eye protection? ARGH IT BURNS.
-						H.Confused(6 SECONDS)
-						H.KnockDown(6 SECONDS)
+			if(ishuman(target))
+				var/mob/living/carbon/human/H = target
+				if(!attackee.is_eyes_covered()) // no eye protection? ARGH IT BURNS.
+					H.Confused(6 SECONDS)
+					H.KnockDown(6 SECONDS)
 					H.lip_style = "spray_face"
 					H.lip_color = colour
 					H.update_body()
+				H.EyeBlurry(6 SECONDS)
+				H.EyeBlind(2 SECONDS)
 	playsound(user, 'sound/effects/spray.ogg', 5, TRUE, 5)
 	..()
 

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -345,7 +345,7 @@
 	if(uses < 10)
 		to_chat(user, "<span class='warning'>Theres not enough paint left to have an effect!</span>")
 		return
-	uses = uses - 10
+	uses -= 10
 	user.visible_message("<span class='danger'> [user] sprays [src] into the face of [target]!</span>")
 	if(!attackee.is_eyes_covered()) // eyes aren't covered? ARGH IT BURNS.
 		attackee.Confused(6 SECONDS)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Changes the spray can knockdown check to be looking for if eyes are covered, rather than eye protection being less than 0
As well as cleans up the proc because whoa. it was bad
AND adds a message if theres not enough uses to effect someone
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
The spraypaint checking for eye protection makes sense, until you notice one pesky thing. You can get less eye protection from multiple means, Mainly nian eyes, as well as cling augmented eyes in xray mode, xray eyes, and thermal eyes. theres some others, but those are the major ones
This is an issue, because spraypaint isnt a flash, its.. paint, pretty much pepper spray lite. so it effecting people that're vulnerable to flashes is a little silly.

Cleaning up the proc is self explanatory, the proc was.. really bad, it was checking multiple things multiple times, checking for a client, to apply the blindness and eye blur, putting it under the eye protection check, it was very silly.
And the chat message is just so you're not leftt wondering why the spaypaint isn't working as a pepper spray.

## Testing
<!-- How did you test the PR, if at all? -->
Compiled, checked if it worked with and without a mask. Works the same with glasses
## Changelog
:cl:
tweak: Spay paint no longer knocks you down if you're flash vulnerable.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
