### PR TITLE
Fixes stacks, attempt 2

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -163,12 +163,12 @@
 		ui_interact(user)
 
 /obj/item/stack/attackby(obj/item/thing, mob/user, params)
-	if(can_merge(thing, TRUE))
-		var/obj/item/stack/material = thing
-		if(merge(material))
-			to_chat(user, "<span class='notice'>Your [material.name] stack now contains [material.get_amount()] [material.singular_name]\s.</span>")
-	else
-		. = ..()
+	if(!can_merge(thing, TRUE))
+		return ..()
+
+	var/obj/item/stack/material = thing
+	if(merge(material))
+		to_chat(user, "<span class='notice'>Your [material.name] stack now contains [material.get_amount()] [material.singular_name]\s.</span>")
 
 /obj/item/stack/use(used, check = TRUE)
 	if(check && is_zero_amount(TRUE))

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -57,9 +57,8 @@
 				continue
 			if(can_merge(item_stack))
 				INVOKE_ASYNC(src, PROC_REF(merge_without_del), item_stack)
-				// we do not want to qdel during initialization, so we just check whether or not we're a 0 count stack
+				// we do not want to qdel during initialization, so we just check whether or not we're a 0 count stack and let the hint handle deletion
 				if(is_zero_amount(FALSE))
-					log_debug("[text_ref(src)] returning qdel hint")
 					return INITIALIZE_HINT_QDEL
 
 	update_icon(UPDATE_ICON_STATE)
@@ -78,9 +77,6 @@
 
 /obj/item/stack/Crossed(obj/O, oldloc)
 	if(O == src)
-		return
-
-	if(QDELETED(O))
 		return
 
 	if(amount >= max_amount || ismob(loc)) // Prevents unnecessary call. Also prevents merging stack automatically in a mob's inventory
@@ -129,8 +125,6 @@
  */
 /obj/item/stack/proc/can_merge(obj/item/stack/check, inhand = FALSE)
 	// We don't only use istype here, since that will match subtypes, and stack things that shouldn't stack
-	if(QDELETED(src) || QDELETED(check))
-		return FALSE
 	if(!istype(check, merge_type) || check.merge_type != merge_type)
 		return FALSE
 	if(is_cyborg) // No merging cyborg stacks into other stacks
@@ -331,7 +325,6 @@
 
 	if(amount < 1)
 		if(delete_if_zero)
-			log_debug("[text_ref(src)] deleting at zero")
 			qdel(src)
 		return TRUE
 	return FALSE
@@ -347,7 +340,6 @@
 	// Cover edge cases where multiple stacks are being merged together and haven't been deleted properly.
 	// Also cover edge case where a stack is being merged into itself, which is supposedly possible.
 	if(QDELETED(material))
-		log_debug("[text_ref(src)] is FUCKING QDELETED.")
 		CRASH("Stack merge attempted on qdeleted target stack.")
 	if(QDELETED(src))
 		CRASH("Stack merge attempted on qdeleted source stack.")

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -37,7 +37,6 @@
 	var/parent_stack = FALSE
 
 /obj/item/stack/Initialize(mapload, new_amount, merge = TRUE)
-	. = ..()
 	if(dynamic_icon_state) //If we have a dynamic icon state, we don't want item states to follow the same pattern.
 		item_state = initial(icon_state)
 
@@ -51,14 +50,16 @@
 	if(!merge_type)
 		merge_type = type
 
-	if(merge && !(amount >= max_amount))
+	. = ..()
+	if(merge)
 		for(var/obj/item/stack/item_stack in loc)
 			if(item_stack == src)
 				continue
-			if(item_stack.merge_type == merge_type)
+			if(can_merge(item_stack))
 				INVOKE_ASYNC(src, PROC_REF(merge_without_del), item_stack)
 				// we do not want to qdel during initialization, so we just check whether or not we're a 0 count stack
 				if(is_zero_amount(FALSE))
+					log_debug("[text_ref(src)] returning qdel hint")
 					return INITIALIZE_HINT_QDEL
 
 	update_icon(UPDATE_ICON_STATE)
@@ -76,17 +77,23 @@
 	icon_state = "[initial(icon_state)]_[state]"
 
 /obj/item/stack/Crossed(obj/O, oldloc)
+	if(O == src)
+		return
+
+	if(QDELETED(O))
+		return
+
 	if(amount >= max_amount || ismob(loc)) // Prevents unnecessary call. Also prevents merging stack automatically in a mob's inventory
 		return
 
-	if(istype(O, merge_type) && !O.throwing)
-		merge(O)
+	if(!O.throwing && can_merge(O))
+		INVOKE_ASYNC(src, PROC_REF(merge), O)
 
 	..()
 
-/obj/item/stack/hitby(atom/movable/AM, skipcatch, hitpush, blocked, datum/thrownthing/throwingdatum)
-	if(istype(AM, merge_type) && !(amount >= max_amount))
-		merge(AM)
+/obj/item/stack/hitby(atom/movable/hitting, skipcatch, hitpush, blocked, datum/thrownthing/throwingdatum)
+	if(can_merge(hitting, inhand = TRUE))
+		merge(hitting)
 	. = ..()
 
 /obj/item/stack/examine(mob/user)
@@ -113,6 +120,24 @@
 	else
 		amount += newamount
 	update_icon(UPDATE_ICON_STATE)
+
+/** Checks whether this stack can merge itself into another stack.
+ *
+ * Arguments:
+ * - [check][/obj/item/stack]: The stack to check for mergeability.
+ * - [inhand][boolean]: Whether or not the stack to check should act like it's in a mob's hand.
+ */
+/obj/item/stack/proc/can_merge(obj/item/stack/check, inhand = FALSE)
+	// We don't only use istype here, since that will match subtypes, and stack things that shouldn't stack
+	if(QDELETED(src) || QDELETED(check))
+		return FALSE
+	if(!istype(check, merge_type) || check.merge_type != merge_type)
+		return FALSE
+	if(is_cyborg) // No merging cyborg stacks into other stacks
+		return FALSE
+	if(ismob(loc) && !inhand) // no merging with items that are on the mob
+		return FALSE
+	return TRUE
 
 /obj/item/stack/attack_self(mob/user)
 	ui_interact(user)
@@ -144,12 +169,12 @@
 		ui_interact(user)
 
 /obj/item/stack/attackby(obj/item/thing, mob/user, params)
-	if((!parent_stack && !istype(thing, merge_type)) || (parent_stack && thing.type != type))
-		return ..()
-
-	var/obj/item/stack/material = thing
-	merge(material)
-	to_chat(user, "<span class='notice'>Your [material.name] stack now contains [material.get_amount()] [material.singular_name]\s.</span>")
+	if(can_merge(thing, TRUE))
+		var/obj/item/stack/material = thing
+		if(merge(material))
+			to_chat(user, "<span class='notice'>Your [material.name] stack now contains [material.get_amount()] [material.singular_name]\s.</span>")
+	else
+		. = ..()
 
 /obj/item/stack/use(used, check = TRUE)
 	if(check && is_zero_amount(TRUE))
@@ -162,8 +187,8 @@
 		return FALSE
 
 	amount -= used
-	if(check)
-		is_zero_amount(TRUE)
+	if(check && is_zero_amount(TRUE))
+		return TRUE
 
 	update_icon(UPDATE_ICON_STATE)
 	return TRUE
@@ -305,10 +330,8 @@
 		return source.amount < cost
 
 	if(amount < 1)
-		if(ismob(loc))
-			var/mob/living/L = loc // At this stage, stack code is so horrible and atrocious, I wouldn't be all surprised ghosts can somehow have stacks. If this happens, then the world deserves to burn.
-			L.unEquip(src, TRUE)
 		if(delete_if_zero)
+			log_debug("[text_ref(src)] deleting at zero")
 			qdel(src)
 		return TRUE
 	return FALSE
@@ -324,6 +347,7 @@
 	// Cover edge cases where multiple stacks are being merged together and haven't been deleted properly.
 	// Also cover edge case where a stack is being merged into itself, which is supposedly possible.
 	if(QDELETED(material))
+		log_debug("[text_ref(src)] is FUCKING QDELETED.")
 		CRASH("Stack merge attempted on qdeleted target stack.")
 	if(QDELETED(src))
 		CRASH("Stack merge attempted on qdeleted source stack.")

--- a/code/game/objects/items/weapons/shards.dm
+++ b/code/game/objects/items/weapons/shards.dm
@@ -67,7 +67,7 @@
 	if(!I.use_tool(src, user, volume = I.tool_volume))
 		return
 	var/obj/item/stack/sheet/new_glass = new welded_type(user.loc)
