### PR TITLE
Adds 3 new light crates

### DIFF
--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -346,21 +346,8 @@
 	desc = "A large box filled to the brim with cheap emergency glowsticks."
 
 /obj/item/storage/box/large/glowstick/emergency/populate_contents()
-	new /obj/item/flashlight/flare/glowstick/emergency(src)
-	new /obj/item/flashlight/flare/glowstick/emergency(src)
-	new /obj/item/flashlight/flare/glowstick/emergency(src)
-	new /obj/item/flashlight/flare/glowstick/emergency(src)
-	new /obj/item/flashlight/flare/glowstick/emergency(src)
-	new /obj/item/flashlight/flare/glowstick/emergency(src)
-	new /obj/item/flashlight/flare/glowstick/emergency(src)
-	new /obj/item/flashlight/flare/glowstick/emergency(src)
-	new /obj/item/flashlight/flare/glowstick/emergency(src)
-	new /obj/item/flashlight/flare/glowstick/emergency(src)
-	new /obj/item/flashlight/flare/glowstick/emergency(src)
-	new /obj/item/flashlight/flare/glowstick/emergency(src)
-	new /obj/item/flashlight/flare/glowstick/emergency(src)
-	new /obj/item/flashlight/flare/glowstick/emergency(src)
-	new /obj/item/flashlight/flare/glowstick/emergency(src)
+	for(var/i in 1 to 15)
+		new /obj/item/flashlight/flare/glowstick/emergency(src)
 
 /obj/item/storage/box/glowstick/premium
 	name = "premium glowstick box"

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -367,11 +367,8 @@
 	desc = "A box filled with high-quality military surplus glowsticks."
 
 /obj/item/storage/box/glowstick/premium/populate_contents()
-	new /obj/item/flashlight/flare/glowstick(src)
-	new /obj/item/flashlight/flare/glowstick(src)
-	new /obj/item/flashlight/flare/glowstick(src)
-	new /obj/item/flashlight/flare/glowstick(src)
-	new /obj/item/flashlight/flare/glowstick(src)
+	for(var/i in 1 to 5)
+		new /obj/item/flashlight/flare/glowstick(src))
 
 /obj/item/storage/box/flares
 	name = "emergency flare box"

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -355,7 +355,7 @@
 
 /obj/item/storage/box/glowstick/premium/populate_contents()
 	for(var/i in 1 to 5)
-		new /obj/item/flashlight/flare/glowstick(src))
+		new /obj/item/flashlight/flare/glowstick(src)
 
 /obj/item/storage/box/flares
 	name = "emergency flare box"

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -341,6 +341,50 @@
 	new /obj/item/stack/sheet/metal/fifty(src)
 	new /obj/item/stack/cable_coil(src)
 
+/obj/item/storage/box/large/glowstick/emergency
+	name = "emergency glowstick box"
+	desc = "A large box filled to the brim with cheap emergency glowsticks."
+
+/obj/item/storage/box/large/glowstick/emergency/populate_contents()
+	new /obj/item/flashlight/flare/glowstick/emergency(src)
+	new /obj/item/flashlight/flare/glowstick/emergency(src)
+	new /obj/item/flashlight/flare/glowstick/emergency(src)
+	new /obj/item/flashlight/flare/glowstick/emergency(src)
+	new /obj/item/flashlight/flare/glowstick/emergency(src)
+	new /obj/item/flashlight/flare/glowstick/emergency(src)
+	new /obj/item/flashlight/flare/glowstick/emergency(src)
+	new /obj/item/flashlight/flare/glowstick/emergency(src)
+	new /obj/item/flashlight/flare/glowstick/emergency(src)
+	new /obj/item/flashlight/flare/glowstick/emergency(src)
+	new /obj/item/flashlight/flare/glowstick/emergency(src)
+	new /obj/item/flashlight/flare/glowstick/emergency(src)
+	new /obj/item/flashlight/flare/glowstick/emergency(src)
+	new /obj/item/flashlight/flare/glowstick/emergency(src)
+	new /obj/item/flashlight/flare/glowstick/emergency(src)
+
+/obj/item/storage/box/glowstick/premium
+	name = "premium glowstick box"
+	desc = "A box filled with high-quality military surplus glowsticks."
+
+/obj/item/storage/box/glowstick/premium/populate_contents()
+	new /obj/item/flashlight/flare/glowstick(src)
+	new /obj/item/flashlight/flare/glowstick(src)
+	new /obj/item/flashlight/flare/glowstick(src)
+	new /obj/item/flashlight/flare/glowstick(src)
+	new /obj/item/flashlight/flare/glowstick(src)
+
+/obj/item/storage/box/flares
+	name = "emergency flare box"
+	desc = "A box full of magnesium signal flares."
+
+/obj/item/storage/box/flares/populate_contents()
+	new /obj/item/flashlight/flare(src)
+	new /obj/item/flashlight/flare(src)
+	new /obj/item/flashlight/flare(src)
+	new /obj/item/flashlight/flare(src)
+	new /obj/item/flashlight/flare(src)
+
+
 //////////////////
 /* Monkey Boxes */
 //////////////////

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -362,11 +362,8 @@
 	desc = "A box full of magnesium signal flares."
 
 /obj/item/storage/box/flares/populate_contents()
-	new /obj/item/flashlight/flare(src)
-	new /obj/item/flashlight/flare(src)
-	new /obj/item/flashlight/flare(src)
-	new /obj/item/flashlight/flare(src)
-	new /obj/item/flashlight/flare(src)
+	for(var/i in 1 to 5)
+		new /obj/item/flashlight/flare(src)
 
 
 //////////////////

--- a/code/modules/supply/supply_packs/pack_emergency.dm
+++ b/code/modules/supply/supply_packs/pack_emergency.dm
@@ -41,6 +41,8 @@
 /datum/supply_packs/emergency/glowstick/premium
 	name = "Premium Glowstick Crate"
 	contains = list(/obj/item/storage/box/glowstick/premium,
+					/obj/item/storage/box/glowstick/premium,
+					/obj/item/storage/box/glowstick/premium,
 					/obj/item/storage/box/glowstick/premium)
 	cost = 200
 	containertype = /obj/structure/closet/crate

--- a/code/modules/supply/supply_packs/pack_emergency.dm
+++ b/code/modules/supply/supply_packs/pack_emergency.dm
@@ -27,6 +27,34 @@
 	containername = "emergency crate"
 	group = SUPPLY_EMERGENCY
 
+/datum/supply_packs/emergency/glowstick/emergency
+	name = "Emergency Glowstick Crate"
+	contains = list(/obj/item/storage/box/large/glowstick/emergency,
+					/obj/item/storage/box/large/glowstick/emergency,
+					/obj/item/storage/box/large/glowstick/emergency,
+					/obj/item/storage/box/large/glowstick/emergency,
+					/obj/item/storage/box/large/glowstick/emergency)
+	cost = 100
+	containertype = /obj/structure/closet/crate
+	containername = "emergency glowstick crate"
+
+/datum/supply_packs/emergency/glowstick/premium
+	name = "Premium Glowstick Crate"
+	contains = list(/obj/item/storage/box/glowstick/premium,
+					/obj/item/storage/box/glowstick/premium)
+	cost = 200
+	containertype = /obj/structure/closet/crate
+	containername = "premium glowstick crate"
+
+/datum/supply_packs/emergency/flares
+	name = "Emergency Flare Crate"
+	contains = list(/obj/item/storage/box/flares,
+					/obj/item/storage/box/flares,
+					/obj/item/storage/box/flares)
+	cost = 150
+	containertype = /obj/structure/closet/crate
+	containername = "emergency flare crate"
+
 /datum/supply_packs/emergency/internals
 	name = "Internals Crate"
 	contains = list(/obj/item/clothing/mask/gas,


### PR DESCRIPTION
## What Does This PR Do
Adds three new crates full of temporary lights for all your aesthetic and emergency needs.

Emergency Glowstick Crate: 75 cheap, shitty glowsticks, the same as what you find in a normal emergency box. Useful for equipping a horde of tiders. 100 credits.

Premium Glowstick Crate: 20 military glowsticks that last a whole lot longer than the emergency ones, and come in a nice green color. 200 credits.

Emergency Flare Crate: 15 magnesium signal flares, they don't last as long as the premium glowsticks but produce a very aesthetic red light. 150 credits.

## Why It's Good For The Game
Having other sources of light beyond just flashlights is neat. The glowsticks and signal flares are also incredibly atmospheric, and barely used at all as of now. Plus, large boxes.

## Testing
- Loaded in.
- Bought crates.
- Opened crates.
- Opened boxes in crates.
- Acquired light.

## Changelog
:cl:
add: Added 3 new emergency light crates
/:cl: