### PR TITLE
Fix inventory hands clickable areas & confusing overlay

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -400,7 +400,10 @@
 /atom/movable/screen/inventory/proc/add_overlays()
 	var/mob/user = hud?.mymob
 
-	if(!user || !slot_id || user != usr)
+	if(!user || user != usr)
+		return
+
+	if(!hud?.mymob || !slot_id || slot_id == SLOT_HUD_LEFT_HAND || slot_id == SLOT_HUD_RIGHT_HAND)
 		return
 
 	var/obj/item/holding = user.get_active_hand()

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -476,6 +476,7 @@ GLOBAL_DATUM_INIT(welding_sparks, /mutable_appearance, mutable_appearance('icons
 	if((flags & NODROP) && !(initial(flags) & NODROP)) // Remove NODROP if dropped. Probably from delimbing.
 		flags &= ~NODROP
 	in_inventory = FALSE
+	mouse_opacity = initial(mouse_opacity)
 	remove_outline()
 	SEND_SIGNAL(src, COMSIG_ITEM_DROPPED,user)
 	if(!silent)
@@ -522,6 +523,7 @@ GLOBAL_DATUM_INIT(welding_sparks, /mutable_appearance, mutable_appearance('icons
 // for items that can be placed in multiple slots
 // Initial is used to indicate whether or not this is the initial equipment (job datums etc) or just a player doing it
 /obj/item/proc/equipped(mob/user, slot, initial = FALSE)
+	mouse_opacity = MOUSE_OPACITY_OPAQUE
 	SEND_SIGNAL(src, COMSIG_ITEM_EQUIPPED, user, slot)
 	for(var/X in actions)
 		var/datum/action/A = X

--- a/code/game/objects/items/weapons/storage/storage_base.dm
+++ b/code/game/objects/items/weapons/storage/storage_base.dm
@@ -534,7 +534,6 @@
 		I.maptext = ""
 	I.on_exit_storage(src)
 	update_icon()
-	I.mouse_opacity = initial(I.mouse_opacity)
 	return TRUE
 
 /obj/item/storage/Exited(atom/A, loc)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR contains fix/qol improvements to hands that i ported from here:
https://github.com/ss220-space/Paradise/pull/2642
https://github.com/ss220-space/Paradise/pull/2659

1. Currently items in inventory slots for Alt+click and Ctrl+click combinations have the clickable area matching the item sprite. This is inconvenient, because for example, to change the transferrable amount of a beaker in your hand you have to Alt+click directly on the beaker. This PR makes the clickable area of items in the inventory a 32x32 area (mouse_opacity = MOUSE_OPACITY_OPAQUE), making it much easier to click. In the code, this is hovered over when equipping an item (including hands) and removed when dropping an item. Nothing should break.

2. Now, if you have an item in your active hand and hover over an empty inventory slot, a green/red overlay will appear if you can/can't put the item in the slot respectively. Clicking on a slot with a green overlay puts the item in that slot.
The same green overlay appears if you hover over an empty inactive hand, but the click changes the hand. This behaviour is unexpected and inconsistent. This PR removes this overlay for hands.

## Why It's Good For The Game
No pixel hunting and inconvenience.

## Images of changes
![inventory_fixes](https://github.com/ParadiseSS13/Paradise/assets/20109643/d82ccd29-f39e-41f0-bd11-25ef20f50b15)

## Testing
Tested on my local. It works.

## Changelog
:cl: dj-34, Lebedev
tweak: Removed confusing green/red overlay of item in hands on hover.
fix: Hands inventory now have fully clickable area. No pixel hunting now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
