### PR TITLE
Knuckledusters now change hitsound again

### DIFF
--- a/code/game/objects/items/weapons/knuckledusters.dm
+++ b/code/game/objects/items/weapons/knuckledusters.dm
@@ -34,13 +34,10 @@
 	gripped = FALSE
 	flags &= ~(NODROP | ABSTRACT)
 
-/obj/item/melee/knuckleduster/attack/(mob/living/user)
-	hitsound = pick('sound/weapons/punch1.ogg', 'sound/weapons/punch2.ogg', 'sound/weapons/punch3.ogg', 'sound/weapons/punch4.ogg')
-	return ..()
-
 /obj/item/melee/knuckleduster/attack(mob/living/target, mob/living/user)
 	. = ..()
-	if(!ishuman(target))
+	hitsound = pick('sound/weapons/punch1.ogg', 'sound/weapons/punch2.ogg', 'sound/weapons/punch3.ogg', 'sound/weapons/punch4.ogg')
+	if(!ishuman(target) || QDELETED(target))
 		return
 
 	var/obj/item/organ/external/punched = target.get_organ(user.zone_selected)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Knuckledusters change their hitsound again
Also tries to catch a runtime from happening - however it may have happened
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
They are supposed to randomize hitsound on every hit
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Hit skrell, heard different hitsounds
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Knuckledusters change their hitsound again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
