### PR TITLE
Makes surgical trays able to hold surgical drapes

### DIFF
--- a/code/game/objects/items/weapons/storage/surgical_tray.dm
+++ b/code/game/objects/items/weapons/storage/surgical_tray.dm
@@ -18,7 +18,8 @@
 		/obj/item/bonegel,
 		/obj/item/bonesetter,
 		/obj/item/stack/medical/bruise_pack,
-		/obj/item/stack/medical/ointment
+		/obj/item/stack/medical/ointment,
+		/obj/item/surgical_drapes
 	)
 
 /obj/item/storage/surgical_tray/Initialize(mapload)


### PR DESCRIPTION
## What Does This PR Do
@lewcc made the surgical drape useful in #25686 (bless) but the surgical tray cannot hold this item. This PR adds the surgical drape to the accepted types of the surgical tray.

## Why It's Good For The Game
Surgical drapes are a part of surgery, they should be able to be inserted into their dedicated container.

## Images of changes

https://github.com/user-attachments/assets/2b38a6b7-2a28-40ee-b470-0bc2af73aa28

## Testing

Video above

<hr>

### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/feature_freeze/CODE_OF_CONDUCT.md#currently-changes-to-the-following-types-of-content-reuires-pre-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<!-- A list of PR types requiring pre-approval can be found here: https://github.com/ParadiseSS13/Paradise/blob/feature_freeze/CODE_OF_CONDUCT.md#currently-changes-to-the-following-types-of-content-reuires-pre-approval -->
<!-- Replace the box with [x] to mark as complete. -->
<hr>

## Changelog
:cl:
tweak: Surgical trays can now hold surgical drapes.
/:cl:
