### PR TITLE
Cloth Golems can no longer be infested by Legions

### DIFF
--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -1168,3 +1168,7 @@ It'll return null if the organ doesn't correspond, so include null checks when u
 		add_attack_logs(user, target, "vampirebit")
 		return TRUE
 		//end vampire codes
+
+/// Is this species able to be legion infested?
+/datum/species/proc/can_be_legion_infested()
+	return TRUE

--- a/code/modules/mob/living/carbon/human/species/golem.dm
+++ b/code/modules/mob/living/carbon/human/species/golem.dm
@@ -707,6 +707,9 @@
 	new /obj/structure/cloth_pile(get_turf(H), H)
 	..()
 
+/datum/species/golem/cloth/can_be_legion_infested()
+	return FALSE // can't infest a pile of cloth,
+
 /obj/structure/cloth_pile
 	name = "pile of bandages"
 	desc = "It emits a strange aura, as if there was still life within it..."

--- a/code/modules/mob/living/simple_animal/hostile/mining/hivelord.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/hivelord.dm
@@ -246,7 +246,7 @@
 	..()
 
 /mob/living/simple_animal/hostile/asteroid/hivelordbrood/legion/proc/infest(mob/living/carbon/human/H)
-	if(!isnull(H?.dna?.species) && !H.dna.species.can_be_legion_infested())
+	if(H?.dna?.species && !H.dna.species.can_be_legion_infested())
 		return
 	visible_message("<span class='warning'>[name] burrows into the flesh of [H]!</span>")
 	var/mob/living/simple_animal/hostile/asteroid/hivelord/legion/L

--- a/code/modules/mob/living/simple_animal/hostile/mining/hivelord.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/hivelord.dm
@@ -246,6 +246,8 @@
 	..()
 
 /mob/living/simple_animal/hostile/asteroid/hivelordbrood/legion/proc/infest(mob/living/carbon/human/H)
+	if(!isnull(H?.dna?.species) && !H.dna.species.can_be_legion_infested())
+		return
 	visible_message("<span class='warning'>[name] burrows into the flesh of [H]!</span>")
 	var/mob/living/simple_animal/hostile/asteroid/hivelord/legion/L
 	if(HAS_TRAIT(H, TRAIT_DWARF)) //dwarf legions aren't just fluff!


### PR DESCRIPTION
## What Does This PR Do
Cloth Golems can no longer be infested by legions but can still be killed by them like before. 

## Why It's Good For The Game
Due to the way that cloth golems operate, they will reanimated anyways before except now a new legion won't be spawned. This prevents cloth golems from creating legions out of thin air (i.g. no host).

## Testing
Compiled, Tested on local server
- Standard infesting still works for golems & other carbons
- Cloth golem was killed but not infested

## Changelog
:cl:
fix: New legions are no longer spawned when a cloth golem is killed by legions
/:cl:
