### PR TITLE
fix squeak component

### DIFF
--- a/code/datums/components/squeak.dm
+++ b/code/datums/components/squeak.dm
@@ -71,25 +71,34 @@
 	else
 		steps++
 
-/datum/component/squeak/proc/play_squeak_crossed(atom/movable/AM)
-	if(isitem(AM))
-		var/obj/item/I = AM
+/datum/component/squeak/proc/play_squeak_crossed(atom/source, atom/movable/crossing)
+	if(istype(crossing, /obj/effect))
+		return
+	if(isitem(crossing))
+		var/obj/item/I = source
 		if(I.flags & ABSTRACT)
 			return
-		else if(isprojectile(AM))
-			var/obj/item/projectile/P = AM
-			if(P.original != parent)
-				return
-	if(ismob(AM))
-		var/mob/M = AM
+	if(isprojectile(crossing))
+		var/obj/item/projectile/P = crossing
+		if(P.original != parent)
+			return
+	if(ismob(source))
+		var/mob/M = source
 		if(M.flying)
 			return
-		if(isliving(AM))
+		if(isliving(source))
 			var/mob/living/L = M
 			if(L.floating)
 				return
-	var/atom/current_parent = parent
-	if(isturf(current_parent.loc))
+	if(ismob(crossing))
+		var/mob/M = crossing
+		if(M.flying)
+			return
+		if(isliving(crossing))
+			var/mob/living/L = M
+			if(L.floating)
+				return
+	if(isturf(source.loc))
 		play_squeak()
 
 /datum/component/squeak/proc/use_squeak()


### PR DESCRIPTION
fixes #10334 "Blood crawling slaughter demons make rubber duckies squeak"
prevents floating and flying mobs from trigger squeaks
prevents some potential runtimes in play_squeak_crossed

<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Effects triggered the squeak component on Crossed. This caused blood crawling slaughter demon and similar things to trigger the squeaking when they intuitively shouldn't. This PR adds an explicit check for effects and returns early if so.

The past implementation of the COMSIG_MOVABLE_CROSSED handler assumed that the first argument is the movable that moves onto the turf when that is in fact the second argument. The first argument is the atom that the handler is attached to (in this case the parent of the squeak component). This caused a couple of potential runtimes and did not prevent floating and flying mobs from triggering the squeak (as was intended). This PR fixes that.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
More predictable squeak behaviour.
Less runtimes.

## Testing
<!-- How did you test the PR, if at all? -->
Walked over ducky as human. Squeaked.
Flew over ducky as wizard with broom. Did not squeak.
Floated over ducky as human in zero G. Did not squeak.
Shot over ducky. Did not squeak.
Shot at ducky. Squeaked.
Walked over ducky as non-crawling slaughter demon. Squeaked.
Moved across ducky as blood crawling slaughter demon. Did not squeak.
Moved across ducky as revenant. Did not squeak.
Threw ducky. Squaked.
No runtimes observed.

<hr>

### Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/feature_freeze/CODE_OF_CONDUCT.md#currently-changes-to-the-following-types-of-content-reuires-pre-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<!-- A list of PR types requiring pre-approval can be found here: https://github.com/ParadiseSS13/Paradise/blob/feature_freeze/CODE_OF_CONDUCT.md#currently-changes-to-the-following-types-of-content-reuires-pre-approval -->
<!-- Replace the box with [x] to mark as complete. -->
<hr>

## Changelog
:cl:
fix: blood crawling demons, floating, and hovering mobs and similar things don't cause things to squeak any more
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
