### PR TITLE
Remove a duplicate TGUI input toggle

### DIFF
--- a/code/modules/client/preference/preferences_toggles.dm
+++ b/code/modules/client/preference/preferences_toggles.dm
@@ -388,16 +388,6 @@
 			usr.set_typing_indicator(FALSE)
 			usr.set_thinking_indicator(FALSE)
 
-/datum/preference_toggle/toggle_tgui_input_lists
-	name = "Toggle TGUI Input"
-	description = "Switches input lists between the TGUI and the standard one"
-	preftoggle_bitflag = PREFTOGGLE_2_DISABLE_TGUI_INPUT
-	preftoggle_toggle = PREFTOGGLE_TOGGLE2
-	preftoggle_category = PREFTOGGLE_CATEGORY_GENERAL
-	enable_message = "You will now use TGUI Input."
-	disable_message = "You will no longer use TGUI Input."
-	blackbox_message = "Toggle TGUI Input"
-
 /datum/preference_toggle/toggle_admin_logs
 	name = "Toggle Admin Log Messages"
 	description = "Disables admin log messages"


### PR DESCRIPTION
## What Does This PR Do
Removes second toggle for TGUI input.

## Why It's Good For The Game
Currently, there are 2 ways to disable TGUI Input:
1. In Game Preferences along with other TGUI Input settings.
2. Using toogle in Genereal Preferences. This is not the most convenient way, which also does not reflect the reality, because in the enabled state it disables TGUI Input, even though it says, "You will now use TGUI Input." and vice versa.

I think it is better to leave only 1 way, which was intended originally, the more obvious and convenient one

## Images of changes
There is only 1
![image](https://github.com/ParadiseSS13/Paradise/assets/69762909/09a0773a-cb12-466c-a41b-63eefb60e5ab)
![image](https://github.com/ParadiseSS13/Paradise/assets/69762909/cb21bbf8-29d3-4a81-8903-6856b1c63466)

## Testing
Run local and watch settings

## Changelog
:cl:
del: Removed Toggle TGUI Input preference into General Preferences tab. A duplicate option to disable TGUI Input
/:cl:
