### PR TITLE
Makes Passive Power Consumption Safer and Fixes Negative Power Issues on APCs

### DIFF
--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -21,6 +21,8 @@
 	var/power_channel = PW_CHANNEL_EQUIPMENT
 	/// The powernet this machine is connected to
 	var/datum/local_powernet/machine_powernet = null
+	/// Has power been initialized on this machine? Set in Initialize(), prevents all power updates to the local powernet until this is TRUE to avoid weird numbers.
+	var/power_initialized = FALSE
 
 	/// how badly will it shock you?
 	var/siemens_strength = 0.7
@@ -45,9 +47,10 @@
 		machine_powernet.register_machine(src)
 		switch(power_state)
 			if(IDLE_POWER_USE)
-				add_static_power(power_channel, idle_power_consumption)
+				_add_static_power(power_channel, idle_power_consumption)
 			if(ACTIVE_POWER_USE)
-				add_static_power(power_channel, active_power_consumption)
+				_add_static_power(power_channel, active_power_consumption)
+		power_initialized = TRUE
 
 	if(!speed_process)
 		START_PROCESSING(SSmachines, src)
@@ -102,17 +105,21 @@
 
 // use active power from the local powernet
 /obj/machinery/proc/use_power(amount, channel)
-	if(!has_power())
+	if(!has_power() || !power_initialized)
 		return FALSE
 	if(!channel)
 		channel = power_channel
 	return machine_powernet.use_active_power(channel, amount)
 
-/obj/machinery/proc/add_static_power(channel, amount)
-	machine_powernet.adjust_static_power(channel, amount)
+/// Helper proc to positively adjust static power tracking on the machine's powernet, not meant for general use!
+/obj/machinery/proc/_add_static_power(channel, amount)
+	PRIVATE_PROC(TRUE)
+	machine_powernet?.adjust_static_power(channel, amount)
 
-/obj/machinery/proc/remove_static_power(channel, amount)
-	machine_powernet.adjust_static_power(channel, -amount)
+/// Helper proc to negatively adjust static power tracking on the machine's powernet, not meant for general use!
+/obj/machinery/proc/_remove_static_power(channel, amount)
+	PRIVATE_PROC(TRUE)
+	machine_powernet?.adjust_static_power(channel, -amount)
 
 /*
 	* # power_change()
@@ -143,26 +150,34 @@
 /obj/machinery/proc/change_power_mode(use_type = IDLE_POWER_USE)
 	if(isnull(use_type) || use_type == power_state || !machine_powernet || !power_channel) //if there is no powernet/channel, just end it here
 		return
+	if(!power_initialized)
+		return FALSE // we set static power values in Initialize(), do not update static consumption until after initialization or you will get weird values on powernet
 	switch(power_state)
 		if(IDLE_POWER_USE)
-			remove_static_power(power_channel, idle_power_consumption)
+			_remove_static_power(power_channel, idle_power_consumption)
 		if(ACTIVE_POWER_USE)
-			remove_static_power(power_channel, active_power_consumption)
+			_remove_static_power(power_channel, active_power_consumption)
 
 	switch(use_type)
 		if(IDLE_POWER_USE)
-			add_static_power(power_channel, idle_power_consumption)
+			_add_static_power(power_channel, idle_power_consumption)
 		if(ACTIVE_POWER_USE)
-			add_static_power(power_channel, active_power_consumption)
+			_add_static_power(power_channel, active_power_consumption)
 
 	power_state = use_type
 
+/// Safely changes the static power on the local powernet based on an adjustment in idle power
 /obj/machinery/proc/update_idle_power_consumption(channel = power_channel, amount)
+	if(!power_initialized)
+		return FALSE // we set static power values in Initialize(), do not update static consumption until after initialization or you will get weird values on powernet
 	if(power_state == IDLE_POWER_USE)
 		machine_powernet.adjust_static_power(power_channel, amount - idle_power_consumption)
 	idle_power_consumption = amount
 
+/// Safely changes the static power on the local powernet based on an adjustment in active power
 /obj/machinery/proc/update_active_power_consumption(channel = power_channel, amount)
+	if(!power_initialized)
+		return FALSE // we set static power values in Initialize(), do not update static consumption until after initialization or you will get weird values on powernet
 	if(power_state == ACTIVE_POWER_USE)
 		machine_powernet.adjust_static_power(power_channel, amount - active_power_consumption)
 	active_power_consumption = amount

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -13,9 +13,9 @@
 
 	/// How is this machine currently passively consuming power?
 	var/power_state = IDLE_POWER_USE
-	/// How much power does this machine consume when it is idling
+	/// How much power does this machine consume when it is idling. This should not be set manually, use the helper procs!
 	var/idle_power_consumption = 0
-	/// How much power does this machine consume when it is in use
+	/// How much power does this machine consume when it is in use. This should not be set manually, use the helper procs!
 	var/active_power_consumption = 0
 	/// The power channel this machine uses, idle/passive power consumption will pull from this channel and machine won't work if power channel has no power
 	var/power_channel = PW_CHANNEL_EQUIPMENT

--- a/code/modules/power/lights.dm
+++ b/code/modules/power/lights.dm
@@ -181,10 +181,6 @@
 	var/on = FALSE
 	/// Is the light currently turning on?
 	var/turning_on = FALSE
-	/// If the light state has changed since the last 'update()', also update the power requirements
-	var/light_state = FALSE
-	/// How much power does it use?
-	var/static_power_used = 0
 	/// Light range (Also used in power calculation)
 	var/brightness_range = 8
 	/// Light intensity
@@ -371,17 +367,10 @@
 	else if(!turned_off())
 		set_emergency_lights()
 	else // Turning off
-		change_power_mode(IDLE_POWER_USE)
+		change_power_mode(NO_POWER_USE)
 		set_light(0)
 	update_icon()
-	active_power_consumption = (brightness_range * 10)
-	if(on != light_state) // Light was turned on/off, so update the power usage
-		light_state = on
-		if(on)
-			static_power_used = brightness_range * 20 //20W per unit of luminosity
-			add_static_power(PW_CHANNEL_LIGHTING, static_power_used)
-		else
-			remove_static_power(PW_CHANNEL_LIGHTING, static_power_used)
+	update_active_power_consumption(PW_CHANNEL_LIGHTING, brightness_range * 10)
 
 
 /**

--- a/code/modules/power/powernets/README.md
+++ b/code/modules/power/powernets/README.md
@@ -29,3 +29,68 @@ This proc will then call `process_power()` on every single registered regional p
 --> All power producing generators dump their production into this variable
 `var/queued_power_demand` - the power in watts that will be guaranteed to be consumed in the NEXT PROCESS CYCLE
 --> Anything machine/item that needs to have priority consumption draws from the queue'd cycle first in order to ensure it gets priority power (electrocution, powersinks, etc)
+
+
+## Local Powernets
+This is a power datum that is locked to an area. There is only one local powernet datum per area which handles all power tracking/consumption
+in that area. Every area will be initialized with a local powernet datum either by the area itself or if a machine intializes before the area does.
+
+
+### The Static/Passive Power System
+Powernets used to iterate through every machine to check power, while this is incredibly accurate and straightforward, we don't really need to
+iterate through every machine (there are 1000's) since most of those machines will never change how much power they consume during their entire
+lifetime except to maybe change power states. So we made the Static/Passive power system which only tracks machine power on the local powernet
+so that we only have to iterate through the powernets instead of their machines.
+
+```dm
+/* Passive consumption vars, only change when machines are added/removed from the powernet (not if the power channel turns on/off) */
+/// The amount of power consumed by equipment in every power cycle
+VAR_PRIVATE/passive_equipment_consumption = 0
+/// The amount of power consumed by lighting in every power cycle
+VAR_PRIVATE/passive_lighting_consumption = 0
+/// The amount of power consumed by environment in every power cycle
+VAR_PRIVATE/passive_environment_consumption = 0
+```
+
+Using `adjust_static_power()`, it's possible to change these variables by inputting a channel and an amount to change the static power by.
+Due to the lack of tracking the machines and their current consumption on the local net (by design), we need to be very particular about
+how we're changing static power so we're maintaining perfect parity.
+
+On Machine types, we have unsafe private setter procs that faciliate static power changes on machines
+```dm
+/// Helper proc to positively adjust static power tracking on the machine's powernet, not meant for general use!
+/obj/machinery/proc/_add_static_power(channel, amount)
+	PRIVATE_PROC(TRUE)
+	machine_powernet?.adjust_static_power(channel, amount)
+
+/// Helper proc to negatively adjust static power tracking on the machine's powernet, not meant for general use!
+/obj/machinery/proc/_remove_static_power(channel, amount)
+	PRIVATE_PROC(TRUE)
+	machine_powernet?.adjust_static_power(channel, -amount)
+```
+These setter procs are called both in Initialize() to set the initial power and by the helper procs we have in machines. **Coders should not be
+using `_add_static_power` or `_remove_static_power` ever unless they're changing how power functions on the base machine type. Instead you should
+be using the safe helper procs below!**
+```dm
+/// Safely changes the static power on the local powernet based on an adjustment in idle power
+/obj/machinery/proc/update_idle_power_consumption(channel = power_channel, amount)
+	if(!power_initialized)
+		return FALSE // we set static power values in Initialize(), do not update static consumption until after initialization or you will get weird values on powernet
+	if(power_state == IDLE_POWER_USE)
+		machine_powernet.adjust_static_power(power_channel, amount - idle_power_consumption)
+	idle_power_consumption = amount
+
+/// Safely changes the static power on the local powernet based on an adjustment in active power
+/obj/machinery/proc/update_active_power_consumption(channel = power_channel, amount)
+	if(!power_initialized)
+		return FALSE // we set static power values in Initialize(), do not update static consumption until after initialization or you will get weird values on powernet
+	if(power_state == ACTIVE_POWER_USE)
+		machine_powernet.adjust_static_power(power_channel, amount - active_power_consumption)
+	active_power_consumption = amount
+```
+These allow you to safely set how much power a machine will use when it's "Active" or "Idle," and the procs will handle changing the static
+power for you. That way you never have to worry about losing parity when you're just trying to make your new machine consume power.
+
+As a note: you should never be manually setting power consumption variables in code, this is a really quick way to get funky number on your
+powernet. So for example don't edit `power_state`, `idle_power_consumption`, or `active_power_consumption`; Use their respective setter procs
+that are already defined on `/machinery`!

--- a/code/modules/power/powernets/local_powernet.dm
+++ b/code/modules/power/powernets/local_powernet.dm
@@ -26,11 +26,11 @@
 
 	/* Passive consumption vars, only change when machines are added/removed from the powernet (not if the power channel turns on/off) */
 	/// The amount of power consumed by equipment in every power cycle
-	var/passive_equipment_consumption = 0
+	VAR_PRIVATE/passive_equipment_consumption = 0
 	/// The amount of power consumed by lighting in every power cycle
-	var/passive_lighting_consumption = 0
+	VAR_PRIVATE/passive_lighting_consumption = 0
 	/// The amount of power consumed by environment in every power cycle
-	var/passive_environment_consumption = 0
+	VAR_PRIVATE/passive_environment_consumption = 0
 
 	/* Active consumption vars, changed when machines need spurts of power, unlike passive consumption these reset to 0 every process() cycle */
 	/// The amount of power consumed by equipment in this power cycle

--- a/code/modules/power/powernets/local_powernet.dm
+++ b/code/modules/power/powernets/local_powernet.dm
@@ -41,8 +41,6 @@
 	var/environment_consumption = 0
 
 	/* Total consumption vars, tracking vars that only count aggregate consumption from active power channels */
-	/// The amount of the total power consumed passively in power cycles (i.e, each cycle), does not include power channels that are off
-	var/passive_consumption = 0
 	/// The amount of total power consumed consumed in only this cycle
 	var/active_consumption = 0
 
@@ -85,17 +83,14 @@
 		if(PW_CHANNEL_EQUIPMENT)
 			if(equipment_powered == new_state)
 				return
-			passive_consumption += (passive_equipment_consumption * (new_state ? 1 : -1))
 			equipment_powered = new_state
 		if(PW_CHANNEL_LIGHTING)
 			if(lighting_powered == new_state)
 				return
-			passive_consumption += (passive_lighting_consumption * (new_state ? 1 : -1))
 			lighting_powered = new_state
 		if(PW_CHANNEL_ENVIRONMENT)
 			if(environment_powered == new_state)
 				return
-			passive_consumption += (passive_environment_consumption * (new_state ? 1 : -1))
 			environment_powered = new_state
 	power_change()
 
@@ -150,12 +145,11 @@
 			passive_environment_consumption += amount
 		else
 			return FALSE
-	if(has_power(channel)) // our total consumption vars don't track unpowered channels, so don't change the var if there's no power
-		passive_consumption += amount
 	return TRUE
 
+/// Returns the local powernets total power usage between all three of its channels, only includes usage on currently powered channels
 /datum/local_powernet/proc/get_total_usage()
-	return passive_consumption + active_consumption
+	return get_channel_usage(PW_CHANNEL_EQUIPMENT) + get_channel_usage(PW_CHANNEL_LIGHTING) + get_channel_usage(PW_CHANNEL_ENVIRONMENT)
 
 /// returns active + passive power of a channel, if the channel is not powered it returns 0 watts
 /datum/local_powernet/proc/get_channel_usage(channel)

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -503,8 +503,8 @@
 // timed process
 // charge the gas reservoir and perform flush if ready
 /obj/machinery/disposal/process()
-	change_power_mode(NO_POWER_USE)
 	if(stat & BROKEN)			// nothing can happen if broken
+		change_power_mode(NO_POWER_USE)
 		return
 
 	flush_count++
@@ -523,20 +523,17 @@
 	if(stat & NOPOWER)			// won't charge if no power
 		return
 
-	change_power_mode(IDLE_POWER_USE)
-
 	if(mode != DISPOSALS_RECHARGING)		// if off or ready, no need to charge
 		return
 
-	// otherwise charge
-	change_power_mode(ACTIVE_POWER_USE)
+	change_power_mode(IDLE_POWER_USE) // only start using power when we're sucking in air
 
 	var/datum/milla_safe/disposal_suck_air/milla = new()
 	milla.invoke_async(src)
 
 // perform a flush
 /obj/machinery/disposal/proc/flush()
-
+	change_power_mode(ACTIVE_POWER_USE)
 	flushing = 1
 	flick("[icon_state]-flush", src)
 
@@ -571,6 +568,9 @@
 	flush = 0
 	if(mode == DISPOSALS_CHARGED)	// if was ready,
 		mode = DISPOSALS_RECHARGING	// switch to charging
+		change_power_mode(IDLE_POWER_USE)
+	else
+		change_power_mode(NO_POWER_USE)
 	update()
 	return
 

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -503,8 +503,8 @@
 // timed process
 // charge the gas reservoir and perform flush if ready
 /obj/machinery/disposal/process()
+	change_power_mode(NO_POWER_USE)
 	if(stat & BROKEN)			// nothing can happen if broken
-		change_power_mode(NO_POWER_USE)
 		return
 
 	flush_count++
@@ -523,17 +523,20 @@
 	if(stat & NOPOWER)			// won't charge if no power
 		return
 
+	change_power_mode(IDLE_POWER_USE)
+
 	if(mode != DISPOSALS_RECHARGING)		// if off or ready, no need to charge
 		return
 
-	change_power_mode(IDLE_POWER_USE) // only start using power when we're sucking in air
+	// otherwise charge
+	change_power_mode(ACTIVE_POWER_USE)
 
 	var/datum/milla_safe/disposal_suck_air/milla = new()
 	milla.invoke_async(src)
 
 // perform a flush
 /obj/machinery/disposal/proc/flush()
-	change_power_mode(ACTIVE_POWER_USE)
+
 	flushing = 1
 	flick("[icon_state]-flush", src)
 
@@ -568,9 +571,6 @@
 	flush = 0
 	if(mode == DISPOSALS_CHARGED)	// if was ready,
 		mode = DISPOSALS_RECHARGING	// switch to charging
-		change_power_mode(IDLE_POWER_USE)
-	else
-		change_power_mode(NO_POWER_USE)
 	update()
 	return
 


### PR DESCRIPTION
## What Does This PR Do
Fixes several issues with negative power & incorrect power readouts on APCs

Namely Fixes #20980

This PR implements much safer procs & variables for the local powernet static/passive power systems. Lights were a flagrant example of unsafe implementation of this system which was resulting in wild numbers that should not be possible and even negative readout. 

Furthermore, passive power tracking in local powernet is removed, instead we just manually readout from each power channel and aggregate the consumption. This is a lot safer and no longer prone to bad tracking.

Finally, machines now have a `power_initialized` variable tacked on to them which tracks whether or not we've initialized power on this machine yet. This locks out consuming power on a machine until we properly set the static power consumption.

## Why It's Good For The Game
Negative power should be impossible.

Sets some groundwork for reviving #21250

## Testing
I wrote an entire TGUI debugging tool to log power changes to investigate how this bug was even occurring in the first place.
After implementing these final code changes, I booted up a local test server and ensure that power values on the local powernet & the public displayed APC numbers were correct.

<hr>

### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/feature_freeze/CODE_OF_CONDUCT.md#currently-changes-to-the-following-types-of-content-reuires-pre-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<!-- A list of PR types requiring pre-approval can be found here: https://github.com/ParadiseSS13/Paradise/blob/feature_freeze/CODE_OF_CONDUCT.md#currently-changes-to-the-following-types-of-content-reuires-pre-approval -->
<!-- Replace the box with [x] to mark as complete. -->
<hr>

## Changelog
:cl:
fix: APCs no longer draw negative power or display incorrect master channel power consumption values
/:cl:
