### PR TITLE
A more precise message for when you detach your Hierophant beacon.

### DIFF
--- a/code/modules/mining/lavaland/loot/hierophant_loot.dm
+++ b/code/modules/mining/lavaland/loot/hierophant_loot.dm
@@ -56,7 +56,7 @@
 	if(HAS_TRAIT(user, TRAIT_PACIFISM))
 		to_chat(user, "<span class='warning'>You don't want to harm other living beings!</span>")
 		return
-	
+
 	if((!is_mining_level(user.z) && !iswizard(user) && !istype(get_area(user), /area/ruin/space/bubblegum_arena))) //Will only spawn a few sparks if not on mining z level, unless a wizard uses it.
 		timer = world.time + cooldown_time
 		user.visible_message("<span class='danger'>[user]'s hierophant club malfunctions!</span>")
@@ -153,7 +153,7 @@
 				beacon = new/obj/effect/hierophant(T)
 				user.update_action_buttons_icon()
 				user.visible_message("<span class='hierophant_warning'>[user] places a strange machine beneath [user.p_their()] feet!</span>", \
-				"<span class='hierophant'>You detach the hierophant beacon, allowing you to teleport yourself and any allies to it at any time!</span>\n\
+				"<span class='hierophant'>You detach the hierophant beacon, allowing you to teleport yourself and any of your allies to it at any time! Beware! The Horrors of Lavaland can still be teleported with you.</span>\n\
 				<span class='notice'>You can remove the beacon to place it again by striking it with the club.</span>")
 			else
 				timer = world.time


### PR DESCRIPTION
## What Does This PR Do

This PR changes the description when deploying the Hierophant beacon.

Fixes #26215

## Why It's Good For The Game

It stops people from accidentally teleporting Mega Fauna / Fauna onto the station.

## Testing
- Thought of a more precise description when deploying the beacon.
- Changed the description of the `user.visible_message()` in line 156 of `hierophant_loot.dm`.
- Checked Grammar.
- Spawned in.
- Spawned in the Hierophant Club.
- Used its beacon detach ability.
- Description was functional.
- Profit.

![image](https://github.com/user-attachments/assets/54f32ac9-6938-462c-966e-63a100a4df47)


<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

  <hr>

## Changelog

:cl:
tweak: Rewrote item description of the Hierophant Club Vortex Recall to be more precise.
/:cl:
