### PR TITLE
Fix Desk Bell Bugs

### DIFF
--- a/code/modules/paperwork/desk_bell.dm
+++ b/code/modules/paperwork/desk_bell.dm
@@ -60,7 +60,6 @@
 	INVOKE_ASYNC(src, PROC_REF(try_ring), null, TRUE) // user=null, from_signaler=TRUE (if nobody broke it)
 
 /obj/item/desk_bell/proc/try_ring(mob/user, from_signaler = FALSE)
-	//WARNING: signal handler depends on user and from_signaler being the first two arguments (in that order)
 	if(ring_cooldown > world.time || !anchored)
 		return TRUE
 	if(!ring_bell(user, from_signaler) && user)

--- a/code/modules/paperwork/desk_bell.dm
+++ b/code/modules/paperwork/desk_bell.dm
@@ -57,12 +57,13 @@
 
 /obj/item/desk_bell/proc/on_signal()
 	SIGNAL_HANDLER  // COMSIG_ASSEMBLY_PULSED
-	INVOKE_ASYNC(src, PROC_REF(try_ring))
+	INVOKE_ASYNC(src, PROC_REF(try_ring), null, TRUE) // user=null, from_signaler=TRUE (if nobody broke it)
 
-/obj/item/desk_bell/proc/try_ring(mob/user)
+/obj/item/desk_bell/proc/try_ring(mob/user, from_signaler = FALSE)
+	//WARNING: signal handler depends on user and from_signaler being the first two arguments (in that order)
 	if(ring_cooldown > world.time || !anchored)
 		return TRUE
-	if(!ring_bell(user) && user)
+	if(!ring_bell(user, from_signaler) && user)
 		to_chat(user, "<span class='notice'>[src] is silent. Some idiot broke it.</span>")
 	ring_cooldown = world.time + ring_cooldown_length
 	return TRUE
@@ -132,6 +133,7 @@
 			return TRUE
 		to_chat(user, "<span class='notice'>You remove [attached_signaler].</span>")
 		user.put_in_hands(attached_signaler)
+		UnregisterSignal(attached_signaler, COMSIG_ASSEMBLY_PULSED)
 		attached_signaler = null
 
 /// Check if the clapper breaks, and if it does, break it
@@ -143,14 +145,14 @@
 		broken_ringer = TRUE
 
 /// Ring the bell
-/obj/item/desk_bell/proc/ring_bell(mob/living/user)
+/obj/item/desk_bell/proc/ring_bell(mob/living/user, from_signaler = FALSE)
 	if(broken_ringer)
 		return FALSE
 	check_clapper(user)
 	// The lack of varying is intentional. The only variance occurs on the strike the bell breaks.
 	playsound(src, ring_sound, 70, vary = broken_ringer, extrarange = SHORT_RANGE_SOUND_EXTRARANGE)
 	flick("desk_bell_ring", src)
-	if(attached_signaler)
+	if(attached_signaler && !from_signaler)
 		attached_signaler.signal()
 	times_rang++
 	return TRUE

--- a/code/modules/paperwork/desk_bell.dm
+++ b/code/modules/paperwork/desk_bell.dm
@@ -57,7 +57,7 @@
 
 /obj/item/desk_bell/proc/on_signal()
 	SIGNAL_HANDLER  // COMSIG_ASSEMBLY_PULSED
-	INVOKE_ASYNC(src, PROC_REF(try_ring), null, TRUE) // user=null, from_signaler=TRUE (if nobody broke it)
+	INVOKE_ASYNC(src, PROC_REF(try_ring), null, TRUE)
 
 /obj/item/desk_bell/proc/try_ring(mob/user, from_signaler = FALSE)
 	if(ring_cooldown > world.time || !anchored)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes a bug where a desk bell with a receiving signaler and another receiving signaler ended up in an infinite loop.
Fixes door bells not unregistering (code) signal handlers for removed (item) signalers.
Probably fixes #25844

## Why It's Good For The Game
Less bugs are good

## Testing
Attached receiving signaler to bell. Pinged with receiving signaler. Only dinged once and did not runtime. (It did runtime previously because recursion limit was reached.) Tried also with only one of the signalers on receive.
Removed the signaler and attached the other one. No runtime. (Previously caused runtime for attaching a duplicate signal handler without override=TRUE because old one wasn't removed.)

## Changelog
:cl:
fix: Door bells with signalers no longer cause infinite dinging loops.
fix: Door bells no longer have a bluespace connection to removed signalers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
