### PR TITLE
Fixes the B-RPED trying to upgrade machinery that dont have stock parts

### DIFF
--- a/code/game/objects/items/weapons/stock_parts.dm
+++ b/code/game/objects/items/weapons/stock_parts.dm
@@ -53,8 +53,8 @@
 	if(get_dist(src, M) <= (user.client.maxview() + 2))
 		if(M.component_parts)
 			M.exchange_parts(user, src)
-		if(works_from_distance)
-			user.Beam(M, icon_state="rped_upgrade", icon='icons/effects/effects.dmi', time=5)
+			if(works_from_distance)
+				user.Beam(M, icon_state="rped_upgrade", icon='icons/effects/effects.dmi', time=5)
 	else
 		message_admins("\[EXPLOIT] [key_name_admin(user)] attempted to upgrade machinery with a BRPED via a camera console (attempted range exploit).")
 		playsound(src, 'sound/machines/synth_no.ogg', 15, TRUE)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
https://github.com/ParadiseSS13/Paradise/pull/26257 had a indentation error that caused the brped to play its beam effect on all `obj/machinery/...` sub types rather than just ones with stock parts, mainly vents. this pr fixes this.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Bug fix, while harmless it was a little strange
## Testing
<!-- How did you test the PR, if at all? -->
compiled, tried to "upgrade" various atmos devices, couldn't. tried to upgrade a machine with stock parts, worked
## Changelog
:cl:
fix: Fixed B-RPED playing its beam effect on all machinery 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
