### PR TITLE
Prevents pseudo-exploit with heal_on_apply reagents and IV bags

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -322,6 +322,9 @@
 	if(method == REAGENT_TOUCH)
 		heal_overall_damage(M, volume)
 
+	if(method == REAGENT_INGEST)
+		data = "Ingested" // sin
+
 	return ..()
 
 /datum/reagent/medicine/heal_on_apply/synthflesh
@@ -336,8 +339,9 @@
 
 /datum/reagent/medicine/heal_on_apply/synthflesh/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
-	update_flags |= M.adjustBruteLoss(-1.25 * REAGENTS_EFFECT_MULTIPLIER, FALSE)
-	update_flags |= M.adjustFireLoss(-1.25 * REAGENTS_EFFECT_MULTIPLIER, FALSE)
+	if(data != "Ingested" || volume > 1)
+		update_flags |= M.adjustBruteLoss(-1.25 * REAGENTS_EFFECT_MULTIPLIER, FALSE)
+		update_flags |= M.adjustFireLoss(-1.25 * REAGENTS_EFFECT_MULTIPLIER, FALSE)
 	return ..() | update_flags
 
 /datum/reagent/medicine/heal_on_apply/synthflesh/reaction_mob(mob/living/M, method = REAGENT_TOUCH, volume, show_message = 1)
@@ -377,7 +381,8 @@
 
 /datum/reagent/medicine/heal_on_apply/styptic_powder/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
-	update_flags |= M.adjustBruteLoss(-2 * REAGENTS_EFFECT_MULTIPLIER, FALSE)
+	if(data != "Ingested" || volume > 1)
+		update_flags |= M.adjustBruteLoss(-2 * REAGENTS_EFFECT_MULTIPLIER, FALSE)
 	return ..() | update_flags
 
 /datum/reagent/medicine/heal_on_apply/styptic_powder/heal_external_limb(obj/item/organ/external/organ, volume)
@@ -411,7 +416,8 @@
 
 /datum/reagent/medicine/heal_on_apply/silver_sulfadiazine/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
-	update_flags |= M.adjustFireLoss(-2 * REAGENTS_EFFECT_MULTIPLIER, FALSE)
+	if(data != "Ingested" || volume > 1)
+		update_flags |= M.adjustFireLoss(-2 * REAGENTS_EFFECT_MULTIPLIER, FALSE)
 	return ..() | update_flags
 
 /datum/reagent/medicine/heal_on_apply/silver_sulfadiazine/heal_external_limb(obj/item/organ/external/organ, volume)

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -166,18 +166,19 @@
 	heart_rate_decrease = 1
 	taste_description = "a safe refuge"
 	goal_difficulty = REAGENT_GOAL_NORMAL
+	data = list()
 
 /datum/reagent/medicine/cryoxadone/reaction_mob(mob/living/M, method = REAGENT_TOUCH, volume, show_message = TRUE)
 	if(iscarbon(M))
+		data["method"] = method
 		if(method == REAGENT_INGEST && M.bodytemperature < TCRYO)
-			data = "Ingested"
 			if(show_message)
 				to_chat(M, "<span class='warning'>[src] freezes solid as it enters your body!</span>") //Burn damage already happens on ingesting
 	..()
 
 /datum/reagent/medicine/cryoxadone/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
-	if(M.bodytemperature < TCRYO && data != "Ingested")
+	if(M.bodytemperature < TCRYO && data["method"] == REAGENT_TOUCH)
 		update_flags |= M.adjustCloneLoss(-4, FALSE)
 		update_flags |= M.adjustOxyLoss(-10, FALSE)
 		update_flags |= M.adjustToxLoss(-3, FALSE)
@@ -282,6 +283,7 @@
 	return ..() | update_flags
 
 /datum/reagent/medicine/heal_on_apply
+	data = list()
 
 /datum/reagent/medicine/heal_on_apply/proc/heal_external_limb(obj/item/organ/external/organ, volume)
 	return
@@ -314,6 +316,7 @@
 	if(!iscarbon(M))
 		return ..()
 
