### PR TITLE
Borgs can now play a sad trombone emote

### DIFF
--- a/code/datums/keybindings/emote_keybinds.dm
+++ b/code/datums/keybindings/emote_keybinds.dm
@@ -602,6 +602,10 @@
 	linked_emote = /datum/emote/living/silicon/no
 	name = "No"
 
+/datum/keybinding/emote/silicon/sad
+	linked_emote = /datum/emote/living/silicon/sad
+	name = "Sad"
+
 /datum/keybinding/emote/silicon/law
 	linked_emote = /datum/emote/living/silicon/law
 	name = "Law"

--- a/code/modules/mob/living/silicon/silicon_emote.dm
+++ b/code/modules/mob/living/silicon/silicon_emote.dm
@@ -78,6 +78,14 @@
 	emote_type = EMOTE_AUDIBLE
 	sound = "sound/machines/synth_no.ogg"
 
+/datum/emote/living/silicon/sad
+	key = "sad"
+	key_third_person = "plays a sad trombone"
+	message = "plays a sad trombone."
+	message_param = "makes a sad noise at %t!"
+	emote_type = EMOTE_AUDIBLE
+	sound = "sound/misc/sadtrombone.ogg"
+
 /datum/emote/living/silicon/law
 	key = "law"
 	message = "shows its legal authorization barcode."


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds a *sad emote for silicons. This will play a sad trombone

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

https://github.com/user-attachments/assets/ed95bbaf-4def-4dc5-943e-5e41a9e83a61


## Testing
<!-- How did you test the PR, if at all? -->
see why it's good for the game
<hr>

### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/feature_freeze/CODE_OF_CONDUCT.md#currently-changes-to-the-following-types-of-content-reuires-pre-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<!-- A list of PR types requiring pre-approval can be found here: https://github.com/ParadiseSS13/Paradise/blob/feature_freeze/CODE_OF_CONDUCT.md#currently-changes-to-the-following-types-of-content-reuires-pre-approval -->
<!-- Replace the box with [x] to mark as complete. -->
<hr>

## Changelog
:cl:
add: Nanotrasen has added a sad trombone sound to the speakers of borgs!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
