### PR TITLE
Delta: Fix arrivals checkpoint access.

### DIFF
--- a/_maps/map_files/stations/deltastation.dmm
+++ b/_maps/map_files/stations/deltastation.dmm
@@ -65028,6 +65028,12 @@
 /obj/effect/mapping_helpers/airlock/windoor/access/any/security/doors{
 	dir = 4
 	},
+/obj/machinery/door/window/reinforced/reversed{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/windoor/autoname{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/station/security/checkpoint/secondary)
 "erg" = (
@@ -99539,13 +99545,6 @@
 /obj/structure/table/reinforced,
 /obj/item/folder/red,
 /obj/item/pen,
-/obj/machinery/door/window/reinforced/reversed{
-	dir = 8;
-	pixel_x = -8
-	},
-/obj/effect/mapping_helpers/airlock/windoor/autoname{
-	dir = 8
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;


### PR DESCRIPTION
## What Does This PR Do
This PR moves a pixel-pushed windoor to its actual tile and ensures its access and name mapping helpers are properly applied.

I was going to make a linter for this but windoors are pixel pushed around in some places for appearance's sake e.g. to line up with the fences in the wrestling ring on Cere.
## Why It's Good For The Game
Security checkpoint should not be all-access.
## Images of changes
### Before
![2024_08_04__10_20_30__paradise dme  deltastation dmm  - StrongDMM](https://github.com/user-attachments/assets/ee479711-2be0-4543-841f-0eaf616b9580)
### After
![2024_08_04__10_28_23__paradise dme  deltastation dmm  - StrongDMM](https://github.com/user-attachments/assets/0ff55de6-5a21-404e-a5f6-8774354f749f)
## Testing
Spawned in, attempted to open door as assistant and security officer.
## Changelog
:cl:
fix: Kerberos: Security Arrivals Checkpoint's windoor now has the correct access.
/:cl: