### PR TITLE
Only small and tiny simplemobs can go on skateboards, shoot people off them [BALANCE PRE APPROVED]

### DIFF
--- a/code/__DEFINES/vehicle_defines.dm
+++ b/code/__DEFINES/vehicle_defines.dm
@@ -24,7 +24,8 @@
 #define RIDER_NEEDS_LEGS   (1<<2)
 /// If the rider is disabled or loses their needed limbs, do they fall off?
 #define UNBUCKLE_DISABLED_RIDER (1<<3)
-
+/// Do we need a carbon, a silicon, or a small mob, to ride the vehicle?
+#define RIDER_CARBON_OR_SILICON_NO_LARGE_MOBS (1<<4)
 
 /// The vehicle being ridden requires pixel offsets for all directions
 #define RIDING_OFFSET_ALL "ALL"

--- a/code/datums/components/riding/riding_vehicle.dm
+++ b/code/datums/components/riding/riding_vehicle.dm
@@ -95,7 +95,7 @@
 
 /datum/component/riding/vehicle/scooter/skateboard
 	vehicle_move_delay = 1.5
-	ride_check_flags = RIDER_NEEDS_LEGS | UNBUCKLE_DISABLED_RIDER
+	ride_check_flags = RIDER_NEEDS_LEGS | UNBUCKLE_DISABLED_RIDER | RIDER_CARBON_OR_SILICON_NO_LARGE_MOBS
 	///If TRUE, the vehicle will be slower (but safer) to ride on walk intent.
 	var/can_slow_down = TRUE
 
@@ -123,23 +123,37 @@
 	if(can_slow_down)
 		RegisterSignal(rider, COMSIG_MOVE_INTENT_TOGGLED, PROC_REF(toggle_move_delay))
 		toggle_move_delay(rider)
+		RegisterSignal(rider, COMSIG_ATOM_BULLET_ACT, PROC_REF(check_knockoff))
 
 /datum/component/riding/vehicle/scooter/skateboard/handle_unbuckle(mob/living/rider)
 	. = ..()
 	if(can_slow_down)
 		toggle_move_delay(rider)
 		UnregisterSignal(rider, COMSIG_MOVE_INTENT_TOGGLED)
+	UnregisterSignal(rider, COMSIG_ATOM_BULLET_ACT)
 
 /datum/component/riding/vehicle/scooter/skateboard/proc/toggle_move_delay(mob/living/rider)
-	SIGNAL_HANDLER //COMSIG_MOVE_INTENT_TOGGLED
+	SIGNAL_HANDLER // COMSIG_MOVE_INTENT_TOGGLED
 	vehicle_move_delay = initial(vehicle_move_delay)
 	if(rider.m_intent == MOVE_INTENT_WALK)
 		vehicle_move_delay += 0.6
 
+/datum/component/riding/vehicle/scooter/skateboard/proc/check_knockoff(datum/source, obj/item/projectile)
+	SIGNAL_HANDLER // COMSIG_ATOM_BULLET_ACT
+	if(!istype(parent, /obj/tgvehicle/scooter/skateboard))
+		return
+	var/obj/tgvehicle/scooter/skateboard/S = parent
+	for(var/mob/living/L in S.return_occupants()) // Only one on a skateboard unless an admin var edits it. If an admin var edits it, that is on them.
+		if((L.staminaloss >= 60 || L.health <= 40) && !L.absorb_stun(0)) // Only injured people can be shot off. Hulks and people on stimulants can not be shot off.
+			S.unbuckle_mob(L)
+			L.KnockDown(2 SECONDS)
+			L.visible_message("<span class='warning'>[L] gets shot off [S] by [projectile]!</span>",
+			"<span class='warning'>You get shot off [S] by [projectile]!</span>")
+
 /datum/component/riding/vehicle/scooter/skateboard/pro
 	vehicle_move_delay = 1
 
-///This one lets the rider ignore gravity, move in zero g and son on, but only on ground turfs or at most one z-level above them.
+/// This one lets the rider ignore gravity, move in zero g and so on, but only on ground turfs or at most one z-level above them.
 /datum/component/riding/vehicle/scooter/skateboard/hover
 	vehicle_move_delay = 1
 	override_allow_spacemove = TRUE

--- a/code/datums/components/riding/riding_vehicle.dm
+++ b/code/datums/components/riding/riding_vehicle.dm
@@ -148,7 +148,7 @@
 			S.unbuckle_mob(L)
 			L.KnockDown(2 SECONDS)
 			L.visible_message("<span class='warning'>[L] gets shot off [S] by [projectile]!</span>",
-			"<span class='warning'>You get shot off [S] by [projectile]!</span>")
+				"<span class='warning'>You get shot off [S] by [projectile]!</span>")
 
 /datum/component/riding/vehicle/scooter/skateboard/pro
 	vehicle_move_delay = 1

--- a/code/datums/elements/ridable.dm
+++ b/code/datums/elements/ridable.dm
@@ -39,11 +39,12 @@
 	return ..()
 
 /// Someone is buckling to this movable, which is literally the only thing we care about (other than speed potions)
-/datum/element/ridable/proc/check_mounting(atom/movable/target_movable, mob/living/potential_rider, force = FALSE, ride_check_flags = NONE)
+/datum/element/ridable/proc/check_mounting(atom/movable/target_movable, mob/living/potential_rider, force = FALSE)
 	SIGNAL_HANDLER //COMSIG_MOVABLE_PREBUCKLE
-	INVOKE_ASYNC(src, PROC_REF(check_mounting_async_edition), target_movable, potential_rider, force, ride_check_flags)
+	var/datum/component/riding/R = riding_component_type
+	return check_mounting_part_two(target_movable, potential_rider, force, R.ride_check_flags)
 
-/datum/element/ridable/proc/check_mounting_async_edition(atom/movable/target_movable, mob/living/potential_rider, force = FALSE, ride_check_flags = NONE)
+/datum/element/ridable/proc/check_mounting_part_two(atom/movable/target_movable, mob/living/potential_rider, force = FALSE, ride_check_flags = NONE)
 	var/arms_needed = 0
 	if(ride_check_flags & RIDER_NEEDS_ARMS)
 		arms_needed = 2
@@ -59,6 +60,10 @@
 	if((ride_check_flags & RIDER_NEEDS_LEGS) && HAS_TRAIT(potential_rider, TRAIT_FLOORED))
 		potential_rider.visible_message("<span class='warning'>[potential_rider] can't get [potential_rider.p_their()] footing on [target_movable]!</span>",
 			"<span class='warning'>You can't get your footing on [target_movable]!</span>")
+		return COMPONENT_BLOCK_BUCKLE
+	if((ride_check_flags & RIDER_CARBON_OR_SILICON_NO_LARGE_MOBS) && !(iscarbon(potential_rider) || issilicon(potential_rider) || potential_rider.mob_size <= MOB_SIZE_SMALL))
+		potential_rider.visible_message("<span class='warning'>[potential_rider] is too big to get [potential_rider.p_their()] footing on [target_movable]!</span>",
+			"<span class='warning'>You are too big to get your footing on [target_movable]!</span>")
 		return COMPONENT_BLOCK_BUCKLE
 
 	var/mob/living/target_living = target_movable

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -52,7 +52,8 @@
 	// 1. This movable doesn't have a ridable element and can't be ridden, so nothing gets returned, so continue on
 	// 2. There's a ridable element but we failed to mount it for whatever reason (maybe it has no seats left, for example), so we cancel the buckling
 	// 3. There's a ridable element and we were successfully able to mount, so keep it going and continue on with buckling
-	if(SEND_SIGNAL(src, COMSIG_MOVABLE_PREBUCKLE, M, force) & COMPONENT_BLOCK_BUCKLE)
+	var/signal_result = SEND_SIGNAL(src, COMSIG_MOVABLE_PREBUCKLE, M, force)
+	if(signal_result & COMPONENT_BLOCK_BUCKLE)
 		return FALSE
 
 	M.buckling = src


### PR DESCRIPTION
Sorry for doing a balance during the freeze already, but I'm not letting this be a complaint for a month. Balance pre approved.


<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Simple mob animals that are normal or larger sized, can not ride skateboards.
The only hostile mob that can ride a skateboard that is a simple mob, is viscerators, and headslugs.
Cyborgs, humans, monkeys, and xenomorphs can still ride them. AI sadly can not.

You can now knock people off skateboards, unbuckling them and knocking them down for 2 seconds, by hitting them with a projectile when they have 60 or more stamina damage, or 60 or more damage. If the user is stun immune (his grace, hulk, stimulants), this will not work

This means skateboards while still effective and high risk, don't let you endlessly evade. Eventually projectiles will catch up to you and get you off it.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Ok, while funny terrors and juggernaughts on skateboard passed the funny balance of say a ambulance, and became a balance nightmare with their speed.
This blocks it for skateboards.
Janitor carts and such unaffected, as they are slower vehicles.

Skateboards were too effective at getaway, this should mean officers can still down those on skateboards one way or another

## Testing
<!-- How did you test the PR, if at all? -->

Shot skrell on skateboards with lethals and non lethals, to see them fall off.

Rode a skateboard as a human.
Rode a skateboard as a xenomorph.
Rode a skateboard as a cyborg.
Rode a skateboard as a bunny (size 0
Rode a skateboard as a fox (size 1)
Failed to ride a skateboard as a spider (size 2)

## Changelog
:cl:
tweak: Normal and large simple animals can no longer ride skateboards.
tweak: A person with 60 or more damage or stamina damage, can be shot off a skateboard.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
