### PR TITLE
fix: set area poweredness for many ruins.

### DIFF
--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_envy.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_envy.dmm
@@ -11,7 +11,7 @@
 "d" = (
 /obj/effect/spawner/random_spawners/wall_rusted_always,
 /turf/simulated/wall,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/envy)
 "e" = (
 /obj/structure/mirror{
 	broken = 1;
@@ -23,7 +23,7 @@
 /obj/effect/decal/cleanable/blood,
 /obj/item/clothing/head/human_head,
 /turf/simulated/floor/plating,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/envy)
 "f" = (
 /obj/structure/mirror{
 	broken = 1;
@@ -32,7 +32,7 @@
 	pixel_x = 28
 	},
 /turf/simulated/floor/plating/burnt,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/envy)
 "g" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /obj/structure/mirror{
@@ -42,18 +42,18 @@
 	pixel_x = -28
 	},
 /turf/simulated/floor/plating,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/envy)
 "h" = (
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plating,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/envy)
 "i" = (
 /turf/simulated/floor/plating,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/envy)
 "j" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/simulated/floor/plating,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/envy)
 "k" = (
 /obj/structure/mirror{
 	broken = 1;
@@ -63,7 +63,7 @@
 	},
 /obj/item/kitchen/knife/envy,
 /turf/simulated/floor/plating,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/envy)
 "l" = (
 /obj/structure/mirror{
 	broken = 1;
@@ -72,7 +72,7 @@
 	pixel_x = 28
 	},
 /turf/simulated/floor/plating,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/envy)
 "m" = (
 /obj/structure/mirror{
 	broken = 1;
@@ -81,10 +81,10 @@
 	pixel_x = -28
 	},
 /turf/simulated/floor/plating,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/envy)
 "n" = (
 /turf/simulated/floor/plating/damaged,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/envy)
 "o" = (
 /obj/structure/mirror{
 	broken = 1;
@@ -93,16 +93,16 @@
 	pixel_x = -28
 	},
 /turf/simulated/floor/plating/damaged,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/envy)
 "p" = (
 /obj/machinery/door/airlock/hatch,
 /obj/structure/fans/tiny/invisible,
 /turf/simulated/floor/plating,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/envy)
 "q" = (
 /obj/effect/baseturf_helper/lava/mapping_lava,
 /turf/simulated/floor/plating,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/envy)
 "A" = (
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_fountain_hall.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_fountain_hall.dmm
@@ -4,34 +4,34 @@
 /area/template_noop)
 "b" = (
 /turf/simulated/wall/cult,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/fountain_hall)
 "c" = (
 /obj/structure/healingfountain,
 /turf/simulated/floor/engine/cult,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/fountain_hall)
 "d" = (
 /obj/structure/fluff/divine/conduit,
 /turf/simulated/floor/engine/cult,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/fountain_hall)
 "e" = (
 /obj/structure/sacrificealtar,
 /turf/simulated/floor/engine/cult,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/fountain_hall)
 "f" = (
 /turf/simulated/floor/engine/cult,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/fountain_hall)
 "g" = (
 /mob/living/simple_animal/butterfly,
 /turf/simulated/floor/engine/cult,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/fountain_hall)
 "h" = (
 /obj/structure/fans/tiny/invisible,
 /turf/simulated/floor/engine/cult,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/fountain_hall)
 "i" = (
 /obj/effect/baseturf_helper/lava/mapping_lava,
 /turf/simulated/floor/engine/cult,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/fountain_hall)
 
 (1,1,1) = {"
 a

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_pizzaparty.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_pizzaparty.dmm
@@ -11,41 +11,41 @@
 /area/lavaland/surface/outdoors)
 "d" = (
 /turf/simulated/wall,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/pizza_party)
 "e" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/lavaland_air,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/pizza_party)
 "f" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/cups,
 /turf/simulated/floor/wood/lavaland_air,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/pizza_party)
 "g" = (
 /obj/structure/reagent_dispensers/water_cooler/pizzaparty,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/lavaland_air,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/pizza_party)
 "h" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/lavaland_air,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/pizza_party)
 "i" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/lavaland_air,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/pizza_party)
 "j" = (
 /obj/item/food/snacks/mushroompizzaslice,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/lavaland_air,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/pizza_party)
 "k" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/pizzaparty,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/lavaland_air,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/pizza_party)
 "l" = (
 /obj/machinery/light{
 	dir = 4
@@ -55,32 +55,32 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/wood/lavaland_air,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/pizza_party)
 "m" = (
 /obj/item/chair/wood/wings,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/lavaland_air,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/pizza_party)
 "n" = (
 /obj/structure/glowshroom,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/lavaland_air,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/pizza_party)
 "o" = (
 /obj/item/trash/plate,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/lavaland_air,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/pizza_party)
 "p" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/lavaland_air,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/pizza_party)
 "q" = (
 /obj/item/chair/wood/wings,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/lavaland_air,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/pizza_party)
 "r" = (
 /obj/structure/chair/wood/wings,
 /obj/effect/decal/remains/human,
@@ -89,19 +89,19 @@
 	name = "party hat"
 	},
 /turf/simulated/floor/wood/lavaland_air,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/pizza_party)
 "s" = (
 /turf/simulated/floor/wood/lavaland_air,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/pizza_party)
 "t" = (
 /obj/structure/chair/wood/wings,
 /obj/effect/decal/remains/human,
 /turf/simulated/floor/wood/lavaland_air,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/pizza_party)
 "u" = (
 /obj/structure/glowshroom,
 /turf/simulated/floor/wood/lavaland_air,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/pizza_party)
 "v" = (
 /obj/structure/lattice,
 /obj/item/chair/wood/wings,
@@ -111,74 +111,74 @@
 /obj/item/kitchen/utensil/fork,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/lavaland_air,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/pizza_party)
 "x" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/pizzaparty,
 /turf/simulated/floor/wood/lavaland_air,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/pizza_party)
 "y" = (
 /obj/structure/table/wood,
 /obj/item/trash/plate,
 /turf/simulated/floor/wood/lavaland_air,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/pizza_party)
 "z" = (
 /obj/structure/table/wood,
 /obj/structure/glowshroom,
 /obj/item/a_gift,
 /turf/simulated/floor/wood/lavaland_air,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/pizza_party)
 "A" = (
 /obj/structure/table/wood,
 /obj/item/trash/plate,
 /obj/item/kitchen/utensil/fork,
 /turf/simulated/floor/wood/lavaland_air,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/pizza_party)
 "B" = (
 /obj/effect/baseturf_helper/lava/mapping_lava,
 /turf/simulated/floor/wood/lavaland_air,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/pizza_party)
 "C" = (
 /obj/structure/chair/wood/wings{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/lavaland_air,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/pizza_party)
 "D" = (
 /obj/structure/table/wood,
 /obj/item/food/snacks/margheritapizzaslice,
 /obj/item/trash/plate,
 /turf/simulated/floor/wood/lavaland_air,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/pizza_party)
 "E" = (
 /obj/structure/table/wood,
 /obj/item/food/snacks/meatpizzaslice,
 /turf/simulated/floor/wood/lavaland_air,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/pizza_party)
 "F" = (
 /obj/structure/table/wood,
 /obj/item/food/snacks/sliceable/birthdaycake,
 /turf/simulated/floor/wood/lavaland_air,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/pizza_party)
 "G" = (
 /obj/structure/table/wood,
 /turf/simulated/floor/wood/lavaland_air,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/pizza_party)
 "H" = (
 /obj/item/chair/wood/wings,
 /turf/simulated/floor/wood/lavaland_air,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/pizza_party)
 "I" = (
 /obj/item/kitchen/utensil/fork,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/lavaland_air,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/pizza_party)
 "J" = (
 /obj/structure/glowshroom,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/lavaland_air,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/pizza_party)
 "K" = (
 /obj/structure/chair/wood/wings{
 	dir = 1
@@ -186,17 +186,17 @@
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/lavaland_air,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/pizza_party)
 "L" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/lavaland_air,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/pizza_party)
 "M" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/a_gift,
 /turf/simulated/floor/wood/lavaland_air,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/pizza_party)
 "N" = (
 /obj/structure/lattice,
 /obj/effect/decal/cleanable/dirt,
@@ -206,17 +206,17 @@
 /obj/item/kitchen/knife,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/lavaland_air,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/pizza_party)
 "P" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/lavaland_air,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/pizza_party)
 "Q" = (
 /turf/simulated/floor/plating/lavaland_air,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/pizza_party)
 
 (1,1,1) = {"
 a

--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_sloth.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_sloth.dmm
@@ -1,48 +1,48 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/simulated/wall/indestructible/riveted,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/sloth)
 "b" = (
 /turf/simulated/floor/lava/mapping_lava,
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/sloth)
 "c" = (
 /obj/item/paper/fluff/stations/lavaland/sloth/note,
 /turf/simulated/floor/sepia{
 	slowdown = 10
 	},
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/sloth)
 "d" = (
 /turf/simulated/floor/sepia{
 	slowdown = 10
 	},
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/sloth)
 "e" = (
 /obj/machinery/door/airlock/wood,
 /obj/structure/fans/tiny/invisible,
 /turf/simulated/floor/sepia{
 	slowdown = 10
 	},
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/sloth)
 "f" = (
 /obj/structure/table/wood,
 /obj/item/food/snacks/grown/citrus/orange,
 /turf/simulated/floor/sepia{
 	slowdown = 10
 	},
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/sloth)
 "g" = (
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
 /turf/simulated/floor/sepia{
 	slowdown = 10
 	},
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/sloth)
 "h" = (
 /obj/effect/baseturf_helper/lava/mapping_lava,
 /turf/simulated/floor/sepia{
 	slowdown = 10
 	},
-/area/ruin/unpowered/misc_lavaruin)
+/area/ruin/powered/sloth)
 
 (1,1,1) = {"
 a

--- a/_maps/map_files/RandomRuins/SpaceRuins/meatpackers.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/meatpackers.dmm
@@ -139,12 +139,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc/off_station/directional/north{
-	environment_channel = 2;
-	equipment_channel = 0;
-	lighting_channel = 0;
-	locked = 0
-	},
+/obj/machinery/power/apc/off_station/directional/north,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -453,12 +448,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc/off_station/directional/north{
-	equipment_channel = 0;
-	lighting_channel = 0;
-	locked = 0;
-	operating = 0
-	},
+/obj/machinery/power/apc/off_station/directional/north,
 /turf/simulated/floor/carpet,
 /area/ruin/unpowered/BMPship/Fore)
 "bT" = (
@@ -783,11 +773,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc/off_station/directional/north{
-	environment_channel = 0;
-	locked = 0;
-	operating = 0
-	},
+/obj/machinery/power/apc/off_station/directional/north,
 /turf/simulated/floor/plating,
 /area/ruin/unpowered/BMPship/Aft)
 "cV" = (
@@ -1118,10 +1104,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc/off_station/directional/north{
-	locked = 0;
-	operating = 0
-	},
+/obj/machinery/power/apc/off_station/directional/north,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},

--- a/_maps/map_files/RandomRuins/SpaceRuins/syndicatedruglab.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/syndicatedruglab.dmm
@@ -59,7 +59,9 @@
 /turf/simulated/floor/pod/dark,
 /area/ruin/space/syndicate_druglab)
 "mA" = (
-/obj/machinery/power/apc/syndicate/directional/east,
+/obj/machinery/power/apc/syndicate/directional/east{
+	cell_type = 10000
+	},
 /turf/simulated/floor/plating,
 /area/ruin/space/syndicate_druglab)
 "mO" = (

--- a/_maps/map_files/RandomRuins/SpaceRuins/syndicatedruglab.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/syndicatedruglab.dmm
@@ -59,7 +59,7 @@
 /turf/simulated/floor/pod/dark,
 /area/ruin/space/syndicate_druglab)
 "mA" = (
-/obj/machinery/power/apc/syndicate/off/directional/east,
+/obj/machinery/power/apc/syndicate/directional/east,
 /turf/simulated/floor/plating,
 /area/ruin/space/syndicate_druglab)
 "mO" = (

--- a/_maps/map_files/RandomRuins/SpaceRuins/wizardcrash.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/wizardcrash.dmm
@@ -4,10 +4,10 @@
 /area/template_noop)
 "ab" = (
 /turf/simulated/floor/plating/asteroid/airless,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "ac" = (
 /turf/simulated/mineral,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "ad" = (
 /obj/structure/grille/broken,
 /obj/item/shard{
@@ -16,53 +16,53 @@
 /turf/simulated/floor/wood{
 	icon_state = "wood-broken3"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "ae" = (
 /turf/simulated/wall/mineral/titanium/nodecon/wizard,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "af" = (
 /obj/structure/computerframe,
 /turf/simulated/floor/wood{
 	icon_state = "wood-broken3"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "ag" = (
 /turf/simulated/floor/wood{
 	icon_state = "wood-broken7"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "ah" = (
 /obj/structure/grille/broken,
 /obj/item/shard,
 /turf/simulated/floor/wood{
 	icon_state = "wood-broken3"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "ai" = (
 /turf/simulated/floor/wood{
 	broken = 1;
 	icon_state = "wood-broken"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "aj" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
 /turf/simulated/floor/wood,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "ak" = (
 /obj/item/shard,
 /turf/simulated/floor/wood,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "al" = (
 /obj/effect/spawner/window/shuttle,
 /turf/simulated/floor/plating/airless,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "am" = (
 /obj/structure/table/wood,
 /obj/item/dice/d20,
 /turf/simulated/floor/wood,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "an" = (
 /obj/item/shard{
 	icon_state = "medium"
@@ -71,7 +71,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/wood,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "ao" = (
 /obj/item/flag/wiz,
 /obj/machinery/light{
@@ -79,15 +79,15 @@
 	in_use = 1
 	},
 /turf/simulated/floor/wood,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "ap" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/wood,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "aq" = (
 /obj/item/clothing/suit/wizrobe,
 /turf/simulated/floor/wood,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "ar" = (
 /obj/item/flag/wiz,
 /obj/machinery/light{
@@ -97,94 +97,94 @@
 /turf/simulated/floor/wood{
 	icon_state = "wood-broken3"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "as" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /turf/simulated/floor/carpet,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "at" = (
 /obj/item/bedsheet/wiz,
 /obj/structure/bed,
 /turf/simulated/floor/carpet,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "au" = (
 /obj/structure/table/wood,
 /obj/item/pen,
 /obj/item/paper/fluff/ruins/wizardcrash,
 /turf/simulated/floor/wood,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "av" = (
 /obj/structure/chair/wood{
 	dir = 8
 	},
 /turf/simulated/floor/wood,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "aw" = (
 /obj/item/shard{
 	icon_state = "small"
 	},
 /turf/simulated/floor/wood,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "ax" = (
 /turf/simulated/floor/wood{
 	icon_state = "wood-broken3"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "ay" = (
 /obj/effect/decal/remains/robot,
 /obj/item/clothing/head/wizard,
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/wood,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "az" = (
 /obj/item/spellbook/oneuse/emp/used,
 /turf/simulated/floor/wood,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "aA" = (
 /turf/simulated/floor/wood{
 	icon_state = "wood-broken6"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "aB" = (
 /turf/simulated/floor/carpet,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "aC" = (
 /turf/simulated/floor/wood,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "aD" = (
 /obj/structure/closet/cabinet,
 /obj/item/storage/backpack/satchel,
 /obj/item/lighter/zippo,
 /turf/simulated/floor/carpet,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "aE" = (
 /obj/structure/bookcase,
 /obj/item/book/codex_gigas,
 /obj/item/book/manual/hydroponics_pod_people,
 /turf/simulated/floor/wood,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "aG" = (
 /obj/structure/table/wood,
 /obj/item/candle/eternal,
 /turf/simulated/floor/wood,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "aH" = (
 /obj/structure/chair/wood{
 	dir = 4
 	},
 /turf/simulated/floor/carpet,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "aI" = (
 /obj/structure/table/wood,
 /obj/item/toy/character/wizard,
 /turf/simulated/floor/carpet,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "aJ" = (
 /obj/structure/cult/pylon,
 /turf/simulated/floor/wood,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "aK" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -194,24 +194,24 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "aL" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "aM" = (
 /obj/machinery/door/airlock/external,
 /turf/space,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "aN" = (
 /obj/structure/bookcase,
 /obj/item/book/manual/barman_recipes,
 /obj/item/book/manual/wiki/hacking,
 /turf/simulated/floor/wood,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "aO" = (
 /obj/item/storage/bag/books{
 	pixel_y = 4;
@@ -223,149 +223,149 @@
 	pixel_y = 4
 	},
 /turf/simulated/floor/wood,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "aP" = (
 /obj/item/reagent_containers/drinks/oilcan,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "aQ" = (
 /obj/machinery/recharge_station,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "aR" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/simulated/floor/wood,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "aS" = (
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "aT" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /obj/structure/reagent_dispensers/oil,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "aU" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/wood,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "aV" = (
 /obj/item/flag/wiz,
 /turf/simulated/floor/wood,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "aW" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/wood{
 	icon_state = "wood-broken6"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "aY" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "aZ" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "ba" = (
 /obj/structure/kitchenspike,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "chapel"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "bb" = (
 /obj/structure/chair/comfy/shuttle,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "chapel"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "bc" = (
 /obj/effect/decal/remains/human,
 /obj/item/food/snacks/meat/monkey,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "bd" = (
 /obj/structure/showcase,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "chapel"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "be" = (
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/blood/old,
 /turf/simulated/floor/wood,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "bf" = (
 /obj/item/shard{
 	icon_state = "medium"
 	},
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "bg" = (
 /obj/item/food/snacks/meat/monkey,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "bh" = (
 /obj/machinery/door/window{
 	dir = 4
 	},
 /turf/simulated/floor/wood,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "bi" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "chapel"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "bj" = (
 /obj/item/food/snacks/meat/human,
 /obj/effect/decal/cleanable/blood/old,
 /turf/simulated/floor/plasteel{
 	icon_state = "chapel"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "bk" = (
 /obj/structure/rack,
 /turf/simulated/floor/plasteel{
 	icon_state = "chapel"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "bl" = (
 /mob/living/simple_animal/hostile/creature{
 	health = 150;
 	name = "Experiment 17e"
 	},
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "bm" = (
 /obj/item/shard{
 	icon_state = "medium"
 	},
 /turf/simulated/floor/wood,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "bn" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "chapel"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "bo" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "chapel"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "bp" = (
 /obj/structure/rack,
 /obj/item/staff,
@@ -373,66 +373,66 @@
 	dir = 4;
 	icon_state = "chapel"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "bq" = (
 /obj/effect/decal/remains/human,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "bs" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "chapel"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "bt" = (
 /obj/structure/showcase,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "chapel"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "bu" = (
 /obj/structure/rack,
 /obj/item/staff/broom,
 /turf/simulated/floor/plasteel{
 	icon_state = "chapel"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "bv" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /turf/simulated/floor/wood,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "bw" = (
 /obj/item/storage/toolbox/electrical,
 /obj/structure/table,
 /obj/item/clothing/gloves/color/yellow,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "bx" = (
 /turf/simulated/floor/mineral/plasma,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "by" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/simulated/floor/mineral/plasma,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "bz" = (
 /mob/living/simple_animal/hostile/mimic/crate,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "bA" = (
 /obj/structure/table,
 /obj/item/wrench,
 /obj/item/weldingtool,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "bB" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/structure/window/plasmareinforced,
 /turf/simulated/floor/mineral/plasma,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "bC" = (
 /obj/structure/rack,
 /obj/item/kitchen/knife/ritual,
@@ -444,18 +444,18 @@
 	dir = 4;
 	icon_state = "chapel"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "bD" = (
 /obj/machinery/atmospherics/portable/canister/air,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "bE" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "chapel"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "bF" = (
 /obj/structure/shuttle/engine/heater,
 /obj/structure/window/reinforced{
@@ -463,60 +463,60 @@
 	layer = 2.9
 	},
 /turf/simulated/floor/plating/airless,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "bG" = (
 /obj/structure/shuttle/engine/propulsion,
 /turf/simulated/floor/plating/airless,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "bH" = (
 /turf/simulated/wall/mineral/titanium/nodecon/wizard,
 /area/space/nearstation)
 "bI" = (
 /obj/structure/window/plasmareinforced,
 /turf/simulated/floor/mineral/plasma,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "bJ" = (
 /obj/structure/window/plasmareinforced{
 	dir = 4
 	},
 /turf/simulated/floor/mineral/plasma,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "bK" = (
 /obj/singularity/onetile,
 /turf/space,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "bL" = (
 /obj/structure/window/plasmareinforced{
 	dir = 8
 	},
 /turf/simulated/floor/mineral/plasma,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "bM" = (
 /obj/structure/window/plasmareinforced{
 	dir = 1
 	},
 /turf/simulated/floor/mineral/plasma,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "bN" = (
 /obj/structure/closet/crate{
 	opened = 1
 	},
 /obj/effect/spawner/lootdrop/wizardcrash,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "bP" = (
 /obj/item/stack/sheet/mineral/plasma,
 /obj/item/stack/sheet/mineral/plasma,
 /obj/structure/table,
 /turf/simulated/floor/plating,
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 "YM" = (
 /obj/structure/table/wood,
 /obj/item/blank_tarot_card,
 /turf/simulated/floor/wood{
 	icon_state = "wood-broken6"
 	},
-/area/ruin/space/unpowered)
+/area/ruin/space/powered)
 
 (1,1,1) = {"
 aa

--- a/code/game/area/areas/ruins/lavaland_areas.dm
+++ b/code/game/area/areas/ruins/lavaland_areas.dm
@@ -24,6 +24,18 @@
 /area/ruin/powered/greed
 	icon_state = "yellow"
 
+/area/ruin/powered/envy
+	icon_state = "yellow"
+
+/area/ruin/powered/sloth
+	icon_state = "yellow"
+
+/area/ruin/powered/fountain_hall
+	icon_state = "yellow"
+
+/area/ruin/powered/pizza_party
+	icon_state = "yellow"
+
 /area/ruin/unpowered/hierophant
 	name = "Hierophant's Arena"
 	icon_state = "yellow"

--- a/code/modules/awaymissions/mission_code/ruins/oldstation.dm
+++ b/code/modules/awaymissions/mission_code/ruins/oldstation.dm
@@ -510,3 +510,4 @@
 /area/ruin/ancientstation/hivebot
 	name = "Hivebot Mothership"
 	icon_state = "teleporter"
+	requires_power = FALSE


### PR DESCRIPTION
## What Does This PR Do
This PR migrates many Lavaland ruins to powered areas, as well as the wizard crash space ruin, and sets the Meatpackers APCs to be active. Fixes #26068.
## Why It's Good For The Game
All of these ruins should be powered, and acted as such, even though they weren't, until #25642. Meatpackers already had a powernet but for some reason its APCs were unlocked and off, which doesn't make any sense considering they should be on for the ship defenses to operate.
## Images of changes
![2024_07_01__05_27_16__Paradise Station 13](https://github.com/ParadiseSS13/Paradise/assets/59303604/498dc650-f211-42ae-9ec7-3907b55993e5)
![2024_07_01__05_27_23__Paradise Station 13](https://github.com/ParadiseSS13/Paradise/assets/59303604/50c21cde-faf1-467f-a59c-0e81627c2d8e)
![2024_07_01__05_32_34__Paradise Station 13](https://github.com/ParadiseSS13/Paradise/assets/59303604/220f8b6a-a421-406b-b51f-fd3de1c03484)
![2024_07_01__05_33_53__Greenshot](https://github.com/ParadiseSS13/Paradise/assets/59303604/8b451a90-494b-45e9-90d5-13cc47f670e1)
![2024_07_01__05_34_47__Paradise Station 13](https://github.com/ParadiseSS13/Paradise/assets/59303604/4f8aa2da-0b64-4549-ac52-2bdd00dcb8b3)


## Testing
Spawned in, visited relevant ruins to ensure they were powered.
## Changelog
:cl:
fix: Several ruins on Lavaland are properly powered again.
fix: The Wizard shuttle crash and Meatpackers space ruins are properly powered.
/:cl: