### PR TITLE
[s] Update HolodeckControl.dm 

### DIFF
--- a/code/game/machinery/computer/HolodeckControl.dm
+++ b/code/game/machinery/computer/HolodeckControl.dm
@@ -232,7 +232,6 @@
 	icon = 'icons/turf/floors/carpet.dmi'
 	icon_state = "carpet-255"
 	base_icon_state = "carpet"
-	floor_tile = /obj/item/stack/tile/carpet
 	smoothing_flags = SMOOTH_BITMASK
 	smoothing_groups = list(SMOOTH_GROUP_TURF, SMOOTH_GROUP_CARPET)
 	canSmoothWith = list(SMOOTH_GROUP_CARPET)
@@ -265,7 +264,6 @@
 	pixel_x = -9
 	pixel_y = -9
 	layer = ABOVE_OPEN_TURF_LAYER
-	floor_tile = /obj/item/stack/tile/grass
 
 /turf/simulated/floor/holofloor/attackby(obj/item/W as obj, mob/user as mob, params)
 	return


### PR DESCRIPTION
## What Does This PR Do
This PR removes the ability to duplicate carpet tiles & grass tiles from the holodeck, as it makes absolutely no sense why it should duplicate it.

## Why It's Good For The Game
You can't duplicate infinite amounts of carpet tiles & grass tiles anymore.

## Testing
- Spawned in, visited the holodeck.
- Selected the Theatre & Picnic area
- Used a crowbar on carpet tiles & grass tiles.
- Carpet tiles & grass tiles drops. (Flabbergasted)
- Removed 2 lines of code responsible for spawning the item if removed via a crowbar.
- Visited the holodeck again, to see the tiles disappear into thin air.
- Profit.

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Fixed being able to duplicate "grass & carpet tiles" in the Holodeck.
/:cl:
