### PR TITLE
Fixes Nanotrasen paper bin + now its tgui_alert instead of alert

### DIFF
--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -84,6 +84,9 @@
 				if("Cancel")
 					return
 
+			if(isnull(P))
+				return
+
 			if(SSholiday.holidays && SSholiday.holidays[APRIL_FOOLS])
 				if(prob(30))
 					P.info = "<font face=\"[P.crayonfont]\" color=\"red\"><b>HONK HONK HONK HONK HONK HONK HONK<br>HOOOOOOOOOOOOOOOOOOOOOONK<br>APRIL FOOLS</b></font>"

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -73,7 +73,7 @@
 			P = papers[length(papers)]
 			papers.Remove(P)
 		else
-			var/choice = tgui_alert(user, "Choose a style", "Paperbin", list("Letterhead","Blank", "Cancel"))
+			var/choice = tgui_alert(user, "Choose a style", "Paperbin", list("Letterhead", "Blank", "Cancel"))
 			if(isnull(choice) || !Adjacent(user))
 				return
 			switch(choice)

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -74,7 +74,7 @@
 			papers.Remove(P)
 		else
 			var/choice = tgui_alert(user, "Choose a style", "Paperbin", list("Letterhead","Blank", "Cancel"))
-			if(isnull(choice) || (choice == "Cancel") || !Adjacent(user))
+			if(isnull(choice) || !Adjacent(user))
 				return
 			switch(choice)
 				if("Letterhead")

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -74,13 +74,15 @@
 			papers.Remove(P)
 		else
 			var/choice = tgui_alert(user, "Choose a style", "Paperbin", list("Letterhead","Blank", "Cancel"))
-			if(!choice || (choice == "Cancel") || !Adjacent(user))
+			if(isnull(choice) || (choice == "Cancel") || !Adjacent(user))
 				return
 			switch(choice)
 				if("Letterhead")
 					P = new letterhead_type
 				if("Blank")
 					P = new /obj/item/paper
+				if("Cancel")
+					return
 
 			if(SSholiday.holidays && SSholiday.holidays[APRIL_FOOLS])
 				if(prob(30))

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -73,10 +73,15 @@
 			P = papers[length(papers)]
 			papers.Remove(P)
 		else
-			if(letterhead_type && alert("Choose a style", null,"Letterhead","Blank")=="Letterhead")
-				P = new letterhead_type
-			else
-				P = new /obj/item/paper
+			var/choice = tgui_alert(user, "Choose a style", "Paperbin", list("Letterhead","Blank", "Cancel"))
+			if(!choice || (choice == "Cancel") || !Adjacent(user))
+				return
+			switch(choice)
+				if("Letterhead")
+					P = new letterhead_type
+				if("Blank")
+					P = new /obj/item/paper
+
 			if(SSholiday.holidays && SSholiday.holidays[APRIL_FOOLS])
 				if(prob(30))
 					P.info = "<font face=\"[P.crayonfont]\" color=\"red\"><b>HONK HONK HONK HONK HONK HONK HONK<br>HOOOOOOOOOOOOOOOOOOOOOONK<br>APRIL FOOLS</b></font>"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
1. Fixes bug 
2. Replaces old alert with a modern looking one
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Fixes #26450
Replaces old alert() with tgui_alert()
## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
Nothing
## Testing
<!-- How did you test the PR, if at all? -->
https://github.com/user-attachments/assets/da8d6a2a-3c3c-4583-81f2-c7638267dc94
<hr>

### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/feature_freeze/CODE_OF_CONDUCT.md#currently-changes-to-the-following-types-of-content-reuires-pre-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<!-- A list of PR types requiring pre-approval can be found here: https://github.com/ParadiseSS13/Paradise/blob/feature_freeze/CODE_OF_CONDUCT.md#currently-changes-to-the-following-types-of-content-reuires-pre-approval -->
<!-- Replace the box with [x] to mark as complete. -->
<hr>

## Changelog
:cl:
fix: Nanotrasen Paperbin now does not let you take paper from it if you are too far away
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
