### PR TITLE
Reflectors now need to be anchored to reflect, as well as lowered the hp of them

### DIFF
--- a/code/game/objects/structures/reflector.dm
+++ b/code/game/objects/structures/reflector.dm
@@ -5,6 +5,7 @@
 	desc = "A frame to create a reflector.\n<span class='notice'>Use <b>5</b> sheets of <b>glass</b> to create a 1 way reflector.\nUse <b>10</b> sheets of <b>reinforced glass</b> to create a 2 way reflector.\nUse <b>1 diamond</b> to create a reflector cube.</span>"
 	anchored = FALSE
 	density = TRUE
+	max_integrity = 50
 	layer = 3
 	var/finished = FALSE
 	var/obj/item/stack/sheet/build_stack_type
@@ -17,7 +18,7 @@
 	if(!istype(P, /obj/item/projectile/beam))
 		return ..()
 	var/new_dir = get_reflection(dir, P.dir)
-	if(new_dir)
+	if(new_dir && anchored)
 		reflect_turf = get_step(reflect_turf, new_dir)
 	else
 		visible_message("<span class='notice'>[src] is hit by [P]!</span>")

--- a/code/game/objects/structures/reflector.dm
+++ b/code/game/objects/structures/reflector.dm
@@ -91,13 +91,13 @@
 		return
 	if(anchored)
 		WELDER_ATTEMPT_FLOOR_SLICE_MESSAGE
-		if(!I.use_tool(src, user, 20, volume = I.tool_volume))
+		if(!I.use_tool(src, user, 5 SECONDS, volume = I.tool_volume))
 			return
 		WELDER_FLOOR_SLICE_SUCCESS_MESSAGE
 		anchored = FALSE
 	else
 		WELDER_ATTEMPT_FLOOR_WELD_MESSAGE
-		if(!I.use_tool(src, user, 20, volume = I.tool_volume))
+		if(!I.use_tool(src, user, 5 SECONDS, volume = I.tool_volume))
 			return
 		WELDER_FLOOR_WELD_SUCCESS_MESSAGE
 		anchored = TRUE


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Reflectors, all kinds. need to be anchored to actually reflect, and lowers the hp to 50, from 300, also ups the weld time to 5 seconds, from 2.

## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Before this, DORVAK was comically easy to cheese with a single reflector box, the combo of lowering the hp, and making the anchor be a requirement should aid in making the ruin a threat todo. 
It'll take three standard laser shots to break the reflectors, and 3 volleys from the malf space drones(the hitscan fire ones)

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![dreamseeker_LtOP6gGPnY](https://github.com/user-attachments/assets/44fdcfe6-91a2-441f-ad7f-a5f61068d57c)


## Testing
<!-- How did you test the PR, if at all? -->
see above
<hr>

### Declaration
- [x] I confirm that I either do not require [pre-approval](../CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
![image](https://github.com/user-attachments/assets/7b881a0c-260f-4f1f-a7e1-cb82ffcf7899)

<!-- Replace the box with [x] to mark as complete. -->
<!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog
:cl:
tweak: All reflector types now need to be anchored to reflect
tweak: Lowered the HP of all reflectors to 50, from 300
tweak: Anchoring reflectors takes 5 seconds now, from 2
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
