### PR TITLE
Fix glass tables. Fix crafting. lower price  / stun

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -459,7 +459,9 @@
 		check_break(M)
 
 /obj/structure/table/glass/proc/check_break(mob/living/M)
-	if(has_gravity(M) && M.mob_size > MOB_SIZE_SMALL && !HAS_TRAIT(M?.buckled, TRAIT_NO_BREAK_GLASS_TABLES))
+	if(has_gravity(M) && M.mob_size > MOB_SIZE_SMALL)
+		if(M.buckled && HAS_TRAIT(M.buckled, TRAIT_NO_BREAK_GLASS_TABLES))
+			return
 		table_shatter(M)
 
 /obj/structure/table/glass/flip(direction)

--- a/code/modules/supply/supply_packs/pack_miscellaneous.dm
+++ b/code/modules/supply/supply_packs/pack_miscellaneous.dm
@@ -529,7 +529,7 @@
 /datum/supply_packs/misc/hoverboard
 	name = "Hoverboard Crate"
 	contains = list(/obj/item/melee/skateboard/hoverboard)
-	cost = 999 //Price of cool. Also under 1000 so it's not grand theft if stolen, lmao
+	cost = 999 // Price of cool. Also under 1000 so it's not grand theft if stolen, lmao
 	containername = "hoverboard crate"
 
 ///////////// Station Goals

--- a/code/modules/supply/supply_packs/pack_miscellaneous.dm
+++ b/code/modules/supply/supply_packs/pack_miscellaneous.dm
@@ -529,7 +529,7 @@
 /datum/supply_packs/misc/hoverboard
 	name = "Hoverboard Crate"
 	contains = list(/obj/item/melee/skateboard/hoverboard)
-	cost = 1000 //Price of cool
+	cost = 999 //Price of cool. Also under 1000 so it's not grand theft if stolen, lmao
 	containername = "hoverboard crate"
 
 ///////////// Station Goals

--- a/code/modules/vehicle/tg_vehicles/scooter.dm
+++ b/code/modules/vehicle/tg_vehicles/scooter.dm
@@ -117,13 +117,13 @@
 			rider.adjustBrainLoss(5)
 			rider.updatehealth()
 		visible_message("<span class='danger'>[src] crashes into [bumped_thing], sending [rider] flying!</span>")
-		rider.Weaken(8 SECONDS)
+		rider.Weaken(6 SECONDS)
 		if(iscarbon(bumped_thing))
 			var/mob/living/carbon/victim = bumped_thing
 			var/grinding_mulitipler = 1
 			if(grinding)
 				grinding_mulitipler = 2
-			victim.Weaken(2 * grinding_mulitipler SECONDS)
+				victim.Weaken(2.5 SECONDS) //This is easier said than done, so probably fine. If officers or crew weaponise it I'll kill it fully.
 			victim.KnockDown(4 * grinding_mulitipler SECONDS)
 	else
 		var/backdir = REVERSE_DIR(dir)
@@ -246,11 +246,14 @@
 /obj/item/scooter_frame/attackby(obj/item/I, mob/user, params)
 	if(!istype(I, /obj/item/stack/sheet/metal))
 		return ..()
-	if(!I.tool_start_check(user, amount = 5))
+	var/obj/item/stack/S = I
+	if(S.get_amount() < 5)
 		return
 	to_chat(user, "<span class='notice'>You begin to add wheels to [src].</span>")
-	if(!I.use_tool(src, user, 80, volume = 50, amount = 5))
-		return
+	if(do_after(user, 5 SECONDS, target = src))
+		if(!loc || !S || S.get_amount() < 2)
+			return
+	S.use(2)
 	to_chat(user, "<span class='notice'>You finish making wheels for [src].</span>")
 	new /obj/tgvehicle/scooter/skateboard/improvised(user.loc)
 	qdel(src)
@@ -269,11 +272,14 @@
 /obj/tgvehicle/scooter/skateboard/improvised/attackby(obj/item/I, mob/user, params)
 	if(!istype(I, /obj/item/stack/rods))
 		return ..()
-	if(!I.tool_start_check(user, amount = 2))
+	var/obj/item/stack/S = I
+	if(S.get_amount() < 2)
 		return
 	to_chat(user, "<span class='notice'>You begin making handlebars for [src].</span>")
-	if(!I.use_tool(src, user, 25, volume = 50, amount = 2))
-		return
+	if(do_after(user, 2.5 SECONDS, target = src))
+		if(!loc || !S || S.get_amount() < 2)
+			return
+	S.use(2)
 	to_chat(user, "<span class='notice'>You add the rods to [src], creating handlebars.</span>")
 	var/obj/tgvehicle/scooter/skaterskoot = new(loc)
 	if(has_buckled_mobs())

--- a/code/modules/vehicle/tg_vehicles/scooter.dm
+++ b/code/modules/vehicle/tg_vehicles/scooter.dm
@@ -277,9 +277,8 @@
 		return
 	to_chat(user, "<span class='notice'>You begin making handlebars for [src].</span>")
 	if(do_after(user, 2.5 SECONDS, target = src))
-		if(!loc || !S || S.get_amount() < 2)
+		if(!loc || !S || S.get_amount() < 2 || !S.use(2))
 			return
-	S.use(2)
 	to_chat(user, "<span class='notice'>You add the rods to [src], creating handlebars.</span>")
 	var/obj/tgvehicle/scooter/skaterskoot = new(loc)
 	if(has_buckled_mobs())

--- a/code/modules/vehicle/tg_vehicles/scooter.dm
+++ b/code/modules/vehicle/tg_vehicles/scooter.dm
@@ -123,7 +123,7 @@
 			var/grinding_mulitipler = 1
 			if(grinding)
 				grinding_mulitipler = 2
-				victim.Weaken(2.5 SECONDS) //This is easier said than done, so probably fine. If officers or crew weaponise it I'll kill it fully.
+				victim.Weaken(2.5 SECONDS) // This is easier said than done, so probably fine. If officers or crew weaponize it I'll kill it fully.
 			victim.KnockDown(4 * grinding_mulitipler SECONDS)
 	else
 		var/backdir = REVERSE_DIR(dir)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Glass tables break again.
Scooters are craftable.
Crashing into someone with a skateboard still knocks them down, but only hardstuns if you are grinding.
Hoverboard now costs 999 credits, so it is not grand theft if a tider steals one.

fix #26059
fixes #23975

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Bugs are bad.
Bugs are bad.
Hardstuns are bad unless the situations that create them are hard to pull off or sufficiently funny.
A tider being arrested for grand theft from a hoverboard is bad.

I'll likely have to make scateboards disembark you if you get hit by enough lethals or stamina in a short period, but not touching  that in this PR.

## Testing
<!-- How did you test the PR, if at all? -->

Crafted skateboard. Screwdrivered. Applied metal. Applied rods.
Threw people on glass tables. Disarmed on glass tables. Climbed on glass tables. Hoverboarded across glass  tables.
Bonked into a skrell

## Changelog
:cl:
tweak: Hoverboard now costs 999 instead of 1000 credits.
tweak: Skateboards only hardstun the person they crash into if they are actively grinding on a skateboard.
fix: Glass tables break again
fix: Scooters craftable
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
