### PR TITLE
[FIX] You can throw stuff over tables again.

### DIFF
--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -140,7 +140,7 @@
 	base_icon_state = "sandbags"
 	max_integrity = 280
 	proj_pass_rate = 20
-	pass_flags = LETPASSTHROW
+	pass_flags_self = LETPASSTHROW
 	bar_material = SAND
 	climbable = TRUE
 	smoothing_flags = SMOOTH_BITMASK

--- a/code/game/objects/items/sport.dm
+++ b/code/game/objects/items/sport.dm
@@ -67,7 +67,7 @@
 	icon_state = "hoop"
 	anchored = TRUE
 	density = TRUE
-	pass_flags = LETPASSTHROW
+	pass_flags_self = LETPASSTHROW
 
 /obj/structure/holohoop/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/grab) && get_dist(src, user) <= 1)

--- a/code/game/objects/structures/holosigns.dm
+++ b/code/game/objects/structures/holosigns.dm
@@ -52,7 +52,7 @@
 	name = "holo barrier"
 	desc = "A short holographic barrier which can only be passed by walking."
 	icon_state = "holosign_sec"
-	pass_flags = LETPASSTHROW
+	pass_flags_self = LETPASSTHROW
 	density = TRUE
 	max_integrity = 20
 	var/allow_walk = TRUE //can we pass through it on walk intent

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -255,7 +255,7 @@
 	layer = 2.0
 	var/obj/structure/morgue/connected = null
 	anchored = TRUE
-	pass_flags = LETPASSTHROW
+	pass_flags_self = LETPASSTHROW
 	max_integrity = 350
 
 /obj/structure/m_tray/attack_hand(mob/user as mob)
@@ -552,7 +552,7 @@ GLOBAL_LIST_EMPTY(crematoriums)
 	layer = 2.0
 	var/obj/structure/crematorium/connected = null
 	anchored = TRUE
-	pass_flags = LETPASSTHROW
+	pass_flags_self = LETPASSTHROW
 
 /obj/structure/c_tray/attack_hand(mob/user as mob)
 	if(connected)

--- a/code/game/objects/structures/railings.dm
+++ b/code/game/objects/structures/railings.dm
@@ -5,7 +5,7 @@
 	icon_state = "railing"
 	density = TRUE
 	anchored = TRUE
-	pass_flags = LETPASSTHROW
+	pass_flags_self = LETPASSTHROW
 	climbable = TRUE
 	layer = ABOVE_MOB_LAYER
 	flags = ON_BORDER

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -21,7 +21,7 @@
 	density = TRUE
 	anchored = TRUE
 	layer = TABLE_LAYER
-	pass_flags = LETPASSTHROW
+	pass_flags_self = LETPASSTHROW
 	climbable = TRUE
 	max_integrity = 100
 	integrity_failure = 30
@@ -862,7 +862,7 @@
 	layer = TABLE_LAYER
 	density = TRUE
 	anchored = TRUE
-	pass_flags = LETPASSTHROW
+	pass_flags_self = LETPASSTHROW
 	max_integrity = 20
 
 /obj/structure/rack/examine(mob/user)

--- a/code/modules/fish/fishtank.dm
+++ b/code/modules/fish/fishtank.dm
@@ -35,8 +35,8 @@
 	icon_state = "bowl1"
 	density = FALSE				// Small enough to not block stuff
 	anchored = FALSE			// Small enough to move even when filled
-	pass_flags = PASSTABLE | LETPASSTHROW // Just like at the county fair, you can't seem to throw the ball in to win the goldfish, and it's small enough to pull onto a table
-
+	pass_flags_self = LETPASSTHROW // Just like at the county fair, you can't seem to throw the ball in to win the goldfish, and it's small enough to pull onto a table
+	pass_flags = PASSTABLE
 	tank_type = "bowl"
 	water_capacity = 50			// Not very big, therefore it can't hold much
 	max_fish = 1				// What a lonely fish
@@ -52,7 +52,7 @@
 	icon_state = "tank1"
 	density = TRUE
 	anchored = TRUE
-	pass_flags = LETPASSTHROW
+	pass_flags = null
 
 	tank_type = "tank"
 	water_capacity = 200		// Decent sized, holds almost 2 full buckets


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
It is once again possible to throw stuff over tables (And a couple of other things, like fishbowls, railings and sandbags.)

Fixes: #26092

PS: As a more general statement, we should probably take a look at the pass_flags_self, and pass_flags variables. Currently *everything* uses pass_flags, rather than pass_flags_self, even though the latter may be more appropriate in certain circumstances. However, tables and such are the most immediately affected by this, and pose a rather significan issue in-game.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
You should be able to throw stuff over tables. And railings. And fishbowls.
C'mon man, your throws can't be THAT weak, can they?
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
I threw something over a table. And a fishbowl.
But not a fish tank.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Things can be thrown over tables again!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
