### PR TITLE
Fixes the Fix of the Fix for the PR Template Pre-approval Link

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,28 +4,34 @@
 <!-- You can view Contributing.MD for a detailed description of the pull request process. -->
 
 ## What Does This PR Do
+
 <!-- Include a small to medium description of what your PR changes. -->
 <!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
 <!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
 
 ## Why It's Good For The Game
+
 <!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
 
 ## Images of changes
+
 <!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
 
 ## Testing
+
 <!-- How did you test the PR, if at all? -->
 
 <hr>
 
 ### Declaration
-- [ ] I confirm that I either do not require [pre-approval](../CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
-<!-- Replace the box with [x] to mark as complete. -->
-<!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
-<hr>
+
+- [ ] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
+  <!-- Replace the box with [x] to mark as complete. -->
+  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
+  <hr>
 
 ## Changelog
+
 :cl:
 add: Added new things
 del: Removed old things


### PR DESCRIPTION
## What Does This PR Do
This PR fixes the link used in the Pull Request Template by switching it to use an absolute link over a relative one. 

## Why It's Good For The Game
Allows contributors to successfully navigate to the page that gives information about Pull Requests that require approval before making a change.

## Testing
Clicked the link to make sure it went to the right page.

<hr>

### Declaration
- [x] I confirm that I either do not require [pre-approval](../CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<!-- Replace the box with [x] to mark as complete. -->
<!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog
NPFC