### PR TITLE
Updates some flag lore

### DIFF
--- a/code/game/objects/items/flag.dm
+++ b/code/game/objects/items/flag.dm
@@ -145,32 +145,32 @@
 
 /obj/item/flag/cargo
 	name = "\improper Cargonia flag"
-	desc = "The flag of the independent, sovereign nation of Cargonia."
+	desc = "The flag of the independent, sovereign nation of Cargonia. Merely glimpsing this majestic banner fills you with the urge to buy enough guns to equip a small army."
 	icon_state = "cargoflag"
 
 /obj/item/flag/med
 	name = "\improper Medistan flag"
-	desc = "The flag of the independent, sovereign nation of Medistan."
+	desc = "The flag of the independent, sovereign nation of Medistan. Looking at this beautiful white and green banner fills you with a powerful compulsion to file malpractice lawsuits."
 	icon_state = "medflag"
 
 /obj/item/flag/sec
 	name = "\improper Brigston flag"
-	desc = "The flag of the independent, sovereign nation of Brigston."
+	desc = "The flag of the independent, sovereign nation of Brigston. The red of the flag represents blood shed in defense of the station, the amount of which varies heavily between shifts."
 	icon_state = "secflag"
 
 /obj/item/flag/rnd
 	name = "\improper Scientopia flag"
-	desc = "The flag of the independent, sovereign nation of Scientopia."
+	desc = "The flag of the independent, sovereign nation of Scientopia. Looking at this laminated beauty of a flag fills you with an irresstible urge to perform SCIENCE!."
 	icon_state = "rndflag"
 
 /obj/item/flag/atmos
 	name = "\improper Atmosia flag"
-	desc = "The flag of the independent, sovereign nation of Atmosia."
+	desc = "The flag of the independent, sovereign nation of Atmosia. This flag has survived dozens of plasmafires, and will endure more, if Atmosia has any say in things."
 	icon_state = "atmosflag"
 
 /obj/item/flag/command
 	name = "\improper Command flag"
-	desc = "The flag of the independent, sovereign nation of Command."
+	desc = "The flag of the independent, sovereign nation of Command. Apparently the budget was all spent on this flag, rather than a creative name."
 	icon_state = "ntflag"
 
 //Antags
@@ -182,27 +182,27 @@
 
 /obj/item/flag/syndi
 	name = "\improper Syndicate flag"
-	desc = "A flag proudly boasting the logo of the Syndicate, in defiance of NT."
+	desc = "A flag proudly boasting the crimson and black colors of the Syndicate, the largest organized criminal entity in the Sector."
 	icon_state = "syndiflag"
 
 /obj/item/flag/wiz
 	name = "\improper Wizard Federation flag"
-	desc = "A flag proudly boasting the logo of the Wizard Federation, sworn enemies of NT."
+	desc = "A flag proudly boasting the logo of the Wizard Federation, a loose collection of magical terrorist cells."
 	icon_state = "wizflag"
 
 /obj/item/flag/cult
 	name = "\improper Nar'Sie Cultist flag"
-	desc = "A flag proudly boasting the logo of the cultists, sworn enemies of NT."
+	desc = "A flag proudly boasting the unholy symbols of the Cult of Nar'sie. Merely possessing this flag is illegal in many polities."
 	icon_state = "cultflag"
 
 /obj/item/flag/ussp
 	name = "\improper USSP flag"
-	desc = "A flag proudly boasting the logo of the USSP, a noticeable faction in the galaxy."
+	desc = "A flag proudly flying the hammer & sickle of the USSP, a powerful socialist nation in the Sector's North."
 	icon_state = "usspflag"
 
 /obj/item/flag/solgov
 	name = "\improper Trans-Solar Federation flag"
-	desc = "A flag proudly boasting the logo of the SolGov, allied to NT government originated from Earth."
+	desc = "A flag proudly flying the golden sun of the Trans-Solar Federation, the militaristic de-facto superpower of the sector, based on Earth."
 	icon_state = "solgovflag"
 
 //Chameleon


### PR DESCRIPTION
## What Does This PR Do
Updates existing lore for department and national flags. Doesn't touch species flags yet.

## Why It's Good For The Game
Old national flag lore was often poorly written or outright incorrect.

Old department flag lore didn't exist.

Remedying both of these issues is good, in my opinion.

## Testing
- loaded in
- spawned flags
- observed flags
- lore has changed

<hr>

### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/feature_freeze/CODE_OF_CONDUCT.md#currently-changes-to-the-following-types-of-content-reuires-pre-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<hr>

## Changelog
:cl:
tweak: Changed flag descriptions
/:cl: