### PR TITLE
Refactors the Attackby Proc of 42 Machines (Mostly Concerning the RPED) and RPED Afterattack

### DIFF
--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -185,9 +185,7 @@
 	return TRUE
 
 /obj/machinery/dna_scannernew/attackby(obj/item/I, mob/user, params)
-	if(exchange_parts(user, I))
-		return
-	else if(istype(I, /obj/item/reagent_containers/glass))
+	if(istype(I, /obj/item/reagent_containers/glass))
 		if(beaker)
 			to_chat(user, "<span class='warning'>A beaker is already loaded into the machine.</span>")
 			return
@@ -201,26 +199,33 @@
 		I.forceMove(src)
 		user.visible_message("[user] adds \a [I] to \the [src]!", "You add \a [I] to \the [src]!")
 		return
+
 	if(istype(I, /obj/item/grab))
 		var/obj/item/grab/G = I
 		if(!ismob(G.affecting))
 			return
+
 		if(occupant)
 			to_chat(user, "<span class='boldnotice'>The scanner is already occupied!</span>")
 			return
+
 		if(G.affecting.abiotic())
 			to_chat(user, "<span class='boldnotice'>Subject may not hold anything in their hands.</span>")
 			return
+
 		if(G.affecting.has_buckled_mobs()) //mob attached to us
 			to_chat(user, "<span class='warning'>[G] will not fit into [src] because [G.affecting.p_they()] [G.affecting.p_have()] a slime latched onto [G.affecting.p_their()] head.</span>")
 			return
+
 		if(panel_open)
 			to_chat(usr, "<span class='boldnotice'>Close the maintenance panel first.</span>")
 			return
+
 		put_in(G.affecting)
 		add_fingerprint(user)
 		qdel(G)
 		return
+
 	return ..()
 
 /obj/machinery/dna_scannernew/crowbar_act(mob/user, obj/item/I)

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -317,19 +317,19 @@
 			to_chat(user, "<span class='warning'>The sleeper has a beaker already.</span>")
 			return
 
-	if(exchange_parts(user, I))
-		return
-
 	if(istype(I, /obj/item/grab))
 		var/obj/item/grab/G = I
 		if(panel_open)
 			to_chat(user, "<span class='boldnotice'>Close the maintenance panel first.</span>")
 			return
+
 		if(!ismob(G.affecting))
 			return
+
 		if(occupant)
 			to_chat(user, "<span class='boldnotice'>The sleeper is already occupied!</span>")
 			return
+
 		if(G.affecting.has_buckled_mobs()) //mob attached to us
 			to_chat(user, "<span class='warning'>[G.affecting] will not fit into [src] because [G.affecting.p_they()] [G.affecting.p_have()] a slime latched onto [G.affecting.p_their()] head.</span>")
 			return
@@ -340,8 +340,10 @@
 			if(occupant)
 				to_chat(user, "<span class='boldnotice'>The sleeper is already occupied!</span>")
 				return
+
 			if(!G || !G.affecting)
 				return
+
 			var/mob/M = G.affecting
 			M.forceMove(src)
 			occupant = M

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -65,26 +65,28 @@
 		icon_state = "bodyscanner-open"
 
 /obj/machinery/bodyscanner/attackby(obj/item/I, mob/user)
-	if(exchange_parts(user, I))
-		return
-
 	if(istype(I, /obj/item/grab))
 		var/obj/item/grab/TYPECAST_YOUR_SHIT = I
 		if(panel_open)
 			to_chat(user, "<span class='notice'>Close the maintenance panel first.</span>")
 			return
+
 		if(!ishuman(TYPECAST_YOUR_SHIT.affecting))
 			return
+
 		if(occupant)
 			to_chat(user, "<span class='notice'>The scanner is already occupied!</span>")
 			return
+
 		if(TYPECAST_YOUR_SHIT.affecting.has_buckled_mobs()) //mob attached to us
 			to_chat(user, "<span class='warning'>[TYPECAST_YOUR_SHIT.affecting] will not fit into [src] because [TYPECAST_YOUR_SHIT.affecting.p_they()] [TYPECAST_YOUR_SHIT.affecting.p_have()] a fucking slime latched onto [TYPECAST_YOUR_SHIT.affecting.p_their()] head.</span>")
 			return
+
 		var/mob/living/carbon/human/M = TYPECAST_YOUR_SHIT.affecting
 		if(M.abiotic())
 			to_chat(user, "<span class='notice'>Subject may not hold anything in their hands.</span>")
 			return
+
 		M.forceMove(src)
 		occupant = M
 		playsound(src, 'sound/machines/podclose.ogg', 5)

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -265,11 +265,10 @@
 /obj/machinery/autolathe/attackby(obj/item/O, mob/user, params)
 	if(busy)
 		to_chat(user, "<span class='alert'>The autolathe is busy. Please wait for completion of previous operation.</span>")
-		return 1
-	if(exchange_parts(user, O))
-		return
+		return TRUE
+
 	if(stat)
-		return 1
+		return TRUE
 
 	// Disks in general
 	if(istype(O, /obj/item/disk))
@@ -280,14 +279,17 @@
 
 				if(design.id in files.known_designs)
 					to_chat(user, "<span class='warning'>This design has already been loaded into the autolathe.</span>")
-					return 1
+					return TRUE
 
 				if(!files.CanAddDesign2Known(design))
 					to_chat(user, "<span class='warning'>This design is not compatible with the autolathe.</span>")
-					return 1
-				user.visible_message("[user] begins to load \the [O] in \the [src]...",
+					return TRUE
+
+				user.visible_message(
+					"[user] begins to load \the [O] in \the [src]...",
 					"You begin to load a design from \the [O]...",
-					"You hear the chatter of a floppy drive.")
+					"You hear the chatter of a floppy drive."
+				)
 				playsound(get_turf(src), 'sound/goonstation/machines/printer_dotmatrix.ogg', 50, 1)
 				busy = TRUE
 				if(do_after(user, 14.4, target = src))
@@ -298,11 +300,12 @@
 				busy = FALSE
 			else
 				to_chat(user, "<span class='warning'>That disk does not have a design on it!</span>")
-			return 1
+			return TRUE
+
 		else
 			// So that people who are bad at computers don't shred their disks
 			to_chat(user, "<span class='warning'>This is not the correct type of disk for the autolathe!</span>")
-			return 1
+			return TRUE
 
 	return ..()
 

--- a/code/game/machinery/clonepod.dm
+++ b/code/game/machinery/clonepod.dm
@@ -556,9 +556,6 @@
 
 //Attackby and x_acts
 /obj/machinery/clonepod/attackby(obj/item/I, mob/user, params)
-	if(exchange_parts(user, I))
-		return
-
 	if(I.is_open_container())
 		return
 

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -149,11 +149,6 @@ GLOBAL_LIST_EMPTY(holopads)
 		holograph_range += 1 * B.rating
 	holo_range = holograph_range
 
-/obj/machinery/hologram/holopad/attackby(obj/item/I, mob/user, params)
-	if(exchange_parts(user, I))
-		return
-	return ..()
-
 /obj/machinery/hologram/holopad/multitool_act(mob/living/user, obj/item/I)
 	. = TRUE
 	if(!I.use_tool(src, user, 0, volume = I.tool_volume))

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -344,28 +344,37 @@
 		power_change()
 
 /obj/machinery/attackby(obj/item/O, mob/user, params)
+	if(exchange_parts(user, O))
+		return
+
 	if(istype(O, /obj/item/stack/nanopaste))
 		var/obj/item/stack/nanopaste/N = O
 		if(stat & BROKEN)
 			to_chat(user, "<span class='notice'>[src] is too damaged to be fixed with nanopaste!</span>")
 			return
+
 		if(obj_integrity == max_integrity)
 			to_chat(user, "<span class='notice'>[src] is fully intact.</span>")
 			return
+
 		if(being_repaired)
 			return
+
 		if(N.get_amount() < 1)
 			to_chat(user, "<span class='warning'>You don't have enough to complete this task!</span>")
 			return
+
 		to_chat(user, "<span class='notice'>You start applying [O] to [src].</span>")
 		being_repaired = TRUE
 		var/result = do_after(user, 3 SECONDS, target = src)
 		being_repaired = FALSE
 		if(!result)
 			return
+
 		if(!N.use(1))
 			to_chat(user, "<span class='warning'>You don't have enough to complete this task!</span>") // this is here, as we don't want to use nanopaste until you finish applying
 			return
+
 		obj_integrity = min(obj_integrity + 50, max_integrity)
 		user.visible_message("<span class='notice'>[user] applied some [O] at [src]'s damaged areas.</span>",\
 			"<span class='notice'>You apply some [O] at [src]'s damaged areas.</span>")
@@ -376,57 +385,58 @@
 	var/shouldplaysound = 0
 	if(flags & NODECONSTRUCT)
 		return FALSE
-	if(istype(W) && component_parts)
-		if(panel_open || W.works_from_distance)
-			var/obj/item/circuitboard/CB = locate(/obj/item/circuitboard) in component_parts
-			var/P
-			if(W.works_from_distance)
-				to_chat(user, display_parts(user))
-			for(var/obj/item/stock_parts/A in component_parts)
-				for(var/D in CB.req_components)
-					if(ispath(A.type, D))
-						P = D
-						break
-				for(var/obj/item/stock_parts/B in W.contents)
-					if(istype(B, P) && istype(A, P))
-						//If it's cell - check: 1) Max charge is better? 2) Max charge same but current charge better? - If both NO -> next content
-						if(ispath(B.type, /obj/item/stock_parts/cell))
-							var/obj/item/stock_parts/cell/tA = A
-							var/obj/item/stock_parts/cell/tB = B
-							if(!(tB.maxcharge > tA.maxcharge) && !((tB.maxcharge == tA.maxcharge) && (tB.charge > tA.charge)))
-								continue
-						//If it's not cell and not better -> next content
-						else if(B.rating <= A.rating)
+
+	if(!istype(W) || !component_parts)
+		return FALSE
+
+	if(panel_open || W.works_from_distance)
+		var/obj/item/circuitboard/CB = locate(/obj/item/circuitboard) in component_parts
+		var/P
+		if(W.works_from_distance)
+			to_chat(user, display_parts(user))
+		for(var/obj/item/stock_parts/A in component_parts)
+			for(var/D in CB.req_components)
+				if(ispath(A.type, D))
+					P = D
+					break
+			for(var/obj/item/stock_parts/B in W.contents)
+				if(istype(B, P) && istype(A, P))
+					//If it's cell - check: 1) Max charge is better? 2) Max charge same but current charge better? - If both NO -> next content
+					if(ispath(B.type, /obj/item/stock_parts/cell))
+						var/obj/item/stock_parts/cell/tA = A
+						var/obj/item/stock_parts/cell/tB = B
+						if(!(tB.maxcharge > tA.maxcharge) && !((tB.maxcharge == tA.maxcharge) && (tB.charge > tA.charge)))
 							continue
-						W.remove_from_storage(B, src)
-						W.handle_item_insertion(A, user, TRUE)
-						component_parts -= A
-						component_parts += B
-						B.loc = null
-						to_chat(user, "<span class='notice'>[A.name] replaced with [B.name].</span>")
-						shouldplaysound = TRUE
-						break
-			for(var/obj/item/reagent_containers/glass/beaker/A in component_parts)
-				for(var/obj/item/reagent_containers/glass/beaker/B in W.contents)
-					// If it's not better -> next content
-					if(B.reagents.maximum_volume <= A.reagents.maximum_volume)
+					//If it's not cell and not better -> next content
+					else if(B.rating <= A.rating)
 						continue
 					W.remove_from_storage(B, src)
-					W.handle_item_insertion(A, TRUE)
+					W.handle_item_insertion(A, user, TRUE)
 					component_parts -= A
 					component_parts += B
 					B.loc = null
 					to_chat(user, "<span class='notice'>[A.name] replaced with [B.name].</span>")
 					shouldplaysound = TRUE
 					break
-			RefreshParts()
-		else
-			to_chat(user, display_parts(user))
-		if(shouldplaysound)
-			W.play_rped_sound()
-		return 1
+		for(var/obj/item/reagent_containers/glass/beaker/A in component_parts)
+			for(var/obj/item/reagent_containers/glass/beaker/B in W.contents)
+				// If it's not better -> next content
+				if(B.reagents.maximum_volume <= A.reagents.maximum_volume)
+					continue
+				W.remove_from_storage(B, src)
+				W.handle_item_insertion(A, TRUE)
+				component_parts -= A
+				component_parts += B
+				B.loc = null
+				to_chat(user, "<span class='notice'>[A.name] replaced with [B.name].</span>")
+				shouldplaysound = TRUE
+				break
+		RefreshParts()
 	else
-		return 0
+		to_chat(user, display_parts(user))
+	if(shouldplaysound)
+		W.play_rped_sound()
+	return TRUE
 
 /obj/machinery/proc/display_parts(mob/user)
 	. = list("<span class='notice'>Following parts detected in the machine:</span>")

--- a/code/game/machinery/quantum_pad.dm
+++ b/code/game/machinery/quantum_pad.dm
@@ -88,11 +88,6 @@
 	teleport_cooldown = initial(teleport_cooldown)
 	teleport_cooldown -= (E * 100)
 
-/obj/machinery/quantumpad/attackby(obj/item/I, mob/user, params)
-	if(exchange_parts(user, I))
-		return
-	return ..()
-
 /obj/machinery/quantumpad/crowbar_act(mob/user, obj/item/I)
 	. = TRUE
 	if(!I.tool_use_check(user, 0))

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -125,13 +125,6 @@
 	else
 		icon_state = "borgcharger0"
 
-/obj/machinery/recharge_station/attackby(obj/item/I, mob/user, params)
-	if(exchange_parts(user, I))
-		return
-
-	else
-		return ..()
-
 /obj/machinery/recharge_station/crowbar_act(mob/user, obj/item/I)
 	if(default_deconstruction_crowbar(user, I))
 		return TRUE

--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -57,12 +57,6 @@
 		return
 	update_icon(UPDATE_ICON_STATE)
 
-/obj/machinery/recycler/attackby(obj/item/I, mob/user, params)
-	add_fingerprint(user)
-	if(exchange_parts(user, I))
-		return
-	return ..()
-
 /obj/machinery/recycler/crowbar_act(mob/user, obj/item/I)
 	if(default_deconstruction_crowbar(user, I))
 		return TRUE

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -419,11 +419,6 @@
 		use_power(5000)
 	return
 
-/obj/machinery/teleport/hub/attackby(obj/item/I, mob/user, params)
-	if(exchange_parts(user, I))
-		return
-	return ..()
-
 /obj/machinery/teleport/hub/crowbar_act(mob/user, obj/item/I)
 	if(default_deconstruction_crowbar(user, I))
 		return TRUE
@@ -555,11 +550,6 @@
 	else
 		set_light(0)
 
-/obj/machinery/teleport/perma/attackby(obj/item/I, mob/user, params)
-	if(exchange_parts(user, I))
-		return
-	return ..()
-
 /obj/machinery/teleport/perma/crowbar_act(mob/user, obj/item/I)
 	if(default_deconstruction_crowbar(user, I))
 		return TRUE
@@ -634,16 +624,16 @@
 	return ..()
 
 /obj/machinery/teleport/station/attackby(obj/item/I, mob/user, params)
-	if(exchange_parts(user, I))
-		return
 	if(panel_open && istype(I, /obj/item/circuitboard/teleporter_perma))
 		if(!teleporter_console)
 			to_chat(user, "<span class='caution'>[src] is not linked to a teleporter console.</span>")
 			return
+
 		var/obj/item/circuitboard/teleporter_perma/C = I
 		C.target = teleporter_console.target
 		to_chat(user, "<span class='caution'>You copy the targeting information from [src] to [C].</span>")
 		return
+
 	return ..()
 
 /obj/machinery/teleport/station/crowbar_act(mob/user, obj/item/I)

--- a/code/game/mecha/mech_bay.dm
+++ b/code/game/mecha/mech_bay.dm
@@ -90,11 +90,6 @@
 		MC += C.rating
 	max_charge = MC * 25
 
-/obj/machinery/mech_bay_recharge_port/attackby(obj/item/I, mob/user, params)
-	if(exchange_parts(user, I))
-		return
-	return ..()
-
 /obj/machinery/mech_bay_recharge_port/screwdriver_act(mob/user, obj/item/I)
 	if(default_deconstruction_screwdriver(user, "recharge_port-o", "recharge_port", I))
 		return TRUE

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -297,10 +297,10 @@
 /obj/machinery/mecha_part_fabricator/attackby(obj/item/W, mob/user, params)
 	if(default_deconstruction_screwdriver(user, "fab-o", "fab-idle", W))
 		return
-	if(exchange_parts(user, W))
-		return
+
 	if(default_deconstruction_crowbar(user, W))
 		return TRUE
+
 	return ..()
 
 /obj/machinery/mecha_part_fabricator/attack_ghost(mob/user)

--- a/code/game/objects/items/weapons/stock_parts.dm
+++ b/code/game/objects/items/weapons/stock_parts.dm
@@ -1,5 +1,6 @@
-///////////////////////////////////////Stock Parts /////////////////////////////////
-
+////////////////////////////////////////
+// MARK: RPEDs
+////////////////////////////////////////
 /obj/item/storage/part_replacer
 	name = "Rapid Part Exchange Device"
 	desc = "Special mechanical module made to store, sort, and apply standard machine parts."
@@ -21,11 +22,11 @@
 	display_contents_with_number = TRUE
 	max_w_class = WEIGHT_CLASS_NORMAL
 	max_combined_w_class = 100
+	toolspeed = 1
+	usesound = 'sound/items/rped.ogg'
 	var/works_from_distance = FALSE
 	var/primary_sound = 'sound/items/rped.ogg'
 	var/alt_sound = null
-	toolspeed = 1
-	usesound = 'sound/items/rped.ogg'
 
 /obj/item/storage/part_replacer/Initialize(mapload)
 	. = ..()
@@ -34,6 +35,7 @@
 /obj/item/storage/part_replacer/can_be_inserted(obj/item/I, stop_messages = FALSE)
 	if(!istype(I, /obj/item/reagent_containers/glass/beaker))
 		return ..()
+
 	var/obj/item/reagent_containers/glass/beaker/B = I
 	if(B.reagents?.total_volume)
 		if(!stop_messages)
@@ -41,18 +43,26 @@
 		return FALSE
 	return ..()
 
-/obj/item/storage/part_replacer/afterattack(obj/machinery/M, mob/user, flag, params)
-	if(!flag && works_from_distance && istype(M))
-		// Make sure its in range
-		if(get_dist(src, M) <= (user.client.maxview() + 2))
-			if(M.component_parts)
-				M.exchange_parts(user, src)
-				user.Beam(M,icon_state="rped_upgrade", icon='icons/effects/effects.dmi', time=5)
-		else
-			message_admins("\[EXPLOIT] [key_name_admin(user)] attempted to upgrade machinery with a BRPED via a camera console. (Attempted range exploit)")
-			playsound(src, 'sound/machines/synth_no.ogg', 15, TRUE)
-			to_chat(user, "<span class='notice'>ERROR: [M] is out of [src]'s range!</span>")
+/obj/item/storage/part_replacer/afterattack(obj/machinery/M, mob/user, proximity_flag, params)
+	if(!istype(M))
+		return ..()
 
+	if(!proximity_flag && !works_from_distance)
+		return
+
+	if(get_dist(src, M) <= (user.client.maxview() + 2))
+		if(M.component_parts)
+			M.exchange_parts(user, src)
+		if(works_from_distance)
+			user.Beam(M, icon_state="rped_upgrade", icon='icons/effects/effects.dmi', time=5)
+	else
+		message_admins("\[EXPLOIT] [key_name_admin(user)] attempted to upgrade machinery with a BRPED via a camera console (attempted range exploit).")
+		playsound(src, 'sound/machines/synth_no.ogg', 15, TRUE)
+		to_chat(user, "<span class='notice'>ERROR: [M] is out of [src]'s range!</span>")
+
+////////////////////////////////////////
+// 		Bluespace Part Replacer
+////////////////////////////////////////
 /obj/item/storage/part_replacer/bluespace
 	name = "bluespace rapid part exchange device"
 	desc = "A version of the RPED that allows for replacement of parts and scanning from a distance, along with higher capacity for parts."
@@ -85,6 +95,9 @@
 	else
 		playsound(src, primary_sound, 40, 1)
 
+////////////////////////////////////////
+// MARK: Stock parts
+////////////////////////////////////////
 /obj/item/stock_parts
 	name = "stock part"
 	desc = "What?"

--- a/code/modules/arcade/arcade_base.dm
+++ b/code/modules/arcade/arcade_base.dm
@@ -57,18 +57,18 @@
 		return
 
 /obj/machinery/economy/arcade/attackby(obj/item/O, mob/user, params)
-	if(exchange_parts(user, O))
-		return
 	if(!freeplay)
 		if(isspacecash(O))
 			insert_cash(O, user, token_price)
 			if(pay_with_cash(token_price, "Arcade Token Purchase", "DonkBook Gaming", user, account_database.vendor_account))
 				tokens += 1
 			return
+
 		if(istype(O, /obj/item/card/id))
 			if(pay_with_card(O, token_price, "Arcade Token Purchase", "DonkBook Gaming", user, account_database.vendor_account))
 				tokens += 1
 			return
+
 	return ..()
 
 /obj/machinery/economy/arcade/screwdriver_act(mob/living/user, obj/item/I)

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -304,9 +304,11 @@
 		if(beaker)
 			to_chat(user, "<span class='warning'>A beaker is already loaded into the machine.</span>")
 			return
+
 		if(!user.drop_item())
-			to_chat(user, "[B] is stuck to you!")
+			to_chat(user, "<span class='warning'>[B] is stuck to you!</span>")
 			return
+
 		B.forceMove(src)
 		beaker =  B
 		add_attack_logs(user, null, "Added [B] containing [B.reagents.log_list()] to a cryo cell at [COORD(src)]")
@@ -314,23 +316,24 @@
 		SStgui.update_uis(src)
 		return
 
-	if(exchange_parts(user, G))
-		return
-
 	if(istype(G, /obj/item/grab))
 		var/obj/item/grab/GG = G
 		if(panel_open)
-			to_chat(user, "<span class='boldnotice'>Close the maintenance panel first.</span>")
+			to_chat(user, "<span class='warning'>Close the maintenance panel first.</span>")
 			return
+
 		if(!ismob(GG.affecting))
 			return
+
 		if(GG.affecting.has_buckled_mobs()) //mob attached to us
 			to_chat(user, "<span class='warning'>[GG.affecting] will not fit into [src] because [GG.affecting.p_they()] [GG.affecting.p_have()] a slime latched onto [GG.affecting.p_their()] head.</span>")
 			return
+
 		var/mob/M = GG.affecting
 		if(put_mob(M))
 			qdel(GG)
 		return
+
 	return ..()
 
 /obj/machinery/atmospherics/unary/cryo_cell/crowbar_act(mob/user, obj/item/I)

--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -123,11 +123,6 @@
 		change_power_mode(IDLE_POWER_USE)
 	return
 
-/obj/machinery/atmospherics/unary/thermomachine/attackby(obj/item/I, mob/user, params)
-	if(exchange_parts(user, I))
-		return
-	return ..()
-
 /obj/machinery/atmospherics/unary/thermomachine/crowbar_act(mob/user, obj/item/I)
 	if(default_deconstruction_crowbar(user, I))
 		return TRUE

--- a/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
@@ -106,14 +106,12 @@
 	if(default_deconstruction_screwdriver(user, "grinder_open", "grinder", P))
 		return
 
-	if(exchange_parts(user, P))
-		return
-
 	if(default_unfasten_wrench(user, P, time = 4 SECONDS))
 		return
 
 	if(default_deconstruction_crowbar(user, P))
 		return
+
 	return ..()
 
 /obj/machinery/gibber/MouseDrop_T(mob/target, mob/user)

--- a/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
@@ -74,11 +74,13 @@
 /obj/machinery/kitchen_machine/attackby(obj/item/O, mob/user, params)
 	if(operating)
 		return
+
 	if(dirty < MAX_DIRT)
 		if(default_deconstruction_screwdriver(user, open_icon, off_icon, O))
 			return
-		if(exchange_parts(user, O))
-			return
+
+		if(istype(O, /obj/item/storage/part_replacer))
+			return ..()
 
 	default_deconstruction_crowbar(user, O)
 
@@ -91,13 +93,16 @@
 				update_icon(UPDATE_ICON_STATE)
 				container_type = OPENCONTAINER
 				return TRUE
+
 		else //Otherwise bad luck!!
 			to_chat(user, "<span class='alert'>It's dirty!</span>")
 			return TRUE
-	else if(is_type_in_list(O, GLOB.cooking_ingredients[recipe_type]) || istype(O, /obj/item/mixing_bowl))
+
+	if(is_type_in_list(O, GLOB.cooking_ingredients[recipe_type]) || istype(O, /obj/item/mixing_bowl))
 		if(length(contents) >= max_n_of_items)
 			to_chat(user, "<span class='alert'>This [src] is full of ingredients, you cannot put more.</span>")
 			return TRUE
+
 		if(istype(O,/obj/item/stack))
 			var/obj/item/stack/S = O
 			if(S.get_amount() > 1)
@@ -111,16 +116,19 @@
 	else if(is_type_in_list(O, list(/obj/item/reagent_containers/glass, /obj/item/reagent_containers/drinks, /obj/item/reagent_containers/condiment)))
 		if(!O.reagents)
 			return TRUE
+
 		for(var/datum/reagent/R in O.reagents.reagent_list)
 			if(!(R.id in GLOB.cooking_reagents[recipe_type]))
 				to_chat(user, "<span class='alert'>Your [O] contains components unsuitable for cookery.</span>")
 				return TRUE
+
 	else if(istype(O, /obj/item/grab))
 		var/obj/item/grab/G = O
 		if(HAS_TRAIT(user, TRAIT_PACIFISM))
 			to_chat(user, "<span class='danger'>Slamming [G.affecting] into [src] might hurt them!</span>")
 			return
 		return special_attack_grab(G, user)
+
 	else
 		to_chat(user, "<span class='alert'>You have no idea what you can cook with [O].</span>")
 		return TRUE

--- a/code/modules/food_and_drinks/kitchen_machinery/monkeyrecycler.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/monkeyrecycler.dm
@@ -58,8 +58,8 @@ GLOBAL_LIST_EMPTY(monkey_recyclers)
 	if(default_deconstruction_screwdriver(user, "grinder_open", "grinder", O))
 		return
 
-	if(exchange_parts(user, O))
-		return
+	if(istype(O, /obj/item/storage/part_replacer))
+		return ..()
 
 	if(default_unfasten_wrench(user, O, time = 4 SECONDS))
 		power_change()

--- a/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -189,16 +189,15 @@
 	return 0
 
 /obj/machinery/processor/attackby(obj/item/O, mob/user, params)
-
 	if(processing)
 		to_chat(user, "<span class='warning'>\the [src] is already processing something!</span>")
-		return 1
+		return TRUE
 
 	if(default_deconstruction_screwdriver(user, "processor_open", "processor", O))
 		return
 
-	if(exchange_parts(user, O))
-		return
+	if(istype(O, /obj/item/storage/part_replacer))
+		return ..()
 
 	if(default_unfasten_wrench(user, O, time = 4 SECONDS))
 		return

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -178,31 +178,43 @@
 	return ..()
 
 /obj/machinery/smartfridge/attackby(obj/item/O, mob/user)
-	if(exchange_parts(user, O))
+	if(istype(O, /obj/item/storage/part_replacer))
+		..()
 		SStgui.update_uis(src)
 		return
+
 	if(stat & (BROKEN|NOPOWER))
-		to_chat(user, "<span class='notice'>\The [src] is unpowered and useless.</span>")
+		to_chat(user, "<span class='notice'>[src] is unpowered and useless.</span>")
 		return
 
 	if(load(O, user))
-		user.visible_message("<span class='notice'>[user] has added \the [O] to \the [src].</span>", "<span class='notice'>You add \the [O] to \the [src].</span>")
+		user.visible_message(
+			"<span class='notice'>[user] has added [O] to [src].</span>",
+			"<span class='notice'>You add [O] to [src].</span>"
+		)
 		SStgui.update_uis(src)
 		update_icon(UPDATE_OVERLAYS)
-	else if(istype(O, /obj/item/storage/bag) || istype(O, /obj/item/storage/box))
+		return
+
+	if(istype(O, /obj/item/storage/bag) || istype(O, /obj/item/storage/box))
 		var/obj/item/storage/P = O
 		var/items_loaded = 0
 		for(var/obj/G in P.contents)
 			if(load(G, user))
 				items_loaded++
 		if(items_loaded)
-			user.visible_message("<span class='notice'>[user] loads \the [src] with \the [P].</span>", "<span class='notice'>You load \the [src] with \the [P].</span>")
+			user.visible_message(
+				"<span class='notice'>[user] loads [src] with [P].</span>",
+				"<span class='notice'>You load [src] with [P].</span>"
+			)
 			SStgui.update_uis(src)
 			update_icon(UPDATE_OVERLAYS)
 		var/failed = length(P.contents)
 		if(failed)
 			to_chat(user, "<span class='notice'>[failed] item\s [failed == 1 ? "is" : "are"] refused.</span>")
-	else if(!istype(O, /obj/item/card/emag))
+		return
+
+	if(!istype(O, /obj/item/card/emag))
 		to_chat(user, "<span class='notice'>\The [src] smartly refuses [O].</span>")
 		return TRUE
 

--- a/code/modules/hydroponics/biogenerator.dm
+++ b/code/modules/hydroponics/biogenerator.dm
@@ -105,19 +105,23 @@
 /obj/machinery/biogenerator/attackby(obj/item/O, mob/user, params)
 	if(user.a_intent == INTENT_HARM)
 		return ..()
+
+	if(istype(O, /obj/item/storage/part_replacer))
+		return ..()
+
 	if(processing)
 		to_chat(user, "<span class='warning'>[src] is currently processing.</span>")
-		return
-	if(exchange_parts(user, O))
 		return
 
 	if(istype(O, /obj/item/reagent_containers/glass))
 		if(panel_open)
 			to_chat(user, "<span class='warning'>Close the maintenance panel first.</span>")
 			return
+
 		if(container)
 			to_chat(user, "<span class='warning'>A container is already loaded into [src].</span>")
 			return
+
 		if(!user.drop_item())
 			return
 
@@ -128,7 +132,7 @@
 		SStgui.update_uis(src)
 		return TRUE
 
-	else if(istype(O, /obj/item/storage/bag/plants))
+	if(istype(O, /obj/item/storage/bag/plants))
 		if(length(stored_plants) >= max_storable_plants)
 			to_chat(user, "<span class='warning'>[src] can't hold any more plants!</span>")
 			return
@@ -149,7 +153,7 @@
 		SStgui.update_uis(src)
 		return TRUE
 
-	else if(is_type_in_typecache(O, acceptable_items))
+	if(is_type_in_typecache(O, acceptable_items))
 		if(length(stored_plants) >= max_storable_plants)
 			to_chat(user, "<span class='warning'>[src] can't hold any more plants!</span>")
 			return
@@ -162,7 +166,7 @@
 		SStgui.update_uis(src)
 		return TRUE
 
-	else if(istype(O, /obj/item/disk/design_disk))
+	if(istype(O, /obj/item/disk/design_disk))
 		user.visible_message("[user] begins to load [O] in [src]...",
 			"You begin to load a design from [O]...",
 			"You hear the chatter of a floppy drive.")
@@ -176,8 +180,8 @@
 		processing = FALSE
 		update_ui_product_list(user)
 		return TRUE
