### PR TITLE
Moving while buckled or while in a locker that is locked / welded will no longer reset resist timer.

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -358,7 +358,7 @@
 
 
 	spawn(0)
-		if(do_after(L,(breakout_time*60*10), target = src)) //minutes * 60seconds * 10deciseconds
+		if(do_after(L,(breakout_time*60*10), target = src, allow_moving = TRUE, allow_moving_target = TRUE)) //minutes * 60seconds * 10deciseconds
 			if(!src || !L || L.stat != CONSCIOUS || L.loc != src || opened) //closet/user destroyed OR user dead/unconcious OR user no longer in closet OR closet opened
 				return
 

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -340,7 +340,7 @@
 	return TRUE
 
 /obj/structure/closet/container_resist(mob/living/L)
-	var/breakout_time = 2 //2 minutes by default
+	var/breakout_time = 2 MINUTES //2 minutes by default
 	if(opened)
 		if(L.loc == src)
 			L.forceMove(get_turf(src)) // Let's just be safe here
@@ -358,7 +358,7 @@
 
 
 	spawn(0)
-		if(do_after(L,(breakout_time*60*10), target = src, allow_moving = TRUE, allow_moving_target = TRUE)) //minutes * 60seconds * 10deciseconds
+		if(do_after(L, breakout_time, target = src, allow_moving = TRUE, allow_moving_target = TRUE)) //minutes * 60seconds * 10deciseconds
 			if(!src || !L || L.stat != CONSCIOUS || L.loc != src || opened) //closet/user destroyed OR user dead/unconcious OR user no longer in closet OR closet opened
 				return
 

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -340,7 +340,7 @@
 	return TRUE
 
 /obj/structure/closet/container_resist(mob/living/L)
-	var/breakout_time = 2 MINUTES //2 minutes by default
+	var/breakout_time = 2 MINUTES
 	if(opened)
 		if(L.loc == src)
 			L.forceMove(get_turf(src)) // Let's just be safe here
@@ -358,7 +358,7 @@
 
 
 	spawn(0)
-		if(do_after(L, breakout_time, target = src, allow_moving = TRUE, allow_moving_target = TRUE)) //minutes * 60seconds * 10deciseconds
+		if(do_after(L, breakout_time, target = src, allow_moving = TRUE, allow_moving_target = TRUE))
 			if(!src || !L || L.stat != CONSCIOUS || L.loc != src || opened) //closet/user destroyed OR user dead/unconcious OR user no longer in closet OR closet opened
 				return
 

--- a/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
@@ -113,7 +113,7 @@
 
 
 	spawn(0)
-		if(do_after(usr,(breakout_time*60*10), target = src)) //minutes * 60seconds * 10deciseconds
+		if(do_after(usr,(breakout_time*60*10), target = src, allow_moving = TRUE, allow_moving_target = TRUE)) //minutes * 60seconds * 10deciseconds
 			if(!src || !L || L.stat != CONSCIOUS || L.loc != src || opened) //closet/user destroyed OR user dead/unconcious OR user no longer in closet OR closet opened
 				return
 

--- a/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
@@ -98,7 +98,7 @@
 		add_overlay("unlocked")
 
 /obj/structure/closet/secure_closet/container_resist(mob/living/L)
-	var/breakout_time = 2 MINUTES//2 minutes by default
+	var/breakout_time = 2 MINUTES
 	if(opened)
 		if(L.loc == src)
 			L.forceMove(get_turf(src)) // Let's just be safe here
@@ -113,7 +113,7 @@
 
 
 	spawn(0)
-		if(do_after(usr, breakout_time, target = src, allow_moving = TRUE, allow_moving_target = TRUE)) //minutes * 60seconds * 10deciseconds
+		if(do_after(usr, breakout_time, target = src, allow_moving = TRUE, allow_moving_target = TRUE)) 
 			if(!src || !L || L.stat != CONSCIOUS || L.loc != src || opened) //closet/user destroyed OR user dead/unconcious OR user no longer in closet OR closet opened
 				return
 

--- a/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
@@ -98,7 +98,7 @@
 		add_overlay("unlocked")
 
 /obj/structure/closet/secure_closet/container_resist(mob/living/L)
-	var/breakout_time = 2 //2 minutes by default
+	var/breakout_time = 2 MINUTES//2 minutes by default
 	if(opened)
 		if(L.loc == src)
 			L.forceMove(get_turf(src)) // Let's just be safe here
@@ -113,7 +113,7 @@
 
 
 	spawn(0)
-		if(do_after(usr,(breakout_time*60*10), target = src, allow_moving = TRUE, allow_moving_target = TRUE)) //minutes * 60seconds * 10deciseconds
+		if(do_after(usr, breakout_time, target = src, allow_moving = TRUE, allow_moving_target = TRUE)) //minutes * 60seconds * 10deciseconds
 			if(!src || !L || L.stat != CONSCIOUS || L.loc != src || opened) //closet/user destroyed OR user dead/unconcious OR user no longer in closet OR closet opened
 				return
 

--- a/code/modules/mob/living/carbon/carbon_procs.dm
+++ b/code/modules/mob/living/carbon/carbon_procs.dm
@@ -830,7 +830,7 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 
 	visible_message("<span class='warning'>[src] attempts to unbuckle [p_themselves()]!</span>",
 				"<span class='notice'>You attempt to unbuckle yourself... (This will take around [breakout_time / 10] seconds and you need to stay still.)</span>")
-	if(!do_after(src, breakout_time, FALSE, src, extra_checks = list(CALLBACK(src, PROC_REF(buckle_check)))))
+	if(!do_after(src, breakout_time, FALSE, src, allow_moving = TRUE, extra_checks = list(CALLBACK(src, PROC_REF(buckle_check))), allow_moving_target = TRUE))
 		if(src && buckled)
 			to_chat(src, "<span class='warning'>You fail to unbuckle yourself!</span>")
 	else


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Moving while buckled and cuffed (or while in a locked locker / welded locker) will no longer reset your unbuckle timer. This leaves the resist timer for breaking out of cuffs untouched.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Buckle-Cuffing in a moving object like a chair, roller-bed, or locker seemed a little broken and unintended especially when it was abusable. Just walking into the person in the object would reset them.
## Testing
<!-- How did you test the PR, if at all? -->
Buckled a human to an office chair, moved them around. They were able to unbuckle themselves.
**Moved around a cuffed human, their timer was reset without fail.**
Moved around a locker that was welded, a person was inside, they were able to break out.
Moved around a secure locker, a person was inside, they were able to break out.
<hr>

### Declaration
- [x] I confirm that I either do not require [pre-approval](/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<!-- Replace the box with [x] to mark as complete. -->
![image](https://github.com/user-attachments/assets/1509e692-d9ec-4de6-8065-433556040027)

<hr>

## Changelog
:cl:
tweak: Moving while resisting in a movable object (or in a welded / locked locker) will no longer result in your buckle/resist timer being reset. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
