### PR TITLE
[s] Stunbaton no longer triggers shields twice

### DIFF
--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -182,9 +182,12 @@
 	var/mob/living/L = M
 
 	if(user.a_intent == INTENT_HARM)
+		. = ..() // Whack them too if in harm intent
+		if(.) // True is returned when blocked, false when not. I know.
+			return
 		if(turned_on)
-			baton_stun(L, user)
-		return ..() // Whack them too if in harm intent
+			baton_stun(L, user, forced = TRUE)
+		return
 
 	if(!turned_on)
 		user.do_attack_animation(L)
@@ -196,7 +199,7 @@
 		user.do_attack_animation(L)
 
 /// returning false results in no baton attack animation, returning true results in an animation.
-/obj/item/melee/baton/proc/baton_stun(mob/living/L, mob/user, skip_cooldown = FALSE)
+/obj/item/melee/baton/proc/baton_stun(mob/living/L, mob/user, skip_cooldown = FALSE, forced = FALSE)
 	if(cooldown > world.time && !skip_cooldown)
 		return FALSE
 
@@ -207,7 +210,7 @@
 	cooldown = world.time + initial(cooldown) // tracks the world.time when hitting will be next available.
 	if(ishuman(L))
 		var/mob/living/carbon/human/H = L
-		if(H.check_shields(src, 0, "[user]'s [name]", MELEE_ATTACK)) //No message; check_shields() handles that
+		if(!forced && H.check_shields(src, 0, "[user]'s [name]", MELEE_ATTACK)) //No message; check_shields() handles that
 			playsound(L, 'sound/weapons/genhit.ogg', 50, TRUE)
 			return FALSE
 		H.Confused(10 SECONDS)
@@ -310,6 +313,6 @@
 	QDEL_NULL(sparkler)
 	return ..()
 
-/obj/item/melee/baton/cattleprod/baton_stun(mob/living/L, mob/user, skip_cooldown = FALSE)
+/obj/item/melee/baton/cattleprod/baton_stun(mob/living/L, mob/user, skip_cooldown = FALSE, forced = FALSE)
 	if(sparkler.activate())
 		return ..()

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -186,7 +186,7 @@
 		if(.) // True is returned when blocked, false when not. I know.
 			return
 		if(turned_on)
-			baton_stun(L, user, forced = TRUE)
+			baton_stun(L, user, ignore_shield_check = TRUE)
 		return
 
 	if(!turned_on)
@@ -198,8 +198,8 @@
 	if(baton_stun(L, user))
 		user.do_attack_animation(L)
 
-/// returning false results in no baton attack animation, returning true results in an animation.
-/obj/item/melee/baton/proc/baton_stun(mob/living/L, mob/user, skip_cooldown = FALSE, forced = FALSE)
+/// returning false results in no baton attack animation, returning true results in an animation. If ignore_shield_check is true, the baton will not run check shields, and will hit if not on cooldown.
+/obj/item/melee/baton/proc/baton_stun(mob/living/L, mob/user, skip_cooldown = FALSE, ignore_shield_check = FALSE)
 	if(cooldown > world.time && !skip_cooldown)
 		return FALSE
 
@@ -210,7 +210,7 @@
 	cooldown = world.time + initial(cooldown) // tracks the world.time when hitting will be next available.
 	if(ishuman(L))
 		var/mob/living/carbon/human/H = L
-		if(!forced && H.check_shields(src, 0, "[user]'s [name]", MELEE_ATTACK)) //No message; check_shields() handles that
+		if(!ignore_shield_check && H.check_shields(src, 0, "[user]'s [name]", MELEE_ATTACK)) //No message; check_shields() handles that
 			playsound(L, 'sound/weapons/genhit.ogg', 50, TRUE)
 			return FALSE
 		H.Confused(10 SECONDS)
@@ -313,6 +313,6 @@
 	QDEL_NULL(sparkler)
 	return ..()
 
-/obj/item/melee/baton/cattleprod/baton_stun(mob/living/L, mob/user, skip_cooldown = FALSE, forced = FALSE)
+/obj/item/melee/baton/cattleprod/baton_stun(mob/living/L, mob/user, skip_cooldown = FALSE, ignore_shield_check = FALSE)
 	if(sparkler.activate())
 		return ..()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Stunbatons no longer check shields when they successfully harm someone, preventing stunbatons from draining 2 shields, or harmbatoning being blocked by the reactive armor but still stunning half the time anyway.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Should behave like other items, shouldn't bypass reactive armors and stun when being blocked

## Testing
<!-- How did you test the PR, if at all? -->

Stuned and harmbatoned a lot of people, doing the same with reactive armors and shielded modsuit modules, only took 1 layer off, never stuned when blocked by armor, always stunned (off cooldown) when not blocked


## Changelog
:cl:
fix: Stunbaton no longer hits through reactives or hits shields twice.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
