### PR TITLE
Nukies can no longer buy the chainsaw.

### DIFF
--- a/code/datums/uplink_items/uplink_general.dm
+++ b/code/datums/uplink_items/uplink_general.dm
@@ -243,6 +243,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/butcher_chainsaw
 	cost = 65
 	surplus = 0 // This has caused major problems with un-needed chainsaw massacres. Bwoink bait.
+	excludefrom = list(UPLINK_TYPE_NUCLEAR)
 
 /datum/uplink_item/dangerous/universal_gun_kit
 	name = "Universal Self Assembling Gun Kit"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Disallows nukies from buying the chainsaw
## Why It's Good For The Game
Currently the nukie "meta" is to buy the following items
![dreamseeker_fYMKsRHOWe](https://github.com/user-attachments/assets/e86d466a-6de2-4a0c-8975-1c712265f637)
```
elite = 40tc
shield module = 200tc
freedom = 25tc
adrenalx2 = 80tc
medical kit = 30tc
```
if i understand the code correctly you get about ~450tc with 60 crew alive. though im probably wrong with that count, but dropping freedoms, and the medkit or the second adrenal implant frees up tc for other stuff.
all that adds upto 440TC, and this makes you very VERY hard to kill. Basically bordering unkillable if someone else in the team of 5 with the same amount of tc buys a medical borg. 
With the adrenals, you run four times as fast as crew can, as well as the chainsaw having a 100% knockdown chance, then the shield module giving 3 free hits that wont effect you at all, you can basically solo entire rooms of people unless they have a durand with a shotgun. 
With how uncounterable this loadout is, its genuinely unfun to fight, or watch fight, as they can carry the entire nukie team with little to no risk of counter play.

Removing the chainsaw will hopefully lead to more equal sided matches of nukies vs crew, as other melee items like the dsword can be knocked out of hands with well timed rubbershot, beanbags, or shoves. And the powerfist is unable to go on unstopable rampages as it needs "fuel"
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

<!-- How did you test the PR, if at all? -->
Compiled, spawned a nukie uplink, checked it if it had a chainsaw
<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
![Discord_gdZxjrEPL4](https://github.com/user-attachments/assets/1777e15a-4018-41ff-b740-337abbc746fa)

  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
tweak: The nuclear uplink no longer has the syndicate chainsaw for sale
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
