### PR TITLE
fix: Correct areas for delta solars.

### DIFF
--- a/_maps/map_files/stations/deltastation.dmm
+++ b/_maps/map_files/stations/deltastation.dmm
@@ -18,7 +18,7 @@
 	icon_state = "1-2"
 	},
 /turf/space,
-/area/station/maintenance/auxsolarstarboard)
+/area/station/engineering/solar/auxstarboard)
 "abD" = (
 /obj/structure/railing{
 	dir = 1
@@ -58,7 +58,7 @@
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "solarpanel"
 	},
-/area/station/maintenance/auxsolarstarboard)
+/area/station/engineering/solar/auxstarboard)
 "acf" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -72,7 +72,7 @@
 	icon_state = "2-4"
 	},
 /turf/space,
-/area/station/maintenance/auxsolarstarboard)
+/area/station/engineering/solar/auxstarboard)
 "acg" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -91,7 +91,7 @@
 	icon_state = "4-8"
 	},
 /turf/space,
-/area/station/maintenance/auxsolarstarboard)
+/area/station/engineering/solar/auxstarboard)
 "ach" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -99,12 +99,12 @@
 	icon_state = "0-8"
 	},
 /turf/space,
-/area/station/maintenance/auxsolarstarboard)
+/area/station/engineering/solar/auxstarboard)
 "aci" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
 /turf/space,
-/area/station/maintenance/auxsolarstarboard)
+/area/station/engineering/solar/auxstarboard)
 "acj" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -112,7 +112,7 @@
 	icon_state = "0-4"
 	},
 /turf/space,
-/area/station/maintenance/auxsolarstarboard)
+/area/station/engineering/solar/auxstarboard)
 "aco" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -131,7 +131,7 @@
 	icon_state = "4-8"
 	},
 /turf/space,
-/area/station/maintenance/auxsolarstarboard)
+/area/station/engineering/solar/auxstarboard)
 "acp" = (
 /obj/machinery/power/tracker,
 /obj/structure/cable{
@@ -141,7 +141,7 @@
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "solarpanel"
 	},
-/area/station/maintenance/auxsolarstarboard)
+/area/station/engineering/solar/auxstarboard)
 "acC" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -159,7 +159,7 @@
 	icon_state = "2-8"
 	},
 /turf/space,
-/area/station/maintenance/auxsolarstarboard)
+/area/station/engineering/solar/auxstarboard)
 "acF" = (
 /obj/structure/lattice/catwalk,
 /turf/space,
@@ -172,7 +172,7 @@
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "solarpanel"
 	},
-/area/station/maintenance/auxsolarstarboard)
+/area/station/engineering/solar/auxstarboard)
 "acJ" = (
 /obj/docking_port/stationary{
 	dheight = 9;
@@ -212,15 +212,7 @@
 "adg" = (
 /obj/structure/lattice/catwalk,
 /turf/space,
-/area/station/maintenance/auxsolarstarboard)
-"adh" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/space,
-/area/space/nearstation)
+/area/station/engineering/solar/auxstarboard)
 "ado" = (
 /obj/item/radio/intercom{
 	name = "south bump";
@@ -258,14 +250,6 @@
 	},
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/pod_1)
-"adz" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/space,
-/area/space/nearstation)
 "adL" = (
 /obj/structure/shuttle/engine/propulsion/burst,
 /turf/simulated/wall/mineral/titanium,
@@ -2558,7 +2542,7 @@
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "solarpanel"
 	},
-/area/station/maintenance/auxsolarport)
+/area/station/engineering/solar/auxport)
 "apG" = (
 /turf/simulated/wall,
 /area/station/maintenance/electrical_shop)
@@ -3532,7 +3516,7 @@
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "solarpanel"
 	},
-/area/station/maintenance/auxsolarport)
+/area/station/engineering/solar/auxport)
 "asi" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -3846,7 +3830,7 @@
 	icon_state = "1-4"
 	},
 /turf/space,
-/area/station/maintenance/auxsolarport)
+/area/station/engineering/solar/auxport)
 "asW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -3891,7 +3875,7 @@
 	icon_state = "4-8"
 	},
 /turf/space,
-/area/station/maintenance/auxsolarport)
+/area/station/engineering/solar/auxport)
 "atb" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -3899,12 +3883,12 @@
 	icon_state = "0-8"
 	},
 /turf/space,
-/area/station/maintenance/auxsolarport)
+/area/station/engineering/solar/auxport)
 "atc" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
 /turf/space,
-/area/station/maintenance/auxsolarport)
+/area/station/engineering/solar/auxport)
 "atd" = (
 /turf/simulated/wall/r_wall,
 /area/station/engineering/controlroom)
@@ -4155,7 +4139,7 @@
 	icon_state = "0-4"
 	},
 /turf/space,
-/area/station/maintenance/auxsolarport)
+/area/station/engineering/solar/auxport)
 "atL" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -4174,7 +4158,7 @@
 	icon_state = "4-8"
 	},
 /turf/space,
-/area/station/maintenance/auxsolarport)
+/area/station/engineering/solar/auxport)
 "atM" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -4245,7 +4229,7 @@
 	icon_state = "2-8"
 	},
 /turf/space,
-/area/station/maintenance/auxsolarport)
+/area/station/engineering/solar/auxport)
 "atV" = (
 /obj/structure/chair/stool{
 	dir = 1
@@ -4289,11 +4273,11 @@
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "solarpanel"
 	},
-/area/station/maintenance/auxsolarport)
+/area/station/engineering/solar/auxport)
 "atZ" = (
 /obj/structure/lattice/catwalk,
 /turf/space,
-/area/station/maintenance/auxsolarport)
+/area/station/engineering/solar/auxport)
 "aua" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -8153,7 +8137,7 @@
 	icon_state = "0-2"
 	},
 /turf/space,
-/area/station/maintenance/auxsolarport)
+/area/station/engineering/solar/auxport)
 "aEc" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -8162,7 +8146,7 @@
 	icon_state = "1-2"
 	},
 /turf/space,
-/area/station/maintenance/auxsolarport)
+/area/station/engineering/solar/auxport)
 "aEe" = (
 /obj/machinery/light{
 	dir = 8
@@ -52052,7 +52036,7 @@
 	icon_state = "0-8"
 	},
 /turf/space,
-/area/station/maintenance/starboardsolar)
+/area/station/engineering/solar/starboard)
 "cSO" = (
 /obj/structure/rack,
 /obj/item/storage/belt/medical,
@@ -52324,7 +52308,7 @@
 "cTN" = (
 /obj/structure/lattice/catwalk,
 /turf/space,
-/area/station/maintenance/starboardsolar)
+/area/station/engineering/solar/starboard)
 "cTO" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -53559,7 +53543,7 @@
 	icon_state = "1-2"
 	},
 /turf/space,
-/area/station/maintenance/starboardsolar)
+/area/station/engineering/solar/starboard)
 "cZb" = (
 /obj/machinery/sleeper{
 	dir = 4
@@ -53908,7 +53892,7 @@
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "solarpanel"
 	},
-/area/station/maintenance/starboardsolar)
+/area/station/engineering/solar/starboard)
 "dal" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -54033,7 +54017,7 @@
 	icon_state = "2-4"
 	},
 /turf/space,
-/area/station/maintenance/starboardsolar)
+/area/station/engineering/solar/starboard)
 "daA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -54057,7 +54041,7 @@
 	icon_state = "4-8"
 	},
 /turf/space,
-/area/station/maintenance/starboardsolar)
+/area/station/engineering/solar/starboard)
 "daD" = (
 /obj/effect/spawner/random_spawners/wall_rusted_always,
 /turf/simulated/wall,
@@ -54087,7 +54071,7 @@
 	icon_state = "0-4"
 	},
 /turf/space,
-/area/station/maintenance/starboardsolar)
+/area/station/engineering/solar/starboard)
 "daI" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
@@ -54165,7 +54149,7 @@
 	icon_state = "4-8"
 	},
 /turf/space,
-/area/station/maintenance/starboardsolar)
+/area/station/engineering/solar/starboard)
 "daW" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -54186,7 +54170,7 @@
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "solarpanel"
 	},
-/area/station/maintenance/starboardsolar)
+/area/station/engineering/solar/starboard)
 "dbd" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/beakers{
@@ -54211,7 +54195,7 @@
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
 /turf/space,
-/area/station/maintenance/starboardsolar)
+/area/station/engineering/solar/starboard)
 "dbp" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -62351,7 +62335,7 @@
 	icon_state = "2-8"
 	},
 /turf/space,
-/area/station/maintenance/starboardsolar)
+/area/station/engineering/solar/starboard)
 "dOO" = (
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
@@ -62843,7 +62827,7 @@
 "dQB" = (
 /obj/structure/lattice/catwalk,
 /turf/space,
-/area/station/maintenance/portsolar)
+/area/station/engineering/solar/port)
 "dQC" = (
 /obj/machinery/field/generator{
 	anchored = 1;
@@ -63734,7 +63718,7 @@
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "solarpanel"
 	},
-/area/station/maintenance/portsolar)
+/area/station/engineering/solar/port)
 "dTY" = (
 /obj/structure/closet/coffin,
 /obj/machinery/light/small{
@@ -64079,7 +64063,7 @@
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "solarpanel"
 	},
-/area/station/maintenance/portsolar)
+/area/station/engineering/solar/port)
 "dVo" = (
 /obj/item/kirbyplants,
 /obj/structure/cable{
@@ -64150,7 +64134,7 @@
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "solarpanel"
 	},
-/area/station/maintenance/portsolar)
+/area/station/engineering/solar/port)
 "dWf" = (
 /obj/docking_port/stationary{
 	dheight = 9;
@@ -64697,7 +64681,7 @@
 	icon_state = "0-4"
 	},
 /turf/space,
-/area/station/maintenance/portsolar)
+/area/station/engineering/solar/port)
 "dYJ" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -64706,7 +64690,7 @@
 	icon_state = "4-8"
 	},
 /turf/space,
-/area/station/maintenance/portsolar)
+/area/station/engineering/solar/port)
 "dYL" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -64720,7 +64704,7 @@
 	icon_state = "1-4"
 	},
 /turf/space,
-/area/station/maintenance/portsolar)
+/area/station/engineering/solar/port)
 "dYM" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -64739,7 +64723,7 @@
 	icon_state = "4-8"
 	},
 /turf/space,
-/area/station/maintenance/portsolar)
+/area/station/engineering/solar/port)
 "dYN" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -64747,7 +64731,7 @@
 	icon_state = "0-8"
 	},
 /turf/space,
-/area/station/maintenance/portsolar)
+/area/station/engineering/solar/port)
 "dYO" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -64766,7 +64750,7 @@
 	icon_state = "4-8"
 	},
 /turf/space,
-/area/station/maintenance/portsolar)
+/area/station/engineering/solar/port)
 "dYP" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -64780,7 +64764,7 @@
 	icon_state = "2-8"
 	},
 /turf/space,
-/area/station/maintenance/portsolar)
+/area/station/engineering/solar/port)
 "dYR" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -64788,7 +64772,7 @@
 	icon_state = "0-2"
 	},
 /turf/space,
-/area/station/maintenance/portsolar)
+/area/station/engineering/solar/port)
 "dYS" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -64797,7 +64781,7 @@
 	icon_state = "1-2"
 	},
 /turf/space,
-/area/station/maintenance/portsolar)
+/area/station/engineering/solar/port)
 "dYT" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -65802,7 +65786,7 @@
 	icon_state = "0-2"
 	},
 /turf/space,
-/area/station/maintenance/starboardsolar)
+/area/station/engineering/solar/starboard)
 "exy" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -86054,7 +86038,7 @@
 	icon_state = "0-8"
 	},
 /turf/space,
-/area/station/maintenance/auxsolarstarboard)
+/area/station/engineering/solar/auxstarboard)
 "qHK" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -87255,7 +87239,7 @@
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "solarpanel"
 	},
-/area/station/maintenance/starboardsolar)
+/area/station/engineering/solar/starboard)
 "rod" = (
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/cryo)
@@ -90534,7 +90518,7 @@
 	icon_state = "4-8"
 	},
 /turf/space,
-/area/station/maintenance/starboardsolar)
+/area/station/engineering/solar/starboard)
 "sWn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -146493,7 +146477,7 @@ acg
 acG
 aaa
 aaa
-adh
+ach
 aaa
 aaa
 ace
@@ -146750,7 +146734,7 @@ ach
 aaa
 aaa
 aaa
-acF
+adg
 aaa
 aaa
 aaa
@@ -147264,7 +147248,7 @@ acj
 aaa
 aaa
 aaa
-acF
+adg
 aaa
 aaa
 aaa
@@ -147521,7 +147505,7 @@ aco
 acG
 aaa
 aaa
-adz
+acj
 aaa
 aaa
 ace


### PR DESCRIPTION
## What Does This PR Do
This PR assigns the correct /area types to Delta solar arrays.
## Why It's Good For The Game
Areas should be correct.
## Images of changes
<details><summary>Before</summary>

![2024_07_03__10_01_35__paradise dme  deltastation dmm  - StrongDMM](https://github.com/ParadiseSS13/Paradise/assets/59303604/e40996c6-041c-4434-9761-53781c631286)

![2024_07_03__10_01_41__paradise dme  deltastation dmm  - StrongDMM](https://github.com/ParadiseSS13/Paradise/assets/59303604/984643eb-4954-4950-b375-362959e26dc4)

![2024_07_03__10_01_47__paradise dme  deltastation dmm  - StrongDMM](https://github.com/ParadiseSS13/Paradise/assets/59303604/bce901fd-1af9-4edd-b589-2351d8c87026)

![2024_07_03__10_01_53__paradise dme  deltastation dmm  - StrongDMM](https://github.com/ParadiseSS13/Paradise/assets/59303604/c81d397c-8c71-418e-adb8-5b3f0869e700)

</details>

<details><summary>After</summary>

![2024_07_03__10_00_24__paradise dme  deltastation dmm  - StrongDMM](https://github.com/ParadiseSS13/Paradise/assets/59303604/a681c4e9-757d-4818-91ac-a7d6e4ed8da5)

![2024_07_03__10_00_34__paradise dme  deltastation dmm  - StrongDMM](https://github.com/ParadiseSS13/Paradise/assets/59303604/e3c06e70-d7a8-4a44-a880-146be58a782c)

![2024_07_03__10_00_40__paradise dme  deltastation dmm  - StrongDMM](https://github.com/ParadiseSS13/Paradise/assets/59303604/8da72c3b-a99b-4839-a6c7-0fd6205c1427)

![2024_07_03__10_00_48__paradise dme  deltastation dmm  - StrongDMM](https://github.com/ParadiseSS13/Paradise/assets/59303604/75b69d20-97a9-406d-8391-3c473e914ba8)


</details>

## Testing
Spawned in, ensured solar array turfs had the proper areas.

## Changelog
NPFC
