### PR TITLE
fix: allow airless chute flushing of small items

### DIFF
--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -287,6 +287,14 @@
 /obj/machinery/disposal/deliveryChute/Bumped(atom/movable/AM) //Go straight into the chute
 	if(isprojectile(AM)	|| isAI(AM) || QDELETED(AM))
 		return
+
+	// We may already contain the object because thrown objects
+	// call CanPass which has a chance to immediately forceMove
+	// them into us.
+	if(AM.loc == src)
+		flush()
+		return
+
 	switch(dir)
 		if(NORTH)
 			if(AM.loc.y != loc.y + 1) return


### PR DESCRIPTION
## What Does This PR Do
This PR allows small items to be immediately flushed through airless disposals chutes.

Disposals and thrown objects are weird. When thrown atoms reach a delivery chute, CanPass is called on them, which has a 75% chance of forceMoving the atom into the disposal:

https://github.com/ParadiseSS13/Paradise/blob/f6b8d87e7850de83b2de149fbb9e7b204164fadc/code/modules/recycling/disposal.dm#L525-L540

However, even if it intakes the item, the disposal still counts as an obstacle, and so the thrown object Bumps against it, and disposal chutes have behavior in Bumped to attempt to flush the thrown object (this is also why objects that "bounce off" a disposal chute still always make it in):

https://github.com/ParadiseSS13/Paradise/blob/f6b8d87e7850de83b2de149fbb9e7b204164fadc/code/modules/recycling/sortingmachinery.dm#L287-L306

This checks to see that the object is coming from the expected direction, but the object might already be in the delivery chute, as per above. So we add a check for that and allow it to flush.

The primary motivation for this fix is to improve disposals on Farragus. Small objects will frequently get caught in chutes because of this behavior. Being in space, they never pressurize and thus never flush regularly. Mobs and large objects (such as crates, which count as structures and thus bypass the first conditional in `/obj/machinery/disposal/CanPass` above) always flush no matter what, because of the existing call to `flush()` in `/obj/machinery/disposal/deliveryChute/Bumped` above, essentially "cheating" the pressurization. Rather than "fix" this for all objects, we just cheat the same way for small objects as well.

## Why It's Good For The Game
See above.

## Testing
Spawned onto Farragus, threw various things into disposals, verified instant flushing.

## Changelog
:cl:
tweak: Unpressurized disposal chutes (such as the ones on Farragus' waste belt) now more reliably flush small items and packages.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
