### PR TITLE
Fix Runtime in stacks

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -140,7 +140,7 @@
 
 /obj/item/stack/attackby(obj/item/thing, mob/user, params)
 	if((parent_stack && !istype(thing, merge_type)) || !(parent_stack && thing.type == type))
-		..()
+		return ..()
 
 	var/obj/item/stack/material = thing
 	merge(material)


### PR DESCRIPTION
## What Does This PR Do
Fixing stupid mistake and unmuting my DEGUB tab in TGchat
Thanks @DGamerL 

## Why It's Good For The Game
Less runtimes

## Testing
![image](https://github.com/user-attachments/assets/cf25996c-37b4-44e7-a87c-86905cb30ac8)

<hr>

### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/feature_freeze/CODE_OF_CONDUCT.md#currently-changes-to-the-following-types-of-content-reuires-pre-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<!-- A list of PR types requiring pre-approval can be found here: https://github.com/ParadiseSS13/Paradise/blob/feature_freeze/CODE_OF_CONDUCT.md#currently-changes-to-the-following-types-of-content-reuires-pre-approval -->
<!-- Replace the box with [x] to mark as complete. -->
<hr>

## Changelog
NPFC