+	data["method"] = method
 	if(ishuman(M) && volume > 20 && method == REAGENT_TOUCH)
 		heal_overall_damage(M, 20)
 		var/applied_volume = splash_human(M, volume - 20)
@@ -321,9 +324,6 @@
 
 	if(method == REAGENT_TOUCH)
 		heal_overall_damage(M, volume)
-
-	if(method == REAGENT_INGEST)
-		data = "Ingested" // sin
 
 	return ..()
 
@@ -339,7 +339,7 @@
 
 /datum/reagent/medicine/heal_on_apply/synthflesh/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
-	if(data != "Ingested" || volume > 1)
+	if(data["method"] == REAGENT_TOUCH || volume > 1)
 		update_flags |= M.adjustBruteLoss(-1.25 * REAGENTS_EFFECT_MULTIPLIER, FALSE)
 		update_flags |= M.adjustFireLoss(-1.25 * REAGENTS_EFFECT_MULTIPLIER, FALSE)
 	return ..() | update_flags
@@ -381,7 +381,7 @@
 
 /datum/reagent/medicine/heal_on_apply/styptic_powder/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
-	if(data != "Ingested" || volume > 1)
+	if(data["method"] == REAGENT_TOUCH || volume > 1)
 		update_flags |= M.adjustBruteLoss(-2 * REAGENTS_EFFECT_MULTIPLIER, FALSE)
 	return ..() | update_flags
 
@@ -416,7 +416,7 @@
 
 /datum/reagent/medicine/heal_on_apply/silver_sulfadiazine/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
-	if(data != "Ingested" || volume > 1)
+	if(data["method"] == REAGENT_TOUCH || volume > 1)
 		update_flags |= M.adjustFireLoss(-2 * REAGENTS_EFFECT_MULTIPLIER, FALSE)
 	return ..() | update_flags
 

--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -438,13 +438,13 @@
 	description = "A toxin that affects the stamina of a person when injected into the bloodstream."
 	reagent_state = LIQUID
 	color = "#6E2828"
-	data = 13
 	taste_description = "bitterness"
+	var/damage_per_cycle = 13
 
 /datum/reagent/staminatoxin/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
-	update_flags |= M.adjustStaminaLoss(REAGENTS_EFFECT_MULTIPLIER * data, FALSE)
-	data = max(data - 1, 3)
+	update_flags |= M.adjustStaminaLoss(damage_per_cycle * REAGENTS_EFFECT_MULTIPLIER, FALSE)
+	damage_per_cycle = max(damage_per_cycle - 1, 3)
 	return ..() | update_flags
 
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This targets a very specific chem mix that has seen use in recent weeks as precisely as possible so that the remaining majority of use cases aren't affected. That is, this mix can no longer heal faster than almost anything in the game, which granted the user near god-mode in combat.
![image](https://github.com/user-attachments/assets/5b09c6d8-a61d-45ef-aff2-b12015864cd1)

As this mix demonstrates, heal_on_apply reagents (styptic powder, silver sulfadiazine, and synthflesh) can be fed via a 1u transfer rate IV drip together at volumes as low as 0.1u per cycle to provide constant, passive, patch-equivalent brute and burn healing. This is just an unfortunate fact of the reagent system. Additionally, the toxin damage that is done on ingestion is proportional to half of the volume. In this specific mix's case, each reagent's volume is 0.1u... so the toxin damage received as a supposed downside is 0.1 per cycle. This is easily healed by the 1 toxin damage per cycle rate of triple citrus.

Instead, I have added a cut off for ingestion healing of the three horsemen below 1u. This means means that there is no 1u-fractional mix that can duplicate the described effect.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Being able to use heal_on_apply reagents in this manner is a serious balance issue. It is so bad that it is considered to be an exploit by Balance Team consensus.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
I injected myself with a 1u drip and didn't get healed by the relevant reagents. Then I stuck a patch on and got healed.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
tweak: Styptic powder, silver sulfadiazine, and synthflesh no longer heal when ingested in quantities below 1u.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
