### PR TITLE
Fixes being unable to ignite bonfire in lavaland

### DIFF
--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -189,7 +189,7 @@
 	if(burning)
 		return
 	if(!CheckOxygen())
-		to_chat(user, "<span class='warning'>You can't seem to ignite [src] in this environment!")
+		to_chat(user, "<span class='warning'>You can't seem to ignite [src] in this environment!</span>")
 		return
 
 	icon_state = "bonfire_on_fire"

--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -160,7 +160,7 @@
 	if(W.get_heat())
 		lighter = user.ckey
 		user.create_log(MISC_LOG, "lit a bonfire", src)
-		StartBurning()
+		StartBurning(user)
 
 
 /obj/structure/bonfire/attack_hand(mob/user)
@@ -181,17 +181,19 @@
 /obj/structure/bonfire/proc/CheckOxygen()
 	var/turf/T = get_turf(src)
 	var/datum/gas_mixture/G = T.get_readonly_air()
-	if(G.oxygen() > 13)
+	if(G.oxygen() > 7)
 		return 1
 	return 0
 
-/obj/structure/bonfire/proc/StartBurning()
+/obj/structure/bonfire/proc/StartBurning(mob/user)
 	if(!burning && CheckOxygen())
 		icon_state = "bonfire_on_fire"
 		burning = 1
 		set_light(6, l_color = "#ED9200")
 		Burn()
 		START_PROCESSING(SSobj, src)
+	if(!CheckOxygen())
+		to_chat(user, "<span class='warning'>You can't seem to ignite [src] in this environment!")
 
 /obj/structure/bonfire/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume, global_overlay = TRUE)
 	..()

--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -186,14 +186,17 @@
 	return 0
 
 /obj/structure/bonfire/proc/StartBurning(mob/user)
-	if(!burning && CheckOxygen())
-		icon_state = "bonfire_on_fire"
-		burning = 1
-		set_light(6, l_color = "#ED9200")
-		Burn()
-		START_PROCESSING(SSobj, src)
+	if(burning)
+		return
 	if(!CheckOxygen())
 		to_chat(user, "<span class='warning'>You can't seem to ignite [src] in this environment!")
+		return
+
+	icon_state = "bonfire_on_fire"
+	burning = TRUE
+	set_light(6, l_color = "#ED9200")
+	Burn()
+	START_PROCESSING(SSobj, src)
 
 /obj/structure/bonfire/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume, global_overlay = TRUE)
 	..()

--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -154,7 +154,7 @@
 		R.use(1)
 		can_buckle = TRUE
 		buckle_requires_restraints = TRUE
-		to_chat(user, "<span class='italics'>You add a rod to [src].")
+		to_chat(user, "<span class='italics'>You add a rod to [src].</span>")
 		var/image/U = image(icon='icons/obj/hydroponics/equipment.dmi',icon_state="bonfire_rod",pixel_y=16)
 		underlays += U
 	if(W.get_heat())
@@ -165,7 +165,7 @@
 
 /obj/structure/bonfire/attack_hand(mob/user)
 	if(burning)
-		to_chat(user, "<span class='warning'>You need to extinguish [src] before removing the logs!")
+		to_chat(user, "<span class='warning'>You need to extinguish [src] before removing the logs!</span>")
 		return
 	if(!has_buckled_mobs() && do_after(user, 50, target = src))
 		for(var/I in 1 to 5)

--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -131,7 +131,7 @@
 	density = FALSE
 	anchored = TRUE
 	buckle_lying = FALSE
-	var/burning = 0
+	var/burning = FALSE
 	var/lighter // Who lit the fucking thing
 	var/fire_stack_strength = 5
 

--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -165,7 +165,6 @@
 		user.create_log(MISC_LOG, "lit a bonfire", src)
 		StartBurning(user)
 
-
 /obj/structure/bonfire/attack_hand(mob/user)
 	if(burning)
 		to_chat(user, "<span class='warning'>You need to extinguish [src] before removing the logs!</span>")

--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -1,3 +1,6 @@
+/// Minimum required mole value of oxygen to ignite a bonfire.
+#define MIN_OXY_IGNITE 7
+
 /obj/item/seeds/tower
 	name = "pack of tower-cap mycelium"
 	desc = "This mycelium grows into tower-cap mushrooms."
@@ -181,7 +184,7 @@
 /obj/structure/bonfire/proc/CheckOxygen()
 	var/turf/T = get_turf(src)
 	var/datum/gas_mixture/G = T.get_readonly_air()
-	if(G.oxygen() > 7)
+	if(G.oxygen() > MIN_OXY_IGNITE)
 		return 1
 	return 0
 
@@ -243,3 +246,5 @@
 /obj/structure/bonfire/unbuckle_mob(mob/living/buckled_mob, force = FALSE)
 	if(..())
 		buckled_mob.pixel_y -= 13
+
+#undef MIN_OXY_IGNITE


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Changes required minimum oxygen mole value to ignite a bonfire from `14` to `8` (each lavaland tile has 8 moles of oxygen) and adds a notification message when there's not enough oxygen. Fixes #26642.

## Why It's Good For The Game

This is likely an oversight. Players should be able to ignite bonfires in lavaland again.

## Testing

Tried to ignite it in both station and lavaland wastes, it burned. Tried again in space vacuum, it didn't burn.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Fixed being unable to ignite bonfires in lavaland.
/:cl: