### PR TITLE
Makes NODROP mops not get stuck in mop buckets

### DIFF
--- a/code/game/objects/items/weapons/mop.dm
+++ b/code/game/objects/items/weapons/mop.dm
@@ -32,7 +32,8 @@
 	if(o.reagents.total_volume < 1)
 		to_chat(user, "[o] is out of water!</span>")
 		if(istype(o, /obj/structure/mopbucket))
-			mopbucket_insert(user, o)
+			var/obj/structure/mopbucket/mopbucket = o
+			mopbucket.mopbucket_insert(user, o)
 		if(istype(o, /obj/structure/janitorialcart))
 			janicart_insert(user, o)
 		return
@@ -126,9 +127,6 @@
 /obj/item/mop/advanced/cyborg
 
 /obj/item/mop/advanced/cyborg/janicart_insert(mob/user, obj/structure/janitorialcart/J)
-	return
-
-/obj/item/mop/advanced/cyborg/mopbucket_insert(mob/user, obj/structure/mopbucket/J)
 	return
 
 #undef MOP_SOUND_CD

--- a/code/game/objects/structures/mop_bucket.dm
+++ b/code/game/objects/structures/mop_bucket.dm
@@ -29,7 +29,7 @@
 		return
 	if(istype(W, /obj/item/mop))
 		var/obj/item/mop/attacking_mop = W
-		if(attacking_mop.reagents.total_volume < M.reagents.maximum_volume)
+		if(attacking_mop.reagents.total_volume < attacking_mop.reagents.maximum_volume)
 			attacking_mop.wet_mop(src, user)
 			return
 

--- a/code/game/objects/structures/mop_bucket.dm
+++ b/code/game/objects/structures/mop_bucket.dm
@@ -23,20 +23,25 @@
 	GLOB.janitorial_equipment -= src
 	return ..()
 
-/obj/structure/mopbucket/attackby(obj/item/W as obj, mob/user as mob, params)
+/obj/structure/mopbucket/attackby(obj/item/W, mob/user, params)
 	if(W.is_robot_module())
 		to_chat(user, "<span class='warning'>You cannot interface your modules with [src]!</span>")
 		return
 	if(istype(W, /obj/item/mop))
-		var/obj/item/mop/M = W
-		if(M.reagents.total_volume < M.reagents.maximum_volume)
-			M.wet_mop(src, user)
+		var/obj/item/mop/attacking_mop = W
+		if(attacking_mop.reagents.total_volume < M.reagents.maximum_volume)
+			attacking_mop.wet_mop(src, user)
 			return
-		if(!stored_mop)
-			M.mopbucket_insert(user, src)
+
+		if(!user.unEquip(attacking_mop))
+			to_chat(user, "<span class='notice'>[attacking_mop] is stuck to your hand!</span>")
 			return
-		to_chat(user, "<span class='notice'>Theres already a mop in the mopbucket.</span>")
-		return
+
+		if(!stored_mop && user.unEquip(attacking_mop))
+			attacking_mop.mopbucket_insert(user, src)
+			return
+
+		to_chat(user, "<span class='notice'>There is already a mop in the mopbucket.</span>")
 
 /obj/structure/mopbucket/proc/put_in_cart(obj/item/mop/I, mob/user)
 	user.drop_item()

--- a/code/game/objects/structures/mop_bucket.dm
+++ b/code/game/objects/structures/mop_bucket.dm
@@ -37,6 +37,10 @@
 			to_chat(user, "<span class='notice'>[attacking_mop] is stuck to your hand!</span>")
 			return
 
+		if(istype(attacking_mop, /obj/item/mop/advanced/cyborg))
+			to_chat(user, "<span class='notice'>[attacking_mop] cannot be removed from you!</span>")
+			return
+
 		if(!stored_mop)
 			mopbucket_insert(user, attacking_mop)
 			return

--- a/code/game/objects/structures/mop_bucket.dm
+++ b/code/game/objects/structures/mop_bucket.dm
@@ -27,6 +27,7 @@
 	if(W.is_robot_module())
 		to_chat(user, "<span class='warning'>You cannot interface your modules with [src]!</span>")
 		return
+
 	if(istype(W, /obj/item/mop))
 		var/obj/item/mop/attacking_mop = W
 		if(attacking_mop.reagents.total_volume < attacking_mop.reagents.maximum_volume)
@@ -35,10 +36,6 @@
 
 		if(!user.unEquip(attacking_mop))
 			to_chat(user, "<span class='notice'>[attacking_mop] is stuck to your hand!</span>")
-			return
-
-		if(istype(attacking_mop, /obj/item/mop/advanced/cyborg))
-			to_chat(user, "<span class='notice'>[attacking_mop] cannot be removed from you!</span>")
 			return
 
 		if(!stored_mop)

--- a/code/game/objects/structures/mop_bucket.dm
+++ b/code/game/objects/structures/mop_bucket.dm
@@ -37,7 +37,7 @@
 			to_chat(user, "<span class='notice'>[attacking_mop] is stuck to your hand!</span>")
 			return
 
-		if(!stored_mop && user.unEquip(attacking_mop))
+		if(!stored_mop)
 			attacking_mop.mopbucket_insert(user, src)
 			return
 

--- a/code/game/objects/structures/mop_bucket.dm
+++ b/code/game/objects/structures/mop_bucket.dm
@@ -38,21 +38,17 @@
 			return
 
 		if(!stored_mop)
-			attacking_mop.mopbucket_insert(user, src)
+			mopbucket_insert(user, attacking_mop)
 			return
 
 		to_chat(user, "<span class='notice'>There is already a mop in the mopbucket.</span>")
 
-/obj/structure/mopbucket/proc/put_in_cart(obj/item/mop/I, mob/user)
-	user.drop_item()
+/obj/structure/mopbucket/proc/mopbucket_insert(mob/user, obj/item/mop/I)
+	stored_mop = I
 	I.forceMove(src)
 	to_chat(user, "<span class='notice'>You put [I] into [src].</span>")
 	update_icon(UPDATE_OVERLAYS)
 	return
-
-/obj/item/mop/proc/mopbucket_insert(mob/user, obj/structure/mopbucket/J)
-	J.stored_mop = src
-	J.put_in_cart(src, user)
 
 /obj/structure/mopbucket/on_reagent_change()
 	update_icon(UPDATE_OVERLAYS)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes NODROP mops not get put into mop buckets
Also cleans up the entire proc a bit

Also refactors a proc that went
`mopbucket calls proc on mop which calls proc on mopbucket`
Into something sensible
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Resolves #26205
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Put a janitorial implant in me
Tried to put the mop in the bucket, did not work

Checked with a normal mop that it could be inserted

Checked that a cyborg couldn't put their mop in a bucket
![image](https://github.com/user-attachments/assets/f599fd7a-0476-4335-9b2f-2b85c663cb42)

<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: NODROP mops now won't get put in mop buckets
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
