### PR TITLE
Fixes a Neural Jumpstarter typo

### DIFF
--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -569,7 +569,7 @@
 	category = list("Medical")
 
 /datum/design/cyberimp_antisleep
-	name = "Neural Jumperstarter Implant"
+	name = "Neural Jumpstarter Implant"
 	desc = "This implant will automatically attempt to jolt you awake when it detects you have fallen unconscious. Has a short cooldown, incompatible with the CNS Rebooter."
 	id = "ci-antisleep"
 	req_tech = list("materials" = 6, "programming" = 5, "biotech" = 6)


### PR DESCRIPTION
## What Does This PR Do
Corrects the designs name from "Neural Jumperstarter Implant" to the implants name of "Neural Jumpstarter Implant"

## Why It's Good For The Game
Typos bad

## Testing
The name correctly updated

## Changelog
:cl: EOD501
spellcheck: Corrected the recipe name of Neural Jumpstarter Implants
/:cl:
