### PR TITLE
fix all occurrences of uppercase links in markdown

### DIFF
--- a/docs/hooks/contributing_path.py
+++ b/docs/hooks/contributing_path.py
@@ -21,6 +21,8 @@ For consistency's sake, we do this for CODE_OF_CONDUCT, despite no worry about
 collisions in this case, because the URL looks nicer.
 """
 
+import re
+
 transforms = {
     "CONTRIBUTING": "contributing",
     "CODE_OF_CONDUCT": "code_of_conduct",
@@ -34,3 +36,11 @@ def on_page_markdown(markdown, *, page, config, files):
             page.file.url = page.file.url.replace(old, new)
             page.file.dest_uri = page.file.dest_uri.replace(old, new)
             page.file.abs_dest_path = page.file.abs_dest_path.replace(old, new)
+
+        # Can't just replace filename and keep extension,
+        # mkdocs will get upset it can't find a file with
+        # that exact name. So we just give it a URL and it
+        # complains, but ignores it and chugs along.
+        markdown = re.sub(f"\.+/{old}.md", f"/{new}/", markdown)
+
+    return markdown

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,8 +5,8 @@ necessary to get started making contributions to Paradise Station.
 
 ## Required Reading
 
-All contributors are expected to read and abide by the Paradise Station [Code of
-Conduct](./CODE_OF_CONDUCT.md) and [Contribution Guidelines](./CONTRIBUTING.md).
+All contributors are expected to read and abide by the Paradise Station [Code of Conduct](./CODE_OF_CONDUCT.md) and
+[Contribution Guidelines](./CONTRIBUTING.md).
 
 ## New Contributors
 


### PR DESCRIPTION
## What Does This PR Do
Makes sure mkdocs rewrites URLs pointing to uppercase filenames, not just the filenames themselves.

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

NPFC
