### PR TITLE
Fixes syndicate mobs not always dropping the correct corpse

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/syndicate_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate_mobs.dm
@@ -303,8 +303,7 @@
 		speed = 2
 		projectiletype = /obj/item/projectile/bullet/sniper/penetrator // Ignores cover.
 		projectilesound = 'sound/weapons/gunshots/gunshot_sniper.ogg'
-		loot -= /obj/item/salvage/loot/syndicate // I don't like this, but it guarantees the stronger version always drop 1 salvage.
-		loot += /obj/item/salvage/loot/syndicate // First remove any salvage that might appear due to the parent call, then make it drop a salvage on death. Prevents 2 salvage.
+		loot |= /obj/item/salvage/loot/syndicate
 	return INITIALIZE_HINT_LATELOAD
 
 /mob/living/simple_animal/hostile/syndicate/melee/autogib/depot/armory/LateInitialize()

--- a/code/modules/mob/living/simple_animal/hostile/syndicate_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate_mobs.dm
@@ -303,6 +303,8 @@
 		speed = 2
 		projectiletype = /obj/item/projectile/bullet/sniper/penetrator // Ignores cover.
 		projectilesound = 'sound/weapons/gunshots/gunshot_sniper.ogg'
+		loot -= /obj/item/salvage/loot/syndicate // I don't like this, but it guarantees the stronger version always drop 1 salvage.
+		loot += /obj/item/salvage/loot/syndicate // First remove any salvage that might appear due to the parent call, then make it drop a salvage on death. Prevents 2 salvage.
 	return INITIALIZE_HINT_LATELOAD
 
 /mob/living/simple_animal/hostile/syndicate/melee/autogib/depot/armory/LateInitialize()

--- a/code/modules/mob/living/simple_animal/hostile/syndicate_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate_mobs.dm
@@ -34,17 +34,11 @@
 	sentience_type = SENTIENCE_OTHER
 	footstep_type = FOOTSTEP_MOB_SHOE
 	robust_searching = TRUE
-	var/list/loot_override = list(/obj/effect/mob_spawn/human/corpse/syndicatesoldier,
-					/obj/item/salvage/loot/syndicate,
-					/obj/effect/decal/cleanable/blood/innards,
-					/obj/effect/decal/cleanable/blood,
-					/obj/effect/gibspawner/generic,
-					/obj/effect/gibspawner/generic)
 
 /mob/living/simple_animal/hostile/syndicate/Initialize(mapload)
 	. = ..()
 	if(prob(50))
-		loot = loot_override
+		loot += /obj/item/salvage/loot/syndicate
 
 /mob/living/simple_animal/hostile/syndicate/Aggro()
 	. = ..()
@@ -290,7 +284,6 @@
 	alert_on_shield_breach = TRUE
 	death_sound = 'sound/mecha/mechmove03.ogg'
 	loot = list(/obj/effect/mob_spawn/human/corpse/syndicatequartermaster, /obj/effect/decal/cleanable/blood/innards, /obj/effect/decal/cleanable/blood, /obj/effect/gibspawner/generic, /obj/effect/gibspawner/generic)
-	loot_override = list(/obj/effect/mob_spawn/human/corpse/syndicatequartermaster, /obj/item/salvage/loot/syndicate, /obj/effect/decal/cleanable/blood/innards, /obj/effect/decal/cleanable/blood, /obj/effect/gibspawner/generic, /obj/effect/gibspawner/generic)
 
 /mob/living/simple_animal/hostile/syndicate/melee/autogib/depot/armory/Initialize(mapload)
 	. = ..()
@@ -357,12 +350,6 @@
 				/obj/effect/decal/cleanable/blood,
 				/obj/effect/gibspawner/generic,
 				/obj/effect/gibspawner/generic)
-	loot_override = list(/obj/effect/mob_spawn/human/corpse/syndicatecommando,
-					/obj/item/salvage/loot/syndicate,
-					/obj/effect/decal/cleanable/blood/innards,
-					/obj/effect/decal/cleanable/blood,
-					/obj/effect/gibspawner/generic,
-					/obj/effect/gibspawner/generic)
 
 
 /mob/living/simple_animal/hostile/syndicate/melee/space/Process_Spacemove(movement_dir = 0)
@@ -393,12 +380,6 @@
 				/obj/effect/decal/cleanable/blood,
 				/obj/effect/gibspawner/generic,
 				/obj/effect/gibspawner/generic)
-	loot_override = list(/obj/effect/mob_spawn/human/corpse/syndicatecommando,
-					/obj/item/salvage/loot/syndicate,
-					/obj/effect/decal/cleanable/blood/innards,
-					/obj/effect/decal/cleanable/blood,
-					/obj/effect/gibspawner/generic,
-					/obj/effect/gibspawner/generic)
 
 
 /mob/living/simple_animal/hostile/syndicate/ranged/space/Initialize(mapload)

--- a/code/modules/mob/living/simple_animal/hostile/syndicate_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate_mobs.dm
@@ -351,7 +351,6 @@
 				/obj/effect/gibspawner/generic,
 				/obj/effect/gibspawner/generic)
 
-
 /mob/living/simple_animal/hostile/syndicate/melee/space/Process_Spacemove(movement_dir = 0)
 	return TRUE
 

--- a/code/modules/mob/living/simple_animal/hostile/syndicate_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate_mobs.dm
@@ -34,16 +34,17 @@
 	sentience_type = SENTIENCE_OTHER
 	footstep_type = FOOTSTEP_MOB_SHOE
 	robust_searching = TRUE
+	var/list/loot_override = list(/obj/effect/mob_spawn/human/corpse/syndicatesoldier,
+                	/obj/item/salvage/loot/syndicate,
+                	/obj/effect/decal/cleanable/blood/innards,
+                	/obj/effect/decal/cleanable/blood,
+                	/obj/effect/gibspawner/generic,
+                	/obj/effect/gibspawner/generic)
 
 /mob/living/simple_animal/hostile/syndicate/Initialize(mapload)
 	. = ..()
 	if(prob(50))
-		loot = list(/obj/effect/mob_spawn/human/corpse/syndicatesoldier,
-				/obj/item/salvage/loot/syndicate,
-				/obj/effect/decal/cleanable/blood/innards,
-				/obj/effect/decal/cleanable/blood,
-				/obj/effect/gibspawner/generic,
-				/obj/effect/gibspawner/generic)
+		loot = loot_override
 
 /mob/living/simple_animal/hostile/syndicate/Aggro()
 	. = ..()
@@ -289,6 +290,7 @@
 	alert_on_shield_breach = TRUE
 	death_sound = 'sound/mecha/mechmove03.ogg'
 	loot = list(/obj/effect/mob_spawn/human/corpse/syndicatequartermaster, /obj/effect/decal/cleanable/blood/innards, /obj/effect/decal/cleanable/blood, /obj/effect/gibspawner/generic, /obj/effect/gibspawner/generic)
+	loot_override = list(/obj/effect/mob_spawn/human/corpse/syndicatequartermaster, /obj/item/salvage/loot/syndicate, /obj/effect/decal/cleanable/blood/innards, /obj/effect/decal/cleanable/blood, /obj/effect/gibspawner/generic, /obj/effect/gibspawner/generic)
 
 /mob/living/simple_animal/hostile/syndicate/melee/autogib/depot/armory/Initialize(mapload)
 	. = ..()
@@ -308,12 +310,6 @@
 		speed = 2
 		projectiletype = /obj/item/projectile/bullet/sniper/penetrator // Ignores cover.
 		projectilesound = 'sound/weapons/gunshots/gunshot_sniper.ogg'
-		loot = list(/obj/effect/mob_spawn/human/corpse/syndicatequartermaster,
-					/obj/item/salvage/loot/syndicate,
-					/obj/effect/decal/cleanable/blood/innards,
-					/obj/effect/decal/cleanable/blood,
-					/obj/effect/gibspawner/generic,
-					/obj/effect/gibspawner/generic)
 	return INITIALIZE_HINT_LATELOAD
 
 /mob/living/simple_animal/hostile/syndicate/melee/autogib/depot/armory/LateInitialize()
@@ -357,23 +353,23 @@
 	speed = 1.5
 	death_sound = 'sound/mecha/mechmove03.ogg'
 	loot = list(/obj/effect/mob_spawn/human/corpse/syndicatecommando,
-				/obj/item/salvage/loot/syndicate,
 				/obj/effect/decal/cleanable/blood/innards,
 				/obj/effect/decal/cleanable/blood,
 				/obj/effect/gibspawner/generic,
 				/obj/effect/gibspawner/generic)
+	loot_override = list(/obj/effect/mob_spawn/human/corpse/syndicatecommando,
+            		/obj/item/salvage/loot/syndicate,
+                	/obj/effect/decal/cleanable/blood/innards,
+                	/obj/effect/decal/cleanable/blood,
+                	/obj/effect/gibspawner/generic,
+                	/obj/effect/gibspawner/generic)
+
 
 /mob/living/simple_animal/hostile/syndicate/melee/space/Process_Spacemove(movement_dir = 0)
 	return TRUE
 
 /mob/living/simple_animal/hostile/syndicate/melee/space/Initialize(mapload)
 	. = ..()
-	if(prob(50))
-		loot = list(/obj/effect/mob_spawn/human/corpse/syndicatecommando,
-				/obj/effect/decal/cleanable/blood/innards,
-				/obj/effect/decal/cleanable/blood,
-				/obj/effect/gibspawner/generic,
-				/obj/effect/gibspawner/generic)
 
 /mob/living/simple_animal/hostile/syndicate/ranged
 	ranged = TRUE
@@ -393,20 +389,20 @@
 	speed = 1.5
 	death_sound = 'sound/mecha/mechmove03.ogg'
 	loot = list(/obj/effect/mob_spawn/human/corpse/syndicatecommando,
-				/obj/item/salvage/loot/syndicate,
 				/obj/effect/decal/cleanable/blood/innards,
 				/obj/effect/decal/cleanable/blood,
 				/obj/effect/gibspawner/generic,
 				/obj/effect/gibspawner/generic)
+	loot_override = list(/obj/effect/mob_spawn/human/corpse/syndicatecommando,
+            		/obj/item/salvage/loot/syndicate,
+                	/obj/effect/decal/cleanable/blood/innards,
+                	/obj/effect/decal/cleanable/blood,
+                	/obj/effect/gibspawner/generic,
+                	/obj/effect/gibspawner/generic)
+
 
 /mob/living/simple_animal/hostile/syndicate/ranged/space/Initialize(mapload)
 	. = ..()
-	if(prob(50))
-		loot = list(/obj/effect/mob_spawn/human/corpse/syndicatecommando,
-				/obj/effect/decal/cleanable/blood/innards,
-				/obj/effect/decal/cleanable/blood,
-				/obj/effect/gibspawner/generic,
-				/obj/effect/gibspawner/generic)
 
 
 /mob/living/simple_animal/hostile/syndicate/ranged/space/Process_Spacemove(movement_dir = 0)

--- a/code/modules/mob/living/simple_animal/hostile/syndicate_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate_mobs.dm
@@ -355,9 +355,6 @@
 /mob/living/simple_animal/hostile/syndicate/melee/space/Process_Spacemove(movement_dir = 0)
 	return TRUE
 
-/mob/living/simple_animal/hostile/syndicate/melee/space/Initialize(mapload)
-	. = ..()
-
 /mob/living/simple_animal/hostile/syndicate/ranged
 	ranged = TRUE
 	rapid = 2
@@ -380,10 +377,6 @@
 				/obj/effect/decal/cleanable/blood,
 				/obj/effect/gibspawner/generic,
 				/obj/effect/gibspawner/generic)
-
-
-/mob/living/simple_animal/hostile/syndicate/ranged/space/Initialize(mapload)
-	. = ..()
 
 
 /mob/living/simple_animal/hostile/syndicate/ranged/space/Process_Spacemove(movement_dir = 0)

--- a/code/modules/mob/living/simple_animal/hostile/syndicate_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate_mobs.dm
@@ -35,11 +35,11 @@
 	footstep_type = FOOTSTEP_MOB_SHOE
 	robust_searching = TRUE
 	var/list/loot_override = list(/obj/effect/mob_spawn/human/corpse/syndicatesoldier,
-                	/obj/item/salvage/loot/syndicate,
-                	/obj/effect/decal/cleanable/blood/innards,
-                	/obj/effect/decal/cleanable/blood,
-                	/obj/effect/gibspawner/generic,
-                	/obj/effect/gibspawner/generic)
+					/obj/item/salvage/loot/syndicate,
+					/obj/effect/decal/cleanable/blood/innards,
+					/obj/effect/decal/cleanable/blood,
+					/obj/effect/gibspawner/generic,
+					/obj/effect/gibspawner/generic)
 
 /mob/living/simple_animal/hostile/syndicate/Initialize(mapload)
 	. = ..()
@@ -358,11 +358,11 @@
 				/obj/effect/gibspawner/generic,
 				/obj/effect/gibspawner/generic)
 	loot_override = list(/obj/effect/mob_spawn/human/corpse/syndicatecommando,
-            		/obj/item/salvage/loot/syndicate,
-                	/obj/effect/decal/cleanable/blood/innards,
-                	/obj/effect/decal/cleanable/blood,
-                	/obj/effect/gibspawner/generic,
-                	/obj/effect/gibspawner/generic)
+					/obj/item/salvage/loot/syndicate,
+					/obj/effect/decal/cleanable/blood/innards,
+					/obj/effect/decal/cleanable/blood,
+					/obj/effect/gibspawner/generic,
+					/obj/effect/gibspawner/generic)
 
 
 /mob/living/simple_animal/hostile/syndicate/melee/space/Process_Spacemove(movement_dir = 0)
@@ -394,11 +394,11 @@
 				/obj/effect/gibspawner/generic,
 				/obj/effect/gibspawner/generic)
 	loot_override = list(/obj/effect/mob_spawn/human/corpse/syndicatecommando,
-            		/obj/item/salvage/loot/syndicate,
-                	/obj/effect/decal/cleanable/blood/innards,
-                	/obj/effect/decal/cleanable/blood,
-                	/obj/effect/gibspawner/generic,
-                	/obj/effect/gibspawner/generic)
+					/obj/item/salvage/loot/syndicate,
+					/obj/effect/decal/cleanable/blood/innards,
+					/obj/effect/decal/cleanable/blood,
+					/obj/effect/gibspawner/generic,
+					/obj/effect/gibspawner/generic)
 
 
 /mob/living/simple_animal/hostile/syndicate/ranged/space/Initialize(mapload)


### PR DESCRIPTION
## What Does This PR Do
Fixes #25947 
Cleans up how syndicate simplemobs handle dropping their corpses

## Why It's Good For The Game
Killing a dangerous mob should give the correct rewards, not sometime give a completely different and random corpse.

## Testing
Killed a bunch of space syndicate mobs
Killed a bunch of syndicate quartermasters
Killed a bunch of regular syndicate mobs

## Changelog
:cl:
fix: Fixed syndicate mobs not always dropping the correct corpse
/:cl: