### PR TITLE
[FIX] You can now throw chem grenades (And some other things) further than 1 tile again

### DIFF
--- a/code/game/objects/effects/effect_system/effects_water.dm
+++ b/code/game/objects/effects/effect_system/effects_water.dm
@@ -14,7 +14,7 @@
 		return 0
 	if(newloc.density)
 		return 0
-	.=..()
+	. = ..()
 
 /obj/effect/particle_effect/water/Bump(atom/A)
 	if(reagents)

--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -234,7 +234,7 @@
 		nadeassembly.HasProximity(AM)
 
 /obj/item/grenade/chem_grenade/Move() // prox sensors and infrared care about this
-	..()
+	. = ..()
 	if(nadeassembly)
 		nadeassembly.process_movement()
 

--- a/code/game/objects/items/weapons/tanks/watertank.dm
+++ b/code/game/objects/items/weapons/tanks/watertank.dm
@@ -255,7 +255,7 @@
 	return ..()
 
 /obj/item/extinguisher/mini/nozzle/Move()
-	. = ..()
+	..()
 	if(tank && loc != tank.loc)
 		forceMove(tank)
 

--- a/code/game/objects/items/weapons/tanks/watertank.dm
+++ b/code/game/objects/items/weapons/tanks/watertank.dm
@@ -152,7 +152,7 @@
 		return TRUE
 
 /obj/item/reagent_containers/spray/mister/Move()
-	. = ..()
+	..()
 	if(loc != tank.loc)
 		loc = tank.loc
 

--- a/code/game/objects/items/weapons/tanks/watertank.dm
+++ b/code/game/objects/items/weapons/tanks/watertank.dm
@@ -152,7 +152,7 @@
 		return TRUE
 
 /obj/item/reagent_containers/spray/mister/Move()
-	..()
+	. = ..()
 	if(loc != tank.loc)
 		loc = tank.loc
 
@@ -255,7 +255,7 @@
 	return ..()
 
 /obj/item/extinguisher/mini/nozzle/Move()
-	..()
+	. = ..()
 	if(tank && loc != tank.loc)
 		forceMove(tank)
 

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -33,7 +33,7 @@
 		qdel(src)
 
 /obj/structure/chair/Move(atom/newloc, direct)
-	..()
+	. = ..()
 	handle_rotation()
 
 /obj/structure/chair/attackby(obj/item/W as obj, mob/user as mob, params)

--- a/code/modules/assembly/proximity.dm
+++ b/code/modules/assembly/proximity.dm
@@ -91,7 +91,7 @@
 		holder.update_icon()
 
 /obj/item/assembly/prox_sensor/Move()
-	..()
+	. = ..()
 	sense()
 
 /obj/item/assembly/prox_sensor/holder_movement()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes a bug where you cannot throw certain items (Chemical grenades, proximity sensor, office chair)

Fixes: #26098
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Being unable to throw stuff far, ESPECIALLY an armed grenade is an issue for obvious reasons.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Throw a cleaning grenade.
It actually flies more than 1 tile.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Chemical grenades, and a couple of other items can be thrown further than 1 tile again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
