### PR TITLE
Tweaks to Dvoraks telecomns sat ruin

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/telecomns_returns.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/telecomns_returns.dmm
@@ -5,6 +5,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/floodlight,
 /turf/simulated/floor/bluegrid{
 	name = "Mainframe Base";
 	nitrogen = 400;
@@ -218,11 +219,6 @@
 "dD" = (
 /obj/structure/closet/crate,
 /obj/item/multitool,
-/obj/machinery/camera{
-	c_tag = "Telecomms Entrance South";
-	dir = 1;
-	network = list("Telecomms")
-	},
 /turf/simulated/floor/plasteel,
 /area/ruin/space/telecomms/tele)
 "dR" = (
@@ -268,6 +264,9 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/space/telecomms/computer)
+"eA" = (
+/turf/simulated/wall/indestructible/riveted,
+/area/ruin/space/telecomms/foyer)
 "eE" = (
 /obj/machinery/mecha_part_fabricator,
 /turf/simulated/floor/plasteel{
@@ -710,7 +709,7 @@
 	pixel_x = 0
 	},
 /obj/structure/grille,
-/turf/simulated/floor/plating/airless,
+/turf/simulated/floor/catwalk/airless,
 /area/space/nearstation)
 "mZ" = (
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -718,6 +717,10 @@
 	locked = 1
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor{
+	id = "dvorak";
+	id_tag = "dvorak"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "vault";
 	dir = 5
@@ -1211,7 +1214,7 @@
 /turf/simulated/floor/plasteel,
 /area/ruin/space/telecomms/computer)
 "tW" = (
-/obj/machinery/r_n_d/server/upgraded,
+/obj/machinery/power/grounding_rod,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "vault";
@@ -1512,6 +1515,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor{
+	id = "dvorak";
+	id_tag = "dvorak"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "vault";
 	dir = 5
@@ -1645,17 +1652,6 @@
 /obj/item/clothing/glasses/night,
 /turf/simulated/floor/plasteel,
 /area/ruin/space/telecomms/tele)
-"zg" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Telecomms Power Control";
-	dir = 2;
-	network = list("Telecomms")
-	},
-/turf/simulated/floor/catwalk,
-/area/ruin/space/telecomms/powercontrol)
 "zk" = (
 /obj/structure/lattice,
 /obj/effect/abstract/cheese_trap,
@@ -1962,6 +1958,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
+/obj/machinery/computer/nonfunctional,
 /turf/simulated/floor/plasteel,
 /area/ruin/space/telecomms/foyer)
 "Dy" = (
@@ -2345,7 +2342,7 @@
 /area/space/nearstation)
 "Jb" = (
 /obj/effect/spawner/random_spawners/fungus_maybe,
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/indestructible/riveted,
 /area/ruin/space/telecomms/foyer)
 "Jm" = (
 /obj/machinery/computer/sm_monitor{
@@ -2478,6 +2475,9 @@
 	temperature = 80
 	},
 /area/ruin/space/telecomms/chamber)
+"Lk" = (
+/turf/simulated/wall/indestructible/riveted,
+/area/ruin/space/telecomms/tele)
 "Ln" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -2502,6 +2502,17 @@
 /mob/living/silicon/decoy/telecomms,
 /turf/simulated/floor/bluegrid{
 	name = "Mainframe Base";
+	nitrogen = 400;
+	oxygen = 0;
+	temperature = 80
+	},
+/area/ruin/space/telecomms/chamber)
+"LC" = (
+/obj/machinery/doppler_array,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "vault";
+	name = "Mainframe floor";
 	nitrogen = 400;
 	oxygen = 0;
 	temperature = 80
@@ -2563,6 +2574,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/effect/abstract/bot_trap,
 /turf/simulated/floor/plasteel{
 	icon_state = "vault";
 	dir = 5
@@ -2745,6 +2757,10 @@
 	req_access_txt = "61"
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/preopen{
+	id = "dvorak";
+	id_tag = "dvorak"
+	},
 /turf/simulated/floor/plasteel,
 /area/ruin/space/telecomms/foyer)
 "PZ" = (
@@ -2804,6 +2820,12 @@
 "Qx" = (
 /turf/simulated/floor/catwalk,
 /area/ruin/space/telecomms/powercontrol)
+"Qz" = (
+/obj/machinery/door_control{
+	id = "dvorak"
+	},
+/turf/simulated/wall/indestructible/riveted,
+/area/ruin/space/telecomms/chamber)
 "QN" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -3106,6 +3128,15 @@
 	temperature = 80
 	},
 /area/ruin/space/telecomms/chamber)
+"Vl" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/grille,
+/turf/simulated/floor/catwalk/airless,
+/area/space/nearstation)
 "Vm" = (
 /obj/machinery/light/small,
 /obj/machinery/light_switch{
@@ -3208,9 +3239,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1;
 	level = 1
-	},
-/obj/item/radio/intercom{
-	pixel_y = 25
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/space/telecomms/foyer)
@@ -6389,7 +6417,7 @@ ik
 Sv
 lW
 Ga
-Ga
+Vl
 mh
 Lp
 Lp
@@ -7123,7 +7151,7 @@ yo
 FC
 FC
 SA
-zg
+Bn
 lr
 Qx
 PA
@@ -7210,7 +7238,7 @@ Zu
 EO
 yr
 Xf
-PQ
+Lk
 oG
 PQ
 PQ
@@ -7296,13 +7324,13 @@ bJ
 Tw
 eE
 il
-tW
+LC
 EM
 Zu
 uM
 IL
 uM
-uM
+eA
 yJ
 BZ
 PQ
@@ -7394,7 +7422,7 @@ Zu
 Qa
 nD
 eJ
-uM
+eA
 DV
 Uw
 PQ
@@ -7578,7 +7606,7 @@ Zu
 WO
 nD
 Ri
-uM
+eA
 xv
 Uw
 UF
@@ -7758,11 +7786,11 @@ gG
 pa
 il
 qe
-Zu
+Qz
 Xb
 oz
 Ri
-uM
+eA
 Rt
 Uw
 UF
@@ -7854,7 +7882,7 @@ Zu
 Gt
 GQ
 cj
-uM
+eA
 Yr
 VO
 PQ
@@ -7946,7 +7974,7 @@ Zu
 ao
 nD
 Bf
-uM
+eA
 iE
 AY
 PQ
@@ -8017,11 +8045,11 @@ yo
 Ed
 xa
 ik
-ik
+iD
 ux
-Hr
-Hr
-Hr
+ux
+ux
+ux
 To
 ME
 Zj
@@ -8038,7 +8066,7 @@ Zu
 uM
 yD
 uM
-uM
+eA
 HR
 De
 PQ
@@ -8130,7 +8158,7 @@ Zu
 EO
 yr
 Xf
-PQ
+Lk
 oW
 PQ
 PQ
@@ -8202,12 +8230,12 @@ Dy
 xa
 ik
 ux
-Hr
+ux
 Aj
-Hr
-Hr
-Hr
-Hr
+ux
+ux
+ux
+ux
 Zu
 fq
 EM

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -713,6 +713,10 @@ to destroy them and players will be able to make replacements.
 	icon_state = "engineering"
 	build_path = /obj/machinery/autolathe/syndicate
 
+/obj/item/circuitboard/autolathe/trapped
+	board_name = "Modified Autolathe"
+	build_path = /obj/machinery/autolathe/trapped
+
 /obj/item/circuitboard/protolathe
 	board_name = "Protolathe"
 	icon_state = "science"

--- a/code/modules/awaymissions/mission_code/ruins/telecomns.dm
+++ b/code/modules/awaymissions/mission_code/ruins/telecomns.dm
@@ -59,6 +59,7 @@ GLOBAL_LIST_EMPTY(telecomms_trap_tank)
 	name = "recharger"
 	desc = "A charging dock for energy based weaponry. Did it just-"
 	icon_state = "autolathe_trap"
+	board_type = /obj/item/circuitboard/autolathe/trapped
 	//Has someone put an item in the autolathe, breaking the hologram?
 	var/disguise_broken = FALSE
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Tweaks the sat in a few ways to reinforce it.

<details>
<summary>Details hidden for those who want the specifics hidden</summary>
<br>
Turns some walls reinforced, to prevent an easier getaway or avoiding a large majority of turrets.
Blast doors have been added, to ensure the middle room is not skipped to avoid turets and bot traps. This closes the blast door behind you, forcing you to engage the turrets and go through the window to get back around. Everyone always opened the windows anyway, now you really will have to.
You may now build the trapped autolathe! Prank security, prank your friends, piss off your fellow explorers!
Adjusts the layout of the core room, so a security bot does not get trapped stuck, and so there is not empty spaces when AA's rnd rework removes the servers.
Removed cameras, missed 2 when removing them originally
</details>

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Some cheese should be tweaked, building certain things is fun.

## Testing
<!-- How did you test the PR, if at all? -->
Spawned the ruin.
confirmed walls were indestructable.
Confirm blast doors were closed or opened, and button worked from the south side.
Confirmed trapped autolathe gave the right board, and could be rebuilt.
Confirmed cameras were removed.
<hr>

### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/feature_freeze/CODE_OF_CONDUCT.md#currently-changes-to-the-following-types-of-content-reuires-pre-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
(not security or antag content, not species, not a large change, shouldn't be contriversal, and building a trapped autolathe should not have far reaching consiquences.)
<!-- A list of PR types requiring pre-approval can be found here: https://github.com/ParadiseSS13/Paradise/blob/feature_freeze/CODE_OF_CONDUCT.md#currently-changes-to-the-following-types-of-content-reuires-pre-approval -->
<!-- Replace the box with [x] to mark as complete. -->
<hr>

## Changelog
:cl:
tweak: Moved some things around on DVORAK's space ruin.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
