### PR TITLE
refactor: Streamline biohazard blackbox recording.

### DIFF
--- a/code/__DEFINES/misc_defines.dm
+++ b/code/__DEFINES/misc_defines.dm
@@ -624,11 +624,17 @@
 #define ROUND_END_CREW_TRANSFER 2
 #define ROUND_END_FORCED 3
 
-#define TS_INFESTATION_GREEN_SPIDER 1
-#define TS_INFESTATION_PRINCE_SPIDER 2
-#define TS_INFESTATION_WHITE_SPIDER 3
-#define TS_INFESTATION_PRINCESS_SPIDER 4
-#define TS_INFESTATION_QUEEN_SPIDER 5
+// These used to be integer values but they were never used numerically or even
+// stored in SSblackbox using their numeric values, and constantly converting
+// them to the actual terror name was redundant and annoying
+#define TS_INFESTATION_GREEN_SPIDER		"Green Terrors"
+#define TS_INFESTATION_PRINCE_SPIDER	"Prince Terror"
+#define TS_INFESTATION_WHITE_SPIDER		"White Terrors"
+#define TS_INFESTATION_PRINCESS_SPIDER	"Princess Terrors"
+#define TS_INFESTATION_QUEEN_SPIDER		"Queen Terrors"
+
+#define BIOHAZARD_BLOB	"Blob"
+#define BIOHAZARD_XENO	"Xenomorphs"
 
 #define MAX_ALLOWED_TELEPORTS_PER_PROCESS 20
 

--- a/code/controllers/subsystem/SSticker.dm
+++ b/code/controllers/subsystem/SSticker.dm
@@ -125,7 +125,7 @@ SUBSYSTEM_DEF(ticker)
 				current_state = GAME_STATE_FINISHED
 		if(GAME_STATE_FINISHED)
 			if(SSshuttle.emergency.mode >= SHUTTLE_ENDGAME && !mode.station_was_nuked)
-				event_blackbox(outcome = ROUND_END_CREW_TRANSFER)
+				record_biohazard_results()
 			current_state = GAME_STATE_FINISHED
 			Master.SetRunLevel(RUNLEVEL_POSTGAME) // This shouldnt process more than once, but you never know
 			auto_toggle_ooc(TRUE) // Turn it on
@@ -801,79 +801,20 @@ SUBSYSTEM_DEF(ticker)
 	records.Cut()
 	flagged_antag_rollers.Cut()
 
-/// This proc is for recording biohazard events, and blackboxing if they lived, died, or ended the round. This currently applies to: Terror spiders, Xenomorphs, and Blob.
-/datum/controller/subsystem/ticker/proc/event_blackbox(outcome = ROUND_END_CREW_TRANSFER)
-	for(var/I in SSevents.biohazards_this_round)
-		switch(I)
-			if(TS_INFESTATION_GREEN_SPIDER, TS_INFESTATION_PRINCE_SPIDER, TS_INFESTATION_WHITE_SPIDER, TS_INFESTATION_PRINCESS_SPIDER, TS_INFESTATION_QUEEN_SPIDER)
-				var/output = "unknown spider type"
-				switch(I)
-					if(TS_INFESTATION_GREEN_SPIDER)
-						output = "Green Terrors"
-					if(TS_INFESTATION_PRINCE_SPIDER)
-						output = "Prince Terror"
-					if(TS_INFESTATION_WHITE_SPIDER)
-						output = "White Terrors"
-					if(TS_INFESTATION_PRINCESS_SPIDER)
-						output = "Princess Terrors"
-					if(TS_INFESTATION_QUEEN_SPIDER)
-						output = "Queen Terrors"
-				var/spiders = 0
-				for(var/mob/living/simple_animal/hostile/poison/terror_spider/S in GLOB.ts_spiderlist)
-					if(S.ckey)
-						spiders++
-				if(spiders >= 5 || (output == "Prince Terror" && spiders == 1)) //If a prince lives, record as win.
-					switch(outcome)
-						if(ROUND_END_NUCLEAR)
-							SSblackbox.record_feedback("tally", "Biohazard nuclear victories", 1, output)
-						if(ROUND_END_CREW_TRANSFER)
-							SSblackbox.record_feedback("tally", "Biohazard survives to normal round end", 1, output)
-						if(ROUND_END_FORCED)
-							SSblackbox.record_feedback("tally", "Biohazard survives to admin round end", 1, output)
-				else
-					switch(outcome)
-						if(ROUND_END_NUCLEAR)
-							SSblackbox.record_feedback("tally", "Biohazard dies station nuked", 1, output)
-						if(ROUND_END_CREW_TRANSFER)
-							SSblackbox.record_feedback("tally", "Biohazard dies normal end", 1, output)
-						if(ROUND_END_FORCED)
-							SSblackbox.record_feedback("tally", "Biohazard dies admin round end", 1, output)
-			if("Xenomorphs")
-				var/living_xenos = count_xenomorps()
-				if(living_xenos > 5)
-					switch(outcome)
-						if(ROUND_END_NUCLEAR)
-							SSblackbox.record_feedback("tally", "Xeno nuclear victories", 1, "Xenomorphs")
-						if(ROUND_END_CREW_TRANSFER)
-							SSblackbox.record_feedback("tally", "Xeno survives to normal round end", 1, "Xenomorphs")
-						if(ROUND_END_FORCED)
-							SSblackbox.record_feedback("tally", "Xeno survives to admin round end", 1, "Xenomorphs")
-				else
-					switch(outcome)
-						if(ROUND_END_NUCLEAR)
-							SSblackbox.record_feedback("tally", "Xeno dies station nuked", 1, "Xenomorphs")
-						if(ROUND_END_CREW_TRANSFER)
-							SSblackbox.record_feedback("tally", "Xeno dies normal end", 1, "Xenomorphs")
-						if(ROUND_END_FORCED)
-							SSblackbox.record_feedback("tally", "Xeno dies admin round end", 1, "Xenomorphs")
-
-			if("Blob")
-				if(length(SSticker.mode.blob_overminds))
-					switch(outcome)
-						if(ROUND_END_NUCLEAR)
-							SSblackbox.record_feedback("tally", "Blob nuclear victories", 1, "Blob")
-						if(ROUND_END_CREW_TRANSFER)
-							SSblackbox.record_feedback("tally", "Blob survives to normal round end", 1, "Blob")
-						if(ROUND_END_FORCED)
-							SSblackbox.record_feedback("tally", "Blob survives to admin round end", 1, "Blob")
-				else
-					switch(outcome)
-						if(ROUND_END_NUCLEAR)
-							SSblackbox.record_feedback("tally", "Blob dies station nuked", 1, "Blob")
-						if(ROUND_END_CREW_TRANSFER)
-							SSblackbox.record_feedback("tally", "Blob dies normal end", 1, "Blob")
-						if(ROUND_END_FORCED)
-							SSblackbox.record_feedback("tally", "Blob dies admin round end", 1, "Blob")
+/// This proc is for recording biohazard events, and blackboxing if they lived,
+/// died, or ended the round. This currently applies to: Terror spiders,
+/// Xenomorphs, and Blob.
+///
+/// This code is predicated on the assumption that multiple midrounds
+/// of the same type are either extremely rare or impossible. We don't want to get
+/// into the insanity of trying to record if the first xeno biohazard was defeated
+/// but the second xeno biohazard was nuked.
+/datum/controller/subsystem/ticker/proc/record_biohazard_results()
+	for(var/biohazard in SSevents.biohazards_this_round)
+		if(biohazard_active_threat(biohazard))
+			SSblackbox.record_feedback("nested tally", "biohazards", 1, list("survived", biohazard))
+		else
+			SSblackbox.record_feedback("nested tally", "biohazards", 1, list("defeated", biohazard))
 
 /datum/controller/subsystem/ticker/proc/count_xenomorps()
 	. = 0
@@ -881,3 +822,23 @@ SUBSYSTEM_DEF(ticker)
 		if(xeno_mind.current?.stat == DEAD)
 			continue
 		.++
+
+/// Return whether or not a given biohazard is an active threat.
+/// For blobs, this is simply if there are any overminds left. For terrors and
+/// xenomorphs, this is whether they have overwhelming numbers.
+/datum/controller/subsystem/ticker/proc/biohazard_active_threat(biohazard)
+	switch(biohazard)
+		if(TS_INFESTATION_GREEN_SPIDER, TS_INFESTATION_WHITE_SPIDER, TS_INFESTATION_PRINCESS_SPIDER, TS_INFESTATION_QUEEN_SPIDER)
+			var/spiders = 0
+			for(var/mob/living/simple_animal/hostile/poison/terror_spider/S in GLOB.ts_spiderlist)
+				if(S.ckey)
+					spiders++
+			return spiders >= 5
+		if(TS_INFESTATION_PRINCE_SPIDER)
+			return length(GLOB.ts_spiderlist)
+		if(BIOHAZARD_XENO)
+			return count_xenomorps() > 5
+		if(BIOHAZARD_BLOB)
+			return length(SSticker.mode.blob_overminds)
+
+	return FALSE

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -632,7 +632,7 @@ GLOBAL_VAR(bomb_set)
 	playsound(src, 'sound/machines/alarm.ogg', 100, FALSE, 5)
 	if(SSticker && SSticker.mode)
 		SSticker.mode.explosion_in_progress = TRUE
-		SSticker.event_blackbox(outcome = ROUND_END_NUCLEAR)
+		SSticker.record_biohazard_results()
 	sleep(100)
 
 	GLOB.enter_allowed = 0

--- a/code/modules/admin/misc_admin_procs.dm
+++ b/code/modules/admin/misc_admin_procs.dm
@@ -405,7 +405,7 @@ GLOBAL_VAR_INIT(nologevent, 0)
 	message_admins("[key_name_admin(usr)] has admin ended the round with message: '[input]'")
 	log_admin("[key_name(usr)] has admin ended the round with message: '[input]'")
 	SSticker.force_ending = TRUE
-	SSticker.event_blackbox(outcome = ROUND_END_FORCED)
+	SSticker.record_biohazard_results()
 	to_chat(world, "<span class='warning'><big><b>[input]</b></big></span>")
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "End Round") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	SSticker.mode_result = "admin ended"


### PR DESCRIPTION
## What Does This PR Do

This PR changes how biohazard victorys and defeats are tallied in SSblackbox.

## Why It's Good For The Game

The previous system suffered from some problems:

- Key names were truncated and nonconformant: with very few exceptions, the key name for feedback is a short, lowercase_underscore value. These key names were short phrases that didn't even fit within the key_name's column length, so "Xeno survives to normal round end" would be missing a "d", "Biohazard survives to normal round end" would be "Biohazard survives to normal rou", etc.
- They were redundant: They described the round end type ("Blob survives to normal round end", "Xeno nuclear victories") even though how the round ended is already available in the Round model, under `end_state`. As well, the row e.g. "Xeno nuclear victories" would include a nested tally `"Xenomorphs": 1`, despite already knowing the feedback row was about xenos.
- They were hard to query: Instead of just being able to check a single feedback row, if I wanted to query Xeno stats, I'd have to look for rows with three different keys: "Xeno nuclear victories", "Xeno dies normal end", and "Xeno survives to normal round en", and munge them together. Storing all biohazard data as one datum in one feedback row is much easier to work with.

If desired (cc @AffectedArc07) I can provide a script that will convert all existing Feedback rows to the new format for the prod database. The data as it currently exists has only been accurate, and has only been in this format, since https://github.com/ParadiseSS13/Paradise/pull/26006. So only 2 months of feedback rows would have to be migrated. I'm basically the only person doing any actual processing of this data in the first place and I don't mind having the two different formats around while I'm still looking at data from the past two months.

## Testing

For both test rounds, I let a blob survive until nuked, and spawned terror
spiders I then killed before the nuke.

Before:

![2024_08_07__16_33_43__Unnamed_paradise_gamedb_feedback_ - HeidiSQL 11 0 0 5919](https://github.com/user-attachments/assets/53b3e8b6-4339-4d1a-b2eb-acd590fbee97)

After:

![2024_08_07__16_20_48__Unnamed_paradise_gamedb_feedback_ - HeidiSQL 11 0 0 5919](https://github.com/user-attachments/assets/6d98118c-7d2f-4fd2-ac6c-7f88385c6465)

With the round type as recorded in the `round` table:

![2024_08_07__16_58_52__Unnamed_paradise_gamedb_round_ - HeidiSQL 11 0 0 5919](https://github.com/user-attachments/assets/4b3f21b7-cfab-4e10-af5d-4e977ac08f05)

Since the feedback is already associated with the round, joining the data here is painless.

## Changelog

NPFC
