### PR TITLE
Fixes client chat href issue

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -161,9 +161,11 @@
 
 	if(href_list["reload_statbrowser"])
 		stat_panel.reinitialize()
+		return
 
 	if(href_list["reload_tguipanel"])
 		nuke_chat()
+		return
 
 	//byond bug ID:2256651
 	if(asset_cache_job && (asset_cache_job in completed_asset_jobs))


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes https://github.com/ParadiseSS13/Paradise/issues/26328 by adding returns after both reload chat and reload stat panel commands.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Without the return the href proc continues to the next link which would usually be a TM'd PR. Ooops.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Loaded chat and pressed the button.

Didn't explode.

![delwedd](https://github.com/user-attachments/assets/132aa213-57df-4221-b7ed-405fb45469b6)

<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Stopped reload chat button from opening TM'd PRs in your browser
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
