### PR TITLE
Creates a New Workflow for Adding Wiki Labels  

### DIFF
--- a/.github/workflows/wiki_label.yml
+++ b/.github/workflows/wiki_label.yml
@@ -18,9 +18,9 @@ jobs:
       - name: Check commenter authorization
         id: check-auth
         run: |
-          AUTHORIZED_USER="SynthTwo"
+          AUTHORIZED_USERS=("SynthTwo")
           COMMENTER="${{ github.event.comment.user.login }}"
-          if [ "$COMMENTER" = "$AUTHORIZED_USER" ]; then
+          if [ "$COMMENTER" = "$AUTHORIZED_USERS" ]; then
             echo "authorized=true" >> $GITHUB_OUTPUT
           else
             echo "authorized=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/wiki_label.yml
+++ b/.github/workflows/wiki_label.yml
@@ -15,25 +15,29 @@ jobs:
         id: check-auth
         run: |
           IFS=',' read -ra WIKI_MANAGERS <<< "${{ vars.WIKI_MANAGERS }}"
-          COMMENTER="${{ github.event.comment.user.login }}"
-          if [[ " ${WIKI_MANAGERS[@]} " =~ " ${COMMENTER} " ]]; then
+          COMMENTER_ID="${{ github.event.comment.user.id }}"
+          if [[ " ${WIKI_MANAGERS[@]} " =~ " ${COMMENTER_ID} " ]]; then
             echo "authorized=true" >> $GITHUB_OUTPUT
           else
             echo "authorized=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Add Wiki label and thumbs up reaction
+      - name: Add thumbs up reaction and Wiki label
         if: steps.check-auth.outputs.authorized == 'true'
         run: |
-          gh pr edit ${{ github.event.issue.number }} --add-label "Requires Wiki Update"
-          echo "Label 'Requires Wiki update' added to PR #${{ github.event.issue.number }}"
+          # Add thumbs up reaction
           curl -X POST \
             -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             -H "Accept: application/vnd.github.v3+json" \
             "https://api.github.com/repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
             -d '{"content":"+1"}'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+          # Add label to PR
+          curl -X POST \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/labels" \
+            -d '["Requires Wiki Update"]'
 
       - name: Unauthorized user thumbs down reaction
         if: steps.check-auth.outputs.authorized == 'false'
@@ -43,5 +47,3 @@ jobs:
             -H "Accept: application/vnd.github.v3+json" \
             "https://api.github.com/repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
             -d '{"content":"-1"}'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/wiki_label.yml
+++ b/.github/workflows/wiki_label.yml
@@ -36,6 +36,7 @@ jobs:
             -H "Accept: application/vnd.github.v3+json" \
             "https://api.github.com/repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
             -d '{"content":"+1"}'
+          gh pr comment ${{ github.event.issue.number }} --body "Label 'Requires Wiki update' has been added."
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/wiki_label.yml
+++ b/.github/workflows/wiki_label.yml
@@ -18,9 +18,9 @@ jobs:
       - name: Check commenter authorization
         id: check-auth
         run: |
-          AUTHORIZED_USERS=("SynthTwo")
+          IFS=',' read -ra AUTHORIZED_USERS <<< "${{ vars.AUTHORIZED_USERS }}"
           COMMENTER="${{ github.event.comment.user.login }}"
-          if [ "$COMMENTER" = "$AUTHORIZED_USERS" ]; then
+          if [[ " ${AUTHORIZED_USERS[@]} " =~ " ${COMMENTER} " ]]; then
             echo "authorized=true" >> $GITHUB_OUTPUT
           else
             echo "authorized=false" >> $GITHUB_OUTPUT
@@ -30,20 +30,18 @@ jobs:
         if: steps.check-auth.outputs.authorized == 'true'
         run: |
           gh pr edit ${{ github.event.issue.number }} --add-label "Requires Wiki Update"
-          echo "Label 'Requires Wiki update' added to PR #${{ github.event.issue.number }}"
+          echo "Label 'Requires Wiki Update' added to PR #${{ github.event.issue.number }}"
           curl -X POST \
             -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             -H "Accept: application/vnd.github.v3+json" \
             "https://api.github.com/repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
             -d '{"content":"+1"}'
-          gh pr comment ${{ github.event.issue.number }} --body "Label 'Requires Wiki update' has been added."
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Unauthorized user comment and thumbs down reaction
+      - name: Unauthorized user thumbs down reaction
         if: steps.check-auth.outputs.authorized == 'false'
         run: |
-          gh pr comment ${{ github.event.issue.number }} --body "Sorry, you are not authorized to use the !wiki_label command."
           curl -X POST \
             -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             -H "Accept: application/vnd.github.v3+json" \

--- a/.github/workflows/wiki_label.yml
+++ b/.github/workflows/wiki_label.yml
@@ -1,0 +1,52 @@
+name: 'PR Wiki Label'
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  wiki-label:
+    runs-on: ubuntu-latest
+    if: github.event.issue.pull_request && github.event.comment.body == '!wiki_label'
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Check commenter authorization
+        id: check-auth
+        run: |
+          AUTHORIZED_USER="SynthTwo"
+          COMMENTER="${{ github.event.comment.user.login }}"
+          if [ "$COMMENTER" = "$AUTHORIZED_USER" ]; then
+            echo "authorized=true" >> $GITHUB_OUTPUT
+          else
+            echo "authorized=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Add Wiki label and thumbs up reaction
+        if: steps.check-auth.outputs.authorized == 'true'
+        run: |
+          gh pr edit ${{ github.event.issue.number }} --add-label "Requires Wiki Update"
+          echo "Label 'Requires Wiki update' added to PR #${{ github.event.issue.number }}"
+          curl -X POST \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
+            -d '{"content":"+1"}'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Unauthorized user comment and thumbs down reaction
+        if: steps.check-auth.outputs.authorized == 'false'
+        run: |
+          gh pr comment ${{ github.event.issue.number }} --body "Sorry, you are not authorized to use the !wiki_label command."
+          curl -X POST \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
+            -d '{"content":"-1"}'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/wiki_label.yml
+++ b/.github/workflows/wiki_label.yml
@@ -8,19 +8,15 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.issue.pull_request && github.event.comment.body == '!wiki_label'
     permissions:
-      contents: read
       issues: write
       pull-requests: write
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
       - name: Check commenter authorization
         id: check-auth
         run: |
-          IFS=',' read -ra AUTHORIZED_USERS <<< "${{ vars.AUTHORIZED_USERS }}"
+          IFS=',' read -ra WIKI_MANAGERS <<< "${{ vars.WIKI_MANAGERS }}"
           COMMENTER="${{ github.event.comment.user.login }}"
-          if [[ " ${AUTHORIZED_USERS[@]} " =~ " ${COMMENTER} " ]]; then
+          if [[ " ${WIKI_MANAGERS[@]} " =~ " ${COMMENTER} " ]]; then
             echo "authorized=true" >> $GITHUB_OUTPUT
           else
             echo "authorized=false" >> $GITHUB_OUTPUT
@@ -30,7 +26,7 @@ jobs:
         if: steps.check-auth.outputs.authorized == 'true'
         run: |
           gh pr edit ${{ github.event.issue.number }} --add-label "Requires Wiki Update"
-          echo "Label 'Requires Wiki Update' added to PR #${{ github.event.issue.number }}"
+          echo "Label 'Requires Wiki update' added to PR #${{ github.event.issue.number }}"
           curl -X POST \
             -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             -H "Accept: application/vnd.github.v3+json" \


### PR DESCRIPTION
## What Does This PR Do
This creates a new workflow that allows people designated to label a PR with `Requires Wiki Update` without needing to be a member of the repository. This can be done by an authorized user by using `!wiki_label`.

~~Additionally this PR adds @SynthTwo to the list of authorized users for this command.~~

This now uses a repository variable and will need to be setup accordingly.

## Why It's Good For The Game
What is good for the code base is good for the game.

## Images of changes
![librewolf_FyKE82QVds](https://github.com/ParadiseSS13/Paradise/assets/116982774/d148180b-768b-4022-bb2b-9be0cb1a591c)
![librewolf_9SSv4nbSAQ](https://github.com/ParadiseSS13/Paradise/assets/116982774/af6075a6-eb90-49ae-9c80-24d8b305849f)


## Testing
Created a separate fork of our repository.
Created a dummy PR to test the function of the workflow.
Tested new changes made during the course of this PR.

Additional thanks to @SynthTwo for helping to test this.

## Changelog
NPFC