### PR TITLE
Changes the in_game name of chameleon mason scanners

### DIFF
--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -290,7 +290,7 @@
 	chameleon_action.emp_randomise(INFINITY)
 
 /obj/item/clothing/glasses/chameleon
-	name = "Optical Meson Scanner"
+	name = "optical meson scanner"
 	desc = "Used by engineering and mining staff to see basic structural and terrain layouts through walls, regardless of lighting condition."
 	icon_state = "meson"
 	item_state = "meson"


### PR DESCRIPTION
## What Does This PR Do

Changes the in_game name of the chameleon optical mason scanner from `Optical Meson Scanner` to `optical meson scanner`.

Fixes #26678

## Why It's Good For The Game

You can't meta the hell out of it if you EVER encounter it.

## Testing

- Spawned in.
- Spawned in `chameleon optical meson scanner`.
- Chameleon X-ray's, Mesons, Thermals have the correct grammar.
- Description fitted changes.
- Profit.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

  <hr>

## Changelog

:cl:
spellcheck: Changed the item's in_game name to chameleon optical meson scanner.
/:cl:
