### PR TITLE
Minor changes to table frames

### DIFF
--- a/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
@@ -869,27 +869,7 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 	density = TRUE
 	anchored = TRUE
 	resistance_flags = FIRE_PROOF | ACID_PROOF
-
-/obj/structure/table_frame/abductor/try_make_table(obj/item/stack/stack, mob/user)
-	if(!istype(stack, /obj/item/stack/sheet/mineral/abductor) && !istype(stack, /obj/item/stack/sheet/mineral/silver))
-		return FALSE
-
-	if(stack.get_amount() < 1) //no need for safeties as we did an istype earlier
-		to_chat(user, "<span class='warning'>You need at least one sheet of [stack] to do this!</span>")
-		return TRUE
-
-	to_chat(user, "<span class='notice'>You start adding [stack] to [src]...</span>")
-
-	if(!(do_after(user, 50, target = src) && stack.use(1)))
-		return TRUE
-
-	if(istype(stack, /obj/item/stack/sheet/mineral/abductor)) //if it's not this then it's silver, so no need for an else afterwards
-		make_new_table(stack.table_type)
-		return TRUE
-
-	new /obj/machinery/optable/abductor(loc)
-	qdel(src)
-	return TRUE
+	restrict_table_types = list(/obj/item/stack/sheet/mineral/silver = /obj/machinery/optable/abductor, /obj/item/stack/sheet/mineral/abductor)
 
 /obj/structure/table/abductor
 	name = "alien table"

--- a/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
@@ -869,7 +869,7 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 	density = TRUE
 	anchored = TRUE
 	resistance_flags = FIRE_PROOF | ACID_PROOF
-	restrict_table_types = list(/obj/item/stack/sheet/mineral/silver = /obj/machinery/optable/abductor, /obj/item/stack/sheet/mineral/abductor == /obj/item/stack/sheet/mineral/abductor::table_type)
+	restrict_table_types = list(/obj/item/stack/sheet/mineral/silver = /obj/machinery/optable/abductor, /obj/item/stack/sheet/mineral/abductor = /obj/item/stack/sheet/mineral/abductor::table_type)
 
 /obj/structure/table/abductor
 	name = "alien table"

--- a/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
@@ -869,7 +869,7 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 	density = TRUE
 	anchored = TRUE
 	resistance_flags = FIRE_PROOF | ACID_PROOF
-	restrict_table_types = list(/obj/item/stack/sheet/mineral/silver = /obj/machinery/optable/abductor, /obj/item/stack/sheet/mineral/abductor)
+	restrict_table_types = list(/obj/item/stack/sheet/mineral/silver = /obj/machinery/optable/abductor, /obj/item/stack/sheet/mineral/abductor == /obj/item/stack/sheet/mineral/abductor::table_type)
 
 /obj/structure/table/abductor
 	name = "alien table"

--- a/code/game/objects/structures/table_frames.dm
+++ b/code/game/objects/structures/table_frames.dm
@@ -18,8 +18,14 @@
 	anchored = FALSE
 	layer = PROJECTILE_HIT_THRESHHOLD_LAYER
 	max_integrity = 100
+	///The resource dropped when the table frame is destroyed or deconstructed
 	var/framestack = /obj/item/stack/rods
+	///How many of framestack resource are dropped
 	var/framestackamount = 2
+	///How long the table takes to make
+	var/construction_time = 5 SECONDS
+	///What stacks can be used to make the table, and if it will result in a unique table
+	var/list/restrict_table_types = list() //ex: list(/obj/item/stack/tile/carpet = /obj/structure/table/wood/poker, /obj/item/stack/sheet/wood), carpet will make poker table, wood will result in standard table_type
 
 /obj/structure/table_frame/attackby(obj/item/I, mob/user, params)
 	if(!try_make_table(I, user))
@@ -30,7 +36,19 @@
 	if(!istype(stack))
 		return FALSE
 
-	if(!stack.table_type)
+	var/obj/structure/table/new_table_type = stack.table_type
+	if(length(restrict_table_types))
+		var/valid_stack_type = FALSE
+		for(var/obj/item/stack/current_stack as anything in restrict_table_types)
+			if(istype(stack, current_stack))
+				if(restrict_table_types[current_stack])
+					new_table_type = restrict_table_types[current_stack]
+				valid_stack_type = TRUE
+				break
+		if(!valid_stack_type)
+			return FALSE
+
+	if(!new_table_type)
 		return FALSE
 
 	if(stack.get_amount() < 1)
@@ -38,13 +56,24 @@
 		return TRUE
 
 	to_chat(user, "<span class='notice'>You start adding [stack] to [src]...</span>")
-
-	if(!(do_after(user, 50, target = src) && stack.use(1)))
+	if(!do_after(user, construction_time, target = src))
 		return TRUE
 
-	if(stack.table_type)
-		make_new_table(stack.table_type)
+	if(!stack.use(1))
+		to_chat(user, "<span class='warning'>You need at least one sheet of [stack] to do this!</span>")
 		return TRUE
+
+	var/obj/structure/table/table_already_there = locate(/obj/structure/table) in get_turf(src)
+	if(table_already_there) //check again after to make sure one wasnt added since
+		to_chat(user, "<span class='warning'>There is already [table_already_there] here.</span>")
+		return TRUE
+
+	if(!istype(new_table_type, /obj/structure/table)) //if its something unique, skip the table parts
+		new new_table_type(loc)
+		qdel(src)
+		return TRUE
+	make_new_table(new_table_type)
+	return TRUE
 
 /obj/structure/table_frame/wrench_act(mob/user, obj/item/I)
 	. = TRUE
@@ -83,26 +112,7 @@
 	framestack = /obj/item/stack/sheet/wood
 	framestackamount = 2
 	resistance_flags = FLAMMABLE
-
-/obj/structure/table_frame/wood/try_make_table(obj/item/stack/stack, mob/user)
-	if(!istype(stack, /obj/item/stack/tile/carpet) && !istype(stack, /obj/item/stack/sheet/wood))
-		return FALSE
-
-	if(stack.get_amount() < 1) //no need for safeties as we did an istype earlier
-		to_chat(user, "<span class='warning'>You need at least one sheet of [stack] to do this!</span>")
-		return TRUE
-
-	to_chat(user, "<span class='notice'>You start adding [stack] to [src]...</span>")
-
-	if(!(do_after(user, 50, target = src) && stack.use(1)))
-		return TRUE
-
-	if(istype(stack, /obj/item/stack/tile/carpet))
-		make_new_table(/obj/structure/table/wood/poker)
-		return TRUE
-
-	make_new_table(stack.table_type)
-	return TRUE
+	restrict_table_types = list(/obj/item/stack/tile/carpet = /obj/structure/table/wood/poker, /obj/item/stack/sheet/wood)
 
 /obj/structure/table_frame/brass
 	name = "brass table frame"
@@ -113,21 +123,8 @@
 	anchored = TRUE
 	framestack = /obj/item/stack/tile/brass
 	framestackamount = 1
-
-/obj/structure/table_frame/brass/try_make_table(obj/item/stack/stack, mob/user)
-	if(!istype(stack, /obj/item/stack/tile/brass))
-		return FALSE
-
-	if(stack.get_amount() < 1) //no need for safeties as we did an istype earlier
-		to_chat(user, "<span class='warning'>You need at least one sheet of [stack] to do this!</span>")
-		return TRUE
-
-	to_chat(user, "<span class='notice'>You start adding [stack] to [src]...</span>")
-
-	if(do_after(user, 20, target = src) && stack.use(1))
-		make_new_table(stack.table_type)
-
-	return TRUE
+	construction_time = 2 SECONDS
+	restrict_table_types = list(/obj/item/stack/tile/brass)
 
 /obj/structure/table_frame/brass/narsie_act()
 	..()

