### PR TITLE
Fixes zombie claws description mentioning "brain_holders"

### DIFF
--- a/code/modules/antagonists/zombie/zombie_spells.dm
+++ b/code/modules/antagonists/zombie/zombie_spells.dm
@@ -42,7 +42,7 @@
 
 /obj/item/zombie_claw
 	name = "claws"
-	desc = "Claws extending from your rotting hands, perfect for ripping open brain_holders for brains."
+	desc = "Claws extending from your rotting hands, perfect for ripping skulls open for the brains inside."
 	icon = 'icons/effects/vampire_effects.dmi'
 	icon_state = "vamp_claws"
 	lefthand_file = 'icons/mob/inhands/weapons_lefthand.dmi'


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Changes the description of the zombie claws to not use "brain_holder". As well as makes it flow a little better as replacing it with just skull or head made it look a little weird.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
i assume when this was ported or added, brain_holder was originally meant to be closed in square brackets to be easily mass changed.

## Testing
<!-- How did you test the PR, if at all? -->
Compiled, spawned zombie claws, checked the description
## Changelog
:cl:
tweak: Tweaked the description of zombie claws to flow a little better as it used to say "brain_holders"
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
