### PR TITLE
[FIX] Tourist Midround fixes

### DIFF
--- a/code/game/gamemodes/miniantags/tourist/tourist_arrivals.dm
+++ b/code/game/gamemodes/miniantags/tourist/tourist_arrivals.dm
@@ -74,13 +74,14 @@
 			M.change_gender(FEMALE)
 		set_appearance(M)
 		M.equipOutfit(T.tourist_outfit)
-		M.mind.special_role = SPECIAL_ROLE_TOURIST
 		GLOB.data_core.manifest_inject(M)
+		M.mind.special_role = SPECIAL_ROLE_TOURIST
 		// Rolls a 20% probability, checks if 3 tourists have been made into tot and check if there's space for a new tot!
 		// If any is false, we don't make a new tourist tot
-		if(prob(chance) && tot_number < 3 && antag_count < max_antag && !jobban_isbanned(M, SPECIAL_ROLE_TRAITOR))
-			tot_number++
-			M.mind.add_antag_datum(/datum/antagonist/traitor)
+		if(prob(chance) && tot_number < 3 && antag_count < max_antag && (SPECIAL_ROLE_TRAITOR in M.client.prefs.be_special) && !jobban_isbanned(M, SPECIAL_ROLE_TRAITOR))
+			if(player_old_enough_antag(M.client, ROLE_TRAITOR))
+				tot_number++
+				M.mind.add_antag_datum(/datum/antagonist/traitor)
 
 		// If they're a tot, they don't get tourist objectives neither the tourist greeting!
 		if(M.mind.special_role != SPECIAL_ROLE_TRAITOR)

--- a/code/game/gamemodes/miniantags/tourist/tourist_arrivals.dm
+++ b/code/game/gamemodes/miniantags/tourist/tourist_arrivals.dm
@@ -74,7 +74,7 @@
 			M.change_gender(FEMALE)
 		set_appearance(M)
 		M.equipOutfit(T.tourist_outfit)
-		GLOB.data_core.manifest_inject(M)
+		GLOB.data_core.manifest_inject(M) // Proc checks if they have a special role before adding to the manifest, if they do, they aren't added. This needs to be done before adding the special role.
 		M.mind.special_role = SPECIAL_ROLE_TOURIST
 		// Rolls a 20% probability, checks if 3 tourists have been made into tot and check if there's space for a new tot!
 		// If any is false, we don't make a new tourist tot


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes a few issues related to the tourist midround, such as:

- Tourists not being added to the manifest;
- Antag roll didn't account for players preferences;
- Players without the hour requirement were able to roll traitor.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Small fixes overall, ensuring that the player preference is taken into consideration. Should be enough to avoid future issues related to the midround.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Logged in to testing, joined as tourist, checked if I was added to the manifest, turned on traitor preference, set the chance of rolling tot to 100, and tried rolling again, got traitor tourist
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:

tweak: Tourist event now takes preferences into consideration when selecting traitors
fix: Tourists are now properly added to the manifest
fix: Player hours are now properly taken into consideration by the tourist event

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
