### PR TITLE
Buffing Explorer megafaunas + nerf Cutlass

### DIFF
--- a/code/game/objects/effects/spawners/depot_spawners.dm
+++ b/code/game/objects/effects/spawners/depot_spawners.dm
@@ -94,7 +94,7 @@
 	name = "rare loot"
 	// Basic stealth, utility and environmental gear.
 	result = list(/datum/nothing = 27,
-		/obj/item/mod/control/pre_equipped/traitor = 1,
+		/obj/item/mod/control/pre_equipped/traitor/empty = 1,
 		/obj/item/ammo_box/magazine/m10mm = 1,
 		/obj/item/storage/backpack/duffel/syndie/med/surgery = 1,
 		/obj/item/clothing/shoes/chameleon/noslip = 1,

--- a/code/game/objects/items/weapons/dice.dm
+++ b/code/game/objects/items/weapons/dice.dm
@@ -261,7 +261,7 @@
 				/obj/item/clothing/glasses/chameleon/thermal,
 				/obj/item/borg/upgrade/modkit/indoors,
 				/obj/item/storage/box/syndie_kit/chameleon,
-				/obj/item/mod/control/pre_equipped/traitor,
+				/obj/item/mod/control/pre_equipped/traitor/empty,
 				/obj/item/bio_chip_implanter/storage,
 				/obj/item/toy/syndicateballoon)
 			var/selected_item = pick(traitor_items)

--- a/code/game/objects/items/weapons/melee/energy_melee_weapons.dm
+++ b/code/game/objects/items/weapons/melee/energy_melee_weapons.dm
@@ -345,12 +345,15 @@
 //////////////////////////////
 /obj/item/melee/energy/sword/pirate
 	name = "energy cutlass"
-	desc = "Arrrr matey."
+	desc = "Broken, but once repaired version of original energy sword. Because of his cheap price and effectiveness higly spread among all space pirates. Arrrr matey!"
 	force_on = 20
+	embedded_impact_pain_multiplier = 2 //this is not uplink sword and common to find. No need PvP bonuses.
+	armour_penetration_percentage = 0
+	armour_penetration_flat = 10
 	icon_state = "cutlass0"
 	icon_state_on = "cutlass1"
 	light_color = LIGHT_COLOR_RED
-	origin_tech = "combat=3;magnets=4;syndicate=2"
+	origin_tech = "combat=3;magnets=4"
 
 //////////////////////////////
 // MARK: HARDLIGHT BLADE

--- a/code/modules/mob/living/simple_animal/corpse.dm
+++ b/code/modules/mob/living/simple_animal/corpse.dm
@@ -57,7 +57,7 @@
 	gloves = /obj/item/clothing/gloves/combat
 	l_ear = /obj/item/radio/headset
 	mask = /obj/item/clothing/mask/gas/syndicate
-	back = /obj/item/mod/control/pre_equipped/traitor_elite
+	back = /obj/item/mod/control/pre_equipped/traitor_elite/empty
 	r_pocket = /obj/item/tank/internals/emergency_oxygen
 	id = /obj/item/card/id
 

--- a/code/modules/mob/living/simple_animal/corpse.dm
+++ b/code/modules/mob/living/simple_animal/corpse.dm
@@ -37,7 +37,7 @@
 	gloves = /obj/item/clothing/gloves/combat
 	l_ear = /obj/item/radio/headset
 	mask = /obj/item/clothing/mask/gas/syndicate
-	back = /obj/item/mod/control/pre_equipped/traitor
+	back = /obj/item/mod/control/pre_equipped/traitor/empty
 	r_pocket = /obj/item/tank/internals/emergency_oxygen
 	id = /obj/item/card/id
 

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
@@ -600,17 +600,12 @@ Difficulty: Medium
 
 /mob/living/simple_animal/hostile/megafauna/dragon/space_dragon
 	name = "space dragon"
-	maxHealth = 1000
-	health = 1000
-	faction = list("carp")
+	faction = list("carp") // Carp-fu makes him friendly!
 	desc = "A space carp turned dragon by vile magic.  Has the same ferocity of a space carp, but also a much more enabling body."
 	icon = 'icons/mob/spacedragon.dmi'
 	icon_state = "spacedragon"
 	icon_living = "spacedragon"
 	icon_dead = "spacedragon_dead"
-	obj_damage = 80
-	melee_damage_upper = 35
-	melee_damage_lower = 35
 	speed = 0
 	mouse_opacity = MOUSE_OPACITY_ICON
 	move_to_delay = 3

--- a/code/modules/mob/living/simple_animal/hostile/syndicate_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate_mobs.dm
@@ -273,14 +273,19 @@
 		projectilesound = 'sound/weapons/gunshots/gunshot_pistol.ogg'
 
 /mob/living/simple_animal/hostile/syndicate/melee/autogib/depot/armory
-	name = "Syndicate Quartermaster"
+	name = "Syndicate Quartermaster" // the REAL boss
 	icon_state = "syndicate_stormtrooper_sword"
 	icon_living = "syndicate_stormtrooper_sword"
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
-	maxHealth = 200
-	health = 200
-	melee_block_chance = 40
+	melee_damage_lower = 30 // REAL energy sword!
+	melee_damage_upper = 30
+	armour_penetration_percentage = 50
+	armour_penetration_flat = 10
+	melee_block_chance = 40 // he know how to use REAL energy sword! not perfectly tho.
+	ranged_block_chance = 40
+	maxHealth = 500 // Real Elite MODsuit human EHP concidering anti-bullet/melee protection!
+	health = 500
 	alert_on_shield_breach = TRUE
 	death_sound = 'sound/mecha/mechmove03.ogg'
 	loot = list(/obj/effect/mob_spawn/human/corpse/syndicatequartermaster, /obj/effect/decal/cleanable/blood/innards, /obj/effect/decal/cleanable/blood, /obj/effect/gibspawner/generic, /obj/effect/gibspawner/generic)
@@ -288,7 +293,7 @@
 /mob/living/simple_animal/hostile/syndicate/melee/autogib/depot/armory/Initialize(mapload)
 	. = ..()
 	if(prob(50))
-		// 50% chance of switching to extremely dangerous ranged variant
+		// 50% chance of switching to even more dangerous ranged variant
 		melee_damage_lower = 10
 		melee_damage_upper = 10
 		attacktext = "punches"

--- a/code/modules/mod/mod_types.dm
+++ b/code/modules/mod/mod_types.dm
@@ -263,6 +263,16 @@
 		/obj/item/mod/module/jetpack,
 	)
 
+/obj/item/mod/control/pre_equipped/traitor/empty // empty version for "free" spots where you can find it
+	theme = /datum/mod_theme/syndicate
+	applied_modules = list(
+		/obj/item/mod/module/storage,
+		/obj/item/mod/module/flashlight,
+	)
+	default_pins = list(
+		/obj/item/mod/module/armor_booster,
+	)
+
 /obj/item/mod/control/pre_equipped/traitor/Initialize(mapload)
 	. = ..()
 	new /obj/item/clothing/mask/gas/syndicate(bag)
@@ -286,7 +296,6 @@
 
 /obj/item/mod/control/pre_equipped/traitor_elite/empty // special version for Syndicate Quartermaster in supply depot.
 	theme = /datum/mod_theme/elite
-	applied_cell = /obj/item/stock_parts/cell/super
 	applied_modules = list( // this doesnt even have jetpack, so you need to apply modules from your MODsuit if you want fly out wearing it.
 		/obj/item/mod/module/storage,
 		/obj/item/mod/module/flashlight,

--- a/code/modules/mod/mod_types.dm
+++ b/code/modules/mod/mod_types.dm
@@ -284,6 +284,17 @@
 		/obj/item/mod/module/jetpack/advanced,
 	)
 
+/obj/item/mod/control/pre_equipped/traitor_elite/empty // special version for Syndicate Quartermaster in supply depot.
+	theme = /datum/mod_theme/elite
+	applied_cell = /obj/item/stock_parts/cell/super
+	applied_modules = list( // this doesnt even have jetpack, so you need to apply modules from your MODsuit if you want fly out wearing it.
+		/obj/item/mod/module/storage,
+		/obj/item/mod/module/flashlight,
+	)
+	default_pins = list(
+		/obj/item/mod/module/armor_booster,
+	)
+
 /obj/item/mod/control/pre_equipped/traitor_elite/Initialize(mapload)
 	. = ..()
 	new /obj/item/clothing/mask/gas/syndicate(bag)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

- Carp dragon have now the same health/damage as generic megafauna.
- Syndicate Quartermaster now wearing REAL energy sword and have REAL Elite Modsuit EHP.
- Energy Cutlass now doesnt have PvP bonuses as high armor penetration, sindycate techs or pain modifier, doesnt changed against PvE content. Description now says he is poor version of esword.
- Traitor MODsuit you can find "for free" no longer have jetpacks, emp shields and other modules, only flashlight and simple storage remained. Now sec can EMP them for sure!

## Why It's Good For The Game

According to https://discord.com/channels/145533722026967040/1276732420720427148, @PollardTheDragon have the reasonable take:
"The main concerns I have with the current numbers of elite/blood red modsuit loot is in three sets.
1: Antag balance. A traitor getting a free blood red is one thing. A changeling with a free blood red ontop of all the other space loot is another.
2: Midround balance. I've seen more than a few instances where explorers fuck off into space the entire round, only come back to dunk on a midround with their S-class loot, then fuck back off.
3: Security culture. Sec heavily prioritizes antags over any other crime, but with the sheer amount of S-Class contraband in space, sec has a tendency to intentionally overlook it or not prioritize it just because of the explorer ID."

According to this takes, i changed it as i look the better:
1. 
- MODsuits you can find(not buy from uplink) now doesnt have anti-EMP, anti-slip or good cell with upgraded jetpack, leaving you with only armor you need to upgrade to have full use. Now security can hadle this free loot with water tanks and EMP as normal MODsuits.
- Energy Cutlass now doesnt have impressive armor penetration and bonuses while embed someone, who deals an impressive damage for armored targets like secs with SWAT armor or captains. Also doesnt contain syndy tech, because this sword is easy to find and you basically have free 3 sindy techs because of that.

2. 
- Having S-tier loot now sugnifically harder than before. 
Syndicate Quartermaster, the Keeper of Gamer loot, now a real boss, because he wearing real energy sword in melee state and have 500 hp, who is the same 200 human HP with 60% damage reduction armor. Now you cant cheese him if you "lucky".

Space Dragon, Gifter of Biohazard Bane, now not that cheesable, due having same HP and damage as any other megafauna. EKA who falls out of him is incredibly powerful against biohazard, allowing minigun-shooting 70 damage projectiles, who 3-shot xenos, leaving no cnahces any terror spooder and have a too powerful advantage over Blob.

3. 
- This is not fixing by code.

## Images of changes

Space drake now tough
![image](https://github.com/user-attachments/assets/20e6aa03-bee4-46d4-879c-1cf11cc076d8)


## Testing

Change stats, seeing stats are that i want to see, mercylessly get killed by Syndicate QM over and over again.

<hr>

### Declaration

- [ ] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
add: Added new things
del: Removed old things
tweak: Tweaked a few things
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
