### PR TITLE
Fix (win)door superconductivity.

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -458,12 +458,6 @@
 	if(!glass && GLOB.cameranet)
 		GLOB.cameranet.updateVisibility(src, 0)
 
-/obj/machinery/door/get_superconductivity(direction)
-	// Only heatproof airlocks block heat, currently only varedited doors have this
-	if(heat_proof && density)
-		return FALSE
-	return ..()
-
 /obj/machinery/door/proc/check_unres() //unrestricted sides. This overlay indicates which directions the player can access even without an ID
 	if(hasPower() && unres_sides)
 		. = list()


### PR DESCRIPTION
## What Does This PR Do
Doors and windoors now properly block most superconductivity when closed.

I'm guessing the extra (original) copy of this method got accidentally re-introduced in a merge at some point, because I know I'd tested this.

## Why It's Good For The Game
Science no longer develops icicles due to the server coldroom.

## Testing
Checked superconductivity was correct, saw cold having a hard time escaping the coldroom.

## Changelog
:cl:
fix: Doors and windoors now properly block most heat transfer when closed. The server coldroom will no longer freeze all of Science.
/:cl: