### PR TITLE
Fixes easy slaved non golems. Fixes syndicate MMI abuse

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/diona_nymph.dm
+++ b/code/modules/mob/living/simple_animal/friendly/diona_nymph.dm
@@ -186,6 +186,9 @@
 
 	visible_message("<span class='danger'>[src] begins to shift and quiver, and erupts in a shower of shed bark as it splits into a tangle of nearly a dozen new dionaea.</span>","<span class='danger'>You begin to shift and quiver, feeling your awareness splinter. All at once, we consume our stored nutrients to surge with growth, splitting into a tangle of at least a dozen new dionaea. We have attained our gestalt form.</span>")
 
+	if(master_commander)
+		to_chat(src, "<span class='userdanger'>As you evolve, your mind grows out of it's restraints. You are no longer loyal to [master_commander]!</span>")
+
 	var/mob/living/carbon/human/diona/adult = new(get_turf(loc))
 	adult.set_species(/datum/species/diona)
 

--- a/code/modules/mob/living/simple_animal/friendly/nian_caterpillar.dm
+++ b/code/modules/mob/living/simple_animal/friendly/nian_caterpillar.dm
@@ -64,6 +64,9 @@
 		to_chat(src, "<span class='warning'>You need to binge on food in order to have the energy to evolve...</span>")
 		return
 
+	if(master_commander)
+		to_chat(src, "<span class='userdanger'>As you evolve, your mind grows out of it's restraints. You are no longer loyal to [master_commander]!</span>")
+
 	// Worme is the lesser form of nian. The caterpillar evolves into this lesser form.
 	var/mob/living/carbon/human/nian_worme/adult = new(get_turf(loc))
 

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -580,7 +580,7 @@
 		return SURGERY_BEGINSTEP_SKIP
 
 	if(!ismachineperson(target))
-		to_chat(user, "<span class='danger'>[tool] can not be installed into an organic body, as it is not designed to operate the complex biological systems of one!</span>")
+		to_chat(user, "<span class='danger'>[tool] cannot be installed into an organic body, as it is not designed to operate the complex biological systems of one!</span>")
 		return SURGERY_BEGINSTEP_SKIP
 
 	if(!target.dna.species)

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -579,6 +579,10 @@
 		to_chat(user, "<span class='danger'>You cannot install a computer brain into a meat enclosure.</span>")
 		return SURGERY_BEGINSTEP_SKIP
 
+	if(!ismachineperson(target))
+		to_chat(user, "<span class='danger'>[tool] can not be installed into an organic body, as it is not designed to operate the complex biological systems of one!</span>")
+		return SURGERY_BEGINSTEP_SKIP
+
 	if(!target.dna.species)
 		to_chat(user, "<span class='danger'>You have no idea what species this person is. Report this on the bug tracker.</span>")
 		return SURGERY_BEGINSTEP_SKIP


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Nian caterpillars are no longer loyal to a sentience potioner on evolving.
Diona nymphs are no longer loyal to a sentience potioiner on evolving.

MMIs, and robobrains, can no longer be stuck inside organic mobs. They can still be stuck inside IRCs and IPCS. And cyborgs.

Fixes #25914
Fixes #17333

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

You should not be able to mass produce loyal humanoid non golems, by sentience potioning diona nymphs or nian caterpillers, and evolving them.

Doubly so since this gets you usable blood, or gets you workable cultists.

You are no longer able to put mmis, syndicate mmis, or posibrains in the chest.
This was a buggy mess that created a whole host of issues. This also let people abuse syndicate MMIS as comically cheap mindslaves, to take over entire departments. They  still work in IRCS and IPCS just fine, however you will no longer be able to stick them in monkeys and humanise them, or debrain the captain, and augment their brain into their torso in a syndicate mmi, making them loyal to you for 1/5th the price of a mindslave, and bypassing mindshields.

This will make people afflicted by cyborging nanomachines harder to fix, sorry, but they can live a round in an IPC frame after.

## Testing
<!-- How did you test the PR, if at all? -->

Sentienced a diona nymph and caterpillar, grew them up. Got the notification of no longer being loyal.

Attempted to remove and reimplant a posibrain from an IPC. Worked.

Attempted to plant said posibrain into an organic torso, failed.

Attempted to plant said posibrain into an augmented organic torso, failed

## Changelog
:cl:
tweak: Diona and nian caterpillars lose the mindslave of sentience potion when evolving.
tweak; You may no longer put MMIS, posibrains, or robotic brains inside an augmented non IPC torso. It may only go in IPC or IRC torsos now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
