### PR TITLE
Various chemthrower fixes

### DIFF
--- a/code/game/objects/items/weapons/chemical_flamethrower/chemical_flamethrower.dm
+++ b/code/game/objects/items/weapons/chemical_flamethrower/chemical_flamethrower.dm
@@ -181,6 +181,7 @@
 		if(canister.ammo - difference <= 0)
 			difference -= canister.ammo
 			canister.ammo = 0
+			canister.has_filled_reagent = FALSE // We're empty now!
 		else
 			canister.ammo -= difference
 			difference = 0
@@ -244,6 +245,10 @@
 		. += "[src] is currently filled with [stored_chemical]"
 
 /obj/item/chemical_canister/on_reagent_change()
+	if(!length(reagents.reagent_list))
+		// Nothing to check. Has to be here because we call `clear_reagents` at the end of this proc.
+		return
+
 	if(has_filled_reagent && ammo != 0)
 		audible_message("<span class='notice'>[src]'s speaker beeps: no new chemicals are accepted!</span>")
 		return
@@ -260,9 +265,8 @@
 
 	if(!first_time_silent)
 		audible_message("<span class='notice'>[src]'s speaker beeps: \
-						All reagents are removed except for [current_reagent_id]. \
 						The reservoir has [reagents.total_volume] out of [required_volume] units. \
-						Reagent effects are [has_enough_reagents ? "in effect" : "not active"].</span>")
+						Reagents are [has_enough_reagents ? "in effect" : "not active"].</span>")
 	first_time_silent = FALSE
 
 	if(has_enough_reagents)
@@ -282,6 +286,8 @@
 	required_volume = 20 // Bigger canister? More reagents needed.
 
 /obj/item/chemical_canister/extended/nuclear
+	name = "\improper Syndicate chemical canister"
+	desc = "A canister pre-filled with napalm to bring a fiery death to capitalism."
 	icon_state = "pyro"
 	accepted_chemicals = list("napalm")
 	first_time_silent = TRUE

--- a/code/game/objects/items/weapons/chemical_flamethrower/chemical_flamethrower.dm
+++ b/code/game/objects/items/weapons/chemical_flamethrower/chemical_flamethrower.dm
@@ -211,7 +211,7 @@
 	desc = "A simple canister of fuel. Does not accept any pyrotechnics except for welding fuel."
 	icon = 'icons/obj/chemical_flamethrower.dmi'
 	icon_state = "normal"
-	container_type = OPENCONTAINER
+	container_type = REFILLABLE
 	/// How much ammo do we have? Empty at 0.
 	var/ammo = 100
 	/// Which reagent IDs do we accept

--- a/code/game/objects/items/weapons/chemical_flamethrower/chemical_flamethrower.dm
+++ b/code/game/objects/items/weapons/chemical_flamethrower/chemical_flamethrower.dm
@@ -239,7 +239,7 @@
 
 /obj/item/chemical_canister/examine(mob/user)
 	. = ..()
-	. += "[src] has [ammo] units left!"
+	. += "[src] has [ammo] out of [initial(ammo)] units left!"
 	if(stored_chemical && ammo != 0)
 		. += "[src] is currently filled with [stored_chemical]"
 

--- a/code/game/objects/items/weapons/chemical_flamethrower/chemical_flamethrower.dm
+++ b/code/game/objects/items/weapons/chemical_flamethrower/chemical_flamethrower.dm
@@ -230,6 +230,8 @@
 	var/has_filled_reagent = FALSE
 	/// Are we silent on the first change of reagents?
 	var/first_time_silent = FALSE // The reason for this is so we can have canisters that spawn with reagents but don't announce it on `Initialize()`
+	/// What chemical do we have? This will be the chemical ID, so a string
+	var/stored_chemical
 
 /obj/item/chemical_canister/Initialize(mapload)
 	. = ..()
@@ -238,6 +240,8 @@
 /obj/item/chemical_canister/examine(mob/user)
 	. = ..()
 	. += "[src] has [ammo] units left!"
+	if(stored_chemical && ammo != 0)
+		. += "[src] is currently filled with [stored_chemical]"
 
 /obj/item/chemical_canister/on_reagent_change()
 	if(has_filled_reagent && ammo != 0)
@@ -250,6 +254,7 @@
 		return
 
 	current_reagent_id = reagents.get_master_reagent_id()
+	stored_chemical = current_reagent_id
 	reagents.isolate_reagent(current_reagent_id)
 	var/has_enough_reagents = reagents.total_volume >= required_volume
 

--- a/code/game/objects/items/weapons/chemical_flamethrower/chemical_flamethrower.dm
+++ b/code/game/objects/items/weapons/chemical_flamethrower/chemical_flamethrower.dm
@@ -235,6 +235,10 @@
 	. = ..()
 	create_reagents(50)
 
+/obj/item/chemical_canister/examine(mob/user)
+	. = ..()
+	. += "[src] has [ammo] units left!"
+
 /obj/item/chemical_canister/on_reagent_change()
 	if(has_filled_reagent && ammo != 0)
 		audible_message("<span class='notice'>[src]'s speaker beeps: no new chemicals are accepted!</span>")
@@ -263,6 +267,7 @@
 		fire_applications = reagent_to_burn.fire_stack_applications
 		ammo = initial(ammo)
 		has_filled_reagent = TRUE
+		reagents.clear_reagents()
 
 /obj/item/chemical_canister/extended
 	name = "extended capacity chemical canister"

--- a/code/game/objects/items/weapons/chemical_flamethrower/fire_effect.dm
+++ b/code/game/objects/items/weapons/chemical_flamethrower/fire_effect.dm
@@ -78,7 +78,8 @@ GLOBAL_LIST_EMPTY(flame_effects)
 /obj/effect/fire/Crossed(atom/movable/AM, oldloc)
 	. = ..()
 	if(isliving(AM))
-		damage_mob(AM)
+		if(!damage_mob(AM))
+			return
 		to_chat(AM, "<span class='warning'>[src] burns you!</span>")
 		return
 
@@ -104,7 +105,7 @@ GLOBAL_LIST_EMPTY(flame_effects)
 		var/mob/living/carbon/human/human_to_burn = mob_to_burn
 		var/fire_armour = human_to_burn.get_thermal_protection()
 		if(fire_armour >= FIRE_IMMUNITY_MAX_TEMP_PROTECT)
-			return
+			return FALSE
 
 		if(fire_armour == FIRE_SUIT_MAX_TEMP_PROTECT) // Good protection but you won't survive infinitely in it
 			fire_damage /= 4

--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -303,6 +303,10 @@
 	reqs = list(/obj/item/chemical_flamethrower = 1,
 			/obj/item/stack/cable_coil = 5,
 			/obj/item/weaponcrafting/gunkit/chemical_flamethrower = 1)
+	time = 10 SECONDS
+	category = CAT_WEAPONRY
+	subcategory = CAT_WEAPON
+	alert_admins_on_craft = TRUE
 
 /datum/crafting_recipe/ed209
 	name = "ED209"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
- Canisters will now show their ammo
- Canisters will now show what reagent they have
- Canisters will clear out their reagents after fully being filled
- You don't get the message from being burned by a fire if you are immune to fire
- Gives a new name and description to the syndicate canister
- Shortens the audible message for adding reagents to canisters
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
These are nice QOL tweaks
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
It compiled, filled some canisters and examined them
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
tweak: Chemthrower canisters now show their ammo properly
tweak: Fires no longer say you are burnt when you are fire immune
tweak: Syndicate chemthrower canisters now have a proper name
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
