### PR TITLE
Fruit Salad Snowcone Tweak

### DIFF
--- a/code/modules/food_and_drinks/recipes/recipes_microwave.dm
+++ b/code/modules/food_and_drinks/recipes/recipes_microwave.dm
@@ -1297,8 +1297,8 @@
 	)
 	result = /obj/item/food/snacks/frozen/snowcone
 
-/datum/recipe/microwave/snowcone/fruitsalad
-	reagents = list("ice" = 15, "orangejuice" = 5, "limejuice" = 5, "lemonjuice" = 5)
+/datum/recipe/microwave/fruitsalad
+	reagents = list("ice" = 15, "watermelonjuice" = 5, "berryjuice" = 5, "lemonjuice" = 5)
 	items = list(
 		/obj/item/reagent_containers/drinks/sillycup
 	)

--- a/code/modules/food_and_drinks/recipes/recipes_microwave.dm
+++ b/code/modules/food_and_drinks/recipes/recipes_microwave.dm
@@ -1298,7 +1298,7 @@
 	result = /obj/item/food/snacks/frozen/snowcone
 
 /datum/recipe/microwave/fruitsalad
-	reagents = list("ice" = 15, "watermelonjuice" = 5, "berryjuice" = 5, "lemonjuice" = 5)
+	reagents = list("ice" = 15, "banana" = 5, "orangejuice" = 5, "watermelonjuice" = 5)
 	items = list(
 		/obj/item/reagent_containers/drinks/sillycup
 	)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #24772

## Why It's Good For The Game
minor tweak to make reagents not mix before adding to the microwave. (from Lemon, lime, and orange juice to banana,orange,and watermelon juice)
New reagents maintain color scheme of snowcone of "yellow > Orange > green" and also stay within the fruit theme.
(YES GREEN FOR WATERMELON IS AN ACCEPTABLE COLOR, SUE ME)

## Testing
made some snowcones

## Changelog
:cl:
tweak: Tweaked fruitsalad recipe
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
