### PR TITLE
Fixes a pulse demon bug

### DIFF
--- a/code/game/gamemodes/miniantags/pulsedemon/pulsedemon_abilities.dm
+++ b/code/game/gamemodes/miniantags/pulsedemon/pulsedemon_abilities.dm
@@ -133,6 +133,9 @@
 	if(!istype(C))
 		to_chat(user, "<span class='warning'>No cable found!</span>")
 		return FALSE
+	if(get_dist(O, T) > 15) //Some extra range to account for them possessing machines away from their APC, but blocking demons from using a camera console to zap across the station.
+		to_chat(user, "<span class='warning'>That cable is too far away!</span>")
+		return FALSE
 	playsound(T, 'sound/magic/lightningshock.ogg', 50, TRUE)
 	O.Beam(target, icon_state = "lightning[rand(1, 12)]", icon = 'icons/effects/effects.dmi', time = 1 SECONDS)
 	for(var/turf/working in get_line(O, T))


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Fixes a pulse demon bug by adding a safety limit of 15 tiles

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

lol

## Testing
<!-- How did you test the PR, if at all? -->
used the ability normaly and through machines, worked fine, worked fine very short distances through camera consoles, attempting to travel greater than 15 tiles is blocked.


<hr>
### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/feature_freeze/CODE_OF_CONDUCT.md#currently-changes-to-the-following-types-of-content-reuires-pre-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<!-- A list of PR types requiring pre-approval can be found here: https://github.com/ParadiseSS13/Paradise/blob/feature_freeze/CODE_OF_CONDUCT.md#currently-changes-to-the-following-types-of-content-reuires-pre-approval -->
<!-- Replace the box with [x] to mark as complete. -->
<hr>

## Changelog
:cl:
fix: Pulse demons have a safety limit on their cable hop ability
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
