### PR TITLE
Fixes cameras runtiming on deconstruction

### DIFF
--- a/code/game/machinery/computer/camera_console.dm
+++ b/code/game/machinery/computer/camera_console.dm
@@ -47,7 +47,6 @@
 
 /obj/machinery/computer/security/Destroy()
 	qdel(cam_screen)
-	QDEL_LIST_CONTENTS(cam_plane_masters)
 	qdel(cam_background)
 	return ..()
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Removes an unneeded qdel call that causes a bunch of runtimes. Fixes #26219
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
When bloom was added, the way cameras handle overlays was changed too. It used to be that cam_plane_master was a list of the overlay objects. Now, it's just a list of the paths that are used further down the proc. Regular variables runtime when they try to get qdel'd, and since there's nothing special about them anymore we can safely let them get deleted with the camera console.

oh right, runtimes bad
## Testing
<!-- How did you test the PR, if at all? -->
Loaded in, made sure that camera consoles still worked and that the bloom/overlay effects were still visible. Deconstructed the console and made sure there were no runtimes or GC issues

