### PR TITLE
fix: remove 'research' camera from meta expedition

### DIFF
--- a/_maps/map_files/stations/metastation.dmm
+++ b/_maps/map_files/stations/metastation.dmm
@@ -26342,9 +26342,6 @@
 	name = "west bump";
 	pixel_x = -28
 	},
-/obj/machinery/camera{
-	c_tag = "Expedition"
-	},
 /obj/machinery/mineral/equipment_vendor/explorer,
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -26902,10 +26899,8 @@
 /area/station/supply/expedition)
 "bSp" = (
 /obj/machinery/camera{
-	c_tag = "Research Test Lab North";
-	dir = 8;
-	network = list("RD","SS13");
-	pixel_y = -22
+	c_tag = "Expedition";
+	dir = 9
 	},
 /obj/machinery/suit_storage_unit/expedition,
 /turf/simulated/floor/plasteel{


### PR DESCRIPTION
## What Does This PR Do
Fixes #26193. This PR removes an errant camera from Expedition on Metastation, moving the actual Expedition camera in its place. This particular prefab seems to have come from Cere; there's no "Research Test Lab North" on Meta.
## Why It's Good For The Game
RDs shouldn't be able to snoop on explorers.
## Images of changes
![2024_07_09__04_57_16__Paradise Station 13](https://github.com/ParadiseSS13/Paradise/assets/59303604/7aa19fc5-45c6-4696-8d18-74a47c761a7f)
![2024_07_09__04_57_58__Paradise Station 13](https://github.com/ParadiseSS13/Paradise/assets/59303604/b8d569e9-5ae3-4719-bcd0-71a65bff29b0)

## Testing
Spawned in, confirmed visibility via AI, confirmed Expedition camera isn't part of RD network.

## Changelog
:cl:
fix: Cerebron: There is no longer a camera in Expedition connected to the Research network.
/:cl:
