### PR TITLE
makes cloning scanner deconstructable

### DIFF
--- a/code/game/machinery/clonescanner.dm
+++ b/code/game/machinery/clonescanner.dm
@@ -204,10 +204,6 @@
 	. = TRUE
 	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
 		return
-	if(flags & NODECONSTRUCT)//We need to check for this early or the contents could be moved before it checks for the flag normally
-		return
-	for(var/obj/thing in contents) // in case there is something in the scanner
-		thing.forceMove(loc)
 	default_deconstruction_crowbar(user, I)
 
 /obj/machinery/clonescanner/screwdriver_act(mob/user, obj/item/I)

--- a/code/game/machinery/clonescanner.dm
+++ b/code/game/machinery/clonescanner.dm
@@ -197,3 +197,22 @@
 
 /obj/machinery/clonescanner/force_eject_occupant(mob/target)
 	remove_mob()
+
+/obj/machinery/clonescanner/crowbar_act(mob/user, obj/item/I)
+	if(!panel_open)
+		return
+	. = TRUE
+	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
+		return
+	if(flags & NODECONSTRUCT)//We need to check for this early or the contents could be moved before it checks for the flag normally
+		return
+	for(var/obj/thing in contents) // in case there is something in the scanner
+		thing.forceMove(loc)
+	default_deconstruction_crowbar(user, I)
+
+/obj/machinery/clonescanner/screwdriver_act(mob/user, obj/item/I)
+	if(occupant)
+		to_chat(user, "<span class='notice'>The maintenance panel is locked.</span>")
+		return TRUE
+	if(default_deconstruction_screwdriver(user, "[icon_state]_maintenance", "[initial(icon_state)]", I))
+		return TRUE


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

fixes:  #26364
makes cloning scanner deconstructable

## Why It's Good For The Game
bugfix good

## Testing
decon'd some scanners

## Changelog
:cl:
fix: now able to decon clone scanner
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
