### PR TITLE
Fixes Chameleon beanies appearing white while a different color is selected.

### DIFF
--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -156,7 +156,7 @@
 		var/obj/item/I = target
 
 		I.item_state = initial(picked_item.item_state)
-		I.item_color = initial(picked_item.item_color)
+		I.color = initial(picked_item.color)
 
 		I.icon_override = initial(picked_item.icon_override)
 		if(initial(picked_item.sprite_sheets))

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -156,6 +156,7 @@
 		var/obj/item/I = target
 
 		I.item_state = initial(picked_item.item_state)
+		I.item_color = initial(picked_item.item_color)
 		I.color = initial(picked_item.color)
 
 		I.icon_override = initial(picked_item.icon_override)


### PR DESCRIPTION
## What Does This PR Do

This PR fixes the Beanies utilized in the Chameleon Hat selection to have color again.

Fixes #26442

## Why It's Good For The Game

Colorful Chameleon Hat Beanies.

## Testing
- Suffer for several hours.
- Find core issue and experience with syntax.
- Added `I.color = initial(picked_item.color)` in line `160`.
- Spawned in.
- Spawned in Chameleon Hat.
- Selected Beanie of different colors.
- Beanies change color with no sprite errors.
- Profit.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog

:cl:
fix: Fixed Chameleon Hat's Beanies not appearing with their corresponding color.
/:cl:
