### PR TITLE
Makes the cryo anomaly more dangerous

### DIFF
--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -405,24 +405,14 @@
 	for(var/turf/T in oview(get_turf(src), 7))
 		turf_targets += T
 
+	var/list/mob_targets = list()
+	for(var/mob/M in oview(get_turf(src), 7))
+		if(!isliving(M))
+			continue
+		mob_targets += M
+
 	for(var/mob/living/carbon/human/H in view(get_turf(src), 3))
 		shootAt(H)
-
-	for(var/I in 1 to rand(1, 3))
-		var/turf/target = pick(turf_targets)
-		shootAt(target)
-
-	if(prob(50))
-		for(var/turf/simulated/floor/nearby_floor in oview(get_turf(src), (drops_core ? 2 : 1)))
-			nearby_floor.MakeSlippery((drops_core? TURF_WET_PERMAFROST : TURF_WET_ICE), (drops_core? null : rand(10, 20 SECONDS)))
-
-		var/turf/simulated/T = get_turf(src)
-		if(istype(T))
-			var/datum/gas_mixture/air = new()
-			air.set_temperature(TCMB)
-			air.set_sleeping_agent(20)
-			air.set_carbon_dioxide(20)
-			T.blind_release_air(air)
 
 	if(prob(10))
 		var/obj/effect/nanofrost_container/A = new /obj/effect/nanofrost_container(get_turf(src))
@@ -430,6 +420,26 @@
 			step_towards(A, pick(turf_targets))
 			sleep(2)
 		A.Smoke()
+
+	// This has to be in the end because we're adding mobs to a turf list
+	for(var/I in 1 to rand(3, 5))
+		if(length(mob_targets))
+			turf_targets += mob_targets
+		shootAt(pick(turf_targets))
+
+	if(prob(50))
+		for(var/turf/possible_floor in view(get_turf(src), (drops_core ? 2 : 1)))
+			if(isfloorturf(possible_floor))
+				var/turf/simulated/floor/nearby_floor = possible_floor
+				nearby_floor.MakeSlippery((drops_core? TURF_WET_PERMAFROST : TURF_WET_ICE), (drops_core? null : rand(10, 20 SECONDS)))
+
+		var/turf/simulated/T = get_turf(src)
+		if(istype(T))
+			var/datum/gas_mixture/air = new()
+			air.set_temperature(TCMB)
+			air.set_sleeping_agent(80)
+			air.set_carbon_dioxide(80)
+			T.blind_release_air(air)
 
 /obj/effect/anomaly/cryo/proc/shootAt(atom/movable/target)
 	var/turf/T = get_turf(src)
@@ -451,8 +461,8 @@
 	if(istype(T) && drops_core)
 		var/datum/gas_mixture/air = new()
 		air.set_temperature(TCMB)
-		air.set_sleeping_agent(1000)
-		air.set_carbon_dioxide(1000)
+		air.set_sleeping_agent(3000)
+		air.set_carbon_dioxide(3000)
 		T.blind_release_air(air)
 
 /////////////////////

--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -422,7 +422,8 @@
 		A.Smoke()
 
 	// This has to be in the end because we're adding mobs to a turf list
-	for(var/I in 1 to rand(3, 5))
+	var/shots = drops_core ? rand(3, 5) : rand(1, 3)
+	for(var/i in 1 to shots)
 		if(length(mob_targets))
 			turf_targets += mob_targets
 		shootAt(pick(turf_targets))

--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -432,7 +432,7 @@
 		for(var/turf/possible_floor in view(get_turf(src), (drops_core ? 2 : 1)))
 			if(isfloorturf(possible_floor))
 				var/turf/simulated/floor/nearby_floor = possible_floor
-				nearby_floor.MakeSlippery((drops_core? TURF_WET_PERMAFROST : TURF_WET_ICE), (drops_core? null : rand(10, 20 SECONDS)))
+				nearby_floor.MakeSlippery((drops_core ? TURF_WET_PERMAFROST : TURF_WET_ICE), (drops_core ? null : rand(10, 20 SECONDS)))
 
 		var/turf/simulated/T = get_turf(src)
 		if(istype(T))


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
- Gives the cryo anomaly some more attempts to shoot mobs in a 7 turf radius
- Quadruples the amount of CO2 and N2O that it spreads normally. This sounds like a lot but it barely spawned anything
- Triples the amount of gas it spawns on detonate
- Increases the amount of random projectiles from 1-3 to 3-5
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Cryo anomalies are quite the joke. They're a non-factor to defuse, as the ambient temperature in a decently sized room will reach barely below 0, which a human's natural heating will easily fix.
With this change, a room can quickly reach -100 C, and people will be hit by more shots generally. You'll be wanting to wear some insulating clothing going in here.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Spawned a cryo anomaly, no runtimes.
Went in the room and got slowed quite fast, and hit by 6 shots before I managed to defuse it.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
tweak: The cryo anomaly is a lot more dangerous
tweak: It shoots more shots, and spews more cold gasses
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
