### PR TITLE
Adds extended descriptions to tarot cards.

### DIFF
--- a/code/game/gamemodes/wizard/magic_tarot.dm
+++ b/code/game/gamemodes/wizard/magic_tarot.dm
@@ -654,7 +654,7 @@
 /datum/tarot/reversed/the_magician
 	name = "I - The Magician?"
 	desc = "May no harm come to you."
-	extended_desc = "contains the power of a great mage, apon use the user will repulse everything away from them."
+	extended_desc = "contains the power of a great mage, upon use the user will repulse everything away from them."
 	card_icon = "the_magician?"
 
 /datum/tarot/reversed/the_magician/activate(mob/living/target)

--- a/code/game/gamemodes/wizard/magic_tarot.dm
+++ b/code/game/gamemodes/wizard/magic_tarot.dm
@@ -304,7 +304,7 @@
 /datum/tarot/the_high_priestess
 	name = "II - The High Priestess"
 	desc = "Mother is watching you."
-	extended_desc = "alerts Bubblegum to the user, allowing her to rend the effected user, dealing heavy damage, and imobilizing the user for a short time."
+	extended_desc = "alerts bubblegum to the user, allowing him to strike them down, dealing heavy damage and immobilizing them."
 	card_icon = "the_high_priestess"
 
 /datum/tarot/the_high_priestess/activate(mob/living/target)
@@ -940,7 +940,7 @@
 /datum/tarot/reversed/the_sun
 	name = "XIX - The Sun?"
 	desc = "May the darkness swallow all around you."
-	extended_desc = "grants the user a weakened version of an umbral vampire's eternal darkness ability for one minute. However, the user will also become nearsighted for the duration."
+	extended_desc = "makes the user emit darkness, freezing anyone nearby. They will also become nearsighted for the duration, however."
 	card_icon = "the_sun?"
 
 /datum/tarot/reversed/the_sun/activate(mob/living/target)

--- a/code/game/gamemodes/wizard/magic_tarot.dm
+++ b/code/game/gamemodes/wizard/magic_tarot.dm
@@ -146,7 +146,7 @@
 	/// Our fancy description given to use by the tarot datum.
 	var/card_desc = "Untold answers... wait what? This is a bug, report this as an issue on github!"
 	/// Used for examine_more, for what cards do
-	var/card_extended_desc = "will make the user report this as an bug on the github!"
+	var/card_extended_desc = "will make the user report this as a bug on GitHub!"
 	/// Is the card face down? Shows the card back, hides the examine / name.
 	var/face_down = FALSE
 	/// Will this card automatically disappear if thrown at a non-mob?
@@ -266,7 +266,7 @@
 	/// Desc used for the card description of the card
 	var/desc = "Untold answers... wait what? This is a bug, report this as an issue on github!"
 	/// Extended desc for the cards. For what they do
-	var/extended_desc = "asks you to report this as a bug on the github!"
+	var/extended_desc = "asks you to report this as a bug on GitHub!"
 	/// What icon is used for the card?
 	var/card_icon = "the_unknown"
 	/// Are we reversed? Used for the card back.
@@ -372,7 +372,7 @@
 /datum/tarot/the_hierophant
 	name = "V - The Hierophant"
 	desc = "Two prayers for the lost."
-	extended_desc = "Enchant the users suit with magic that's strong enough to negate three attacks."
+	extended_desc = "enchants the user's suit with magic that's strong enough to negate three attacks."
 	card_icon = "the_hierophant"
 
 /datum/tarot/the_hierophant/activate(mob/living/target)
@@ -428,7 +428,7 @@
 /datum/tarot/the_hermit
 	name = "IX - The Hermit"
 	desc = "May you see what life has to offer."
-	extended_desc = "warps the user to a random vending machine within the station"
+	extended_desc = "teleports the user to a random vending machine within the station."
 	card_icon = "the_hermit"
 
 /datum/tarot/the_hermit/activate(mob/living/target)
@@ -448,7 +448,7 @@
 /datum/tarot/wheel_of_fortune
 	name = "X - Wheel of Fortune"
 	desc = "Spin the wheel of destiny."
-	extended_desc = "summons a random vender right out of bluespace."
+	extended_desc = "summons a random vending machine right out of bluespace."
 	card_icon = "wheel_of_fortune"
 
 /datum/tarot/wheel_of_fortune/activate(mob/living/target)
@@ -462,7 +462,7 @@
 /datum/tarot/strength
 	name = "XI - Strength"
 	desc = "May your power bring rage."
-	extended_desc = "grants the user strength only matched by powerful vampires. The strength blocks use of ranged weapons."
+	extended_desc = "grants the user strength only matched by powerful vampires. The strength renders the user unable to handle ranged weapons."
 	card_icon = "strength"
 
 /datum/tarot/strength/activate(mob/living/target)
@@ -520,7 +520,7 @@
 /datum/tarot/the_devil
 	name = "XV - The Devil"
 	desc = "Revel in the power of darkness."
-	extended_desc = "grants a large amount of healing, at the cost of others around the user."
+	extended_desc = "grants a large amount of healing at the cost of others around the user."
 	card_icon = "the_devil"
 
 /datum/tarot/the_devil/activate(mob/living/target)
@@ -529,7 +529,7 @@
 /datum/tarot/the_tower
 	name = "XVI - The Tower"
 	desc = "Destruction brings creation."
-	extended_desc = "contains the raw power of the grey tide within. Summons a primed cluster IED."
+	extended_desc = "contains the raw power of the greytide within. Summons a primed cluster IED."
 	card_icon = "the_tower"
 
 /datum/tarot/the_tower/activate(mob/living/target)
@@ -540,7 +540,7 @@
 /datum/tarot/the_stars
 	name = "XVII - The Stars"
 	desc = "May you find what you desire."
-	extended_desc = "warps the user to the stations evidence lockup, and opens a single locker within."
+	extended_desc = "teleports the user to the station's evidence room, and opens a single locker within."
 	card_icon = "the_stars"
 
 /datum/tarot/the_stars/activate(mob/living/target)
@@ -614,7 +614,7 @@
 /datum/tarot/judgement
 	name = "XX - Judgement"
 	desc = "Judge lest ye be judged."
-	extended_desc = "alerts the denizens of the afterlife to the users existence. Prepare to be judged."
+	extended_desc = "alerts the denizens of the afterlife to the user's existence. Prepare to be judged."
 	card_icon = "judgement"
 
 /datum/tarot/judgement/activate(mob/living/target)
@@ -639,7 +639,7 @@
 /datum/tarot/reversed/the_fool
 	name = "0 - The Fool?"
 	desc = "Let go and move on."
-	extended_desc = "removes all items off of the user, leaving them completely naked."
+	extended_desc = "removes all items from the user, leaving them completely naked."
 	card_icon = "the_fool?"
 
 /datum/tarot/reversed/the_fool/activate(mob/living/target)
@@ -698,7 +698,7 @@
 /datum/tarot/reversed/the_empress
 	name = "III - The Empress?"
 	desc = "May your love bring protection."
-	extended_desc = "will leave anyone within range unable to commit an act of violence for 40 seconds, aside from the user."
+	extended_desc = "makes everyone within range unable to commit an act of violence for 40 seconds, aside from the user."
 	card_icon = "the_empress?"
 
 /datum/tarot/reversed/the_empress/activate(mob/living/target)
@@ -708,7 +708,7 @@
 /datum/tarot/reversed/the_emperor
 	name = "IV - The Emperor?"
 	desc = "May you find a worthy opponent."
-	extended_desc = "warps the user of this card to a random head of staff."
+	extended_desc = "teleports the user to a random head of staff."
 	card_icon = "the_emperor?"
 
 /datum/tarot/reversed/the_emperor/activate(mob/living/target)
@@ -747,7 +747,7 @@
 /datum/tarot/reversed/the_lovers
 	name = "VI - The Lovers?"
 	desc = "May your heart shatter to pieces."
-	extended_desc = "causes the user of this card to experience true heart break. Leaving their chest broken, and battered."
+	extended_desc = "causes the user of this card to experience true heartbreak - leaving their chest broken and battered."
 	card_icon = "the_lovers?"
 
 /datum/tarot/reversed/the_lovers/activate(mob/living/target)
@@ -765,7 +765,7 @@
 /datum/tarot/reversed/the_chariot
 	name = "VII - The Chariot?"
 	desc = "May nothing walk past you."
-	extended_desc = "will petrify the user for two minutes. However they will be totally indestructible."
+	extended_desc = "will petrify the user for two minutes, rendering them completely indestructible."
 	card_icon = "the_chariot?"
 
 /datum/tarot/reversed/the_chariot/activate(mob/living/target)
@@ -815,7 +815,7 @@
 /datum/tarot/reversed/wheel_of_fortune
 	name = "X - Wheel of Fortune?"
 	desc = "Throw the dice of fate."
-	extended_desc = "forces the user of the card to roll a powerful magical artifact, the outcome can be highly positive or highly negative, it is up to fate what happens now."
+	extended_desc = "forces the user to roll for a powerful magical artifact. The outcome can be highly positive or highly negative, it is up to fate."
 	card_icon = "wheel_of_fortune?"
 
 /datum/tarot/reversed/wheel_of_fortune/activate(mob/living/target)
@@ -837,7 +837,7 @@
 /datum/tarot/reversed/the_hanged_man
 	name = "XII - The Hanged Man?"
 	desc = "May your greed know no bounds."
-	extended_desc = "forces the user of this card to roll a cursed slot machine."
+	extended_desc = "forces the user to spin a cursed slot machine."
 	card_icon = "the_hanged_man?"
 
 /datum/tarot/reversed/the_hanged_man/activate(mob/living/target)
@@ -876,7 +876,7 @@
 /datum/tarot/reversed/the_devil
 	name = "XV - The Devil?"
 	desc = "Bask in the light of your mercy."
-	extended_desc = "summons a primed cluster flashbang at the users feet."
+	extended_desc = "summons a primed cluster flashbang at the user's feet."
 	card_icon = "the_devil?"
 
 /datum/tarot/reversed/the_devil/activate(mob/living/target)
@@ -930,7 +930,7 @@
 /datum/tarot/reversed/the_moon
 	name = "XVIII - The Moon?"
 	desc = "May you remember lost memories."
-	extended_desc = "will reveal the users memory to those within 5 tiles. This can include uplink codes."
+	extended_desc = "will reveal the memories of everyone within 5 tiles to the user, including bank account information and uplink codes."
 	card_icon = "the_moon?"
 
 /datum/tarot/reversed/the_moon/activate(mob/living/target)
@@ -940,7 +940,7 @@
 /datum/tarot/reversed/the_sun
 	name = "XIX - The Sun?"
 	desc = "May the darkness swallow all around you."
-	extended_desc = "the user of this card will gain a weakened version of a umbral vampire's eternal darkness ability for one minute. However the user will also become nearsighted for the duration"
+	extended_desc = "grants the user a weakened version of an umbral vampire's eternal darkness ability for one minute. However, the user will also become nearsighted for the duration."
 	card_icon = "the_sun?"
 
 /datum/tarot/reversed/the_sun/activate(mob/living/target)
@@ -949,7 +949,7 @@
 /datum/tarot/reversed/judgement
 	name = "XX - Judgement?"
 	desc = "May you redeem those found wanting" //Who wants more, but ghosts for something interesting
-	extended_desc = "will nudge future events during the shift to be more...interesting. Perhaps the spirits will be merciful to you for this." // yeah right they will
+	extended_desc = "nudges the future events of the shift to be more... interesting. Perhaps the spirits will be merciful to you for this." // yeah right they will
 	card_icon = "judgement?"
 
 /datum/tarot/reversed/judgement/activate(mob/living/target)
@@ -961,7 +961,7 @@
 /datum/tarot/reversed/the_world
 	name = "XXI - The World?"
 	desc = "Step into the abyss."
-	extended_desc = "warps the user to the station's mining outpost."
+	extended_desc = "teleports the user to the station's mining outpost."
 	card_icon = "the_world?"
 
 /datum/tarot/reversed/the_world/activate(mob/living/target)

--- a/code/game/gamemodes/wizard/magic_tarot.dm
+++ b/code/game/gamemodes/wizard/magic_tarot.dm
@@ -387,7 +387,7 @@
 /datum/tarot/the_lovers
 	name = "VI - The Lovers"
 	desc = "May you prosper and be in good health."
-	extended_desc = "will mend both brute and burn damage, restores blood, clears toxins form their blood, and helps them get their breath back."
+	extended_desc = "will restore the overall health of the user."
 	card_icon = "the_lovers"
 
 /datum/tarot/the_lovers/activate(mob/living/target)
@@ -448,7 +448,7 @@
 /datum/tarot/wheel_of_fortune
 	name = "X - Wheel of Fortune"
 	desc = "Spin the wheel of destiny."
-	extended_desc = "summons a random vending machine right out of bluespace."
+	extended_desc = "summons a random vending machine."
 	card_icon = "wheel_of_fortune"
 
 /datum/tarot/wheel_of_fortune/activate(mob/living/target)
@@ -462,7 +462,7 @@
 /datum/tarot/strength
 	name = "XI - Strength"
 	desc = "May your power bring rage."
-	extended_desc = "grants the user strength only matched by powerful vampires. The strength renders the user unable to handle ranged weapons."
+	extended_desc = "grants the user strength beyond belief, but renders them unable to handle ranged weapons."
 	card_icon = "strength"
 
 /datum/tarot/strength/activate(mob/living/target)
@@ -472,7 +472,7 @@
 /datum/tarot/the_hanged_man
 	name = "XII - The Hanged Man"
 	desc = "May you find enlightenment."
-	extended_desc = "allows the user to float off the ground for an entire minute."
+	extended_desc = "allows the user to fly for a minute."
 	card_icon = "the_hanged_man"
 
 /datum/tarot/the_hanged_man/activate(mob/living/target)
@@ -495,7 +495,7 @@
 /datum/tarot/temperance
 	name = "XIV - Temperance"
 	desc = "May you be pure in heart."
-	extended_desc = "cures all diseases, disabilities, radiation, toxins, drunkenness, and brain damage in the user, as well as heavy organ damage."
+	extended_desc = "cures all ailments the user has. Also reinvigorates their organs."
 	card_icon = "temperance"
 
 /datum/tarot/temperance/activate(mob/living/target)
@@ -520,7 +520,7 @@
 /datum/tarot/the_devil
 	name = "XV - The Devil"
 	desc = "Revel in the power of darkness."
-	extended_desc = "grants a large amount of healing at the cost of others around the user."
+	extended_desc = "steals the life-force of everyone around the user."
 	card_icon = "the_devil"
 
 /datum/tarot/the_devil/activate(mob/living/target)
@@ -529,7 +529,7 @@
 /datum/tarot/the_tower
 	name = "XVI - The Tower"
 	desc = "Destruction brings creation."
-	extended_desc = "contains the raw power of the greytide within. Summons a primed cluster IED."
+	extended_desc = "summons a self-replicating bomb."
 	card_icon = "the_tower"
 
 /datum/tarot/the_tower/activate(mob/living/target)
@@ -566,7 +566,7 @@
 /datum/tarot/the_moon
 	name = "XVIII - The Moon"
 	desc = "May you find all you have lost."
-	extended_desc = "teleports the user to a random place of interest for miners and explorers, starting with the sector the user is in first."
+	extended_desc = "teleports the user to a random place of interest, starting with the sector the user is in first."
 	card_icon = "the_moon"
 
 /datum/tarot/the_moon/activate(mob/living/target)
@@ -605,7 +605,7 @@
 /datum/tarot/the_sun
 	name = "XIX - The Sun"
 	desc = "May the light heal and enlighten you."
-	extended_desc = "heals the user back to the their peak strength. Some say this card holds the power of a god."
+	extended_desc = "fully rejuvenates the user back to their peak strength."
 	card_icon = "the_sun"
 
 /datum/tarot/the_sun/activate(mob/living/target)
@@ -654,7 +654,7 @@
 /datum/tarot/reversed/the_magician
 	name = "I - The Magician?"
 	desc = "May no harm come to you."
-	extended_desc = "contains the power of a great mage, upon use the user will repulse everything away from them."
+	extended_desc = "will repulse everything away from the user."
 	card_icon = "the_magician?"
 
 /datum/tarot/reversed/the_magician/activate(mob/living/target)
@@ -688,7 +688,7 @@
 /datum/tarot/reversed/the_high_priestess
 	name = "II - The High Priestess?"
 	desc = "Run."
-	extended_desc = "summons Bubblegum to tear portals open around the user that she will use to grab at them, and people around them at random. This will often be lethal." // iirc bubblegum is a she
+	extended_desc = "summons Bubblegum to tear portals open around the user that will grab and damage <i>everyone</i> nearby."
 	card_icon = "the_high_priestess?"
 
 /datum/tarot/reversed/the_high_priestess/activate(mob/living/target)
@@ -698,7 +698,7 @@
 /datum/tarot/reversed/the_empress
 	name = "III - The Empress?"
 	desc = "May your love bring protection."
-	extended_desc = "makes everyone within range unable to commit an act of violence for 40 seconds, aside from the user."
+	extended_desc = "pacifies everyone in range, except for the user, for 40 seconds."
 	card_icon = "the_empress?"
 
 /datum/tarot/reversed/the_empress/activate(mob/living/target)
@@ -728,7 +728,7 @@
 /datum/tarot/reversed/the_hierophant
 	name = "V - The Hierophant?"
 	desc = "Two prayers for the forgotten."
-	extended_desc = "causes the Hierophant to send out two trails to attack others within range of the user."
+	extended_desc = "makes the Hierophant attack two random mobs in range."
 	card_icon = "the_hierophant?"
 
 /datum/tarot/reversed/the_hierophant/activate(mob/living/target)
@@ -775,7 +775,7 @@
 /datum/tarot/reversed/justice
 	name = "VIII - Justice?"
 	desc = "May your sins come back to torment you."
-	extended_desc = "creates a random cargo crate. This can include crates cargo would otherwise not have access to at the time."
+	extended_desc = "creates a random orderable crate. This can include crates Supply would otherwise not have access to at the time."
 	card_icon = "justice?"
 
 /datum/tarot/reversed/justice/activate(mob/living/target)
@@ -815,7 +815,7 @@
 /datum/tarot/reversed/wheel_of_fortune
 	name = "X - Wheel of Fortune?"
 	desc = "Throw the dice of fate."
-	extended_desc = "forces the user to roll for a powerful magical artifact. The outcome can be highly positive or highly negative, it is up to fate."
+	extended_desc = "forces the user to roll for a powerful magical artifact. The outcome can be highly positive or highly negative; it is up to fate."
 	card_icon = "wheel_of_fortune?"
 
 /datum/tarot/reversed/wheel_of_fortune/activate(mob/living/target)
@@ -902,7 +902,7 @@
 /datum/tarot/reversed/the_stars
 	name = "XVII - The Stars?"
 	desc = "May your loss bring fortune."
-	extended_desc = "will deal a large ammount of genetic damage to the user, as well as giving a random limb either a fracture, internal bleeding, or a burn wound. However, such cost is rewarding, as the user will draw two additional cards."
+	extended_desc = "will cause a large amount of genetic decomposition to the user, as well as hurting a limb. However, it will reward the user with two additional cards."
 	card_icon = "the_stars?"
 
 /datum/tarot/reversed/the_stars/activate(mob/living/target) //Heavy clone damage hit, but gain 2 cards. Not teathered to the card producer. Could lead to card stacking, but would require the sun to fix easily
@@ -930,7 +930,7 @@
 /datum/tarot/reversed/the_moon
 	name = "XVIII - The Moon?"
 	desc = "May you remember lost memories."
-	extended_desc = "will reveal the memories of everyone within 5 tiles to the user, including bank account information and uplink codes."
+	extended_desc = "will reveal the memories of everyone in range to the user."
 	card_icon = "the_moon?"
 
 /datum/tarot/reversed/the_moon/activate(mob/living/target)
@@ -949,7 +949,7 @@
 /datum/tarot/reversed/judgement
 	name = "XX - Judgement?"
 	desc = "May you redeem those found wanting" //Who wants more, but ghosts for something interesting
-	extended_desc = "nudges the future events of the shift to be more... interesting. Perhaps the spirits will be merciful to you for this." // yeah right they will
+	extended_desc = "nudges the future events of this shift to be more... interesting."
 	card_icon = "judgement?"
 
 /datum/tarot/reversed/judgement/activate(mob/living/target)
@@ -961,7 +961,7 @@
 /datum/tarot/reversed/the_world
 	name = "XXI - The World?"
 	desc = "Step into the abyss."
-	extended_desc = "teleports the user to the station's mining outpost."
+	extended_desc = "teleports the user to the mining outpost."
 	card_icon = "the_world?"
 
 /datum/tarot/reversed/the_world/activate(mob/living/target)

--- a/code/game/gamemodes/wizard/magic_tarot.dm
+++ b/code/game/gamemodes/wizard/magic_tarot.dm
@@ -775,7 +775,7 @@
 /datum/tarot/reversed/justice
 	name = "VIII - Justice?"
 	desc = "May your sins come back to torment you."
-	extended_desc = "creates a random crate from cargo. This can include stuff they would otherwise not have access to at the time."
+	extended_desc = "creates a random cargo crate. This can include crates cargo would otherwise not have access to at the time."
 	card_icon = "justice?"
 
 /datum/tarot/reversed/justice/activate(mob/living/target)

--- a/code/game/gamemodes/wizard/magic_tarot.dm
+++ b/code/game/gamemodes/wizard/magic_tarot.dm
@@ -340,7 +340,7 @@
 /datum/tarot/the_empress
 	name = "III - The Empress"
 	desc = "May your rage bring power."
-	extended_desc = "gives the user a temporary boost of speed. This includes attack speed"
+	extended_desc = "gives the user a temporary boost of speed. This includes attack speed."
 	card_icon = "the_empress"
 
 /datum/tarot/the_empress/activate(mob/living/target)

--- a/code/game/gamemodes/wizard/magic_tarot.dm
+++ b/code/game/gamemodes/wizard/magic_tarot.dm
@@ -387,7 +387,7 @@
 /datum/tarot/the_lovers
 	name = "VI - The Lovers"
 	desc = "May you prosper and be in good health."
-	extended_desc = "knits the user's wounds, repairs burnt flesh, restores blood, and gives their breath back. Works on non-organic limbs as well." // I cant think of a better way of explaining this in a ic sense, please give feedback on this
+	extended_desc = "will mend both brute and burn damage, restores blood, clears toxins form their blood, and helps them get their breath back."
 	card_icon = "the_lovers"
 
 /datum/tarot/the_lovers/activate(mob/living/target)
@@ -566,7 +566,7 @@
 /datum/tarot/the_moon
 	name = "XVIII - The Moon"
 	desc = "May you find all you have lost."
-	extended_desc = "warps the user to a random place of intrest for miners and explorers, within the sector they're in first."
+	extended_desc = "teleports the user to a random place of interest for miners and explorers, starting with the sector the user is in first."
 	card_icon = "the_moon"
 
 /datum/tarot/the_moon/activate(mob/living/target)
@@ -654,7 +654,7 @@
 /datum/tarot/reversed/the_magician
 	name = "I - The Magician?"
 	desc = "May no harm come to you."
-	extended_desc = "grants the user the power of a powerful mage upon use, throwing everything away from the user."
+	extended_desc = "contains the power of a great mage, apon use the user will repulse everything away from them."
 	card_icon = "the_magician?"
 
 /datum/tarot/reversed/the_magician/activate(mob/living/target)
@@ -688,7 +688,7 @@
 /datum/tarot/reversed/the_high_priestess
 	name = "II - The High Priestess?"
 	desc = "Run."
-	extended_desc = "summons Bubblegum to tear portals open, that will chase the user, and grab people at random, causing major damage."
+	extended_desc = "summons Bubblegum to tear portals open around the user, that she will use to grab at them, and people around them at random, causing major damage." // iirc bubblegum is a she
 	card_icon = "the_high_priestess?"
 
 /datum/tarot/reversed/the_high_priestess/activate(mob/living/target)
@@ -886,7 +886,7 @@
 /datum/tarot/reversed/the_tower
 	name = "XVI - The Tower?"
 	desc = "Creation brings destruction."
-	extended_desc = "makes stone containing minerals to shoot from the ground."
+	extended_desc = "will create large stone walls that erupt from the ground around the user."
 	card_icon = "the_tower?"
 
 /datum/tarot/reversed/the_tower/activate(mob/living/target)
@@ -902,7 +902,7 @@
 /datum/tarot/reversed/the_stars
 	name = "XVII - The Stars?"
 	desc = "May your loss bring fortune."
-	extended_desc = "will deal heavy genetic damage to the user, as well as giving a random limb either a fracture, IB, or a burn wound. However the user will also draw two additional cards."
+	extended_desc = "will deal a large ammount of genetic damage to the user, as well as giving a random limb either a fracture, internal bleeding, or a burn wound. However, such cost is rewarding, as the user will draw two additional cards."
 	card_icon = "the_stars?"
 
 /datum/tarot/reversed/the_stars/activate(mob/living/target) //Heavy clone damage hit, but gain 2 cards. Not teathered to the card producer. Could lead to card stacking, but would require the sun to fix easily

--- a/code/game/gamemodes/wizard/magic_tarot.dm
+++ b/code/game/gamemodes/wizard/magic_tarot.dm
@@ -304,7 +304,7 @@
 /datum/tarot/the_high_priestess
 	name = "II - The High Priestess"
 	desc = "Mother is watching you."
-	extended_desc = "alerts bubblegum to the user, allowing him to strike them down, dealing heavy damage and immobilizing them."
+	extended_desc = "alerts bubblegum to the user, who will strike them down. The user will receive heavy damage and will be immobilized."
 	card_icon = "the_high_priestess"
 
 /datum/tarot/the_high_priestess/activate(mob/living/target)

--- a/code/game/gamemodes/wizard/magic_tarot.dm
+++ b/code/game/gamemodes/wizard/magic_tarot.dm
@@ -145,8 +145,6 @@
 	var/datum/tarot/our_tarot
 	/// Our fancy description given to use by the tarot datum.
 	var/card_desc = "Untold answers... wait what? This is a bug, report this as an issue on github!"
-	/// Used for examine_more, for what cards do
-	var/card_extended_desc = "will make the user report this as a bug on GitHub!"
 	/// Is the card face down? Shows the card back, hides the examine / name.
 	var/face_down = FALSE
 	/// Will this card automatically disappear if thrown at a non-mob?
@@ -165,7 +163,6 @@
 		our_tarot = new tarotpath
 	name = our_tarot.name
 	card_desc = our_tarot.desc
-	card_extended_desc = our_tarot.extended_desc
 	icon_state = "tarot_[our_tarot.card_icon]"
 
 /obj/item/magic_tarot_card/Destroy()
@@ -688,7 +685,7 @@
 /datum/tarot/reversed/the_high_priestess
 	name = "II - The High Priestess?"
 	desc = "Run."
-	extended_desc = "summons Bubblegum to tear portals open around the user that will grab and damage <i>everyone</i> nearby."
+	extended_desc = "summons Bubblegum to tear portals open around the user that will grab and damage everyone nearby."
 	card_icon = "the_high_priestess?"
 
 /datum/tarot/reversed/the_high_priestess/activate(mob/living/target)

--- a/code/game/gamemodes/wizard/magic_tarot.dm
+++ b/code/game/gamemodes/wizard/magic_tarot.dm
@@ -304,7 +304,7 @@
 /datum/tarot/the_high_priestess
 	name = "II - The High Priestess"
 	desc = "Mother is watching you."
-	extended_desc = "alerts Bubblegum to the user, allowing them to rend them, dealing heavy damage, and imobilizing them."
+	extended_desc = "alerts Bubblegum to the user, allowing her to rend the effected user, dealing heavy damage, and imobilizing the user for a short time."
 	card_icon = "the_high_priestess"
 
 /datum/tarot/the_high_priestess/activate(mob/living/target)
@@ -688,7 +688,7 @@
 /datum/tarot/reversed/the_high_priestess
 	name = "II - The High Priestess?"
 	desc = "Run."
-	extended_desc = "summons Bubblegum to tear portals open around the user, that she will use to grab at them, and people around them at random, causing major damage." // iirc bubblegum is a she
+	extended_desc = "summons Bubblegum to tear portals open around the user that she will use to grab at them, and people around them at random. This will often be lethal." // iirc bubblegum is a she
 	card_icon = "the_high_priestess?"
 
 /datum/tarot/reversed/the_high_priestess/activate(mob/living/target)

--- a/code/game/gamemodes/wizard/magic_tarot.dm
+++ b/code/game/gamemodes/wizard/magic_tarot.dm
@@ -340,7 +340,7 @@
 /datum/tarot/the_empress
 	name = "III - The Empress"
 	desc = "May your rage bring power."
-	extended_desc = "gives the user a mixture of powerful reagents that allow them to move and interact with things at inhuman speeds."
+	extended_desc = "gives the user a temporary boost of speed. This includes attack speed"
 	card_icon = "the_empress"
 
 /datum/tarot/the_empress/activate(mob/living/target)

--- a/code/game/gamemodes/wizard/magic_tarot.dm
+++ b/code/game/gamemodes/wizard/magic_tarot.dm
@@ -151,6 +151,8 @@
 	var/needs_mob_target = TRUE
 	/// Has the card been activated? If it has, don't activate it again
 	var/has_been_activated = FALSE
+	/// Used for examine_more, for what cards do
+	var/card_extended_desc = "will make you report this as an bug on the github!"
 
 /obj/item/magic_tarot_card/Initialize(mapload, obj/item/tarot_generator/source, datum/tarot/chosen_tarot)
 	. = ..()
@@ -163,6 +165,7 @@
 		our_tarot = new tarotpath
 	name = our_tarot.name
 	card_desc = our_tarot.desc
+	card_extended_desc = our_tarot.extended_desc
 	icon_state = "tarot_[our_tarot.card_icon]"
 
 /obj/item/magic_tarot_card/Destroy()
@@ -175,6 +178,11 @@
 	if(!face_down)
 		. += "<span class='hierophant'>[card_desc]</span>"
 	. += "<span class='hierophant'>Alt-Shift-Click to flip the card over.</span>"
+
+/obj/item/magic_tarot_card/examine_more(mob/user)
+	. = ..()
+	if(!face_down)
+		. += "<span class='hierophant'>[src] [our_tarot.extended_desc]</span>"
 
 /obj/item/magic_tarot_card/attack_self(mob/user)
 	poof()
@@ -257,6 +265,8 @@
 	var/name = "XXII - The Unknown."
 	/// Desc used for the card description of the card
 	var/desc = "Untold answers... wait what? This is a bug, report this as an issue on github!"
+	/// Extended desc for the cards. For what they do
+	var/extended_desc = "Asks you to report this as a bug on the github!"
 	/// What icon is used for the card?
 	var/card_icon = "the_unknown"
 	/// Are we reversed? Used for the card back.
@@ -274,6 +284,7 @@
 /datum/tarot/the_fool
 	name = "0 - The Fool"
 	desc = "Where journey begins."
+	extended_desc = "returns the affected user to the arrival point of this forsaken journey."
 	card_icon = "the_fool"
 
 /datum/tarot/the_fool/activate(mob/living/target)
@@ -283,6 +294,7 @@
 /datum/tarot/the_magician
 	name = "I - The Magician"
 	desc = "May you never miss your goal."
+	extended_desc = "makes the user feel extraordinarily <b>badass</b> for a couple of minutes"
 	card_icon = "the_magician"
 
 /datum/tarot/the_magician/activate(mob/living/target)
@@ -292,6 +304,7 @@
 /datum/tarot/the_high_priestess
 	name = "II - The High Priestess"
 	desc = "Mother is watching you."
+	extended_desc = "alerts Bubblegum to the user, allowing them to rend them, dealing heavy damage, and imobilizing them."
 	card_icon = "the_high_priestess"
 
 /datum/tarot/the_high_priestess/activate(mob/living/target)
@@ -327,6 +340,7 @@
 /datum/tarot/the_empress
 	name = "III - The Empress"
 	desc = "May your rage bring power."
+	extended_desc = "gives the user a mixture of powerful reagnets that allow them to move and interact with things at inhuman speeds."
 	card_icon = "the_empress"
 
 /datum/tarot/the_empress/activate(mob/living/target)
@@ -338,6 +352,7 @@
 /datum/tarot/the_emperor
 	name = "IV - The Emperor"
 	desc = "Challenge me!"
+	extended_desc = "warps the user to where command commonly reside, be ready for a fight."
 	card_icon = "the_emperor"
 
 /datum/tarot/the_emperor/activate(mob/living/target)
@@ -357,6 +372,7 @@
 /datum/tarot/the_hierophant
 	name = "V - The Hierophant"
 	desc = "Two prayers for the lost."
+	extended_desc = "allows the Hierophant to enchant the users suit, that is strong enough to entirely negate three attacks."
 	card_icon = "the_hierophant"
 
 /datum/tarot/the_hierophant/activate(mob/living/target)
@@ -371,6 +387,7 @@
 /datum/tarot/the_lovers
 	name = "VI - The Lovers"
 	desc = "May you prosper and be in good health."
+	extended_desc = "knits the users wounds, repairs burnt flesh, restores blood, gives their breath back. Works on non-organic limbs as well." // I cant think of a better way of explaining this in a ic sense, please give feedback on this
 	card_icon = "the_lovers"
 
 /datum/tarot/the_lovers/activate(mob/living/target)
@@ -388,6 +405,7 @@
 /datum/tarot/the_chariot
 	name = "VII - The Chariot"
 	desc = "May nothing stand before you."
+	extended_desc = "imbues the user with immense power and speed, making them practically immortal for 10 seconds. at a heavy cost of being unable to harm another living thing."
 	card_icon = "the_chariot"
 
 /datum/tarot/the_chariot/activate(mob/living/target)
@@ -397,6 +415,7 @@
 /datum/tarot/justice
 	name = "VIII - Justice"
 	desc = "May your future become balanced."
+	extended_desc = "grants the user a medical firstaid kit, a magical key that can open a single door, and 100 credits."
 	card_icon = "justice"
 
 /datum/tarot/justice/activate(mob/living/target)
@@ -409,6 +428,7 @@
 /datum/tarot/the_hermit
 	name = "IX - The Hermit"
 	desc = "May you see what life has to offer."
+	extended_desc = "warps the user to a random vending machine within the station"
 	card_icon = "the_hermit"
 
 /datum/tarot/the_hermit/activate(mob/living/target)
@@ -428,6 +448,7 @@
 /datum/tarot/wheel_of_fortune
 	name = "X - Wheel of Fortune"
 	desc = "Spin the wheel of destiny."
+	extended_desc = "summons a random vender right out of bluespace."
 	card_icon = "wheel_of_fortune"
 
 /datum/tarot/wheel_of_fortune/activate(mob/living/target)
@@ -441,6 +462,7 @@
 /datum/tarot/strength
 	name = "XI - Strength"
 	desc = "May your power bring rage."
+	extended_desc = "grants the user strength only matched by powerful vampires gladiators. The strength blocks use of ranged weapons."
 	card_icon = "strength"
 
 /datum/tarot/strength/activate(mob/living/target)
@@ -450,6 +472,7 @@
 /datum/tarot/the_hanged_man
 	name = "XII - The Hanged Man"
 	desc = "May you find enlightenment."
+	extended_desc = "allows the user to float off the ground for an entire minute."
 	card_icon = "the_hanged_man"
 
 /datum/tarot/the_hanged_man/activate(mob/living/target)
@@ -461,6 +484,7 @@
 /datum/tarot/death
 	name = "XIII - Death"
 	desc = "Lay waste to all that oppose you."
+	extended_desc = "deals damage to all those the user can see. Aside from themselves, of cause."
 	card_icon = "death"
 
 /datum/tarot/death/activate(mob/living/target)
@@ -471,6 +495,7 @@
 /datum/tarot/temperance
 	name = "XIV - Temperance"
 	desc = "May you be pure in heart."
+	extended_desc = "cures all diseases, disabilities, radiation, toxins, drunkenness, and brain damage in the user. As well as repairs heavy organ damage."
 	card_icon = "temperance"
 
 /datum/tarot/temperance/activate(mob/living/target)
@@ -495,6 +520,7 @@
 /datum/tarot/the_devil
 	name = "XV - The Devil"
 	desc = "Revel in the power of darkness."
+	extended_desc = "grants a large ammount of healing, at the cost of others around the user."
 	card_icon = "the_devil"
 
 /datum/tarot/the_devil/activate(mob/living/target)
@@ -503,6 +529,7 @@
 /datum/tarot/the_tower
 	name = "XVI - The Tower"
 	desc = "Destruction brings creation."
+	extended_desc = "contains the raw power of the grey tide within. Summons a primed cluster IED"
 	card_icon = "the_tower"
 
 /datum/tarot/the_tower/activate(mob/living/target)
@@ -513,6 +540,7 @@
 /datum/tarot/the_stars
 	name = "XVII - The Stars"
 	desc = "May you find what you desire."
+	extended_desc = "warps the user to the stations evidice lockup. As well as opens a single locker within."
 	card_icon = "the_stars"
 
 /datum/tarot/the_stars/activate(mob/living/target)
@@ -538,6 +566,7 @@
 /datum/tarot/the_moon
 	name = "XVIII - The Moon"
 	desc = "May you find all you have lost."
+	extended_desc = "warps the user to a random place of intrest for miners and explorers, within the sector they're in first."
 	card_icon = "the_moon"
 
 /datum/tarot/the_moon/activate(mob/living/target)
@@ -576,6 +605,7 @@
 /datum/tarot/the_sun
 	name = "XIX - The Sun"
 	desc = "May the light heal and enlighten you."
+	extended_desc = "heals you back to the users peak strength. Some say this card holds the power of a god."
 	card_icon = "the_sun"
 
 /datum/tarot/the_sun/activate(mob/living/target)
@@ -584,6 +614,7 @@
 /datum/tarot/judgement
 	name = "XX - Judgement"
 	desc = "Judge lest ye be judged."
+	extended_desc = "alerts those once living to the users exitense, prepare to be judged."
 	card_icon = "judgement"
 
 /datum/tarot/judgement/activate(mob/living/target)
@@ -592,6 +623,7 @@
 /datum/tarot/the_world
 	name = "XXI - The World"
 	desc = "Open your eyes and see."
+	extended_desc = "bellows out smoke and grants the user full xray for two minutes."
 	card_icon = "the_world"
 
 /datum/tarot/the_world/activate(mob/living/target)
@@ -607,6 +639,7 @@
 /datum/tarot/reversed/the_fool
 	name = "0 - The Fool?"
 	desc = "Let go and move on."
+	extended_desc = "removes all items off of the user, leaving them completely naked."
 	card_icon = "the_fool?"
 
 /datum/tarot/reversed/the_fool/activate(mob/living/target)
@@ -621,6 +654,7 @@
 /datum/tarot/reversed/the_magician
 	name = "I - The Magician?"
 	desc = "May no harm come to you."
+	extended_desc = "grants the user the power of a powerful mage apon use, throwing everything and one away from the user."
 	card_icon = "the_magician?"
 
 /datum/tarot/reversed/the_magician/activate(mob/living/target)
@@ -654,6 +688,7 @@
 /datum/tarot/reversed/the_high_priestess
 	name = "II - The High Priestess?"
 	desc = "Run."
+	extended_desc = "summons Bubblegum to tear portals open, that will chase the user, grabbing people at random, causing major damage."
 	card_icon = "the_high_priestess?"
 
 /datum/tarot/reversed/the_high_priestess/activate(mob/living/target)
@@ -663,6 +698,7 @@
 /datum/tarot/reversed/the_empress
 	name = "III - The Empress?"
 	desc = "May your love bring protection."
+	extended_desc = "will leave anyone within range unable to commit an act of violence, aside from the user."
 	card_icon = "the_empress?"
 
 /datum/tarot/reversed/the_empress/activate(mob/living/target)
@@ -672,6 +708,7 @@
 /datum/tarot/reversed/the_emperor
 	name = "IV - The Emperor?"
 	desc = "May you find a worthy opponent."
+	extended_desc = "warps the user of this card to a random head of staff."
 	card_icon = "the_emperor?"
 
 /datum/tarot/reversed/the_emperor/activate(mob/living/target)
@@ -691,6 +728,7 @@
 /datum/tarot/reversed/the_hierophant
 	name = "V - The Hierophant?"
 	desc = "Two prayers for the forgotten."
+	extended_desc = "causes the Hierophant to send out two trails to attack others within range of the user."
 	card_icon = "the_hierophant?"
 
 /datum/tarot/reversed/the_hierophant/activate(mob/living/target)
@@ -709,6 +747,7 @@
 /datum/tarot/reversed/the_lovers
 	name = "VI - The Lovers?"
 	desc = "May your heart shatter to pieces."
+	extended_desc = "causes the user of this card to experience true heart break. Leaving their chest broken, and battered."
 	card_icon = "the_lovers?"
 
 /datum/tarot/reversed/the_lovers/activate(mob/living/target)
@@ -726,6 +765,7 @@
 /datum/tarot/reversed/the_chariot
 	name = "VII - The Chariot?"
 	desc = "May nothing walk past you."
+	extended_desc = "will petrify the user for two minutes. However they will be totally indestructible."
 	card_icon = "the_chariot?"
 
 /datum/tarot/reversed/the_chariot/activate(mob/living/target)
@@ -735,6 +775,7 @@
 /datum/tarot/reversed/justice
 	name = "VIII - Justice?"
 	desc = "May your sins come back to torment you."
+	extended_desc = "creates a random crate from cargo. This can include stuff they would otherwise not have access to at the time."
 	card_icon = "justice?"
 
 /datum/tarot/reversed/justice/activate(mob/living/target)
@@ -752,6 +793,7 @@
 /datum/tarot/reversed/the_hermit
 	name = "IX - The Hermit?"
 	desc = "May you see the value of all things in life."
+	extended_desc = "will sell all loose guns, grenadeds, battons, and armour around the user, directly into cash."
 	card_icon = "the_hermit?"
 
 /datum/tarot/reversed/the_hermit/activate(mob/living/target) //Someone can improve this in the future (hopefully comment will not be here in 10 years.)
@@ -773,6 +815,7 @@
 /datum/tarot/reversed/wheel_of_fortune
 	name = "X - Wheel of Fortune?"
 	desc = "Throw the dice of fate."
+	extended_desc = "forces the user of the card to roll a powerful magical artifact, the outcome can be highly positive or highly negitive, it is up to fate what happens now."
 	card_icon = "wheel_of_fortune?"
 
 /datum/tarot/reversed/wheel_of_fortune/activate(mob/living/target)
@@ -782,6 +825,7 @@
 /datum/tarot/reversed/strength
 	name = "XI - Strength?"
 	desc = "May you break their resolve."
+	extended_desc = "breaks the mind of those around the user, dealing heavy brain damage, and causing two minutes of hallucinations."
 	card_icon = "strength?"
 
 /datum/tarot/reversed/strength/activate(mob/living/target)
@@ -793,6 +837,7 @@
 /datum/tarot/reversed/the_hanged_man
 	name = "XII - The Hanged Man?"
 	desc = "May your greed know no bounds."
+	extended_desc = "forces the user of this card to roll a cursed slot machine."
 	card_icon = "the_hanged_man?"
 
 /datum/tarot/reversed/the_hanged_man/activate(mob/living/target)
@@ -804,6 +849,7 @@
 /datum/tarot/reversed/death
 	name = "XIII - Death?"
 	desc = "May life spring forth from the fallen."
+	extended_desc = "grants the user a soulstone and construct to freely use on the dead."
 	card_icon = "death?"
 
 /datum/tarot/reversed/death/activate(mob/living/target)
@@ -813,6 +859,7 @@
 /datum/tarot/reversed/temperance
 	name = "XIV - Temperance?"
 	desc = "May your hunger be satiated."
+	extended_desc = "forces the user to eat five pills containing random reagents."
 	card_icon = "temperance?"
 
 /datum/tarot/reversed/temperance/activate(mob/living/target)
@@ -829,6 +876,7 @@
 /datum/tarot/reversed/the_devil
 	name = "XV - The Devil?"
 	desc = "Bask in the light of your mercy."
+	extended_desc = "summons a primed cluster flashbang at the users feet."
 	card_icon = "the_devil?"
 
 /datum/tarot/reversed/the_devil/activate(mob/living/target)
@@ -838,6 +886,7 @@
 /datum/tarot/reversed/the_tower
 	name = "XVI - The Tower?"
 	desc = "Creation brings destruction."
+	extended_desc = "makes stone containing minerals to shoot from the ground."
 	card_icon = "the_tower?"
 
 /datum/tarot/reversed/the_tower/activate(mob/living/target)
@@ -853,6 +902,7 @@
 /datum/tarot/reversed/the_stars
 	name = "XVII - The Stars?"
 	desc = "May your loss bring fortune."
+	extended_desc = "will deal heavy genetic damage to the user, as well as giving a random limb either a fracture, IB, or a burn wound. However the user will also draw two additional cards."
 	card_icon = "the_stars?"
 
 /datum/tarot/reversed/the_stars/activate(mob/living/target) //Heavy clone damage hit, but gain 2 cards. Not teathered to the card producer. Could lead to card stacking, but would require the sun to fix easily
@@ -880,6 +930,7 @@
 /datum/tarot/reversed/the_moon
 	name = "XVIII - The Moon?"
 	desc = "May you remember lost memories."
+	extended_desc = "will reveal the users memory to those within 5 tiles. This can include uplink codes."
 	card_icon = "the_moon?"
 
 /datum/tarot/reversed/the_moon/activate(mob/living/target)
@@ -889,6 +940,7 @@
 /datum/tarot/reversed/the_sun
 	name = "XIX - The Sun?"
 	desc = "May the darkness swallow all around you."
+	extended_desc = "the user of this card will gain a weakened version of a umbral vapmires eternal darkness ability for one minute. However the user will also become nearsighted for the duration"
 	card_icon = "the_sun?"
 
 /datum/tarot/reversed/the_sun/activate(mob/living/target)
@@ -897,6 +949,7 @@
 /datum/tarot/reversed/judgement
 	name = "XX - Judgement?"
 	desc = "May you redeem those found wanting" //Who wants more, but ghosts for something interesting
+	extended_desc = "will nudge things that may happen during the shift into gear, perhaps the spirits will be merciful to you for this." // yeah right they will
 	card_icon = "judgement?"
 
 /datum/tarot/reversed/judgement/activate(mob/living/target)
@@ -908,6 +961,7 @@
 /datum/tarot/reversed/the_world
 	name = "XXI - The World?"
 	desc = "Step into the abyss."
+	extended_desc = "warps the user to the stations mining outpost."
 	card_icon = "the_world?"
 
 /datum/tarot/reversed/the_world/activate(mob/living/target)

--- a/code/game/gamemodes/wizard/magic_tarot.dm
+++ b/code/game/gamemodes/wizard/magic_tarot.dm
@@ -145,14 +145,14 @@
 	var/datum/tarot/our_tarot
 	/// Our fancy description given to use by the tarot datum.
 	var/card_desc = "Untold answers... wait what? This is a bug, report this as an issue on github!"
+	/// Used for examine_more, for what cards do
+	var/card_extended_desc = "will make the user report this as an bug on the github!"
 	/// Is the card face down? Shows the card back, hides the examine / name.
 	var/face_down = FALSE
 	/// Will this card automatically disappear if thrown at a non-mob?
 	var/needs_mob_target = TRUE
 	/// Has the card been activated? If it has, don't activate it again
 	var/has_been_activated = FALSE
-	/// Used for examine_more, for what cards do
-	var/card_extended_desc = "will make you report this as an bug on the github!"
 
 /obj/item/magic_tarot_card/Initialize(mapload, obj/item/tarot_generator/source, datum/tarot/chosen_tarot)
 	. = ..()
@@ -266,7 +266,7 @@
 	/// Desc used for the card description of the card
 	var/desc = "Untold answers... wait what? This is a bug, report this as an issue on github!"
 	/// Extended desc for the cards. For what they do
-	var/extended_desc = "Asks you to report this as a bug on the github!"
+	var/extended_desc = "asks you to report this as a bug on the github!"
 	/// What icon is used for the card?
 	var/card_icon = "the_unknown"
 	/// Are we reversed? Used for the card back.
@@ -294,7 +294,7 @@
 /datum/tarot/the_magician
 	name = "I - The Magician"
 	desc = "May you never miss your goal."
-	extended_desc = "makes the user feel extraordinarily <b>badass</b> for a couple of minutes"
+	extended_desc = "makes the user feel extraordinarily badass for a couple of minutes."
 	card_icon = "the_magician"
 
 /datum/tarot/the_magician/activate(mob/living/target)
@@ -529,7 +529,7 @@
 /datum/tarot/the_tower
 	name = "XVI - The Tower"
 	desc = "Destruction brings creation."
-	extended_desc = "contains the raw power of the grey tide within. Summons a primed cluster IED"
+	extended_desc = "contains the raw power of the grey tide within. Summons a primed cluster IED."
 	card_icon = "the_tower"
 
 /datum/tarot/the_tower/activate(mob/living/target)
@@ -698,7 +698,7 @@
 /datum/tarot/reversed/the_empress
 	name = "III - The Empress?"
 	desc = "May your love bring protection."
-	extended_desc = "will leave anyone within range unable to commit an act of violence, aside from the user."
+	extended_desc = "will leave anyone within range unable to commit an act of violence for 40 seconds, aside from the user."
 	card_icon = "the_empress?"
 
 /datum/tarot/reversed/the_empress/activate(mob/living/target)

--- a/code/game/gamemodes/wizard/magic_tarot.dm
+++ b/code/game/gamemodes/wizard/magic_tarot.dm
@@ -340,7 +340,7 @@
 /datum/tarot/the_empress
 	name = "III - The Empress"
 	desc = "May your rage bring power."
-	extended_desc = "gives the user a mixture of powerful reagnets that allow them to move and interact with things at inhuman speeds."
+	extended_desc = "gives the user a mixture of powerful reagents that allow them to move and interact with things at inhuman speeds."
 	card_icon = "the_empress"
 
 /datum/tarot/the_empress/activate(mob/living/target)
@@ -352,7 +352,7 @@
 /datum/tarot/the_emperor
 	name = "IV - The Emperor"
 	desc = "Challenge me!"
-	extended_desc = "warps the user to where command commonly reside, be ready for a fight."
+	extended_desc = "warps the user to where command commonly resides. Be ready for a fight."
 	card_icon = "the_emperor"
 
 /datum/tarot/the_emperor/activate(mob/living/target)
@@ -372,7 +372,7 @@
 /datum/tarot/the_hierophant
 	name = "V - The Hierophant"
 	desc = "Two prayers for the lost."
-	extended_desc = "allows the Hierophant to enchant the users suit, that is strong enough to entirely negate three attacks."
+	extended_desc = "Enchant the users suit with magic that's strong enough to negate three attacks."
 	card_icon = "the_hierophant"
 
 /datum/tarot/the_hierophant/activate(mob/living/target)
@@ -387,7 +387,7 @@
 /datum/tarot/the_lovers
 	name = "VI - The Lovers"
 	desc = "May you prosper and be in good health."
-	extended_desc = "knits the users wounds, repairs burnt flesh, restores blood, gives their breath back. Works on non-organic limbs as well." // I cant think of a better way of explaining this in a ic sense, please give feedback on this
+	extended_desc = "knits the user's wounds, repairs burnt flesh, restores blood, and gives their breath back. Works on non-organic limbs as well." // I cant think of a better way of explaining this in a ic sense, please give feedback on this
 	card_icon = "the_lovers"
 
 /datum/tarot/the_lovers/activate(mob/living/target)
@@ -405,7 +405,7 @@
 /datum/tarot/the_chariot
 	name = "VII - The Chariot"
 	desc = "May nothing stand before you."
-	extended_desc = "imbues the user with immense power and speed, making them practically immortal for 10 seconds. at a heavy cost of being unable to harm another living thing."
+	extended_desc = "imbues the user with immense power and speed, rendering them practically immortal for 10 seconds, at the cost of being unable to harm another living thing."
 	card_icon = "the_chariot"
 
 /datum/tarot/the_chariot/activate(mob/living/target)
@@ -415,7 +415,7 @@
 /datum/tarot/justice
 	name = "VIII - Justice"
 	desc = "May your future become balanced."
-	extended_desc = "grants the user a medical firstaid kit, a magical key that can open a single door, and 100 credits."
+	extended_desc = "grants the user a medical first aid kit, a magical key that can open a single door, and 100 credits."
 	card_icon = "justice"
 
 /datum/tarot/justice/activate(mob/living/target)
@@ -462,7 +462,7 @@
 /datum/tarot/strength
 	name = "XI - Strength"
 	desc = "May your power bring rage."
-	extended_desc = "grants the user strength only matched by powerful vampires gladiators. The strength blocks use of ranged weapons."
+	extended_desc = "grants the user strength only matched by powerful vampires. The strength blocks use of ranged weapons."
 	card_icon = "strength"
 
 /datum/tarot/strength/activate(mob/living/target)
@@ -484,7 +484,7 @@
 /datum/tarot/death
 	name = "XIII - Death"
 	desc = "Lay waste to all that oppose you."
-	extended_desc = "deals damage to all those the user can see. Aside from themselves, of cause."
+	extended_desc = "deals damage to all those the user can see. Aside from themselves, of course."
 	card_icon = "death"
 
 /datum/tarot/death/activate(mob/living/target)
@@ -495,7 +495,7 @@
 /datum/tarot/temperance
 	name = "XIV - Temperance"
 	desc = "May you be pure in heart."
-	extended_desc = "cures all diseases, disabilities, radiation, toxins, drunkenness, and brain damage in the user. As well as repairs heavy organ damage."
+	extended_desc = "cures all diseases, disabilities, radiation, toxins, drunkenness, and brain damage in the user, as well as heavy organ damage."
 	card_icon = "temperance"
 
 /datum/tarot/temperance/activate(mob/living/target)
@@ -520,7 +520,7 @@
 /datum/tarot/the_devil
 	name = "XV - The Devil"
 	desc = "Revel in the power of darkness."
-	extended_desc = "grants a large ammount of healing, at the cost of others around the user."
+	extended_desc = "grants a large amount of healing, at the cost of others around the user."
 	card_icon = "the_devil"
 
 /datum/tarot/the_devil/activate(mob/living/target)
@@ -540,7 +540,7 @@
 /datum/tarot/the_stars
 	name = "XVII - The Stars"
 	desc = "May you find what you desire."
-	extended_desc = "warps the user to the stations evidice lockup. As well as opens a single locker within."
+	extended_desc = "warps the user to the stations evidence lockup, and opens a single locker within."
 	card_icon = "the_stars"
 
 /datum/tarot/the_stars/activate(mob/living/target)
@@ -605,7 +605,7 @@
 /datum/tarot/the_sun
 	name = "XIX - The Sun"
 	desc = "May the light heal and enlighten you."
-	extended_desc = "heals you back to the users peak strength. Some say this card holds the power of a god."
+	extended_desc = "heals the user back to the their peak strength. Some say this card holds the power of a god."
 	card_icon = "the_sun"
 
 /datum/tarot/the_sun/activate(mob/living/target)
@@ -614,7 +614,7 @@
 /datum/tarot/judgement
 	name = "XX - Judgement"
 	desc = "Judge lest ye be judged."
-	extended_desc = "alerts those once living to the users exitense, prepare to be judged."
+	extended_desc = "alerts the denizens of the afterlife to the users existence. Prepare to be judged."
 	card_icon = "judgement"
 
 /datum/tarot/judgement/activate(mob/living/target)
@@ -623,7 +623,7 @@
 /datum/tarot/the_world
 	name = "XXI - The World"
 	desc = "Open your eyes and see."
-	extended_desc = "bellows out smoke and grants the user full xray for two minutes."
+	extended_desc = "bellows out smoke and grants the user full x-ray vision for two minutes."
 	card_icon = "the_world"
 
 /datum/tarot/the_world/activate(mob/living/target)
@@ -654,7 +654,7 @@
 /datum/tarot/reversed/the_magician
 	name = "I - The Magician?"
 	desc = "May no harm come to you."
-	extended_desc = "grants the user the power of a powerful mage apon use, throwing everything and one away from the user."
+	extended_desc = "grants the user the power of a powerful mage upon use, throwing everything away from the user."
 	card_icon = "the_magician?"
 
 /datum/tarot/reversed/the_magician/activate(mob/living/target)
@@ -688,7 +688,7 @@
 /datum/tarot/reversed/the_high_priestess
 	name = "II - The High Priestess?"
 	desc = "Run."
-	extended_desc = "summons Bubblegum to tear portals open, that will chase the user, grabbing people at random, causing major damage."
+	extended_desc = "summons Bubblegum to tear portals open, that will chase the user, and grab people at random, causing major damage."
 	card_icon = "the_high_priestess?"
 
 /datum/tarot/reversed/the_high_priestess/activate(mob/living/target)
@@ -793,7 +793,7 @@
 /datum/tarot/reversed/the_hermit
 	name = "IX - The Hermit?"
 	desc = "May you see the value of all things in life."
-	extended_desc = "will sell all loose guns, grenadeds, battons, and armour around the user, directly into cash."
+	extended_desc = "will sell all loose guns, grenades, batons, and armor around the user, transforming them directly into cash."
 	card_icon = "the_hermit?"
 
 /datum/tarot/reversed/the_hermit/activate(mob/living/target) //Someone can improve this in the future (hopefully comment will not be here in 10 years.)
@@ -815,7 +815,7 @@
 /datum/tarot/reversed/wheel_of_fortune
 	name = "X - Wheel of Fortune?"
 	desc = "Throw the dice of fate."
-	extended_desc = "forces the user of the card to roll a powerful magical artifact, the outcome can be highly positive or highly negitive, it is up to fate what happens now."
+	extended_desc = "forces the user of the card to roll a powerful magical artifact, the outcome can be highly positive or highly negative, it is up to fate what happens now."
 	card_icon = "wheel_of_fortune?"
 
 /datum/tarot/reversed/wheel_of_fortune/activate(mob/living/target)
@@ -825,7 +825,7 @@
 /datum/tarot/reversed/strength
 	name = "XI - Strength?"
 	desc = "May you break their resolve."
-	extended_desc = "breaks the mind of those around the user, dealing heavy brain damage, and causing two minutes of hallucinations."
+	extended_desc = "breaks the minds of those around the user, dealing heavy brain damage, and causing two minutes of hallucinations."
 	card_icon = "strength?"
 
 /datum/tarot/reversed/strength/activate(mob/living/target)
@@ -849,7 +849,7 @@
 /datum/tarot/reversed/death
 	name = "XIII - Death?"
 	desc = "May life spring forth from the fallen."
-	extended_desc = "grants the user a soulstone and construct to freely use on the dead."
+	extended_desc = "grants the user a soulstone and a construct to freely use on the dead."
 	card_icon = "death?"
 
 /datum/tarot/reversed/death/activate(mob/living/target)
@@ -940,7 +940,7 @@
 /datum/tarot/reversed/the_sun
 	name = "XIX - The Sun?"
 	desc = "May the darkness swallow all around you."
-	extended_desc = "the user of this card will gain a weakened version of a umbral vapmires eternal darkness ability for one minute. However the user will also become nearsighted for the duration"
+	extended_desc = "the user of this card will gain a weakened version of a umbral vampire's eternal darkness ability for one minute. However the user will also become nearsighted for the duration"
 	card_icon = "the_sun?"
 
 /datum/tarot/reversed/the_sun/activate(mob/living/target)
@@ -949,7 +949,7 @@
 /datum/tarot/reversed/judgement
 	name = "XX - Judgement?"
 	desc = "May you redeem those found wanting" //Who wants more, but ghosts for something interesting
-	extended_desc = "will nudge things that may happen during the shift into gear, perhaps the spirits will be merciful to you for this." // yeah right they will
+	extended_desc = "will nudge future events during the shift to be more...interesting. Perhaps the spirits will be merciful to you for this." // yeah right they will
 	card_icon = "judgement?"
 
 /datum/tarot/reversed/judgement/activate(mob/living/target)
@@ -961,7 +961,7 @@
 /datum/tarot/reversed/the_world
 	name = "XXI - The World?"
 	desc = "Step into the abyss."
-	extended_desc = "warps the user to the stations mining outpost."
+	extended_desc = "warps the user to the station's mining outpost."
 	card_icon = "the_world?"
 
 /datum/tarot/reversed/the_world/activate(mob/living/target)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Adds what tarot cards do to their extended descriptions, so its easier to tell what they do without the wiki open.
I've tried my best to keep it "ic" and somewhat magical with the wordings, and whatnot. please do give feedback on the wordings though.

<details open>
<summary>Added descriptions</summary>

- The fool - "returns the affected user to the arrival point of this forsaken journey."
- the magician - "makes the user feel extraordinarily badass for a couple of minutes."
- The high priestess - "alerts bubblegum to the user, allowing him to strike them down, dealing heavy damage and immobilizing them."
- The empress - "gives the user a temporary boost of speed. This includes attack speed."
- The emperor - "warps the user to where command commonly resides. Be ready for a fight."
- The hierophant - "enchants the user's suit with magic that's strong enough to negate three attacks."
- the lovers - "will restore the overall health of the user."
- The chariot - "imbues the user with immense power and speed, rendering them practically immortal for 10 seconds, at the cost of being unable to harm another living thing."
- Justice - "grants the user a medical first aid kit, a magical key that can open a single door, and 100 credits."
- the hermit - "teleports the user to a random vending machine within the station."
- wheel of fortune - "summons a random vending machine."
- strength - "grants the user strength beyond belief, but renders them unable to handle ranged weapons."
- the hanged man - "allows the user to fly for a minute."
- death - "deals damage to all those the user can see. Aside from themselves, of course."
- temperance - "cures all ailments the user has. Also reinvigorates their organs."
- the devil - "steals the life-force of everyone around the user."
- the tower - "summons a self-replicating bomb."
- the stars - "teleports the user to the station's evidence room, and opens a single locker within."
- the moon - "teleports the user to a random place of interest, starting with the sector the user is in first."
- the sun - "fully rejuvenates the user back to their peak strength."
- judgement - "alerts the denizens of the afterlife to the user's existence. Prepare to be judged."
- the world - "bellows out smoke and grants the user full x-ray vision for two minutes."

</details>

<details open>
<summary>Added revered descriptions</summary>

- the fool? - "removes all items from the user, leaving them completely naked."
- the magician? - "will repulse everything away from the user."
- The high priestess? - "summons Bubblegum to tear portals open around the user that will grab and damage everyone nearby."
- the empress? - "pacifies everyone in range, except for the user, for 40 seconds."
- the emperor? - "teleports the user to a random head of staff."
- the hierophant? - "makes the Hierophant attack two random mobs in range."
- The lovers? - "causes the user of this card to experience true heartbreak - leaving their chest broken and battered."
- The chariot? - "will petrify the user for two minutes, rendering them completely indestructible."
- justice? - "creates a random orderable crate. This can include crates Supply would otherwise not have access to at the time."
- the hermit? - "will sell all loose guns, grenades, batons, and armor around the user, transforming them directly into cash."
- wheel of fortune? - "forces the user to roll for a powerful magical artifact. The outcome can be highly positive or highly negative; it is up to fate."
- strength? - "breaks the minds of those around the user, dealing heavy brain damage, and causing two minutes of hallucinations."
- the hanged man? - "forces the user to spin a cursed slot machine."
- death? - "grants the user a soulstone and a construct to freely use on the dead."
- temperance? - "forces the user to eat five pills containing random reagents."
- the devil? - "summons a primed cluster flashbang at the user's feet."
- the tower? - "will create large stone walls that erupt from the ground around the user."
- the stars? - "will cause a large amount of genetic decomposition to the user, as well as hurting a limb. However, it will reward the user with two additional cards."
- the moon? - "will reveal the memories of everyone in range to the user."
- the sun? - "makes the user emit darkness, freezing anyone nearby. They will also become nearsighted for the duration, however."
- judgement? - "nudges the future events of this shift to be more... interesting."
- the world? - "teleports the user to the mining outpost."

</details>

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
The tarot cards(by design) lacked information on what they did as the original author is a huge issac nerd, however i personally believe this is poor design, while the descriptions hint at what they do, you still cant really tell *what* they do without the wizard wiki open in the background, leading to fights with the cards being somewhat tough. 

## Testing
<!-- How did you test the PR, if at all? -->
Checked both reversed and face versions of the fool, as well as when they're flipped, and a couple others. as far as i can tell it  works.
I do not want to spend however long looking through 40 cards descriptions, however they all use the same thing, so it *should* be fine :clueless:
<hr>

### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/feature_freeze/CODE_OF_CONDUCT.md#currently-changes-to-the-following-types-of-content-reuires-pre-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<!-- A list of PR types requiring pre-approval can be found here: https://github.com/ParadiseSS13/Paradise/blob/feature_freeze/CODE_OF_CONDUCT.md#currently-changes-to-the-following-types-of-content-reuires-pre-approval -->
![Discord_V4gIP16kak](https://github.com/user-attachments/assets/3d8ad3a5-cfd0-4ef6-b1f0-55c99c1a74cd)
(apologies if i need more than one members approval for this, it isn't stated if i do or not.)
<!-- Replace the box with [x] to mark as complete. -->
<hr>

## Changelog
:cl:
add: Added extended descriptions to the magical tarot cards, better outlining what effects they give.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
