### PR TITLE
fix: Autoapply disposal sort junction names.

### DIFF
--- a/_maps/map_files/stations/boxstation.dmm
+++ b/_maps/map_files/stations/boxstation.dmm
@@ -3433,7 +3433,6 @@
 /obj/structure/disposalpipe/sortjunction{
 	dir = 2;
 	icon_state = "pipe-j2s";
-	name = "Sci Robotics";
 	sort_type_txt = "14"
 	},
 /turf/simulated/floor/plasteel,
@@ -49549,7 +49548,6 @@
 /obj/structure/disposalpipe/sortjunction{
 	dir = 2;
 	icon_state = "pipe-j2s";
-	name = "Sci R&D";
 	sort_type_txt = "12"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -52713,7 +52711,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/sortjunction{
 	dir = 8;
-	name = "Medbay Hall";
 	sort_type_txt = "9"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -53459,7 +53456,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 8;
-	name = "Disposals Maint";
 	sort_type_txt = "1"
 	},
 /turf/simulated/floor/plasteel,
@@ -54114,7 +54110,6 @@
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/sortjunction{
 	dir = 1;
-	name = "Brig Equipment Storage";
 	sort_type_txt = "8"
 	},
 /obj/structure/cable{
@@ -54693,7 +54688,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 1;
-	name = "Brig HoS Office";
 	sort_type_txt = "7"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -55665,7 +55659,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 2;
-	name = "Detective";
 	sort_type_txt = "24"
 	},
 /turf/simulated/floor/plasteel{
@@ -56012,7 +56005,6 @@
 "fzc" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 4;
-	name = "Botany";
 	sort_type_txt = "21"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -57169,7 +57161,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 2;
-	name = "Eng Chief Engineer's Office";
 	sort_type_txt = "5"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -60519,7 +60510,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 1;
-	name = "Sorting Office";
 	sort_type_txt = "2"
 	},
 /turf/simulated/floor/plasteel,
@@ -60857,7 +60847,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 1;
-	name = "QM Office";
 	sort_type_txt = "3"
 	},
 /turf/simulated/floor/plasteel,
@@ -61778,7 +61767,6 @@
 /obj/structure/disposalpipe/sortjunction{
 	dir = 8;
 	icon_state = "pipe-j2s";
-	name = "Med. CMO";
 	sort_type_txt = "10"
 	},
 /obj/machinery/light{
@@ -64501,7 +64489,6 @@
 /obj/structure/disposalpipe/sortjunction{
 	dir = 4;
 	icon_state = "pipe-j2s";
-	name = "Chapel";
 	sort_type_txt = "17"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -64995,7 +64982,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/sortjunction{
-	name = "Bar";
 	sort_type_txt = "19"
 	},
 /turf/simulated/floor/plating,
@@ -65252,7 +65238,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/sortjunction{
 	dir = 8;
-	name = "Med Chemistry";
 	sort_type_txt = "11"
 	},
 /obj/structure/cable{
@@ -67195,7 +67180,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 2;
-	name = "Sci Robotics";
 	sort_type_txt = "14"
 	},
 /turf/simulated/floor/plasteel{
@@ -70338,7 +70322,6 @@
 /obj/structure/disposalpipe/sortjunction{
 	dir = 2;
 	icon_state = "pipe-j2s";
-	name = "Library";
 	sort_type_txt = "16"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -73585,7 +73568,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 2;
-	name = "Eng Atmospherics";
 	sort_type_txt = "6"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -74121,7 +74103,6 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/structure/disposalpipe/sortjunction{
 	dir = 1;
-	name = "Sci R&D";
 	sort_type_txt = "12"
 	},
 /obj/structure/cable{
@@ -76123,7 +76104,6 @@
 /obj/structure/disposalpipe/sortjunction{
 	dir = 8;
 	icon_state = "pipe-j2s";
-	name = "Engineering Main";
 	sort_type_txt = "4"
 	},
 /obj/structure/railing/corner{
@@ -77970,7 +77950,6 @@
 /obj/structure/disposalpipe/sortjunction{
 	dir = 2;
 	icon_state = "pipe-j2s";
-	name = "Sci RD Office 1";
 	sort_type_txt = "13"
 	},
 /obj/structure/cable{
@@ -79824,7 +79803,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 4;
-	name = "Kitchen";
 	sort_type_txt = "20"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -83442,7 +83420,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 2;
-	name = "Janitor";
 	sort_type_txt = "22"
 	},
 /turf/simulated/floor/plating,
@@ -83457,7 +83434,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 8;
-	name = "Captain's Office";
 	sort_type_txt = "18"
 	},
 /turf/simulated/floor/plasteel,
@@ -85329,7 +85305,6 @@
 "tQe" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 4;
-	name = "Sci RD Office 1";
 	sort_type_txt = "13"
 	},
 /turf/simulated/floor/plasteel{
@@ -86155,7 +86130,6 @@
 "ukw" = (
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 2;
-	name = "Genetics";
 	sort_type_txt = "23"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -89700,7 +89674,6 @@
 "wcQ" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 8;
-	name = "HoP Office";
 	sort_type_txt = "15"
 	},
 /turf/simulated/floor/plasteel,

--- a/_maps/map_files/stations/cerestation.dmm
+++ b/_maps/map_files/stations/cerestation.dmm
@@ -1871,7 +1871,6 @@
 "alM" = (
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 8;
-	name = "disposal pipe - HoP Office";
 	sort_type_txt = "15"
 	},
 /obj/machinery/light/small{
@@ -6469,7 +6468,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 8;
-	name = "disposal pipe - HoS";
 	sort_type_txt = "7"
 	},
 /turf/simulated/floor/plasteel{
@@ -17396,7 +17394,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 8;
-	name = "disposal pipe - Atmospherics";
 	sort_type_txt = "6"
 	},
 /turf/simulated/floor/plating,
@@ -18205,7 +18202,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 8;
-	name = "disposal pipe - CE Office";
 	sort_type_txt = "5"
 	},
 /turf/simulated/floor/plasteel{
@@ -21740,9 +21736,8 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/sortjunction/reversed{
-	name = "disposal pipe - Medbay";
-	sort_type_txt = "9";
-	dir = 8
+	dir = 8;
+	sort_type_txt = "9"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
@@ -26172,7 +26167,6 @@
 "cNN" = (
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 1;
-	name = "disposal pipe - CMO Office";
 	sort_type_txt = "10"
 	},
 /turf/simulated/floor/plating,
@@ -29580,7 +29574,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 8;
-	name = "disposal pipe - QM Office";
 	sort_type_txt = "3"
 	},
 /turf/simulated/floor/plasteel{
@@ -31107,7 +31100,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 8;
-	name = "disposal pipe - RD Office";
 	sort_type_txt = "13"
 	},
 /obj/structure/cable/orange{
@@ -33654,7 +33646,6 @@
 "dGr" = (
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 2;
-	name = "disposal pipe - Library";
 	sort_type_txt = "16"
 	},
 /turf/simulated/floor/plating,
@@ -33725,7 +33716,6 @@
 "dHs" = (
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 1;
-	name = "disposal pipe - Research";
 	sort_type_txt = "12"
 	},
 /turf/simulated/floor/plasteel{
@@ -34764,7 +34754,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 2;
-	name = "disposal pipe - Library";
 	sort_type_txt = "16"
 	},
 /turf/simulated/floor/carpet/green,
@@ -34911,7 +34900,6 @@
 "eag" = (
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 1;
-	name = "disposal pipe - Atmospherics";
 	sort_type_txt = "6"
 	},
 /obj/structure/grille/broken,
@@ -35494,7 +35482,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 8;
-	name = "disposal pipe - Engineering";
 	sort_type_txt = "4"
 	},
 /turf/simulated/floor/plasteel{
@@ -36163,7 +36150,6 @@
 "exL" = (
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 1;
-	name = "disposal pipe - Medbay";
 	sort_type_txt = "9"
 	},
 /obj/item/wrench,
@@ -39151,7 +39137,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 4;
-	name = "disposal pipe - Robotics";
 	sort_type_txt = "14"
 	},
 /turf/simulated/floor/plasteel/white,
@@ -43233,7 +43218,6 @@
 "gZc" = (
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 1;
-	name = "disposal pipe - Chemistry";
 	sort_type_txt = "11"
 	},
 /obj/structure/cable/orange{
@@ -43613,7 +43597,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 4;
-	name = "disposal pipe - Chapel";
 	sort_type_txt = "17"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -45543,7 +45526,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 8;
-	name = "disposal pipe - Robotics";
 	sort_type_txt = "14"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -46693,7 +46675,6 @@
 "idV" = (
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 1;
-	name = "disposal pipe - CE Office";
 	sort_type_txt = "5"
 	},
 /turf/simulated/floor/plating,
@@ -47593,7 +47574,6 @@
 "ira" = (
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 4;
-	name = "disposal pipe - Research";
 	sort_type_txt = "12"
 	},
 /obj/structure/cable/orange{
@@ -48168,7 +48148,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 4;
-	name = "disposal pipe - CMO Office";
 	sort_type_txt = "10"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -51640,7 +51619,6 @@
 "jCE" = (
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 1;
-	name = "disposal pipe - Kitchen";
 	sort_type_txt = "20"
 	},
 /turf/simulated/floor/plating{
@@ -53661,7 +53639,6 @@
 "klh" = (
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 2;
-	name = "disposal pipe - Hydroponics";
 	sort_type_txt = "21"
 	},
 /obj/structure/cable/orange{
@@ -56232,7 +56209,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 4;
-	name = "disposal pipe - Morgue";
 	sort_type_txt = "25"
 	},
 /turf/simulated/floor/plating,
@@ -58028,7 +58004,6 @@
 "lye" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 8;
-	name = "disposal pipe - Morgue";
 	sort_type_txt = "25"
 	},
 /obj/structure/cable/orange{
@@ -58087,7 +58062,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 1;
-	name = "disposal pipe - Research";
 	sort_type_txt = "12"
 	},
 /obj/structure/cable/orange{
@@ -58984,7 +58958,6 @@
 "lOw" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 4;
-	name = "disposal pipe - Chapel";
 	sort_type_txt = "17"
 	},
 /turf/simulated/floor/carpet/green,
@@ -62258,7 +62231,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 8;
-	name = "disposal pipe - Hydroponics";
 	sort_type_txt = "21"
 	},
 /obj/structure/cable{
@@ -63542,7 +63514,6 @@
 "noS" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 4;
-	name = "disposal pipe - HoS";
 	sort_type_txt = "7"
 	},
 /turf/simulated/floor/plating,
@@ -65143,7 +65114,6 @@
 "nPH" = (
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 2;
-	name = "disposal pipe - Kitchen";
 	sort_type_txt = "20"
 	},
 /turf/simulated/floor/plating,
@@ -66043,7 +66013,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/sortjunction{
 	dir = 2;
-	name = "disposal pipe - Genetics";
 	sort_type_txt = "23"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -66198,7 +66167,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 1;
-	name = "disposal pipe - Atmospherics";
 	sort_type_txt = "6"
 	},
 /turf/simulated/floor/plasteel{
@@ -66821,7 +66789,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 4;
-	name = "disposal pipe - Detective";
 	sort_type_txt = "24"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -70515,7 +70482,6 @@
 "pBh" = (
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 4;
-	name = "disposal pipe - Robotics";
 	sort_type_txt = "14"
 	},
 /turf/simulated/floor/plating,
@@ -70724,7 +70690,6 @@
 "pEA" = (
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 2;
-	name = "disposal pipe - Bar";
 	sort_type_txt = "19"
 	},
 /turf/simulated/floor/plating,
@@ -72013,7 +71978,6 @@
 /obj/structure/grille,
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 8;
-	name = "disposal pipe - Custodials";
 	sort_type_txt = "22"
 	},
 /turf/simulated/floor/plating,
@@ -75453,7 +75417,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/sortjunction{
 	dir = 8;
-	name = "disposal pipe - Captain's Office";
 	sort_type_txt = "18"
 	},
 /turf/simulated/floor/plasteel{
@@ -76159,7 +76122,6 @@
 "rpk" = (
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 2;
-	name = "disposal pipe - Chapel";
 	sort_type_txt = "17"
 	},
 /turf/simulated/floor/plating,
@@ -76817,7 +76779,6 @@
 "rCJ" = (
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 1;
-	name = "disposal pipe - Genetics";
 	sort_type_txt = "23"
 	},
 /obj/structure/cable/orange{
@@ -77084,7 +77045,6 @@
 "rIJ" = (
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 8;
-	name = "disposal pipe - Captain's Office";
 	sort_type_txt = "18"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -77958,7 +77918,6 @@
 "rXV" = (
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 1;
-	name = "disposal pipe - Engineering";
 	sort_type_txt = "4"
 	},
 /turf/simulated/floor/plating,
@@ -79401,7 +79360,6 @@
 "stC" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 4;
-	name = "disposal pipe - Detective";
 	sort_type_txt = "24"
 	},
 /turf/simulated/floor/plating,
@@ -82284,7 +82242,6 @@
 "tqm" = (
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 1;
-	name = "disposal pipe - Chemistry";
 	sort_type_txt = "11"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
@@ -82354,7 +82311,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 8;
-	name = "disposal pipe - Engineering";
 	sort_type_txt = "4"
 	},
 /obj/item/assembly/mousetrap/armed,
@@ -82738,7 +82694,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 1;
-	name = "disposal pipe - HoP Office";
 	sort_type_txt = "15"
 	},
 /turf/simulated/floor/plasteel{
@@ -82937,7 +82892,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 8;
-	name = "disposal pipe - Bar";
 	sort_type_txt = "19"
 	},
 /turf/simulated/floor/plasteel{
@@ -85360,7 +85314,6 @@
 "uqM" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 4;
-	name = "disposal pipe - Security";
 	sort_type_txt = "8"
 	},
 /obj/effect/decal/cleanable/cobweb,
@@ -85930,7 +85883,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 1;
-	name = "disposal pipe - Security";
 	sort_type_txt = "7"
 	},
 /turf/simulated/floor/plasteel{
@@ -86288,7 +86240,6 @@
 "uEm" = (
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 4;
-	name = "disposal pipe - RD Office";
 	sort_type_txt = "13"
 	},
 /turf/simulated/floor/plating,
@@ -89869,7 +89820,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 8;
-	name = "disposal pipe - Hydroponics";
 	sort_type_txt = "21"
 	},
 /turf/simulated/floor/plating{
@@ -90001,7 +89951,6 @@
 "vHe" = (
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 4;
-	name = "disposal pipe - CMO Office";
 	sort_type_txt = "10"
 	},
 /turf/simulated/floor/plasteel{
@@ -92858,7 +92807,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 4;
-	name = "disposal pipe - Library";
 	sort_type_txt = "16"
 	},
 /turf/simulated/floor/plating{
@@ -94706,9 +94654,8 @@
 	pixel_y = 32
 	},
 /obj/structure/disposalpipe/sortjunction{
-	name = "disposal pipe - Custodials";
-	sort_type_txt = "22";
-	dir = 4
+	dir = 4;
+	sort_type_txt = "22"
 	},
 /obj/structure/cable/orange{
 	d1 = 4;
@@ -95260,7 +95207,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 8;
-	name = "disposal pipe - CE Office";
 	sort_type_txt = "5"
 	},
 /turf/simulated/floor/plating{
@@ -97144,7 +97090,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 8;
-	name = "disposal pipe - Kitchen";
 	sort_type_txt = "20"
 	},
 /turf/simulated/floor/plasteel{

--- a/_maps/map_files/stations/deltastation.dmm
+++ b/_maps/map_files/stations/deltastation.dmm
@@ -6961,7 +6961,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 1;
-	name = "Medbay Junction";
 	sort_type_txt = "9"
 	},
 /obj/structure/cable{
@@ -26170,7 +26169,7 @@
 	dir = 8;
 	level = 3;
 	name = "Distribution and Waste Monitor";
-	autolink_sensors = list("mair_in_meter"="Mixed Air In","air_sensor"="Mixed Air Supply Tank","mair_out_meter"="Mixed Air Out","dloop_atm_meter"="Distribution Loop","wloop_atm_meter"="Waste Loop")
+	autolink_sensors = list("mair_in_meter" = "Mixed Air In", "air_sensor" = "Mixed Air Supply Tank", "mair_out_meter" = "Mixed Air Out", "dloop_atm_meter" = "Distribution Loop", "wloop_atm_meter" = "Waste Loop")
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -27323,7 +27322,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 2;
-	name = "Bar Junction";
 	sort_type_txt = "19"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -57396,7 +57394,6 @@
 "dog" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 8;
-	name = "Quartermaster Junction";
 	sort_type_txt = "3"
 	},
 /obj/machinery/navbeacon{
@@ -66339,7 +66336,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/sortjunction{
 	dir = 8;
-	name = "Detective";
 	sort_type_txt = "24"
 	},
 /turf/simulated/floor/plasteel{
@@ -68236,7 +68232,6 @@
 	dir = 5
 	},
 /obj/structure/disposalpipe/sortjunction{
-	name = "Atmospherics Junction";
 	sort_type_txt = "6"
 	},
 /turf/simulated/floor/plasteel{
@@ -68268,7 +68263,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 1;
-	name = "Captain's Junction";
 	sort_type_txt = "18"
 	},
 /obj/structure/cable{
@@ -72403,7 +72397,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/sortjunction{
 	dir = 1;
-	name = "HoS Junction";
 	sort_type_txt = "7"
 	},
 /turf/simulated/floor/plasteel{
@@ -74189,7 +74182,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 4;
-	name = "Library Junction";
 	sort_type_txt = "16"
 	},
 /turf/simulated/floor/plasteel,
@@ -75647,7 +75639,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 1;
-	name = "Morgue";
 	sort_type_txt = "25"
 	},
 /turf/simulated/floor/plasteel/white,
@@ -77039,7 +77030,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 2;
-	name = "RD Junction 1";
 	sort_type_txt = "13"
 	},
 /turf/simulated/floor/plasteel/white,
@@ -77466,7 +77456,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 8;
-	name = "Genetics";
 	sort_type_txt = "23"
 	},
 /obj/effect/landmark/lightsout,
@@ -78055,7 +78044,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 8;
-	name = "Medbay Hall";
 	sort_type_txt = "9"
 	},
 /turf/simulated/floor/plasteel/white,
@@ -80147,7 +80135,6 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/sortjunction{
-	name = "CE's Junction";
 	sort_type_txt = "5"
 	},
 /turf/simulated/floor/plasteel{
@@ -81191,7 +81178,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 4;
-	name = "Robotics Junction";
 	sort_type_txt = "14"
 	},
 /obj/effect/turf_decal/delivery,
@@ -82082,7 +82068,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 1;
-	name = "Security Junction";
 	sort_type_txt = "8"
 	},
 /turf/simulated/floor/plasteel{
@@ -83398,7 +83383,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 1;
-	name = "Kitchen Junction";
 	sort_type_txt = "20"
 	},
 /turf/simulated/floor/plasteel{
@@ -84337,7 +84321,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 4;
-	name = "Chapel Junction";
 	sort_type_txt = "17"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -85961,7 +85944,6 @@
 "qAH" = (
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 2;
-	name = "Research Junction";
 	sort_type_txt = "12"
 	},
 /turf/simulated/floor/plasteel{
@@ -86393,7 +86375,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 8;
-	name = "Medbay CMO";
 	sort_type_txt = "10"
 	},
 /turf/simulated/floor/plasteel/white,
@@ -87706,7 +87687,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 4;
-	name = "HoP Junction";
 	sort_type_txt = "15"
 	},
 /obj/structure/cable{
@@ -88779,7 +88759,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 1;
-	name = "Chemistry";
 	sort_type_txt = "11"
 	},
 /obj/structure/chair{
@@ -89067,7 +89046,6 @@
 "sjA" = (
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 8;
-	name = "Hydroponics Junction";
 	sort_type_txt = "21"
 	},
 /obj/structure/cable{
@@ -93947,7 +93925,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/sortjunction{
 	dir = 1;
-	name = "Disposals Maint";
 	sort_type_txt = "1"
 	},
 /turf/simulated/floor/plating,
@@ -96859,7 +96836,6 @@
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/sortjunction{
-	name = "Engineering Junction";
 	sort_type_txt = "4"
 	},
 /turf/simulated/floor/plasteel,
@@ -99288,7 +99264,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 8;
-	name = "Custodial Junction";
 	sort_type_txt = "22"
 	},
 /obj/structure/cable{

--- a/_maps/map_files/stations/metastation.dmm
+++ b/_maps/map_files/stations/metastation.dmm
@@ -959,7 +959,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/sortjunction{
-	name = "Engineering Junction";
 	sort_type_txt = "4"
 	},
 /obj/effect/landmark/start/engineer,
@@ -44053,7 +44052,6 @@
 "dsr" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 1;
-	name = "Bar Junction";
 	sort_type_txt = "19"
 	},
 /obj/structure/cable{
@@ -46666,7 +46664,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 1;
-	name = "HoP Junction";
 	sort_type_txt = "15"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -47405,7 +47402,6 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/sortjunction{
-	name = "CE's Junction";
 	sort_type_txt = "5"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -55325,7 +55321,6 @@
 "icA" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 1;
-	name = "Medbay Junction";
 	sort_type_txt = "9"
 	},
 /obj/structure/cable{
@@ -57397,7 +57392,6 @@
 /obj/structure/disposalpipe/sortjunction{
 	dir = 2;
 	icon_state = "pipe-j2s";
-	name = "HoS Junction";
 	sort_type_txt = "7"
 	},
 /turf/simulated/floor/plasteel,
@@ -59414,7 +59408,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/sortjunction{
 	dir = 1;
-	name = "Custodial Junction";
 	sort_type_txt = "22"
 	},
 /turf/simulated/floor/plasteel,
@@ -63102,7 +63095,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 1;
-	name = "CMO's Junction";
 	sort_type_txt = "10"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -63440,7 +63432,6 @@
 /obj/structure/disposalpipe/sortjunction{
 	dir = 8;
 	icon_state = "pipe-j2s";
-	name = "Chapel";
 	sort_type_txt = "17"
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -63589,7 +63580,6 @@
 /obj/structure/disposalpipe/sortjunction{
 	dir = 1;
 	icon_state = "pipe-j2s";
-	name = "Disposals Junction";
 	sort_type_txt = "1"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -64312,7 +64302,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 1;
-	name = "Chemistry Junction";
 	sort_type_txt = "11"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -64749,7 +64738,6 @@
 "maV" = (
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 4;
-	name = "Security Junction";
 	sort_type_txt = "8"
 	},
 /turf/simulated/floor/plasteel{
@@ -66644,7 +66632,6 @@
 /obj/structure/disposalpipe/sortjunction{
 	dir = 8;
 	icon_state = "pipe-j2s";
-	name = "Atmospherics Junction";
 	sort_type_txt = "6"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -69051,7 +69038,6 @@
 "nLV" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 8;
-	name = "Research Junction";
 	sort_type_txt = "12"
 	},
 /obj/structure/cable{
@@ -76101,7 +76087,6 @@
 /obj/structure/disposalpipe/sortjunction{
 	dir = 2;
 	icon_state = "pipe-j2s";
-	name = "Hydroponics Junction";
 	sort_type_txt = "21"
 	},
 /turf/simulated/floor/plasteel,
@@ -78897,7 +78882,6 @@
 /obj/structure/disposalpipe/sortjunction{
 	dir = 2;
 	icon_state = "pipe-j2s";
-	name = "Bar Junction";
 	sort_type_txt = "19"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -84604,7 +84588,6 @@
 "uxV" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 1;
-	name = "Quartermaster Junction";
 	sort_type_txt = "3"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -84772,7 +84755,6 @@
 /obj/structure/disposalpipe/sortjunction{
 	dir = 4;
 	icon_state = "pipe-j2s";
-	name = "Library Junction";
 	sort_type_txt = "16"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -85798,7 +85780,6 @@
 "uXA" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 8;
-	name = "Robotics Junction";
 	sort_type_txt = "14"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -86277,9 +86258,8 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/sortjunction/reversed{
-	name = "Detective";
-	sort_type_txt = "24";
-	dir = 4
+	dir = 4;
+	sort_type_txt = "24"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -89401,7 +89381,6 @@
 /obj/structure/disposalpipe/sortjunction{
 	dir = 2;
 	icon_state = "pipe-j2s";
-	name = "Kitchen Junction";
 	sort_type_txt = "20"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -90992,7 +90971,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/sortjunction{
-	name = "Captain's Junction";
 	sort_type_txt = "18"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -91917,7 +91895,6 @@
 "xLw" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 4;
-	name = "Kitchen Junction";
 	sort_type_txt = "20"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -92452,7 +92429,6 @@
 /obj/structure/disposalpipe/sortjunction{
 	dir = 2;
 	icon_state = "pipe-j2s";
-	name = "RD Junction";
 	sort_type_txt = "13"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -1196,7 +1196,7 @@
 	updatedir()
 	if(mapload)
 		parse_sort_destinations()
-	update_appearance(UPDATE_DESC)
+	update_appearance(UPDATE_NAME|UPDATE_DESC)
 	update()
 	return
 

--- a/tools/maplint/lints/sort_junction_names.yml
+++ b/tools/maplint/lints/sort_junction_names.yml
@@ -1,0 +1,4 @@
+help: "Sort Junctions update their own names. Do not varedit them."
+/obj/structure/disposalpipe/sortjunction:
+  banned_variables:
+  - name


### PR DESCRIPTION
## What Does This PR Do
This PR updates disposals junctions to update their names on Initialize, which uses the `TAGGERLOCATIONS` list to include the correct direction in the name. This would normally happen if their destinations were changed with a tagger (did you know you could do that?) but not on Initialize.

It then removes these varedits from the station maps, and adds a maplint to prohibit their inclusion.
## Why It's Good For The Game
Less varedits are good, this ensures appropriate naming consistency.
## Images of changes
Samples of junctions autonamed on Initialize and their `sort_type_txt`:
![2024_08_02__21_36_32__](https://github.com/user-attachments/assets/d67b49d5-838e-4767-a808-1b4e043d7c7e) ![2024_08_02__21_36_56__](https://github.com/user-attachments/assets/62252524-3521-490c-9464-fbfb6467563e)
![2024_08_02__21_37_26__](https://github.com/user-attachments/assets/86f17324-bda5-418b-9fd5-a24870728c2e) ![2024_08_02__21_38_08__](https://github.com/user-attachments/assets/3bc5019c-84f4-4019-b174-8ac911f1130f)

## Testing
Visual inspection.

## Changelog
:cl:
fix: Disposal sort junction names are now standardized and correctly refer to destinations as displayed on the tagger.
/:cl: