### PR TITLE
Makes Indestructible Titanium Walls Into an Indestructible Wall Subtype

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/ussp.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/ussp.dmm
@@ -1,8 +1,4 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"aa" = (
-/obj/effect/landmark/burnturf,
-/turf/simulated/wall/indestructible/titanium/soviet/nosmooth,
-/area/ruin/space/derelict/hallway/primary)
 "ab" = (
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "solarpanel"
@@ -2901,7 +2897,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/simulated/wall/indestructible/titanium/soviet/nosmooth,
+/turf/simulated/wall/indestructible/titanium/soviet/nodiagonal,
 /area/ruin/space/derelict/hallway/primary)
 "hi" = (
 /obj/effect/landmark/burnturf,
@@ -3652,9 +3648,6 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/simulated/floor/wood,
 /area/ruin/space/derelict/crew_quarters)
-"jh" = (
-/turf/simulated/wall/indestructible/titanium/soviet/nosmooth,
-/area/ruin/space/derelict/hallway/primary)
 "ji" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -5416,7 +5409,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/simulated/wall/indestructible/titanium/soviet/nosmooth,
+/turf/simulated/wall/indestructible/titanium/soviet/nodiagonal,
 /area/ruin/space/derelict/hallway/primary)
 "nA" = (
 /obj/machinery/hydroponics,
@@ -6062,9 +6055,6 @@
 	icon_state = "orange"
 	},
 /area/ruin/space/derelict/crew_quarters)
-"pj" = (
-/turf/simulated/wall/indestructible/titanium/soviet/nosmooth,
-/area/ruin/space/derelict/crew_quarters)
 "pk" = (
 /turf/simulated/wall/indestructible/titanium/soviet,
 /area/space/nearstation)
@@ -6430,9 +6420,6 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "redfull"
 	},
-/area/ruin/space/derelict/arrival)
-"qk" = (
-/turf/simulated/wall/indestructible/titanium/soviet/nosmooth,
 /area/ruin/space/derelict/arrival)
 "ql" = (
 /obj/machinery/economy/vending/cigarette/free{
@@ -7491,10 +7478,6 @@
 	icon_state = "red"
 	},
 /area/ruin/space/derelict/arrival)
-"Ud" = (
-/obj/effect/spawner/airlock,
-/turf/simulated/wall/indestructible/titanium/soviet,
-/area/ruin/space/derelict/arrival)
 "XQ" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -8016,14 +7999,14 @@ ac
 ac
 ac
 ac
-qk
+bn
 bn
 jm
 bn
 bn
 lu
 bn
-qk
+bn
 ac
 ac
 ac
@@ -8377,7 +8360,7 @@ ac
 aW
 bn
 bn
-qk
+bn
 gq
 gK
 ha
@@ -8647,7 +8630,7 @@ ac
 ac
 ac
 aW
-qk
+bn
 ed
 en
 eI
@@ -8738,7 +8721,7 @@ ac
 ac
 ac
 aW
-qk
+bn
 dU
 do
 do
@@ -8931,7 +8914,7 @@ de
 fE
 fZ
 gs
-qk
+bn
 bn
 aW
 ac
@@ -9292,7 +9275,7 @@ dB
 do
 do
 dR
-qk
+bn
 dF
 aW
 ac
@@ -9383,7 +9366,7 @@ dq
 dC
 do
 dR
-qk
+bn
 aW
 ac
 ac
@@ -9466,7 +9449,7 @@ ac
 ac
 ac
 aW
-qk
+bn
 cm
 cA
 cM
@@ -9474,7 +9457,7 @@ cA
 do
 dD
 dM
-qk
+bn
 aW
 ac
 ac
@@ -9557,7 +9540,7 @@ ac
 ac
 ac
 aW
-qk
+bn
 bS
 cn
 cB
@@ -9852,7 +9835,7 @@ ac
 ac
 dW
 eL
-jh
+eg
 hw
 hN
 eP
@@ -10033,7 +10016,7 @@ ac
 ac
 ac
 dW
-jh
+eg
 gt
 gP
 fk
@@ -10072,7 +10055,7 @@ iy
 rb
 qM
 rx
-qk
+bn
 aW
 ac
 ac
@@ -10124,7 +10107,7 @@ ac
 ac
 ag
 dW
-jh
+eg
 ga
 gu
 gQ
@@ -10157,7 +10140,7 @@ ac
 ac
 ac
 aW
-qk
+bn
 qv
 hY
 qM
@@ -10314,7 +10297,7 @@ fj
 fJ
 fR
 hx
-jh
+eg
 eL
 dW
 ac
@@ -10322,7 +10305,7 @@ jy
 km
 lb
 ac
-jh
+eg
 ml
 ii
 ii
@@ -10342,7 +10325,7 @@ ac
 ac
 ac
 aW
-qk
+bn
 qF
 hY
 re
@@ -10398,7 +10381,7 @@ ac
 ac
 ac
 dW
-jh
+eg
 fi
 eP
 fj
@@ -10587,7 +10570,7 @@ fj
 fJ
 eP
 gw
-jh
+eg
 eL
 dW
 ag
@@ -10688,7 +10671,7 @@ ac
 dW
 eg
 kn
-jh
+eg
 ii
 ac
 ac
@@ -10778,7 +10761,7 @@ ag
 ac
 dW
 eg
-jh
+dW
 iE
 ii
 ii
@@ -10869,7 +10852,7 @@ ac
 ag
 dW
 eg
-jh
+dW
 iE
 ko
 ii
@@ -10904,7 +10887,7 @@ hY
 rO
 bn
 bn
-Ud
+Nv
 ac
 ac
 jO
@@ -10960,7 +10943,7 @@ ac
 ac
 ac
 eg
-jh
+dW
 iE
 jz
 ii
@@ -11150,7 +11133,7 @@ jA
 ii
 ld
 iE
-jh
+dW
 eg
 ac
 ac
@@ -11241,7 +11224,7 @@ ii
 iE
 kp
 iE
-jh
+dW
 eg
 dW
 ac
@@ -11272,7 +11255,7 @@ hY
 rS
 rZ
 bn
-aW
+bn
 ac
 ac
 jO
@@ -11330,9 +11313,9 @@ ac
 iq
 iY
 iZ
-jh
+dW
 kq
-jh
+dW
 eg
 dW
 ac
@@ -11421,7 +11404,7 @@ ac
 ac
 ak
 ac
-jh
+eg
 eg
 kr
 eg
@@ -11507,7 +11490,7 @@ fs
 fQ
 eP
 gA
-aa
+gy
 eL
 dW
 ac
@@ -11686,7 +11669,7 @@ ac
 ac
 ag
 dW
-jh
+eg
 ft
 eP
 fs
@@ -11786,7 +11769,7 @@ gB
 fQ
 eP
 hB
-jh
+eg
 eL
 dW
 ac
@@ -11814,7 +11797,7 @@ ac
 ac
 ac
 aW
-qk
+bn
 qt
 hY
 hY
@@ -11871,7 +11854,7 @@ ag
 ag
 ag
 dW
-jh
+eg
 fS
 gj
 fJ
@@ -11997,7 +11980,7 @@ ac
 ac
 ac
 aW
-qk
+bn
 qt
 hY
 hY
@@ -12096,7 +12079,7 @@ hY
 hY
 hY
 rC
-qk
+bn
 aW
 ac
 ac
@@ -12150,7 +12133,7 @@ ac
 ac
 ac
 dW
-jh
+eg
 gU
 hl
 hC
@@ -12244,7 +12227,7 @@ ac
 ac
 dW
 eL
-jh
+eg
 hD
 hR
 eP
@@ -13089,7 +13072,7 @@ ac
 ac
 aV
 dH
-pj
+bm
 ng
 ng
 ng
@@ -13554,7 +13537,7 @@ ol
 ol
 ol
 pc
-pj
+bm
 aV
 ac
 ac
@@ -13644,7 +13627,7 @@ ng
 nX
 om
 oC
-pj
+bm
 bm
 pk
 ac
@@ -14089,11 +14072,11 @@ ac
 ac
 ac
 ac
-aV
+bm
 lo
 bm
 lo
-aV
+bm
 ag
 ag
 ac

--- a/_maps/map_files/RandomRuins/SpaceRuins/ussp.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/ussp.dmm
@@ -1,10 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aa" = (
 /obj/effect/landmark/burnturf,
-/turf/simulated/wall/mineral/titanium/nodecon/tileblend{
-	fixed_underlay = list("icon" = 'icons/turf/floors.dmi', "icon_state" = "cautionfull");
-	icon_state = "4-i"
-	},
+/turf/simulated/wall/indestructible/titanium/soviet/nosmooth,
 /area/ruin/space/derelict/hallway/primary)
 "ab" = (
 /turf/simulated/floor/plasteel/airless{
@@ -55,10 +52,10 @@
 /turf/template_noop,
 /area/space/nearstation)
 "al" = (
-/turf/simulated/wall/mineral/titanium/nodecon,
+/turf/simulated/wall/indestructible/titanium/soviet,
 /area/ruin/space/derelict/bridge)
 "am" = (
-/turf/simulated/wall/mineral/titanium/nodecon/nodiagonal,
+/turf/simulated/wall/indestructible/titanium/soviet/nodiagonal,
 /area/ruin/space/derelict/bridge)
 "an" = (
 /obj/effect/spawner/window/shuttle,
@@ -72,12 +69,12 @@
 /area/ruin/space/derelict/bridge)
 "ao" = (
 /obj/effect/landmark/damageturf,
-/turf/simulated/wall/mineral/titanium/nodecon/nodiagonal,
+/turf/simulated/wall/indestructible/titanium/soviet/nodiagonal,
 /area/ruin/space/derelict/bridge)
 "ap" = (
 /obj/effect/landmark/damageturf,
 /obj/effect/landmark/burnturf,
-/turf/simulated/wall/mineral/titanium/nodecon/nodiagonal,
+/turf/simulated/wall/indestructible/titanium/soviet/nodiagonal,
 /area/ruin/space/derelict/bridge)
 "aq" = (
 /obj/effect/landmark/burnturf,
@@ -218,7 +215,7 @@
 /area/ruin/space/derelict/bridge)
 "aE" = (
 /obj/structure/sign/nuke,
-/turf/simulated/wall/mineral/titanium/nodecon/nodiagonal,
+/turf/simulated/wall/indestructible/titanium/soviet/nodiagonal,
 /area/ruin/space/derelict/bridge)
 "aF" = (
 /obj/item/kirbyplants,
@@ -350,10 +347,10 @@
 	},
 /area/ruin/space/derelict/bridge)
 "aV" = (
-/turf/simulated/wall/mineral/titanium/nodecon,
+/turf/simulated/wall/indestructible/titanium/soviet,
 /area/ruin/space/derelict/crew_quarters)
 "aW" = (
-/turf/simulated/wall/mineral/titanium/nodecon,
+/turf/simulated/wall/indestructible/titanium/soviet,
 /area/ruin/space/derelict/arrival)
 "aX" = (
 /obj/structure/closet/cabinet,
@@ -470,10 +467,10 @@
 	},
 /area/ruin/space/derelict/bridge)
 "bm" = (
-/turf/simulated/wall/mineral/titanium/nodecon/nodiagonal,
+/turf/simulated/wall/indestructible/titanium/soviet/nodiagonal,
 /area/ruin/space/derelict/crew_quarters)
 "bn" = (
-/turf/simulated/wall/mineral/titanium/nodecon/nodiagonal,
+/turf/simulated/wall/indestructible/titanium/soviet/nodiagonal,
 /area/ruin/space/derelict/arrival)
 "bo" = (
 /obj/structure/cable{
@@ -617,12 +614,6 @@
 	icon_state = "darkblue"
 	},
 /area/ruin/space/derelict/bridge)
-"bE" = (
-/turf/simulated/wall/mineral/titanium/nodecon/tileblend{
-	fixed_underlay = list("icon" = 'icons/turf/floors.dmi', "icon_state" = "dark");
-	icon_state = "4-i"
-	},
-/area/ruin/space/derelict/arrival)
 "bF" = (
 /obj/machinery/light/spot{
 	dir = 1
@@ -1076,11 +1067,11 @@
 /area/ruin/space/derelict/crew_quarters)
 "cL" = (
 /obj/structure/sign/mech,
-/turf/simulated/wall/mineral/titanium/nodecon/nodiagonal,
+/turf/simulated/wall/indestructible/titanium/soviet/nodiagonal,
 /area/ruin/space/derelict/arrival)
 "cM" = (
 /obj/structure/sign/securearea,
-/turf/simulated/wall/mineral/titanium/nodecon/nodiagonal,
+/turf/simulated/wall/indestructible/titanium/soviet/nodiagonal,
 /area/ruin/space/derelict/arrival)
 "cN" = (
 /obj/machinery/door/airlock/hatch{
@@ -1279,7 +1270,7 @@
 /area/ruin/space/derelict/crew_quarters)
 "dl" = (
 /obj/effect/decal/cleanable/fungus,
-/turf/simulated/wall/mineral/titanium/nodecon/nodiagonal,
+/turf/simulated/wall/indestructible/titanium/soviet/nodiagonal,
 /area/ruin/space/derelict/crew_quarters)
 "dm" = (
 /obj/machinery/computer/security,
@@ -1512,11 +1503,6 @@
 /obj/item/clothing/under/costume/soviet,
 /turf/simulated/floor/plasteel,
 /area/ruin/space/derelict/crew_quarters)
-"dO" = (
-/turf/simulated/wall/mineral/titanium/nodecon/tileblend{
-	icon_state = "4-i"
-	},
-/area/ruin/space/derelict/arrival)
 "dP" = (
 /obj/item/clothing/under/retro/security,
 /obj/item/clothing/under/retro/security,
@@ -1552,9 +1538,6 @@
 	icon_state = "darkred"
 	},
 /area/ruin/space/derelict/arrival)
-"dS" = (
-/turf/simulated/wall/mineral/titanium/interior,
-/area/ruin/space/derelict/arrival)
 "dT" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -1575,11 +1558,11 @@
 	},
 /area/ruin/space/derelict/arrival)
 "dW" = (
-/turf/simulated/wall/mineral/titanium/nodecon,
+/turf/simulated/wall/indestructible/titanium/soviet,
 /area/ruin/space/derelict/hallway/primary)
 "dX" = (
 /obj/structure/sign/securearea,
-/turf/simulated/wall/mineral/titanium/nodecon/nodiagonal,
+/turf/simulated/wall/indestructible/titanium/soviet/nodiagonal,
 /area/ruin/space/derelict/hallway/primary)
 "dY" = (
 /obj/structure/cable{
@@ -1641,7 +1624,7 @@
 	},
 /area/ruin/space/derelict/arrival)
 "eg" = (
-/turf/simulated/wall/mineral/titanium/nodecon/nodiagonal,
+/turf/simulated/wall/indestructible/titanium/soviet/nodiagonal,
 /area/ruin/space/derelict/hallway/primary)
 "eh" = (
 /obj/machinery/light/spot{
@@ -1758,7 +1741,7 @@
 /area/ruin/space/derelict/hallway/primary)
 "et" = (
 /obj/structure/sign/science,
-/turf/simulated/wall/mineral/titanium/nodecon/nodiagonal,
+/turf/simulated/wall/indestructible/titanium/soviet/nodiagonal,
 /area/ruin/space/derelict/hallway/primary)
 "eu" = (
 /turf/simulated/floor/plasteel{
@@ -1812,7 +1795,7 @@
 /area/ruin/space/derelict/hallway/primary)
 "ez" = (
 /obj/structure/noticeboard,
-/turf/simulated/wall/mineral/titanium/nodecon/nodiagonal,
+/turf/simulated/wall/indestructible/titanium/soviet/nodiagonal,
 /area/ruin/space/derelict/hallway/primary)
 "eA" = (
 /obj/machinery/atmospherics/unary/passive_vent,
@@ -1873,7 +1856,7 @@
 "eI" = (
 /obj/structure/sign/securearea,
 /obj/effect/decal/cleanable/blood/splatter,
-/turf/simulated/wall/mineral/titanium/nodecon/nodiagonal,
+/turf/simulated/wall/indestructible/titanium/soviet/nodiagonal,
 /area/ruin/space/derelict/arrival)
 "eJ" = (
 /obj/machinery/door/poddoor/impassable{
@@ -1913,12 +1896,6 @@
 	name = "Central Annex Lockdown"
 	},
 /turf/simulated/floor/plating,
-/area/ruin/space/derelict/hallway/primary)
-"eM" = (
-/turf/simulated/wall/mineral/titanium/nodecon/tileblend{
-	fixed_underlay = list("icon" = 'icons/turf/floors.dmi', "icon_state" = "purplefull");
-	icon_state = "4-i"
-	},
 /area/ruin/space/derelict/hallway/primary)
 "eN" = (
 /obj/structure/table,
@@ -2024,12 +2001,6 @@
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "caution"
-	},
-/area/ruin/space/derelict/hallway/primary)
-"eZ" = (
-/turf/simulated/wall/mineral/titanium/nodecon/tileblend{
-	fixed_underlay = list("icon" = 'icons/turf/floors.dmi', "icon_state" = "cautionfull");
-	icon_state = "4-i"
 	},
 /area/ruin/space/derelict/hallway/primary)
 "fa" = (
@@ -2369,7 +2340,7 @@
 /area/ruin/space/derelict/hallway/primary)
 "fL" = (
 /obj/structure/sign/nosmoking_1,
-/turf/simulated/wall/mineral/titanium/nodecon/nodiagonal,
+/turf/simulated/wall/indestructible/titanium/soviet/nodiagonal,
 /area/ruin/space/derelict/hallway/primary)
 "fM" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2521,7 +2492,7 @@
 /area/ruin/space/derelict/hallway/primary)
 "ge" = (
 /obj/effect/decal/cleanable/fungus,
-/turf/simulated/wall/mineral/titanium/nodecon/nodiagonal,
+/turf/simulated/wall/indestructible/titanium/soviet/nodiagonal,
 /area/ruin/space/derelict/hallway/primary)
 "gf" = (
 /obj/structure/chair/wood{
@@ -2573,7 +2544,7 @@
 /area/ruin/space/derelict/hallway/primary)
 "gk" = (
 /obj/structure/sign/poster/contraband/random,
-/turf/simulated/wall/mineral/titanium/nodecon/nodiagonal,
+/turf/simulated/wall/indestructible/titanium/soviet/nodiagonal,
 /area/ruin/space/derelict/hallway/primary)
 "gl" = (
 /obj/structure/chair/wood,
@@ -2667,7 +2638,7 @@
 /area/ruin/space/derelict/hallway/primary)
 "gy" = (
 /obj/effect/landmark/burnturf,
-/turf/simulated/wall/mineral/titanium/nodecon/nodiagonal,
+/turf/simulated/wall/indestructible/titanium/soviet/nodiagonal,
 /area/ruin/space/derelict/hallway/primary)
 "gz" = (
 /obj/machinery/recharge_station,
@@ -2749,7 +2720,7 @@
 /area/ruin/space/derelict/crew_quarters)
 "gJ" = (
 /obj/effect/decal/cleanable/fungus,
-/turf/simulated/wall/mineral/titanium/nodecon/nodiagonal,
+/turf/simulated/wall/indestructible/titanium/soviet/nodiagonal,
 /area/ruin/space/derelict/arrival)
 "gK" = (
 /obj/structure/chair{
@@ -2930,10 +2901,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/simulated/wall/mineral/titanium/nodecon/tileblend{
-	fixed_underlay = list("icon" = 'icons/turf/floors.dmi', "icon_state" = "whiteredfull");
-	icon_state = "4-i"
-	},
+/turf/simulated/wall/indestructible/titanium/soviet/nosmooth,
 /area/ruin/space/derelict/hallway/primary)
 "hi" = (
 /obj/effect/landmark/burnturf,
@@ -3013,7 +2981,7 @@
 	dir = 1;
 	pixel_y = 7
 	},
-/turf/simulated/wall/mineral/titanium/nodecon/nodiagonal,
+/turf/simulated/wall/indestructible/titanium/soviet/nodiagonal,
 /area/ruin/space/derelict/arrival)
 "hu" = (
 /obj/machinery/door/airlock/security/glass{
@@ -3065,7 +3033,7 @@
 /area/ruin/space/derelict/hallway/primary)
 "hz" = (
 /obj/effect/landmark/damageturf,
-/turf/simulated/wall/mineral/titanium/nodecon/nodiagonal,
+/turf/simulated/wall/indestructible/titanium/soviet/nodiagonal,
 /area/ruin/space/derelict/hallway/primary)
 "hA" = (
 /obj/structure/table/reinforced,
@@ -3349,7 +3317,7 @@
 /area/ruin/space/derelict/hallway/primary)
 "il" = (
 /obj/structure/sign/poster/contraband/communist_state,
-/turf/simulated/wall/mineral/titanium/nodecon/nodiagonal,
+/turf/simulated/wall/indestructible/titanium/soviet/nodiagonal,
 /area/ruin/space/derelict/crew_quarters)
 "im" = (
 /obj/structure/cable{
@@ -3470,12 +3438,6 @@
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "purple"
-	},
-/area/ruin/space/derelict/hallway/primary)
-"iD" = (
-/turf/simulated/wall/mineral/titanium/nodecon/tileblend{
-	fixed_underlay = list("icon" = 'icons/turf/floors.dmi', "icon_state" = "engine");
-	icon_state = "4-i"
 	},
 /area/ruin/space/derelict/hallway/primary)
 "iE" = (
@@ -3691,7 +3653,7 @@
 /turf/simulated/floor/wood,
 /area/ruin/space/derelict/crew_quarters)
 "jh" = (
-/turf/simulated/wall/mineral/titanium/nodecon/nosmooth,
+/turf/simulated/wall/indestructible/titanium/soviet/nosmooth,
 /area/ruin/space/derelict/hallway/primary)
 "ji" = (
 /obj/machinery/light/small{
@@ -4379,7 +4341,7 @@
 /area/ruin/space/derelict/crew_quarters)
 "kG" = (
 /obj/structure/sign/vacuum,
-/turf/simulated/wall/mineral/titanium/nodecon/nodiagonal,
+/turf/simulated/wall/indestructible/titanium/soviet/nodiagonal,
 /area/ruin/space/derelict/crew_quarters)
 "kH" = (
 /obj/structure/cable{
@@ -4539,11 +4501,6 @@
 	dir = 1
 	},
 /turf/template_noop,
-/area/ruin/space/derelict/hallway/primary)
-"lc" = (
-/turf/simulated/wall/mineral/titanium/nodecon/nosmooth{
-	icon_state = "swallc2"
-	},
 /area/ruin/space/derelict/hallway/primary)
 "ld" = (
 /obj/structure/flora/rock,
@@ -4717,7 +4674,7 @@
 /area/ruin/space/derelict/arrival)
 "lz" = (
 /obj/structure/sign/botany,
-/turf/simulated/wall/mineral/titanium/nodecon/nodiagonal,
+/turf/simulated/wall/indestructible/titanium/soviet/nodiagonal,
 /area/ruin/space/derelict/hallway/primary)
 "lA" = (
 /obj/machinery/door/airlock/glass{
@@ -5114,9 +5071,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/derelict/crew_quarters)
-"mG" = (
-/turf/simulated/wall/mineral/titanium/nodiagonal,
-/area/ruin/space/derelict/arrival)
 "mH" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Medical Wing";
@@ -5129,7 +5083,7 @@
 /area/ruin/space/derelict/arrival)
 "mI" = (
 /obj/structure/sign/greencross,
-/turf/simulated/wall/mineral/titanium/nodecon,
+/turf/simulated/wall/indestructible/titanium/soviet,
 /area/ruin/space/derelict/arrival)
 "mJ" = (
 /obj/structure/cable{
@@ -5148,7 +5102,7 @@
 /area/ruin/space/derelict/arrival)
 "mK" = (
 /obj/structure/sign/directions/medical,
-/turf/simulated/wall/mineral/titanium/nodecon/nodiagonal,
+/turf/simulated/wall/indestructible/titanium/soviet/nodiagonal,
 /area/ruin/space/derelict/arrival)
 "mL" = (
 /obj/effect/landmark/damageturf,
@@ -5462,10 +5416,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/simulated/wall/mineral/titanium/nodecon/tileblend{
-	fixed_underlay = list("icon" = 'icons/turf/floors.dmi', "icon_state" = "whiteredfull");
-	icon_state = "4-i"
-	},
+/turf/simulated/wall/indestructible/titanium/soviet/nosmooth,
 /area/ruin/space/derelict/hallway/primary)
 "nA" = (
 /obj/machinery/hydroponics,
@@ -5630,12 +5581,6 @@
 	icon_state = "whitered"
 	},
 /area/ruin/space/derelict/hallway/primary)
-"nU" = (
-/turf/simulated/wall/mineral/titanium/nodecon/tileblend{
-	fixed_underlay = list("icon" = 'icons/turf/floors.dmi', "icon_state" = "hydrofloor");
-	icon_state = "4-i"
-	},
-/area/ruin/space/derelict/crew_quarters)
 "nV" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "orangefull"
@@ -6118,13 +6063,10 @@
 	},
 /area/ruin/space/derelict/crew_quarters)
 "pj" = (
-/turf/simulated/wall/mineral/titanium/nodecon/tileblend{
-	fixed_underlay = list("icon" = 'icons/turf/floors.dmi', "icon_state" = "orangefull");
-	icon_state = "4-i"
-	},
+/turf/simulated/wall/indestructible/titanium/soviet/nosmooth,
 /area/ruin/space/derelict/crew_quarters)
 "pk" = (
-/turf/simulated/wall/mineral/titanium/nodecon,
+/turf/simulated/wall/indestructible/titanium/soviet,
 /area/space/nearstation)
 "pl" = (
 /obj/structure/cable{
@@ -6140,7 +6082,7 @@
 /area/ruin/space/derelict/hallway/primary)
 "pm" = (
 /obj/structure/sign/poster/contraband/random,
-/turf/simulated/wall/mineral/titanium/nodecon/nodiagonal,
+/turf/simulated/wall/indestructible/titanium/soviet/nodiagonal,
 /area/ruin/space/derelict/crew_quarters)
 "pn" = (
 /obj/machinery/door/airlock/hatch{
@@ -6293,7 +6235,7 @@
 /area/ruin/space/derelict/arrival)
 "pJ" = (
 /obj/effect/landmark/damageturf,
-/turf/simulated/wall/mineral/titanium/nodecon/nodiagonal,
+/turf/simulated/wall/indestructible/titanium/soviet/nodiagonal,
 /area/ruin/space/derelict/arrival)
 "pK" = (
 /obj/structure/window/reinforced,
@@ -6475,7 +6417,7 @@
 /area/ruin/space/derelict/arrival)
 "qh" = (
 /obj/structure/sign/examroom,
-/turf/simulated/wall/mineral/titanium/nodecon/nodiagonal,
+/turf/simulated/wall/indestructible/titanium/soviet/nodiagonal,
 /area/ruin/space/derelict/arrival)
 "qi" = (
 /obj/machinery/computer/arcade,
@@ -6490,10 +6432,7 @@
 	},
 /area/ruin/space/derelict/arrival)
 "qk" = (
-/turf/simulated/wall/mineral/titanium/nodecon/tileblend{
-	fixed_underlay = list("icon" = 'icons/turf/floors.dmi', "icon_state" = "redfull");
-	icon_state = "4-i"
-	},
+/turf/simulated/wall/indestructible/titanium/soviet/nosmooth,
 /area/ruin/space/derelict/arrival)
 "ql" = (
 /obj/machinery/economy/vending/cigarette/free{
@@ -6531,11 +6470,11 @@
 /area/ruin/space/derelict/crew_quarters)
 "qp" = (
 /obj/effect/landmark/burnturf,
-/turf/simulated/wall/mineral/titanium/nodecon/nodiagonal,
+/turf/simulated/wall/indestructible/titanium/soviet/nodiagonal,
 /area/ruin/space/derelict/arrival)
 "qq" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/wall/mineral/titanium/nodecon/nodiagonal,
+/turf/simulated/wall/indestructible/titanium/soviet/nodiagonal,
 /area/ruin/space/derelict/arrival)
 "qr" = (
 /obj/structure/cable{
@@ -6548,7 +6487,7 @@
 /area/ruin/space/derelict/arrival)
 "qs" = (
 /obj/structure/sign/nosmoking_2,
-/turf/simulated/wall/mineral/titanium/nodecon/nodiagonal,
+/turf/simulated/wall/indestructible/titanium/soviet/nodiagonal,
 /area/ruin/space/derelict/arrival)
 "qt" = (
 /turf/simulated/floor/plasteel{
@@ -6934,7 +6873,7 @@
 /area/ruin/space/derelict/crew_quarters)
 "ro" = (
 /obj/structure/sign/greencross,
-/turf/simulated/wall/mineral/titanium/nodecon/nodiagonal,
+/turf/simulated/wall/indestructible/titanium/soviet/nodiagonal,
 /area/ruin/space/derelict/arrival)
 "rp" = (
 /obj/structure/table,
@@ -7307,7 +7246,7 @@
 /area/ruin/space/derelict/arrival)
 "rZ" = (
 /obj/structure/sign/vacuum,
-/turf/simulated/wall/mineral/titanium/nodecon/nodiagonal,
+/turf/simulated/wall/indestructible/titanium/soviet/nodiagonal,
 /area/ruin/space/derelict/arrival)
 "sc" = (
 /obj/structure/cable{
@@ -7501,7 +7440,7 @@
 /obj/item/gps/ruin{
 	gpstag = "Russian Distress Signal"
 	},
-/turf/simulated/wall/mineral/titanium/nodecon/nodiagonal,
+/turf/simulated/wall/indestructible/titanium/soviet/nodiagonal,
 /area/ruin/space/derelict/arrival)
 "vm" = (
 /obj/effect/decal/cleanable/dirt,
@@ -7526,7 +7465,7 @@
 /area/ruin/space/derelict/crew_quarters)
 "Nv" = (
 /obj/effect/spawner/airlock,
-/turf/simulated/wall/mineral/titanium/nodecon/nodiagonal,
+/turf/simulated/wall/indestructible/titanium/soviet/nodiagonal,
 /area/ruin/space/derelict/arrival)
 "NK" = (
 /obj/structure/cable{
@@ -7537,16 +7476,13 @@
 /area/template_noop)
 "Oh" = (
 /obj/effect/spawner/airlock/w_to_e,
-/turf/simulated/wall/mineral/titanium/nodecon/nodiagonal,
+/turf/simulated/wall/indestructible/titanium/soviet/nodiagonal,
 /area/ruin/space/derelict/crew_quarters)
 "PR" = (
 /mob/living/simple_animal/hostile/pirate,
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "white"
 	},
-/area/ruin/space/derelict/arrival)
-"QN" = (
-/turf/simulated/wall/mineral/titanium/nodecon/nosmooth,
 /area/ruin/space/derelict/arrival)
 "Sv" = (
 /obj/item/flag/ussp,
@@ -7557,7 +7493,7 @@
 /area/ruin/space/derelict/arrival)
 "Ud" = (
 /obj/effect/spawner/airlock,
-/turf/simulated/wall/mineral/titanium/nodecon,
+/turf/simulated/wall/indestructible/titanium/soviet,
 /area/ruin/space/derelict/arrival)
 "XQ" = (
 /obj/structure/chair/wood{
@@ -8080,14 +8016,14 @@ ac
 ac
 ac
 ac
-QN
+qk
 bn
 jm
 bn
 bn
 lu
 bn
-QN
+qk
 ac
 ac
 ac
@@ -8365,10 +8301,10 @@ hY
 hY
 me
 mu
-mG
 bn
 bn
-mG
+bn
+bn
 aW
 ac
 ac
@@ -8441,7 +8377,7 @@ ac
 aW
 bn
 bn
-dO
+qk
 gq
 gK
 ha
@@ -8461,9 +8397,9 @@ bn
 mR
 ni
 nw
-mG
 bn
-mG
+bn
+bn
 aW
 ac
 ai
@@ -8711,7 +8647,7 @@ ac
 ac
 ac
 aW
-dO
+qk
 ed
 en
 eI
@@ -8802,7 +8738,7 @@ ac
 ac
 ac
 aW
-dO
+qk
 dU
 do
 do
@@ -8995,7 +8931,7 @@ de
 fE
 fZ
 gs
-dO
+qk
 bn
 aW
 ac
@@ -9011,7 +8947,7 @@ ac
 ac
 aW
 bn
-mG
+bn
 ny
 nK
 ob
@@ -9356,7 +9292,7 @@ dB
 do
 do
 dR
-dO
+qk
 dF
 aW
 ac
@@ -9447,8 +9383,8 @@ dq
 dC
 do
 dR
-dO
-dS
+qk
+aW
 ac
 ac
 ac
@@ -9530,7 +9466,7 @@ ac
 ac
 ac
 aW
-bE
+qk
 cm
 cA
 cM
@@ -9538,8 +9474,8 @@ cA
 do
 dD
 dM
-dO
-dS
+qk
+aW
 ac
 ac
 ac
@@ -9621,7 +9557,7 @@ ac
 ac
 ac
 aW
-bE
+qk
 bS
 cn
 cB
@@ -9630,7 +9566,7 @@ cB
 dr
 dE
 bn
-dS
+aW
 ac
 ac
 ac
@@ -9916,7 +9852,7 @@ ac
 ac
 dW
 eL
-eM
+jh
 hw
 hN
 eP
@@ -10097,7 +10033,7 @@ ac
 ac
 ac
 dW
-eM
+jh
 gt
 gP
 fk
@@ -10188,7 +10124,7 @@ ac
 ac
 ag
 dW
-eM
+jh
 ga
 gu
 gQ
@@ -10378,7 +10314,7 @@ fj
 fJ
 fR
 hx
-eM
+jh
 eL
 dW
 ac
@@ -10462,7 +10398,7 @@ ac
 ac
 ac
 dW
-eM
+jh
 fi
 eP
 fj
@@ -10651,7 +10587,7 @@ fj
 fJ
 eP
 gw
-eM
+jh
 eL
 dW
 ag
@@ -10752,7 +10688,7 @@ ac
 dW
 eg
 kn
-lc
+jh
 ii
 ac
 ac
@@ -10842,7 +10778,7 @@ ag
 ac
 dW
 eg
-iD
+jh
 iE
 ii
 ii
@@ -10933,7 +10869,7 @@ ac
 ag
 dW
 eg
-iD
+jh
 iE
 ko
 ii
@@ -11024,7 +10960,7 @@ ac
 ac
 ac
 eg
-iD
+jh
 iE
 jz
 ii
@@ -11214,7 +11150,7 @@ jA
 ii
 ld
 iE
-iD
+jh
 eg
 ac
 ac
@@ -11305,7 +11241,7 @@ ii
 iE
 kp
 iE
-iD
+jh
 eg
 dW
 ac
@@ -11396,7 +11332,7 @@ iY
 iZ
 jh
 kq
-iD
+jh
 eg
 dW
 ac
@@ -11750,7 +11686,7 @@ ac
 ac
 ag
 dW
-eZ
+jh
 ft
 eP
 fs
@@ -11850,7 +11786,7 @@ gB
 fQ
 eP
 hB
-eZ
+jh
 eL
 dW
 ac
@@ -11935,7 +11871,7 @@ ag
 ag
 ag
 dW
-eZ
+jh
 fS
 gj
 fJ
@@ -12214,7 +12150,7 @@ ac
 ac
 ac
 dW
-eZ
+jh
 gU
 hl
 hC
@@ -12308,7 +12244,7 @@ ac
 ac
 dW
 eL
-eZ
+jh
 hD
 hR
 eP
@@ -13153,7 +13089,7 @@ ac
 ac
 aV
 dH
-nU
+pj
 ng
 ng
 ng
@@ -13708,7 +13644,7 @@ ng
 nX
 om
 oC
-nU
+pj
 bm
 pk
 ac

--- a/_maps/map_files/RandomRuins/SpaceRuins/wizardcrash.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/wizardcrash.dmm
@@ -14,10 +14,10 @@
 	icon_state = "small"
 	},
 /obj/effect/landmark/damageturf,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/plating,
 /area/ruin/space/powered)
 "ae" = (
-/turf/simulated/wall/mineral/titanium/nodecon/wizard,
+/turf/simulated/wall/indestructible/titanium/nodiagonal,
 /area/ruin/space/powered)
 "af" = (
 /obj/structure/computerframe,
@@ -32,7 +32,7 @@
 /obj/structure/grille/broken,
 /obj/item/shard,
 /obj/effect/landmark/damageturf,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/plating,
 /area/ruin/space/powered)
 "aj" = (
 /obj/structure/chair/comfy/shuttle{
@@ -447,8 +447,8 @@
 /turf/simulated/floor/plating/airless,
 /area/ruin/space/powered)
 "bH" = (
-/turf/simulated/wall/mineral/titanium/nodecon/wizard,
-/area/space/nearstation)
+/turf/simulated/wall/indestructible/titanium,
+/area/ruin/space/powered)
 "bI" = (
 /obj/structure/window/plasmareinforced,
 /turf/simulated/floor/mineral/plasma,
@@ -588,7 +588,7 @@ aa
 aa
 aa
 aa
-ae
+bH
 ae
 ae
 ae
@@ -624,7 +624,7 @@ aa
 aa
 aa
 aa
-ae
+bH
 ae
 aY
 aS
@@ -654,13 +654,13 @@ ac
 ac
 ac
 ac
-ae
-ae
-al
-ae
+bH
 ae
 al
 ae
+ae
+al
+bH
 ae
 ae
 bc
@@ -764,8 +764,8 @@ ac
 ac
 ac
 ac
-ae
-ae
+bH
+bH
 ao
 aw
 aC
@@ -874,7 +874,7 @@ ac
 ac
 ac
 ac
-ae
+bH
 ag
 ak
 aC
@@ -912,8 +912,8 @@ ac
 ac
 ac
 ac
-ae
-ae
+bH
+bH
 ar
 ag
 aC
@@ -1024,13 +1024,13 @@ ac
 ac
 ac
 ac
-ae
+bH
 ae
 al
 ae
 ae
 aM
-ae
+bH
 ae
 ae
 bd
@@ -1068,7 +1068,7 @@ aa
 aa
 aa
 aa
-ae
+bH
 ae
 bC
 bk
@@ -1106,7 +1106,7 @@ aa
 aa
 aa
 aa
-ae
+bH
 ae
 ae
 ae

--- a/_maps/map_files/RandomRuins/SpaceRuins/wizardcrash.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/wizardcrash.dmm
@@ -764,8 +764,8 @@ ac
 ac
 ac
 ac
-bH
-bH
+ae
+ae
 ao
 aw
 aC
@@ -874,7 +874,7 @@ ac
 ac
 ac
 ac
-bH
+ae
 ag
 ak
 aC
@@ -912,8 +912,8 @@ ac
 ac
 ac
 ac
-bH
-bH
+ae
+ae
 ar
 ag
 aC

--- a/code/game/turfs/simulated/walls_indestructible.dm
+++ b/code/game/turfs/simulated/walls_indestructible.dm
@@ -261,6 +261,38 @@ GLOBAL_DATUM(title_splash, /turf/simulated/wall/indestructible/splashscreen)
 	smoothing_groups = list(SMOOTH_GROUP_SIMULATED_TURFS, SMOOTH_GROUP_WALLS, SMOOTH_GROUP_REINFORCED_WALLS)
 	canSmoothWith = list(SMOOTH_GROUP_WALLS, SMOOTH_GROUP_REGULAR_WALLS, SMOOTH_GROUP_REINFORCED_WALLS)
 
+/turf/simulated/wall/indestructible/titanium
+	icon = 'icons/turf/walls/plastinum_wall.dmi'
+	icon_state = "plastinum_wall-0"
+	base_icon_state = "plastinum_wall"
+	flags_ricochet = RICOCHET_SHINY | RICOCHET_HARD
+	smoothing_flags = SMOOTH_BITMASK | SMOOTH_DIAGONAL_CORNERS
+	smoothing_groups = list(SMOOTH_GROUP_TITANIUM_WALLS, SMOOTH_GROUP_WINDOW_FULLTILE_SHUTTLE)
+	canSmoothWith = list(SMOOTH_GROUP_TITANIUM_WALLS, SMOOTH_GROUP_AIRLOCK, SMOOTH_GROUP_SHUTTLE_PARTS, SMOOTH_GROUP_WINDOW_FULLTILE_SHUTTLE)
+
+/turf/simulated/wall/indestructible/titanium/nodiagonal
+	icon_state = "map-shuttle_nd"
+	smoothing_flags = SMOOTH_BITMASK
+
+/turf/simulated/wall/indestructible/titanium/nosmooth
+	icon_state = "plastinum_wall"
+	smoothing_flags = NONE
+
+/turf/simulated/wall/indestructible/titanium/tileblend
+	fixed_underlay = list("icon"='icons/turf/floors.dmi', "icon_state"="darkredfull")
+
+/turf/simulated/wall/indestructible/titanium/soviet
+	name = "\improper USSP wall"
+	desc = "Like regular titanium, but able to deflect capitalist aggressors!"
+
+/turf/simulated/wall/indestructible/titanium/soviet/nodiagonal
+	icon_state = "map-shuttle_nd"
+	smoothing_flags = SMOOTH_BITMASK
+
+/turf/simulated/wall/indestructible/titanium/soviet/nosmooth
+	icon_state = "plastinum_wall"
+	smoothing_flags = NONE
+
 /turf/simulated/wall/indestructible/syndicate
 	icon = 'icons/turf/walls/plastitanium_wall.dmi'
 	icon_state = "plastitanium_wall-0"

--- a/code/game/turfs/simulated/walls_indestructible.dm
+++ b/code/game/turfs/simulated/walls_indestructible.dm
@@ -279,7 +279,7 @@ GLOBAL_DATUM(title_splash, /turf/simulated/wall/indestructible/splashscreen)
 	smoothing_flags = NONE
 
 /turf/simulated/wall/indestructible/titanium/tileblend
-	fixed_underlay = list("icon"='icons/turf/floors.dmi', "icon_state"="darkredfull")
+	fixed_underlay = list("icon" = 'icons/turf/floors.dmi', "icon_state" = "darkredfull")
 
 /turf/simulated/wall/indestructible/titanium/soviet
 	name = "\improper USSP wall"

--- a/code/game/turfs/simulated/walls_mineral.dm
+++ b/code/game/turfs/simulated/walls_mineral.dm
@@ -279,44 +279,6 @@
 
 /turf/simulated/wall/mineral/titanium/survival/pod
 
-//undeconstructable type for derelict
-//these walls are undeconstructable/unthermitable
-/turf/simulated/wall/mineral/titanium/nodecon
-	name = "russian wall"
-	desc = "Like regular titanium, but able to deflect capitalist aggressors."
-	can_dismantle_with_welder = FALSE
-
-/turf/simulated/wall/mineral/titanium/nodecon/wizard
-	name = "wizard wall"
-	desc = "Like regular titanium, but able to deflect wizards aggressors."
-
-/turf/simulated/wall/mineral/titanium/nodecon/tileblend
-	fixed_underlay = list("icon"='icons/turf/floors.dmi', "icon_state"="darkredfull")
-
-/turf/simulated/wall/mineral/titanium/nodecon/nodiagonal
-	icon_state = "map-shuttle_nd"
-	smoothing_flags = SMOOTH_BITMASK
-
-/turf/simulated/wall/mineral/titanium/nodecon/nosmooth
-	icon_state = "plastinum_wall"
-	smoothing_flags = NONE
-
-//properties for derelict sub-type to prevent said deconstruction/thermiting
-/turf/simulated/wall/mineral/titanium/nodecon/try_decon(obj/item/I, mob/user, params)
-	return
-
-/turf/simulated/wall/mineral/titanium/nodecon/thermitemelt(mob/user as mob, speed)
-	return
-
-/turf/simulated/wall/mineral/titanium/nodecon/burn_down()
-	return
-
-/turf/simulated/wall/mineral/titanium/nodecon/welder_act()
-	return
-
-/turf/simulated/wall/mineral/titanium/nodecon/try_destroy()
-	return
-
 /////////////////////Plastitanium walls/////////////////////
 
 /turf/simulated/wall/mineral/plastitanium


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes indestructible titanium walls into a subtype of indestructible walls rather than being their own thing, with all the additional strengthening to their indestructibility this brings.

The Wizard and USSP ruins have been remapped with the new walls.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
This prevents two entire ruins from being completely bypassed by using the RCD to deconstruct a single wall. This is clearly not intentional given the effort that was put into making the walls resist other methods of destruction.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Visited the wizard shuttle and USSP ruin.
Verified that I couldn't deconstruct them with the RCD.
Made sure that there were no weird smoothing issues with the walls at either location.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration
- [x] I confirm that I either do not require [pre-approval](../CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<!-- Replace the box with [x] to mark as complete. -->
<!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog
:cl:
fix: You cannot deconstruct indestructible titanium walls with an RCD anymore.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
