### PR TITLE
Ranged Holoparasites in Scout Form no longer instantly die when flying over the blob

### DIFF
--- a/code/game/gamemodes/miniantags/guardian/types/ranged.dm
+++ b/code/game/gamemodes/miniantags/guardian/types/ranged.dm
@@ -77,7 +77,7 @@
 
 	to_chat(src, "<span class='notice'>[msg]</span>")
 
-/mob/living/simple_animal/hostile/guardian/blob_act(obj/structure/blob/B)
+/mob/living/simple_animal/hostile/guardian/ranged/blob_act(obj/structure/blob/B)
 	if(toggle)
 		return // we don't want blob tiles to hurt us when we fly over them and trigger /Crossed(), this prevents ranged scouts from being insta killed
 	return ..() // otherwise do normal damage!

--- a/code/game/gamemodes/miniantags/guardian/types/ranged.dm
+++ b/code/game/gamemodes/miniantags/guardian/types/ranged.dm
@@ -82,7 +82,6 @@
 		return // we don't want blob tiles to hurt us when we fly over them and trigger /Crossed(), this prevents ranged scouts from being insta killed
 	return ..() // otherwise do normal damage!
 
-
 /obj/item/effect/snare
 	name = "snare"
 	desc = "You shouldn't be seeing this!"

--- a/code/game/gamemodes/miniantags/guardian/types/ranged.dm
+++ b/code/game/gamemodes/miniantags/guardian/types/ranged.dm
@@ -77,6 +77,12 @@
 
 	to_chat(src, "<span class='notice'>[msg]</span>")
 
+/mob/living/simple_animal/hostile/guardian/blob_act(obj/structure/blob/B)
+	if(toggle)
+		return // we don't want blob tiles to hurt us when we fly over them and trigger /Crossed(), this prevents ranged scouts from being insta killed
+	return ..() // otherwise do normal damage!
+
+
 /obj/item/effect/snare
 	name = "snare"
 	desc = "You shouldn't be seeing this!"


### PR DESCRIPTION
## What Does This PR Do
Ranged Holoparasites in scout form no longer take `blob_act()` damage when flying over blob tiles. This prevents ranged holoparas from instantly dying if they accidently fly over a large amount of blob tiles!

This does not preclude ranged holoparas from damage from the blob, however.

## Why It's Good For The Game
This really is not a fair way for the player to go out, since there is no cooldown on how many times you can be `blob_act()`'d in 1 second, players can lose their entire round by a near unavoidable mistake.

## Testing
Compiled, ran on local test server.
Spawned Holopara with host, toggled to scout mode, flew over the blob, did not take damage.
Toggled back into regular mode and stood next to blob tile, took regular `blob_act()` damage like normal!

## Changelog
:cl:
fix: Ranged holoparasites no longer die when flying over 1+ blob tiles
/:cl:
