### PR TITLE
New mecha module - Engineering toolbox

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -70,12 +70,12 @@
 		return
 
 	if(!force)
-		playsound(loc, 'sound/weapons/tap.ogg', get_clamped_volume(), TRUE, -1)
+		playsound(user.loc, 'sound/weapons/tap.ogg', get_clamped_volume(), TRUE, -1)
 	else
 		SEND_SIGNAL(M, COMSIG_ITEM_ATTACK)
 		add_attack_logs(user, M, "Attacked with [name] ([uppertext(user.a_intent)]) ([uppertext(damtype)])", (M.ckey && force > 0 && damtype != STAMINA) ? null : ATKLOG_ALMOSTALL)
 		if(hitsound)
-			playsound(loc, hitsound, get_clamped_volume(), TRUE, extrarange = stealthy_audio ? SILENCED_SOUND_EXTRARANGE : -1, falloff_distance = 0)
+			playsound(user.loc, hitsound, get_clamped_volume(), TRUE, extrarange = stealthy_audio ? SILENCED_SOUND_EXTRARANGE : -1, falloff_distance = 0)
 
 	M.lastattacker = user.real_name
 	M.lastattackerckey = user.ckey

--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -159,7 +159,15 @@
 	if(!interactable(user))
 		return
 
-	var/obj/item/I = user.get_active_hand()
+	var/obj/item/I
+	if(ismecha(user.loc))
+		var/obj/mecha/mecha = user.loc
+		if(istype(mecha.selected, /obj/item/mecha_parts/mecha_equipment/eng_toolset))
+			var/obj/item/mecha_parts/mecha_equipment/eng_toolset/toolset = mecha.selected
+			I = toolset.selected_item
+
+	else
+		I = user.get_active_hand()
 	var/color = lowertext(params["wire"])
 	holder.add_hiddenprint(user)
 

--- a/code/game/mecha/equipment/mecha_equipment.dm
+++ b/code/game/mecha/equipment/mecha_equipment.dm
@@ -157,3 +157,6 @@
 /obj/item/mecha_parts/mecha_equipment/proc/log_message(message)
 	if(chassis)
 		chassis.log_message("<i>[src]:</i> [message]")
+
+/obj/item/mecha_parts/mecha_equipment/proc/self_occupant_attack()
+	return

--- a/code/game/mecha/equipment/tools/work_tools.dm
+++ b/code/game/mecha/equipment/tools/work_tools.dm
@@ -492,7 +492,7 @@
 		if(item == selected_item)
 			. += "|<b>[short_name]</b> "
 		else
-			. += "|<a href='?src=[UID()];select=[item.UID()]'>[short_name]</a>"
+			. += "|<a href='byond://?src=[UID()];select=[item.UID()]'>[short_name]</a>"
 	. += "|"
 
 /obj/item/mecha_parts/mecha_equipment/eng_toolset/Topic(href,href_list)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1591,8 +1591,8 @@
 		choices[MT.name] = MA
 		choices_to_refs[MT.name] = MT
 
-	var/choice = show_radial_menu(L, L, choices, radius = 48, custom_check = CALLBACK(src, PROC_REF(check_menu), L))
-	if(!check_menu(L) || choice == "Cancel / No Change")
+	var/choice = show_radial_menu(L, L, choices, radius = 48, custom_check = CALLBACK(src, PROC_REF(open_radial_menu), L))
+	if(!open_radial_menu(L) || choice == "Cancel / No Change")
 		return
 
 	var/obj/item/mecha_parts/mecha_equipment/new_sel = LAZYACCESS(choices_to_refs, choice)
@@ -1602,7 +1602,7 @@
 		visible_message("[src] raises [selected]")
 		send_byjax(occupant, "exosuit.browser", "eq_list", get_equipment_list())
 
-/obj/mecha/proc/check_menu(mob/living/L)
+/obj/mecha/proc/open_radial_menu(mob/living/L)
 	if(L != occupant || !istype(L))
 		return FALSE
 	if(L.incapacitated())

--- a/code/game/objects/items/roulette.dm
+++ b/code/game/objects/items/roulette.dm
@@ -51,7 +51,7 @@
 							"Red" = image(icon = 'icons/obj/roulette.dmi', icon_state = colors[5]),
 							"Purple" = image(icon = 'icons/obj/roulette.dmi', icon_state = colors[6])
 							)
-	var/choice = show_radial_menu(user, src, radials, radius = 38,  custom_check = CALLBACK(src, PROC_REF(check_menu), user), require_near = TRUE)
+	var/choice = show_radial_menu(user, src, radials, radius = 38,  custom_check = CALLBACK(src, PROC_REF(open_radial_menu), user), require_near = TRUE)
 	switch(choice)
 		if("Blue")
 			options[1] = input("Customise the blue option:", name, options[1]) as text
@@ -66,7 +66,7 @@
 		if("Purple")
 			options[6] = input("Customise the purple option:", name, options[6]) as text
 
-/obj/structure/roulette/proc/check_menu(mob/living/user)
+/obj/structure/roulette/proc/open_radial_menu(mob/living/user)
 	return (istype(user) && !HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
 
 #undef SPINNING_DURATION

--- a/code/game/objects/items/tools/welder.dm
+++ b/code/game/objects/items/tools/welder.dm
@@ -27,7 +27,7 @@
 	pickup_sound =  'sound/items/handling/weldingtool_pickup.ogg'
 	var/maximum_fuel = 20
 	/// Set to FALSE if it doesn't need fuel, but serves equally well as a cost modifier.
-	var/requires_fuel = TRUE 
+	var/requires_fuel = TRUE
 	/// If TRUE, fuel will regenerate over time.
 	var/refills_over_time = FALSE
 	/// Sound played when turned on.
@@ -305,6 +305,13 @@
 	toolspeed = 0.5
 	refills_over_time = TRUE
 	low_fuel_changes_icon = FALSE
+
+/obj/item/weldingtool/mecha
+	name = "integrated welding tool"
+	desc = "An advanced welder designed to be used in robotic systems."
+	maximum_fuel = 80
+	light_intensity = 0
+	toolspeed = 0.5
 
 /obj/item/weldingtool/experimental/brass
 	name = "brass welding tool"

--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -358,13 +358,13 @@
 
 	user.visible_message("<span class='suicide'>[user] puts the barrel of [src] into [user.p_their()] mouth and pulls the trigger. It looks like [user.p_theyre()] trying to commit suicide!</span>")
 	if(!afterattack(suicide_tile, user, TRUE))
-		flags &= ~NODROP  
+		flags &= ~NODROP
 		return SHAME
 	user.visible_message("<span class='suicide'>[user] explodes as [src] builds a structure inside [user.p_them()]!</span>")
-	flags &= ~NODROP  
+	flags &= ~NODROP
 	user.gib()
-	return OBLITERATION	
-	
+	return OBLITERATION
+
 /**
  * Creates and returns a base64 icon of the given `airlock_type`.
  *
@@ -390,7 +390,7 @@
  * Arguments:
  * * user - the mob trying to open the radial menu.
  */
-/obj/item/rcd/proc/check_menu(mob/living/user)
+/obj/item/rcd/proc/open_radial_menu(mob/living/user)
 	if(!istype(user))
 		return FALSE
 	if(user.incapacitated() || !user.Adjacent(src))
@@ -425,7 +425,7 @@
  * * user - the mob trying to open the RCD radial.
  */
 /obj/item/rcd/proc/radial_menu(mob/user)
-	if(!check_menu(user))
+	if(!open_radial_menu(user))
 		return
 	var/list/choices = list(
 		MODE_AIRLOCK = image(icon = 'icons/obj/interface.dmi', icon_state = "airlock"),
@@ -440,8 +440,8 @@
 			"Change Airlock Type" = image(icon = 'icons/obj/interface.dmi', icon_state = "airlocktype")
 		)
 	choices -= mode // Get rid of the current mode, clicking it won't do anything.
-	var/choice = show_radial_menu(user, src, choices, custom_check = CALLBACK(src, PROC_REF(check_menu), user))
-	if(!check_menu(user))
+	var/choice = show_radial_menu(user, src, choices, custom_check = CALLBACK(src, PROC_REF(open_radial_menu), user))
+	if(!open_radial_menu(user))
 		return
 	switch(choice)
 		if(MODE_AIRLOCK, MODE_DECON, MODE_WINDOW, MODE_TURF)

--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -219,6 +219,17 @@
 	desc = "A cyborg-mounted plasteel knife. Extremely sharp and durable."
 	origin_tech = null
 
+/obj/item/kitchen/knife/combat/cyborg/mecha
+	name = "integrated machete"
+	desc = "A hidden plasteel blade, capable to fight with any dangerous animal. Even human."
+	force = 25
+	armour_penetration_flat = 20
+	flags = NODROP
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
+	slot_flags = null
+	w_class = WEIGHT_CLASS_HUGE
+	materials = null
+
 /*
  * Rolling Pins
  */

--- a/code/game/objects/items/weapons/rpd.dm
+++ b/code/game/objects/items/weapons/rpd.dm
@@ -251,7 +251,7 @@
 			mode = isnum(params[action]) ? params[action] : text2num(params[action])
 
 //RPD radial menu
-/obj/item/rpd/proc/check_menu(mob/living/user)
+/obj/item/rpd/proc/open_radial_menu(mob/living/user)
 	if(!istype(user))
 		return
 	if(user.incapacitated())
@@ -261,7 +261,7 @@
 	return TRUE
 
 /obj/item/rpd/proc/radial_menu(mob/user)
-	if(!check_menu(user))
+	if(!open_radial_menu(user))
 		to_chat(user, "<span class='notice'>You can't do that right now!</span>")
 		return
 	var/list/choices = list(
@@ -270,8 +270,8 @@
 		RPD_MENU_DELETE = image(icon = 'icons/obj/interface.dmi', icon_state = "rpd_delete"),
 		"UI" = image(icon = 'icons/obj/interface.dmi', icon_state = "ui_interact")
 	)
-	var/selected_mode = show_radial_menu(user, src, choices, custom_check = CALLBACK(src, PROC_REF(check_menu), user))
-	if(!check_menu(user))
+	var/selected_mode = show_radial_menu(user, src, choices, custom_check = CALLBACK(src, PROC_REF(open_radial_menu), user))
+	if(!open_radial_menu(user))
 		return
 	if(selected_mode == "UI")
 		ui_interact(user)

--- a/code/game/objects/structures/engicart.dm
+++ b/code/game/objects/structures/engicart.dm
@@ -132,7 +132,7 @@
 	if(!length(engicart_items))
 		return
 
-	var/pick = show_radial_menu(user, src, engicart_items, custom_check = CALLBACK(src, PROC_REF(check_menu), user), require_near = TRUE)
+	var/pick = show_radial_menu(user, src, engicart_items, custom_check = CALLBACK(src, PROC_REF(open_radial_menu), user), require_near = TRUE)
 
 	if(!pick)
 		return
@@ -183,7 +183,7 @@
 
 	update_icon(UPDATE_OVERLAYS)
 
-/obj/structure/engineeringcart/proc/check_menu(mob/living/user)
+/obj/structure/engineeringcart/proc/open_radial_menu(mob/living/user)
 	return istype(user) && !HAS_TRAIT(user, TRAIT_HANDS_BLOCKED)
 
 /obj/structure/engineeringcart/update_overlays()

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -143,7 +143,7 @@
 	if(!length(cart_items))
 		return
 
-	var/pick = show_radial_menu(user, src, cart_items, custom_check = CALLBACK(src, PROC_REF(check_menu), user), require_near = TRUE)
+	var/pick = show_radial_menu(user, src, cart_items, custom_check = CALLBACK(src, PROC_REF(open_radial_menu), user), require_near = TRUE)
 
 	if(!pick)
 		return
@@ -192,7 +192,7 @@
 
 	update_icon(UPDATE_OVERLAYS)
 
-/obj/structure/janitorialcart/proc/check_menu(mob/living/user)
+/obj/structure/janitorialcart/proc/open_radial_menu(mob/living/user)
 	return (istype(user) && !HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
 
 /obj/structure/janitorialcart/update_overlays()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -686,6 +686,11 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 
 	DEFAULT_QUEUE_OR_CALL_VERB(VERB_CALLBACK(src, PROC_REF(run_mode)))
 
+	if(ismecha(loc))
+		var/obj/mecha/mecha = loc
+		if(src == mecha.occupant)
+			mecha.selected?.self_occupant_attack()
+
 ///proc version to finish /mob/verb/mode() execution. used in case the proc needs to be queued for the tick after its first called
 /mob/proc/run_mode()
 	if(ismecha(loc)) return

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -633,6 +633,17 @@
 	construction_time = 10 SECONDS
 	category = list("Exosuit Equipment")
 
+/datum/design/mech_eng_toolset
+	name = "Exosuit Engineering Equipment (Engineering Toolset)"
+	desc = "Exosuit toolset. Gives a set of good tools."
+	id = "mech_eng_toolset"
+	build_type = MECHFAB
+	req_tech = list("materials" = 6, "engineering" = 4)
+	build_path = /obj/item/mecha_parts/mecha_equipment/eng_toolset
+	materials = list(MAT_METAL = 10000, MAT_TITANIUM = 2000, MAT_PLASMA = 2000)
+	construction_time = 20 SECONDS
+	category = list("Exosuit Equipment")
+
 /datum/design/mech_sleeper
 	name = "Exosuit Medical Equipment (Mounted Sleeper)"
 	id = "mech_sleeper"

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -164,15 +164,15 @@
 	else
 		Retract()
 
-/obj/item/organ/internal/cyberimp/arm/proc/check_menu(mob/user)
+/obj/item/organ/internal/cyberimp/arm/proc/open_radial_menu(mob/user)
 	return (owner && owner == user && owner.stat != DEAD && (src in owner.internal_organs) && !holder)
 
 /obj/item/organ/internal/cyberimp/arm/proc/radial_menu(mob/user)
 	var/list/choices = list()
 	for(var/obj/I in items_list)
 		choices["[I.name]"] = image(icon = I.icon, icon_state = I.icon_state)
-	var/choice = show_radial_menu(user, user, choices, custom_check = CALLBACK(src, PROC_REF(check_menu), user))
-	if(!check_menu(user))
+	var/choice = show_radial_menu(user, user, choices, custom_check = CALLBACK(src, PROC_REF(open_radial_menu), user))
+	if(!open_radial_menu(user))
 		return
 	var/obj/item/selected
 	for(var/obj/item in items_list)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Add a new module to engineering mechas - toolbox. He contains all regular tools for primary engineer with x2 speed modifyer. Steal your NanoMed now!
With emag, revealing 25 damage knife, which is copypasted behavior of toolbelt implant, but due to "this is mecha", it slightly better than combat knife.

According to https://github.com/ParadiseSS13/Paradise/pull/23802 previous attempt, welding tool now doesnt self-refill, but have a faster interaction + lower energy consumption

Also rename all proc check_menu into open_radial_menu for better understanding.

## Why It's Good For The Game
More useful modules for engineering mechas, more funny things happened because of that. 

## Images of changes
![image](https://github.com/user-attachments/assets/a596e95c-68ba-4d10-9358-fa89dbcb10a5)
![image](https://github.com/user-attachments/assets/20b41d63-302a-45ce-8970-331f3e1b79e9)
after emag, we have machete
![image](https://github.com/user-attachments/assets/e81220ac-575e-47b4-a0a8-2f5bc553bc4f)


## Testing
Copy code from (https://github.com/ParadiseSS13/Paradise/pull/23802), cut the not needed code, all work perfectly in local server.

<hr>

### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/feature_freeze/CODE_OF_CONDUCT.md#currently-changes-to-the-following-types-of-content-reuires-pre-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<!-- A list of PR types requiring pre-approval can be found here: https://github.com/ParadiseSS13/Paradise/blob/feature_freeze/CODE_OF_CONDUCT.md#currently-changes-to-the-following-types-of-content-reuires-pre-approval -->
<!-- Replace the box with [x] to mark as complete. -->
<hr>

## Changelog
:cl:
add: Added toolbox module for mecha, who contain x2 faster toolbelt. With emag, reveal 25 damage machete for tator shenanigans.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
