### PR TITLE
You can now feel how hot the damage medbeam is. and slightly changes the description

### DIFF
--- a/code/modules/projectiles/guns/medbeam.dm
+++ b/code/modules/projectiles/guns/medbeam.dm
@@ -190,7 +190,7 @@
 		if(60 to 74) // i want it to be in the 'smoke' range at ~40 heat so as magic smoke is sudden but quick reaction time can stop it
 			. += "<span class='warning'>[src] is so hot it hurts to hold.</span>"
 		if(75 to INFINITY)
-			. += "<span class='warning'>[src] is emitting it's magic smoke, and is practically melting.</span>"
+			. += "<span class='warning'>[src] is emitting its magic smoke and is practically melting.</span>"
 
 /obj/item/gun/medbeam/damaged/process()
 	. = ..()

--- a/code/modules/projectiles/guns/medbeam.dm
+++ b/code/modules/projectiles/guns/medbeam.dm
@@ -158,7 +158,7 @@
 /obj/item/gun/medbeam/damaged/examine(mob/user) //The 8 Trials of Asclepius
 	. = ..()
 	. += "<span class= 'warning'>This ones cooling systems are damaged beyond repair, and will overheat rapidly. \
-	Despite the damged cooling system, its still mostly functional, however if overheated it will need to be repaired.</span>"
+	Despite the damaged cooling system, it's still mostly functional. However, if overheated, it will need to be repaired.</span>"
 	if(broken)
 		. += "<span class='notice'>It is broken, and will not function without repairs.</span>"
 	switch(broken)

--- a/code/modules/projectiles/guns/medbeam.dm
+++ b/code/modules/projectiles/guns/medbeam.dm
@@ -157,7 +157,8 @@
 
 /obj/item/gun/medbeam/damaged/examine(mob/user) //The 8 Trials of Asclepius
 	. = ..()
-	. += "<span class= 'warning'>This ones cooling systems are damaged beyond repair, and will over heat rapidly.</span>"
+	. += "<span class= 'warning'>This ones cooling systems are damaged beyond repair, and will overheat rapidly. \
+	Despite the damged cooling system, its still mostly functional, however if overheated it will need to be repaired.</span>"
 	if(broken)
 		. += "<span class='notice'>It is broken, and will not function without repairs.</span>"
 	switch(broken)

--- a/code/modules/projectiles/guns/medbeam.dm
+++ b/code/modules/projectiles/guns/medbeam.dm
@@ -137,7 +137,7 @@
 
 /obj/item/gun/medbeam/damaged
 	name = "damaged beamgun"
-	desc = "Delivers volatile medical nanites in a focused beam. Don't cross the beams! It is damaged and will rapidly overheat."
+	desc = "Delivers volatile medical nanites in a focused beam. Don't cross the beams!"
 	///How hot the beamgun is, if it hits max heat it will break
 	var/current_heat = 0
 	///How much heat the beamgun needs to break
@@ -157,10 +157,9 @@
 
 /obj/item/gun/medbeam/damaged/examine(mob/user) //The 8 Trials of Asclepius
 	. = ..()
-	if(!broken)
-		return
-
-	. += "<span class='notice'>It is broken, and will not function without repairs.</span>"
+	. += "<span class= 'warning'>This ones cooling systems are damaged beyond repair, and will over heat rapidly.</span>"
+	if(broken)
+		. += "<span class='notice'>It is broken, and will not function without repairs.</span>"
 	switch(broken)
 		if(SCREWDRIVER_OPEN)
 			. += "<span class='notice'>The panel can be <b>screwed</b> open to access the internals.</span>"
@@ -178,6 +177,19 @@
 			. += "<span class='notice'>The electronics need to be tested and reactivated with a <b>multitool</b>.</span>"
 		if(SCREWDRIVER_CLOSED)
 			. += "<span class='notice'>The panel needs to be <b>screwed</b> shut before it is usable.</span>"
+
+	if(!in_range(src, user))
+		return
+	var/heat_percent = (current_heat / max_heat) * 100
+	switch(heat_percent)
+		if(20 to 39)
+			. += "<span class='notice'>[src] feels warm.</span>"
+		if(40 to 59)
+			. += "<span class='notice'>[src] feels hot.</span>"
+		if(60 to 74) // i want it to be in the 'smoke' range at ~40 heat so as magic smoke is sudden but quick reaction time can stop it
+			. += "<span class='warning'>[src] is so hot it hurts to hold.</span>"
+		if(75 to INFINITY)
+			. += "<span class='warning'>[src] is emitting it's magic smoke, and is practically melting.</span>"
 
 /obj/item/gun/medbeam/damaged/process()
 	. = ..()
@@ -197,6 +209,8 @@
 	if(current_heat >= max_heat)
 		user.visible_message("<span class='warning'>[src] pops as it shuts off!</span>", "<span class='warning'>[src] pops and hisses as it shuts off. It is broken.</span>")
 		broken = SCREWDRIVER_OPEN
+		playsound(src, 'sound/effects/snap.ogg', 70, TRUE) // that didn't sound good...
+		user.adjustFireLoss(30) // you do NOT want to be holding this if it breaks. 5 more damage than hive lord cores heal, so not /thattt/ bad
 		user.adjust_fire_stacks(20)
 		user.IgniteMob()
 		LoseTarget()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Allows you to feel how hot the damaged medbeam is so you can better control how hot its getting, as well as makes it directly deal fire damage to you if it over heats as a tradeoff.
As well as makes it loudly snap on overheat.
Also slightly changes the description to better explain how it works. 
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Currently the damaged medbeam only sets you on fire, but if you're.. in space, like a explorer usually would be, that doesn't do much to them, so it doing direct damage on overheat should alleviate that a little.
The description is somewhat self explanatory. its not very explanatory on when/if it needs to be repaired when not overheated
And the snap is just fun feedback

## Testing
<!-- How did you test the PR, if at all? -->
Tested the repair steps, the heat prompts, sounds, and damage. all worked as expected
<hr>

### Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/feature_freeze/CODE_OF_CONDUCT.md#currently-changes-to-the-following-types-of-content-reuires-pre-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<!-- A list of PR types requiring pre-approval can be found here: https://github.com/ParadiseSS13/Paradise/blob/feature_freeze/CODE_OF_CONDUCT.md#currently-changes-to-the-following-types-of-content-reuires-pre-approval -->
<!-- Replace the box with [x] to mark as complete. -->
<hr>

## Changelog
:cl:
tweak: You can tell how hot the damaged medbeam is now.
tweak: Tweaked the description of the damaged medbeam.
Tweak: when overheated, the damaged medbeam will directly burn you, and play a sound
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
