### PR TITLE
fix: Unfrozen mobs keep their bodies.

### DIFF
--- a/code/modules/admin/verbs/freeze.dm
+++ b/code/modules/admin/verbs/freeze.dm
@@ -64,6 +64,12 @@ GLOBAL_LIST_EMPTY(frozen_atom_list) // A list of admin-frozen atoms.
 		revive()
 
 /mob/living/simple_animal/admin_Freeze(admin)
+	// If we were frozen before this call, make sure we
+	// reset our health before attempting a rejuvenate,
+	// as removing status effects can perform stat calls.
+	if(frozen && del_on_death)
+		health = admin_prev_health
+
 	if(..()) // The result of the parent call here will be the value of the mob's `frozen` variable after they get (un)frozen.
 		admin_prev_health = health
 		health = 0


### PR DESCRIPTION
## What Does This PR Do
This PR resets an afrozen mob's health if they are set to delete their bodies on death, just before they are unfrozen. This prevents them from dying during the unfreeze, which will kick the player out of their bodies. Fixes #26102.

An afrozen mob's health is never actually reset back to admin_prev_health anywhere, but it doesn't matter because their health is set to the mob's maxHealth on rejuvenate.

Not going to even ask why or think too hard about why their health is set to 0 in the first place.
## Why It's Good For The Game
Losing one's body can be disruptive to their round.
## Testing
Spawned a wraith, entered it, afroze self, unfroze self.

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Afrozen mobs whose bodies are destroyed on death will no longer have that happen when unfrozen.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
