### PR TITLE
Fixes a runtime with buildmode

### DIFF
--- a/code/modules/buildmode/submodes/advanced.dm
+++ b/code/modules/buildmode/submodes/advanced.dm
@@ -11,7 +11,6 @@
 	to_chat(user, "<span class='notice'>Left Mouse Button + alt on turf/obj    = Copy object type")
 	to_chat(user, "<span class='notice'>Left Mouse Button on turf/obj          = Place objects</span>")
 	to_chat(user, "<span class='notice'>Right Mouse Button                     = Delete objects</span>")
-	to_chat(user, "")
 	to_chat(user, "<span class='notice'>Use the button in the upper left corner to</span>")
 	to_chat(user, "<span class='notice'>change the direction of built objects.</span>")
 	to_chat(user, "<span class='notice'>***********************************************************</span>")

--- a/code/modules/buildmode/submodes/basic.dm
+++ b/code/modules/buildmode/submodes/basic.dm
@@ -7,7 +7,6 @@
 	to_chat(user, "<span class='notice'>Right Mouse Button       = Deconstruct / Delete / Downgrade</span>")
 	to_chat(user, "<span class='notice'>Left Mouse Button + ctrl = R-Window</span>")
 	to_chat(user, "<span class='notice'>Left Mouse Button + alt  = Airlock</span>")
-	to_chat(user, "")
 	to_chat(user, "<span class='notice'>Use the button in the upper left corner to</span>")
 	to_chat(user, "<span class='notice'>change the direction of built objects.</span>")
 	to_chat(user, "<span class='notice'>***********************************************************</span>")


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Fixes a to_chat runtime when clicking on the buildmode help button
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Having less runtimes is better than having more runtimes

## Testing
<!-- How did you test the PR, if at all? -->
Clicked the button in both advanced and basic build mode, no runtime
<hr>

### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/feature_freeze/CODE_OF_CONDUCT.md#currently-changes-to-the-following-types-of-content-reuires-pre-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<!-- A list of PR types requiring pre-approval can be found here: https://github.com/ParadiseSS13/Paradise/blob/feature_freeze/CODE_OF_CONDUCT.md#currently-changes-to-the-following-types-of-content-reuires-pre-approval -->
<!-- Replace the box with [x] to mark as complete. -->
<hr>

## Changelog
NPFC

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
