### PR TITLE
Makes the vortex anomaly more dangerous

### DIFF
--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -489,7 +489,7 @@
 			O.ex_act(EXPLODE_HEAVY)
 
 /obj/effect/anomaly/bhole/proc/grav(radius = 0, ex_act_force, pull_chance, turf_removal_chance)
-	if(!radius || prob(25)) // Base 25% chance of not damaging any floors or pulling mobs
+	if(radius <= 0 || prob(25)) // Base 25% chance of not damaging any floors or pulling mobs
 		return
 
 	for(var/t in -radius to (radius - 1))

--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -462,14 +462,20 @@
 	icon_state = "bhole3"
 	desc = "That's a nice station you have there. It'd be a shame if something happened to it."
 	aSignal = /obj/item/assembly/signaler/anomaly/vortex
+	/// The timer that will give us an extra proccall of ripping the floors up
+	var/timer
 
 /obj/effect/anomaly/bhole/anomalyEffect()
 	..()
 	if(!isturf(loc)) //blackhole cannot be contained inside anything. Weird stuff might happen
 		qdel(src)
 		return
+	rip_and_tear()
+	// We queue up another `rip_and_tear` in a second, effectively making it tick once per second without having to switch this anomaly to another SS
+	timer = addtimer(CALLBACK(src, PROC_REF(rip_and_tear)), 1 SECONDS, TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_DELETE_ME)
 
-	grav(rand(0, 3), rand(2, 3), 100, 30)
+/obj/effect/anomaly/bhole/proc/rip_and_tear()
+	grav(rand(1, 4), rand(2, 3), 100, 30)
 
 	//Throwing stuff around!
 	for(var/obj/O in range(3, src))
@@ -482,12 +488,15 @@
 		else
 			O.ex_act(EXPLODE_HEAVY)
 
-/obj/effect/anomaly/bhole/proc/grav(r, ex_act_force, pull_chance, turf_removal_chance)
-	for(var/t = -r, t < r, t++)
-		affect_coord(x + t, y - r, ex_act_force, pull_chance, turf_removal_chance)
-		affect_coord(x - t, y + r, ex_act_force, pull_chance, turf_removal_chance)
-		affect_coord(x + r, y + t, ex_act_force, pull_chance, turf_removal_chance)
-		affect_coord(x - r, y - t, ex_act_force, pull_chance, turf_removal_chance)
+/obj/effect/anomaly/bhole/proc/grav(radius = 0, ex_act_force, pull_chance, turf_removal_chance)
+	if(!radius || prob(25)) // Base 25% chance of not damaging any floors or pulling mobs
+		return
+
+	for(var/t in -radius to (radius - 1))
+		affect_coord(x + t, y - radius, ex_act_force, pull_chance, turf_removal_chance)
+		affect_coord(x - t, y + radius, ex_act_force, pull_chance, turf_removal_chance)
+		affect_coord(x + radius, y + t, ex_act_force, pull_chance, turf_removal_chance)
+		affect_coord(x - radius, y - t, ex_act_force, pull_chance, turf_removal_chance)
 
 /obj/effect/anomaly/bhole/proc/affect_coord(x, y, ex_act_force, pull_chance, turf_removal_chance)
 	//Get turf at coordinate


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes the vortex anomaly more dangerous by:
- Increasing it's max range by a single tile, this will cause it to hit at most 4 tiles more, and hitting 4 more tiles a bit more heavily
- It now does it's floor ripping move + the mob pulling once every second instead of two. This will make it a lot more dangerous.
- It keeps the 25% chance to do nothing per tick.

Also rewrites a loop because it was genuinely illegible
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Anomalies should be dangerous, and the vortex has for a while now been a slightly worse gravitational anomaly. The Vortex anomaly is also the only anomaly that is announced **in advance**. This PR will make it live up to it's reputation as an anomaly that will have to be dealt with ASAP - and worthy of a pre-spawn-announcement.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
Arrivals after an anomaly has done it's thing
![image](https://github.com/user-attachments/assets/e641c965-9e24-457a-b0fd-e4ac1a3ad94e)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
See above, no runtimes
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/feature_freeze/CODE_OF_CONDUCT.md#currently-changes-to-the-following-types-of-content-reuires-pre-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<!-- A list of PR types requiring pre-approval can be found here: https://github.com/ParadiseSS13/Paradise/blob/feature_freeze/CODE_OF_CONDUCT.md#currently-changes-to-the-following-types-of-content-reuires-pre-approval -->
<!-- Replace the box with [x] to mark as complete. -->
<hr>

## Changelog
:cl:
tweak: The vortex anomaly is now more dangerous. It has slightly more range and it destroys things much faster
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
