### PR TITLE
Remove icon_stated broken wood floors

### DIFF
--- a/_maps/map_files/RandomRuins/LavaRuins/chasm_bridges/lavaland_bridge_horizontal_5.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/chasm_bridges/lavaland_bridge_horizontal_5.dmm
@@ -9,20 +9,14 @@
 /turf/template_noop,
 /area/lavaland/surface/outdoors/unexplored/danger)
 "v" = (
-/turf/simulated/floor/wood/lavaland_air{
-	icon_state = "wood-broken3"
-	},
-/area/lavaland/surface/outdoors/unexplored/danger)
-"C" = (
-/turf/simulated/floor/wood/lavaland_air{
-	icon_state = "wood-broken7"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood/lavaland_air,
 /area/lavaland/surface/outdoors/unexplored/danger)
 
 (1,1,1) = {"
 c
 a
-C
+v
 a
 c
 "}

--- a/_maps/map_files/RandomRuins/LavaRuins/chasm_bridges/lavaland_bridge_vertical_5.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/chasm_bridges/lavaland_bridge_vertical_5.dmm
@@ -3,26 +3,14 @@
 /turf/simulated/floor/wood/lavaland_air,
 /area/lavaland/surface/outdoors/unexplored/danger)
 "b" = (
-/turf/simulated/floor/wood/lavaland_air{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood/lavaland_air,
 /area/lavaland/surface/outdoors/unexplored/danger)
 "c" = (
 /turf/template_noop,
 /area/lavaland/surface/outdoors/unexplored/danger)
-"q" = (
-/turf/simulated/floor/wood/lavaland_air{
-	icon_state = "wood-broken3"
-	},
-/area/lavaland/surface/outdoors/unexplored/danger)
 "y" = (
 /turf/simulated/wall/mineral/wood,
-/area/lavaland/surface/outdoors/unexplored/danger)
-"S" = (
-/turf/simulated/floor/wood/lavaland_air{
-	icon_state = "wood-broken7"
-	},
 /area/lavaland/surface/outdoors/unexplored/danger)
 
 (1,1,1) = {"
@@ -40,11 +28,11 @@ c
 y
 "}
 (3,1,1) = {"
-q
+b
 a
 b
 a
-S
+b
 "}
 (4,1,1) = {"
 y

--- a/_maps/map_files/RandomRuins/SpaceRuins/listeningpost.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/listeningpost.dmm
@@ -1,9 +1,8 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "at" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken5"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/ruin/space/syndicate_listening_station)
 "aW" = (
 /obj/structure/disposalpipe/segment{

--- a/_maps/map_files/RandomRuins/SpaceRuins/rocky_motel.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/rocky_motel.dmm
@@ -8,9 +8,8 @@
 "ci" = (
 /obj/machinery/door/airlock,
 /obj/structure/fans/tiny,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken3"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/ruin/space/powered)
 "cx" = (
 /turf/simulated/floor/plasteel{
@@ -76,17 +75,15 @@
 /area/ruin/space/powered)
 "gP" = (
 /obj/structure/table/wood,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken6"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/ruin/space/powered)
 "gY" = (
 /obj/structure/chair/sofa/left{
 	dir = 4
 	},
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/ruin/space/powered)
 "hB" = (
 /turf/simulated/floor/plasteel,
@@ -246,9 +243,8 @@
 /turf/simulated/floor/plating,
 /area/ruin/space/powered)
 "Cq" = (
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken7"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/ruin/space/powered)
 "Cw" = (
 /obj/structure/disposalpipe/trunk{

--- a/_maps/map_files/RandomRuins/SpaceRuins/ussp.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/ussp.dmm
@@ -745,9 +745,8 @@
 	},
 /area/ruin/space/derelict/arrival)
 "bV" = (
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken7"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/ruin/space/derelict/bridge)
 "bW" = (
 /obj/structure/reagent_dispensers/water_cooler,
@@ -916,10 +915,8 @@
 /obj/structure/rack,
 /obj/item/reagent_containers/drinks/bottle/vodka/badminka,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/ruin/space/derelict/bridge)
 "ct" = (
 /obj/machinery/light/spot,
@@ -1831,9 +1828,8 @@
 /area/ruin/space/derelict/crew_quarters)
 "eC" = (
 /obj/structure/chair/wood,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken7"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/ruin/space/derelict/crew_quarters)
 "eD" = (
 /turf/simulated/floor/wood,
@@ -1859,9 +1855,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/ruin/space/derelict/crew_quarters)
 "eH" = (
 /obj/machinery/newscaster{
@@ -2254,9 +2249,8 @@
 /obj/structure/chair/wood{
 	dir = 4
 	},
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken3"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/ruin/space/derelict/crew_quarters)
 "fx" = (
 /obj/structure/cable{
@@ -2275,9 +2269,8 @@
 /area/ruin/space/derelict/crew_quarters)
 "fz" = (
 /obj/structure/mopbucket,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken6"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/ruin/space/derelict/crew_quarters)
 "fA" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2435,9 +2428,8 @@
 /obj/machinery/economy/vending/cigarette/free{
 	slogan_list = list("Just remember! No capitalist.","Best enjoyed with Vodka!.","Smoke!","Nine out of ten USSP scientists agree, smoking reduces stress!","There's no cigarette like a Russian cigarette!","Cigarettes! Now with 100% less capitalism.")
 	},
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/ruin/space/derelict/crew_quarters)
 "fU" = (
 /obj/item/trash/spentcasing,
@@ -2594,9 +2586,8 @@
 /area/ruin/space/derelict/crew_quarters)
 "gn" = (
 /obj/structure/chair/stool/bar,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken7"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/ruin/space/derelict/crew_quarters)
 "go" = (
 /obj/structure/table/reinforced,
@@ -7568,17 +7559,6 @@
 /obj/effect/spawner/airlock,
 /turf/simulated/wall/mineral/titanium/nodecon,
 /area/ruin/space/derelict/arrival)
-"Xn" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
-/area/ruin/space/derelict/crew_quarters)
 "XQ" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -13431,7 +13411,7 @@ fx
 fd
 fd
 fd
-Xn
+eG
 fd
 hE
 hS

--- a/_maps/map_files/RandomRuins/SpaceRuins/wizardcrash.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/wizardcrash.dmm
@@ -13,36 +13,26 @@
 /obj/item/shard{
 	icon_state = "small"
 	},
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken3"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/ruin/space/powered)
 "ae" = (
 /turf/simulated/wall/mineral/titanium/nodecon/wizard,
 /area/ruin/space/powered)
 "af" = (
 /obj/structure/computerframe,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken3"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/ruin/space/powered)
 "ag" = (
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken7"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/ruin/space/powered)
 "ah" = (
 /obj/structure/grille/broken,
 /obj/item/shard,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken3"
-	},
-/area/ruin/space/powered)
-"ai" = (
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/ruin/space/powered)
 "aj" = (
 /obj/structure/chair/comfy/shuttle{
@@ -94,9 +84,8 @@
 	dir = 1;
 	in_use = 1
 	},
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken3"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/ruin/space/powered)
 "as" = (
 /obj/structure/window/reinforced{
@@ -127,11 +116,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/ruin/space/powered)
-"ax" = (
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken3"
-	},
-/area/ruin/space/powered)
 "ay" = (
 /obj/effect/decal/remains/robot,
 /obj/item/clothing/head/wizard,
@@ -141,11 +125,6 @@
 "az" = (
 /obj/item/spellbook/oneuse/emp/used,
 /turf/simulated/floor/wood,
-/area/ruin/space/powered)
-"aA" = (
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken6"
-	},
 /area/ruin/space/powered)
 "aB" = (
 /turf/simulated/floor/carpet,
@@ -261,9 +240,8 @@
 /area/ruin/space/powered)
 "aW" = (
 /obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken6"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/ruin/space/powered)
 "aY" = (
 /obj/machinery/light{
@@ -513,9 +491,8 @@
 "YM" = (
 /obj/structure/table/wood,
 /obj/item/blank_tarot_card,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken6"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/ruin/space/powered)
 
 (1,1,1) = {"
@@ -825,14 +802,14 @@ ac
 ac
 ac
 aC
-ai
+ag
 ap
-ax
+ag
 aC
 aC
 aG
 aC
-aA
+ag
 aV
 aC
 aC
@@ -938,7 +915,7 @@ ac
 ae
 ae
 ar
-aA
+ag
 aC
 aC
 aC

--- a/_maps/map_files/generic/centcomm.dmm
+++ b/_maps/map_files/generic/centcomm.dmm
@@ -2359,9 +2359,8 @@
 /turf/simulated/floor/wood,
 /area/ghost_bar)
 "ip" = (
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken3"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/ghost_bar)
 "iq" = (
 /obj/machinery/door/poddoor/impassable{
@@ -4394,11 +4393,6 @@
 	icon_state = "bar"
 	},
 /area/syndicate_mothership)
-"oH" = (
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken"
-	},
-/area/ghost_bar)
 "oI" = (
 /obj/effect/spawner/lootdrop/trade_sol/civ,
 /obj/structure/closet,
@@ -6233,9 +6227,8 @@
 /turf/simulated/floor/plasteel,
 /area/admin)
 "vh" = (
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken2"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/centcom/evac)
 "vj" = (
 /obj/effect/decal/cleanable/blood,
@@ -8716,11 +8709,6 @@
 /obj/structure/chair/comfy/black,
 /turf/simulated/floor/carpet,
 /area/centcom/control)
-"EX" = (
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken7"
-	},
-/area/ghost_bar)
 "EZ" = (
 /obj/machinery/computer/bsa_control/admin,
 /turf/simulated/floor/carpet,
@@ -11882,11 +11870,6 @@
 	icon_state = "darkred"
 	},
 /area/centcom/gamma)
-"Pt" = (
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken"
-	},
-/area/centcom/evac)
 "Pu" = (
 /turf/simulated/floor/plasteel/freezer,
 /area/ghost_bar)
@@ -45829,7 +45812,7 @@ nC
 Il
 Ng
 Ng
-Pt
+vh
 Ng
 El
 Xx
@@ -72311,11 +72294,11 @@ vd
 vd
 rf
 Me
-EX
+ip
 Jy
 Jy
 Jy
-oH
+ip
 Jy
 Jy
 Jy

--- a/_maps/map_files/stations/boxstation.dmm
+++ b/_maps/map_files/stations/boxstation.dmm
@@ -6674,9 +6674,8 @@
 /obj/structure/chair{
 	dir = 1
 	},
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken7"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/asmaint)
 "awO" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
@@ -7821,10 +7820,8 @@
 /obj/structure/chair/stool/bar{
 	dir = 4
 	},
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/abandonedbar)
 "aAc" = (
 /obj/structure/grille/broken,
@@ -8152,10 +8149,8 @@
 /obj/structure/chair/wood/wings{
 	dir = 8
 	},
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/abandonedbar)
 "aBf" = (
 /obj/structure/chair/wood/wings{
@@ -8356,16 +8351,12 @@
 	layer = 4;
 	pixel_y = 32
 	},
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/abandonedbar)
 "aBV" = (
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/abandonedbar)
 "aBW" = (
 /obj/structure/sink/kitchen{
@@ -8374,10 +8365,8 @@
 /obj/machinery/light_construct/small{
 	dir = 4
 	},
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/abandonedbar)
 "aBX" = (
 /obj/item/trash/liquidfood,
@@ -8695,10 +8684,8 @@
 /area/station/maintenance/abandonedbar)
 "aCS" = (
 /obj/item/lighter/random,
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/abandonedbar)
 "aCT" = (
 /obj/effect/spawner/window/reinforced,
@@ -9089,10 +9076,8 @@
 "aEa" = (
 /obj/structure/table/wood,
 /obj/item/trash/can,
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/abandonedbar)
 "aEc" = (
 /obj/machinery/economy/vending/boozeomat,
@@ -9332,10 +9317,8 @@
 "aEH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/spawner/xeno,
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/fpmaint2)
 "aEI" = (
 /obj/structure/chair/comfy/black,
@@ -9406,10 +9389,8 @@
 "aEX" = (
 /obj/item/trash/pistachios,
 /obj/machinery/light_construct,
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/abandonedbar)
 "aEY" = (
 /obj/effect/decal/cleanable/dirt,
@@ -9428,10 +9409,8 @@
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = 32
 	},
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/abandonedbar)
 "aFb" = (
 /obj/structure/table/wood,
@@ -9788,10 +9767,8 @@
 /obj/structure/mineral_door/wood{
 	name = "Abandoned Bar"
 	},
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/abandonedbar)
 "aGd" = (
 /obj/effect/decal/cleanable/fungus,
@@ -9827,9 +9804,8 @@
 /obj/structure/chair/stool{
 	dir = 4
 	},
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/fpmaint)
 "aGm" = (
 /obj/structure/chair/stool{
@@ -9856,9 +9832,8 @@
 /area/station/maintenance/fpmaint)
 "aGp" = (
 /obj/machinery/economy/vending/coffee,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken6"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/fpmaint)
 "aGq" = (
 /obj/structure/chair,
@@ -10133,9 +10108,8 @@
 "aHm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken7"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/fpmaint2)
 "aHn" = (
 /obj/effect/decal/cleanable/dirt,
@@ -10484,9 +10458,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
 "aIy" = (
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken7"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/fpmaint2)
 "aIA" = (
 /obj/structure/cable{
@@ -10542,11 +10515,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/public/dorms)
-"aIH" = (
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken3"
-	},
-/area/station/maintenance/fpmaint2)
 "aIJ" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 1
@@ -10561,9 +10529,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 5
 	},
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken6"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/fpmaint2)
 "aIN" = (
 /obj/structure/disposalpipe/segment,
@@ -10903,9 +10870,8 @@
 "aJW" = (
 /mob/living/simple_animal/mouse,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken3"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/fpmaint)
 "aJX" = (
 /obj/structure/chair/stool{
@@ -11476,9 +11442,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken7"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/fpmaint)
 "aLM" = (
 /obj/structure/table,
@@ -12676,10 +12641,8 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/asmaint)
 "aPr" = (
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/asmaint)
 "aPs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -26347,9 +26310,8 @@
 /area/station/public/storage/tools/auxiliary)
 "bGb" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/port)
 "bGc" = (
 /turf/simulated/floor/plasteel{
@@ -27171,9 +27133,8 @@
 "bIP" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/effect/spawner/random_spawners/cobweb_right_rare,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken3"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/port)
 "bIR" = (
 /obj/machinery/navbeacon{
@@ -32925,9 +32886,8 @@
 /area/station/maintenance/asmaint2)
 "ceK" = (
 /obj/effect/spawner/random_spawners/cobweb_right_frequent,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken7"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/asmaint2)
 "ceM" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -34603,9 +34563,8 @@
 	},
 /area/station/medical/patients_rooms_secondary)
 "clg" = (
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken7"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/asmaint2)
 "clh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -34790,16 +34749,13 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/asmaint2)
 "clX" = (
 /obj/structure/fermenting_barrel,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/asmaint2)
 "clY" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -35202,9 +35158,8 @@
 /area/station/command/office/ntrep)
 "cnv" = (
 /obj/item/seeds/berry,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken3"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/asmaint2)
 "cnw" = (
 /obj/structure/disposalpipe/segment,
@@ -35498,9 +35453,8 @@
 /area/station/medical/storage/secondary)
 "coA" = (
 /obj/item/seeds/apple,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken5"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/asmaint2)
 "coH" = (
 /obj/effect/spawner/random_spawners/cobweb_right_frequent,
@@ -36070,12 +36024,6 @@
 /area/station/medical/virology)
 "cri" = (
 /turf/simulated/floor/wood,
-/area/station/maintenance/asmaint2)
-"crj" = (
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
 /area/station/maintenance/asmaint2)
 "crm" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -36879,11 +36827,6 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/station/science/explab)
-"ctv" = (
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken6"
-	},
-/area/station/maintenance/asmaint2)
 "ctw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -41181,9 +41124,8 @@
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos/control)
 "cIj" = (
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken7"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/aft)
 "cIl" = (
 /obj/effect/decal/cleanable/dirt,
@@ -41837,11 +41779,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
-"cKS" = (
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken3"
-	},
-/area/station/maintenance/aft)
 "cKT" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -52881,10 +52818,8 @@
 /obj/structure/sign/poster/contraband/red_rum{
 	pixel_y = 30
 	},
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/apmaint2)
 "efD" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -54015,9 +53950,8 @@
 /obj/structure/chair/stool{
 	dir = 4
 	},
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken3"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/aft)
 "eGZ" = (
 /obj/structure/disposalpipe/segment{
@@ -57949,9 +57883,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken3"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/fpmaint2)
 "gyt" = (
 /obj/structure/toilet{
@@ -58061,9 +57994,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint2)
 "gAJ" = (
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken7"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/port)
 "gAK" = (
 /obj/structure/chair/sofa/corp/left{
@@ -58309,9 +58241,8 @@
 /area/station/maintenance/assembly_line)
 "gIn" = (
 /obj/item/lighter/random,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken3"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/aft)
 "gIp" = (
 /obj/effect/landmark/spawner/rev,
@@ -58870,13 +58801,6 @@
 /obj/machinery/alarm/directional/east,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/sw)
-"gTV" = (
-/obj/structure/fermenting_barrel,
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
-/area/station/maintenance/asmaint2)
 "gUm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -59389,9 +59313,8 @@
 /area/station/science/robotics/chargebay)
 "hgb" = (
 /obj/structure/chair,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken7"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/asmaint)
 "hgj" = (
 /obj/effect/decal/cleanable/dirt,
@@ -59698,11 +59621,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/exit)
-"hqi" = (
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken5"
-	},
-/area/station/maintenance/port)
 "hqo" = (
 /obj/item/stack/sheet/mineral/plasma{
 	pixel_x = -2;
@@ -62142,11 +62060,6 @@
 	icon_state = "darkpurple"
 	},
 /area/station/command/office/rd)
-"iDX" = (
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken5"
-	},
-/area/station/maintenance/aft)
 "iEg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/visible,
@@ -63806,9 +63719,8 @@
 /area/station/hallway/primary/aft/north)
 "jtP" = (
 /obj/item/kirbyplants,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken5"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/asmaint)
 "jum" = (
 /obj/machinery/shower{
@@ -66207,9 +66119,8 @@
 /area/station/maintenance/aft)
 "kEe" = (
 /obj/machinery/economy/vending/coffee,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken7"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/asmaint)
 "kEs" = (
 /obj/effect/decal/cleanable/dirt,
@@ -69386,10 +69297,8 @@
 /obj/item/food/grown/cannabis,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/mask/cigarette/medical_marijuana,
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/asmaint)
 "med" = (
 /obj/effect/decal/cleanable/dirt,
@@ -69525,9 +69434,8 @@
 /obj/machinery/floodlight{
 	light_power = 1
 	},
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken6"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/asmaint)
 "mhC" = (
 /obj/machinery/door/window/classic/reversed{
@@ -69898,9 +69806,8 @@
 /obj/structure/chair/stool{
 	dir = 1
 	},
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/aft)
 "mrw" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -70855,12 +70762,6 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/public/arcade)
-"mPM" = (
-/obj/structure/fermenting_barrel,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken7"
-	},
-/area/station/maintenance/asmaint2)
 "mPT" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable,
@@ -73540,9 +73441,8 @@
 	pixel_x = -32
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken5"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/asmaint)
 "ojT" = (
 /obj/structure/cable{
@@ -78146,9 +78046,8 @@
 	dir = 8;
 	name = "Glass Door"
 	},
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken3"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/asmaint2)
 "qqk" = (
 /obj/structure/barricade/wooden,
@@ -79620,9 +79519,8 @@
 /area/station/security/permabrig)
 "qYC" = (
 /obj/item/pen/fancy,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken3"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/asmaint)
 "qYE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -79962,9 +79860,8 @@
 /area/station/maintenance/aft)
 "rfh" = (
 /obj/item/clothing/under/misc/assistantformal,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/asmaint)
 "rfn" = (
 /obj/effect/decal/cleanable/dirt,
@@ -80964,9 +80861,8 @@
 /turf/simulated/wall,
 /area/station/maintenance/apmaint2)
 "rFc" = (
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken3"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/apmaint2)
 "rFe" = (
 /obj/structure/chair/sofa/bench{
@@ -82989,9 +82885,8 @@
 /area/station/service/chapel/office)
 "sJC" = (
 /obj/machinery/economy/slot_machine,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken6"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/apmaint2)
 "sJQ" = (
 /obj/effect/spawner/random_spawners/oil_maybe,
@@ -83362,9 +83257,8 @@
 /obj/structure/chair/wood{
 	dir = 8
 	},
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken5"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/aft)
 "sSb" = (
 /obj/structure/cable/yellow{
@@ -84270,9 +84164,8 @@
 /area/station/maintenance/fsmaint)
 "tue" = (
 /obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken5"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/asmaint)
 "tum" = (
 /turf/simulated/floor/plasteel,
@@ -86061,9 +85954,8 @@
 /obj/item/reagent_containers/drinks/drinkingglass/shotglass{
 	pixel_x = -5
 	},
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/asmaint)
 "ulE" = (
 /obj/effect/decal/cleanable/dirt,
@@ -86969,10 +86861,8 @@
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = -32
 	},
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/apmaint2)
 "uMu" = (
 /obj/machinery/light/small{
@@ -88437,9 +88327,8 @@
 /area/station/medical/morgue)
 "vyw" = (
 /obj/structure/chair/stool,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken6"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/apmaint2)
 "vyx" = (
 /obj/structure/cable{
@@ -93916,9 +93805,8 @@
 "yhY" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/maintenance/three,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken7"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/apmaint2)
 "yif" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -109244,7 +109132,7 @@ bqr
 bqr
 bqr
 bIP
-hqi
+gAJ
 blQ
 bst
 bCk
@@ -109982,7 +109870,7 @@ aDz
 aEG
 aFV
 aHk
-aIH
+aIy
 aGn
 aLu
 aLm
@@ -138560,8 +138448,8 @@ fQr
 vDR
 bGG
 lqd
-gTV
-mPM
+clX
+clX
 nbx
 nbx
 cuQ
@@ -138822,9 +138710,9 @@ clX
 cnv
 dlD
 lqd
-crj
+clg
 huo
-ctv
+clg
 bWg
 bIi
 cpI
@@ -139128,7 +139016,7 @@ chf
 nbC
 eGX
 cIm
-iDX
+cIj
 cIm
 vnY
 rEz
@@ -139643,7 +139531,7 @@ ntr
 juH
 tNc
 xOM
-cKS
+cIj
 bZZ
 chf
 chf

--- a/_maps/map_files/stations/cerestation.dmm
+++ b/_maps/map_files/stations/cerestation.dmm
@@ -32839,9 +32839,8 @@
 	},
 /area/station/hallway/spacebridge/dockmed)
 "dUZ" = (
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken5"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/starboard)
 "dVe" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -32982,9 +32981,8 @@
 /area/station/hallway/primary/aft/east)
 "dXP" = (
 /obj/machinery/computer/arcade,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/gambling_den)
 "dXT" = (
 /obj/structure/table/reinforced,
@@ -34363,9 +34361,8 @@
 /area/station/hallway/primary/fore/west)
 "ewN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken7"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/service/bar)
 "exv" = (
 /obj/structure/disposalpipe/segment/corner{
@@ -39735,9 +39732,8 @@
 /turf/simulated/floor/plating,
 /area/station/supply/warehouse)
 "gpZ" = (
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken7"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/asmaint)
 "gqH" = (
 /obj/structure/cable/orange{
@@ -40002,12 +39998,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/maintcentral)
-"gvx" = (
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
-/area/station/maintenance/starboard)
 "gvI" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable{
@@ -44019,9 +44009,8 @@
 "hIU" = (
 /obj/structure/cable/orange,
 /obj/machinery/power/apc/directional/south,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/gambling_den)
 "hIX" = (
 /obj/machinery/atmospherics/meter,
@@ -47614,11 +47603,6 @@
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
-"iNe" = (
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken7"
-	},
-/area/station/maintenance/starboard)
 "iNj" = (
 /obj/machinery/computer/shuttle/mining{
 	dir = 1
@@ -49269,9 +49253,8 @@
 	pixel_x = -28;
 	name = "custom placement"
 	},
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/public/vacant_office)
 "jmc" = (
 /obj/structure/disposalpipe/segment,
@@ -53401,9 +53384,8 @@
 /area/station/maintenance/apmaint)
 "kwq" = (
 /obj/structure/chair/stool/bar,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken5"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/starboard)
 "kwu" = (
 /obj/structure/chair/office/dark{
@@ -57631,11 +57613,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard/south)
-"lJL" = (
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken3"
-	},
-/area/station/maintenance/asmaint)
 "lJM" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -60403,9 +60380,8 @@
 /obj/structure/table/wood/poker,
 /obj/item/gun/projectile/revolver/russian,
 /obj/effect/landmark/spawner/rev,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/gambling_den)
 "mFk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -60986,9 +60962,8 @@
 /obj/machinery/barsign{
 	pixel_y = 32
 	},
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/gambling_den)
 "mPz" = (
 /obj/structure/table,
@@ -61082,9 +61057,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken7"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/service/bar)
 "mRS" = (
 /obj/effect/spawner/window/reinforced/grilled,
@@ -65698,9 +65672,8 @@
 "opD" = (
 /obj/machinery/kitchen_machine/microwave,
 /obj/structure/table,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/asmaint)
 "opP" = (
 /obj/effect/decal/cleanable/blood/gibs/old,
@@ -66127,11 +66100,6 @@
 	icon_state = "white"
 	},
 /area/station/science/toxins/mixing)
-"owP" = (
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken3"
-	},
-/area/station/maintenance/starboard)
 "owY" = (
 /obj/machinery/washing_machine,
 /obj/structure/disposalpipe/segment{
@@ -68222,9 +68190,8 @@
 /obj/structure/chair/wood{
 	dir = 1
 	},
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken6"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/asmaint)
 "pfm" = (
 /obj/effect/turf_decal/stripes/line{
@@ -73094,9 +73061,8 @@
 /turf/simulated/floor/engine,
 /area/station/medical/chemistry)
 "qDR" = (
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/gambling_den)
 "qDS" = (
 /obj/structure/table/glass,
@@ -76521,9 +76487,8 @@
 	layer = 2.9
 	},
 /obj/effect/decal/cleanable/cobweb2,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken5"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/asmaint)
 "rNw" = (
 /obj/structure/barricade/wooden,
@@ -80201,9 +80166,8 @@
 	pixel_y = -32;
 	random_basetype = /obj/structure/sign/poster/contraband
 	},
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/gambling_den)
 "sUK" = (
 /obj/machinery/conveyor/auto{
@@ -80701,9 +80665,8 @@
 /area/station/hallway/primary/port/south)
 "tcs" = (
 /obj/item/chair,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/public/vacant_office)
 "tcw" = (
 /obj/structure/closet/crate,
@@ -81288,12 +81251,6 @@
 /obj/structure/cable/orange,
 /turf/simulated/floor/plasteel/dark/telecomms,
 /area/station/science/server)
-"tlk" = (
-/obj/structure/chair/stool/bar,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken3"
-	},
-/area/station/maintenance/starboard)
 "tlq" = (
 /obj/structure/lattice,
 /obj/structure/railing{
@@ -84149,9 +84106,8 @@
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/station/maintenance/asmaint)
 "uix" = (
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/public/vacant_office)
 "uiD" = (
 /obj/effect/decal/cleanable/dirt,
@@ -87766,9 +87722,8 @@
 /area/station/maintenance/port)
 "vjB" = (
 /obj/structure/chair/wood,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken3"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/asmaint)
 "vjI" = (
 /obj/machinery/suit_storage_unit/mime/secure,
@@ -88054,12 +88009,6 @@
 	icon_state = "tranquillite"
 	},
 /area/station/service/mime)
-"voe" = (
-/obj/structure/chair/stool/bar,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken6"
-	},
-/area/station/maintenance/starboard)
 "vok" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -98075,11 +98024,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/patients_rooms)
-"yhf" = (
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken"
-	},
-/area/station/maintenance/asmaint)
 "yhg" = (
 /obj/item/t_scanner/adv_mining_scanner/lesser,
 /obj/structure/rack,
@@ -139953,7 +139897,7 @@ mnl
 ncF
 fbs
 imG
-lJL
+gpZ
 hAJ
 aXn
 wLr
@@ -140208,7 +140152,7 @@ hhs
 qkF
 qkF
 uxS
-lJL
+gpZ
 nca
 per
 jty
@@ -140722,7 +140666,7 @@ vjB
 tWA
 pfe
 fbs
-yhf
+gpZ
 rNo
 bDF
 opD
@@ -154063,9 +154007,9 @@ itf
 sbg
 itf
 mSF
-iNe
-owP
-gvx
+dUZ
+dUZ
+dUZ
 fMl
 rNK
 rNK
@@ -154577,8 +154521,8 @@ gFg
 oXz
 jPu
 gFg
-tlk
-voe
+kwq
+kwq
 kwq
 fMl
 rNK
@@ -155091,7 +155035,7 @@ aLH
 itf
 itf
 gFg
-iNe
+dUZ
 jsE
 mqm
 bDv
@@ -155349,7 +155293,7 @@ itf
 itf
 qkR
 jsE
-gvx
+dUZ
 pep
 bDv
 rNK
@@ -155604,7 +155548,7 @@ pXp
 itf
 itf
 itf
-gvx
+dUZ
 dUZ
 gFg
 nEw

--- a/_maps/map_files/stations/deltastation.dmm
+++ b/_maps/map_files/stations/deltastation.dmm
@@ -2878,10 +2878,8 @@
 /obj/structure/table/wood,
 /obj/item/storage/briefcase,
 /obj/item/taperecorder,
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/electrical_shop)
 "aqC" = (
 /obj/structure/table/wood,
@@ -3176,10 +3174,8 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/maintenance/electrical_shop)
 "arr" = (
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/electrical_shop)
 "ars" = (
 /turf/simulated/floor/wood,
@@ -3188,10 +3184,8 @@
 /obj/structure/chair/comfy/brown{
 	dir = 4
 	},
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/electrical_shop)
 "aru" = (
 /obj/structure/table/wood,
@@ -3219,10 +3213,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/electrical_shop)
 "arw" = (
 /obj/effect/decal/cleanable/dirt,
@@ -3927,10 +3919,8 @@
 /area/station/maintenance/electrical_shop)
 "ath" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/electrical_shop)
 "ati" = (
 /obj/structure/chair/comfy/brown{
@@ -3988,10 +3978,8 @@
 /area/station/maintenance/fore)
 "atr" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/fore)
 "ats" = (
 /obj/structure/table/wood,
@@ -4000,9 +3988,8 @@
 "att" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/drinks/drinkingglass,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/fore)
 "atu" = (
 /obj/structure/closet/cabinet{
@@ -4010,9 +3997,8 @@
 	},
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/spawner/lootdrop/maintenance/two,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken6"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/fore)
 "atv" = (
 /obj/structure/table/wood,
@@ -4571,10 +4557,8 @@
 	icon_state = "1-2"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/fore)
 "auO" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5912,10 +5896,8 @@
 /obj/item/camera_film,
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/cobweb2,
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/fore)
 "ayh" = (
 /obj/machinery/power/apc/directional/north,
@@ -6612,10 +6594,8 @@
 /obj/structure/chair/comfy/brown{
 	dir = 8
 	},
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/fore)
 "aAq" = (
 /obj/structure/sign/nosmoking_2{
@@ -7450,10 +7430,8 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/fore)
 "aCu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -11723,10 +11701,8 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/gambling_den)
 "aOu" = (
 /obj/item/kirbyplants,
@@ -12225,10 +12201,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/gambling_den)
 "aPN" = (
 /obj/structure/chair/stool,
@@ -13350,19 +13324,15 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/gambling_den)
 "aSP" = (
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/gambling_den)
 "aSQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/gambling_den)
 "aSR" = (
 /obj/structure/cable{
@@ -14083,10 +14053,8 @@
 /area/station/maintenance/gambling_den)
 "aUq" = (
 /obj/structure/chair/stool,
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/gambling_den)
 "aUs" = (
 /obj/structure/chair/office/dark{
@@ -54180,10 +54148,8 @@
 /area/station/maintenance/apmaint)
 "dcR" = (
 /obj/structure/chair/wood,
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/abandonedbar)
 "dcS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -55066,10 +55032,8 @@
 /obj/structure/chair/wood{
 	dir = 8
 	},
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/abandonedbar)
 "dfR" = (
 /obj/effect/turf_decal/stripes/line{
@@ -55805,10 +55769,8 @@
 /obj/structure/chair/wood{
 	dir = 4
 	},
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/abandonedbar)
 "diZ" = (
 /obj/effect/decal/cleanable/vomit,
@@ -57661,10 +57623,8 @@
 /area/station/maintenance/abandonedbar)
 "drc" = (
 /obj/structure/table/wood/poker,
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/abandonedbar)
 "drd" = (
 /obj/structure/table/wood/poker,
@@ -58840,29 +58800,23 @@
 /area/station/maintenance/theatre)
 "dwW" = (
 /obj/item/kirbyplants,
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/theatre)
 "dwX" = (
 /obj/structure/dresser,
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/theatre)
 "dwY" = (
 /obj/structure/table/wood,
 /obj/item/instrument/guitar,
 /obj/effect/decal/cleanable/cobweb2,
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/theatre)
 "dwZ" = (
 /obj/effect/turf_decal/stripes/line{
@@ -59058,10 +59012,8 @@
 "dyj" = (
 /obj/structure/table/wood,
 /obj/item/tape,
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/theatre)
 "dyl" = (
 /obj/item/kirbyplants,
@@ -59361,10 +59313,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/theatre)
 "dAF" = (
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/starboard)
 "dAH" = (
 /turf/simulated/floor/plasteel/airless,
@@ -59487,10 +59437,8 @@
 "dBu" = (
 /obj/structure/table/wood,
 /obj/item/clothing/under/costume/jester,
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/theatre)
 "dBv" = (
 /obj/structure/table/wood,
@@ -59722,10 +59670,8 @@
 /obj/machinery/status_display{
 	pixel_x = -32
 	},
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/theatre)
 "dCs" = (
 /obj/structure/table/wood,
@@ -59739,10 +59685,8 @@
 	},
 /area/station/maintenance/theatre)
 "dCu" = (
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/theatre)
 "dCv" = (
 /obj/structure/table/wood,
@@ -64143,10 +64087,8 @@
 "dYz" = (
 /obj/structure/chair/stool/bar,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/abandonedbar)
 "dYA" = (
 /obj/effect/turf_decal/stripes/line{
@@ -66821,10 +66763,8 @@
 	dir = 1
 	},
 /obj/effect/landmark/spawner/xeno,
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/starboard)
 "fox" = (
 /obj/machinery/door_control{
@@ -67437,9 +67377,8 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/office/ce)
 "fHD" = (
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken3"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/library)
 "fIk" = (
 /obj/structure/lattice/catwalk,
@@ -67458,10 +67397,8 @@
 /obj/item/book/manual/wiki/security_space_law,
 /obj/item/book/manual/detective,
 /obj/item/camera/detective,
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/starboard)
 "fIv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -68552,10 +68489,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/electrical_shop)
 "gow" = (
 /obj/structure/cable{
@@ -68931,9 +68866,8 @@
 	pixel_y = 6
 	},
 /obj/item/storage/bag/dice,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken7"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/library)
 "gDy" = (
 /obj/structure/cable{
@@ -70607,9 +70541,8 @@
 /obj/structure/chair/office/dark{
 	dir = 8
 	},
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken3"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/library)
 "hDF" = (
 /obj/effect/spawner/random_spawners/wall_rusted_always,
@@ -72309,10 +72242,8 @@
 	},
 /area/station/public/fitness)
 "iFl" = (
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/abandonedbar)
 "iFr" = (
 /obj/machinery/door/firedoor,
@@ -73466,9 +73397,8 @@
 	pixel_x = -12;
 	pixel_y = 2
 	},
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/apmaint)
 "jnJ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -75848,11 +75778,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/west)
-"kIP" = (
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken6"
-	},
-/area/station/maintenance/library)
 "kJg" = (
 /obj/item/kirbyplants,
 /obj/item/radio/intercom{
@@ -76420,9 +76345,8 @@
 /obj/structure/chair/office/dark{
 	dir = 4
 	},
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken5"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/library)
 "lcy" = (
 /obj/structure/closet/crate/hydroponics,
@@ -76524,10 +76448,8 @@
 /area/station/medical/reception)
 "lfd" = (
 /obj/machinery/economy/slot_machine,
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/gambling_den)
 "lfg" = (
 /turf/simulated/wall,
@@ -78366,10 +78288,8 @@
 	dir = 4
 	},
 /obj/machinery/economy/slot_machine,
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/gambling_den)
 "mmt" = (
 /obj/machinery/economy/vending/cola,
@@ -81227,9 +81147,8 @@
 "nOO" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken7"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/library)
 "nPe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -84880,9 +84799,8 @@
 /obj/item/multitool,
 /obj/item/wrench,
 /obj/effect/spawner/lootdrop/maintenance/two,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken7"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/apmaint)
 "pTv" = (
 /obj/machinery/door/poddoor{
@@ -88568,10 +88486,8 @@
 /area/station/medical/storage/secondary)
 "rYP" = (
 /obj/structure/bookcase,
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/library)
 "rYV" = (
 /obj/structure/window/reinforced{
@@ -89462,9 +89378,8 @@
 /area/station/hallway/primary/central)
 "sqZ" = (
 /obj/effect/landmark/spawner/xeno,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken6"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/library)
 "sre" = (
 /obj/machinery/door/window/brigdoor{
@@ -94071,10 +93986,8 @@
 	dir = 1
 	},
 /obj/effect/landmark/spawner/xeno,
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/theatre)
 "uWj" = (
 /obj/item/target/syndicate,
@@ -97696,9 +97609,8 @@
 /turf/simulated/floor/plating,
 /area/station/security/prison/cell_block)
 "xaR" = (
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken5"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/apmaint)
 "xbI" = (
 /obj/effect/turf_decal/woodsiding{
@@ -131816,7 +131728,7 @@ dOO
 dOO
 xdd
 lRc
-kIP
+fHD
 nNZ
 thL
 lct

--- a/_maps/map_files/stations/metastation.dmm
+++ b/_maps/map_files/stations/metastation.dmm
@@ -3267,9 +3267,8 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken6"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/starboard)
 "avD" = (
 /obj/structure/dispenser,
@@ -7566,9 +7565,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken5"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/service/bar)
 "aLD" = (
 /obj/structure/table,
@@ -14817,9 +14815,8 @@
 "bgV" = (
 /obj/item/kirbyplants/plant22,
 /obj/effect/spawner/random_spawners/cobweb_left_rare,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken3"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/starboard)
 "bgW" = (
 /obj/effect/spawner/window/reinforced/grilled,
@@ -20727,9 +20724,8 @@
 /turf/space,
 /area/space/nearstation)
 "bwO" = (
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/service/bar)
 "bwP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -25501,9 +25497,8 @@
 "bNf" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/glass/rag,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken4"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/apmaint)
 "bNg" = (
 /obj/machinery/door/firedoor,
@@ -26329,9 +26324,8 @@
 /area/station/hallway/secondary/bridge)
 "bQu" = (
 /obj/machinery/economy/slot_machine,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken4"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/apmaint)
 "bQy" = (
 /obj/structure/table/wood,
@@ -27440,9 +27434,8 @@
 /area/station/science/research)
 "bUz" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken4"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/starboard2)
 "bUA" = (
 /obj/item/apc_electronics,
@@ -27647,9 +27640,8 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken6"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/science/robotics/showroom)
 "bVe" = (
 /obj/machinery/alarm/directional/east,
@@ -27788,9 +27780,8 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken6"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/starboard)
 "bVN" = (
 /obj/machinery/atmospherics/unary/portables_connector{
@@ -28131,9 +28122,8 @@
 /turf/simulated/floor/wood,
 /area/station/science/robotics/showroom)
 "bWJ" = (
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken3"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/science/robotics/showroom)
 "bWK" = (
 /obj/structure/table/wood,
@@ -28805,9 +28795,8 @@
 	},
 /area/station/ai_monitored/storage/eva)
 "bYT" = (
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken7"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/apmaint)
 "bYW" = (
 /obj/structure/cable{
@@ -31594,11 +31583,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/science/xenobiology)
-"cjm" = (
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken4"
-	},
-/area/station/maintenance/apmaint)
 "cjn" = (
 /obj/structure/sign/vacuum/external{
 	pixel_y = 32
@@ -31733,9 +31717,8 @@
 /obj/structure/chair/stool{
 	dir = 8
 	},
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken4"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/apmaint)
 "cjH" = (
 /obj/structure/disposalpipe/segment{
@@ -33267,9 +33250,8 @@
 /area/station/maintenance/aft)
 "cqi" = (
 /obj/item/shovel/spade,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken7"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/starboard2)
 "cqj" = (
 /obj/machinery/hologram/holopad,
@@ -33377,9 +33359,8 @@
 /obj/item/reagent_containers/glass/bucket,
 /obj/item/vending_refill/hydroseeds,
 /obj/effect/spawner/random_spawners/cobweb_right_rare,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken3"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/starboard2)
 "cqK" = (
 /turf/simulated/floor/engine/n2,
@@ -34668,9 +34649,8 @@
 /obj/structure/chair/stool{
 	dir = 1
 	},
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken4"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/apmaint)
 "cvS" = (
 /obj/effect/turf_decal/delivery/blue/hollow,
@@ -35252,9 +35232,8 @@
 /obj/item/seeds/banana,
 /obj/item/seeds/chanter,
 /obj/item/seeds/chili,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken7"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/starboard2)
 "cyf" = (
 /obj/structure/table,
@@ -35321,9 +35300,8 @@
 "cyx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/stool,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken7"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/apmaint)
 "cyy" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -35732,11 +35710,6 @@
 	icon_state = "dark"
 	},
 /area/station/medical/cloning)
-"cAn" = (
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken5"
-	},
-/area/station/maintenance/apmaint)
 "cAq" = (
 /obj/machinery/atmospherics/unary/tank/air{
 	dir = 1
@@ -36242,11 +36215,6 @@
 	icon_state = "white"
 	},
 /area/station/medical/virology)
-"cCn" = (
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken6"
-	},
-/area/station/maintenance/apmaint)
 "cCo" = (
 /obj/structure/closet,
 /obj/machinery/light/small{
@@ -37558,9 +37526,8 @@
 	pixel_x = -32
 	},
 /obj/structure/bed/dogbed,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken3"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/apmaint)
 "cHf" = (
 /obj/structure/cable{
@@ -40338,9 +40305,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken4"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/starboard2)
 "cSg" = (
 /obj/structure/disposalpipe/segment{
@@ -42410,9 +42376,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken3"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/starboard)
 "dcd" = (
 /obj/effect/turf_decal/stripes/line{
@@ -47072,9 +47037,8 @@
 	},
 /area/station/hallway/secondary/entry/lounge)
 "ePK" = (
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken3"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/starboard2)
 "ePT" = (
 /obj/effect/turf_decal/stripes/line{
@@ -49945,9 +49909,8 @@
 	},
 /area/station/science/lobby)
 "fTV" = (
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken3"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/starboard)
 "fUf" = (
 /obj/structure/rack,
@@ -54864,9 +54827,8 @@
 "hTl" = (
 /obj/item/book/manual/random,
 /obj/machinery/light/small,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken6"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/starboard)
 "hTx" = (
 /obj/machinery/shower{
@@ -60539,11 +60501,6 @@
 	icon_state = "red"
 	},
 /area/station/security/main)
-"kry" = (
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken7"
-	},
-/area/station/maintenance/starboard)
 "krF" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "cult"
@@ -69398,9 +69355,8 @@
 /area/station/maintenance/starboard)
 "nXk" = (
 /obj/structure/bookcase,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken7"
-	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
 /area/station/maintenance/starboard)
 "nXr" = (
 /obj/machinery/light{
@@ -106534,7 +106490,7 @@ cMR
 cMR
 cMR
 ckK
-cjm
+bYT
 qFz
 tIb
 tIb
@@ -106789,7 +106745,7 @@ cdN
 cdN
 ceW
 cAx
-cCn
+bYT
 bYT
 cJO
 cMR
@@ -107303,7 +107259,7 @@ ckK
 cjE
 oqk
 cMR
-cAn
+bYT
 cMR
 cMR
 cJO
@@ -107562,7 +107518,7 @@ csv
 crG
 cMR
 cMR
-cAn
+bYT
 cMR
 tIb
 tIb
@@ -107812,7 +107768,7 @@ cAq
 bZP
 cfb
 cAx
-cAn
+bYT
 cMR
 cMR
 crG
@@ -108072,7 +108028,7 @@ bWH
 cMR
 lGp
 cMR
-cjm
+bYT
 cBd
 cMR
 cMR
@@ -132731,7 +132687,7 @@ axh
 axh
 bgV
 hdc
-kry
+fTV
 fTV
 bZH
 aoG
@@ -132989,7 +132945,7 @@ axh
 cyv
 kQF
 bZH
-kry
+fTV
 nXk
 aoG
 aAL

--- a/code/game/turfs/simulated/floor/fancy_floor.dm
+++ b/code/game/turfs/simulated/floor/fancy_floor.dm
@@ -18,6 +18,10 @@
 		return
 	remove_tile(user, FALSE, FALSE)
 
+/turf/simulated/floor/wood/break_tile()
+	broken = TRUE
+	update_icon()
+
 /turf/simulated/floor/wood/get_broken_states()
 	return list("wood-broken", "wood-broken2", "wood-broken3", "wood-broken4", "wood-broken5", "wood-broken6", "wood-broken7")
 

--- a/code/game/turfs/simulated/floor/fancy_floor.dm
+++ b/code/game/turfs/simulated/floor/fancy_floor.dm
@@ -18,10 +18,6 @@
 		return
 	remove_tile(user, FALSE, FALSE)
 
-/turf/simulated/floor/wood/break_tile()
-	broken = TRUE
-	update_icon()
-
 /turf/simulated/floor/wood/get_broken_states()
 	return list("wood-broken", "wood-broken2", "wood-broken3", "wood-broken4", "wood-broken5", "wood-broken6", "wood-broken7")
 

--- a/tools/UpdatePaths/Scripts/26395_broken_floor_converter.txt
+++ b/tools/UpdatePaths/Scripts/26395_broken_floor_converter.txt
@@ -1,2 +1,1 @@
-/turf/simulated/floor/wood{icon_state=@ANY} : /turf/simulated/floor/wood{@OLD;icon_state=@SKIP;broken=@SKIP} , /obj/effect/landmark/damageturf
-/turf/simulated/floor/wood/lavaland_air{icon_state=@ANY} : /turf/simulated/floor/wood/lavaland_air{@OLD;icon_state=@SKIP;broken=@SKIP} , /obj/effect/landmark/damageturf
+/turf/simulated/floor/wood/@SUBTYPES{icon_state=@ANY} : /turf/simulated/floor/wood/@SUBTYPES{@OLD;icon_state=@SKIP;broken=@SKIP} , /obj/effect/landmark/damageturf

--- a/tools/UpdatePaths/Scripts/26395_broken_floor_converter.txt
+++ b/tools/UpdatePaths/Scripts/26395_broken_floor_converter.txt
@@ -1,0 +1,2 @@
+/turf/simulated/floor/wood{icon_state=@ANY} : /turf/simulated/floor/wood{@OLD;icon_state=@SKIP;broken=@SKIP} , /obj/effect/landmark/damageturf
+/turf/simulated/floor/wood/lavaland_air{icon_state=@ANY} : /turf/simulated/floor/wood/lavaland_air{@OLD;icon_state=@SKIP;broken=@SKIP} , /obj/effect/landmark/damageturf


### PR DESCRIPTION
## What Does This PR Do
Removes all broken states for wooden floors on maps, replace it with damageturf landmark

## Why It's Good For The Game
Less unnecessary code on maps
Every round, random looking broken floors (No one will notice :c)
Possibility to make grayscale wood floors in the future

## Testing
Look's fine
![image](https://github.com/user-attachments/assets/659114da-33d2-4f3e-93fd-cb9e2fc6fa0a)

## Changelog
NPFC

