### PR TITLE
Skateboard Nerfs - The Bigger One

### DIFF
--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -493,15 +493,6 @@
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
 
-/datum/crafting_recipe/skateboard
-	name = "Skateboard"
-	result = list(/obj/tgvehicle/scooter/skateboard/improvised)
-	time = 1.5 SECONDS
-	reqs = list(/obj/item/stack/sheet/metal = 5,
-				/obj/item/stack/rods = 10)
-	tools = list(TOOL_WELDER, TOOL_WRENCH)
-	category = CAT_MISC
-
 /datum/crafting_recipe/spear_primal // alternative recipe for Ash Walkers
 	name = "Spear"
 	result = list(/obj/item/spear)

--- a/code/modules/economy/merch_items.dm
+++ b/code/modules/economy/merch_items.dm
@@ -121,14 +121,14 @@
 	name = "Skateboard"
 	desc = "A skateboard. It can be placed on its wheels and ridden, or used as a radical weapon."
 	typepath = /obj/item/melee/skateboard
-	cost = 250
+	cost = 500
 	category = MERCH_CAT_TOY
 
 /datum/merch_item/pro_skateboard
 	name = "Pro Skateboard"
 	desc = "An EightO brand professional skateboard. It looks sturdy and well made."
 	typepath = /obj/item/melee/skateboard/pro
-	cost = 600 //Quite fast, though I expect people to fall flat on their face with this a lot.
+	cost = 750 //Quite fast, though I expect people to fall flat on their face with this a lot.
 	category = MERCH_CAT_TOY
 
 /datum/merch_item/flag_slime

--- a/code/modules/economy/merch_items.dm
+++ b/code/modules/economy/merch_items.dm
@@ -121,14 +121,14 @@
 	name = "Skateboard"
 	desc = "A skateboard. It can be placed on its wheels and ridden, or used as a radical weapon."
 	typepath = /obj/item/melee/skateboard
-	cost = 500
+	cost = 250
 	category = MERCH_CAT_TOY
 
 /datum/merch_item/pro_skateboard
 	name = "Pro Skateboard"
 	desc = "An EightO brand professional skateboard. It looks sturdy and well made."
 	typepath = /obj/item/melee/skateboard/pro
-	cost = 750 //Quite fast, though I expect people to fall flat on their face with this a lot.
+	cost = 600 //Quite fast, though I expect people to fall flat on their face with this a lot.
 	category = MERCH_CAT_TOY
 
 /datum/merch_item/flag_slime

--- a/code/modules/vehicle/tg_vehicles/scooter.dm
+++ b/code/modules/vehicle/tg_vehicles/scooter.dm
@@ -38,6 +38,7 @@
 	name = "skateboard"
 	desc = "An old, battered skateboard. It's still rideable, but probably unsafe."
 	icon_state = "skateboard"
+	w_class = WEIGHT_CLASS_BULKY
 	density = FALSE
 	///Sparks datum for when we grind on tables
 	var/datum/effect_system/spark_spread/sparks
@@ -213,6 +214,7 @@
 	board_item_type = /obj/item/melee/skateboard/hoverboard
 	instability = 3
 	icon_state = "hoverboard_red"
+	w_class = WEIGHT_CLASS_NORMAL
 	resistance_flags = LAVA_PROOF | FIRE_PROOF
 
 /obj/tgvehicle/scooter/skateboard/hoverboard/Initialize(mapload)

--- a/code/modules/vehicle/tg_vehicles/scooter.dm
+++ b/code/modules/vehicle/tg_vehicles/scooter.dm
@@ -38,7 +38,6 @@
 	name = "skateboard"
 	desc = "An old, battered skateboard. It's still rideable, but probably unsafe."
 	icon_state = "skateboard"
-	w_class = WEIGHT_CLASS_BULKY
 	density = FALSE
 	///Sparks datum for when we grind on tables
 	var/datum/effect_system/spark_spread/sparks
@@ -214,7 +213,6 @@
 	board_item_type = /obj/item/melee/skateboard/hoverboard
 	instability = 3
 	icon_state = "hoverboard_red"
-	w_class = WEIGHT_CLASS_NORMAL
 	resistance_flags = LAVA_PROOF | FIRE_PROOF
 
 /obj/tgvehicle/scooter/skateboard/hoverboard/Initialize(mapload)
@@ -315,7 +313,8 @@
 	item_state = "skateboard"
 	force = 12
 	throwforce = 4
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_BULKY
+	slot_flags = SLOT_FLAG_BACK
 	attack_verb = list("smacks", "whacks", "slams", "smashes")
 	///The vehicle counterpart for the board
 	var/board_item_type = /obj/tgvehicle/scooter/skateboard
@@ -340,6 +339,7 @@
 /obj/item/melee/skateboard/hoverboard
 	name = "hoverboard"
 	desc = "A blast from the past, so retro!"
+	w_class = WEIGHT_CLASS_NORMAL
 	icon_state = "hoverboard_red_held"
 	item_state = "hoverboard_red"
 	board_item_type = /obj/tgvehicle/scooter/skateboard/hoverboard


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
**Pre-Approved: MattTheFicus, Komrad, Dudley**

- Skateboards and Pro Skateboards no longer fit in Bags. Hoverboard can still fit in a bag since its expensive. They can now fit on your back slot.
- Craftable Skateboard completely removed from crafting.

- [ ] TODO: Back Slot Sprites

## Why It's Good For The Game
Skateboards are oppressive and frankly needed a Balance pass in hindsight. Security should not be rolling around at mach six arresting people. Speed is, after all, king in SS13.

## Images of changes
TBA

## Testing
Logged in, couldnt equip boards in my bag anymore.

## Changelog
:cl:
tweak: skateboards no longer fit in bags, fit in back slot. Hoverboard unchanged.
del: you can no longer craft the improvised skateboard.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
