### PR TITLE
Falsebottom Briefcase now shoots the weapon within the false bottom of the briefcase

### DIFF
--- a/code/game/objects/items/weapons/storage/briefcase.dm
+++ b/code/game/objects/items/weapons/storage/briefcase.dm
@@ -42,11 +42,10 @@
 	return ..()
 
 /obj/item/storage/briefcase/false_bottomed/afterattack(atom/A, mob/user, flag, params)
+	..()
 	if(stored_item && isgun(stored_item))
 		var/obj/item/gun/stored_gun = stored_item
 		stored_gun.afterattack(A, user, flag, params)
-		return
-	..()
 
 /obj/item/storage/briefcase/false_bottomed/attackby(obj/item/I, mob/user)
 	if(bottom_open)

--- a/code/game/objects/items/weapons/storage/briefcase.dm
+++ b/code/game/objects/items/weapons/storage/briefcase.dm
@@ -42,10 +42,11 @@
 	return ..()
 
 /obj/item/storage/briefcase/false_bottomed/afterattack(atom/A, mob/user, flag, params)
-	..()
-	if(stored_item && isgun(stored_item) && !Adjacent(A))
+	if(stored_item && isgun(stored_item))
 		var/obj/item/gun/stored_gun = stored_item
 		stored_gun.afterattack(A, user, flag, params)
+		return
+	..()
 
 /obj/item/storage/briefcase/false_bottomed/attackby(obj/item/I, mob/user)
 	if(bottom_open)

--- a/code/modules/projectiles/firing.dm
+++ b/code/modules/projectiles/firing.dm
@@ -38,7 +38,7 @@
 
 /obj/item/ammo_casing/proc/throw_proj(atom/target, turf/targloc, mob/living/user, params, spread, atom/firer_source_atom)
 	var/turf/curloc = get_turf(firer_source_atom)
-	if (!istype(curloc)) // False-bottomed briefcase check.
+	if(!istype(curloc)) // False-bottomed briefcase check.
 	{
 		var/obj/item/holding = user.get_active_hand();
 		if(istype(holding, /obj/item/storage/briefcase/false_bottomed))

--- a/code/modules/projectiles/firing.dm
+++ b/code/modules/projectiles/firing.dm
@@ -38,6 +38,12 @@
 
 /obj/item/ammo_casing/proc/throw_proj(atom/target, turf/targloc, mob/living/user, params, spread, atom/firer_source_atom)
 	var/turf/curloc = get_turf(firer_source_atom)
+	if (!istype(curloc)) // False-bottomed briefcase check.
+	{
+		var/obj/item/holding = user.get_active_hand();
+		if(istype(holding, /obj/item/storage/briefcase/false_bottomed))
+			curloc = get_turf(holding);
+	}
 	if(!istype(targloc) || !istype(curloc) || !BB)
 		return
 	BB.ammo_casing = src

--- a/code/modules/projectiles/firing.dm
+++ b/code/modules/projectiles/firing.dm
@@ -39,11 +39,9 @@
 /obj/item/ammo_casing/proc/throw_proj(atom/target, turf/targloc, mob/living/user, params, spread, atom/firer_source_atom)
 	var/turf/curloc = get_turf(firer_source_atom)
 	if(!istype(curloc)) // False-bottomed briefcase check.
-	{
-		var/obj/item/holding = user.get_active_hand();
+		var/obj/item/holding = user.get_active_hand()
 		if(istype(holding, /obj/item/storage/briefcase/false_bottomed))
-			curloc = get_turf(holding);
-	}
+			curloc = get_turf(holding)
 	if(!istype(targloc) || !istype(curloc) || !BB)
 		return
 	BB.ammo_casing = src


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Fixes https://github.com/ParadiseSS13/Paradise/issues/26308

Allows guns inside the falsebottom briefcase to be fired, as intended.

TO NOTE:
Having a gun inside the falsebottom affects the click melee CD, allowing for some sick combinations. Only while it has ammo though. Once the gun inside is empty... it goes back to regular melee CD. I think this is neat.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Falsebottom is 10TC and besides hiding a high-risk item or contraband.... it's useless. It is also intended to shoot the weapon inside
> A modified briefcase capable of **storing and firing a gun** under a false bottom. Use a screwdriver to pry away the false bottom and make modifications. Distinguishable upon close examination due to the added weight.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![image](https://github.com/user-attachments/assets/18edfd7c-fa36-44cd-8c1c-b25f82ddb8e6)


## Testing
<!-- How did you test the PR, if at all? -->
Local server.

Autotot'd, bought a briefcase, a stetty, and a suppressor. Shot someone (worme) from range. 007 style.
Bought another briefcase, put a u-ion in it and performed a nasty assassination.
Bought a THIRD briefcase, put a stetty in it and bashed a worme's face in... causing the gun inside to introduce the vile creature to god.

## Changelog
:cl:
fix: Fixed the falsebottom briefcase, allowing guns within the false bottom of the briefcase to be fired again. You can now cosplay as Agent 007 and smash people in the face and shoot them simultaneously.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
