### PR TITLE
Lowers scope eyes cost

### DIFF
--- a/code/datums/uplink_items/uplink_general.dm
+++ b/code/datums/uplink_items/uplink_general.dm
@@ -903,7 +903,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	This pair has been hardened for special operations personnel."
 	reference = "KOE"
 	item = /obj/item/autosurgeon/organ/syndicate/oneuse/scope_eyes
-	cost = 20
+	cost = 10
 
 
 ////////////////////////////////////////


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
This PR lowers scope eyes (as "Hardened Kaleido Optics Eyes Autoimplanter") cost in uplink to 10 TC

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
While the item sounds good, you would actually use it just to check areas for people with thermals or look down the hallway for secuirity. You cant really use it in fight since accuracy at this distance would be really fucked. So, with all that, cost of 20 TC makes it just not worth the cost

## Testing
<!-- How did you test the PR, if at all? -->
Compiled. There is just one number changed.

## Changelog
:cl:
tweak: Hardened Kaleido Optics Eyes Autoimplanter aka scope eyes now cost 10 TC(was 20 TC)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