-	to_chat(user, "<span class='notice'>You add the newly-formed glass to the stack. It now contains [new_glass.amount] sheet\s.</span>")
+	to_chat(user, "<span class='notice'>You add the newly-formed glass to the stack.</span>")
 	qdel(src)
 
 /obj/item/shard/Crossed(mob/living/L, oldloc)

--- a/code/game/objects/items/weapons/shards.dm
+++ b/code/game/objects/items/weapons/shards.dm
@@ -66,16 +66,8 @@
 	. = TRUE
 	if(!I.use_tool(src, user, volume = I.tool_volume))
 		return
-	var/obj/item/stack/sheet/NG = new welded_type(user.loc)
-	for(var/obj/item/stack/sheet/G in user.loc)
-		if(!istype(G, welded_type))
-			continue
-		if(G == NG)
-			continue
-		if(G.amount >= G.max_amount)
-			continue
-		G.attackby(NG, user)
-	to_chat(user, "<span class='notice'>You add the newly-formed glass to the stack. It now contains [NG.amount] sheet\s.</span>")
+	var/obj/item/stack/sheet/new_glass = new welded_type(user.loc)
+	to_chat(user, "<span class='notice'>You add the newly-formed glass to the stack. It now contains [new_glass.amount] sheet\s.</span>")
 	qdel(src)
 
 /obj/item/shard/Crossed(mob/living/L, oldloc)

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -50,8 +50,8 @@ LINEN BINS
 		var/obj/item/stack/sheet/cloth/C = new (get_turf(src), 3)
 		transfer_fingerprints_to(C)
 		C.add_fingerprint(user)
-		qdel(src)
 		to_chat(user, "<span class='notice'>You tear [src] up.</span>")
+		qdel(src)
 	else
 		return ..()
 

--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -59,10 +59,8 @@
 		if(seed)
 			seed_modifier = round(seed.potency / 25)
 		var/obj/item/stack/plank = new plank_type(user.loc, 1 + seed_modifier)
+		//plank.forceMove((Adjacent(user) ? user.drop_location() : loc))
 		var/old_plank_amount = plank.amount
-		for(var/obj/item/stack/ST in user.loc)
-			if(ST != plank && istype(ST, plank_type) && ST.amount < ST.max_amount)
-				ST.attackby(plank, user) //we try to transfer all old unfinished stacks to the new stack we created.
 		if(plank.amount > old_plank_amount)
 			to_chat(user, "<span class='notice'>You add the newly-formed [plank_name] to the stack. It now contains [plank.amount] [plank_name].</span>")
 		qdel(src)

--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -59,10 +59,7 @@
 		if(seed)
 			seed_modifier = round(seed.potency / 25)
 		var/obj/item/stack/plank = new plank_type(user.loc, 1 + seed_modifier)
-		//plank.forceMove((Adjacent(user) ? user.drop_location() : loc))
-		var/old_plank_amount = plank.amount
-		if(plank.amount > old_plank_amount)
-			to_chat(user, "<span class='notice'>You add the newly-formed [plank_name] to the stack. It now contains [plank.amount] [plank_name].</span>")
+		to_chat(user, "<span class='notice'>You add the newly-formed [plank_name] to the stack.</span>")
 		qdel(src)
 
 	if(CheckAccepted(W))


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
- Cleans up old code in towercap logs and glass shards that didn't let stacks handle merging on their own. This caused runtimes when logs and shards were spam clicked. Now, they just make a new object at the user's loc and let stacks take it from there. An unfortunate side effect of letting stacks handle merging and deletion is that you can no longer see the resulting amount of items in the new stack. This is because there is no guarantee that the stack you have just created will be the final stack and not merged/deleted to form a new one.
- Implements can_merge() (ported from TG stacks) to generalize merge checks. 
- Makes Crossed() call merge() via INVOKE_ASYNC().

After banging my head against the wall for several hours, I can no longer reproduce the spam click stack creation runtimes caused by towercap log cutting and shard welding with this diff. 
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Fixing my mistakes
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


## Testing
Spawned 50 logs and glass shards. Spam clicked them with a sharp object. Kept doing this until the merge runtimes stopped. 

Fair warning: I tried testing everything I could think of, but there are so many things that can go wrong with stacks that I can guarantee I've missed some test cases. Please triple check me!
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
