### PR TITLE
Fix: Bespoke DCS elements use all requested args.

### DIFF
--- a/code/__DEFINES/dcs/dcs_flags.dm
+++ b/code/__DEFINES/dcs/dcs_flags.dm
@@ -12,7 +12,7 @@
 /// Causes the detach proc to be called when the host object is being deleted
 #define ELEMENT_DETACH_ON_HOST_DESTROY		(1 << 0)
 /**
-  * Only elements created with the same arguments given after `id_arg_index` share an element instance
+  * Only elements created with the same arguments given after `argument_hash_start_idx` share an element instance
   * The arguments are the same when the text and number values are the same and all other values have the same ref
   */
 #define ELEMENT_BESPOKE		(1 << 1)

--- a/code/controllers/subsystem/processing/SSdcs.dm
+++ b/code/controllers/subsystem/processing/SSdcs.dm
@@ -34,7 +34,7 @@ PROCESSING_SUBSYSTEM_DEF(dcs)
 	var/datum/element/eletype = arguments[1]
 	var/list/fullid = list(eletype)
 	var/list/named_arguments
-	for(var/i in initial(eletype.id_arg_index) to (initial(eletype.id_arg_index) || length(arguments)))
+	for(var/i in initial(eletype.argument_hash_start_idx) to (initial(eletype.argument_hash_end_idx) || length(arguments)))
 		var/key = arguments[i]
 
 		if(istext(key))

--- a/code/datums/elements/_element.dm
+++ b/code/datums/elements/_element.dm
@@ -10,11 +10,21 @@
 	/**
 	  * The index of the first attach argument to consider for duplicate elements
 	  *
+	  * All arguments from this index onwards (1 based, until `argument_hash_end_idx` is reached, if set)
+	  * are hashed into the key to determine if this is a new unique element or one already exists
+	  *
 	  * Is only used when flags contains [ELEMENT_BESPOKE]
 	  *
 	  * This is infinity so you must explicitly set this
 	  */
-	var/id_arg_index = INFINITY
+	var/argument_hash_start_idx = INFINITY
+
+	/**
+	  * The index of the last attach argument to consider for duplicate elements
+	  * Only used when `element_flags` contains [ELEMENT_BESPOKE].
+	  * If not set, it'll copy every argument from `argument_hash_start_idx` onwards as normal
+	  */
+	var/argument_hash_end_idx = 0
 
 /// Activates the functionality defined by the element on the given target datum
 /datum/element/proc/Attach(datum/target)

--- a/code/datums/elements/rad_insulation.dm
+++ b/code/datums/elements/rad_insulation.dm
@@ -1,6 +1,6 @@
 /datum/element/rad_insulation
 	element_flags = ELEMENT_DETACH_ON_HOST_DESTROY | ELEMENT_BESPOKE
-	id_arg_index = 2
+	argument_hash_start_idx = 2
 	var/amount					// Multiplier for radiation strength passing through
 
 /datum/element/rad_insulation/Attach(datum/target, _amount = RAD_MEDIUM_INSULATION, protects = TRUE, contamination_proof = TRUE)

--- a/code/datums/elements/ridable.dm
+++ b/code/datums/elements/ridable.dm
@@ -8,7 +8,7 @@
  */
 /datum/element/ridable
 	element_flags = ELEMENT_BESPOKE
-	id_arg_index = 2
+	argument_hash_start_idx = 2
 	/// The specific riding component subtype we're loading our instructions from, don't leave this as default please!
 	var/riding_component_type = /datum/component/riding
 	/// If we have a xenobio red potion applied to us, we get split off so we can pass our special status onto new riding components

--- a/code/datums/elements/shatters_when_thrown.dm
+++ b/code/datums/elements/shatters_when_thrown.dm
@@ -3,7 +3,7 @@
  */
 /datum/element/shatters_when_thrown
 	element_flags = ELEMENT_BESPOKE
-	id_arg_index = 2
+	argument_hash_start_idx = 2
 	/// What type of item is spawned as a 'shard' once the shattering happens
 	var/obj/item/shard_type
 	/// How many shards total are made when the thing we're attached to shatters

--- a/code/datums/elements/strippable.dm
+++ b/code/datums/elements/strippable.dm
@@ -3,7 +3,7 @@
 /// An element for atoms that, when dragged and dropped onto a mob, opens a strip panel.
 /datum/element/strippable
 	element_flags = ELEMENT_BESPOKE | ELEMENT_DETACH_ON_HOST_DESTROY
-	id_arg_index = 2
+	argument_hash_start_idx = 2
 
 	/// An assoc list of keys to /datum/strippable_item
 	var/list/items

--- a/code/modules/unit_tests/element_tests.dm
+++ b/code/modules/unit_tests/element_tests.dm
@@ -1,4 +1,4 @@
 /datum/unit_test/bespoke_element/Run()
 	for(var/datum/element/element_type as anything in subtypesof(/datum/element))
-		if(initial(element_type.element_flags) & ELEMENT_BESPOKE && initial(element_type.id_arg_index) == INFINITY)
-			Fail("Element type [element_type] has ELEMENT_BESPOKE and a default id_arg_index.")
+		if(initial(element_type.element_flags) & ELEMENT_BESPOKE && initial(element_type.argument_hash_start_idx) == INFINITY)
+			Fail("Element type [element_type] has ELEMENT_BESPOKE and a default argument_hash_start_idx.")


### PR DESCRIPTION
## What Does This PR Do
This PR fixes `/datum/element` to include both a start and end index for hashing arguments when generating IDs for elements, and ensures they are used when doing so. This crept in while porting some of TG's element code, which add arguments to the end of element declarations that they don't want as part of its ID.
## Why It's Good For The Game
This is a regression; currently only the first argument of an element will be used in its identifier, which causes collisions if two elements have the same first argument but different arguments after that.
## Images of changes
First, observe the `AddElement` call for `/datum/element/shatters_when_thrown`:
https://github.com/ParadiseSS13/Paradise/blob/3f75f3b8c391d29afcf3b78ebb32f760853c0c2e/code/modules/surgery/organs/augments_internal.dm#L435-L438
### Before
Then, note that the `/datum/element/shatters_when_thrown` attached to the spent Qani-Laaca cartridge has an ID that only includes its type path and a UID pointing to the second argument (the type `/obj/effect/decal/cleanable/glass`). It doesn't include the integer 1 (number of shards) or the string "shatter" (the shattering sound).
![2024_08_03__15_40_59__](https://github.com/user-attachments/assets/2d0d41dd-a03b-4474-b756-0b793c46af9c)
### After
Now, after this change, all arguments passed to `AddElement` are recognizable in the element's identifier.
![2024_08_03__15_37_31__Paradise Station 13](https://github.com/user-attachments/assets/bf21221c-819c-4d2b-9021-7999c79cf734)
## Testing
See above.
## Changelog
NPFC

cc @chuga-git 