### PR TITLE
fix: Cleans up lighter code a tiny bit and fixes colored lighters becoming green

### DIFF
--- a/code/game/objects/items/weapons/lighters.dm
+++ b/code/game/objects/items/weapons/lighters.dm
@@ -5,7 +5,6 @@
 	icon = 'icons/obj/lighter.dmi'
 	lefthand_file = 'icons/mob/inhands/lighter_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/lighter_righthand.dmi'
-	base_icon_state = "lighter"
 	icon_state = "lighter-g"
 	item_state = "lighter-g"
 	w_class = WEIGHT_CLASS_TINY
@@ -19,14 +18,16 @@
 	var/next_on_message
 	/// Cooldown until the next turned off message/sound can be activated
 	var/next_off_message
-	/// Our base state for the lighter.
-	var/base_item_state = "lighter"
+	/// Our base state for the lighter. This is for random color lighters
+	var/base_item_state = null
 	/// Our lighter color suffix. => [base_icon_state]-[lightercolor] => lighter-r
-	var/lighter_color = "g"
+	var/lighter_color = null
 
 /obj/item/lighter/random/Initialize(mapload)
 	. = ..()
 	lighter_color = pick("r","c","y","g")
+	base_icon_state = "lighter"
+	base_item_state = "lighter"
 	update_icon_state()
 	update_overlays()
 
@@ -124,10 +125,10 @@
 	return
 
 /obj/item/lighter/update_icon_state()
-	icon_state = "[base_icon_state]-[lighter_color][lit ? "-on" : ""]"
+	icon_state = "[base_icon_state ? "[base_icon_state]" : initial(icon_state)][lighter_color ? "-[lighter_color]" : ""][lit ? "-on" : ""]"
 
 /obj/item/lighter/update_overlays()
-	item_state = "[base_item_state]-[lighter_color][lit ? "-on" : ""]"
+	item_state = "[base_item_state ? "[base_item_state]" : initial(item_state)][lighter_color ? "-[lighter_color]" : ""][lit ? "-on" : ""]"
 
 /obj/item/lighter/get_heat()
 	return lit * 1500

--- a/code/game/objects/items/weapons/lighters.dm
+++ b/code/game/objects/items/weapons/lighters.dm
@@ -5,6 +5,7 @@
 	icon = 'icons/obj/lighter.dmi'
 	lefthand_file = 'icons/mob/inhands/lighter_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/lighter_righthand.dmi'
+	base_icon_state = "lighter"
 	icon_state = "lighter-g"
 	item_state = "lighter-g"
 	w_class = WEIGHT_CLASS_TINY
@@ -18,16 +19,16 @@
 	var/next_on_message
 	/// Cooldown until the next turned off message/sound can be activated
 	var/next_off_message
-
-/obj/item/lighter/random
-	/// Random color that is assigned whenever we initialize a new random color lighter.
-	var/random_color = "g"
+	/// Our base state for the lighter.
+	var/base_item_state = "lighter"
+	/// Our lighter color suffix. => [base_icon_state]-[lightercolor] => lighter-r
+	var/lighter_color = "g"
 
 /obj/item/lighter/random/Initialize(mapload)
-	..()
-	random_color = pick("r","c","y","g")
-	icon_state = "lighter-[random_color]"
-	item_state = "lighter-[random_color]"
+	. = ..()
+	lighter_color = pick("r","c","y","g")
+	update_icon_state()
+	update_overlays()
 
 /obj/item/lighter/attack_self(mob/living/user)
 	. = ..()
@@ -123,16 +124,10 @@
 	return
 
 /obj/item/lighter/update_icon_state()
-	icon_state = "[initial(icon_state)][lit ? "-on" : ""]"
+	icon_state = "[base_icon_state]-[lighter_color][lit ? "-on" : ""]"
 
 /obj/item/lighter/update_overlays()
-	item_state = "[initial(item_state)][lit ? "-on" : ""]"
-
-/obj/item/lighter/random/update_icon_state()
-	icon_state = "lighter-[random_color][lit ? "-on" : ""]" // We don't use initial here because we're using a nonconstant randomly selected color upon initialization.
-
-/obj/item/lighter/random/update_overlays()
-	item_state = "lighter-[random_color][lit ? "-on" : ""]" // We don't use initial here because we're using a nonconstant randomly selected color upon initialization.
+	item_state = "[base_item_state]-[lighter_color][lit ? "-on" : ""]"
 
 /obj/item/lighter/get_heat()
 	return lit * 1500

--- a/code/game/objects/items/weapons/lighters.dm
+++ b/code/game/objects/items/weapons/lighters.dm
@@ -19,10 +19,15 @@
 	/// Cooldown until the next turned off message/sound can be activated
 	var/next_off_message
 
-/obj/item/lighter/random/New()
+/obj/item/lighter/random
+	/// Random color that is assigned whenever we initialize a new random color lighter.
+	var/random_color = "g"
+
+/obj/item/lighter/random/Initialize(mapload)
 	..()
-	var/color = pick("r","c","y","g")
-	icon_state = "lighter-[color]"
+	random_color = pick("r","c","y","g")
+	icon_state = "lighter-[random_color]"
+	item_state = "lighter-[random_color]"
 
 /obj/item/lighter/attack_self(mob/living/user)
 	. = ..()
@@ -119,11 +124,15 @@
 
 /obj/item/lighter/update_icon_state()
 	icon_state = "[initial(icon_state)][lit ? "-on" : ""]"
-	return ..()
 
 /obj/item/lighter/update_overlays()
 	item_state = "[initial(item_state)][lit ? "-on" : ""]"
-	return ..()
+
+/obj/item/lighter/random/update_icon_state()
+	icon_state = "lighter-[random_color][lit ? "-on" : ""]" // We don't use initial here because we're using a nonconstant randomly selected color upon initialization.
+
+/obj/item/lighter/random/update_overlays()
+	item_state = "lighter-[random_color][lit ? "-on" : ""]" // We don't use initial here because we're using a nonconstant randomly selected color upon initialization.
 
 /obj/item/lighter/get_heat()
 	return lit * 1500

--- a/code/game/objects/items/weapons/lighters.dm
+++ b/code/game/objects/items/weapons/lighters.dm
@@ -18,8 +18,6 @@
 	var/next_on_message
 	/// Cooldown until the next turned off message/sound can be activated
 	var/next_off_message
-	/// Our base state for the lighter. This is for random color lighters
-	var/base_item_state = null
 	/// Our lighter color suffix. => [base_icon_state]-[lightercolor] => lighter-r
 	var/lighter_color = null
 
@@ -27,7 +25,6 @@
 	. = ..()
 	lighter_color = pick("r","c","y","g")
 	base_icon_state = "lighter"
-	base_item_state = "lighter"
 	update_icon_state()
 	update_overlays()
 
@@ -128,7 +125,7 @@
 	icon_state = "[base_icon_state ? "[base_icon_state]" : initial(icon_state)][lighter_color ? "-[lighter_color]" : ""][lit ? "-on" : ""]"
 
 /obj/item/lighter/update_overlays()
-	item_state = "[base_item_state ? "[base_item_state]" : initial(item_state)][lighter_color ? "-[lighter_color]" : ""][lit ? "-on" : ""]"
+	item_state = "[base_icon_state ? "[base_icon_state]" : initial(item_state)][lighter_color ? "-[lighter_color]" : ""][lit ? "-on" : ""]"
 
 /obj/item/lighter/get_heat()
 	return lit * 1500

--- a/code/game/objects/items/weapons/lighters.dm
+++ b/code/game/objects/items/weapons/lighters.dm
@@ -19,12 +19,14 @@
 	/// Cooldown until the next turned off message/sound can be activated
 	var/next_off_message
 	/// Our lighter color suffix. => [base_icon_state]-[lightercolor] => lighter-r
-	var/lighter_color = null
+	var/lighter_color
+
+/obj/item/lighter/random
+	base_icon_state = "lighter"
 
 /obj/item/lighter/random/Initialize(mapload)
 	. = ..()
 	lighter_color = pick("r","c","y","g")
-	base_icon_state = "lighter"
 	update_icon()
 
 /obj/item/lighter/attack_self(mob/living/user)

--- a/code/game/objects/items/weapons/lighters.dm
+++ b/code/game/objects/items/weapons/lighters.dm
@@ -25,8 +25,7 @@
 	. = ..()
 	lighter_color = pick("r","c","y","g")
 	base_icon_state = "lighter"
-	update_icon_state()
-	update_overlays()
+	update_icon()
 
 /obj/item/lighter/attack_self(mob/living/user)
 	. = ..()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Fixes https://github.com/ParadiseSS13/Paradise/issues/23111

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Bugs bad.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![image](https://github.com/ParadiseSS13/Paradise/assets/60483458/ce2e5968-027b-4c01-a34b-84eac8cc2c42)
![image](https://github.com/ParadiseSS13/Paradise/assets/60483458/0a4d3b4b-4e41-4e8b-b244-32922fd16f9d)


## Testing
<!-- How did you test the PR, if at all? -->
Flicked a randomly colored lighter on and off, it stayed the same color.
## Changelog
:cl:
fix: Fixed lighters becoming green if they were not green before.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
