### PR TITLE
Removes hoverboard from SOO starting inventory

### DIFF
--- a/code/game/jobs/job/central.dm
+++ b/code/game/jobs/job/central.dm
@@ -83,7 +83,6 @@
 	backpack_contents = list(
 		/obj/item/clothing/shoes/magboots/advance = 1,
 		/obj/item/storage/box/zipties = 1,
-		/obj/item/melee/skateboard/hoverboard/admin = 1 //How do you do, fellow kids?
 	)
 	bio_chips = list(
 		/obj/item/bio_chip/mindshield,

--- a/code/game/jobs/job/central.dm
+++ b/code/game/jobs/job/central.dm
@@ -82,7 +82,7 @@
 	box = /obj/item/storage/box/centcomofficer
 	backpack_contents = list(
 		/obj/item/clothing/shoes/magboots/advance = 1,
-		/obj/item/storage/box/zipties = 1,
+		/obj/item/storage/box/zipties = 1
 	)
 	bio_chips = list(
 		/obj/item/bio_chip/mindshield,


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Removes hoverboard from SOO starting inventory

## Why It's Good For The Game

Not needed? Random bloat to inventory of this role, silly to have. If an admin specifically wants it they can spawn it.

## Testing

Despite being a one-line change, I did test it. And then I noticed that I forgot to remove the comma.
So yeah testing PR's is important.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
I literally cannot imagine this needing pre-approval.
  <hr>


## Changelog

:cl:
tweak: SOO's will no longer spawn with a hoverboard. They're not cool enough.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
