### PR TITLE
fix: cere departures sec room access/floor plating

### DIFF
--- a/_maps/map_files/stations/cerestation.dmm
+++ b/_maps/map_files/stations/cerestation.dmm
@@ -49517,8 +49517,8 @@
 /obj/machinery/door/airlock/security/glass{
 	name = "Escape Shuttle Cell"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/turf/simulated/floor/plating,
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
+/turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
 "iWF" = (
 /obj/machinery/atmospherics/unary/portables_connector{
@@ -78588,10 +78588,10 @@
 /obj/machinery/door/airlock/security/glass{
 	name = "Escape Shuttle Cell"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/mapping_helpers/airlock/access/all/security/doors,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
 "shh" = (


### PR DESCRIPTION
## What Does This PR Do
This PR fixes the access helpers on the security room of Cere departures to match other stations. It also replaces a plating tile with a floor tile under one of the airlocks.
## Why It's Good For The Game
This allows all people with the right access (i.e. all of Command) to access the security room as expected.
## Testing
Spawned in, changed job outfit to each Command member in turn, tested airlocks.
## Changelog
:cl:
fix: Farragus: Command should now be able to access the departures security room.
fix: Farragus: A plating tile under the departures security room airlock is now a proper floor.
/:cl:
