### PR TITLE
Proto pulse slugs no longer immediately destroy reinforced walls

### DIFF
--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -133,9 +133,9 @@
 
 /obj/item/projectile/beam/pulse/on_hit(atom/target, blocked = 0)
 	if(isreinforcedwallturf(target) && weakened_against_rwalls)
-		target.ex_act(3)
+		target.ex_act(EXPLODE_LIGHT)
 	else if(isturf(target) || isstructure(target) || ismachinery(target))
-		target.ex_act(2)
+		target.ex_act(EXPLODE_HEAVY)
 	..()
 
 /obj/item/projectile/beam/pulse/shot

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -111,6 +111,8 @@
 	damage = 50
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/blue_laser
 	light_color = LIGHT_COLOR_DARKBLUE
+	/// If this shot can immediately destroy rwalls or not
+	var/weakened_against_rwalls = FALSE
 
 /obj/item/projectile/beam/pulse/hitscan
 	impact_effect_type = null
@@ -130,13 +132,16 @@
 	impact_light_color_override = LIGHT_COLOR_DARKBLUE
 
 /obj/item/projectile/beam/pulse/on_hit(atom/target, blocked = 0)
-	if(isturf(target) || isstructure(target) || ismachinery(target))
+	if(isreinforcedwallturf(target) && weakened_against_rwalls)
+		target.ex_act(3)
+	else if(isturf(target) || isstructure(target) || ismachinery(target))
 		target.ex_act(2)
 	..()
 
 /obj/item/projectile/beam/pulse/shot
 	name = "proto pulse"
 	damage = 40
+	weakened_against_rwalls = TRUE
 
 /obj/item/projectile/beam/emitter
 	name = "emitter beam"


### PR DESCRIPTION
## What Does This PR Do
This changes proto pulse slugs to call `ex_act(3)` (damaging them) on rwalls instead of `ex_act(2)` that can delete them immediately with 50% chance.

Here it is in action and here is the parent (the dsquad pulse) not affected by it:

https://github.com/user-attachments/assets/992bbdf8-9362-4692-afc5-f792acc1897a

## Why It's Good For The Game

This is no longer possible:

https://github.com/user-attachments/assets/83255766-f1f6-4035-8744-6d6aaab86310

It was/is being discussed in this [Discord thread](https://discord.com/channels/145533722026967040/1271439593161621598/1271439593161621598).


## Images of changes

See video above.

## Testing

~~It compiled~~ I made the video above.

<hr>

### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/feature_freeze/CODE_OF_CONDUCT.md#currently-changes-to-the-following-types-of-content-reuires-pre-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

![image](https://github.com/user-attachments/assets/027b782c-cce5-4258-a1c1-a4e89cfc858a)


## Changelog
:cl:
tweak: Proto pulse slugs can no longer destroy reinforced walls with a 50% chance. Instead, they deal damage to them. The deathsquad pulse slugs are not affected by this change.
/:cl:
