### PR TITLE
Re-weight secondary goals.

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -40,6 +40,7 @@
 	var/list/blob_overminds = list()
 
 	var/list/datum/station_goal/station_goals = list() // A list of all station goals for this game mode
+	var/list/secondary_goal_grab_bags = null // Once initialized, contains an associative list of department_name -> list(secondary_goal_type). When a goal is requested, a type will be pulled out of the department's grab bag. When the bag is empty, it will be refilled from the list of all goals in that department, with the amount of each set to the type's weight, max 10.
 	var/list/datum/station_goal/secondary/secondary_goals = list() // A list of all secondary goals issued
 
 	/// Each item in this list can only be rolled once on average.

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -3373,7 +3373,7 @@
 			if(T == /datum/station_goal/secondary)
 				continue
 			var/datum/station_goal/secondary/SG = T
-			if(initial(SG.abstract))
+			if(initial(SG.weight) < 1)
 				type_choices -= SG
 		var/picked = pick_closest_path(FALSE, make_types_fancy(type_choices), skip_filter = TRUE)
 		if(!picked)

--- a/code/modules/station_goals/secondary/bar/random_bulk_drink.dm
+++ b/code/modules/station_goals/secondary/bar/random_bulk_drink.dm
@@ -1,7 +1,7 @@
 /datum/station_goal/secondary/random_bulk_reagent/bar
 	name = "Random Bulk Drink"
 	department = "Bar"
-	abstract = FALSE
+	weight = 9
 
 /datum/station_goal/secondary/random_bulk_reagent/bar/randomize_params()
 	..()

--- a/code/modules/station_goals/secondary/bar/variety_drinks.dm
+++ b/code/modules/station_goals/secondary/bar/variety_drinks.dm
@@ -3,7 +3,7 @@
 	progress_type = /datum/secondary_goal_progress/variety_reagent
 	department = "Bar"
 	generic_name_plural = "alcoholic drinks"
-	abstract = FALSE
+	weight = 1
 
 /datum/station_goal/secondary/variety_reagent/bar/randomize_params()
 	..()

--- a/code/modules/station_goals/secondary/botany/kudzu_goal.dm
+++ b/code/modules/station_goals/secondary/botany/kudzu_goal.dm
@@ -2,7 +2,7 @@
 	name = "Random Kudzu"
 	department = "Hydroponics"
 	progress_type = /datum/secondary_goal_progress/random_kudzu
-	abstract = FALSE
+	weight = 1
 	var/list/traits = list()
 	var/amount = 5
 

--- a/code/modules/station_goals/secondary/kitchen/random_bulk_condiment.dm
+++ b/code/modules/station_goals/secondary/kitchen/random_bulk_condiment.dm
@@ -1,7 +1,7 @@
 /datum/station_goal/secondary/random_bulk_reagent/kitchen
 	name = "Random Bulk Condiment"
 	department = "Kitchen"
-	abstract = FALSE
+	weight = 1
 
 /datum/station_goal/secondary/random_bulk_reagent/kitchen/randomize_params()
 	..()

--- a/code/modules/station_goals/secondary/kitchen/random_bulk_food.dm
+++ b/code/modules/station_goals/secondary/kitchen/random_bulk_food.dm
@@ -2,7 +2,7 @@
 	name = "Random Bulk Food"
 	department = "Kitchen"
 	progress_type = /datum/secondary_goal_progress/random_bulk_food
-	abstract = FALSE
+	weight = 8
 	var/obj/item/food/food_type
 	var/amount
 	var/reward

--- a/code/modules/station_goals/secondary/kitchen/variety_food.dm
+++ b/code/modules/station_goals/secondary/kitchen/variety_food.dm
@@ -2,7 +2,7 @@
 	name = "Variety of Food"
 	progress_type = /datum/secondary_goal_progress/variety_food
 	department = "Kitchen"
-	abstract = FALSE
+	weight = 1
 	/// How many different types of food are needed.
 	var/different_types = 10
 	/// How many of each food type are needed.

--- a/code/modules/station_goals/secondary/medical/random_bulk_medicine.dm
+++ b/code/modules/station_goals/secondary/medical/random_bulk_medicine.dm
@@ -1,7 +1,7 @@
 /datum/station_goal/secondary/random_bulk_reagent/medchem
 	name = "Random Bulk Medicine"
 	department = "Chemistry"
-	abstract = FALSE
+	weight = 9
 
 /datum/station_goal/secondary/random_bulk_reagent/medchem/randomize_params()
 	..()

--- a/code/modules/station_goals/secondary/medical/variety_medicine.dm
+++ b/code/modules/station_goals/secondary/medical/variety_medicine.dm
@@ -3,7 +3,7 @@
 	progress_type = /datum/secondary_goal_progress/variety_reagent
 	department = "Chemistry"
 	generic_name_plural = "medicines"
-	abstract = FALSE
+	weight = 1
 
 /datum/station_goal/secondary/variety_reagent/medchem/randomize_params()
 	..()

--- a/code/modules/station_goals/secondary/science/random_bulk_chemical.dm
+++ b/code/modules/station_goals/secondary/science/random_bulk_chemical.dm
@@ -1,7 +1,7 @@
 /datum/station_goal/secondary/random_bulk_reagent/scichem
 	name = "Random Bulk Chemical"
 	department = "Science"
-	abstract = FALSE
+	weight = 9
 
 /datum/station_goal/secondary/random_bulk_reagent/scichem/randomize_params()
 	..()

--- a/code/modules/station_goals/secondary/science/random_ripley.dm
+++ b/code/modules/station_goals/secondary/science/random_ripley.dm
@@ -3,7 +3,7 @@
 	department = "Robotics"
 	progress_type = /datum/secondary_goal_progress/random_ripley
 	should_send_crate = FALSE
-	abstract = FALSE
+	weight = 1
 	var/list/modules = list()
 	var/static/list/general_modules = list(
 		/obj/item/mecha_parts/mecha_equipment/repair_droid,

--- a/code/modules/station_goals/secondary/science/variety_chemicals.dm
+++ b/code/modules/station_goals/secondary/science/variety_chemicals.dm
@@ -4,7 +4,7 @@
 	different_types = 5
 	department = "Science"
 	generic_name_plural = "chemicals"
-	abstract = FALSE
+	weight = 1
 
 /datum/station_goal/secondary/variety_reagent/scichem/randomize_params()
 	..()


### PR DESCRIPTION
## What Does This PR Do
Before this PR, requesting a secondary goal got you an un-weighted random type of goal.
With this PR, there is instead a grab bag of goal types, with the number of each defined by the goal type's weight. Requesting a goal pulls from the grab bag, and when the bag is empty, it gets refilled.

## Why It's Good For The Game
Getting variety tasks 1/2 or 1/3 of the time means that, ironically, you have less variety in your secondary goals. By adding the grab bag system and increasing the weight of other goal types, you will get a much more interesting mix of goals.

## Testing
Spawned as chef, requested 11 goals in the kitchen. First ten contained exactly the expected mix, 11th began a new bag as expected.
Requested a goal in robotics, got one there, too.
Requested a goal in the chapel, got the list of valid departments.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <hr>

## Changelog

:cl:
tweak: Secondary goals are now much, much less likely to give you multiple "X of Y different things" goals back-to-back.
/:cl: