### PR TITLE
Prevents depot mob from dropping two salvage

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/syndicate_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate_mobs.dm
@@ -38,7 +38,7 @@
 /mob/living/simple_animal/hostile/syndicate/Initialize(mapload)
 	. = ..()
 	if(prob(50))
-		loot += /obj/item/salvage/loot/syndicate
+		loot |= /obj/item/salvage/loot/syndicate
 
 /mob/living/simple_animal/hostile/syndicate/Aggro()
 	. = ..()


### PR DESCRIPTION
## What Does This PR Do
When making #26134 I did not consider the depot mob agents who had a guaranteed salvage spawn. This made it so one mob dropping two salvage was possible.

## Why It's Good For The Game
Mobs shouldn't drop two salvage

## Testing
Killed every single syndicate simplemobs. Multiple time. Made sure they only dropped 1 salvage at most.

## Changelog
:cl:
fix: Depot Agents no longer have a chance of dropping 2 syndicate intel salvages
/:cl: