### PR TITLE
Cleans up disposal chute power state changes to reduce the number of proc calls it makes throughout the round

### DIFF
--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -1196,7 +1196,7 @@
 	updatedir()
 	if(mapload)
 		parse_sort_destinations()
-	update_appearance(UPDATE_DESC)
+	update_appearance(UPDATE_NAME|UPDATE_DESC)
 	update()
 	return
 

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -503,8 +503,8 @@
 // timed process
 // charge the gas reservoir and perform flush if ready
 /obj/machinery/disposal/process()
-	change_power_mode(NO_POWER_USE)
 	if(stat & BROKEN)			// nothing can happen if broken
+		change_power_mode(NO_POWER_USE)
 		return
 
 	flush_count++
@@ -523,20 +523,17 @@
 	if(stat & NOPOWER)			// won't charge if no power
 		return
 
-	change_power_mode(IDLE_POWER_USE)
-
 	if(mode != DISPOSALS_RECHARGING)		// if off or ready, no need to charge
 		return
 
-	// otherwise charge
-	change_power_mode(ACTIVE_POWER_USE)
+	change_power_mode(IDLE_POWER_USE) // only start using power when we're sucking in air
 
 	var/datum/milla_safe/disposal_suck_air/milla = new()
 	milla.invoke_async(src)
 
 // perform a flush
 /obj/machinery/disposal/proc/flush()
-
+	change_power_mode(ACTIVE_POWER_USE)
 	flushing = 1
 	flick("[icon_state]-flush", src)
 
@@ -571,6 +568,9 @@
 	flush = 0
 	if(mode == DISPOSALS_CHARGED)	// if was ready,
 		mode = DISPOSALS_RECHARGING	// switch to charging
+		change_power_mode(IDLE_POWER_USE)
+	else
+		change_power_mode(NO_POWER_USE)
 	update()
 	return
 
@@ -1196,7 +1196,7 @@
 	updatedir()
 	if(mapload)
 		parse_sort_destinations()
-	update_appearance(UPDATE_NAME|UPDATE_DESC)
+	update_appearance(UPDATE_DESC)
 	update()
 	return
 


### PR DESCRIPTION
## What Does This PR Do
Updates Disposals power changes to only change it's power state when absolutely neccesary. Instead of changing every `process()` cycle, the disposal chute only changes power states when it is flushed or broken.

## Why It's Good For The Game
Currently, disposal chutes update their power state to `NO_POWER_USE` at the beginning of `process()` and then assigns it to `IDLE_POWER_USE` or `ACTIVE_POWER_USE` later in the proc. This doesn't seem like a big deal until you do the math.

65+ Disposals Chutes on Box and each time the state is changed, 4 separate procs are called in the chain. Since the state is currently changed twice every process() cycle and the disposal chute processes 30 times a minute each, it adds up over a 2 hour round

**Before Change:** 65 chutes * 8 Proc Calls a Process() * 30 Proceses a Minute * 120 Minutes = 1,872,000 proc calls over a round

Our new changes ensure that we do not unnecessarily change states, we still always call `change_power_mode()` in `process()` but early returns catch and stop the proc chain since our power_state is generally going to always be the same as what we're trying to change it to compared to before

**After Change:** 65 chutes * 1 Proc Call a Process() * 30 Processes a Minute * 120 Minutes = 234,000 Proc Calls

The total numbers are higher just b/c 65 chutes is a guestimate based on searching the .dmm file. However, the magnitude in the difference is the same. It's about 8 times less proc calls. Another thing I haven't mentioned, is this is only now when the chute is charging, which means that for about 95% of a chutes lifespan (unless people are constantly throwing shit in them), it's not going to be changing power states due to an early return. So it may actually end up only being around 12,000 proc calls in total which is 00.6% of the previous performance cost.

Cleaning up power code to start working on #21250 again
## Testing
Used my powernet debugger to check disposals power changes on local powernets
* Saw repeated back and forth switches before edits were made
* Confirmed power changes only happen when chute flushes/starts charging/breaks after edits were applied

<hr>

### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/feature_freeze/CODE_OF_CONDUCT.md#currently-changes-to-the-following-types-of-content-reuires-pre-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<hr>

## Changelog
NPFC