### PR TITLE
Airlock Access Buttons will now correctly consume power on powernets

### DIFF
--- a/code/game/machinery/airlock_control/airlock_button.dm
+++ b/code/game/machinery/airlock_control/airlock_button.dm
@@ -7,7 +7,8 @@ GLOBAL_LIST_EMPTY(all_airlock_access_buttons)
 	desc = "Controls an airlock controller, requesting the doors open on this side."
 	layer = ABOVE_WINDOW_LAYER
 	anchored = TRUE
-	power_state = PW_CHANNEL_ENVIRONMENT
+	power_channel = PW_CHANNEL_ENVIRONMENT
+	power_state = IDLE_POWER_USE
 	/// Id to be used by the controller to grab us on spawn
 	var/autolink_id
 	/// UID of the airlock controller that owns us


### PR DESCRIPTION
## What Does This PR Do
Makes it so that airlock access buttons have a properly set power use state and power channel.

## Why It's Good For The Game
Airlock access buttons are machines and should consume power properly like everything else. This fixes that.
Even though they're not set to consume power atm, later they likely will be and this patches that issue before it ever becomes a problem.

cleaning up code in preparation to revive #21250

## Images of changes
<details>

Before
![before](https://github.com/user-attachments/assets/66b3ccb3-1cbf-49e6-92f8-8431d92a1f56)

After
![after](https://github.com/user-attachments/assets/d453ebf1-9394-42dc-a403-cbc922583390)

</details>

## Testing
Checked Airlock Access Button power state vars before and after, fixed state confirmed in above screenshots

<hr>

### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/feature_freeze/CODE_OF_CONDUCT.md#currently-changes-to-the-following-types-of-content-reuires-pre-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<hr>

## Changelog
:cl:
fix: Airlock Access Buttons consume power properly again
/:cl:
