### PR TITLE
Fixes blood spraying from the summoner when a holoparasite is healed

### DIFF
--- a/code/game/gamemodes/miniantags/guardian/guardian.dm
+++ b/code/game/gamemodes/miniantags/guardian/guardian.dm
@@ -163,7 +163,7 @@
 
 	if(summoner.stat == UNCONSCIOUS)
 		to_chat(summoner, "<span class='danger'>Your body can't take the strain of sustaining [src] in this condition, it begins to fall apart!</span>")
-		summoner.adjustCloneLoss(damage/2)
+		summoner.adjustCloneLoss(damage / 2)
 
 /mob/living/simple_animal/hostile/guardian/ex_act(severity, target)
 	switch(severity)


### PR DESCRIPTION
## What Does This PR Do
If the holoparasites health is adjusted by less than 0, healing it, it will not cause the summoner to spray blood and get warnings of the holoparasite getting damaged.

## Why It's Good For The Game
Fixes #12993 

## Testing
Tested by hurting holoparasite and healing holoparasite and both worked

## Changelog
:cl: EOD501
fix: Holoparasites dont alert the summoner of taking damage when healing
/:cl:
