### PR TITLE
Replace Magic Numbers Related to EMP and Explosion Severity with Defines

### DIFF
--- a/code/datums/beam.dm
+++ b/code/datums/beam.dm
@@ -133,7 +133,7 @@
 
 /obj/effect/ebeam/deadly/Crossed(atom/A, oldloc)
 	..()
-	A.ex_act(1)
+	A.ex_act(EXPLODE_DEVASTATE)
 
 /obj/effect/ebeam/vetus/Destroy()
 	for(var/mob/living/M in get_turf(src))

--- a/code/game/gamemodes/cult/blood_magic.dm
+++ b/code/game/gamemodes/cult/blood_magic.dm
@@ -188,7 +188,7 @@
 		return
 	owner.visible_message("<span class='warning'>[owner]'s body flashes a bright blue!</span>", \
 						"<span class='cultitalic'>You speak the cursed words, channeling an electromagnetic pulse from your body.</span>")
-	owner.emp_act(2)
+	owner.emp_act(EMP_LIGHT)
 	INVOKE_ASYNC(GLOBAL_PROC, GLOBAL_PROC_REF(empulse), owner, 2, 5, TRUE, "cult")
 	owner.whisper(invocation)
 	charges--

--- a/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
@@ -223,7 +223,7 @@ CONTENTS:
 		if(isradio(I))
 			var/obj/item/radio/R = I
 			R.listening = FALSE // Prevents the radio from buzzing due to the EMP, preserving possible stealthiness.
-			R.emp_act(1)
+			R.emp_act(EMP_HEAVY)
 
 /obj/item/gun/energy/alien
 	name = "alien pistol"

--- a/code/game/gamemodes/miniantags/guardian/types/explosive_guardian.dm
+++ b/code/game/gamemodes/miniantags/guardian/types/explosive_guardian.dm
@@ -86,7 +86,7 @@
 	to_chat(spawner, "<span class='danger'>Success! Your trap on [src] caught [user]!</span>")
 	stored_obj.forceMove(get_turf(loc))
 	playsound(get_turf(src),'sound/effects/explosion2.ogg', 200, 1)
-	user.ex_act(2)
+	user.ex_act(EXPLODE_HEAVY)
 	user.Stun(3 SECONDS)//A bomb went off in your hands. Actually lets people follow up with it if they bait someone, right now it is unreliable.
 	qdel(src)
 

--- a/code/game/gamemodes/miniantags/guardian/types/protector.dm
+++ b/code/game/gamemodes/miniantags/guardian/types/protector.dm
@@ -15,7 +15,7 @@
 	var/list/connected_shields = list()
 
 /mob/living/simple_animal/hostile/guardian/protector/ex_act(severity)
-	if(severity == 1)
+	if(severity == EXPLODE_DEVASTATE)
 		adjustBruteLoss(200) //if in protector mode, will do 20 damage and not actually necessarily kill the summoner
 	else
 		..()

--- a/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
@@ -441,7 +441,7 @@
 	to_chat(src, "<span class='warning'>You feel [pick("your sense of direction flicker out", "a stabbing pain in your head", "your mind fill with static")].</span>")
 	new /obj/effect/temp_visual/revenant(loc)
 	if(cause_emp)
-		emp_act(1)
+		emp_act(EMP_HEAVY)
 
 /mob/living/simple_animal/bot/rev_malfunction(cause_emp = TRUE)
 	if(!emagged)
@@ -456,7 +456,7 @@
 			new /obj/effect/temp_visual/revenant(loc)
 		emag_act(usr)
 	else if(cause_emp)
-		emp_act(1)
+		emp_act(EMP_HEAVY)
 
 /obj/machinery/clonepod/rev_malfunction(cause_emp = TRUE)
 	..(cause_emp = FALSE)
@@ -472,7 +472,7 @@
 	new /obj/effect/temp_visual/revenant(loc)
 	spark_system.start()
 	if(cause_emp)
-		emp_act(1)
+		emp_act(EMP_HEAVY)
 
 /turf/defile()
 	if(flags & BLESSED_TILE)

--- a/code/game/machinery/computer/HolodeckControl.dm
+++ b/code/game/machinery/computer/HolodeckControl.dm
@@ -75,7 +75,7 @@
 			for(var/turf/T in linkedholodeck)
 				if(prob(30))
 					do_sparks(2, 1, T)
-				T.ex_act(3)
+				T.ex_act(EXPLODE_LIGHT)
 				T.hotspot_expose(1000,500,1)
 
 /obj/machinery/computer/HolodeckControl/proc/loadProgram(area/A)

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -39,9 +39,9 @@
 		return
 	var/num_of_prizes = 0
 	switch(severity)
-		if(1)
+		if(EMP_HEAVY)
 			num_of_prizes = rand(1,4)
-		if(2)
+		if(EMP_LIGHT)
 			num_of_prizes = rand(0,2)
 	for(var/i = num_of_prizes; i > 0; i--)
 		prizevend()

--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -116,10 +116,10 @@
 /obj/machinery/computer/emp_act(severity)
 	..()
 	switch(severity)
-		if(1)
+		if(EMP_HEAVY)
 			if(prob(50))
 				obj_break(ENERGY)
-		if(2)
+		if(EMP_LIGHT)
 			if(prob(10))
 				obj_break(ENERGY)
 

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -397,7 +397,7 @@
 		qdel(src)
 
 /obj/structure/dropwall_generator/ex_act(severity)
-	if(protected && severity > 1) //We would throw the explosion at the shield, but it is already getting hit
+	if(protected && severity > EXPLODE_DEVASTATE) //We would throw the explosion at the shield, but it is already getting hit
 		return
 	qdel(src)
 

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -50,7 +50,7 @@
 
 //"BLAST" doors are obviously stronger than regular doors when it comes to BLASTS.
 /obj/machinery/door/poddoor/ex_act(severity)
-	if(severity == 3)
+	if(severity == EXPLODE_LIGHT)
 		return
 	..()
 

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -409,7 +409,7 @@
 			breakthrough = TRUE
 
 		else if(istype(obstacle, /obj/structure/reagent_dispensers/fueltank))
-			obstacle.ex_act(1)
+			obstacle.ex_act(EXPLODE_DEVASTATE)
 
 		else if(isliving(obstacle))
 			var/mob/living/L = obstacle

--- a/code/game/objects/effects/decals/Cleanable/misc_cleanables.dm
+++ b/code/game/objects/effects/decals/Cleanable/misc_cleanables.dm
@@ -232,7 +232,7 @@
 	mergeable_decal = FALSE
 
 /obj/effect/decal/cleanable/shreds/ex_act(severity, target)
-	if(severity == 1) //so shreds created during an explosion aren't deleted by the explosion.
+	if(severity == EXPLODE_DEVASTATE) //so shreds created during an explosion aren't deleted by the explosion.
 		qdel(src)
 
 /obj/effect/decal/cleanable/shreds/Initialize(mapload)

--- a/code/game/objects/effects/snowcloud.dm
+++ b/code/game/objects/effects/snowcloud.dm
@@ -113,7 +113,7 @@
 	qdel(src)
 
 /obj/effect/snow/ex_act(severity)
-	if(severity == 3 && prob(50))
+	if(severity == EXPLODE_LIGHT && prob(50))
 		return
 	qdel(src)
 

--- a/code/game/objects/empulse.dm
+++ b/code/game/objects/empulse.dm
@@ -37,16 +37,16 @@
 		var/will_affect = FALSE
 
 		if(distance < heavy_range)
-			will_affect = T.emp_act(1)
+			will_affect = T.emp_act(EMP_HEAVY)
 
 		else if(distance == heavy_range)
 			if(prob(50))
-				will_affect = T.emp_act(1)
+				will_affect = T.emp_act(EMP_HEAVY)
 			else
-				will_affect = T.emp_act(2)
+				will_affect = T.emp_act(EMP_LIGHT)
 
 		else if(distance <= light_range)
-			will_affect = T.emp_act(2)
+			will_affect = T.emp_act(EMP_LIGHT)
 
 		if(will_affect)
 			if(cause == "cult")

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -182,7 +182,7 @@
 					if(breach)
 						T.ex_act(dist)
 					else
-						T.ex_act(3)
+						T.ex_act(EXPLODE_LIGHT)
 
 			CHECK_TICK
 
@@ -206,7 +206,7 @@
 
 /proc/secondaryexplosion(turf/epicenter, range)
 	for(var/turf/tile in spiral_range_turfs(range, epicenter))
-		tile.ex_act(2)
+		tile.ex_act(EXPLODE_HEAVY)
 
 /client/proc/check_bomb_impacts()
 	set name = "Check Bomb Impact"

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -393,7 +393,7 @@
 			var/mob/M = A
 			add_attack_logs(user, M, "Hit with EMP-light")
 		to_chat(user, "[src] now has [emp_cur_charges] charge\s.")
-		A.emp_act(1)
+		A.emp_act(EMP_HEAVY)
 	else
 		to_chat(user, "<span class='warning'>\The [src] needs time to recharge!</span>")
 	return

--- a/code/game/objects/items/devices/laserpointer.dm
+++ b/code/game/objects/items/devices/laserpointer.dm
@@ -129,7 +129,7 @@
 	else if(istype(target, /obj/machinery/camera))
 		var/obj/machinery/camera/C = target
 		if(prob(effectchance * diode.rating))
-			C.emp_act(1)
+			C.emp_act(EMP_HEAVY)
 			outmsg = "<span class='notice'>You hit the lens of [C] with [src], temporarily disabling the camera!</span>"
 
 			log_admin("[key_name(user)] EMPd a camera with a laser pointer")

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -722,12 +722,12 @@
 		if(HAS_TRAIT(src, TRAIT_WIELDED))
 			if(iswallturf(A))
 				var/turf/simulated/wall/Z = A
-				Z.ex_act(2)
+				Z.ex_act(EXPLODE_HEAVY)
 				charged = 3
 				playsound(user, 'sound/weapons/marauder.ogg', 50, 1)
 			else if(isstructure(A) || ismecha(A))
 				var/obj/Z = A
-				Z.ex_act(2)
+				Z.ex_act(EXPLODE_HEAVY)
 				charged = 3
 				playsound(user, 'sound/weapons/marauder.ogg', 50, 1)
 

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -272,7 +272,7 @@
 		var/atom/throw_target = get_edge_target_turf(target, user.dir)
 		user.visible_message("<span class='userdanger'>It's a home run!</span>")
 		target.throw_at(throw_target, rand(8,10), 14, user)
-		target.ex_act(2)
+		target.ex_act(EXPLODE_HEAVY)
 		playsound(get_turf(src), 'sound/weapons/homerun.ogg', 100, 1)
 		homerun_ready = 0
 		return

--- a/code/game/objects/structures/depot_structures.dm
+++ b/code/game/objects/structures/depot_structures.dm
@@ -28,7 +28,7 @@
 	return ..()
 
 /obj/structure/fusionreactor/ex_act(severity)
-	if(severity < 3)
+	if(severity < EXPLODE_LIGHT)
 		obj_integrity = 0
 		healthcheck()
 

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -71,7 +71,7 @@ GLOBAL_LIST_INIT(icons_to_ignore_at_floor_init, list("damaged1","damaged2","dama
 	return
 
 /turf/simulated/floor/burn_down()
-	ex_act(2)
+	ex_act(EXPLODE_HEAVY)
 
 /turf/simulated/floor/is_shielded()
 	for(var/obj/structure/A in contents)

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -138,7 +138,7 @@
 
 /obj/item/clothing/head/helmet/space/hardsuit/emp_act(severity)
 	..()
-	display_visor_message("[severity > 1 ? "Light" : "Strong"] electromagnetic pulse detected!")
+	display_visor_message("[severity > EMP_HEAVY ? "Light" : "Strong"] electromagnetic pulse detected!")
 
 /obj/item/clothing/suit/space/hardsuit
 	name = "hardsuit"

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -103,7 +103,7 @@
 	return
 
 /turf/simulated/floor/vines/ex_act(severity)
-	if(severity < 3)
+	if(severity < EXPLODE_LIGHT)
 		ChangeTurf(baseturf)
 
 /turf/simulated/floor/vines/narsie_act()
@@ -209,7 +209,7 @@
 	nofun = TRUE
 
 /datum/spacevine_mutation/explosive/on_explosion(explosion_severity, obj/structure/spacevine/holder)
-	if(explosion_severity < 3)
+	if(explosion_severity < EXPLODE_LIGHT)
 		qdel(holder)
 	else
 		addtimer(CALLBACK(holder, TYPE_PROC_REF(/obj/structure/spacevine, wither)), 5)

--- a/code/modules/mining/equipment/mining_charges.dm
+++ b/code/modules/mining/equipment/mining_charges.dm
@@ -107,7 +107,7 @@
 		location = get_atom_on_turf(src)
 	if(location)
 		explosion(location, boom_sizes[1], boom_sizes[2], boom_sizes[3], cause = src)
-		location.ex_act(2, target)
+		location.ex_act(EXPLODE_HEAVY, target)
 	qdel(src)
 
 /obj/item/grenade/plastic/miningcharge/proc/override_safety()

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -288,7 +288,7 @@
 
 /obj/machinery/mineral/equipment_vendor/ex_act(severity, target)
 	do_sparks(5, TRUE, src)
-	if(prob(50 / severity) && severity < 3)
+	if(prob(50 / severity) && severity < EXPLODE_LIGHT)
 		qdel(src)
 
 /obj/machinery/mineral/equipment_vendor/Destroy()

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -353,7 +353,7 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 
 
 /obj/item/stack/ore/ex_act(severity)
-	if(!severity || severity >= 2)
+	if(!severity || severity >= EXPLODE_HEAVY)
 		return
 	qdel(src)
 

--- a/code/modules/mob/living/brain/robotic_brain.dm
+++ b/code/modules/mob/living/brain/robotic_brain.dm
@@ -160,12 +160,10 @@
 	if(!brainmob)
 		return
 	switch(severity)
-		if(1)
+		if(EMP_HEAVY)
 			brainmob.emp_damage += rand(20, 30)
-		if(2)
+		if(EMP_LIGHT)
 			brainmob.emp_damage += rand(10, 20)
-		if(3)
-			brainmob.emp_damage += rand(0, 10)
 	..()
 
 /obj/item/mmi/robotic_brain/New()

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/ancient_robot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/ancient_robot.dm
@@ -600,8 +600,8 @@ Difficulty: Hard
 			if(mode == VORTEX)
 				var/turf/T = get_turf(src)
 				for(var/atom/A in T)
-					A.ex_act(3) //Body is immune to explosions of this strength.
-				T.ex_act(3)
+					A.ex_act(EXPLODE_LIGHT) //Body is immune to explosions of this strength.
+				T.ex_act(EXPLODE_LIGHT)
 			if(mode == CRYO)
 				var/turf/simulated/S = get_turf(src)
 				S.MakeSlippery(TURF_WET_ICE, enraged ? rand(25, 35 SECONDS) : rand(10, 20 SECONDS))

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -356,7 +356,7 @@ Difficulty: Very Hard
 /obj/item/projectile/colossus/on_hit(atom/target, blocked = 0)
 	. = ..()
 	if(isturf(target) || isobj(target))
-		target.ex_act(2)
+		target.ex_act(EXPLODE_HEAVY)
 		for(var/obj/machinery/light/L in range(2, src))
 			L.break_light_tube(0, 1) //No leaving lights floating their as colossus breaks the station
 	if(isliving(target))

--- a/code/modules/mod/mod_control.dm
+++ b/code/modules/mod/mod_control.dm
@@ -455,7 +455,7 @@
 	. = ..()
 	if(!active || !wearer)
 		return
-	to_chat(wearer, "<span class='warning'>[severity > 1 ? "Light" : "Strong"] electromagnetic pulse detected!")
+	to_chat(wearer, "<span class='warning'>[severity > EMP_HEAVY ? "Light" : "Strong"] electromagnetic pulse detected!")
 	if(emp_proof)
 		return
 	selected_module?.on_deactivation(display_message = TRUE)

--- a/code/modules/power/engines/singularity/narsie.dm
+++ b/code/modules/power/engines/singularity/narsie.dm
@@ -84,7 +84,7 @@
 /obj/singularity/narsie/proc/godsmack(atom/A)
 	if(isobj(A))
 		var/obj/O = A
-		O.ex_act(1)
+		O.ex_act(EXPLODE_DEVASTATE)
 		if(O) qdel(O)
 
 	else if(isturf(A))

--- a/code/modules/power/gravitygenerator.dm
+++ b/code/modules/power/gravitygenerator.dm
@@ -25,7 +25,7 @@ GLOBAL_LIST_EMPTY(gravity_generators)
 	flags_2 = NO_MALF_EFFECT_2
 
 /obj/machinery/gravity_generator/ex_act(severity)
-	if(severity == 1) // Very sturdy.
+	if(severity == EXPLODE_DEVASTATE) // Very sturdy.
 		set_broken()
 
 /obj/machinery/gravity_generator/blob_act(obj/structure/blob/B)

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -134,7 +134,7 @@
 	icon_state = "[initial(icon_state)][beaker ? "_working" : ""]"
 
 /obj/machinery/chem_dispenser/ex_act(severity)
-	if(severity < 3)
+	if(severity < EXPLODE_LIGHT)
 		if(beaker)
 			beaker.ex_act(severity)
 		..()

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -78,7 +78,7 @@
 		reagents.maximum_volume += B.reagents.maximum_volume
 
 /obj/machinery/chem_master/ex_act(severity)
-	if(severity < 3)
+	if(severity < EXPLODE_LIGHT)
 		if(beaker)
 			beaker.ex_act(severity)
 		if(loaded_pill_bottle)

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -688,7 +688,7 @@
 			SEND_SOUND(M, loud_crash_sound)
 	for(var/turf/T in L2)
 		for(var/atom/movable/A in T.contents)
-			A.ex_act(1)
+			A.ex_act(EXPLODE_DEVASTATE)
 			if(istype(A, /obj/machinery/atmospherics/supermatter_crystal))
 				var/obj/machinery/atmospherics/supermatter_crystal/bakoom = A
 				addtimer(CALLBACK(bakoom, TYPE_PROC_REF(/obj/machinery/atmospherics/supermatter_crystal, explode), bakoom.combined_gas, bakoom.power, bakoom.gasmix_power_ratio), 1 SECONDS)

--- a/code/modules/station_goals/bsa.dm
+++ b/code/modules/station_goals/bsa.dm
@@ -198,9 +198,9 @@
 /obj/machinery/bsa/full/proc/fire(mob/user, turf/bullseye, target)
 	var/turf/point = get_front_turf()
 	for(var/turf/T in get_line(get_step(point,dir),get_target_turf()))
-		T.ex_act(1)
+		T.ex_act(EXPLODE_DEVASTATE)
 		for(var/atom/A in T)
-			A.ex_act(1)
+			A.ex_act(EXPLODE_DEVASTATE)
 
 	point.Beam(get_target_turf(), icon_state = "bsa_beam", time = 50, maxdistance = world.maxx, beam_type = /obj/effect/ebeam/deadly) //ZZZAP
 	playsound(src, 'sound/machines/bsa_fire.ogg', 100, 1)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Replaces most if not all magic numbers that are compared to EMP severity or explosion severity with the appropritate defines.

(Lesser severity numers are still smaller than more powerful severity numbers and there are lesser than, and greater than comparisons, but I'm not confident enough in my abilities to touch that yet.)
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Makes code easier to read.
## Testing
<!-- How did you test the PR, if at all? -->
It compiles and starts the round. I double checked all changes in the PR preview. I have faith in the review process.
Used EMP flashlight on self. It showed the message for being hit with a heavy EMP. (which is what should happen as far as I can tell)
Used syndie minibomb next to grav gen. The ex_act proc resulted in set_broken being called. (which is what should happen as far as I can tell)

<hr>

### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/feature_freeze/CODE_OF_CONDUCT.md#currently-changes-to-the-following-types-of-content-reuires-pre-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<!-- A list of PR types requiring pre-approval can be found here: https://github.com/ParadiseSS13/Paradise/blob/feature_freeze/CODE_OF_CONDUCT.md#currently-changes-to-the-following-types-of-content-reuires-pre-approval -->
<!-- Replace the box with [x] to mark as complete. -->
<hr>

## Changelog
npfc

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
