### PR TITLE
Cleans up /obj/effect/decal/cleanable 

### DIFF
--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -98,15 +98,12 @@
 		if(!locate(/obj/structure/grille/) in T && !locate(/obj/structure/window/) in T)
 			qdel(src) //no free floating dried blood in space, thatd look weird
 
-/obj/effect/decal/cleanable/blood/ex_act()
-	. = ..()
-	update_icon()
-
 /obj/effect/decal/cleanable/blood/proc/splat(atom/AT)
 	if(gravity_check) //only floating blood can splat :C
 		return
 	var/turf/T = get_turf(AT)
-	if(try_merging_decal(T))
+	if(should_merge_decal(T))
+		qdel(src)
 		return
 	if(loc != T)
 		forceMove(T) //move to the turf to splatter on
@@ -118,7 +115,7 @@
 	plane = initial(plane)
 	update_icon()
 
-/obj/effect/decal/cleanable/blood/try_merging_decal(turf/T)
+/obj/effect/decal/cleanable/blood/should_merge_decal(turf/T)
 	..()
 
 /obj/effect/decal/cleanable/blood/Process_Spacemove(movement_dir)
@@ -140,11 +137,18 @@
 
 
 /obj/effect/decal/cleanable/blood/Bump(atom/A, yes)
+	// this is to prevent double or triple bumps from calling splat after src is qdel'd.
+	// only god knows why this fixes the issue
+	if(yes)
+		return
+
 	if(gravity_check)
 		return ..()
+
 	if(iswallturf(A) || istype(A, /obj/structure/window))
 		splat(A)
 		return
+
 	else if(A.density)
 		splat(get_turf(A))
 		return
@@ -153,7 +157,7 @@
 		bloodyify_human(A)
 		return
 
-	..()
+	return ..()
 
 /obj/effect/decal/cleanable/blood/proc/bloodyify_human(mob/living/carbon/human/H)
 	if(inertia_dir && H.inertia_dir == inertia_dir) //if they are moving the same direction we are, no collison

--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -115,8 +115,6 @@
 	plane = initial(plane)
 	update_icon()
 
-/obj/effect/decal/cleanable/blood/should_merge_decal(turf/T)
-	..()
 
 /obj/effect/decal/cleanable/blood/Process_Spacemove(movement_dir)
 	if(gravity_check)

--- a/code/game/objects/effects/decals/Cleanable/misc_cleanables.dm
+++ b/code/game/objects/effects/decals/Cleanable/misc_cleanables.dm
@@ -185,7 +185,8 @@
 	if(gravity_check)
 		return
 	var/turf/T = get_turf(A)
-	if(try_merging_decal(T))
+	if(should_merge_decal(T))
+		qdel(src)
 		return
 	if(loc != T)
 		forceMove(T)

--- a/code/game/objects/effects/decals/cleanable.dm
+++ b/code/game/objects/effects/decals/cleanable.dm
@@ -87,12 +87,12 @@
 
 /obj/effect/decal/cleanable/Initialize(mapload)
 	. = ..()
+	if(should_merge_decal(loc))
+		return INITIALIZE_HINT_QDEL
 	var/datum/atom_hud/data/janitor/jani_hud = GLOB.huds[DATA_HUD_JANITOR]
 	prepare_huds()
 	jani_hud.add_to_hud(src)
 	jani_hud_set_sign()
-	if(try_merging_decal())
-		return TRUE
 	if(random_icon_states && length(src.random_icon_states) > 0)
 		src.icon_state = pick(src.random_icon_states)
 	if(smoothing_flags)
@@ -108,14 +108,13 @@
 	jani_hud.remove_from_hud(src)
 	return ..()
 
-/obj/effect/decal/cleanable/proc/try_merging_decal(turf/T)
+/obj/effect/decal/cleanable/proc/should_merge_decal(turf/T)
 	if(!T)
 		T = loc
 	if(isturf(T))
 		for(var/obj/effect/decal/cleanable/C in T)
 			if(C != src && C.type == type && !QDELETED(C))
 				if(C.gravity_check && replace_decal(C))
-					qdel(src)
 					return TRUE
 	return FALSE
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
#26611 made cleanable decals destroy properly, revealing a host of issues to do with Bump() getting called multiple times on a deleting decal.

- Bump() getting called multiple times caused the decal to try to splat() when it was already qdel'd. This suddenly started causing a runtime because it never properly destroyed before.
- Tries to make cleanable decals not qdel in initialize via try_merging_decal() (which was called in initialize), instead returning a qdel hint
- removes /obj/effect/decal/cleanable/blood/ex_act() because for some reason it was calling update_icon() after the parent call made it qdel and it caused runtimes out the ass.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Bug and runtime fix
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

<!-- How did you test the PR, if at all? -->
Threw a shit ton of blood drips at windows and observed they didn't runtime or do other funny business.
Dropped a bomb on a bunch of blood drips and observed they didn't runtime.
<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
