### PR TITLE
cere: Add a sink to genetics.

### DIFF
--- a/_maps/map_files/stations/cerestation.dmm
+++ b/_maps/map_files/stations/cerestation.dmm
@@ -48804,6 +48804,9 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/structure/sink{
+	pixel_y = 24
+	},
 /turf/simulated/floor/grass,
 /area/station/science/genetics)
 "iXD" = (


### PR DESCRIPTION
## What Does This PR Do
This PR adds a sink to Cere genetics.
## Why It's Good For The Game
All genetics departments should have sinks so they don't need to wander around finding a water source for expanding cubes or wasting a fire extinguisher on it. The lack of one here is an oversight.
## Images of changes
![2024_08_19__12_04_17__Paradise Station 13](https://github.com/user-attachments/assets/74ee6917-3fda-42ee-a4f9-96a95d093228)
## Testing
Spawned in, confirmed sink properly worked with a monkey cube.
<hr>

### Declaration
- [X] I confirm that I either do not require [pre-approval](../CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<!-- Replace the box with [x] to mark as complete. -->
<!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog
:cl:
add: Farragus: Genetics finally has a sink.
/:cl:
