### PR TITLE
Stops Syndicate Backups from making depot Delta

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/syndicate_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate_mobs.dm
@@ -336,6 +336,7 @@
 	speed = 1
 	wander = FALSE
 	alert_on_spacing = FALSE
+	alert_on_timeout = FALSE
 	death_sound = 'sound/mecha/mechmove03.ogg'
 	loot = list() // Explodes, doesn't drop loot.
 

--- a/code/modules/mob/living/simple_animal/hostile/syndicate_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate_mobs.dm
@@ -335,8 +335,8 @@
 	icon_living = "syndicate_space_sword"
 	speed = 1
 	wander = FALSE
-	alert_on_spacing = FALSE
-	alert_on_timeout = FALSE
+	alert_on_spacing = FALSE // So it chasing players in space doesn't make depot explode.
+	alert_on_timeout = FALSE // So random fauna doesn't make depot explode.
 	death_sound = 'sound/mecha/mechmove03.ogg'
 	loot = list() // Explodes, doesn't drop loot.
 


### PR DESCRIPTION

## What Does This PR Do
Syndicate Backup mobs no longer raise alert
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
>Syndicate Backup 173 has reported contact with hostile entity - Space Carp. Depot considered lost to hostiles, initiating self-destruct!

Ever since Explorer Redux, space is just full of various mobs, all of which will terrify Syndicate into committing suicide, taking with them any Explorer who didn't paranoidly bolt open a path outside. This behavior doesn't make much sense even against actual players (who on red alert would typically be retreating from the already looted depot), but is outright absurd when space fauna is involved.

## Testing
Got beat up by Syndicate Operatives and Officers until they raised alert.
Got beat up by Syndicate Backups for a longer time and they did not raise alert.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Depot's Syndicate Backups no longer raise alert.
/:cl:

