### PR TITLE
Removes the 1s option from flashbangs

### DIFF
--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -36,7 +36,7 @@
 			det_time = 5 SECONDS
 			to_chat(user, "<span class='notice'>You set [src] for 5 second detonation time.</span>")
 		if(5 SECONDS)
-			det_time = 0.01 SECONDS
+			det_time = 0.1 SECONDS
 			to_chat(user, "<span class='notice'>You set [src] for instant detonation.</span>")
 	add_fingerprint(user)
 	return TRUE

--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -27,6 +27,20 @@
 		bang(T, src, range)
 	qdel(src)
 
+/obj/item/grenade/flashbang/screwdriver_act(mob/living/user, obj/item/I)
+	switch(det_time)
+		if(1)
+			det_time = 30
+			to_chat(user, "<span class='notice'>You set [src] for 3 second detonation time.</span>")
+		if(30)
+			det_time = 50
+			to_chat(user, "<span class='notice'>You set [src] for 5 second detonation time.</span>")
+		if(50)
+			det_time = 1
+			to_chat(user, "<span class='notice'>You set [src] for instant detonation.</span>")
+	add_fingerprint(user)
+	return TRUE
+
 /**
   * Creates a flashing effect that blinds and deafens mobs within range
   *

--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -29,14 +29,14 @@
 
 /obj/item/grenade/flashbang/screwdriver_act(mob/living/user, obj/item/I)
 	switch(det_time)
-		if(1)
-			det_time = 30
+		if(0.01 SECONDS)
+			det_time = 3 SECONDS
 			to_chat(user, "<span class='notice'>You set [src] for 3 second detonation time.</span>")
-		if(30)
-			det_time = 50
+		if(3 SECONDS)
+			det_time = 5 SECONDS
 			to_chat(user, "<span class='notice'>You set [src] for 5 second detonation time.</span>")
-		if(50)
-			det_time = 1
+		if(5 SECONDS)
+			det_time = 0.01 SECONDS
 			to_chat(user, "<span class='notice'>You set [src] for instant detonation.</span>")
 	add_fingerprint(user)
 	return TRUE

--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -29,7 +29,7 @@
 
 /obj/item/grenade/flashbang/screwdriver_act(mob/living/user, obj/item/I)
 	switch(det_time)
-		if(0.01 SECONDS)
+		if(0.1 SECONDS)
 			det_time = 3 SECONDS
 			to_chat(user, "<span class='notice'>You set [src] for 3 second detonation time.</span>")
 		if(3 SECONDS)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
You can no longer set the fuse timer on flashbangs to one second

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
This is with 2(?) balance team members pre approval. (im unsure what the second member meant, but they seem fine with it?)

Flashbangs have started to become a quite cheesy method of closing the distance with people who lack one of the two forms of bang(ear) protection, and theres been a rather sharp increase of players treating others like a blob, and throwing upwards of 6 flashbangs on 1s timers, leading to no reaction time on the victim, removing the one second option should hopefully add a little skill requirement to 'insta flashing' as accurately timing 5/3 seconds with adrenaline in your system isn't the easiest thing todo.

not to mention if you lack eye protection the flashbang spam will likely blind you very quickly

this does not effect base grenades, only flashbangs
the options it gets now are as follows
0.1seconds ('truly' instant, if a clown gets ahold of your flashbox, you're in for a surprise. and as the bang part of the flashbang also effects you even if you have ear pro i think its fine.)
3 seconds
5 seconds


Hopefully this discourages/adds more skill to using flashbangs, as you will need to actually count in your head if you wish to surprise people with a flashbang

~~also technically a blob buff~~
## Testing
<!-- How did you test the PR, if at all? -->
compiled, checked the flashbang options with a screwdriver
## Changelog
:cl:
tweak: you can no longer set flashbangs to a one second primer
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
