### PR TITLE
Renames Diona Organs

### DIFF
--- a/code/modules/surgery/organs/subtypes/diona_organs.dm
+++ b/code/modules/surgery/organs/subtypes/diona_organs.dm
@@ -73,30 +73,30 @@
 
 /// Turns into a nymph instantly, no transplanting possible.
 /obj/item/organ/internal/heart/diona
-	name = "neural strata"
+	name = "circulatory siphonostele"
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "nymph"
 
 /obj/item/organ/internal/lungs/diona
-	name = "respiratory vacuoles"
+	name = "respiratory nodules"
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "nymph"
 
 /// Turns into a nymph instantly, no transplanting possible.
 /obj/item/organ/internal/brain/diona
-	name = "gas bladder"
+	name = "neural strata"
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "nymph"
 
 /// Turns into a nymph instantly, no transplanting possible.
 /obj/item/organ/internal/kidneys/diona
-	name = "polyp segment"
+	name = "sieve-tube bundles"
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "nymph"
 
 /// Turns into a nymph instantly, no transplanting possible.
 /obj/item/organ/internal/appendix/diona
-	name = "anchoring ligament"
+	name = "auxiliary bud"
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "nymph"
 
@@ -110,7 +110,7 @@
 
 /// Turns into a nymph instantly, no transplanting possible.
 /obj/item/organ/internal/liver/diona
-	name = "nutrient vessel"
+	name = "nutrient sac"
 	icon = 'icons/mob/alien.dmi'
 	icon_state = "claw"
 	alcohol_intensity = 0.5


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Changes the names of most internal Diona organs.

The brain (**gas bladder**) is now the **neural strata**.
The heart (**neural strata**) is now the **circulatory siphonostele**.
The lungs (**respiratory vacuoles**) is now the **respiratory nodules**.
The kidneys (**polyp segment**) is now the **sieve-tube bundles**.
The appendix (**anchoring ligament**) is now the **auxiliary bud**.
The liver (**"nutrient vessel**) is now the **nutrient sac**.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Neural tissue is now the brain.

Most of the rest of the organs are now named after real plant structures, and they mostly do roughly the same thing as the organs or something related.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Looked inside a diona.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Renamed diona organs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
