### PR TITLE
Xenomorph Spells State Their Casting Cost in Their Descriptions.

### DIFF
--- a/code/datums/spells/alien_spells/build_resin_structure.dm
+++ b/code/datums/spells/alien_spells/build_resin_structure.dm
@@ -5,7 +5,7 @@
 
 /datum/spell/alien_spell/build_resin
 	name = "Build Resin Structure"
-	desc = "Allows you to create resin structures. Does not work while in space."
+	desc = "Allows you to create resin structures. Does not work while in space. Consumes 55 plasma."
 	plasma_cost = 55
 	action_icon_state = "alien_resin"
 
@@ -47,7 +47,7 @@
 
 /datum/spell/touch/alien_spell/consume_resin
 	name = "Consume resin structures"
-	desc = "Allows you to rip and tear straight through resin structures."
+	desc = "Allows you to rip and tear straight through resin structures. Consumes 10 plasma."
 	action_icon_state = "alien_resin"
 	hand_path = "/obj/item/melee/touch_attack/alien/consume_resin"
 	plasma_cost = 10

--- a/code/datums/spells/alien_spells/corrosive_acid_spit.dm
+++ b/code/datums/spells/alien_spells/corrosive_acid_spit.dm
@@ -1,6 +1,6 @@
 /datum/spell/touch/alien_spell/corrosive_acid
 	name = "Corrosive acid"
-	desc = "Spit acid on someone in range, this acid melts through nearly anything and heavily damages anyone lacking proper safety equipment."
+	desc = "Spit acid on someone in range, this acid melts through nearly anything and heavily damages anyone lacking proper safety equipment. Consumes 200 plasma."
 	hand_path = "/obj/item/melee/touch_attack/alien/corrosive_acid"
 	action_icon_state = "alien_acid"
 	plasma_cost = 200
@@ -34,7 +34,7 @@
 
 /datum/spell/touch/alien_spell/burning_touch
 	name = "Blazing touch"
-	desc = "Boil acid within your hand to burn through anything you touch with it, deals a lot of damage to aliens and destroys resin structures instantly."
+	desc = "Boil acid within your hand to burn through anything you touch with it, deals a lot of damage to aliens and destroys resin structures instantly. Consumes 100 plasma."
 	hand_path = "/obj/item/melee/touch_attack/alien/burning_touch"
 	action_icon_state = "alien_acid"
 	plasma_cost = 100

--- a/code/datums/spells/alien_spells/lay_alien_eggs.dm
+++ b/code/datums/spells/alien_spells/lay_alien_eggs.dm
@@ -1,6 +1,6 @@
 /datum/spell/alien_spell/plant_weeds/eggs
 	name = "Plant alien eggs"
-	desc = "Allows you to plant alien eggs on your current turf, does not work while in space."
+	desc = "Allows you to plant alien eggs on your current turf, does not work while in space. Consumes 75 plasma."
 	plasma_cost = 75
 	weed_type = /obj/structure/alien/egg
 	weed_name = "alien egg"
@@ -9,7 +9,7 @@
 
 /datum/spell/alien_spell/combust_facehuggers
 	name = "Combust facehuggers and eggs"
-	desc = "Take over the programming of facehuggers and eggs, sending out a shockwave which causes them to combust."
+	desc = "Take over the programming of facehuggers and eggs, sending out a shockwave which causes them to combust. Consumes 25 plasma."
 	plasma_cost = 25
 	action_icon_state = "alien_egg"
 	base_cooldown = 3 SECONDS

--- a/code/datums/spells/alien_spells/neurotoxin_spit.dm
+++ b/code/datums/spells/alien_spells/neurotoxin_spit.dm
@@ -1,6 +1,6 @@
 /datum/spell/alien_spell/neurotoxin
 	name = "Neurotoxin spit"
-	desc = "This ability allows you to fire some neurotoxin. Knocks down anyone you hit, applies a small amount of stamina damage as well."
+	desc = "This ability allows you to fire some neurotoxin. Knocks down anyone you hit, applies a small amount of stamina damage as well. Consumes 50 plasma."
 	base_cooldown = 3 SECONDS
 	plasma_cost = 50
 	selection_activated_message		= "<span class='notice'><B>Your prepare some neurotoxin!</B></span>"
@@ -37,6 +37,6 @@
 
 /datum/spell/alien_spell/neurotoxin/death_to_xenos
 	name = "Neurotoxin spit"
-	desc = "This ability allows you to fire some neurotoxin. Knocks aliens down."
+	desc = "This ability allows you to fire some neurotoxin. Knocks aliens down. Consumes 50 plasma."
 	neurotoxin_type = /obj/item/projectile/bullet/anti_alien_toxin
 	base_cooldown = 2 SECONDS

--- a/code/datums/spells/alien_spells/plasma_weeds.dm
+++ b/code/datums/spells/alien_spells/plasma_weeds.dm
@@ -1,6 +1,6 @@
 /datum/spell/alien_spell/plant_weeds
 	name = "Plant weeds"
-	desc = "Allows you to plant some alien weeds on the floor below you. Does not work while in space."
+	desc = "Allows you to plant some alien weeds on the floor below you. Does not work while in space. Consumes 50 plasma."
 	plasma_cost = 50
 	var/atom/weed_type = /obj/structure/alien/weeds/node
 	var/weed_name = "alien weed node"

--- a/code/datums/spells/alien_spells/transfer_plasma.dm
+++ b/code/datums/spells/alien_spells/transfer_plasma.dm
@@ -1,6 +1,6 @@
 /datum/spell/alien_spell/transfer_plasma
 	name = "Transfer Plasma"
-	desc = "Transfers 50 plasma to a nearby alien"
+	desc = "Transfers 50 plasma to a nearby alien."
 	action_icon_state = "alien_transfer"
 	plasma_cost = 50
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #26209. All xenomorph spells' descriptions now include the quantity of plasma that will be consumed upon use.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Being able to tell casting costs is good, allows more informed resource management decisions.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
It compiled.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
tweak: Added casting costs of xeno abilities to the ability descriptions.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
