### PR TITLE
fix: Hands should now rely on hand_blood_color instead of feet_blood_color

### DIFF
--- a/code/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/code/modules/mob/living/carbon/human/human_update_icons.dm
@@ -688,11 +688,11 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 		if(blood_DNA) // Checks for hands to make sure we don't get mysterious floating blood.
 			if(get_organ("l_hand"))
 				var/mutable_appearance/bloodsies_left = mutable_appearance(dna.species.blood_mask, "bloodyhand_left", layer = -L_HAND_BLOOD_LAYER)
-				bloodsies_left.color = feet_blood_color
+				bloodsies_left.color = hand_blood_color
 				overlays_standing[L_HAND_BLOOD_LAYER] = bloodsies_left
 			if(get_organ("r_hand"))
 				var/mutable_appearance/bloodsies_right = mutable_appearance(dna.species.blood_mask, "bloodyhand_right", layer = -R_HAND_BLOOD_LAYER)
-				bloodsies_right.color = feet_blood_color
+				bloodsies_right.color = hand_blood_color
 				overlays_standing[R_HAND_BLOOD_LAYER] = bloodsies_right
 	apply_overlay(GLOVES_LAYER)
 	apply_overlay(L_HAND_BLOOD_LAYER)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Fixes an oversight.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Hands != Feet

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
N/A

## Testing
<!-- How did you test the PR, if at all? -->
Loaded it, stuck my ungloved hands into a skrell's chest cavity and inserted a nian plushie vv'd to be tiny.

## Changelog
:cl:
fix: Fixed an issue with ungloved hands being the wrong blood color.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
