### PR TITLE
Hoverboards will now get cursed if used during megafauna

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
@@ -161,7 +161,7 @@
 		addtimer(VARSET_CALLBACK(C, density, TRUE), 2 SECONDS) // Needed to make them path. I hate it.
 
 /mob/living/simple_animal/hostile/megafauna/proc/hoverboard_deactivation(source, target)
-	SIGNAL_HANDLER //COMSIG_HOSTILE_FOUND_TARGET
+	SIGNAL_HANDLER // COMSIG_HOSTILE_FOUND_TARGET
 	if(!isliving(target))
 		return
 	var/mob/living/L = target
@@ -170,7 +170,7 @@
 	if(!istype(L.buckled, /obj/tgvehicle/scooter/skateboard/hoverboard))
 		return
 	var/obj/tgvehicle/scooter/skateboard/hoverboard/cursed_board = L.buckled
-	// Not a visable message, as walls or such may be in the way
+	// Not a visible message, as walls or such may be in the way
 	to_chat(L, "<span class='userdanger'><b>You hear a loud roar in the distance, and the lights on [cursed_board] begin to spark dangerously, as the board rumbles heavily!</b></span>")
 	playsound(get_turf(src), 'sound/effects/tendril_destroyed.ogg', 200, FALSE, 50, TRUE, TRUE)
 	cursed_board.necropolis_curse()

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
@@ -161,7 +161,7 @@
 		addtimer(VARSET_CALLBACK(C, density, TRUE), 2 SECONDS) // Needed to make them path. I hate it.
 
 /mob/living/simple_animal/hostile/megafauna/proc/hoverboard_deactivation(source, target)
-	SIGNAL_HANDLER
+	SIGNAL_HANDLER //COMSIG_HOSTILE_FOUND_TARGET
 	if(!isliving(target))
 		return
 	var/mob/living/L = target
@@ -171,7 +171,7 @@
 		return
 	var/obj/tgvehicle/scooter/skateboard/hoverboard/cursed_board = L.buckled
 	// Not a visable message, as walls or such may be in the way
-	to_chat(L, "<span class='danger'><b>You hear a loud roar in the distance, and the lights on [cursed_board] begin to spark dangerously, as the board rumbles heavily!</b></span>")
+	to_chat(L, "<span class='userdanger'><b>You hear a loud roar in the distance, and the lights on [cursed_board] begin to spark dangerously, as the board rumbles heavily!</b></span>")
 	playsound(get_turf(src), 'sound/effects/tendril_destroyed.ogg', 200, FALSE, 50, TRUE, TRUE)
 	cursed_board.necropolis_curse()
 

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
@@ -52,9 +52,11 @@
 	for(var/action_type in attack_action_types)
 		var/datum/action/innate/megafauna_attack/attack_action = new action_type()
 		attack_action.Grant(src)
+	RegisterSignal(src, COMSIG_HOSTILE_FOUND_TARGET, PROC_REF(hoverboard_deactivation))
 
 /mob/living/simple_animal/hostile/megafauna/Destroy()
 	QDEL_NULL(internal_gps)
+	UnregisterSignal(src, COMSIG_HOSTILE_FOUND_TARGET)
 	return ..()
 
 /mob/living/simple_animal/hostile/megafauna/Moved()
@@ -157,6 +159,21 @@
 	for(var/turf/simulated/floor/chasm/C in circlerangeturfs(src, 1))
 		C.density = FALSE //I hate it.
 		addtimer(VARSET_CALLBACK(C, density, TRUE), 2 SECONDS) // Needed to make them path. I hate it.
