### PR TITLE
Using explosives at end round now gibs you

### DIFF
--- a/code/controllers/subsystem/SSticker.dm
+++ b/code/controllers/subsystem/SSticker.dm
@@ -544,6 +544,7 @@ SUBSYSTEM_DEF(ticker)
 
 /datum/controller/subsystem/ticker/proc/declare_completion()
 	GLOB.nologevent = TRUE //end of round murder and shenanigans are legal; there's no need to jam up attack logs past this point.
+	GLOB.disable_explosions = TRUE // that said, if people want to be """FUNNY""" and bomb at EORG, they can fuck themselves up
 	set_observer_default_invisibility(0) //spooks things up
 	//Round statistics report
 	var/datum/station_state/ending_station_state = new /datum/station_state()

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -13,6 +13,19 @@
 	if(!epicenter)
 		return
 
+	// If we are in end round, make explosions gib the user
+	// Why? Its funny
+	if(GLOB.disable_explosions && usr && istype(usr, /mob/living/carbon/human))
+		to_chat(usr, "<span class='userdanger'>Your explosive backfires!</span>")
+		var/mob/living/carbon/human/H = usr
+		H.gib() // lol
+		return
+
+	// If explosions are disabled, and there isnt a user, or the user isnt an admin, abort
+	// Admins can still ruin things :P
+	if(GLOB.disable_explosions && ((!usr) || !is_admin(usr)))
+		return
+
 	// Archive the uncapped explosion for the doppler array
 	var/orig_dev_range = devastation_range
 	var/orig_heavy_range = heavy_impact_range

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -69,6 +69,14 @@
 		if(response == "Yes")
 			user.visible_message("<span class='warning'>[user] grins as [user.p_they()] begin[user.p_s()] to put a Bag of Holding into a Bag of Holding!</span>", "<span class='warning'>You begin to put the Bag of Holding into the Bag of Holding!</span>")
 			if(do_after(user, 30, target=src))
+				if(GLOB.disable_explosions)
+					if(istype(user, /mob/living/carbon/human))
+						to_chat(user, "<span class='userdanger'>You seem to stuff yourself into the quantum hellscape between the two bags. That wasn't wise.</span>")
+						var/mob/living/carbon/human/H = user
+						H.gib()
+
+					return
+
 				investigate_log("has become a singularity. Caused by [user.key]","singulo")
 				user.visible_message("<span class='warning'>[user] erupts in evil laughter as [user.p_they()] put[user.p_s()] the Bag of Holding into another Bag of Holding!</span>", "<span class='warning'>You can't help but laugh wildly as you put the Bag of Holding into another Bag of Holding, complete darkness surrounding you.</span>","<span class='danger'> You hear the sound of scientific evil brewing!</span>")
 				qdel(W)

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -70,10 +70,9 @@
 			user.visible_message("<span class='warning'>[user] grins as [user.p_they()] begin[user.p_s()] to put a Bag of Holding into a Bag of Holding!</span>", "<span class='warning'>You begin to put the Bag of Holding into the Bag of Holding!</span>")
 			if(do_after(user, 30, target=src))
 				if(GLOB.disable_explosions)
-					if(istype(user, /mob/living/carbon/human))
+					if(istype(user))
 						to_chat(user, "<span class='userdanger'>You seem to stuff yourself into the quantum hellscape between the two bags. That wasn't wise.</span>")
-						var/mob/living/carbon/human/H = user
-						H.gib()
+						user.gib()
 
 					return
 

--- a/code/modules/admin/misc_admin_procs.dm
+++ b/code/modules/admin/misc_admin_procs.dm
@@ -1,5 +1,8 @@
+/// Is admin BSA (damage a user) currently on cooldown?
 GLOBAL_VAR_INIT(BSACooldown, FALSE)
+/// Are we in a no-log event (EORG, highlander, etc)?
 GLOBAL_VAR_INIT(nologevent, FALSE)
+/// Are explosions currently disabled for EORG?
 GLOBAL_VAR_INIT(disable_explosions, FALSE)
 
 ////////////////////////////////

--- a/code/modules/admin/misc_admin_procs.dm
+++ b/code/modules/admin/misc_admin_procs.dm
@@ -1,5 +1,6 @@
-GLOBAL_VAR_INIT(BSACooldown, 0)
-GLOBAL_VAR_INIT(nologevent, 0)
+GLOBAL_VAR_INIT(BSACooldown, FALSE)
+GLOBAL_VAR_INIT(nologevent, FALSE)
+GLOBAL_VAR_INIT(disable_explosions, FALSE)
 
 ////////////////////////////////
 /proc/message_admins(msg)

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1829,9 +1829,8 @@
 			to_chat(owner, "Standby. Reload cycle in progress. Gunnery crews ready in five seconds!")
 			return
 
-		GLOB.BSACooldown = 1
-		spawn(50)
-			GLOB.BSACooldown = 0
+		GLOB.BSACooldown = TRUE
+		addtimer(VARSET_CALLBACK(GLOB, BSACooldown, FALSE), 5 SECONDS)
 
 		to_chat(M, "You've been hit by bluespace artillery!")
 		log_admin("[key_name(M)] has been hit by Bluespace Artillery fired by [key_name(owner)]")


### PR DESCRIPTION
## What Does This PR Do
Using explosives at end round grief now gibs the user.

If there is no user it just backfires and does nothing. Admins are immune to this if they need to bomb CC for whatever reason.

## Why It's Good For The Game
Gibbing the entire shuttle at EORG is boring.

## Testing
Threw a grenade at round end
![image](https://github.com/user-attachments/assets/b3b0ca5d-15ea-4ba4-b0a2-85276705d30d)


<hr>

### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/feature_freeze/CODE_OF_CONDUCT.md#currently-changes-to-the-following-types-of-content-reuires-pre-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<hr>

## Changelog
This is intentionally vague just to see who gets caught out.

:cl: AffectedArc07
tweak: Tweaked explosive behaviour during end of round grief.
/:cl:
