### PR TITLE
fix: Remove wall under vendor on Delta.

### DIFF
--- a/_maps/map_files/stations/deltastation.dmm
+++ b/_maps/map_files/stations/deltastation.dmm
@@ -92520,7 +92520,7 @@
 "uaS" = (
 /obj/machinery/economy/vending/cigarette,
 /obj/effect/turf_decal/delivery,
-/turf/simulated/wall,
+/turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central)
 "ubm" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{


### PR DESCRIPTION
## What Does This PR Do
This PR replaces a wall that was occupying the same tile as a vendor with a floor on Delta.
## Why It's Good For The Game
Mapping error.
## Images of changes
Before:
![2024_08_01__14_03_06__paradise dme  deltastation dmm  - StrongDMM](https://github.com/user-attachments/assets/be6fa563-3f35-4993-939e-30d051c54ce7)

After:
![2024_08_01__14_02_57__paradise dme  deltastation dmm  - StrongDMM](https://github.com/user-attachments/assets/9f43a7ff-5e44-4f89-8e5b-c59302ebf713)

## Testing
Visual inspection.

## Changelog
:cl:
fix: Kerberos: A wall underneath a vendor in the primary hall has been fixed.
/:cl:
