### PR TITLE
Cult Teleport Spell has a 3 second cast time on yourself

### DIFF
--- a/code/__HELPERS/mob_helpers.dm
+++ b/code/__HELPERS/mob_helpers.dm
@@ -477,7 +477,7 @@ GLOBAL_LIST_EMPTY(do_after_once_tracker)
 		to_chat(user, "<span class='warning'>[attempt_cancel_message]</span>")
 		return FALSE
 	GLOB.do_after_once_tracker[cache_key] = TRUE
-	. = do_after(user, delay, needhand, target, progress, allow_moving, must_be_held, list(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(do_after_once_checks),  cache_key)), use_default_checks, allow_moving_target)
+	. = do_after(user, delay, needhand, target, progress, allow_moving, must_be_held, list(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(do_after_once_checks), cache_key)), use_default_checks, allow_moving_target)
 	GLOB.do_after_once_tracker[cache_key] = FALSE
 
 /proc/do_after_once_checks(cache_key)

--- a/code/__HELPERS/mob_helpers.dm
+++ b/code/__HELPERS/mob_helpers.dm
@@ -467,7 +467,7 @@
 
 #define DOAFTERONCE_MAGIC "Magic~~"
 GLOBAL_LIST_EMPTY(do_after_once_tracker)
-/proc/do_after_once(mob/user, delay, needhand = 1, atom/target = null, progress = 1, allow_moving, must_be_held, attempt_cancel_message = "Attempt cancelled.", special_identifier)
+/proc/do_after_once(mob/user, delay, needhand = 1, atom/target = null, progress = 1, allow_moving, must_be_held, use_default_checks, allow_moving_target, attempt_cancel_message = "Attempt cancelled.", special_identifier)
 	if(!user || !target)
 		return
 
@@ -477,7 +477,7 @@ GLOBAL_LIST_EMPTY(do_after_once_tracker)
 		to_chat(user, "<span class='warning'>[attempt_cancel_message]</span>")
 		return FALSE
 	GLOB.do_after_once_tracker[cache_key] = TRUE
-	. = do_after(user, delay, needhand, target, progress, allow_moving, must_be_held, extra_checks = list(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(do_after_once_checks), cache_key)))
+	. = do_after(user, delay, needhand, target, progress, allow_moving, must_be_held, list(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(do_after_once_checks),  cache_key)), use_default_checks, allow_moving_target)
 	GLOB.do_after_once_tracker[cache_key] = FALSE
 
 /proc/do_after_once_checks(cache_key)

--- a/code/game/gamemodes/cult/blood_magic.dm
+++ b/code/game/gamemodes/cult/blood_magic.dm
@@ -529,10 +529,10 @@
 	if(QDELETED(src) || !user || !user.is_holding(src) || user.incapacitated() || !actual_selected_rune)
 		return
 
-	if(HAS_TRAIT(user, TRAIT_FLOORED))
-		to_chat(user, "<span class='cultitalic'>You cannot cast this spell while knocked down!</span>")
-		return
-
+	if(user == target)
+		if(!do_after(user, 3 SECONDS, allow_moving = TRUE, allow_moving_target = TRUE, target = teleportee))
+			to_chat(user, "<span class='cultitalic'>Your concentration is interrupted, and the spell fizzles out!</span>")
+			return
 	uses--
 
 	var/turf/origin = get_turf(teleportee)

--- a/code/game/gamemodes/cult/blood_magic.dm
+++ b/code/game/gamemodes/cult/blood_magic.dm
@@ -530,7 +530,7 @@
 		return
 
 	if(user == target)
-		if(!do_after(user, 3 SECONDS, allow_moving = TRUE, allow_moving_target = TRUE, target = teleportee))
+		if(!do_after_once(user, 3 SECONDS, allow_moving = TRUE, allow_moving_target = TRUE, target = teleportee))
 			to_chat(user, "<span class='cultitalic'>Your concentration is interrupted, and the spell fizzles out!</span>")
 			return
 	uses--

--- a/code/game/gamemodes/cult/blood_magic.dm
+++ b/code/game/gamemodes/cult/blood_magic.dm
@@ -530,7 +530,7 @@
 		return
 
 	if(user == target)
-		if(!do_after_once(user, 3 SECONDS, allow_moving = TRUE, allow_moving_target = TRUE, target = teleportee))
+		if(!do_after(user, 3 SECONDS, allow_moving = TRUE, allow_moving_target = TRUE, target = teleportee))
 			to_chat(user, "<span class='cultitalic'>Your concentration is interrupted, and the spell fizzles out!</span>")
 			return
 	uses--


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Self-casting the Cult teleport-hand spell will start a 3 second do_after, where _cultists can continue to move_, after which they will teleport to their destination. This is specifically done after selecting the destination, not before, to avoid people just holding the teleport destination window up at all times like some players currently apparently do. If they are stunned, the spell fizzles out and fails. This is deliberately 0.5 seconds longer than it takes a player to fall over after being hit by a baton, so cult doesn't just get a free ticket out of a stun. 

This cooldown is specifically not present when using the spell on an ally, in equal parts to encourage effective team-play as cult, and because it sounds really annoying to implement with how do_after is coded for moving targets.

Technically this PR also removes my previous check for being horizontal to cancel the teleport spell, because the do_after will handle that inherently.

## Why It's Good For The Game

Right now, Cult can run around with teleport spell in their offhand, the menu open, and do whatever they want safe in the knowledge knowing that if they get into a lick of danger they need to simply confirm the teleport and they are instantly whooshed away from danger. This does not present much counterplay from Security, as the only ways to prevent this were to knock them down (a previous PR of mine) or kill them before they could, both options were fine if cultists had to actively activate the spell and select a destination which took time. The emerging strategy of just keeping the window open at all times to instantly select the destination does again remove the risk present with acting as cult due to the free instant escape, so hence, 3 second timer upon ye. 

To be clear, it is not newer cult players that is being targeted here, I doubt any of them are using this teleport cheese method, and frequently newer cult players don't use teleport spell defensively at all. This lifeline is almost explicitly used by high-skill cultists who eliminate risk while being very active. The idea of this is to remove such a lifeline, discouraging continued solo-play on a team antagonist and hopefully causing them to rely on their teammates a bit more. 

I also seek to encourage people to use Veil Shifter more outside of just instant kidnaps with it. It's a well-balanced item that would serve much better as a combat-teleport for Cultists than the teleport spell due to it having a much more reasonable and predictable range, giving pursuers the chance to continue pursuit. For the savvy cultist, it will only take one use of the veil shifter to break pursuit long enough to use the teleport spell to escape anyways - that's fine, this PR is specifically targeted on it just being used as a get-out-of-every-situation-scot-free card.

## Testing

Used Teleport Hand on self, 3 second timer, went to rune.
Used Teleport Hand on self, 3 second timer, stunned self before it ended, did not teleport anyways.
Used Teleport Hand on ally, no timer, they went to rune.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
![image](https://github.com/user-attachments/assets/997933c3-75a4-4258-9044-1c1f4583dbb5)
![image](https://github.com/user-attachments/assets/c95a945b-9ae0-404d-a69d-b5047c31df94)
(yeah I use light mode, fight me)
As per the request of the Balance Team member consulted, please add testmerge requested on this to see how it affects cult play.
  <hr>

## Changelog

:cl:
tweak: The Cult Teleport spell now has a 3 second timer when using it on yourself, not interrupted by movement. No such timer exists for teleporting a fellow Cultist with it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
