### PR TITLE
Stops runtime in cult spirit realm rune when observer doesn't have a mind

### DIFF
--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -940,7 +940,9 @@ structure_check() searches for nearby cultist structures required for the invoca
 			continue
 		if(!HAS_TRAIT(O, TRAIT_RESPAWNABLE) || QDELETED(src) || QDELETED(O))
 			continue
-		if(O?.mind?.current && HAS_TRAIT(O.mind.current, SCRYING))
+		if(!O.mind || !O.mind.current)
+			continue
+		if(HAS_TRAIT(O.mind.current, SCRYING))
 			continue
 		ghosts_on_rune += O
 	if(!length(ghosts_on_rune))

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -940,9 +940,9 @@ structure_check() searches for nearby cultist structures required for the invoca
 			continue
 		if(!HAS_TRAIT(O, TRAIT_RESPAWNABLE) || QDELETED(src) || QDELETED(O))
 			continue
-		if(!O.mind || !O.mind.current)
+		if(!O.mind)
 			continue
-		if(HAS_TRAIT(O.mind.current, SCRYING))
+		if(O.mind.current && HAS_TRAIT(O.mind.current, SCRYING))
 			continue
 		ghosts_on_rune += O
 	if(!length(ghosts_on_rune))

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -940,7 +940,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 			continue
 		if(!HAS_TRAIT(O, TRAIT_RESPAWNABLE) || QDELETED(src) || QDELETED(O))
 			continue
-		if(O.mind.current && HAS_TRAIT(O.mind.current, SCRYING))
+		if(O?.mind?.current && HAS_TRAIT(O.mind.current, SCRYING))
 			continue
 		ghosts_on_rune += O
 	if(!length(ghosts_on_rune))


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
See title. This will shortcircuit and continue before the HAS_TRAIT check can runtime as well. Observers having valid clients but a null mind is really funky and should probably be investigated further.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Fixes edge case runtime.
## Testing
<!-- How did you test the PR, if at all? -->
I can't test this locally (or reproduce the original issue), but it compiles. 
<hr>

### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/feature_freeze/CODE_OF_CONDUCT.md#currently-changes-to-the-following-types-of-content-reuires-pre-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<!-- A list of PR types requiring pre-approval can be found here: https://github.com/ParadiseSS13/Paradise/blob/feature_freeze/CODE_OF_CONDUCT.md#currently-changes-to-the-following-types-of-content-reuires-pre-approval -->
<!-- Replace the box with [x] to mark as complete. -->
<hr>

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
