### PR TITLE
Cleans up a few more duplicate var definitions

### DIFF
--- a/code/modules/awaymissions/mission_code/ruins/deepstorage.dm
+++ b/code/modules/awaymissions/mission_code/ruins/deepstorage.dm
@@ -7,12 +7,13 @@
 	icon = 'icons/mob/fleshling.dmi'
 	icon_state = "fleshling"
 	icon_living = "fleshling"
+	attack_sound = 'sound/misc/demon_attack1.ogg'
+	death_sound = 'sound/misc/demon_dies.ogg'
 	icon_dead = ""
 	speed = 5
 	move_to_delay = 4
 	ranged = TRUE
 	pixel_x = -16
-	attack_sound = 'sound/misc/demon_attack1.ogg'
 	melee_damage_lower = 20
 	melee_damage_upper = 20
 	wander = TRUE
@@ -23,8 +24,6 @@
 	a_intent = INTENT_HARM
 	deathmessage = "collapses into a pile of gibs. From the looks of it this is the deadest it can get... "
 	del_on_death = TRUE
-	death_sound = 'sound/misc/demon_dies.ogg'
-	attack_sound = 'sound/misc/demon_attack1.ogg'
 
 	/// Is the boss charging right now?
 	var/charging = FALSE

--- a/code/modules/mod/mod_actions.dm
+++ b/code/modules/mod/mod_actions.dm
@@ -89,7 +89,7 @@
 /datum/action/item_action/mod/pinned_module
 	desc = "Activate the module."
 	button_overlay_icon = 'icons/obj/clothing/modsuit/mod_modules.dmi'
-	button_overlay_icon = 'icons/mob/actions/actions_mod.dmi'
+	button_background_icon = 'icons/mob/actions/actions_mod.dmi'
 	button_overlay_icon_state = "module"
 	/// Module we are linked to.
 	var/obj/item/mod/module/module

--- a/code/modules/vehicle/tg_vehicles/tg_vehicles.dm
+++ b/code/modules/vehicle/tg_vehicles/tg_vehicles.dm
@@ -10,7 +10,6 @@
 	blocks_emissive = EMISSIVE_BLOCK_GENERIC
 	buckle_lying = FALSE
 	can_buckle = TRUE
-	buckle_lying = 0
 	pass_flags = PASSTABLE
 	COOLDOWN_DECLARE(message_cooldown)
 	COOLDOWN_DECLARE(cooldown_vehicle_move)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
See title.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
code cleanup
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


## Testing
It compiles
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

my sanity

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
