### PR TITLE
Fixes a few tiles that were misaligned decal wise on farragus

### DIFF
--- a/_maps/map_files/stations/cerestation.dmm
+++ b/_maps/map_files/stations/cerestation.dmm
@@ -35518,7 +35518,7 @@
 	color = "#954535"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore/north)
 "emw" = (
@@ -81285,18 +81285,6 @@
 	icon_state = "browncorner"
 	},
 /area/station/supply/office)
-"sZq" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	color = "#954535"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/fore/north)
 "sZz" = (
 /obj/effect/spawner/airlock/w_to_e,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -84060,9 +84048,7 @@
 	dir = 4;
 	color = "#954535"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
-	},
+/turf/simulated/floor/plasteel,
 /area/station/hallway/primary/fore/north)
 "tXf" = (
 /obj/structure/cable/orange{
@@ -91239,20 +91225,6 @@
 	icon_state = "darkyellow"
 	},
 /area/station/engineering/control)
-"weN" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	color = "#954535"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/primary/fore/north)
 "weW" = (
 /obj/effect/spawner/window/reinforced/polarized/grilled{
 	id = "bridge"
@@ -98330,6 +98302,13 @@
 "ykj" = (
 /turf/simulated/floor/plasteel,
 /area/station/security/prisonlockers)
+"ykC" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	color = "#954535"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/fore/north)
 "ykM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -132666,7 +132645,7 @@ tpA
 eMh
 dwE
 vuY
-sGY
+ykC
 cWn
 gXb
 cWn
@@ -133951,7 +133930,7 @@ abW
 aKp
 dwg
 dTC
-sZq
+qtB
 aKp
 npV
 npV
@@ -134208,7 +134187,7 @@ abW
 aKp
 dxt
 dQg
-weN
+qtB
 fXC
 fXC
 fXC
@@ -134465,7 +134444,7 @@ cMz
 cMz
 dxw
 dTI
-sZq
+qtB
 fXC
 gYN
 hUg


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Fixes some decals being miss aligned on farragus below bridge, as they were aligned to a door that was moved at some point
closes #26253

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
decals were misaligned, making faragus completely unplayable.
this'll hopefully make it a liked map
## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![StrongDMM_qaQTj9L4v7](https://github.com/user-attachments/assets/923c5fd4-cdaa-45b0-ac1b-9a26e08e4a47)

## Testing
<!-- How did you test the PR, if at all? -->
compiled into faragus, looked at tiles
## Changelog
:cl:
fix: Fixed a few misaligned tile decals on faragus
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
