### PR TITLE
Fixes a oversight with xenobiology

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/retaliate/undead.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/undead.dm
@@ -89,6 +89,7 @@
 	melee_damage_lower = 15
 	melee_damage_upper = 15
 	deathmessage = null
+	gold_core_spawnable = NO_SPAWN
 
 /mob/living/simple_animal/hostile/retaliate/skeleton/warden/Process_Spacemove(movement_dir)
 	return TRUE
@@ -109,6 +110,7 @@
 	melee_damage_lower = 30
 	melee_damage_upper = 30
 	loot = list(/obj/effect/decal/remains/human, /obj/item/clothing/head/warden, /obj/item/card/sec_shuttle_ruin)
+	gold_core_spawnable = NO_SPAWN
 
 /mob/living/simple_animal/hostile/skeleton/angered_warden/Process_Spacemove(movement_dir)
 	return TRUE


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Fixes a massive oversight.
## Why It's Good For The Game
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Balance would kill me if I didn't, also spawning boss monsters en mass is not good for the experience go figure.

## Testing
<!-- How did you test the PR, if at all? -->
It runs.
<hr>

### Declaration
- [x] I confirm that I either do not require [pre-approval](../CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<!-- Replace the box with [x] to mark as complete. -->
<!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog
:cl:
fix: Removes Warden Skeletons from the gold slime core pool
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
