### PR TITLE
You can no longer put items in crates when a mob is buckled to them

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -77,10 +77,8 @@
 			continue
 		if(ismob(O) && !HAS_TRAIT(O, TRAIT_CONTORTED_BODY))
 			continue
-		if(istype(O, /obj/structure/bed)) //This is only necessary because of rollerbeds and swivel chairs.
-			var/obj/structure/bed/B = O
-			if(B.has_buckled_mobs())
-				continue
+		if(O.has_buckled_mobs()) // You can't put mobs into crates, so naturally if a mob is attached to something, it shouldn't be able to go in the crate
+			continue
 		O.forceMove(src)
 		itemcount++
 


### PR DESCRIPTION
## What Does This PR Do
Makes it so that crates cannot suck in items that a mob is currently buckled to

## Why It's Good For The Game
If you somehow manage to be sitting on a non-anchored item on the same tile as a crate, you can close the chair into the crate without unbuckling yourself. It's really hard to actually exploit this in some meaningful way but it does a weird teleportation thing over 1-2 tiles (you're still attached to the chair) if you move stuff around in a certain fashion.

## Testing
Compiled, ran on local test server
- Closed chair into crate normally, works
- Buckled myself to chair and attempted to close it in, did nothing
- ???
- Profit

## Changelog
Not really any actual player facing changes, not ones they'd even care about anyway.
