### PR TITLE
Move global access procs to the mapping subsystem

### DIFF
--- a/code/controllers/subsystem/non_firing/SSmapping.dm
+++ b/code/controllers/subsystem/non_firing/SSmapping.dm
@@ -16,6 +16,10 @@ SUBSYSTEM_DEF(mapping)
 	var/datum/lavaland_theme/lavaland_theme
 	///What primary cave theme we have picked for cave generation today.
 	var/cave_theme
+	// Tells if all maintenance airlocks have emergency access enabled
+	var/maint_all_access = FALSE
+	// Tells if all station airlocks have emergency access enabled
+	var/station_all_access = FALSE
 
 	/// A mapping of environment names to MILLA environment IDs.
 	var/list/environments
@@ -356,25 +360,22 @@ SUBSYSTEM_DEF(mapping)
 
 	log_world("Ruin loader finished with [budget] left to spend.")
 
-GLOBAL_VAR_INIT(maint_all_access, FALSE)
-GLOBAL_VAR_INIT(station_all_access, FALSE)
-
 /datum/controller/subsystem/mapping/proc/make_maint_all_access()
-	for(var/area/station/maintenance/A in world)
+	for(var/area/station/maintenance/A in existing_station_areas)
 		for(var/obj/machinery/door/airlock/D in A)
 			D.emergency = TRUE
 			D.update_icon()
 	GLOB.minor_announcement.Announce("Access restrictions on maintenance and external airlocks have been removed.")
-	GLOB.maint_all_access = TRUE
+	maint_all_access = TRUE
 	SSblackbox.record_feedback("nested tally", "keycard_auths", 1, list("emergency maintenance access", "enabled"))
 
 /datum/controller/subsystem/mapping/proc/revoke_maint_all_access()
-	for(var/area/station/maintenance/A in world)
+	for(var/area/station/maintenance/A in existing_station_areas)
 		for(var/obj/machinery/door/airlock/D in A)
 			D.emergency = FALSE
 			D.update_icon()
 	GLOB.minor_announcement.Announce("Access restrictions on maintenance and external airlocks have been re-added.")
-	GLOB.maint_all_access = FALSE
+	maint_all_access = FALSE
 	SSblackbox.record_feedback("nested tally", "keycard_auths", 1, list("emergency maintenance access", "disabled"))
 
 /datum/controller/subsystem/mapping/proc/make_station_all_access()
@@ -383,7 +384,7 @@ GLOBAL_VAR_INIT(station_all_access, FALSE)
 			D.emergency = TRUE
 			D.update_icon()
 	GLOB.minor_announcement.Announce("Access restrictions on all station airlocks have been removed due to an ongoing crisis. Trespassing laws still apply unless ordered otherwise by Command staff.")
-	GLOB.station_all_access = TRUE
+	station_all_access = TRUE
 	SSblackbox.record_feedback("nested tally", "keycard_auths", 1, list("emergency station access", "enabled"))
 
 /datum/controller/subsystem/mapping/proc/revoke_station_all_access()
@@ -392,7 +393,7 @@ GLOBAL_VAR_INIT(station_all_access, FALSE)
 			D.emergency = FALSE
 			D.update_icon()
 	GLOB.minor_announcement.Announce("Access restrictions on all station airlocks have been re-added. Seek station AI or a colleague's assistance if you are stuck.")
-	GLOB.station_all_access = FALSE
+	station_all_access = FALSE
 	SSblackbox.record_feedback("nested tally", "keycard_auths", 1, list("emergency station access", "disabled"))
 
 /datum/controller/subsystem/mapping/Recover()

--- a/code/controllers/subsystem/non_firing/SSmapping.dm
+++ b/code/controllers/subsystem/non_firing/SSmapping.dm
@@ -356,5 +356,44 @@ SUBSYSTEM_DEF(mapping)
 
 	log_world("Ruin loader finished with [budget] left to spend.")
 
+GLOBAL_VAR_INIT(maint_all_access, FALSE)
+GLOBAL_VAR_INIT(station_all_access, FALSE)
+
+/datum/controller/subsystem/mapping/proc/make_maint_all_access()
+	for(var/area/station/maintenance/A in world)
+		for(var/obj/machinery/door/airlock/D in A)
+			D.emergency = TRUE
+			D.update_icon()
+	GLOB.minor_announcement.Announce("Access restrictions on maintenance and external airlocks have been removed.")
+	GLOB.maint_all_access = TRUE
+	SSblackbox.record_feedback("nested tally", "keycard_auths", 1, list("emergency maintenance access", "enabled"))
+
+/datum/controller/subsystem/mapping/proc/revoke_maint_all_access()
+	for(var/area/station/maintenance/A in world)
+		for(var/obj/machinery/door/airlock/D in A)
+			D.emergency = FALSE
+			D.update_icon()
+	GLOB.minor_announcement.Announce("Access restrictions on maintenance and external airlocks have been re-added.")
+	GLOB.maint_all_access = FALSE
+	SSblackbox.record_feedback("nested tally", "keycard_auths", 1, list("emergency maintenance access", "disabled"))
+
+/datum/controller/subsystem/mapping/proc/make_station_all_access()
+	for(var/obj/machinery/door/airlock/D in GLOB.airlocks)
+		if(is_station_level(D.z))
+			D.emergency = TRUE
+			D.update_icon()
+	GLOB.minor_announcement.Announce("Access restrictions on all station airlocks have been removed due to an ongoing crisis. Trespassing laws still apply unless ordered otherwise by Command staff.")
+	GLOB.station_all_access = TRUE
+	SSblackbox.record_feedback("nested tally", "keycard_auths", 1, list("emergency station access", "enabled"))
+
+/datum/controller/subsystem/mapping/proc/revoke_station_all_access()
+	for(var/obj/machinery/door/airlock/D in GLOB.airlocks)
+		if(is_station_level(D.z))
+			D.emergency = FALSE
+			D.update_icon()
+	GLOB.minor_announcement.Announce("Access restrictions on all station airlocks have been re-added. Seek station AI or a colleague's assistance if you are stuck.")
+	GLOB.station_all_access = FALSE
+	SSblackbox.record_feedback("nested tally", "keycard_auths", 1, list("emergency station access", "disabled"))
+
 /datum/controller/subsystem/mapping/Recover()
 	flags |= SS_NO_INIT

--- a/code/datums/weather/weather_types/radiation_storm.dm
+++ b/code/datums/weather/weather_types/radiation_storm.dm
@@ -38,8 +38,8 @@
 /datum/weather/rad_storm/telegraph()
 	..()
 	status_alarm(TRUE)
-	pre_maint_all_access = GLOB.maint_all_access
-	if(!GLOB.maint_all_access)
+	pre_maint_all_access = SSmapping.maint_all_access
+	if(!SSmapping.maint_all_access)
 		SSmapping.make_maint_all_access()
 
 /datum/weather/rad_storm/weather_act(mob/living/L)

--- a/code/datums/weather/weather_types/radiation_storm.dm
+++ b/code/datums/weather/weather_types/radiation_storm.dm
@@ -40,7 +40,7 @@
 	status_alarm(TRUE)
 	pre_maint_all_access = GLOB.maint_all_access
 	if(!GLOB.maint_all_access)
-		make_maint_all_access()
+		SSmapping.make_maint_all_access()
 
 /datum/weather/rad_storm/weather_act(mob/living/L)
 	if(!prob(60))
@@ -74,7 +74,7 @@
 	status_alarm(FALSE)
 	if(!pre_maint_all_access)
 		GLOB.minor_announcement.Announce("The radiation threat has passed. Please return to your workplaces. Door access resetting momentarily.", "Anomaly Alert")
-		addtimer(CALLBACK(SSweather, GLOBAL_PROC_REF(revoke_maint_all_access)), 10 SECONDS) // Bit of time to get out / break into somewhere.
+		addtimer(CALLBACK(SSmapping, TYPE_PROC_REF(/datum/controller/subsystem/mapping, revoke_maint_all_access)), 10 SECONDS) // Bit of time to get out / break into somewhere.
 	else
 		GLOB.minor_announcement.Announce("The radiation threat has passed. Please return to your workplaces.", "Anomaly Alert")
 

--- a/code/modules/security_levels/keycard_authentication.dm
+++ b/code/modules/security_levels/keycard_authentication.dm
@@ -177,13 +177,13 @@
 		if("Red Alert")
 			INVOKE_ASYNC(SSsecurity_level, TYPE_PROC_REF(/datum/controller/subsystem/security_level, set_level), SEC_LEVEL_RED)
 		if("Grant Emergency Maintenance Access")
-			make_maint_all_access()
+			SSmapping.make_maint_all_access()
 		if("Revoke Emergency Maintenance Access")
-			revoke_maint_all_access()
+			SSmapping.revoke_maint_all_access()
 		if("Activate Station-Wide Emergency Access")
-			make_station_all_access()
+			SSmapping.make_station_all_access()
 		if("Deactivate Station-Wide Emergency Access")
-			revoke_station_all_access()
+			SSmapping.revoke_station_all_access()
 		if("Emergency Response Team")
 			if(is_ert_blocked())
 				atom_say("All Emergency Response Teams are dispatched and can not be called at this time.")
@@ -215,43 +215,3 @@
 
 /obj/machinery/keycard_auth/proc/is_ert_blocked()
 	return SSticker.mode && SSticker.mode.ert_disabled
-
-GLOBAL_VAR_INIT(maint_all_access, 0)
-GLOBAL_VAR_INIT(station_all_access, 0)
-
-// Why are these global procs?
-/proc/make_maint_all_access()
-	for(var/area/station/maintenance/A in world) // Why are these global lists? AAAAAAAAAAAAAA
-		for(var/obj/machinery/door/airlock/D in A)
-			D.emergency = 1
-			D.update_icon()
-	GLOB.minor_announcement.Announce("Access restrictions on maintenance and external airlocks have been removed.")
-	GLOB.maint_all_access = 1
-	SSblackbox.record_feedback("nested tally", "keycard_auths", 1, list("emergency maintenance access", "enabled"))
-
-/proc/revoke_maint_all_access()
-	for(var/area/station/maintenance/A in world)
-		for(var/obj/machinery/door/airlock/D in A)
-			D.emergency = 0
-			D.update_icon()
-	GLOB.minor_announcement.Announce("Access restrictions on maintenance and external airlocks have been re-added.")
-	GLOB.maint_all_access = 0
-	SSblackbox.record_feedback("nested tally", "keycard_auths", 1, list("emergency maintenance access", "disabled"))
-
-/proc/make_station_all_access()
-	for(var/obj/machinery/door/airlock/D in GLOB.airlocks)
-		if(is_station_level(D.z))
-			D.emergency = 1
-			D.update_icon()
-	GLOB.minor_announcement.Announce("Access restrictions on all station airlocks have been removed due to an ongoing crisis. Trespassing laws still apply unless ordered otherwise by Command staff.")
-	GLOB.station_all_access = 1
-	SSblackbox.record_feedback("nested tally", "keycard_auths", 1, list("emergency station access", "enabled"))
-
-/proc/revoke_station_all_access()
-	for(var/obj/machinery/door/airlock/D in GLOB.airlocks)
-		if(is_station_level(D.z))
-			D.emergency = 0
-			D.update_icon()
-	GLOB.minor_announcement.Announce("Access restrictions on all station airlocks have been re-added. Seek station AI or a colleague's assistance if you are stuck.")
-	GLOB.station_all_access = 0
-	SSblackbox.record_feedback("nested tally", "keycard_auths", 1, list("emergency station access", "disabled"))


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Moves some global procs to the mapping subsystem.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Global procs cannot be overriden, these procs should belong to some type.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
All features work.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

NPFC

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
