### PR TITLE
Extend mule pathfinding range for cere and remove some obstacles.

### DIFF
--- a/_maps/map_files/stations/cerestation.dmm
+++ b/_maps/map_files/stations/cerestation.dmm
@@ -23368,7 +23368,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/visible,
-/turf/simulated/wall,
+/turf/simulated/floor/plating,
 /area/station/science/misc_lab)
 "czg" = (
 /turf/simulated/floor/plasteel{
@@ -61497,17 +61497,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/starboard/south)
-"mGE" = (
-/obj/structure/cable/orange{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/grille,
-/turf/simulated/floor/plating{
-	icon_state = "asteroidplating"
-	},
-/area/station/maintenance/apmaint)
 "mGK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -123710,7 +123699,7 @@ ciG
 gPL
 nwv
 pQN
-mGE
+nta
 cGd
 pAi
 pAi

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -27,6 +27,10 @@
 	bot_purpose = "deliver crates and other packages between departments, as requested"
 	req_access = list(ACCESS_CARGO)
 
+	/// The maximum amount of tiles the MULE can search via SSpathfinder before giving up.
+	/// Stored as a variable to allow VVing if there's any weirdness.
+	var/maximum_pathfind_range = 350
+
 
 	suffix = ""
 
@@ -606,7 +610,7 @@
 // given an optional turf to avoid
 /mob/living/simple_animal/bot/mulebot/calc_path(turf/avoid = null)
 	check_bot_access()
-	set_path(get_path_to(src, target, 250, access = access_card.access, exclude = avoid))
+	set_path(get_path_to(src, target, max_distance = maximum_pathfind_range, access = access_card.access, exclude = avoid))
 
 // sets the current destination
 // signals all beacons matching the delivery code


### PR DESCRIPTION
## What Does This PR Do
This PR extends the pathfinding range of MULEbots from 250 to 350. This allows them to find all departments on Cerestation. The performance change is indistinguishable. SSpathfinder is very fast.

It also removes a grille and wall that got in the way of proper delivery to Cere science.
## Why It's Good For The Game
MULEbots should be able to reach all expected destinations.

## Images of changes
![2024_07_23__15_24_37__Paradise Station 13](https://github.com/user-attachments/assets/ea94724f-9dca-4506-b2c8-c33a750736e4)

![2024_07_23__15_37_58__paradise dme  cerestation dmm  - StrongDMM](https://github.com/user-attachments/assets/335c78f0-c506-4d82-a420-b8fa334347f8)

## Testing

https://github.com/user-attachments/assets/f2354113-4b82-4019-bf08-5fd010a49007

## Changelog
:cl:
fix: Mulebots can now reach all departments on Farragus.
/:cl:
