### PR TITLE
Replaces the changeling gamemode with a vampires + changelings gamemode.

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -282,10 +282,10 @@
 				candidates += player.mind
 				players -= player
 
-	// Remove candidates who want to be antagonist but have a job that precludes it
+	// Remove candidates who want to be antagonist but have a job (or other antag datum) that precludes it
 	if(restricted_jobs)
 		for(var/datum/mind/player in candidates)
-			if(player.assigned_role in restricted_jobs)
+			if((player.assigned_role in restricted_jobs) || player.special_role)
 				candidates -= player
 
 
@@ -311,9 +311,9 @@
 	// Shuffle the players list so that it becomes ping-independent.
 	players = shuffle(players)
 
-	// Get a list of all the people who want to be the antagonist for this round, except those with incompatible species
+	// Get a list of all the people who want to be the antagonist for this round, except those with incompatible species, and those who are already antagonists
 	for(var/mob/living/carbon/human/player in players)
-		if(player.client.skip_antag || !(allow_offstation_roles || !player.mind?.offstation_role))
+		if(player.client.skip_antag || !(allow_offstation_roles || !player.mind?.offstation_role) || player.mind?.special_role)
 			continue
 
 		if(!(role in player.client.prefs.be_special) || (player.client.prefs.active_character.species in protected_species))

--- a/code/game/gamemodes/vampire/vampire_chan.dm
+++ b/code/game/gamemodes/vampire/vampire_chan.dm
@@ -1,0 +1,46 @@
+/datum/game_mode/vampire/changeling
+	name = "vampire_changeling"
+	config_tag = "vampchan"
+	restricted_jobs = list("AI", "Cyborg")
+	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Blueshield", "Nanotrasen Representative", "Magistrate", "Chaplain", "Internal Affairs Agent", "Nanotrasen Navy Officer", "Special Operations Officer", "Syndicate Officer", "Solar Federation General")
+	protected_species = list("Machine")
+	required_players = 1 //Testing, TODO blah balh
+	required_enemies = 1
+	recommended_enemies = 3
+	secondary_enemies_scaling = 0.025
+	vampire_penalty = 0.6 // Cut out 40% of the vampires since we'll replace some with changelings
+	/// A list of all soon-to-be changelings
+	var/list/datum/mind/pre_changelings = list()
+
+/datum/game_mode/vampire/changeling/pre_setup()
+	if(GLOB.configuration.gamemode.prevent_mindshield_antags)
+		restricted_jobs += protected_jobs
+
+	var/list/datum/mind/possible_changelings = get_players_for_role(ROLE_CHANGELING)
+	secondary_enemies = CEILING((secondary_enemies_scaling * num_players()), 1)
+
+	for(var/mob/new_player/player in GLOB.player_list)
+		if((player.mind in possible_changelings) && (player.client.prefs.active_character.species in secondary_protected_species))
+			possible_changelings -= player.mind
+
+	if(!length(possible_changelings))
+		return ..()
+
+	for(var/I in possible_changelings)
+		if(length(pre_changelings) >= secondary_enemies)
+			break
+		var/datum/mind/changeling = pick_n_take(possible_changelings)
+		pre_changelings += changeling
+		changeling.restricted_roles = (restricted_jobs + secondary_restricted_jobs)
+		changeling.special_role = SPECIAL_ROLE_CHANGELING
+
+	return ..()
+
+/datum/game_mode/vampire/announce()
+	to_chat(world, "<B>The current game mode is - Vampires+Changelings!</B>")
+	to_chat(world, "<B>Some of your co-workers are vampires, and others might not even be your coworkers!</B>")
+
+/datum/game_mode/vampire/changeling/post_setup()
+	for(var/datum/mind/changeling as anything in pre_changelings)
+		changeling.add_antag_datum(/datum/antagonist/changeling)
+	..()

--- a/code/game/gamemodes/vampire/vampire_chan.dm
+++ b/code/game/gamemodes/vampire/vampire_chan.dm
@@ -4,7 +4,7 @@
 	restricted_jobs = list("AI", "Cyborg")
 	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Blueshield", "Nanotrasen Representative", "Magistrate", "Chaplain", "Internal Affairs Agent", "Nanotrasen Navy Officer", "Special Operations Officer", "Syndicate Officer", "Solar Federation General")
 	protected_species = list("Machine")
-	required_players = 1 //Testing, TODO blah balh
+	required_players = 15
 	required_enemies = 1
 	recommended_enemies = 3
 	secondary_enemies_scaling = 0.025

--- a/code/game/gamemodes/vampire/vampire_chan.dm
+++ b/code/game/gamemodes/vampire/vampire_chan.dm
@@ -37,8 +37,8 @@
 	return ..()
 
 /datum/game_mode/vampire/announce()
-	to_chat(world, "<B>The current game mode is - Vampires+Changelings!</B>")
-	to_chat(world, "<B>Some of your co-workers are vampires, and others might not even be your coworkers!</B>")
+	to_chat(world, "<b>The current game mode is - Vampires+Changelings!</b>")
+	to_chat(world, "<b>Some of your co-workers are vampires, and others might not even be your coworkers!</b>")
 
 /datum/game_mode/vampire/changeling/post_setup()
 	for(var/datum/mind/changeling as anything in pre_changelings)

--- a/code/game/gamemodes/vampire/vampire_gamemode.dm
+++ b/code/game/gamemodes/vampire/vampire_gamemode.dm
@@ -7,6 +7,8 @@
 	required_players = 15
 	required_enemies = 1
 	recommended_enemies = 4
+	/// If this gamemode should spawn less vampires than a usual vampire round, as a percentage of how many you want relative to the regular amount
+	var/vampire_penalty = 0
 
 	///list of minds of soon to be vampires
 	var/list/datum/mind/pre_vampires = list()
@@ -22,7 +24,7 @@
 
 	var/list/datum/mind/possible_vampires = get_players_for_role(ROLE_VAMPIRE)
 
-	var/vampire_amount = 1 + round(num_players() / 10)
+	var/vampire_amount = 1 + (round(num_players() / 10) * (1 - vampire_penalty))
 
 	if(length(possible_vampires))
 		for(var/i in 1 to vampire_amount)

--- a/config/example/config.toml
+++ b/config/example/config.toml
@@ -255,7 +255,7 @@ antag_account_age_restrictions = false
 # Gamemode probabilities map for if you are using secret or random
 gamemode_probabilities = [
 	{ gamemode = "abduction", probability = 0 },
-	{ gamemode = "changeling", probability = 3 },
+	{ gamemode = "changeling", probability = 0 },
 	{ gamemode = "cult", probability = 3 },
 	{ gamemode = "extend-a-traitormongous", probability = 2 }, # Autotraitor
 	{ gamemode = "extended", probability = 3 },
@@ -265,6 +265,7 @@ gamemode_probabilities = [
 	{ gamemode = "traitor", probability = 2 },
 	{ gamemode = "traitorchan", probability = 3 },
 	{ gamemode = "traitorvamp", probability = 3 },
+	{ gamemode = "vampchan", probability = 3},
 	{ gamemode = "vampire", probability = 3 },
 	{ gamemode = "wizard", probability = 2 },
 	{ gamemode = "trifecta", probability = 3 },

--- a/paradise.dme
+++ b/paradise.dme
@@ -785,6 +785,7 @@
 #include "code\game\gamemodes\trifecta\trifecta.dm"
 #include "code\game\gamemodes\vampire\traitor_vamp.dm"
 #include "code\game\gamemodes\vampire\vampire_gamemode.dm"
+#include "code\game\gamemodes\vampire\vampire_chan.dm"
 #include "code\game\gamemodes\wizard\artefact.dm"
 #include "code\game\gamemodes\wizard\godhand.dm"
 #include "code\game\gamemodes\wizard\magic_tarot.dm"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Title + Adds extra logic to gamemodes that prevents someone from being picked for multiple antagonist roles.
## Why It's Good For The Game
<details>
<summary>
I've gotten on my soapbox on the Discord a few times already, so I'll copy+paste my thoughts from there.
</summary>

I think the changeling gamemode is very flawed, and here are the main reasons why.

- A roundtype of exclusively KOS antags means escalation will only ever increase.

- Changelings don't have enough varied playstyles to make 5-7 in a single round interesting.

- Having such relatively few antags in a round that perma-die when dealt with means that good security officers can quickly run out of things to do, and will cryo with the meta-knowledge that the round has like 2 interesting clings left.

- Once one changeling goes loud, every other changeling is subject to whatever the highest level of escalation so far has been. I feel like it's very uncommon that processing gibbers ever get disassembled, even if the main problem cling has been dealt with.

- Playing changeling stealthily tends to result in people getting round removed very early. Since a stealthy changeling having their identity leaked is the worst thing that could happen to them, they're incentivized to perma-kill both victims AND witnesses.

- Changelings are nearly unkillable if there's a team of more than two, or security is too spread out by multiple loud clings. Having less changelings in a round will make this happen significantly less.

Overall, I strongly believe that changelings work significantly better when there are other antagonists in the round, both for security, and the changeling's sake.
</details>
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

<!-- How did you test the PR, if at all? -->
Made sure that I couldn't get two different antagonists at once, and used breakpoints to simulate what a full population round might look like.
<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>
![image](https://github.com/user-attachments/assets/febb1912-9a6c-4dd8-88f2-82cdd76bdf92)

## Changelog

:cl:
del: Removed the changeling gamemode from rotation.
add: Added the vampires + changelings gamemode to rotation.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
