### PR TITLE
516 compat: Replace `caller` with `requester`

### DIFF
--- a/code/__HELPERS/paths/jps.dm
+++ b/code/__HELPERS/paths/jps.dm
@@ -55,7 +55,7 @@
 
 /datum/pathfind/jps
 	/// The movable we are pathing
-	var/atom/movable/caller
+	var/atom/movable/caller_
 	/// The turf we're trying to path to (note that this won't track a moving target)
 	var/turf/end
 	/// The open list/stack we pop nodes out from (TODO: make this a normal list and macro-ize the heap operations to reduce proc overhead)
@@ -72,9 +72,9 @@
 	///Defines how we handle diagonal moves. See __DEFINES/path.dm
 	var/diagonal_handling = DIAGONAL_REMOVE_CLUNKY
 
-/datum/pathfind/jps/proc/setup(atom/movable/caller, list/access, max_distance, simulated_only, avoid, list/datum/callback/on_finish, atom/goal, mintargetdist, skip_first, diagonal_handling)
-	src.caller = caller
-	src.pass_info = new(caller, access)
+/datum/pathfind/jps/proc/setup(atom/movable/caller_, list/access, max_distance, simulated_only, avoid, list/datum/callback/on_finish, atom/goal, mintargetdist, skip_first, diagonal_handling)
+	src.caller_ = caller_
+	src.pass_info = new(caller_, access)
 	src.max_distance = max_distance
 	src.simulated_only = simulated_only
 	src.avoid = avoid
@@ -88,12 +88,12 @@
 
 /datum/pathfind/jps/Destroy(force)
 	. = ..()
-	caller = null
+	caller_ = null
 	end = null
 	open = null
 
 /datum/pathfind/jps/start()
-	start = start || get_turf(caller)
+	start = start || get_turf(caller_)
 	. = ..()
 	if(!.)
 		return .
@@ -115,7 +115,7 @@
 	. = ..()
 	if(!.)
 		return .
-	if(QDELETED(caller))
+	if(QDELETED(caller_))
 		return FALSE
 
 	while(!open.IsEmpty() && !path)

--- a/code/__HELPERS/paths/jps.dm
+++ b/code/__HELPERS/paths/jps.dm
@@ -55,7 +55,7 @@
 
 /datum/pathfind/jps
 	/// The movable we are pathing
-	var/atom/movable/caller_
+	var/atom/movable/requester
 	/// The turf we're trying to path to (note that this won't track a moving target)
 	var/turf/end
 	/// The open list/stack we pop nodes out from (TODO: make this a normal list and macro-ize the heap operations to reduce proc overhead)
@@ -72,9 +72,9 @@
 	///Defines how we handle diagonal moves. See __DEFINES/path.dm
 	var/diagonal_handling = DIAGONAL_REMOVE_CLUNKY
 
-/datum/pathfind/jps/proc/setup(atom/movable/caller_, list/access, max_distance, simulated_only, avoid, list/datum/callback/on_finish, atom/goal, mintargetdist, skip_first, diagonal_handling)
-	src.caller_ = caller_
-	src.pass_info = new(caller_, access)
+/datum/pathfind/jps/proc/setup(atom/movable/requester, list/access, max_distance, simulated_only, avoid, list/datum/callback/on_finish, atom/goal, mintargetdist, skip_first, diagonal_handling)
+	src.requester = requester
+	src.pass_info = new(requester, access)
 	src.max_distance = max_distance
 	src.simulated_only = simulated_only
 	src.avoid = avoid
@@ -88,12 +88,12 @@
 
 /datum/pathfind/jps/Destroy(force)
 	. = ..()
-	caller_ = null
+	requester = null
 	end = null
 	open = null
 
 /datum/pathfind/jps/start()
-	start = start || get_turf(caller_)
+	start = start || get_turf(requester)
 	. = ..()
 	if(!.)
 		return .
@@ -115,7 +115,7 @@
 	. = ..()
 	if(!.)
 		return .
-	if(QDELETED(caller_))
+	if(QDELETED(requester))
 		return FALSE
 
 	while(!open.IsEmpty() && !path)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Caller is a protected/reserved var in 516, but we use it in JPS! This fixes that.

```
- caller and callee vars

	- The current proc has caller and callee vars that return a reference to
	  the running caller and to the running proc itself, respectively. The
	  returned var is of internal type /callee.

	- /callee has vars src, usr, args, file, line, caller, and all vars that
	  apply to proc prototypes (name, type, desc, category, invisibility).	 
```
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
516 should compile.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Watched the mulebot take a (non optional) path to a department
<!-- How did you test the PR, if at all? -->