### PR TITLE
Adds starting localhost with DreamDaemon to VSCode's Run and Debug

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,18 +1,26 @@
 {
 	"version": "0.2.0",
 	"configurations": [
-	  {
+	{
 		"type": "byond",
 		"request": "launch",
 		"name": "Build & DS Debug",
 		"preLaunchTask": "dm: build - ${command:CurrentDME}",
 		"dmb": "${workspaceFolder}/${command:CurrentDMB}"
-	  },
-	  {
+	},
+	{
+		"type": "byond",
+		"request": "launch",
+		"name": "Build & DD Debug",
+		"preLaunchTask": "dm: build - ${command:CurrentDME}",
+		"dmb": "${workspaceFolder}/${command:CurrentDMB}",
+		"dreamDaemon": true
+	},
+	{
 		"type": "byond",
 		"request": "launch",
 		"name": "DS Debug",
 		"dmb": "${workspaceFolder}/${command:CurrentDMB}"
-	  }
+	}
 	]
-  }
+}


### PR DESCRIPTION
## What Does This PR Do
Adds the ability to run with DreamDaemon instead of DreamSeeker

## Why It's Good For The Game
Allows the localhost to start initializing before the client joins, and keep the localhost open even after closing the client.

I kept accidentally closing the server
## Testing
Launched with DreamDaemon and it worked

## Changelog
No player facing changes