### PR TITLE
Fix runtimes when events cannot find a valid event area

### DIFF
--- a/code/game/objects/effects/spawners/mess_spawners.dm
+++ b/code/game/objects/effects/spawners/mess_spawners.dm
@@ -194,6 +194,9 @@
 	var/mess_count = rand(5, 10)
 	for(var/i in 1 to mess_count)
 		var/area/target_area = findEventArea()
+		if(!target_area)
+			log_debug("Failed to generate themed messes: No valid event areas were found.")
+			return
 		var/list/turfs = get_area_turfs(target_area)
 		while(length(turfs))
 			var/turf/T = pick_n_take(turfs)

--- a/code/modules/events/event_procs.dm
+++ b/code/modules/events/event_procs.dm
@@ -39,6 +39,8 @@
 	var/list/remove_these_areas = safe_areas - allowed_areas
 	var/list/possible_areas = typecache_filter_list_reverse(SSmapping.existing_station_areas, remove_these_areas)
 
+	if(!length(possible_areas))
+		return null
 	return pick(possible_areas)
 
 /proc/findUnrestrictedEventArea() //Does almost the same as findEventArea() but hits a few more areas including maintenance and the AI sat, and also returns a list of all the areas, instead of just one area

--- a/code/modules/events/tear.dm
+++ b/code/modules/events/tear.dm
@@ -18,6 +18,8 @@
 	impact_area = findEventArea()
 
 /datum/event/tear/start()
+	if(isnull(impact_area))
+		log_debug("No valid event areas could be generated for dimensional tear.")
 	var/list/area_turfs = get_area_turfs(impact_area)
 	while(length(area_turfs))
 		var/turf/T = pick_n_take(area_turfs)
@@ -45,6 +47,8 @@
 	if(!target_area)
 		if(false_alarm)
 			target_area = findEventArea()
+				log_debug("Tried to announce a false-alarm tear without a valid area!")
+				kill()
 		else
 			log_debug("Tried to announce a tear without a valid area!")
 			kill()

--- a/code/modules/events/tear.dm
+++ b/code/modules/events/tear.dm
@@ -47,6 +47,7 @@
 	if(!target_area)
 		if(false_alarm)
 			target_area = findEventArea()
+			if(isnull(target_area))
 				log_debug("Tried to announce a false-alarm tear without a valid area!")
 				kill()
 		else


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes runtimes that occur when events cannot find valid event areas. This usually only occurs when debugging on tiny_test, since it has no valid areas.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Getting smacked with unrelated runtimes on startup when debugging is really annoying. This fixes that.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


## Testing
Compiled and started up the game, saw no runtimes.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

NPFC

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
