### PR TITLE
Fixes phasing through the skateboard

### DIFF
--- a/code/modules/vehicle/tg_vehicles/tg_vehicle_actions.dm
+++ b/code/modules/vehicle/tg_vehicles/tg_vehicle_actions.dm
@@ -239,7 +239,11 @@
 	var/old_v_pass = vehicle.pass_flags
 	rider.pass_flags |= PASSTABLE | PASSFENCE
 	vehicle.pass_flags |= PASSTABLE | PASSFENCE
-
+	for(var/mob/living/buckled_mob as anything in vehicle.buckled_mobs) //In the event the board doesn't move, we need to refresh the pixel_y
+		if(buckled_mob.get_num_legs() > 0)
+			buckled_mob.pixel_y = 5
+		else
+			buckled_mob.pixel_y = -4
 	rider.Move(landing_turf, vehicle_target.dir)
 	rider.pass_flags = old_pass
 	vehicle.pass_flags = old_v_pass


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Fixes #26103
Updates pixel y on ollie, for the cases when someone does not move, causing the game to animate their pixel y through the skateboard

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Misaligned pixel y bad

## Testing
<!-- How did you test the PR, if at all? -->

Did ollies, looked normal.
Did walk intent ollies into a wall, looked normal

## Changelog
:cl:
fix: Fixes phasing through the skateboard
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