-	else
-		to_chat(user, "<span class='warning'>You cannot put this in [name]!</span>")
+	
+	to_chat(user, "<span class='warning'>You cannot put [src] in [name]!</span>")
 
 /**
  * Builds/Updates the `product_list` used by the UI.

--- a/code/modules/hydroponics/gene_modder.dm
+++ b/code/modules/hydroponics/gene_modder.dm
@@ -134,22 +134,23 @@
 	if(default_deconstruction_screwdriver(user, "dnamod", "dnamod", I))
 		update_icon(UPDATE_OVERLAYS)
 		return
-	if(exchange_parts(user, I))
-		return
+
 	if(default_deconstruction_crowbar(user, I))
 		return
-	if(isrobot(user))
+
+	if(istype(I, /obj/item/unsorted_seeds))
+		to_chat(user, "<span class='warning'>You need to sort [I] first!</span>")
 		return
 
 	if(istype(I, /obj/item/seeds))
 		add_seed(I, user)
-	else if(istype(I, /obj/item/unsorted_seeds))
-		to_chat(user, "<span class='warning'>You need to sort [I] first!</span>")
-		return ..()
-	else if(istype(I, /obj/item/disk/plantgene) || istype(I, /obj/item/storage/box))
+		return
+
+	if(istype(I, /obj/item/disk/plantgene) || istype(I, /obj/item/storage/box))
 		add_disk(I, user)
-	else
-		return ..()
+		return
+
+	return ..()
 
 /obj/machinery/plantgenes/proc/add_seed(obj/item/seeds/new_seed, mob/user)
 	if(seed)

--- a/code/modules/hydroponics/hydroponics_tray.dm
+++ b/code/modules/hydroponics/hydroponics_tray.dm
@@ -122,7 +122,7 @@
 	return ..()
 
 /obj/machinery/hydroponics/constructable/attackby(obj/item/I, mob/user, params)
-	if(default_deconstruction_screwdriver(user, "hydrotray3", "hydrotray3", I) || exchange_parts(user, I))
+	if(default_deconstruction_screwdriver(user, "hydrotray3", "hydrotray3", I))
 		return
 	return ..()
 

--- a/code/modules/hydroponics/seed_extractor.dm
+++ b/code/modules/hydroponics/seed_extractor.dm
@@ -77,13 +77,17 @@
 /obj/machinery/seed_extractor/attackby(obj/item/O, mob/user, params)
 	if(default_deconstruction_screwdriver(user, "sextractor_open", "sextractor", O))
 		return
-	if(exchange_parts(user, O))
-		return
+
 	if(default_unfasten_wrench(user, O, time = 4 SECONDS))
 		return
+
 	if(default_deconstruction_crowbar(user, O))
 		return
 
+	if(istype(O, /obj/item/storage/part_replacer))
+		..()
+		SStgui.update_uis(src)
+		return
 
 	if(istype(O, /obj/item/storage/bag/plants))
 		var/obj/item/storage/P = O
@@ -106,26 +110,32 @@
 			if(!seedable)
 				to_chat(user, "<span class='notice'>There are no seeds or plants in [O].</span>")
 				return
+
 			to_chat(user, "<span class='notice'>You dump the plants in [O] into [src].</span>")
 			if(!O.use_tool(src, user, min(5, seedable/2) SECONDS))
 				return
+
 			for(var/thing in P)
 				seedify(thing,-1, src, user)
 		return
 
-	else if(istype(O, /obj/item/unsorted_seeds))
+	if(istype(O, /obj/item/unsorted_seeds))
 		to_chat(user, "<span class='warning'>You need to sort [O] first!</span>")
 		return ..()
-	else if(istype(O, /obj/item/seeds))
+
+	if(istype(O, /obj/item/seeds))
 		add_seed(O, user)
 		to_chat(user, "<span class='notice'>You add [O] to [name].</span>")
 		SStgui.update_uis(src)
 		return
-	else if(seedify(O,-1, src, user))
+
+	if(seedify(O,-1, src, user))
 		to_chat(user, "<span class='notice'>You extract some seeds.</span>")
 		return
-	else if(user.a_intent != INTENT_HARM)
+
+	if(user.a_intent != INTENT_HARM)
 		to_chat(user, "<span class='warning'>You can't extract any seeds from \the [O.name]!</span>")
+
 	return ..()
 
 /obj/machinery/seed_extractor/attack_ai(mob/user)

--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -181,8 +181,9 @@
 
 // Interactions
 /obj/machinery/mineral/ore_redemption/attackby(obj/item/I, mob/user, params)
-	if(exchange_parts(user, I))
-		return
+	if(istype(I, /obj/item/storage/part_replacer))
+		return ..()
+
 	if(!has_power())
 		return ..()
 
@@ -202,18 +203,20 @@
 		add_fingerprint(usr)
 		return
 
-	else if(istype(I, /obj/item/disk/design_disk))
+	if(istype(I, /obj/item/disk/design_disk))
 		if(!user.drop_item())
 			return
 		I.forceMove(src)
 		inserted_disk = I
 		SStgui.update_uis(src)
 		interact(user)
-		user.visible_message("<span class='notice'>[user] inserts [I] into [src].</span>",
-							"<span class='notice'>You insert [I] into [src].</span>")
+		user.visible_message(
+			"<span class='notice'>[user] inserts [I] into [src].</span>",
+			"<span class='notice'>You insert [I] into [src].</span>"
+		)
 		return
 
-	else if(istype(I, /obj/item/gripper))
+	if(istype(I, /obj/item/gripper))
 		if(!try_refill_storage(user))
 			to_chat(user, "<span class='notice'>You fail to retrieve any sheets from [src].</span>")
 		return

--- a/code/modules/power/engines/singularity/emitter.dm
+++ b/code/modules/power/engines/singularity/emitter.dm
@@ -147,25 +147,23 @@
 		step(src, get_dir(M, src))
 
 /obj/machinery/power/emitter/attackby(obj/item/I, mob/user, params)
-	if(istype(I, /obj/item/card/id) || istype(I, /obj/item/pda))
-		if(emagged)
-			to_chat(user, "<span class='warning'>The lock seems to be broken.</span>")
-			return
-		if(allowed(user))
-			if(active)
-				locked = !locked
-				to_chat(user, "<span class='notice'>The controls are now [locked ? "locked" : "unlocked"].</span>")
-			else
-				locked = FALSE //just in case it somehow gets locked
-				to_chat(user, "<span class='warning'>The controls can only be locked when [src] is online!</span>")
-		else
-			to_chat(user, "<span class='warning'>Access denied.</span>")
+	if(!istype(I, /obj/item/card/id) || !istype(I, /obj/item/pda))
+		return ..()
+
+	if(emagged)
+		to_chat(user, "<span class='warning'>The lock seems to be broken.</span>")
 		return
 
-	if(exchange_parts(user, I))
+	if(!allowed(user))
+		to_chat(user, "<span class='warning'>Access denied.</span>")
 		return
 
-	return ..()
+	if(active)
+		locked = !locked
+		to_chat(user, "<span class='notice'>The controls are now [locked ? "locked" : "unlocked"].</span>")
+	else
+		locked = FALSE //just in case it somehow gets locked
+		to_chat(user, "<span class='warning'>The controls can only be locked when [src] is online!</span>")
 
 /obj/machinery/power/emitter/wrench_act(mob/living/user, obj/item/I)
 	. = TRUE

--- a/code/modules/power/engines/tesla/coil.dm
+++ b/code/modules/power/engines/tesla/coil.dm
@@ -44,12 +44,8 @@
 		. += "<span class='notice'>The status display reads: Power generation at <b>[input_power_multiplier*100]%</b>.<br>Shock interval at <b>[zap_cooldown*0.1]</b> seconds.</span>"
 
 /obj/machinery/power/tesla_coil/attackby(obj/item/W, mob/user, params)
-	if(exchange_parts(user, W))
-		return
-
-	else if(istype(W, /obj/item/assembly/signaler) && panel_open)
+	if(istype(W, /obj/item/assembly/signaler) && panel_open)
 		wires.Interact(user)
-
 	else
 		return ..()
 

--- a/code/modules/power/generators/portable generators/pacman.dm
+++ b/code/modules/power/generators/portable generators/pacman.dm
@@ -198,15 +198,13 @@
 		if(amount < 1)
 			to_chat(user, "<span class='notice'>[src] is full!</span>")
 			return
+
 		to_chat(user, "<span class='notice'>You add [amount] sheet\s to [src].</span>")
 		sheets += amount
 		addstack.use(amount)
 		SStgui.update_uis(src)
 		return
-	if(!active)
-		if(istype(O, /obj/item/storage/part_replacer) && panel_open)
-			exchange_parts(user, O)
-		return
+
 	return ..()
 
 /obj/machinery/power/port_gen/pacman/crowbar_act(mob/living/user, obj/item/I)

--- a/code/modules/power/generators/turbine.dm
+++ b/code/modules/power/generators/turbine.dm
@@ -145,8 +145,6 @@
 			stat |= BROKEN
 		return
 
-	if(exchange_parts(user, I))
-		return
 	return ..()
 
 /obj/machinery/power/compressor/crowbar_act(mob/user, obj/item/I)
@@ -352,11 +350,9 @@
 			stat |= BROKEN
 		return
 
-	if(exchange_parts(user, I))
-		return
-
 	if(default_deconstruction_crowbar(user, I))
 		return
+
 	return ..()
 
 /obj/machinery/power/turbine/attack_hand(mob/user)

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -120,10 +120,6 @@
 		update_icon()
 		return
 
-	//exchanging parts using the RPE
-	if(exchange_parts(user, I))
-		return
-
 	//building and linking a terminal
 	if(istype(I, /obj/item/stack/cable_coil))
 		var/dir = get_dir(user,src)
@@ -216,6 +212,7 @@
 	//crowbarring it !
 	if(default_deconstruction_crowbar(user, I))
 		return
+
 	return ..()
 
 /obj/machinery/power/smes/disconnect_terminal()

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -235,20 +235,20 @@
 	add_fingerprint(usr)
 
 /obj/machinery/chem_dispenser/attackby(obj/item/I, mob/user, params)
-	if(exchange_parts(user, I))
+	if(istype(I, /obj/item/storage/part_replacer))
+		..()
 		SStgui.update_uis(src)
-		return
-
-	if(isrobot(user))
 		return
 
 	if((istype(I, /obj/item/reagent_containers/glass) || istype(I, /obj/item/reagent_containers/drinks)) && user.a_intent != INTENT_HARM)
 		if(panel_open)
 			to_chat(user, "<span class='notice'>Close the maintenance panel first.</span>")
 			return
+
 		if(!user.drop_item())
 			to_chat(user, "<span class='warning'>[I] is stuck to you!</span>")
 			return
+
 		I.forceMove(src)
 		if(beaker)
 			to_chat(usr, "<span class='notice'>You swap [I] with [beaker].</span>")

--- a/code/modules/reagents/chemistry/machinery/chem_heater.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_heater.dm
@@ -63,23 +63,20 @@
 		stat |= NOPOWER
 
 /obj/machinery/chem_heater/attackby(obj/item/I, mob/user)
-	if(isrobot(user))
-		return
-
 	if(istype(I, /obj/item/reagent_containers/glass) && user.a_intent != INTENT_HARM)
 		if(beaker)
 			to_chat(user, "<span class='notice'>A beaker is already loaded into the machine.</span>")
 			return
 
-		if(user.drop_item())
-			beaker = I
-			I.forceMove(src)
-			to_chat(user, "<span class='notice'>You add the beaker to the machine!</span>")
-			icon_state = "mixer1b"
-			SStgui.update_uis(src)
+		if(!user.drop_item())
+			to_chat(user, "<span class='warning'>[I] is stuck to you!</span>")
 			return
 
-	if(exchange_parts(user, I))
+		beaker = I
+		I.forceMove(src)
+		to_chat(user, "<span class='notice'>You add the beaker to the machine!</span>")
+		icon_state = "mixer1b"
+		SStgui.update_uis(src)
 		return
 
 	return ..()

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -112,8 +112,8 @@
 	update_icon()
 
 /obj/machinery/chem_master/attackby(obj/item/I, mob/user, params)
-	if(exchange_parts(user, I))
-		return
+	if(istype(I, /obj/item/storage/part_replacer))
+		return ..()
 
 	if(panel_open)
 		to_chat(user, "<span class='warning'>You can't use [src] while it's panel is opened!</span>")
@@ -123,6 +123,7 @@
 		if(!user.drop_item())
 			to_chat(user, "<span class='warning'>[I] is stuck to you!</span>")
 			return
+
 		I.forceMove(src)
 		if(beaker)
 			to_chat(usr, "<span class='notice'>You swap [I] with [beaker] inside.</span>")

--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -157,7 +157,8 @@
 	default_unfasten_wrench(user, I)
 
 /obj/machinery/reagentgrinder/attackby(obj/item/I, mob/user, params)
-	if(exchange_parts(user, I))
+	if(istype(I, /obj/item/storage/part_replacer))
+		..()
 		SStgui.update_uis(src)
 		return
 
@@ -169,6 +170,7 @@
 		else
 			if(!user.drop_item())
 				return FALSE
+
 			beaker =  I
 			beaker.loc = src
 			update_icon(UPDATE_ICON_STATE)
@@ -206,6 +208,7 @@
 		if(length(B.contents) == original_contents_len)
 			to_chat(user, "<span class='warning'>Nothing in [B] can be put into the All-In-One grinder.</span>")
 			return FALSE
+
 		else if(!length(B.contents))
 			to_chat(user, "<span class='notice'>You empty all of [B]'s contents into the All-In-One grinder.</span>")
 		else

--- a/code/modules/research/circuitprinter.dm
+++ b/code/modules/research/circuitprinter.dm
@@ -75,15 +75,17 @@ using metal and glass, it uses glass and reagents (usually sulfuric acis).
 	return round(A / max(1, (all_materials[M] * efficiency_coeff)))
 
 /obj/machinery/r_n_d/circuit_imprinter/attackby(obj/item/O as obj, mob/user as mob, params)
-	if(exchange_parts(user, O))
-		return
+	if(istype(O, /obj/item/storage/part_replacer))
+		return ..()
+
 	if(panel_open)
 		to_chat(user, "<span class='warning'>You can't load [src] while it's opened.</span>")
 		return
+
 	if(O.is_open_container())
 		return FALSE
-	else
-		return ..()
+
+	return ..()
 
 /obj/machinery/r_n_d/circuit_imprinter/crowbar_act(mob/living/user, obj/item/I)
 	if(!panel_open)

--- a/code/modules/research/destructive_analyzer.dm
+++ b/code/modules/research/destructive_analyzer.dm
@@ -49,6 +49,9 @@ Note: Must be placed within 3 tiles of the R&D Console
 
 
 /obj/machinery/r_n_d/destructive_analyzer/attackby(obj/item/O as obj, mob/user as mob, params)
+	if(istype(O, /obj/item/storage/part_replacer))
+		return ..()
+
 	if(default_deconstruction_screwdriver(user, "d_analyzer_t", "d_analyzer", O))
 		if(linked_console)
 			linked_console.linked_destroy = null
@@ -73,13 +76,16 @@ Note: Must be placed within 3 tiles of the R&D Console
 		if(!O.origin_tech)
 			to_chat(user, "<span class='warning'>This doesn't seem to have a tech origin!</span>")
 			return
+
 		var/list/temp_tech = ConvertReqString2List(O.origin_tech)
 		if(length(temp_tech) == 0)
 			to_chat(user, "<span class='warning'>You cannot deconstruct this item!</span>")
 			return
+
 		if(!user.drop_item())
 			to_chat(user, "<span class='warning'>[O] is stuck to your hand, you cannot put it in [src]!</span>")
 			return
+
 		busy = TRUE
 		loaded_item = O
 		O.loc = src

--- a/code/modules/research/experimentor.dm
+++ b/code/modules/research/experimentor.dm
@@ -99,8 +99,8 @@
 	return TRUE
 
 /obj/machinery/r_n_d/experimentor/attackby(obj/item/O, mob/user, params)
-	if(exchange_parts(user, O))
-		return
+	if(istype(O, /obj/item/storage/part_replacer))
+		return ..()
 
 	if(!checkCircumstances(O))
 		to_chat(user, "<span class='warning'>[O] is not yet valid for [src] and must be completed!</span>")
@@ -118,12 +118,15 @@
 		if(!O.origin_tech)
 			to_chat(user, "<span class='warning'>This doesn't seem to have a tech origin!</span>")
 			return
+
 		var/list/temp_tech = ConvertReqString2List(O.origin_tech)
 		if(length(temp_tech) == 0)
 			to_chat(user, "<span class='warning'>You cannot experiment on this item!</span>")
 			return
+
 		if(!user.drop_item())
 			return
+
 		loaded_item = O
 		O.loc = src
 		to_chat(user, "<span class='notice'>You add [O] to the machine.</span>")

--- a/code/modules/research/protolathe.dm
+++ b/code/modules/research/protolathe.dm
@@ -77,13 +77,13 @@ Note: Must be placed west/left of and R&D console to function.
 	return A
 
 /obj/machinery/r_n_d/protolathe/attackby(obj/item/O as obj, mob/user as mob, params)
+	if(istype(O, /obj/item/storage/part_replacer))
+		return ..()
+
 	if(default_deconstruction_screwdriver(user, "protolathe_t", "protolathe", O))
 		if(linked_console)
 			linked_console.linked_lathe = null
 			linked_console = null
-		return FALSE
-
-	if(exchange_parts(user, O))
 		return FALSE
 
 	if(panel_open)
@@ -92,8 +92,8 @@ Note: Must be placed west/left of and R&D console to function.
 
 	if(O.is_open_container())
 		return FALSE
-	else
-		return ..()
+
+	return ..()
 
 /obj/machinery/r_n_d/protolathe/crowbar_act(mob/living/user, obj/item/I)
 	if(!panel_open)

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -147,11 +147,6 @@
 	removed.set_temperature(min((removed.temperature() * heat_capacity + server.heating_power) / heat_capacity, 1000))
 	env.merge(removed)
 
-/obj/machinery/r_n_d/server/attackby(obj/item/O as obj, mob/user as mob, params)
-	if(exchange_parts(user, O))
-		return TRUE
-	return ..()
-
 /obj/machinery/r_n_d/server/crowbar_act(mob/living/user, obj/item/I)
 	if(!panel_open)
 		return

--- a/code/modules/telesci/telepad.dm
+++ b/code/modules/telesci/telepad.dm
@@ -35,11 +35,6 @@
 		E += C.rating
 	efficiency = E
 
-/obj/machinery/telepad/attackby(obj/item/I, mob/user, params)
-	if(exchange_parts(user, I))
-		return
-	return ..()
-
 /obj/machinery/telepad/screwdriver_act(mob/user, obj/item/I)
 	. = TRUE
 	default_deconstruction_screwdriver(user, "pad-idle-o", "pad-idle", I)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #25806. ALSO fixes gun rechargers suffering from the same issue.

Refactors RPED interactions so that `obj/machine`'s attackby handles the interaction. Some specific machines still need a typecheck for the RPED, but number of code lines has gone down by a tidy portion.

Removed 3 unnecessary `isrobot()` checks from the `attackby()` of the chem heater, chem dispenser, and gene modifier. The nodrop of robot modules already handles ensuring they cannot put their beakers inside.

Added a missing span class to the nodrop check of the cryo cell.

Added a missing nodrop warning to the chem heater.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Crushing an annoying bug.

Removing unnecessary code is good.

Code now more maintainable, cannot accidentally forget to add the RPED part exchange proc (as happened with the cell and gun chargers).

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Used BRPED and RPED on all 42 machine types. Prodded some other random machines too.

Cell charger now gets upgrades.

Screwdrivering is still required for RPED to work. BRPED unaffected.

Became a cyborg, tried to stick my beaker into the machines I removed the `isrobot()` check from. I could not.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Cell and gun chargers can be upgraded with a regular RPED.
fix: Cryo cell nodrop message now has a span class (warning).
fix: Chemical heater now has a nodrop message.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