--- a/code/game/objects/structures/table_frames.dm
+++ b/code/game/objects/structures/table_frames.dm
@@ -112,7 +112,7 @@
 	framestack = /obj/item/stack/sheet/wood
 	framestackamount = 2
 	resistance_flags = FLAMMABLE
-	restrict_table_types = list(/obj/item/stack/tile/carpet = /obj/structure/table/wood/poker, /obj/item/stack/sheet/wood)
+	restrict_table_types = list(/obj/item/stack/tile/carpet = /obj/structure/table/wood/poker, /obj/item/stack/sheet/wood = /obj/item/stack/sheet/wood::table_type)
 
 /obj/structure/table_frame/brass
 	name = "brass table frame"

--- a/code/game/objects/structures/table_frames.dm
+++ b/code/game/objects/structures/table_frames.dm
@@ -25,7 +25,7 @@
 	///How long the table takes to make
 	var/construction_time = 5 SECONDS
 	///What stacks can be used to make the table, and if it will result in a unique table
-	var/list/restrict_table_types = list() //ex: list(/obj/item/stack/tile/carpet = /obj/structure/table/wood/poker, /obj/item/stack/sheet/wood = /obj/item/stack/sheet/wood::table_type), carpet will make poker table, wood will result in standard table_type
+	var/list/restrict_table_types = list() //ex: list(/obj/item/stack/tile/carpet = /obj/structure/table/wood/poker, /obj/item/stack/sheet/wood = /obj/item/stack/sheet/wood::table_type), carpet will make poker table, wood will result in standard table_type. If the list is empty, any material can be used for its default table_type.
 
 /obj/structure/table_frame/attackby(obj/item/I, mob/user, params)
 	if(!try_make_table(I, user))

--- a/code/game/objects/structures/table_frames.dm
+++ b/code/game/objects/structures/table_frames.dm
@@ -41,8 +41,7 @@
 		var/valid_stack_type = FALSE
 		for(var/obj/item/stack/current_stack as anything in restrict_table_types)
 			if(istype(stack, current_stack))
-				if(restrict_table_types[current_stack])
-					new_table_type = restrict_table_types[current_stack]
+				new_table_type = restrict_table_types[current_stack]
 				valid_stack_type = TRUE
 				break
 		if(!valid_stack_type)
@@ -124,7 +123,7 @@
 	framestack = /obj/item/stack/tile/brass
 	framestackamount = 1
 	construction_time = 2 SECONDS
-	restrict_table_types = list(/obj/item/stack/tile/brass)
+	restrict_table_types = list(/obj/item/stack/tile/brass = /obj/item/stack/tile/brass::table_type)
 
 /obj/structure/table_frame/brass/narsie_act()
 	..()

--- a/code/game/objects/structures/table_frames.dm
+++ b/code/game/objects/structures/table_frames.dm
@@ -25,7 +25,7 @@
 	///How long the table takes to make
 	var/construction_time = 5 SECONDS
 	///What stacks can be used to make the table, and if it will result in a unique table
-	var/list/restrict_table_types = list() //ex: list(/obj/item/stack/tile/carpet = /obj/structure/table/wood/poker, /obj/item/stack/sheet/wood), carpet will make poker table, wood will result in standard table_type
+	var/list/restrict_table_types = list() //ex: list(/obj/item/stack/tile/carpet = /obj/structure/table/wood/poker, /obj/item/stack/sheet/wood = /obj/item/stack/sheet/wood::table_type), carpet will make poker table, wood will result in standard table_type
 
 /obj/structure/table_frame/attackby(obj/item/I, mob/user, params)
 	if(!try_make_table(I, user))


### PR DESCRIPTION
## What Does This PR Do
Makes table construction more generic
Removes the ability to build multiple tables on a single tile

## Why It's Good For The Game
Fixes #12957 

## Testing
Tested many combinations of material and table frames, and tried to build multiple tables on one tile

## Changelog
:cl: EOD501
fix: Fixes being able to stack multiple tables on one tile
/:cl:
