### PR TITLE
docs: enable site search

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,6 +30,7 @@ extra:
 
 plugins:
   - gh-admonitions
+  - search
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
## What Does This PR Do
This PR enables the search plugin for devdocs.
## Why It's Good For The Game
This should have been enabled originally.
## Images of changes
![2024_09_05__09_54_44__Guide to Testing - Paradise Contributor Documentation](https://github.com/user-attachments/assets/5872d654-48c2-489f-945c-f50df242028e)
## Testing
Rebuilt site, ensured search index was sent, ensured UI worked, ensured clicking on search results worked.

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog
NPFC