### PR TITLE
Blood spread fixes and tweaks

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -19,6 +19,8 @@
 	var/blood_color
 	/// Wont gloves/hands spend blood spill points to make this bloody
 	var/easy_to_spill_blood = FALSE
+	/// Will the atom spread blood when touched?
+	var/should_spread_blood = FALSE
 	var/pass_flags = 0
 	/// The higher the germ level, the more germ on the atom.
 	var/germ_level = GERM_LEVEL_AMBIENT
@@ -898,10 +900,14 @@ GLOBAL_LIST_EMPTY(blood_splatter_icons)
 	return FALSE
 
 /obj/add_blood(list/blood_dna, b_color)
+	if(isnull(b_color))
+		b_color = "#A10808"
 	blood_color = b_color
 	return transfer_blood_dna(blood_dna)
 
 /obj/item/add_blood(list/blood_dna, b_color)
+	if(isnull(b_color))
+		b_color = "#A10808"
 	var/blood_count = !blood_DNA ? 0 : length(blood_DNA)
 	if(!..())
 		return FALSE
@@ -915,6 +921,8 @@ GLOBAL_LIST_EMPTY(blood_splatter_icons)
 	transfer_blood = rand(2, 4)
 
 /turf/add_blood(list/blood_dna, b_color)
+	if(isnull(b_color))
+		b_color = "#A10808"
 	var/obj/effect/decal/cleanable/blood/splatter/B = locate() in src
 	if(!B)
 		B = new /obj/effect/decal/cleanable/blood/splatter(src)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -54,6 +54,7 @@ GLOBAL_DATUM_INIT(welding_sparks, /mutable_appearance, mutable_appearance('icons
 	/// Determines what it can pass over/through. IE. 'PASSTABLE' will allow it to pass over tables
 	pass_flags = PASSTABLE
 	pressure_resistance = 4
+	should_spread_blood = TRUE
 	var/obj/item/master
 
 	/// Flags which determine which body parts are protected from heat. Use the HEAD, UPPER_TORSO, LOWER_TORSO, etc. flags. See setup.dm

--- a/code/game/objects/items/weapons/soap.dm
+++ b/code/game/objects/items/weapons/soap.dm
@@ -96,7 +96,7 @@
 					if(!istype(carried_item, /obj/item/bio_chip))//If it's not an implant.
 						carried_item.add_mob_blood(target)//Oh yes, there will be blood...
 				var/mob/living/carbon/human/H = target
-				H.bloody_hands(target,0)
+				H.make_bloody_hands(H.get_blood_dna_list(), H.get_blood_color())
 				H.bloody_body(target)
 
 	return

--- a/code/game/objects/items/weapons/soap.dm
+++ b/code/game/objects/items/weapons/soap.dm
@@ -31,6 +31,9 @@
 			return
 	target.cleaning_act(user, src, cleanspeed)
 
+/obj/item/soap/add_blood(list/blood_dna, b_color)
+	return
+
 /obj/item/soap/proc/eat_soap(mob/living/carbon/human/drask/user)
 	times_eaten++
 	playsound(user.loc, 'sound/items/eatfood.ogg', 50, 0)

--- a/code/modules/detective_work/detective_work.dm
+++ b/code/modules/detective_work/detective_work.dm
@@ -8,7 +8,7 @@
 		else if(G.transfer_blood > 1 && add_blood(G.blood_DNA, G.blood_color))
 			G.transfer_blood--
 
-		if(blood_DNA)
+		if(blood_DNA && should_spread_blood)
 			var/old_transfer_blood = G.transfer_blood
 			G.add_blood(blood_DNA, blood_color)
 			G.transfer_blood = old_transfer_blood
@@ -20,11 +20,10 @@
 		else if(M.bloody_hands > 1 && add_blood(M.blood_DNA, M.hand_blood_color))
 			M.bloody_hands--
 
-		if(blood_DNA)
+		if(blood_DNA && should_spread_blood)
 			var/old_bloody_hands = M.bloody_hands
-			M.add_blood(blood_DNA, blood_color)
-			M.bloody_hands = old_bloody_hands
-			M.update_inv_gloves()
+			M.make_bloody_hands(blood_DNA, blood_color)
+			M.bloody_hands = max(1, old_bloody_hands)
 
 	if(!suit_fibers) suit_fibers = list()
 	var/fibertext

--- a/code/modules/detective_work/detective_work.dm
+++ b/code/modules/detective_work/detective_work.dm
@@ -11,7 +11,7 @@
 		if(blood_DNA && should_spread_blood)
 			var/old_transfer_blood = G.transfer_blood
 			G.add_blood(blood_DNA, blood_color)
-			G.transfer_blood = old_transfer_blood
+			G.transfer_blood = max(1, old_transfer_blood)
 			M.update_inv_gloves()
 
 	else

--- a/code/modules/mob/living/carbon/human/appearance.dm
+++ b/code/modules/mob/living/carbon/human/appearance.dm
@@ -498,3 +498,10 @@
 		valid_alt_heads += alternate_head
 
 	return sortTim(valid_alt_heads, GLOBAL_PROC_REF(cmp_text_asc))
+
+/mob/living/carbon/human/proc/get_blood_color()
+	var/bloodcolor = "#A10808"
+	var/list/b_data = get_blood_data(get_blood_id())
+	if(b_data)
+		bloodcolor = b_data["blood_color"]
+	return bloodcolor

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -616,11 +616,14 @@ emp_act
 	visible_message("<span class='danger'>[I] embeds itself in [src]'s [L.name]!</span>","<span class='userdanger'>[I] embeds itself in your [L.name]!</span>")
 	return TRUE
 
-/mob/living/carbon/human/proc/bloody_hands(mob/living/source, amount = 2)
+/mob/living/carbon/human/proc/make_bloody_hands(list/blood_dna, b_color)
 	if(gloves)
-		gloves.add_mob_blood(source)
+		gloves.add_blood(blood_dna, blood_color)
 	else
-		add_mob_blood(source)
+		hand_blood_color = b_color
+		bloody_hands = rand(2, 4)
+		transfer_blood_dna(blood_dna)
+		add_verb(src, /mob/living/carbon/human/proc/bloody_doodle)
 	update_inv_gloves()		//updates on-mob overlays for bloody hands and/or bloody gloves
 
 /mob/living/carbon/human/proc/bloody_body(mob/living/source)
@@ -657,7 +660,7 @@ emp_act
 
 	if(bleed_rate && ishuman(user))
 		var/mob/living/carbon/human/attacker = user
-		attacker.bloody_hands(src)
+		attacker.make_bloody_hands(get_blood_dna_list(), get_blood_color())
 
 /mob/living/carbon/human/attack_larva(mob/living/carbon/alien/larva/L)
 	if(..()) //successful larva bite.

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -617,6 +617,8 @@ emp_act
 	return TRUE
 
 /mob/living/carbon/human/proc/make_bloody_hands(list/blood_dna, b_color)
+	if(isnull(b_color))
+		b_color = "#A10808"
 	if(gloves)
 		gloves.add_blood(blood_dna, blood_color)
 	else

--- a/code/modules/projectiles/projectile_base.dm
+++ b/code/modules/projectiles/projectile_base.dm
@@ -201,7 +201,7 @@
 				L.add_splatter_floor(target_loca, shift_x = shift["x"], shift_y = shift["y"])
 				if(istype(H))
 					for(var/mob/living/carbon/human/M in step_over) //Bloody the mobs who're infront of the spray.
-						M.bloody_hands(H)
+						M.make_bloody_hands(H.get_blood_dna_list(), H.get_blood_color())
 						/* Uncomment when bloody_body stops randomly not transferring blood colour.
 						M.bloody_body(H) */
 		else if(impact_effect_type && !hitscan)

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -109,7 +109,7 @@
 	affected.fix_internal_bleeding()
 	if(ishuman(user) && prob(40))
 		var/mob/living/carbon/human/U = user
-		U.bloody_hands(target, 0)
+		U.make_bloody_hands(target.get_blood_dna_list(), target.get_blood_color())
 
 	return SURGERY_STEP_CONTINUE
 

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -446,7 +446,7 @@
 		var/mob/living/carbon/human/H = user
 		switch(blood_level)
 			if(SURGERY_BLOODSPREAD_HANDS)
-				H.bloody_hands(target, 0)
+				H.make_bloody_hands(target.get_blood_dna_list(), target.get_blood_color())
 			if(SURGERY_BLOODSPREAD_FULLBODY)
 				H.bloody_body(target)
 	return


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Objects without blood overlay(such as airlock) not make your hands/gloves bloody
Touching something bloody with bare hands now makes only hands bloody
Cleaning bare hands cleans overlay too
Replaces null blood color with red blood
Soap cant be covered in blood

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Blood spread PR caused some bugs and unexpected behaviour, this PR fixes that.

## Testing
<!-- How did you test the PR, if at all? -->
Compiled, touched various bloody things with gloves and without, cleaned that all

## Changelog
:cl:
tweak: Only bloody items now make your hands/gloves bloody. Airlocks and other objects in game no longer spreads blood on your hands.
tweak: Soap cant be covered in blood.
fix: Cleaning bloody bare hands now removes blood overlay too.
fix: Touching bloody object with bare hands now only spreads blood on your hands.
fix: White blood(null color) shouldnt be a thing anymore.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
