### PR TITLE
Fix ore picking with bag

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -139,7 +139,7 @@
 		ui_interact(user)
 
 /obj/item/stack/attackby(obj/item/thing, mob/user, params)
-	if((parent_stack && !istype(thing, merge_type)) || (parent_stack && thing.type != type))
+	if((!parent_stack && !istype(thing, merge_type)) || (parent_stack && thing.type != type))
 		..()
 		return
 

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -140,8 +140,7 @@
 
 /obj/item/stack/attackby(obj/item/thing, mob/user, params)
 	if((!parent_stack && !istype(thing, merge_type)) || (parent_stack && thing.type != type))
-		..()
-		return
+		return ..()
 
 	var/obj/item/stack/material = thing
 	merge(material)


### PR DESCRIPTION
## What Does This PR Do
Another stack fix thanks to my stupidity.

## Testing
I don't see what the point of this is anymore if it's the third time in a row I've missed a bug, but yeah

Pick's up some stack's, try merge unmergable stacks, picked up some ore with ore bag, dig some ore and pick it up without clicking and trying to merge steel with ore

<hr>

### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/feature_freeze/CODE_OF_CONDUCT.md#currently-changes-to-the-following-types-of-content-reuires-pre-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<!-- A list of PR types requiring pre-approval can be found here: https://github.com/ParadiseSS13/Paradise/blob/feature_freeze/CODE_OF_CONDUCT.md#currently-changes-to-the-following-types-of-content-reuires-pre-approval -->
<!-- Replace the box with [x] to mark as complete. -->
<hr>

## Changelog
:cl:
fix: You can pick up ore with ore bag again
/:cl:

