### PR TITLE
Coffin healing now updates vampire's overall health

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -654,14 +654,15 @@
 	var/mob/living/carbon/dreamer = owner
 
 	if(dreamer.mind?.has_antag_datum(/datum/antagonist/vampire))
-		if(istype(dreamer.loc, /obj/structure/closet/coffin))
-			dreamer.adjustBruteLoss(-1, FALSE)
-			dreamer.adjustFireLoss(-1, FALSE)
-			dreamer.adjustToxLoss(-1)
-			dreamer.adjustOxyLoss(-1)
-			dreamer.adjustCloneLoss(-0.5)
-			if(dreamer.HasDisease(/datum/disease/critical/heart_failure) && prob(25))
-				for(var/datum/disease/critical/heart_failure/HF in dreamer.viruses)
+		var/mob/living/carbon/human/V = owner
+		if(istype(V.loc, /obj/structure/closet/coffin))
+			V.adjustBruteLoss(-1)
+			V.adjustFireLoss(-1)
+			V.adjustToxLoss(-1)
+			V.adjustOxyLoss(-1)
+			V.adjustCloneLoss(-0.5)
+			if(V.HasDisease(/datum/disease/critical/heart_failure) && prob(25))
+				for(var/datum/disease/critical/heart_failure/HF in V.viruses)
 					HF.cure()
 	dreamer.handle_dreams()
 	dreamer.adjustStaminaLoss(-10)


### PR DESCRIPTION
…aling.

<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #26324
Uses human scoped damage adjust procs when healing a vampire via sleeping in a coffin.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Vampires heal properly now
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
-Got robotic leg, became vampire, damaged myself in various ways, went to sleep. 
-Damage was updates and the robotic limb did not heal
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Coffing healing updates vampire health
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
