### PR TITLE
blackbox: Add station traits.

### DIFF
--- a/code/controllers/subsystem/processing/SSstation.dm
+++ b/code/controllers/subsystem/processing/SSstation.dm
@@ -68,6 +68,7 @@ PROCESSING_SUBSYSTEM_DEF(station)
 ///Creates a given trait of a specific type, while also removing any blacklisted ones from the future pool.
 /datum/controller/subsystem/processing/station/proc/setup_trait(datum/station_trait/trait_type)
 	var/datum/station_trait/trait_instance = new trait_type()
+	SSblackbox.record_feedback("text", "station_traits", 1, "[trait_type]")
 	station_traits += trait_instance
 	log_game("Station Trait: [trait_instance.name] chosen for this round.")
 	trait_instance.blacklist += trait_instance.type


### PR DESCRIPTION
## What Does This PR Do
This PR adds station traits rolled each round to feedback.
## Why It's Good For The Game
If and when station traits have effects on other things in the feedback DB, it's important to know when that happens.
## Images of changes
![2024_08_15__18_26_00__Unnamed_paradise_gamedb_feedback_ - HeidiSQL 11 0 0 5919](https://github.com/user-attachments/assets/03301f78-8b17-4b54-9bc7-0c554d69c4f8)
## Testing
Added several traits to `data/next_traits.txt`, started and ended round, verified results in DB.
<hr>
### Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/feature_freeze/CODE_OF_CONDUCT.md#currently-changes-to-the-following-types-of-content-reuires-pre-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<hr>

## Changelog
NPFC