### PR TITLE
Fix: Active mousetrap inhand sprite

### DIFF
--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -2,6 +2,7 @@
 	name = "mousetrap"
 	desc = "A handy little spring-loaded trap for catching pesty rodents."
 	icon_state = "mousetrap"
+	item_state = "mousetrap"
 	materials = list(MAT_METAL=100)
 	origin_tech = "combat=1;materials=2;engineering=1"
 	var/armed = FALSE
@@ -19,12 +20,11 @@
 		return
 
 	armed = !armed
-	if(!armed)
-		if(ishuman(usr))
-			var/mob/living/carbon/human/user = usr
-			if((user.getBrainLoss() >= 60 || HAS_TRAIT(user, TRAIT_CLUMSY)) && prob(50))
-				to_chat(user, "Your hand slips, setting off the trigger.")
-				pulse(0)
+	if(!armed && ishuman(usr))
+		var/mob/living/carbon/human/user = usr
+		if((user.getBrainLoss() >= 60 || HAS_TRAIT(user, TRAIT_CLUMSY)) && prob(50))
+			to_chat(user, "Your hand slips, setting off the trigger.")
+			pulse(0)
 
 	update_icon()
 


### PR DESCRIPTION
## What Does This PR Do
Adds item_state, cause icon_state can be changed and inhand icon disapear
Also removed a small ladder into the code

## Why It's Good For The Game
That's a very important fix
Fixes #26175 

## Testing
https://github.com/ParadiseSS13/Paradise/assets/69762909/9e888a1c-8b7f-4da2-8cd6-93f822b8acdb

<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Mousetrap no longer disappears from your hands if you activate it
/:cl:

