### PR TITLE
Prevent maintenance drones from using chem dispensers.

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -302,6 +302,9 @@
 	default_unfasten_wrench(user, I, 4 SECONDS)
 
 /obj/machinery/chem_dispenser/attack_ai(mob/user)
+	if(isdrone(user))
+		// There's nothing a drone can do here that wouldn't violate their laws and/or the rules.
+		return
 	return attack_hand(user)
 
 /obj/machinery/chem_dispenser/attack_ghost(mob/user)

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -303,8 +303,11 @@
 
 /obj/machinery/chem_dispenser/attack_ai(mob/user)
 	if(isdrone(user))
-		// There's nothing a drone can do here that wouldn't violate their laws and/or the rules.
-		return
+		var/mob/living/silicon/robot/drone/drone = user
+		if(!drone.emagged)
+			// There's nothing a drone can do here that wouldn't violate their laws and/or the rules.
+			to_chat(user, "<span class='warning'>Your safety protocols refuse to connect to [src].</span>")
+			return
 	return attack_hand(user)
 
 /obj/machinery/chem_dispenser/attack_ghost(mob/user)


### PR DESCRIPTION
## What Does This PR Do
Prevent maintenance drones from using chem dispensers.

## Why It's Good For The Game
It's only a vector to break their laws and/or the rules.

## Testing
Spawned as drone. Couldn't use.
Reincarnated as chemist. Could use.
Transformed to robot. Could use.
Emagged a drone. Could use.

## Changelog
:cl:
del: Maintenance drones can no longer use chem dispensers.
/:cl: