### PR TITLE
fix: ratvar ruin fixes

### DIFF
--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_dead_ratvar.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_dead_ratvar.dmm
@@ -11,9 +11,11 @@
 /area/lavaland/surface/outdoors/unexplored)
 "d" = (
 /obj/structure/clockwork/wall_gear,
+/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/unexplored)
 "e" = (
+/obj/effect/mapping_helpers/no_lava,
 /obj/item/stack/tile/brass,
 /turf/simulated/floor/clockwork/lavaland_air,
 /area/lavaland/surface/outdoors/unexplored)
@@ -25,6 +27,7 @@
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/unexplored)
 "h" = (
+/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/clockwork/lavaland_air,
 /area/lavaland/surface/outdoors/unexplored)
 "i" = (
@@ -32,9 +35,11 @@
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/unexplored)
 "j" = (
+/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/wall/clockwork,
 /area/lavaland/surface/outdoors/unexplored)
 "k" = (
+/obj/effect/mapping_helpers/no_lava,
 /obj/item/clockwork/alloy_shards/small,
 /turf/simulated/floor/clockwork/lavaland_air,
 /area/lavaland/surface/outdoors/unexplored)
@@ -47,6 +52,7 @@
 /area/lavaland/surface/outdoors/unexplored)
 "n" = (
 /obj/item/clockwork/component/belligerent_eye/blind_eye,
+/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/unexplored)
 "o" = (
@@ -54,77 +60,83 @@
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/unexplored)
 "p" = (
+/obj/effect/mapping_helpers/no_lava,
 /obj/item/clockwork/alloy_shards/medium,
 /turf/simulated/floor/clockwork/lavaland_air,
 /area/lavaland/surface/outdoors/unexplored)
-"q" = (
-/obj/structure/lattice/catwalk/clockwork,
-/turf/simulated/floor/lava/mapping_lava,
-/area/lavaland/surface/outdoors/unexplored)
 "r" = (
-/obj/structure/lattice/clockwork,
+/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/unexplored)
 "s" = (
+/obj/effect/mapping_helpers/no_lava,
 /obj/item/clockwork/alloy_shards/large,
 /turf/simulated/floor/clockwork/lavaland_air,
 /area/lavaland/surface/outdoors/unexplored)
 "t" = (
 /obj/item/stack/tile/brass,
+/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/unexplored)
 "u" = (
+/obj/effect/mapping_helpers/no_lava,
 /obj/structure/grille/ratvar,
 /turf/simulated/floor/clockwork/lavaland_air,
 /area/lavaland/surface/outdoors/unexplored)
-"v" = (
-/obj/item/clockwork/alloy_shards/medium,
-/obj/structure/lattice/clockwork,
-/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/unexplored)
 "w" = (
+/obj/effect/mapping_helpers/no_lava,
 /obj/structure/grille/ratvar/broken,
 /turf/simulated/floor/clockwork/lavaland_air,
 /area/lavaland/surface/outdoors/unexplored)
 "x" = (
+/obj/effect/mapping_helpers/no_lava,
 /obj/structure/clockwork/wall_gear,
 /obj/item/stack/tile/brass,
 /turf/simulated/floor/clockwork/lavaland_air,
 /area/lavaland/surface/outdoors/unexplored)
 "y" = (
+/obj/effect/mapping_helpers/no_lava,
 /obj/item/clockwork/component/geis_capacitor/fallen_armor,
 /turf/simulated/floor/clockwork/lavaland_air,
 /area/lavaland/surface/outdoors/unexplored)
 "z" = (
+/obj/effect/mapping_helpers/no_lava,
 /obj/structure/clockwork/wall_gear,
 /turf/simulated/floor/clockwork/lavaland_air,
 /area/lavaland/surface/outdoors/unexplored)
 "A" = (
+/obj/effect/mapping_helpers/no_lava,
 /obj/item/clockwork/alloy_shards/clockgolem_remains,
 /turf/simulated/floor/clockwork/lavaland_air,
 /area/lavaland/surface/outdoors/unexplored)
 "B" = (
+/obj/effect/mapping_helpers/no_lava,
 /obj/item/clockwork/weapon/ratvarian_spear,
 /turf/simulated/floor/clockwork/lavaland_air,
 /area/lavaland/surface/outdoors/unexplored)
 "C" = (
+/obj/effect/mapping_helpers/no_lava,
 /obj/item/clockwork/alloy_shards/medium/gear_bit,
 /turf/simulated/floor/clockwork/lavaland_air,
 /area/lavaland/surface/outdoors/unexplored)
 "D" = (
 /obj/structure/grille/ratvar,
+/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/unexplored)
 "E" = (
 /obj/item/clockwork/alloy_shards/clockgolem_remains,
+/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/unexplored)
 "F" = (
+/obj/effect/mapping_helpers/no_lava,
 /obj/structure/dead_ratvar,
 /turf/simulated/floor/clockwork/lavaland_air,
 /area/lavaland/surface/outdoors/unexplored)
 "G" = (
 /obj/item/stack/tile/brass/fifty,
+/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/unexplored)
 
@@ -167,7 +179,7 @@ b
 a
 h
 b
-r
+b
 c
 j
 x
@@ -191,7 +203,7 @@ f
 b
 l
 b
-v
+m
 b
 p
 w
@@ -216,7 +228,7 @@ a
 f
 l
 l
-r
+b
 b
 b
 l
@@ -228,7 +240,7 @@ l
 b
 h
 c
-r
+b
 a
 a
 "}
@@ -254,7 +266,7 @@ l
 l
 D
 h
-r
+b
 a
 a
 "}
@@ -323,7 +335,7 @@ l
 l
 n
 h
-r
+b
 l
 l
 b
@@ -404,7 +416,7 @@ k
 h
 h
 h
-r
+b
 l
 l
 l
@@ -424,13 +436,13 @@ l
 l
 b
 l
-q
-r
+l
+b
 h
 h
 h
 c
-q
+l
 l
 b
 l
@@ -450,7 +462,7 @@ l
 b
 p
 s
-r
+b
 h
 h
 h
@@ -526,7 +538,7 @@ l
 l
 l
 l
-q
+l
 b
 h
 h
@@ -553,8 +565,8 @@ l
 l
 b
 l
-q
-r
+l
+b
 h
 h
 h
@@ -562,9 +574,9 @@ h
 h
 b
 s
-r
+b
 l
-r
+b
 l
 l
 b
@@ -585,11 +597,11 @@ h
 h
 h
 h
-r
+b
 k
 b
 C
-r
+b
 h
 b
 b
@@ -612,12 +624,12 @@ h
 h
 h
 h
-r
+b
 j
 h
 c
 h
-r
+b
 h
 b
 b
@@ -644,7 +656,7 @@ l
 l
 b
 E
-r
+b
 G
 o
 "}
@@ -656,9 +668,9 @@ l
 l
 l
 l
-r
+b
 h
-r
+b
 h
 h
 h
@@ -672,7 +684,7 @@ l
 l
 j
 j
-r
+b
 "}
 (22,1,1) = {"
 c
@@ -714,7 +726,7 @@ u
 r
 p
 h
-r
+b
 h
 b
 l
@@ -723,7 +735,7 @@ l
 b
 b
 w
-r
+b
 b
 "}
 (24,1,1) = {"
@@ -736,7 +748,7 @@ l
 l
 j
 j
-q
+l
 p
 h
 m
@@ -765,7 +777,7 @@ l
 l
 b
 h
-r
+b
 x
 h
 l
@@ -791,7 +803,7 @@ l
 l
 l
 g
-q
+l
 b
 h
 l


### PR DESCRIPTION
## What Does This PR Do
This PR adds no_lava mapping helpers to the clockwork floor turfs and turfs with clockwork cult items (except the tiny replicant alloy shards), and removes all `/obj/structure/lattice/clockwork` and `/obj/structure/lattice/catwalk/clockwork` objects.
## Why It's Good For The Game
Without the no_lava helpers, chasms can rip right through the ruin, going so far as to drop the Ratvar corpse into the chasm. The clockwork lattices and catwalks not only don't instantiate correctly (presumably because they only spawn in space and not on floor turfs) but don't have the proper smoothing sprites even if they were able to spawn.
## Images of changes
![2024_07_15__08_33_41__paradise dme  lavaland_surface_dead_ratvar dmm  - StrongDMM](https://github.com/user-attachments/assets/f80a067f-601b-4157-bec9-d9a49f7a718d)
## Testing
Spawned hundreds of dead gods with lots of chasms.

Before:

![2024_07_15__08_46_34__Paradise Station 13](https://github.com/user-attachments/assets/6b254761-2838-4a5c-84dd-4fb781b0a175)

After:

![2024_07_15__08_42_44__Paradise Station 13](https://github.com/user-attachments/assets/92cc1419-3ad6-43e8-b573-9c52900dee31)

## Changelog
:cl:
fix: Ratvar will no longer fall into chasms.
/:cl: