### PR TITLE
Changes energy sword sharpening to use signals

### DIFF
--- a/code/game/objects/items/weapons/melee/energy_melee_weapons.dm
+++ b/code/game/objects/items/weapons/melee/energy_melee_weapons.dm
@@ -100,9 +100,6 @@
 	throwforce_off = clamp(throwforce_off + amount, 0, max_amount)
 	force_on = clamp(force_on + amount, 0, max_amount)
 	force_off = clamp(force_off + amount, 0, max_amount)
-	if(active)
-		force += amount
-	return COMPONENT_SHARPEN_APPLIED
 
 /obj/item/melee/energy/axe
 	name = "energy axe"

--- a/code/game/objects/items/weapons/melee/energy_melee_weapons.dm
+++ b/code/game/objects/items/weapons/melee/energy_melee_weapons.dm
@@ -29,8 +29,8 @@
 	RegisterSignal(src, COMSIG_ITEM_SHARPEN_ACT, PROC_REF(try_sharpen))
 
 /obj/item/melee/energy/Destroy()
-	. = ..()
 	UnregisterSignal(src, COMSIG_ITEM_SHARPEN_ACT)
+	return ..()
 
 /obj/item/melee/energy/attack(mob/living/target, mob/living/carbon/human/user)
 	var/nemesis_faction = FALSE

--- a/code/game/objects/items/weapons/melee/energy_melee_weapons.dm
+++ b/code/game/objects/items/weapons/melee/energy_melee_weapons.dm
@@ -94,7 +94,7 @@
 	return active * 3500
 
 /obj/item/melee/energy/proc/try_sharpen(obj/item/item, amount, max_amount)
-	if(force_on > initial(force_on) || force_on > max_amount)
+	if(force_on > initial(force_on) || force_on >= max_amount)
 		return COMPONENT_BLOCK_SHARPEN_MAXED
 	throwforce_on = clamp(throwforce_on + amount, 0, max_amount)
 	throwforce_off = clamp(throwforce_off + amount, 0, max_amount)

--- a/code/game/objects/items/weapons/melee/energy_melee_weapons.dm
+++ b/code/game/objects/items/weapons/melee/energy_melee_weapons.dm
@@ -94,6 +94,7 @@
 	return active * 3500
 
 /obj/item/melee/energy/proc/try_sharpen(obj/item/item, amount, max_amount)
+	SIGNAL_HANDLER // COMSIG_ITEM_SHARPEN_ACT
 	if(force_on > initial(force_on) || force_on >= max_amount)
 		return COMPONENT_BLOCK_SHARPEN_MAXED
 	throwforce_on = clamp(throwforce_on + amount, 0, max_amount)

--- a/code/game/objects/items/weapons/melee/energy_melee_weapons.dm
+++ b/code/game/objects/items/weapons/melee/energy_melee_weapons.dm
@@ -26,6 +26,11 @@
 	. = ..()
 	force_off = initial(force) //We want to check this only when initializing, not when swapping, so sharpening works.
 	throwforce_off = initial(throwforce)
+	RegisterSignal(src, COMSIG_ITEM_SHARPEN_ACT, PROC_REF(try_sharpen))
+
+/obj/item/melee/energy/Destroy()
+	. = ..()
+	UnregisterSignal(src, COMSIG_ITEM_SHARPEN_ACT)
 
 /obj/item/melee/energy/attack(mob/living/target, mob/living/carbon/human/user)
 	var/nemesis_faction = FALSE
@@ -87,6 +92,17 @@
 
 /obj/item/melee/energy/get_heat()
 	return active * 3500
+
+/obj/item/melee/energy/proc/try_sharpen(obj/item/item, amount, max_amount)
+	if(force_on > initial(force_on) || force_on > max_amount)
+		return COMPONENT_BLOCK_SHARPEN_MAXED
+	throwforce_on = clamp(throwforce_on + amount, 0, max_amount)
+	throwforce_off = clamp(throwforce_off + amount, 0, max_amount)
+	force_on = clamp(force_on + amount, 0, max_amount)
+	force_off = clamp(force_off + amount, 0, max_amount)
+	if(active)
+		force += amount
+	return COMPONENT_SHARPEN_APPLIED
 
 /obj/item/melee/energy/axe
 	name = "energy axe"

--- a/code/game/objects/items/weapons/whetstone.dm
+++ b/code/game/objects/items/weapons/whetstone.dm
@@ -31,15 +31,6 @@
 	if((signal_out & COMPONENT_BLOCK_SHARPEN_ALREADY) || (I.force > initial(I.force) && !(signal_out & COMPONENT_SHARPEN_APPLIED))) //No sharpening stuff twice
 		to_chat(user, "<span class='warning'>[I] has already been refined before. It cannot be sharpened further!</span>")
 		return
-	if(istype(I, /obj/item/melee/energy))
-		var/obj/item/melee/energy/E = I
-		if(E.force_on > initial(E.force_on))
-			to_chat(user, "<span class='warning'>[E] is much too powerful to sharpen further!</span>")
-			return
-		E.throwforce_on = clamp(E.throwforce_on + increment, 0, max)
-		E.throwforce_off = clamp(E.throwforce_off + increment, 0, max)
-		E.force_on = clamp(E.force_on + increment, 0, max)
-		E.force_off = clamp(E.force_off + increment, 0, max)
 
 	if(!(signal_out & COMPONENT_SHARPEN_APPLIED)) //If the item has a relevant component and COMPONENT_BLOCK_SHARPEN_APPLIED is returned, the item only gets the throw force increase
 		I.force = clamp(I.force + increment, 0, max)
@@ -49,7 +40,7 @@
 		set_sharpness(TRUE)
 	I.throwforce = clamp(I.throwforce + increment, 0, max)
 	I.name = "[prefix] [I.name]"
-	playsound(get_turf(src), usesound, 50, 1)
+	playsound(get_turf(src), usesound, 50, TRUE)
 	name = "worn out [name]"
 	desc = "[desc] At least, it used to."
 	used = TRUE


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes energy sword sharpening use signals instead of an `istype()` hijack on the whetstone proc
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Cleaner code and allows for things like sharpening cutlasses while they're active, and immediate updating of the force
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://github.com/ParadiseSS13/Paradise/assets/108773801/0087f743-4598-45a1-9cf9-d1d1c1927efd)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
See above
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Energy weapons can now be sharpened while they are active
fix: Energy weapons now immediately update their force when you sharpen them
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
