### PR TITLE
Fix DNA modifier update_icon_state() proc

### DIFF
--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -139,7 +139,7 @@
 
 /obj/machinery/dna_scannernew/update_icon_state()
 	if(panel_open)
-		icon_state = "scanner" + (occupant ? "" : "_open") + "_maintenance"
+		icon_state = "scanner_[occupant ? "" : "open_"]maintenance"
 		return
 	if(stat & NOPOWER)
 		icon_state = "scanner"

--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -138,10 +138,16 @@
 			M.forceMove(get_turf(src))
 
 /obj/machinery/dna_scannernew/update_icon_state()
-	if(occupant)
-		icon_state = "scanner_occupied"
-	else
+	if(panel_open)
+		icon_state = "scanner" + (occupant ? "" : "_open") + "_maintenance"
+		return
+	if(stat & NOPOWER)
+		icon_state = "scanner"
+		return
+	if(!occupant)
 		icon_state = "scanner_open"
+		return
+	icon_state = "scanner_occupied"
 
 /obj/machinery/dna_scannernew/MouseDrop_T(atom/movable/O, mob/user)
 	if(!istype(O))


### PR DESCRIPTION
## What Does This PR Do
Fixes update_icon_state() proc of the DNA modifier.

## Why It's Good For The Game
Bugfix is always good

## Images of changes
Before:
![image](https://github.com/user-attachments/assets/09004149-6caa-47ee-a195-87650737e2c6)
After:
![image](https://github.com/user-attachments/assets/ed0be8ad-dd55-4418-80c9-3a339004b30a)

## Testing
Spawned DNA modifier.
Used screwdriver on it.
Put human inside.
Saw the right sprite.
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: DNA modifier now uses right sprites.
/:cl: