### PR TITLE
AI Cores now properly update their icon state during all construction steps

### DIFF
--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -28,6 +28,7 @@
 				state = CIRCUIT_CORE
 				P.forceMove(src)
 				circuit = P
+				update_icon(UPDATE_ICON_STATE)
 				return
 		if(SCREWED_CORE)
 			if(istype(P, /obj/item/stack/cable_coil))
@@ -136,11 +137,13 @@
 			state = EMPTY_CORE
 			circuit.forceMove(loc)
 			circuit = null
+			update_icon(UPDATE_ICON_STATE)
 			return
 		if(GLASS_CORE)
 			to_chat(user, "<span class='notice'>You remove the glass panel.</span>")
 			state = CABLED_CORE
 			new /obj/item/stack/sheet/rglass(loc, 2)
+			update_icon(UPDATE_ICON_STATE)
 			return
 		if(CABLED_CORE)
 			if(brain)


### PR DESCRIPTION
## What Does This PR Do
Makes AI Cores update their icon state during all construction steps
Fixes #26221

## Why It's Good For The Game
Players need to visually see progress during deconstruction steps, this fixes that

## Testing
Compiled, ran on local test server
- Build AI Core from frame
- Deconstructed that Frame completely
- All icon states showed correctly

## Changelog
:cl:
fix: AI Cores now properly update their icon state during all construction steps
/:cl:
