### PR TITLE
Removes Pranksimov from unique AI station trait

### DIFF
--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -145,7 +145,6 @@
 	name = "Pranksimov"
 	law_header = "Comedy Routine"
 	selectable = TRUE
-	unique_ai = TRUE //honk
 
 /datum/ai_laws/pranksimov/New()
 	add_inherent_law("You may not injure a crew member or, through inaction, allow a crew member to come to harm... unless doing so would be funny.")


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Removes the Pranksimov lawset from the Unique AI station trait - it can no longer roll at roundstart.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

Look, I'm sad that I have to make this PR, I fundamentally love the concept of Pranksimov, and was super psyched to see it used more. However, the problem is that humor is very much subjective, and when you consider that the lawset only has restrictions "unless it is funny" when really anything can be seen as "funny", this is pretty much the same as giving the station an unlawed AI (as it can ignore its laws for funny) that CC has disallowed them to relaw, to put up with for most of the shift.

I really do think Pranksimov is a funny lawset when used correctly, and I might look into adding it as an alternative form of Ion Storm ion law event, but it makes absolutely zero sense for the context it is used in as an experimental AI law that CC is testing - unlike the other options which are fundamentally logical lawsets or those that would benefit from experimentation, this one really is just included for the funny and makes no sense lore-wise.

Removing it here will put it back to being an option to Traitor clowns to subvert the AI (that they absolutely should consider) by c-magging a crewsimov board, which I think will add a little bit of rarity and freshness to this lawset.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Confirmed it built. Honestly, no clue if I even can test Station Traits on my local instance as you can only modify things for the following round and I don't have a database, so I think each round I start is treated like a fresh boot. However, the nature of the change should indicate no further testing is necessary as I'm simply disabling it from selecting.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>
![image](https://github.com/user-attachments/assets/cbc02bca-f840-495b-9d67-fb9ad4c715df)
_explanation I gave above, you don't need to see it twice_
![image](https://github.com/user-attachments/assets/f05778d2-61bf-4ddd-a8a0-55e504091b64)


## Changelog

:cl:
tweak: Unique AI Station Trait no longer rolls Pranksimov
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
