### PR TITLE
fix: syndie depot bots patrol correctly

### DIFF
--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -1054,7 +1054,6 @@ GLOBAL_LIST_EMPTY(turret_icons)
 	interact_offline = TRUE
 	power_state = NO_POWER_USE
 	has_cover = FALSE
-	raised = TRUE
 	scan_range = 9
 
 	faction = "syndicate"
@@ -1095,6 +1094,7 @@ GLOBAL_LIST_EMPTY(turret_icons)
 		req_one_access.Cut()
 	req_access = list(ACCESS_SYNDICATE)
 	one_access = FALSE
+	pop_up()
 
 /obj/machinery/porta_turret/syndicate/update_icon_state()
 	if(stat & BROKEN)


### PR DESCRIPTION
## What Does This PR Do
This PR fixes the behavior of turrets spawned on the Syndicate depot, using the correct proc to raise up, which correctly sets their density. This allows SSpathfinder to correctly consider them as obstacles when the Syndicate "mech" (actually a reskinned ED209, the more you know) patrols the depot perimeter.
## Why It's Good For The Game
Fixes a regression causing bad pathing logic.
## Testing

https://github.com/user-attachments/assets/92c791e8-6e74-4ce5-bf5d-8a9d2115959d

## Changelog
:cl:
fix: Syndicate depot mechs correctly patrol the depot perimeter.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
