### PR TITLE
Lets the players know that they can steal just the photo of the blueprints instead of the entire thing.

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -593,8 +593,7 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 	explanation_text = "Steal [steal_target.name]. One was last seen in [get_location()]. "
 	if(length(steal_target.protected_jobs) && steal_target.job_possession)
 		explanation_text += "It may also be in the possession of the [english_list(steal_target.protected_jobs, and_text = " or ")]. "
-	if(/obj/item/photo in steal_target.altitems)
-		explanation_text += "Stealing a photograph of the item is also an option."
+	explanation_text += steal_target.extra_information
 
 /datum/objective/steal/check_completion()
 	if(!steal_target)

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -592,7 +592,9 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 /datum/objective/steal/update_explanation_text()
 	explanation_text = "Steal [steal_target.name]. One was last seen in [get_location()]. "
 	if(length(steal_target.protected_jobs) && steal_target.job_possession)
-		explanation_text += "It may also be in the possession of the [english_list(steal_target.protected_jobs, and_text = " or ")]."
+		explanation_text += "It may also be in the possession of the [english_list(steal_target.protected_jobs, and_text = " or ")]. "
+	if(/obj/item/photo in steal_target.altitems)
+		explanation_text += "Stealing a photograph of the item is also an option."
 
 /datum/objective/steal/check_completion()
 	if(!steal_target)

--- a/code/game/gamemodes/steal_items.dm
+++ b/code/game/gamemodes/steal_items.dm
@@ -86,7 +86,7 @@
 	protected_jobs = list("Chief Engineer")
 	altitems = list(/obj/item/photo)
 	location_override = "the Chief Engineer's Office"
-	extra_information = "Stealing a photograph of the item is also an option."
+	extra_information = "Obtaining a photograph of the blueprints is also an option."
 
 /datum/theft_objective/blueprints/check_special_completion(obj/item/I)
 	if(istype(I, /obj/item/areaeditor/blueprints/ce))

--- a/code/game/gamemodes/steal_items.dm
+++ b/code/game/gamemodes/steal_items.dm
@@ -16,6 +16,8 @@
 	var/special_equipment = null
 	/// If a steal objective has forbidden jobs, and the forbidden jobs would not be in the possession of this item, set this to false
 	var/job_possession = TRUE
+	/// Any extra information about the objective
+	var/extra_information = ""
 
 /datum/theft_objective/proc/check_completion(datum/mind/owner)
 	if(!owner.current)
@@ -84,6 +86,7 @@
 	protected_jobs = list("Chief Engineer")
 	altitems = list(/obj/item/photo)
 	location_override = "the Chief Engineer's Office"
+	extra_information = "Stealing a photograph of the item is also an option."
 
 /datum/theft_objective/blueprints/check_special_completion(obj/item/I)
 	if(istype(I, /obj/item/areaeditor/blueprints/ce))


### PR DESCRIPTION

## What Does This PR Do
Theft objectives that accept a photo of an item (currently only being the blueprints) now state that outright
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
As far as I know, the only place mentioning this is the "High-Risk Items" page on the wiki. It's good to explain a mechanic in-game.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


## Testing
Turned myself into a traitor until I rolled blueprints theft. Saw the new message. Did not see the message on any other objective.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Blueprints theft objective now explains that a photo of the blueprints also counts.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
