### PR TITLE
Wrapping Paper now Requires Harm Intent to Wrap Wrapping Paper

### DIFF
--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -154,16 +154,23 @@
 	. = ..()
 	if(!in_range(A, user))
 		return
+
 	if(!isobj(A))
 		return
-	var/obj/target = A
 
+	var/obj/target = A
 	if(is_type_in_list(target, no_wrap))
 		return
+	
+	if(istype(target, /obj/item/stack/packageWrap) && user.a_intent != INTENT_HARM)
+		return
+
 	if(is_type_in_list(A.loc, list(/obj/item/smallDelivery, /obj/structure/bigDelivery)))
 		return
+
 	if(target.anchored)
 		return
+
 	if(target in user)
 		return
 
@@ -171,6 +178,7 @@
 		var/obj/item/O = target
 		if(!use(1))
 			return FALSE
+
 		var/obj/item/smallDelivery/P = new /obj/item/smallDelivery(get_turf(O.loc)) //Aaannd wrap it up!
 		if(!isturf(O.loc))
 			if(user.client)
@@ -198,9 +206,11 @@
 			return FALSE
 		D.init_welded = C.welded
 		C.welded = TRUE
+
 	else if(target.GetComponent(/datum/component/two_handed))
 		to_chat(user, "<span class='notice'>[target] is too unwieldy to wrap effectively.</span>")
 		return FALSE
+
 	else
 		to_chat(user, "<span class='notice'>The object you are trying to wrap is unsuitable for the sorting machinery.</span>")
 		return FALSE


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #26189. You can now merge wrapping paper instead of wrapping it up.

If you are evil and want to wrap up some wrapping paper for the funnies, you can still do it on harm intent.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Merging the stacks together instead of accidentally wrapping them up is good.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Played with wrapping paper.
Only made packages when I did harm intent.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: You no longer wrap wrapping paper in wrapping paper unless you want to wrap wrapping paper in wrapping paper.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
