### PR TITLE
Tweak: SMES charge overlay is now more accurate

### DIFF
--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -244,7 +244,7 @@
 	return ..()
 
 /obj/machinery/power/smes/proc/chargedisplay()
-	return clamp(round(5.5 * charge / capacity), 0, 5)
+	return clamp(round(ceil(charge * 5 / capacity)), 0, 5)
 
 /obj/machinery/power/smes/process()
 	if(stat & BROKEN)


### PR DESCRIPTION
## What Does This PR Do
The display charge is now rounded upwards so that all overlays are used correctly.
100-81 -> 80-61 -> 60-41 -> 40-21 -> 20-0 and no overlay

## Why It's Good For The Game
More info from sprite, and less misunderstandings, when UI show you have 40% charge, but overlay is blinking like it low charge

## Images of changes
| 100-81 | 80-61 | 60-41 | 40-21 | 20-0 |
| - | - | - | - | - |
| ![image](https://github.com/user-attachments/assets/1b751837-8025-4eb0-b5de-02796c700ebd) | ![image](https://github.com/user-attachments/assets/d997309f-c216-4053-8dd4-efb297a1528a) | ![image](https://github.com/user-attachments/assets/beed34f4-11ff-4612-934f-6030fa0a5adf) | ![image](https://github.com/user-attachments/assets/1589f2c7-2d42-4557-971e-20f7c923114a) | ![dreamseeker_e8JKKgK7qs](https://github.com/user-attachments/assets/7caf1f46-5794-43f7-ac66-4d0e4257c900) |

## Changelog
:cl:
tweak: Smes sprite shows more accurate charge info
/:cl:
