### PR TITLE
[FIX] Mobs that were offered up to ghosts no longer get taken over by their old owners

### DIFF
--- a/code/datums/components/defibrillator.dm
+++ b/code/datums/components/defibrillator.dm
@@ -183,8 +183,8 @@
 	)
 
 	busy = TRUE
-	var/mob/dead/observer/ghost = target.get_ghost(TRUE)
-	if(ghost?.can_reenter_corpse)
+	var/mob/dead/observer/ghost = target.get_ghost()
+	if(ghost)
 		to_chat(ghost, "<span class='ghostalert'>Your heart is being defibrillated. Return to your body if you want to be revived!</span> (Verbs -> Ghost -> Re-enter corpse)")
 		window_flash(ghost.client)
 		SEND_SOUND(ghost, sound('sound/effects/genetics.ogg'))

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -1757,7 +1757,7 @@
 
 /datum/mind/proc/get_ghost(even_if_they_cant_reenter)
 	for(var/mob/dead/observer/G in GLOB.dead_mob_list)
-		if(G.mind == src)
+		if(G.mind == src && G.mind.key == G.key)
 			if(G.can_reenter_corpse || even_if_they_cant_reenter)
 				return G
 			break

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -200,14 +200,8 @@
 			revivable_state = "flatline"
 		else if(!mind)
 			revivable_state = "dead"
-		else
-			var/foundghost = FALSE
-			for(var/mob/dead/observer/G in GLOB.player_list)
-				if(G.mind.current == src)
-					foundghost = (G.can_reenter_corpse && G.client)
-					break
-			if(foundghost || key)
-				revivable_state = "hassoul"
+		else if(get_ghost() || key)
+			revivable_state = "hassoul"
 
 		holder.icon_state = "hud[revivable_state]"
 

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -241,6 +241,7 @@
 						M.next_possible_ghost_ping = world.time + 30 SECONDS // Avoid spam
 				else
 					to_chat(user, "<span class='notice'>[M] is completely unresponsive; there's no point.</span>")
+					return
 				to_chat(user, "<span class='warning'>[M] is currently inactive. Try again later.</span>")
 				return
 

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -234,19 +234,14 @@
 				return
 
 			if(!M.brainmob.key)
-				var/ghost_can_reenter = FALSE
-				if(M.brainmob.mind)
-					for(var/mob/dead/observer/G in GLOB.player_list)
-						if(G.can_reenter_corpse && G.mind == M.brainmob.mind)
-							ghost_can_reenter = TRUE
-							if(M.next_possible_ghost_ping < world.time)
-								G.notify_cloning("Somebody is trying to borg you! Re-enter your corpse if you want to be borged!", 'sound/voice/liveagain.ogg', src)
-								M.next_possible_ghost_ping = world.time + 30 SECONDS // Avoid spam
-							break
-				if(!ghost_can_reenter)
-					to_chat(user, "<span class='notice'>[M] is completely unresponsive; there's no point.</span>")
+				var/mob/dead/observer/G = M.brainmob.get_ghost()
+				if(G)
+					if(M.next_possible_ghost_ping < world.time)
+						G.notify_cloning("Somebody is trying to borg you! Re-enter your corpse if you want to be borged!", 'sound/voice/liveagain.ogg', src)
+						M.next_possible_ghost_ping = world.time + 30 SECONDS // Avoid spam
 				else
-					to_chat(user, "<span class='warning'>[M] is currently inactive. Try again later.</span>")
+					to_chat(user, "<span class='notice'>[M] is completely unresponsive; there's no point.</span>")
+				to_chat(user, "<span class='warning'>[M] is currently inactive. Try again later.</span>")
 				return
 
 			if(M.brainmob.stat == DEAD)

--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -221,13 +221,7 @@
 		if(!just_sleeping)
 			msg += "<span class='deadsay'>[p_they(TRUE)] [p_are()] limp and unresponsive; there are no signs of life"
 			if(get_int_organ(/obj/item/organ/internal/brain) && !key)
-				var/foundghost = FALSE
-				if(mind)
-					for(var/mob/dead/observer/G in GLOB.player_list)
-						if(G.mind == mind && G.can_reenter_corpse)
-							foundghost = TRUE
-							break
-				if(!foundghost)
+				if(!get_ghost())
 					msg += " and [p_their()] soul has departed"
 			msg += "...</span>\n"
 

--- a/code/modules/mob/mob_misc_procs.dm
+++ b/code/modules/mob/mob_misc_procs.dm
@@ -175,7 +175,8 @@
 		theghost = pick(candidates)
 		to_chat(M, "Your mob has been taken over by a ghost!")
 		message_admins("[key_name_admin(theghost)] has taken control of ([key_name_admin(M)])")
-		M.ghostize()
+		var/mob/dead/observer/ghost = M.ghostize(TRUE) // Keep them respawnable
+		ghost.can_reenter_corpse = FALSE // but keep them out of their old body
 		M.key = theghost.key
 		dust_if_respawnable(theghost)
 	else

--- a/code/modules/surgery/organs/brain.dm
+++ b/code/modules/surgery/organs/brain.dm
@@ -59,14 +59,7 @@
 		. += "You can feel a bright spark of life in this one!"
 		return
 	if(brainmob?.mind)
-		var/foundghost = FALSE
-		for(var/mob/dead/observer/G in GLOB.player_list)
-			if(G.mind == brainmob.mind)
-				foundghost = TRUE
-				if(!G.can_reenter_corpse)
-					foundghost = FALSE
-				break
-		if(foundghost)
+		if(brainmob.get_ghost())
 			. += "You can feel the small spark of life still left in this one."
 			return
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Changes the `get_ghost()` proc so that it now checks if the mind also has the right `key`. This should prevent an issue where if a mob that was offered up to ghosts get killed, and then when revived (through cloning, defib, revive rune, etc.) have the original owner of the body take the body back instead of the new owner. 

Also gets rid of some superfluous loops that look for ghosts in favour of the `get_ghost()` proc.

fixes: #24691
fixes: #19323
fixes: #20480
fixes: #17669
fixes: #10266
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
It's very annoying getting kicked out of a body you thought you were in charge of.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Be a cultist, offer body to ghosts.
Ghost maintains respawnibility.
Body is taken over, now ascend to dark spirit. The original owner of the body cannot enter my currently uninhabited body.
Try and put a brain in an MMI in cyborg body, works fine.
HUD shows me as revivable when dead.
I can tell on examine if a body/brain is revivable.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Mobs that were offered up to ghosts can no longer get taken over by their old owners
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
