### PR TITLE
Lowers the minimum crew amount needed to War

### DIFF
--- a/code/game/gamemodes/nuclear/nuclear_challenge.dm
+++ b/code/game/gamemodes/nuclear/nuclear_challenge.dm
@@ -2,7 +2,7 @@
 #define CHALLENGE_TIME_LIMIT 10 MINUTES
 #define CHALLENGE_SCALE_PLAYER 1 // How many player per scaling bonus
 #define CHALLENGE_SCALE_BONUS 10 // How many TC per scaling bonus
-#define CHALLENGE_MIN_PLAYERS 50
+#define CHALLENGE_MIN_PLAYERS 30
 #define CHALLENGE_SHUTTLE_DELAY 30 MINUTES // So the ops have at least 10 minutes before the shuttle is callable. Gives the nuke ops at least 15 minutes before shuttle arrive.
 
 /obj/item/nuclear_challenge


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Currently with the requirement of 50 people to go to war, we've seen an uptick in what people call "Blitz ops" where crew has no fore warning of 5 individuals with hijack perms and nukie gear rushing after a single objective. And its not even that the nukies WANT to do this, its cause they CANT war at all. 

So this lowers the minimum crew pop requirement from 50 to 30.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
The element of surprise is extremely strong. Catching crew with their pants down prevents them from mobilizing fast enough to counter the nukies before they push the captain and nuke the station. Its not fun for the crew when you just die/lose without much of a fight.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Compiled!
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Lowered the minimum required players for nukies to declare war to 30
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
