### PR TITLE
Fixes Cybersun trading shuttle Storage bio-chip

### DIFF
--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -467,7 +467,7 @@
 	loot = list(
 				/obj/item/shield/energy = 20,
 				/obj/item/gun/projectile/automatic/pistol = 50,
-				/obj/item/bio_chip/storage = 50,
+				/obj/item/bio_chip_implanter/storage = 50,
 				/obj/item/melee/knuckleduster/syndie = 50,
 				/obj/item/clothing/glasses/thermal/eyepatch = 50,
 				/obj/item/toy/syndicateballoon = 60,
@@ -631,7 +631,7 @@
 				/obj/item/organ/internal/cyberimp/arm/gun/laser = 10,
 				/obj/item/fireaxe = 10,
 				/obj/item/gun/projectile/revolver/nagant = 10,
-				/obj/item/bio_chip/storage = 10,
+				/obj/item/bio_chip_implanter/storage = 10,
 				/obj/item/rcd/combat = 10
 				)
 


### PR DESCRIPTION
## What Does This PR Do
Converts Cybersun trading shuttle Storage bio-chip into it's injector type which is what it was intended originally to be.
Fixes #26271

## Why It's Good For The Game
Players should actually be able to inject the bio-chips they purchase

## Testing
Compiled, ran on local

- Spawned cybersun loot spawns, succesfully got injectors for minor and major spawns

## Changelog
:cl:
fix: Cybersun trading shuttle Storage bio-chip spawn in their injectors properly now
/:cl:
