### PR TITLE
fix: Unintentional night-shift despite disabled in configuration.

### DIFF
--- a/code/controllers/subsystem/SSticker.dm
+++ b/code/controllers/subsystem/SSticker.dm
@@ -350,7 +350,8 @@ SUBSYSTEM_DEF(ticker)
 		if(N.client)
 			N.new_player_panel_proc()
 
-	SSnightshift.check_nightshift(TRUE)
+	if(GLOB.configuration.general.enable_night_shifts)
+		SSnightshift.check_nightshift(TRUE)
 
 	#ifdef UNIT_TESTS
 	// Run map tests first in case unit tests futz with map state


### PR DESCRIPTION
## What Does This PR Do
This PR prevents a night-shift check from being run during SSticker setup if it was disabled in `config.toml`. This was two different attempts at refactoring SSnightshift but it made me want to die so it's just the simplest thing that could possibly work.
## Why It's Good For The Game
The configuration should work.
## Testing
- Set game time offset to 0. Set `enable_night_shifts = true`. Ensured night shift was enabled immediately, with IC message.
- Raised alert level to red, ensured night shift disabled. Lowered to green, ensured night shift enabled.
- Used admin secrets to change nightshift mode, confirmed correct behavior.
- Set `enable_night_shifts = false` in `config.toml`. Ensure night shift didn't get enabled on roundstart.
<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <hr>

## Changelog
NPFC because night shift is enabled on prod.