### PR TITLE
Fix item stacks qdeling themselves in Init and some item stack self-merge scenarios (port)

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -314,7 +314,7 @@
 	return FALSE
 
 /**
- * Merges as much of src into target_stack as possible.
+ * Merges as much of src into material as possible.
  *
  * This calls use() without check = FALSE, preventing the item from qdeling itself if it reaches 0 stack size.
  *
@@ -346,7 +346,7 @@
 	return transfer
 
 /**
- * Merges as much of src into target_stack as possible. If present, the limit arg overrides target_stack.max_amount for transfer.
+ * Merges as much of src into material as possible.
  *
  * This proc deletes src if the remaining amount after the transfer is 0.
  */

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -52,9 +52,14 @@
 		merge_type = type
 
 	if(merge && !(amount >= max_amount))
-		for(var/obj/item/stack/S in loc)
-			if(S.merge_type == merge_type)
-				merge(S)
+		for(var/obj/item/stack/item_stack in loc)
+			if(item_stack == src)
+				continue
+			if(item_stack.merge_type == merge_type)
+				INVOKE_ASYNC(src, PROC_REF(merge_without_del), item_stack)
+				// we do not want to qdel during initialization, so we just check whether or not we're a 0 count stack
+				if(is_zero_amount(FALSE))
+					return INITIALIZE_HINT_QDEL
 
 	update_icon(UPDATE_ICON_STATE)
 
@@ -147,7 +152,7 @@
 	to_chat(user, "<span class='notice'>Your [material.name] stack now contains [material.get_amount()] [material.singular_name]\s.</span>")
 
 /obj/item/stack/use(used, check = TRUE)
-	if(check && zero_amount())
+	if(check && is_zero_amount(TRUE))
 		return FALSE
 
 	if(is_cyborg)
@@ -158,7 +163,7 @@
 
 	amount -= used
 	if(check)
-		zero_amount()
+		is_zero_amount(TRUE)
 
 	update_icon(UPDATE_ICON_STATE)
 	return TRUE
@@ -289,9 +294,13 @@
 	use(amount)
 	SStgui.update_uis(src)
 
-// Returns TRUE if the stack amount is zero.
-// Also qdels the stack gracefully if it is.
-/obj/item/stack/proc/zero_amount()
+/**
+ * Returns TRUE if the item stack is the equivalent of a 0 amount item.
+ *
+ * Also deletes the item if delete_if_zero is TRUE and the stack does not have
+ * is_cyborg set to true.
+ */
+/obj/item/stack/proc/is_zero_amount(delete_if_zero = TRUE)
 	if(is_cyborg)
 		return source.amount < cost
 
@@ -299,17 +308,27 @@
 		if(ismob(loc))
 			var/mob/living/L = loc // At this stage, stack code is so horrible and atrocious, I wouldn't be all surprised ghosts can somehow have stacks. If this happens, then the world deserves to burn.
 			L.unEquip(src, TRUE)
-		if(amount < 1)
-			// If you stand on top of a stack, and drop a - different - 0-amount stack on the floor,
-			// the two get merged, so the amount of items in the stack can increase from the 0 that it had before.
-			// Check the amount again, to be sure we're not qdeling healthy stacks.
+		if(delete_if_zero)
 			qdel(src)
 		return TRUE
 	return FALSE
 
-/obj/item/stack/proc/merge(obj/item/stack/material) //Merge src into S, as much as possible
-	if(QDELETED(material) || QDELETED(src) || material == src) //amusingly this can cause a stack to consume itself, let's not allow that.
-		return FALSE
+/**
+ * Merges as much of src into target_stack as possible.
+ *
+ * This calls use() without check = FALSE, preventing the item from qdeling itself if it reaches 0 stack size.
+ *
+ * As a result, this proc can leave behind a 0 amount stack.
+ */
+/obj/item/stack/proc/merge_without_del(obj/item/stack/material)
+	// Cover edge cases where multiple stacks are being merged together and haven't been deleted properly.
+	// Also cover edge case where a stack is being merged into itself, which is supposedly possible.
+	if(QDELETED(material))
+		CRASH("Stack merge attempted on qdeleted target stack.")
+	if(QDELETED(src))
+		CRASH("Stack merge attempted on qdeleted source stack.")
+	if(material == src)
+		CRASH("Stack attempted to merge into itself.")
 
 	var/transfer = get_amount()
 	if(material.is_cyborg)
@@ -317,17 +336,23 @@
 	else
 		transfer = min(transfer, material.max_amount - material.amount)
 
-	if(transfer <= 0)
-		return
-
 	if(pulledby)
 		pulledby.start_pulling(material)
 
 	material.copy_evidences(src)
+	use(transfer, FALSE)
 	material.add(transfer)
-	use(transfer)
-	SStgui.update_uis(material)
+
 	return transfer
+
+/**
+ * Merges as much of src into target_stack as possible. If present, the limit arg overrides target_stack.max_amount for transfer.
+ *
+ * This proc deletes src if the remaining amount after the transfer is 0.
+ */
+/obj/item/stack/proc/merge(obj/item/stack/material)
+	. = merge_without_del(material)
+	is_zero_amount(TRUE)
 
 /obj/item/stack/proc/copy_evidences(obj/item/stack/material)
 	blood_DNA			= material.blood_DNA


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Ports https://github.com/tgstation/tgstation/pull/60835 in an attempt to stop the scourge of locally non-reproducible /obj/item/stack harddels. This is kind of a shot in the dark, but I can't think of any other reason for such a consistently high occurrence of failure.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Hopefully stops major and consistent harddels.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Stack stuff seems fine in game, but please check me on this.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

NPFC

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
