### PR TITLE
[FIX]Energy swords can now be sharpened while extended.

### DIFF
--- a/code/game/objects/items/weapons/whetstone.dm
+++ b/code/game/objects/items/weapons/whetstone.dm
@@ -19,9 +19,9 @@
 		return
 	if(istype(I, /obj/item/melee/energy))
 		var/obj/item/melee/energy/E = I
-		if(E.force_on > initial(E.force_on))
+		if(E.force_on > initial(E.force_on) || E.force_off > initial(E.force_off))
 			to_chat(user, "<span class='warning'>[E] has already been refined before. It cannot be sharpened further!</span>")
-		if(E.force_on >= max)
+		if(E.force_on >= max || E.force_off >= max)
 			to_chat(user, "<span class='warning'>[E] is much too powerful to sharpen further!</span>")
 			return
 		E.throwforce_on = clamp(E.throwforce_on + increment, 0, max)

--- a/code/game/objects/items/weapons/whetstone.dm
+++ b/code/game/objects/items/weapons/whetstone.dm
@@ -19,7 +19,7 @@
 		return
 	if(istype(I, /obj/item/melee/energy))
 		var/obj/item/melee/energy/E = I
-		if(E.force_on > initial(E.force_on) || E.force_off > initial(E.force_off))
+		if(E.force_on > initial(E.force_on) || E.force_off > initial(E.force))//force_off checks against intitial force becasue it always starts at 0 and is initialized to initial(force)
 			to_chat(user, "<span class='warning'>[E] has already been refined before. It cannot be sharpened further!</span>")
 			return
 		if(E.force_on >= max || E.force_off >= max)

--- a/code/game/objects/items/weapons/whetstone.dm
+++ b/code/game/objects/items/weapons/whetstone.dm
@@ -17,37 +17,39 @@
 	if(used)
 		to_chat(user, "<span class='warning'>The whetstone is too worn to use again!</span>")
 		return
-	if(requires_sharpness && !I.sharp)
-		to_chat(user, "<span class='warning'>You can only sharpen items that are already sharp, such as knives!</span>")
-		return
-	var/signal_out = SEND_SIGNAL(I, COMSIG_ITEM_SHARPEN_ACT, increment, max)
-
-	if((signal_out & COMPONENT_BLOCK_SHARPEN_MAXED) || I.force >= max || I.throwforce >= max) //If the item's components enforce more limits on maximum power from sharpening,  we fail
-		to_chat(user, "<span class='warning'>[I] is much too powerful to sharpen further!</span>")
-		return
-	if(signal_out & COMPONENT_BLOCK_SHARPEN_BLOCKED)
-		to_chat(user, "<span class='warning'>[I] is not able to be sharpened right now!</span>")
-		return
-	if((signal_out & COMPONENT_BLOCK_SHARPEN_ALREADY) || (I.force > initial(I.force) && !(signal_out & COMPONENT_SHARPEN_APPLIED))) //No sharpening stuff twice
-		to_chat(user, "<span class='warning'>[I] has already been refined before. It cannot be sharpened further!</span>")
-		return
 	if(istype(I, /obj/item/melee/energy))
 		var/obj/item/melee/energy/E = I
 		if(E.force_on > initial(E.force_on))
+			to_chat(user, "<span class='warning'>[E] has already been refined before. It cannot be sharpened further!</span>")
+		if(E.force_on >= max)
 			to_chat(user, "<span class='warning'>[E] is much too powerful to sharpen further!</span>")
 			return
 		E.throwforce_on = clamp(E.throwforce_on + increment, 0, max)
 		E.throwforce_off = clamp(E.throwforce_off + increment, 0, max)
 		E.force_on = clamp(E.force_on + increment, 0, max)
 		E.force_off = clamp(E.force_off + increment, 0, max)
+	else
+		if(requires_sharpness && !I.sharp)
+			to_chat(user, "<span class='warning'>You can only sharpen items that are already sharp, such as knives!</span>")
+			return
+		var/signal_out = SEND_SIGNAL(I, COMSIG_ITEM_SHARPEN_ACT, increment, max)
 
-	if(!(signal_out & COMPONENT_SHARPEN_APPLIED)) //If the item has a relevant component and COMPONENT_BLOCK_SHARPEN_APPLIED is returned, the item only gets the throw force increase
-		I.force = clamp(I.force + increment, 0, max)
+		if((signal_out & COMPONENT_BLOCK_SHARPEN_MAXED) || I.force >= max || I.throwforce >= max) //If the item's components enforce more limits on maximum power from sharpening,  we fail
+			to_chat(user, "<span class='warning'>[I] is much too powerful to sharpen further!</span>")
+			return
+		if(signal_out & COMPONENT_BLOCK_SHARPEN_BLOCKED)
+			to_chat(user, "<span class='warning'>[I] is not able to be sharpened right now!</span>")
+			return
+		if((signal_out & COMPONENT_BLOCK_SHARPEN_ALREADY) || (I.force > initial(I.force) && !(signal_out & COMPONENT_SHARPEN_APPLIED))) //No sharpening stuff twice
+			to_chat(user, "<span class='warning'>[I] has already been refined before. It cannot be sharpened further!</span>")
+			return
+		if(!(signal_out & COMPONENT_SHARPEN_APPLIED)) //If the item has a relevant component and COMPONENT_BLOCK_SHARPEN_APPLIED is returned, the item only gets the throw force increase
+			I.force = clamp(I.force + increment, 0, max)
+			I.throwforce = clamp(I.throwforce + increment, 0, max)
 
 	user.visible_message("<span class='notice'>[user] sharpens [I] with [src]!</span>", "<span class='notice'>You sharpen [I], making it much more deadly than before.</span>")
 	if(!requires_sharpness)
 		set_sharpness(TRUE)
-	I.throwforce = clamp(I.throwforce + increment, 0, max)
 	I.name = "[prefix] [I.name]"
 	playsound(get_turf(src), usesound, 50, 1)
 	name = "worn out [name]"

--- a/code/game/objects/items/weapons/whetstone.dm
+++ b/code/game/objects/items/weapons/whetstone.dm
@@ -21,6 +21,7 @@
 		var/obj/item/melee/energy/E = I
 		if(E.force_on > initial(E.force_on) || E.force_off > initial(E.force_off))
 			to_chat(user, "<span class='warning'>[E] has already been refined before. It cannot be sharpened further!</span>")
+			return
 		if(E.force_on >= max || E.force_off >= max)
 			to_chat(user, "<span class='warning'>[E] is much too powerful to sharpen further!</span>")
 			return


### PR DESCRIPTION
Checks for an energy weapon before the other conditions(and excludes them if the item being sharpened is an energy weapon)

<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Allows melee energy weapons to be sharpened while extended, and the messages printed when attempting to sharpen one are now consistent with those of other items.
E weapons won't use a whetstone if they're too strong to sharpen to begin with.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Less bugs more good
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Attempted to sharpen an Esword, Ecutlass and a Chef's knife
-Ecutlass and Chef's knife could be sharpened once using a regular or super whetstone. Cutlass could be sharpened while extended.
-Esword required a super whetstone to sharpen and could be sharpened once while extended. It also didn't use up a normal whetstone.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: E weapon sharpening works when they are extended
fix: Sharpening an E weapon won't use a whetstone if it's too powerful to sharpen to begin with
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
