### PR TITLE
Fixes invisible TTV tanks

### DIFF
--- a/code/game/objects/items/devices/transfer_valve.dm
+++ b/code/game/objects/items/devices/transfer_valve.dm
@@ -174,12 +174,14 @@
 		var/tank_one_icon_state = tank_one.icon_state
 		if(!(tank_one_icon_state in TTV_TANK_ICON_STATES)) //if no valid sprite fall back to an oxygen tank
 			tank_one_icon_state = "oxygen"
+			stack_trace("[tank_one] was inserted into a TTV with an invalid icon_state, \"[tank_one.icon_state]\"")
 		. += "[tank_one_icon_state]"
 
 	if(tank_two)
 		var/tank_two_icon_state = tank_two.icon_state
 		if(!(tank_two_icon_state in TTV_TANK_ICON_STATES)) //if no valid sprite fall back to an oxygen tank
 			tank_two_icon_state = "oxygen"
+			stack_trace("[tank_two] was inserted into a TTV with an invalid icon_state, \"[tank_two.icon_state]\"")
 		var/icon/tank_two_icon = new(icon, icon_state = tank_two_icon_state)
 		tank_two_icon.Shift(WEST, 13)
 		underlays += tank_two_icon

--- a/code/game/objects/items/devices/transfer_valve.dm
+++ b/code/game/objects/items/devices/transfer_valve.dm
@@ -1,3 +1,6 @@
+///if the icon_state for the TTV's tank is in assemblies.dmi
+#define TTV_TANK_ICON_STATES list("anesthetic", "emergency", "emergency_double", "emergency_engi", "emergency_sleep", "jetpack", "jetpack_black", "jetpack_void", "oxygen", "oxygen_f", "oxygen_fr", "plasma")
+
 /obj/item/transfer_valve
 	icon = 'icons/obj/assemblies.dmi'
 	name = "tank transfer valve"
@@ -166,12 +169,21 @@
 	underlays.Cut()
 	if(!tank_one && !tank_two && !attached_device)
 		return
+
 	if(tank_one)
-		. += "[tank_one.icon_state]"
+		var/tank_one_icon_state = tank_one.icon_state
+		if(!(tank_one_icon_state in TTV_TANK_ICON_STATES)) //if no valid sprite fall back to an oxygen tank
+			tank_one_icon_state = "oxygen"
+		. += "[tank_one_icon_state]"
+
 	if(tank_two)
-		var/icon/J = new(icon, icon_state = "[tank_two.icon_state]")
-		J.Shift(WEST, 13)
-		underlays += J
+		var/tank_two_icon_state = tank_two.icon_state
+		if(!(tank_two_icon_state in TTV_TANK_ICON_STATES)) //if no valid sprite fall back to an oxygen tank
+			tank_two_icon_state = "oxygen"
+		var/icon/tank_two_icon = new(icon, icon_state = tank_two_icon_state)
+		tank_two_icon.Shift(WEST, 13)
+		underlays += tank_two_icon
+
 	if(attached_device)
 		. += "device"
 
@@ -225,3 +237,5 @@
 		split_gases()
 		valve_open = FALSE
 		update_icon()
+
+#undef TTV_TANK_ICON_STATES


### PR DESCRIPTION
## What Does This PR Do
If there isnt an icon state for the tank, itll default to "oxygen"

I would add sprites but I hate sprites and I cant do sprites on my phone, i might get to it eventually
## Why It's Good For The Game
Fixes #12802 

## Testing
Put a tank in the defines list in the TTV, overlay updated to tanks icon state, put a tank not in the defines list in the TTV, overlay updated to "oxygen" icon state

## Changelog
:cl: EOD501
fix: Fixes invisible TTV tank overlays
/:cl: