### PR TITLE
Locks HUD/UI buttons by default

### DIFF
--- a/code/_onclick/hud/action_button.dm
+++ b/code/_onclick/hud/action_button.dm
@@ -19,7 +19,7 @@
 	/// Whether or not this should be shown to observers
 	var/shown_to_observers = FALSE
 	/// Whether or not this button is locked, preventing it from being dragged.
-	var/locked = FALSE
+	var/locked = TRUE
 
 /atom/movable/screen/movable/action_button/Destroy()
 	. = ..()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Fixes https://github.com/ParadiseSS13/Paradise/issues/26195

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Upon getting a new button it's unlocked meaning that in the heat of the moment and in combat you intend to just click the button and instead drag it; causing the intended action to be tossed out the window can be aggravating. Especially in the case where it's needed.

## Testing
<!-- How did you test the PR, if at all? -->
Compiled, loaded up a server. Gave random skrell changeling, tried dragging their actions / spells, nada :)

## Changelog
:cl:
tweak: Actions/Spells on the HUD are now locked in place by default.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
