### PR TITLE
The cloner once again mulches people on emag or emp

### DIFF
--- a/code/game/machinery/clonepod.dm
+++ b/code/game/machinery/clonepod.dm
@@ -87,6 +87,8 @@
 	var/price_modifier = 1.1
 	/// Our storage modifier, which is used in calculating organ and biomass storage.
 	var/storage_modifier = 1
+	/// How resistant the cloner is to being emp'd. Equal to the average level of all the stock parts
+	var/emp_resistance = 1
 
 	/// The cloner's biomass count.
 	var/biomass = 0
@@ -164,15 +166,17 @@
 	. += "<span class='notice'>[desc_flavor]</span>"
 
 /obj/machinery/clonepod/RefreshParts()
-	speed_modifier = 0 //Since we have multiple manipulators, which affect this modifier, we reset here so we can just use += later
+	speed_modifier = 0 // Since we have multiple manipulators, which affect this modifier, we reset here so we can just use += later
+	emp_resistance = 0
 	for(var/obj/item/stock_parts/SP as anything in component_parts)
-		if(istype(SP, /obj/item/stock_parts/matter_bin/)) // Matter bins for storage modifier
+		if(istype(SP, /obj/item/stock_parts/matter_bin)) // Matter bins for storage modifier
 			storage_modifier = round(10 * (SP.rating / 2)) // 5 at tier 1, 10 at tier 2, 15 at tier 3, 20 at tier 4
 		else if(istype(SP, /obj/item/stock_parts/scanning_module)) //Scanning modules for price modifier (more accurate scans = more efficient)
 			price_modifier = -(SP.rating / 10) + 1.2 // 1.1 at tier 1, 1 at tier 2, 0.9 at tier 3, 0.8 at tier 4
 		else if(istype(SP, /obj/item/stock_parts/manipulator)) //Manipulators for speed modifier
 			speed_modifier += SP.rating / 2 // 1 at tier 1, 2 at tier 2, et cetera
-
+		emp_resistance += SP.rating
+	emp_resistance /= 4 // 4 stock parts, this brings us to a value between 1 to 4. Decimals can happen and are fine.
 	for(var/obj/item/reagent_containers/glass/beaker/B in component_parts)
 		if(istype(B))
 			reagents.maximum_volume = B.volume //The default cloning pod has a large beaker in it, so 100u.
@@ -623,13 +627,35 @@
 
 /obj/machinery/clonepod/emag_act(user)
 	. = ..()
-	eject_clone(TRUE)
+	malfunction()
 	return TRUE
 
 /obj/machinery/clonepod/emp_act(severity)
-	if(prob(50))
-		eject_clone(TRUE)
+	if(prob(100 / (severity * emp_resistance)))
+		malfunction()
 	return ..()
+
+/obj/machinery/clonepod/proc/malfunction()
+	if(clone)
+		var/datum/mind/patient_mind = locateUID(patient_data.mindUID)
+		patient_mind.transfer_to(clone)
+		clone.grab_ghost()
+		var/message
+		message += "<b>Agony blazes across your consciousness as your body is torn apart.</b><br>"
+		message += "<i>Is this what dying is like? Yes it is.</i>"
+		to_chat(clone, "<span class='warning'>[message]</span>")
+		SEND_SOUND(clone, sound('sound/hallucinations/veryfar_noise.ogg', 0, 1, 50))
+		sleep(40)
+		new /obj/effect/gibspawner/generic(get_turf(src), clone.dna)
+		new /obj/effect/gibspawner/generic(get_turf(src), clone.dna)
+		new /obj/effect/gibspawner/generic(get_turf(src), clone.dna)
+		playsound(loc, 'sound/effects/splat.ogg', 50, TRUE)
+		qdel(clone)
+		reset_cloning()
+
+	playsound(loc, 'sound/machines/warning-buzzer.ogg', 50, 0)
+	update_icon()
+
 
 //TGUI
 /obj/machinery/clonepod/ui_interact(mob/user, datum/tgui/ui = null)

--- a/code/game/machinery/clonepod.dm
+++ b/code/game/machinery/clonepod.dm
@@ -171,11 +171,13 @@
 	for(var/obj/item/stock_parts/SP as anything in component_parts)
 		if(istype(SP, /obj/item/stock_parts/matter_bin)) // Matter bins for storage modifier
 			storage_modifier = round(10 * (SP.rating / 2)) // 5 at tier 1, 10 at tier 2, 15 at tier 3, 20 at tier 4
+			emp_resistance += SP.rating
 		else if(istype(SP, /obj/item/stock_parts/scanning_module)) //Scanning modules for price modifier (more accurate scans = more efficient)
 			price_modifier = -(SP.rating / 10) + 1.2 // 1.1 at tier 1, 1 at tier 2, 0.9 at tier 3, 0.8 at tier 4
+			emp_resistance += SP.rating
 		else if(istype(SP, /obj/item/stock_parts/manipulator)) //Manipulators for speed modifier
 			speed_modifier += SP.rating / 2 // 1 at tier 1, 2 at tier 2, et cetera
-		emp_resistance += SP.rating
+			emp_resistance += SP.rating
 	emp_resistance /= 4 // 4 stock parts, this brings us to a value between 1 to 4. Decimals can happen and are fine.
 	for(var/obj/item/reagent_containers/glass/beaker/B in component_parts)
 		if(istype(B))

--- a/code/game/machinery/clonepod.dm
+++ b/code/game/machinery/clonepod.dm
@@ -646,7 +646,7 @@
 		message += "<b>Agony blazes across your consciousness as your body is torn apart.</b><br>"
 		message += "<i>Is this what dying is like? Yes it is.</i>"
 		to_chat(clone, "<span class='warning'>[message]</span>")
-		SEND_SOUND(clone, sound('sound/hallucinations/veryfar_noise.ogg', 0, 1, 50))
+		SEND_SOUND(clone, sound('sound/hallucinations/veryfar_noise.ogg', 0, TRUE, 50))
 		sleep(40)
 		new /obj/effect/gibspawner/generic(get_turf(src), clone.dna)
 		new /obj/effect/gibspawner/generic(get_turf(src), clone.dna)

--- a/code/game/machinery/clonepod.dm
+++ b/code/game/machinery/clonepod.dm
@@ -655,7 +655,7 @@
 		qdel(clone)
 		reset_cloning()
 
-	playsound(loc, 'sound/machines/warning-buzzer.ogg', 50, 0)
+	playsound(loc, 'sound/machines/warning-buzzer.ogg', 50, FALSE)
 	update_icon()
 
 

--- a/code/game/machinery/clonepod.dm
+++ b/code/game/machinery/clonepod.dm
@@ -642,10 +642,8 @@
 		var/datum/mind/patient_mind = locateUID(patient_data.mindUID)
 		patient_mind.transfer_to(clone)
 		clone.grab_ghost()
-		var/message
-		message += "<b>Agony blazes across your consciousness as your body is torn apart.</b><br>"
-		message += "<i>Is this what dying is like? Yes it is.</i>"
-		to_chat(clone, "<span class='warning'>[message]</span>")
+		to_chat(clone, "<span class='warning'><b>Agony blazes across your consciousness as your body is torn apart.</b>\
+		<br><i>Is this what dying is like? Yes it is.</i></span>")
 		SEND_SOUND(clone, sound('sound/hallucinations/veryfar_noise.ogg', 0, TRUE, 50))
 		sleep(40)
 		new /obj/effect/gibspawner/generic(get_turf(src), clone.dna)

--- a/code/game/machinery/clonepod.dm
+++ b/code/game/machinery/clonepod.dm
@@ -640,11 +640,12 @@
 /obj/machinery/clonepod/proc/malfunction()
 	if(clone)
 		var/datum/mind/patient_mind = locateUID(patient_data.mindUID)
-		patient_mind.transfer_to(clone)
-		clone.grab_ghost()
-		to_chat(clone, "<span class='warning'><b>Agony blazes across your consciousness as your body is torn apart.</b>\
-		<br><i>Is this what dying is like? Yes it is.</i></span>")
-		SEND_SOUND(clone, sound('sound/hallucinations/veryfar_noise.ogg', 0, TRUE, 50))
+		if(istype(patient_mind, /datum/mind))
+			patient_mind.transfer_to(clone)
+			clone.grab_ghost()
+			to_chat(clone, "<span class='warning'><b>Agony blazes across your consciousness as your body is torn apart.</b>\
+			<br><i>Is this what dying is like? Yes it is.</i></span>")
+			SEND_SOUND(clone, sound('sound/hallucinations/veryfar_noise.ogg', 0, TRUE, 50))
 		sleep(40)
 		new /obj/effect/gibspawner/generic(get_turf(src), clone.dna)
 		new /obj/effect/gibspawner/generic(get_turf(src), clone.dna)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

The cloner once again mulches people on emag, or a prob (100 / (severity of emp * average level of stock parts)). Upgrading the cloner if emps are about would be a good idea.

People mulched by the cloner are grabbed into the cloned body, before being ripped apart, spreading gibs all over.
Unlike before, this does not turn the cloner into the mess, as the mess function was not brought over with the rework.
This prevents the person from being cloned again, as their current body is now the mulched one, like before.

The cloner running out of power, or being early ejected, acts the same. This only will come into play if an antagonist is trying to make sure you stay dead, or an emp related accident happens.

As for it being too easy to remove someone, one still has to kill them in the first place. c4 to gib them is 5 tc.

## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

See above, but brings a bit of risk back to the cloner, that was removed during the rework, I was unaware it was removed until today!

## Testing

<!-- How did you test the PR, if at all? -->

Start cloning a person I killed.
Ensure emp resistance was the correct value.
Emaged the cloner.
This killed them, made gibs, and emptied out the cloner propperly.
Ensured previous body was now souless.
Emp'd the cloner, malfunction happened. Upgraded stock parts, value upgraded (after a second fix, because circuit boards and beakers are passed as stock parts on the clonepod, requiring an adjustment from my first attempt). This reduced how often emp's caused malfunction.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>
![image](https://github.com/user-attachments/assets/a9a6ba3c-76a4-4fab-a86f-587c32e83c96)


## Changelog
:cl:
tweak: The cloner will once again mulch people being cloned when the clone pod is emaged, and has a chance to mulch depending on upgrades when the cloning pod is emp'd
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
