### PR TITLE
Makes dry mops insert properly into the janicart

### DIFF
--- a/code/game/objects/items/weapons/mop.dm
+++ b/code/game/objects/items/weapons/mop.dm
@@ -37,6 +37,7 @@
 		if(istype(O, /obj/structure/janitorialcart))
 			var/obj/structure/janitorialcart/janicart = O
 			if(!janicart.mymop)
+				janicart.mymop = I
 				janicart.put_in_cart(user, src)
 		return
 

--- a/code/game/objects/items/weapons/mop.dm
+++ b/code/game/objects/items/weapons/mop.dm
@@ -37,7 +37,7 @@
 		if(istype(O, /obj/structure/janitorialcart))
 			var/obj/structure/janitorialcart/janicart = O
 			if(!janicart.mymop)
-				janicart.mymop = I
+				janicart.mymop = src
 				janicart.put_in_cart(user, src)
 		return
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes dry/halfdry mops not inserting properly into the janicart
Resolves #26426
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Testing
I compiled it, the issue was really that the janicart didn't properly get the inserted mop set
<!-- How did you test the PR, if at all? -->

## Changelog
:cl:
fix: Dry mops can be put in janicarts again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
