### PR TITLE
Makes the Voyager space ruins reward accessable

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/voyager.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/voyager.dmm
@@ -23,7 +23,7 @@
 "q" = (
 /obj/structure/safe/floor,
 /obj/item/golden_record,
-/turf/simulated/satellite,
+/turf/simulated/wall/satellite,
 /area/template_noop)
 "O" = (
 /obj/structure/target_stake{

--- a/code/modules/ruins/spaceruin_code/voyager.dm
+++ b/code/modules/ruins/spaceruin_code/voyager.dm
@@ -18,7 +18,7 @@
 
 /turf/simulated/wall/satellite
 	name = "satellite components storage"
-	desc = "There is plate covering inside storage, its wide and it have engraved 'Voyager' on it."
+	desc = "There is a large plate covering the internal storage, 'Voyager' is engraved on it."
 	icon = 'icons/turf/shuttle.dmi'
 	icon_state = "wall"
 	smoothing_flags = NONE

--- a/code/modules/ruins/spaceruin_code/voyager.dm
+++ b/code/modules/ruins/spaceruin_code/voyager.dm
@@ -16,7 +16,7 @@
 	. = ..()
 	AddComponent(/datum/component/two_handed, require_twohands = TRUE)
 
-/turf/simulated/satellite
+/turf/simulated/wall/satellite
 	name = "satellite components storage"
 	desc = "There is plate covering inside storage, its wide and it have engraved 'Voyager' on it."
 	icon = 'icons/turf/shuttle.dmi'


### PR DESCRIPTION
## What Does This PR Do
Makes the voyagers satellite components storage a wall subtype so it can be deconstructed and the safe under it can be reached.
Also fixed the spelling on the wall.

## Why It's Good For The Game
Fixes #26023 

## Images of changes
No visual changes to the dmm

## Testing
Tested on localhost, wall was deconstructible and the floor safe could be reached

## Changelog
:cl:
fix: The Voyager space ruin's reward is accessible
spellcheck: Fixed the spelling on Voyager's wall
/:cl: