### PR TITLE
fix: Cloner Pod should no longer shove the wrong mind into a cloned patient

### DIFF
--- a/code/__DEFINES/cloning_defines.dm
+++ b/code/__DEFINES/cloning_defines.dm
@@ -4,6 +4,7 @@
 #define SCANNER_ABSORBED "absorbed"
 #define SCANNER_NO_SOUL "soulless"
 #define SCANNER_BRAIN_ISSUE "suicide or missing brain"
+#define SCANNER_POD_IN_PROGRESS "cloning in progress"
 #define SCANNER_MISC "miscellanious"
 #define SCANNER_SUCCESSFUL "successful"
 

--- a/code/game/machinery/clonescanner.dm
+++ b/code/game/machinery/clonescanner.dm
@@ -101,6 +101,8 @@
 
 	has_scanned = TRUE
 
+	if(console.selected_pod?.currently_cloning)
+		return SCANNER_POD_IN_PROGRESS
 	if(!scanned.dna || HAS_TRAIT(scanned, TRAIT_GENELESS))
 		return SCANNER_MISC
 	if(HAS_TRAIT(scanned, TRAIT_BADDNA) && scanning_tier < 4)

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -341,6 +341,8 @@
 			feedback = list("text" = "Failed to sequence the patient's brain. Further attempts may succeed.", "color" = "average", "scan_succeeded" = FALSE)
 		if(SCANNER_BRAIN_ISSUE)
 			feedback = list("text" = "The patient's brain is inactive or missing.", "color" = "bad", "scan_succeeded" = FALSE)
+		if(SCANNER_POD_IN_PROGRESS)
+			feedback = list("text" = "The selected pod is currently cloning someone.", "color" = "average", "scan_succeeded" = FALSE)
 		else
 			var/datum/cloning_data/scan = scanner_result
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Fixes https://github.com/ParadiseSS13/Paradise/issues/25823


## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
This was an oversight from the cloning rework, bugs are bad. Inconsistent cloning isn't intended.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![image](https://github.com/ParadiseSS13/Paradise/assets/60483458/31402cd7-468d-4b59-bfce-8ab160d02a09)
The above image doesn't show the up to date feedback message. It is currently:
"The selected pod is currently cloning someone."

## Testing
<!-- How did you test the PR, if at all? -->
Shot a unathi with a death wand, shoved their writhing corpse into the scanner, the pod itself was already scanning. (VV'd to be such because I am lazy)
> currently_cloning set to 1

## Changelog
:cl:
fix: Fixed a cloning issue where the wrong mind would be transferred into a cloned patient
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
