### PR TITLE
Fix CI failures by shuffling RNG in Lavaland procgen

### DIFF
--- a/code/game/turfs/simulated/river.dm
+++ b/code/game/turfs/simulated/river.dm
@@ -68,7 +68,7 @@
 		var/cur_dir = get_dir(cur_turf, target_turf)
 		while(cur_turf != target_turf)
 			if(detouring) //randomly snake around a bit
-				if(prob(20))
+				if(prob(21))
 					detouring = 0
 					cur_dir = get_dir(cur_turf, target_turf)
 			else if(prob(20))


### PR DESCRIPTION
## What Does This PR Do
This PR makes a tiny change to the RNG probabilities of the Lavaland river procgen. This shuffles about the RNG during unit tests to prevent a runtime, while having effectively no perceptible effect on in-game results.
## Why It's Good For The Game
Me not getting around to fixing the procgen runtime means it's blocking a PR that is otherwise fine but failing CI because of this (https://github.com/ParadiseSS13/Paradise/pull/26067).
## Testing
Ran CI on top of failing PR.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/feature_freeze/CODE_OF_CONDUCT.md#currently-changes-to-the-following-types-of-content-reuires-pre-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<hr>

## Changelog
I am dying to write something here like "tweak: the probability of the Lavaland lava river generator continuing to make detours while generating tiles towards its destination has been reduced from 80 to 79 percent" but there is no way anyone will notice or care.