### PR TITLE
Fix a runtime with empty turf lists on hallucinations

### DIFF
--- a/code/modules/hallucinations/effects/moderate.dm
+++ b/code/modules/hallucinations/effects/moderate.dm
@@ -344,7 +344,10 @@
 /obj/effect/hallucination/stunprodding/Initialize(mapload, mob/living/carbon/target)
 	. = ..()
 
-	var/turf/T = pick(RANGE_TURFS(15, target))
+	var/list/possible_turfs = RANGE_TURFS(15, target)
+	if(!length(possible_turfs))
+		return INITIALIZE_HINT_QDEL
+	var/turf/T = pick(possible_turfs)
 	target.playsound_local(T, 'sound/weapons/egloves.ogg', 25, TRUE)
 	target.playsound_local(T, get_sfx("bodyfall"), 25, TRUE)
 	target.playsound_local(T, "sparks", 50, TRUE)
@@ -366,7 +369,10 @@
 /obj/effect/hallucination/energy_sword/Initialize(mapload, mob/living/carbon/target)
 	. = ..()
 
-	var/turf/T = pick(RANGE_TURFS(15, target))
+	var/list/possible_turfs = RANGE_TURFS(15, target)
+	if(!length(possible_turfs))
+		return INITIALIZE_HINT_QDEL
+	var/turf/T = pick(possible_turfs)
 	forceMove(T)
 	target.playsound_local(T, 'sound/weapons/saberon.ogg', 20, TRUE)
 
@@ -398,7 +404,10 @@
 /obj/effect/hallucination/gunfire/Initialize(mapload, mob/living/carbon/target)
 	. = ..()
 
-	var/turf/T = pick(RANGE_TURFS(15, target))
+	var/list/possible_turfs = RANGE_TURFS(15, target)
+	if(!length(possible_turfs))
+		return INITIALIZE_HINT_QDEL
+	var/turf/T = pick(possible_turfs)
 	forceMove(T)
 
 	var/gun_sound = pick('sound/weapons/gunshots/gunshot_pistol.ogg', 'sound/weapons/gunshots/gunshot_strong.ogg')


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes a runtime that pops up on occasion with hallucinations.
```dm
[2024-07-23T22:56:09] Runtime in code/modules/hallucinations/effects/moderate.dm:401: pick() from empty list
   proc name: Initialize (/obj/effect/hallucination/gunfire/Initialize)
   src: the gunfire (/obj/effect/hallucination/gunfire)
   src.loc: the floor (181,101,2) (/turf/simulated/floor/plasteel)
   call stack:
   the gunfire (/obj/effect/hallucination/gunfire): Initialize
   Atoms (/datum/controller/subsystem/atoms): InitAtom
   the gunfire (/obj/effect/hallucination/gunfire): attempt_init
   the gunfire (/obj/effect/hallucination/gunfire): attempt_init
   the gunfire (/obj/effect/hallucination/gunfire): New
   /datum/status_effect/transient... (/datum/status_effect/transient/hallucination): hallucinate
   /datum/status_effect/transient... (/datum/status_effect/transient/hallucination): tick
   /datum/status_effect/transient... (/datum/status_effect/transient/hallucination): process
   Fast Processing (/datum/controller/subsystem/processing/fastprocess): fire
   Fast Processing (/datum/controller/subsystem/processing/fastprocess): ignite
   Master (/datum/controller/master): RunQueue
   Master (/datum/controller/master): Loop
   Master (/datum/controller/master): StartProcessing
   ```
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
I don't think this appears super frequently, and it's mostly NPFC, but it'll be good to not have this one pop up all the time.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Compiled -- we don't really have a repro, but this follows how other hallucinations are cleaned up.
<!-- How did you test the PR, if at all? -->

## Changelog

NPFC

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
