### PR TITLE
Fixes eyestabbing not dealing a correct amount of damage

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -611,7 +611,7 @@ GLOBAL_DATUM_INIT(welding_sparks, /mutable_appearance, mutable_appearance('icons
 		if(!eyes) // should still get stabbed in the head
 			var/obj/item/organ/external/head/head = H.bodyparts_by_name["head"]
 			if(head)
-				head.receive_damage(rand(10, 14), 1)
+				head.receive_damage(force)
 			return
 		eyes.receive_damage(rand(3,4), 1)
 		if(eyes.damage >= eyes.min_bruised_damage)
@@ -629,10 +629,10 @@ GLOBAL_DATUM_INIT(welding_sparks, /mutable_appearance, mutable_appearance('icons
 				if(M.stat != 2)
 					to_chat(M, "<span class='danger'>You go blind!</span>")
 		var/obj/item/organ/external/affecting = H.get_organ("head")
-		if(istype(affecting) && affecting.receive_damage(7))
+		if(istype(affecting) && affecting.receive_damage(force))
 			H.UpdateDamageIcon()
 	else
-		M.take_organ_damage(7)
+		M.take_organ_damage(force)
 	M.AdjustEyeBlurry(rand(6 SECONDS, 8 SECONDS))
 	return
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -611,7 +611,7 @@ GLOBAL_DATUM_INIT(welding_sparks, /mutable_appearance, mutable_appearance('icons
 		if(!eyes) // should still get stabbed in the head
 			var/obj/item/organ/external/head/head = H.bodyparts_by_name["head"]
 			if(head)
-				head.receive_damage(force)
+				head.receive_damage(force, TRUE)
 			return
 		eyes.receive_damage(rand(3,4), 1)
 		if(eyes.damage >= eyes.min_bruised_damage)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Changes eyestabs from dealing a flat 7 damage to dealing damage based on the force of the object you're stabbing with. Fixes #25161
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Damage should be consistent

## Testing
<!-- How did you test the PR, if at all? -->
Used health scanner to check how much damage each item was dealing
## Changelog
:cl:
fix: Stabbing someone in the eye now deals the correct amount of damage
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
