### PR TITLE
Fixes runtime with ridable element and adds unit test for bespoke elements

### DIFF
--- a/code/datums/elements/ridable.dm
+++ b/code/datums/elements/ridable.dm
@@ -8,7 +8,7 @@
  */
 /datum/element/ridable
 	element_flags = ELEMENT_BESPOKE
-
+	id_arg_index = 2
 	/// The specific riding component subtype we're loading our instructions from, don't leave this as default please!
 	var/riding_component_type = /datum/component/riding
 	/// If we have a xenobio red potion applied to us, we get split off so we can pass our special status onto new riding components

--- a/code/datums/elements/shatters_when_thrown.dm
+++ b/code/datums/elements/shatters_when_thrown.dm
@@ -3,7 +3,7 @@
  */
 /datum/element/shatters_when_thrown
 	element_flags = ELEMENT_BESPOKE
-
+	id_arg_index = 2
 	/// What type of item is spawned as a 'shard' once the shattering happens
 	var/obj/item/shard_type
 	/// How many shards total are made when the thing we're attached to shatters

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -11,6 +11,7 @@
 #include "component_tests.dm"
 #include "config_sanity.dm"
 #include "crafting_lists.dm"
+#include "element_tests.dm"
 #include "emotes.dm"
 #include "init_sanity.dm"
 #include "log_format.dm"

--- a/code/modules/unit_tests/element_tests.dm
+++ b/code/modules/unit_tests/element_tests.dm
@@ -1,0 +1,5 @@
+/datum/unit_test/bespoke_element/Run()
+	for(var/E in subtypesof(/datum/element))
+		var/datum/element/element_type = E
+		if(initial(element_type.element_flags) & ELEMENT_BESPOKE && initial(element_type.id_arg_index) == INFINITY)
+			Fail("Element type [element_type] has ELEMENT_BESPOKE and a default id_arg_index.")

--- a/code/modules/unit_tests/element_tests.dm
+++ b/code/modules/unit_tests/element_tests.dm
@@ -1,5 +1,4 @@
 /datum/unit_test/bespoke_element/Run()
-	for(var/E in subtypesof(/datum/element))
-		var/datum/element/element_type = E
+	for(var/datum/element/element_type as anything in subtypesof(/datum/element))
 		if(initial(element_type.element_flags) & ELEMENT_BESPOKE && initial(element_type.id_arg_index) == INFINITY)
 			Fail("Element type [element_type] has ELEMENT_BESPOKE and a default id_arg_index.")


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
See title. 
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
![image](https://github.com/ParadiseSS13/Paradise/assets/98280110/c0056a7e-a2ad-48fb-99cb-5c9a7ab6c9bb)
If `id_arg_index` is not overridden on elements with the `ELEMENT_BESPOKE` flag, the id generation proc will attempt to index its argument list at `INFINITY`. This is not good!
## Testing
<!-- How did you test the PR, if at all? -->
Added the unit test, watched `ridable` and `shatters_when_thrown` fail the test. Fixed them, saw both elements pass the unit test.


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
