### PR TITLE
SSD overlay gets re applied to rejuvenated SSD players

### DIFF
--- a/code/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/code/modules/mob/living/carbon/human/human_update_icons.dm
@@ -564,6 +564,8 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 	update_fire()
 	update_icons()
 	update_emissive_block()
+	if(player_logged) //make sure the SSD overlay stays
+		overlays += image('icons/effects/effects.dmi', icon_state = "zzz_glow")
 
 /* --------------------------------------- */
 //vvvvvv UPDATE_INV PROCS vvvvvv


### PR DESCRIPTION
## What Does This PR Do
Re adds the ssd overlay after `regenerate_icon()` if the player is logged out

## Why It's Good For The Game
Fixes #11306 

## Testing
Rejuvenated an ssd mob and the overlay stayed

## Changelog
:cl: EOD501
fix: SSD overlay persists through rejuvenate
/:cl: