### PR TITLE
Fixes a baton runtime. And fixes a related bug todo with the runtime

### DIFF
--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -110,6 +110,7 @@
 		cell = null
 		turned_on = FALSE
 		update_icon(UPDATE_ICON_STATE)
+		return
 	if(cell.charge < (hitcost)) // If after the deduction the baton doesn't have enough charge for a stun hit it turns off.
 		turned_on = FALSE
 		update_icon()

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -99,15 +99,12 @@
 	if(istype(W, /obj/item/reagent_containers/syringe))
 		var/obj/item/reagent_containers/syringe/S = W
 
-		to_chat(user, "You inject the solution into the power cell.")
-
 		if(S.reagents.has_reagent("plasma", 5) || S.reagents.has_reagent("plasma_dust", 5))
-
+			to_chat(user, "You inject the solution into the power cell.")
 			rigged = TRUE
 
 			log_admin("LOG: [key_name(user)] injected a power cell with plasma, rigging it to explode.")
 			message_admins("LOG: [key_name_admin(user)] injected a power cell with plasma, rigging it to explode.")
-
 		S.reagents.clear_reagents()
 	else
 		return ..()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Fixes a runtime from batons with rigged cells trying to check the charge of the now exploded cell
Also fixes syringes always saying "you inject the solution" even if the syringe is empty, As well as cleaned the code up slightly. i similar enough, lemme know if i should split the fixes though
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Runtime bad, cant see any issues with it not checking the charge since cell is being deleted anyway.
Also it saying you injected something when you didn't is bad. also the code was hard to read

## Testing
<!-- How did you test the PR, if at all? -->
Rigged a cell, hit myself. no runtime
tried to inject a cell with an empty syringe, no message

## Changelog
:cl:
fix: Fixed a runtime with batons trying to check charge of a exploded cell
fix: Fixed syringes saying they injected something into a cell when empty
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
