### PR TITLE
Makes emitter hits that didn't turn on the SM not get logged by investigate

### DIFF
--- a/code/modules/power/engines/singularity/emitter.dm
+++ b/code/modules/power/engines/singularity/emitter.dm
@@ -302,6 +302,8 @@
 	else
 		fire_delay = rand(minimum_fire_delay, maximum_fire_delay)
 		shot_number = 0
+
+	P.firer = src
 	P.setDir(dir)
 	P.starting = loc
 	P.Angle = null

--- a/code/modules/power/engines/singularity/emitter.dm
+++ b/code/modules/power/engines/singularity/emitter.dm
@@ -303,7 +303,6 @@
 		fire_delay = rand(minimum_fire_delay, maximum_fire_delay)
 		shot_number = 0
 
-	P.firer = src
 	P.setDir(dir)
 	P.starting = loc
 	P.Angle = null

--- a/code/modules/power/engines/supermatter/supermatter.dm
+++ b/code/modules/power/engines/supermatter/supermatter.dm
@@ -681,19 +681,19 @@
 			countdown()
 	return 1
 
-/obj/machinery/atmospherics/supermatter_crystal/bullet_act(obj/item/projectile/Proj)
+/obj/machinery/atmospherics/supermatter_crystal/bullet_act(obj/item/projectile/proj)
 	var/turf/L = loc
 	if(!istype(L))
 		return FALSE
-	if(!istype(Proj.firer, /obj/machinery/power/emitter) && power_changes)
-		investigate_log("has been hit by [Proj] fired by [key_name(Proj.firer)]", "supermatter")
-	if(Proj.flag != BULLET)
+	if(!istype(proj, /obj/item/projectile/beam/emitter/hitscan) && power_changes)
+		investigate_log("has been hit by [proj] fired by [key_name(proj.firer)]", "supermatter")
+	if(proj.flag != BULLET)
 		if(power_changes) //This needs to be here I swear
-			power += Proj.damage * bullet_energy
+			power += proj.damage * bullet_energy
 			if(!has_been_powered)
 				enable_for_the_first_time()
 	else if(takes_damage)
-		damage += Proj.damage * bullet_energy
+		damage += proj.damage * bullet_energy
 	return FALSE
 
 /obj/machinery/atmospherics/supermatter_crystal/singularity_act()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes emitter beams from stationary emitters not add an investigate log.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Dear fucking lord the investigate log gets spammed you genuinely can't get any useful data out of it at a glance
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://github.com/user-attachments/assets/1a58f69a-fb68-439f-8186-b23ea5649cd9)
This is after running the SM with 3 emitters for 5 minutes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
See above
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: [ADMIN] The supermatter investigate log is no longer spammed by emitter beams
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