+
+/mob/living/simple_animal/hostile/megafauna/proc/hoverboard_deactivation(source, target)
+	SIGNAL_HANDLER
+	if(!isliving(target))
+		return
+	var/mob/living/L = target
+	if(!L.buckled)
+		return
+	if(!istype(L.buckled, /obj/tgvehicle/scooter/skateboard/hoverboard))
+		return
+	var/obj/tgvehicle/scooter/skateboard/hoverboard/cursed_board = L.buckled
+	// Not a visable message, as walls or such may be in the way
+	to_chat(L, "<span class='danger'><b>You hear a loud roar in the distance, and the lights on [cursed_board] begin to spark dangerously, as the board rumbles heavily!</b></span>")
+	playsound(get_turf(src), 'sound/effects/tendril_destroyed.ogg', 200, FALSE, 50, TRUE, TRUE)
+	cursed_board.necropolis_curse()
 
 /datum/action/innate/megafauna_attack
 	name = "Megafauna Attack"

--- a/code/modules/vehicle/tg_vehicles/scooter.dm
+++ b/code/modules/vehicle/tg_vehicles/scooter.dm
@@ -238,7 +238,8 @@
 	can_buckle = FALSE
 	addtimer(CALLBACK(src, PROC_REF(remove_rider)), 5 SECONDS)
 	curse_overlay = mutable_appearance('icons/effects/cult_effects.dmi', "cult-mark", ABOVE_MOB_LAYER)
-	
+	curse_overlay.pixel_y -= 10
+
 	add_overlay(curse_overlay)
 
 /obj/tgvehicle/scooter/skateboard/hoverboard/proc/remove_rider()

--- a/code/modules/vehicle/tg_vehicles/scooter.dm
+++ b/code/modules/vehicle/tg_vehicles/scooter.dm
@@ -236,7 +236,7 @@
 /obj/tgvehicle/scooter/skateboard/hoverboard/proc/necropolis_curse()
 	cursed = TRUE
 	can_buckle = FALSE
-	addtimer(CALLBACK(src, PROC_REF(remove_rider)), 5 SECONDS)
+	addtimer(CALLBACK(src, PROC_REF(remove_rider)), 5 SECONDS, TIMER_UNIQUE|TIMER_STOPPABLE|TIMER_DELETE_ME)
 	curse_overlay = mutable_appearance('icons/effects/cult_effects.dmi', "cult-mark", ABOVE_MOB_LAYER)
 	curse_overlay.pixel_y -= 10
 
@@ -247,7 +247,7 @@
 	if(has_buckled_mobs())
 		var/mob/living/carbon/skaterboy = buckled_mobs[1]
 		unbuckle_mob(skaterboy)
-	addtimer(CALLBACK(src, PROC_REF(clear_curse)), 30 SECONDS)
+	addtimer(CALLBACK(src, PROC_REF(clear_curse)), 30 SECONDS,TIMER_UNIQUE|TIMER_STOPPABLE|TIMER_DELETE_ME)
 
 /obj/tgvehicle/scooter/skateboard/hoverboard/proc/clear_curse()
 	can_buckle = TRUE

--- a/code/modules/vehicle/tg_vehicles/scooter.dm
+++ b/code/modules/vehicle/tg_vehicles/scooter.dm
@@ -33,6 +33,11 @@
 			buckled_mob.pixel_y = 5
 		else
 			buckled_mob.pixel_y = -4
+		if(istype(get_turf(src), /turf/simulated/floor/plating/asteroid)) //Rocks are bad for wheels mkay?
+			if(!HAS_TRAIT(src, TRAIT_NO_BREAK_GLASS_TABLES))
+				buckled_mob.adjustStaminaLoss(2)
+				if(prob(7)) //Not to much spam.
+					to_chat(buckled_mob, "<span class='warning'>The rocky terrain you are riding on is tiring you out!</span>")
 
 /obj/tgvehicle/scooter/skateboard
 	name = "skateboard"
@@ -51,6 +56,8 @@
 	var/instability = 10
 	///If true, riding the skateboard with walk intent on will prevent crashing.
 	var/can_slow_down = TRUE
+	///Is this board cursed, preventing the cheeser from picking it up right away and using it again. Can not get on it while cursed either.
+	var/cursed = FALSE
 
 /obj/tgvehicle/scooter/skateboard/Initialize(mapload)
 	. = ..()
@@ -191,6 +198,9 @@
 /obj/tgvehicle/scooter/skateboard/proc/pick_up_board(mob/living/carbon/skater)
 	if(skater.incapacitated() || !Adjacent(skater))
 		return
+	if(cursed)
+		to_chat(skater, "<span class='danger'>Some magic burns your hands whenever you go to pick it up!</span>")
+		return
 	if(has_buckled_mobs())
 		to_chat(skater, "<span class='warning'>You can't lift this up when somebody's on it.</span>")
 		return
@@ -214,6 +224,7 @@
 	instability = 3
 	icon_state = "hoverboard_red"
 	resistance_flags = LAVA_PROOF | FIRE_PROOF
+	var/mutable_appearance/curse_overlay
 
 /obj/tgvehicle/scooter/skateboard/hoverboard/Initialize(mapload)
 	. = ..()
@@ -221,6 +232,26 @@
 
 /obj/tgvehicle/scooter/skateboard/hoverboard/make_ridable()
 	AddElement(/datum/element/ridable, /datum/component/riding/vehicle/scooter/skateboard/hover)
+
+/obj/tgvehicle/scooter/skateboard/hoverboard/proc/necropolis_curse()
+	cursed = TRUE
+	can_buckle = FALSE
+	addtimer(CALLBACK(src, PROC_REF(remove_rider)), 5 SECONDS)
+	curse_overlay = mutable_appearance('icons/effects/cult_effects.dmi', "cult-mark", ABOVE_MOB_LAYER)
+	
+	add_overlay(curse_overlay)
+
+/obj/tgvehicle/scooter/skateboard/hoverboard/proc/remove_rider()
+	visible_message("<span class='warning'>The boosters on [src] burn out as the magic extinguishes it!</span>")
+	if(has_buckled_mobs())
+		var/mob/living/carbon/skaterboy = buckled_mobs[1]
+		unbuckle_mob(skaterboy)
+	addtimer(CALLBACK(src, PROC_REF(clear_curse)), 30 SECONDS)
+
+/obj/tgvehicle/scooter/skateboard/hoverboard/proc/clear_curse()
+	can_buckle = TRUE
+	cursed = FALSE
+	cut_overlay(curse_overlay)
 
 /obj/tgvehicle/scooter/skateboard/hoverboard/admin
 	name = "\improper Board Of Directors"

--- a/code/modules/vehicle/tg_vehicles/scooter.dm
+++ b/code/modules/vehicle/tg_vehicles/scooter.dm
@@ -238,7 +238,7 @@
 	can_buckle = FALSE
 	addtimer(CALLBACK(src, PROC_REF(remove_rider)), 5 SECONDS, TIMER_UNIQUE|TIMER_STOPPABLE|TIMER_DELETE_ME)
 	curse_overlay = mutable_appearance('icons/effects/cult_effects.dmi', "cult-mark", ABOVE_MOB_LAYER)
-	curse_overlay.pixel_y -= 10
+	curse_overlay.pixel_y = -10
 
 	add_overlay(curse_overlay)
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Hoverboards get cursed if used to fight megafauna.
After 5 seconds, the hoverboard will kick the user off. You can not buckle to a cursed board or pick it up. After 30 seconds the board will be uncursed and can be picked up.
Normal skateboards will cause stamina damage when ridden on basalt, due to the rocky terrain.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
I am off vacation, though I should have fixed this ages ago.
It lets you cheese megafauna far too easily, I intended for the boards to be used for chasm or lava crossing, not fauna fighting.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

<!-- How did you test the PR, if at all? -->
Fought ash drake, it kicked me off the board, could not pick up, or ride it, wore off later.
Rode hoverboard on lavaland, no stamina.
Rode pro skateboard, took stamina and got message
<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>
![image](https://github.com/user-attachments/assets/28aab002-4858-4704-9d72-ce1934034a76)


## Changelog

:cl:
tweak: Necropolis will curse your hoverboard if used against megafauna.
tweak: Non hoverboard users will find riding a skateboard on basalt tiring from all the small rocks, and will take stamina damage from the ride.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
