### PR TITLE
fix: Make ruin area names more consistent.

### DIFF
--- a/code/game/area/areas/ruins/blackmarketpackers.dm
+++ b/code/game/area/areas/ruins/blackmarketpackers.dm
@@ -7,17 +7,17 @@
 	requires_power = TRUE
 
 /area/ruin/unpowered/BMPship/Aft
-	name = "\improper Aft Block"
+	name = "\improper BMP Aft Block"
 	icon_state = "away1"
 
 /area/ruin/unpowered/BMPship/Midship
-	name = "\improper Midship Block"
+	name = "\improper BMP Midship Block"
 	icon_state = "away2"
 
 /area/ruin/unpowered/BMPship/Fore
-	name = "\improper Fore Block"
+	name = "\improper BMP Fore Block"
 	icon_state = "away3"
 
 /area/ruin/unpowered/BMPship/Delta
-	name = "\improper Delta Block"
+	name = "\improper BMP Delta Block"
 	icon_state = "away4"

--- a/code/game/area/areas/ruins/space_areas.dm
+++ b/code/game/area/areas/ruins/space_areas.dm
@@ -28,19 +28,19 @@
 
 // Ruins of "onehalf" ship
 /area/ruin/space/onehalf/hallway
-	name = "Hallway"
+	name = "DK Excavator 453 Hallway"
 	icon_state = "hallC"
 
 /area/ruin/space/onehalf/drone_bay
-	name = "Mining Drone Bay"
+	name = "DK Excavator 453 Mining Drone Bay"
 	icon_state = "engine"
 
 /area/ruin/space/onehalf/dorms_med
-	name = "Crew Quarters"
+	name = "DK Excavator 453 Crew Quarters"
 	icon_state = "Sleep"
 
 /area/ruin/space/onehalf/abandonedbridge
-	name = "Abandoned Bridge"
+	name = "DK Excavator 453 Abandoned Bridge"
 	icon_state = "bridge"
 
 //DJSTATION
@@ -111,7 +111,7 @@
 	icon_state = "GENsolar"
 
 /area/ruin/space/derelict/se_solar
-	name = "South East Solars"
+	name = "\improper Derelict South East Solars"
 	icon_state = "GENsolar"
 
 /area/ruin/space/derelict/crew_quarters
@@ -187,32 +187,32 @@
 	requires_power = TRUE
 
 /area/ruin/space/powered/casino/docked_ships
-	name = "Shuttle"
+	name = "Dorian Casino Shuttle"
 	requires_power = FALSE
 
 /area/ruin/space/powered/casino/arrivals
-	name = "Arrivals"
+	name = "Dorian Casino Arrivals"
 
 /area/ruin/space/powered/casino/kitchen
-	name = "Dining and Kitchen"
+	name = "Dorian Casino Dining and Kitchen"
 
 /area/ruin/space/powered/casino/floor
-	name = "Casino Floor"
+	name = "Dorian Casino Casino Floor"
 
 /area/ruin/space/powered/casino/hall
-	name = "Main Hall"
+	name = "Dorian Casino Main Hall"
 
 /area/ruin/space/powered/casino/engine
-	name = "Engine Room"
+	name = "Dorian Casino Engine Room"
 
 /area/ruin/space/powered/casino/security
-	name = "Security"
+	name = "Dorian Casino Security"
 
 /area/ruin/space/powered/casino/teleporter
-	name = "Teleporter"
+	name = "Dorian Casino Teleporter"
 
 /area/ruin/space/powered/casino/maints
-	name = "Service Tunnels"
+	name = "Dorian Casino Service Tunnels"
 
 /// telecomms: Alternative telecomms sat
 /area/ruin/space/telecomms

--- a/code/game/area/ss13_areas/engineering_areas.dm
+++ b/code/game/area/ss13_areas/engineering_areas.dm
@@ -61,7 +61,7 @@
 	icon_state = "gravgen"
 
 /area/station/engineering/ai_transit_tube
-	name = "\improper Ai Minisat Tranit Tube"
+	name = "\improper AI Minisat Tranit Tube"
 	icon_state = "ai"
 	sound_environment = SOUND_AREA_SMALL_ENCLOSED
 


### PR DESCRIPTION
## What Does This PR Do
This PR:
- Prefixes every casino ruin `/area` name with "Dorian Casino"
- Prefixes every onehalf ruin `/area` name with "DK Excavator 453"
- Prefixes every meatpackers ruin `/area` name with "BMP"
- Prefixes one of the ussp derelict ruin `/areas` with "Derelict"
- Fixes a capitalization error with the "AI Minisat Transit Tube" area
## Why It's Good For The Game
By giving these areas consistent names prefixed with their ruin name, the "Jump to Area" UI is much more useful when trying to quickly jump to station areas. The AI Minisat name is now properly displayed.
## Testing
Spawned many ruins with increased budget over multiple rounds and inspected Jump to Area UI.
<hr>

### Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/feature_freeze/CODE_OF_CONDUCT.md#currently-changes-to-the-following-types-of-content-reuires-pre-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<!-- A list of PR types requiring pre-approval can be found here: https://github.com/ParadiseSS13/Paradise/blob/feature_freeze/CODE_OF_CONDUCT.md#currently-changes-to-the-following-types-of-content-reuires-pre-approval -->
<!-- Replace the box with [x] to mark as complete. -->
<hr>

## Changelog
:cl:
fix: The names of ruin areas in the Jump To Area menu are more consistent and less difficult to confuse with station areas.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
