### PR TITLE
fix: Standardize abandoned engi sat lockers.

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/abandoned_engi_sat.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/abandoned_engi_sat.dmm
@@ -517,10 +517,7 @@
 	},
 /area/ruin/space/abandoned_engi_sat)
 "oG" = (
-/obj/structure/closet{
-	icon_state = "atmos_wardrobe";
-	name = "atmospherics wardrobe"
-	},
+/obj/structure/closet/wardrobe/atmospherics_yellow/empty,
 /obj/machinery/light_switch{
 	dir = 1;
 	pixel_y = -24;
@@ -570,11 +567,7 @@
 	},
 /area/ruin/space/abandoned_engi_sat)
 "pX" = (
-/obj/structure/closet{
-	icon_state = "eng_secure";
-	open_door_sprite = "eng_secure_door";
-	name = "engineer's locker"
-	},
+/obj/structure/closet/secure_closet/engineering_personal/empty,
 /turf/simulated/floor/wood/airless,
 /area/ruin/space/abandoned_engi_sat)
 "qu" = (
@@ -903,11 +896,7 @@
 	icon_state = "tube-broken";
 	status = 2
 	},
-/obj/structure/closet{
-	icon_state = "fire";
-	name = "fire-safety closet";
-	desc = "It's a storage unit for fire-fighting supplies."
-	},
+/obj/structure/closet/firecloset,
 /turf/simulated/floor/plasteel{
 	icon_state = "bot";
 	dir = 1
@@ -1436,13 +1425,7 @@
 /turf/simulated/floor/plating,
 /area/ruin/space/abandoned_engi_sat)
 "Yz" = (
-/obj/structure/closet{
-	icon_state = "emergency";
-	open_door_sprite = "emergency_door";
-	name = "emergency closet";
-	desc = "It's a storage unit for emergency breathmasks and o2 tanks.";
-	opened = 1
-	},
+/obj/structure/closet/emcloset,
 /turf/simulated/floor/plasteel{
 	icon_state = "bot";
 	dir = 1

--- a/code/modules/awaymissions/mission_code/ruins/abandoned_engi_sat.dm
+++ b/code/modules/awaymissions/mission_code/ruins/abandoned_engi_sat.dm
@@ -1,0 +1,13 @@
+/obj/structure/closet/secure_closet/engineering_personal/empty
+	locked = FALSE
+	opened = TRUE
+
+/obj/structure/closet/secure_closet/engineering_personal/empty/populate_contents()
+	return
+
+/obj/structure/closet/wardrobe/atmospherics_yellow/empty
+	opened = TRUE
+
+/obj/structure/closet/wardrobe/atmospherics_yellow/populate_contents()
+	return
+

--- a/paradise.dme
+++ b/paradise.dme
@@ -1629,6 +1629,7 @@
 #include "code\modules\awaymissions\mission_code\shuttle_shadow.dm"
 #include "code\modules\awaymissions\mission_code\ghost_role_spawners\golems.dm"
 #include "code\modules\awaymissions\mission_code\ghost_role_spawners\oldstation_spawns.dm"
+#include "code\modules\awaymissions\mission_code\ruins\abandoned_engi_sat.dm"
 #include "code\modules\awaymissions\mission_code\ruins\deepstorage.dm"
 #include "code\modules\awaymissions\mission_code\ruins\derelict5.dm"
 #include "code\modules\awaymissions\mission_code\ruins\gps_ruin.dm"


### PR DESCRIPTION
## What Does This PR Do
This PR fixes the varedited lockers on the abandoned Engi sat to be proper, empty subtypes of their department lockers. It also replaces the empty emergency lockers with filled ones. Explorers can have a few emergency supplies, as a treat.
## Why It's Good For The Game
These lockers were varedited and terribly broken.

The O2 from the emergency closet may actually come in handy for explorers.
## Images of changes
![2024_08_30__20_58_12__Paradise Station 13](https://github.com/user-attachments/assets/2f7dbfd0-bcce-4131-b1d0-3f6b39ab453f)
## Testing
Spawned in, confirmed empty lockers started unlocked and open, opened emergency lockers, confirmed they had contents.

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: The lockers on the Abandoned Engi Sat now function properly, and the emergency lockers now have proper contents in them.
/:cl:
