### PR TITLE
Updates chem smoke to work visually again

### DIFF
--- a/code/game/objects/effects/effect_system/effects_chem_smoke.dm
+++ b/code/game/objects/effects/effect_system/effects_chem_smoke.dm
@@ -48,7 +48,7 @@
 	var/eff_range = 2
 	var/eff_colour = "#12A5F4" // This is a random blue incase it doesnt get set right
 	var/process_count = 0
-	var/max_process_count = 10
+	var/max_process_count = 50 //50 ticks, every 0.2 seconds, or 10 seconds of smoke.
 	var/obj/chemholder
 	var/list/smoked_atoms = list()
 
@@ -100,18 +100,19 @@
 /datum/effect_system/smoke_spread/chem/start(effect_range = 2)
 	eff_colour = mix_color_from_reagents(chemholder.reagents.reagent_list)
 	eff_range = effect_range
-	START_PROCESSING(SSprocessing, src)
+	START_PROCESSING(SSfastprocess, src)
 
 /datum/effect_system/smoke_spread/chem/process()
 	process_count++
-	if(eff_range < 3)
-		new /obj/effect/particle_effect/chem_smoke/small(location, eff_colour)
-	else
-		new /obj/effect/particle_effect/chem_smoke(location, eff_colour)
-
-	INVOKE_ASYNC(src, PROC_REF(SmokeEm), eff_range)
+	for(var/i = 0, i < (2 * rand(2, 6)), i++) //Every 0.2 seconds, create 4-12 smoke particles. This keeps it consitant with the 2-6 every 0.1 seconds before
+		if(eff_range < 3)
+			new /obj/effect/particle_effect/chem_smoke/small(location, eff_colour)
+		else
+			new /obj/effect/particle_effect/chem_smoke(location, eff_colour)
+	if(process_count % 5 == 0) //Every 5 ticks, or 1 second.
+		INVOKE_ASYNC(src, PROC_REF(SmokeEm), eff_range)
 	if(process_count > max_process_count)
-		STOP_PROCESSING(SSprocessing, src)
+		STOP_PROCESSING(SSfastprocess, src)
 		qdel(src)
 
 

--- a/code/game/objects/effects/effect_system/effects_chem_smoke.dm
+++ b/code/game/objects/effects/effect_system/effects_chem_smoke.dm
@@ -109,7 +109,7 @@
 			new /obj/effect/particle_effect/chem_smoke/small(location, eff_colour)
 		else
 			new /obj/effect/particle_effect/chem_smoke(location, eff_colour)
-	if(process_count % 5 == 0) //Every 5 ticks, or 1 second.
+	if(process_count % 5 == 0) //Every 5 ssfastprocess, 10 ticks, or 1 second.
 		INVOKE_ASYNC(src, PROC_REF(SmokeEm), eff_range)
 	if(process_count > max_process_count)
 		STOP_PROCESSING(SSfastprocess, src)

--- a/code/game/objects/effects/effect_system/effects_chem_smoke.dm
+++ b/code/game/objects/effects/effect_system/effects_chem_smoke.dm
@@ -104,7 +104,7 @@
 
 /datum/effect_system/smoke_spread/chem/process()
 	process_count++
-	for(var/i = 0, i < (2 * rand(2, 6)), i++) //Every 0.2 seconds, create 4-12 smoke particles. This keeps it consitant with the 2-6 every 0.1 seconds before
+	for(var/i in 1 to (2 * rand(2, 6))) // Every 0.2 seconds, create 4-12 smoke particles. This keeps it consitant with the 2-6 every 0.1 seconds before
 		if(eff_range < 3)
 			new /obj/effect/particle_effect/chem_smoke/small(location, eff_colour)
 		else


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Adjusts the tweaks made in #25801 to chemical smoke, moving it from process to fastprocess, and fixing it's visuals.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Smoke should actually show up, compared to currently as this:  https://imgur.com/a/ufYbCFy

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->


Fixed: https://imgur.com/a/OhXuMAP

## Testing
<!-- How did you test the PR, if at all? -->
Through tear gas, looked right.

Got gassed by it.
Timed it to ensure it lasted the right time.
walked through smoke after 10 seconds, not hit.
Walked through smoke after 8 seconds, hit.

## Changelog
:cl:
fix: Chemical smoke should look normal again, and produce over 1600+ particles again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
