### PR TITLE
fix: Prevent backgrounding of unit tests.

### DIFF
--- a/code/modules/unit_tests/test_runner.dm
+++ b/code/modules/unit_tests/test_runner.dm
@@ -43,6 +43,8 @@
 				if(test.failure_count >= MAX_MAP_TEST_FAILURE_COUNT)
 					test.Fail(T, "failure threshold reached at this tile")
 
+		CHECK_TICK
+
 	for(var/datum/map_per_tile_test/test in tests)
 		if(!test.succeeded)
 			failed_any_test = TRUE


### PR DESCRIPTION
## What Does This PR Do
This PR adds a `CHECK_TICK` check between tiles while looping over per-tile map checks in the unit tests. This (seems to) prevent BYOND's infinite loop detector from triggering, which backgrounds the unit tests and may cause them to fail to run before the world shuts down.

Fixes #24893.
## Why It's Good For The Game
Unit tests should run to completion.
## Testing
Created a pull request on my fork and ran unit tests before and after the change. CI logs seemed to confirm the tests were no longer backgrounded. Compare [before]() and [after]() by searching for "infinite loop".

[before]: https://gist.github.com/warriorstar-orion/68375fb9e28df34da07c5b4cc6037d6c
[after]: https://gist.github.com/warriorstar-orion/806d89866b46f5fbdf456f7891406065
## Changelog
NPFC
