### PR TITLE
Fix door/windoor superconductivity, again.

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -140,6 +140,11 @@
 /obj/machinery/door/CanAtmosPass(direction)
 	return !density
 
+/obj/machinery/door/get_superconductivity(direction)
+	if(density)
+		return superconductivity
+	return ..()
+
 /obj/machinery/door/proc/bumpopen(mob/user)
 	if(operating)
 		return


### PR DESCRIPTION
## What Does This PR Do
#26322 accidentally removed the only remaining definition of this proc, causing ALL doors to not block heat. This re-adds the proc and fixes that.

Fixes #26350

## Why It's Good For The Game
Doors should mostly block heat transfer. Heatproof doors should fully block it.

## Testing
Checked that a closed door had lowered superconductivity again.

## Changelog
:cl:
fix: Fixed a merge error that made ALL doors and windoors not block heat, even the heatproof ones on the SM.
/:cl: