### PR TITLE
Shoving someone into a vendor now informs people around them.

### DIFF
--- a/code/game/machinery/vendors/vending.dm
+++ b/code/game/machinery/vendors/vending.dm
@@ -980,14 +980,14 @@
 	if(!HAS_TRAIT(attacker, TRAIT_PACIFISM))
 		add_attack_logs(attacker, target, "shoved into a vending machine ([src])")
 		tilt(target, from_combat = TRUE)
-		target.visible_message("<span class='warning'>[attacker] slams [target] into [src]!</span>", \
+		target.visible_message("<span class='danger'>[attacker] slams [target] into [src]!</span>", \
 								"<span class='userdanger'>You get slammed into [src] by [attacker]!</span>", \
-								"You hear a loud crunch.")
+								"<span class='danger'>You hear a loud crunch.</span>")
 	else if(HAS_TRAIT_FROM(attacker, TRAIT_PACIFISM, GHOST_ROLE))  // should only apply to the ghost bar
 		add_attack_logs(attacker, target, "shoved into a vending machine ([src]), but flattened themselves.")
 		tilt(attacker, crit = TRUE, from_anywhere = TRUE) // get fucked
 		target.visible_message("<span class='warning'>[attacker] tries to slam [target] into [src], but falls face first into [src]!</span>", \
-								"<span class='userdanger'>You get pushed into [src] by [attacker], but narrowly move out of the way as it tips over ontop of [attacker]!</span>", \
+								"<span class='userdanger'>You get pushed into [src] by [attacker], but narrowly move out of the way as it tips over on top of [attacker]!</span>", \
 								"You hear a loud crunch.")
 	else
 		attacker.visible_message("<span class='notice'>[attacker] lightly presses [target] against [src].</span>", "<span class='warning'>You lightly press [target] against [src], you don't want to hurt [target.p_them()]!</span>")

--- a/code/game/machinery/vendors/vending.dm
+++ b/code/game/machinery/vendors/vending.dm
@@ -980,9 +980,15 @@
 	if(!HAS_TRAIT(attacker, TRAIT_PACIFISM))
 		add_attack_logs(attacker, target, "shoved into a vending machine ([src])")
 		tilt(target, from_combat = TRUE)
+		target.visible_message("<span class='warning'>[attacker] slams [target] into [src]!</span>", \
+								"<span class='userdanger'>You get slammed into [src] by [attacker]!</span>", \
+								"You hear a loud crunch.")
 	else if(HAS_TRAIT_FROM(attacker, TRAIT_PACIFISM, GHOST_ROLE))  // should only apply to the ghost bar
 		add_attack_logs(attacker, target, "shoved into a vending machine ([src]), but flattened themselves.")
 		tilt(attacker, crit = TRUE, from_anywhere = TRUE) // get fucked
+		target.visible_message("<span class='warning'>[attacker] tries to slam [target] into [src], but falls face first into [src]!</span>", \
+								"<span class='userdanger'>You get pushed into [src] by [attacker], but narrowly move out of the way as it tips over ontop of [attacker]!</span>", \
+								"You hear a loud crunch.")
 	else
 		attacker.visible_message("<span class='notice'>[attacker] lightly presses [target] against [src].</span>", "<span class='warning'>You lightly press [target] against [src], you don't want to hurt [target.p_them()]!</span>")
 	return TRUE

--- a/code/game/machinery/vendors/vending.dm
+++ b/code/game/machinery/vendors/vending.dm
@@ -988,7 +988,7 @@
 		tilt(attacker, crit = TRUE, from_anywhere = TRUE) // get fucked
 		target.visible_message("<span class='warning'>[attacker] tries to slam [target] into [src], but falls face first into [src]!</span>", \
 								"<span class='userdanger'>You get pushed into [src] by [attacker], but narrowly move out of the way as it tips over on top of [attacker]!</span>", \
-								"You hear a loud crunch.")
+								"<span class='danger'>You hear a loud crunch.</span>")
 	else
 		attacker.visible_message("<span class='notice'>[attacker] lightly presses [target] against [src].</span>", "<span class='warning'>You lightly press [target] against [src], you don't want to hurt [target.p_them()]!</span>")
 	return TRUE


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Fixes #26072

Shoving someone into a vendor now informs people around them who shoved the poor sucker.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Fixes an oversight.

On late arrival station traits, shove spamming is an issue, you can tell who shoves who into a wall but... not into a vendor meaning that the crime is often let go. People scrambling out of the shuttle like that and shoving one another sporadically like maniacs is... not good.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
N/A

## Testing
<!-- How did you test the PR, if at all? -->
There was a lot of moth-on-moth violence. I shoved a moth into a vendor! And another! And another!

## Changelog
:cl:
fix: Fixed vendors not announcing who shoved who into them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
