### PR TITLE
[s] Nian Caterpillars Cannot be Spawned by Gold Slime Cores

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/nian_caterpillar.dm
+++ b/code/modules/mob/living/simple_animal/friendly/nian_caterpillar.dm
@@ -32,8 +32,8 @@
 	response_disarm = "shoos"
 	response_harm   = "kicks"
 
-	// Xenobiology and cargo are the only ways to get the caterpillar.
-	gold_core_spawnable = FRIENDLY_SPAWN
+	// Cargo is the only way to get the caterpillar. Do not add them to gold cores, they are banned because of xenobio cult shenanigans.
+	gold_core_spawnable = NO_SPAWN
 
 	melee_damage_lower = 5
 	melee_damage_upper = 8


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Prevents gold slime cores from creating Nian Caterpillars. They can only be obtained from Cargo now.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Prevents xenobiology-related cult shenanigans.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
It compiled.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Removes Nian Caterpillars from gold slime core spawn pool.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
