### PR TITLE
refactor: use DCS signal for explosion sensors.

### DIFF
--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -1,5 +1,3 @@
-GLOBAL_LIST_EMPTY(doppler_arrays)
-
 /obj/machinery/doppler_array
 	name = "tachyon-doppler array"
 	desc = "A highly precise directional sensor array which measures the release of quants from decaying tachyons. The doppler shifting of the mirror-image formed by these quants can reveal the size, location and temporal affects of energetic disturbances within a large radius ahead of the array."
@@ -28,13 +26,13 @@ GLOBAL_LIST_EMPTY(doppler_arrays)
 
 /obj/machinery/doppler_array/Initialize(mapload)
 	. = ..()
-	GLOB.doppler_arrays += src
+	RegisterSignal(SSdcs, COMSIG_GLOB_EXPLOSION, PROC_REF(sense_explosion))
 	explosion_target = rand(8, 20)
 	toxins_tech = new /datum/tech/toxins(src)
 
 /obj/machinery/doppler_array/Destroy()
-	GLOB.doppler_arrays -= src
 	logged_explosions.Cut()
+	UnregisterSignal(SSdcs, COMSIG_GLOB_EXPLOSION)
 	return ..()
 
 /obj/machinery/doppler_array/attackby(obj/item/I, mob/user, params)
@@ -97,28 +95,28 @@ GLOBAL_LIST_EMPTY(doppler_arrays)
 	P.info += "</table><hr/>\
 	<em>Printed at [station_time_timestamp()].</em>"
 
-/obj/machinery/doppler_array/proc/sense_explosion(var/x0,var/y0,var/z0,var/devastation_range,var/heavy_impact_range,var/light_impact_range,
-												var/took,var/orig_dev_range,var/orig_heavy_range,var/orig_light_range)
+/obj/machinery/doppler_array/proc/sense_explosion(datum/source, turf/epicenter, devastation_range, heavy_impact_range,
+		light_impact_range, took, orig_dev_range, orig_heavy_range, orig_light_range)
 	if(stat & NOPOWER)
 		return
-	if(z != z0)
+	if(z != epicenter.z)
 		return
 
-	var/dx = abs(x0-x)
-	var/dy = abs(y0-y)
+	var/dx = abs(epicenter.x - x)
+	var/dy = abs(epicenter.y - y)
 	var/distance
 	var/direct
 	var/capped = FALSE
 
 	if(dx > dy)
 		distance = dx
-		if(x0 > x)
+		if(epicenter.x > x)
 			direct = EAST
 		else
 			direct = WEST
 	else
 		distance = dy
-		if(y0 > y)
+		if(epicenter.y > y)
 			direct = NORTH
 		else
 			direct = SOUTH
@@ -128,15 +126,16 @@ GLOBAL_LIST_EMPTY(doppler_arrays)
 	if(!(direct & dir))
 		return
 
+	var/coordinates = "[epicenter.x],[epicenter.y]"
 	var/list/messages = list("Explosive disturbance detected.", \
-							"Epicenter at: grid ([x0],[y0]). Temporal displacement of tachyons: [took] seconds.", \
+							"Epicenter at: grid ([coordinates]). Temporal displacement of tachyons: [took] seconds.", \
 							"Actual: Epicenter radius: [devastation_range]. Outer radius: [heavy_impact_range]. Shockwave radius: [light_impact_range].")
 
 	// If the bomb was capped, say its theoretical size.
 	if(devastation_range < orig_dev_range || heavy_impact_range < orig_heavy_range || light_impact_range < orig_light_range)
 		capped = TRUE
 		messages += "Theoretical: Epicenter radius: [orig_dev_range]. Outer radius: [orig_heavy_range]. Shockwave radius: [orig_light_range]."
-	logged_explosions.Insert(1, new /datum/explosion_log(station_time_timestamp(), "[x0],[y0]", "[devastation_range], [heavy_impact_range], [light_impact_range]", capped ? "[orig_dev_range], [orig_heavy_range], [orig_light_range]" : "n/a")) //Newer logs appear first
+	logged_explosions.Insert(1, new /datum/explosion_log(station_time_timestamp(), "[coordinates]", "[devastation_range], [heavy_impact_range], [light_impact_range]", capped ? "[orig_dev_range], [orig_heavy_range], [orig_light_range]" : "n/a")) //Newer logs appear first
 	messages += "Event successfully logged in internal database."
 	var/miss_by = abs(explosion_target - orig_light_range)
 	var/tmp_tech = max_toxins_tech - miss_by

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -203,16 +203,7 @@
 		//You need to press the DebugGame verb to see these now....they were getting annoying and we've collected a fair bit of data. Just -test- changes  to explosion code using this please so we can compare
 		log_world("## DEBUG: Explosion([x0],[y0],[z0])(d[devastation_range],h[heavy_impact_range],l[light_impact_range]): Took [took] seconds.")
 
-		//Machines which report explosions.
-		for(var/array in GLOB.doppler_arrays)
-			if(!array)
-				continue
-			if(istype(array, /obj/machinery/doppler_array))
-				var/obj/machinery/doppler_array/Array = array
-				Array.sense_explosion(x0,y0,z0,devastation_range,heavy_impact_range,light_impact_range,took,orig_dev_range,orig_heavy_range,orig_light_range)
-			if(istype(array, /obj/item/mod/module/reagent_scanner/advanced))
-				var/obj/item/mod/module/reagent_scanner/advanced/Mod_Array = array
-				Mod_Array.sense_explosion(x0,y0,z0,devastation_range,heavy_impact_range,light_impact_range,took,orig_dev_range,orig_heavy_range,orig_light_range)
+		SEND_GLOBAL_SIGNAL(COMSIG_GLOB_EXPLOSION, epicenter, devastation_range, heavy_impact_range, light_impact_range, took, orig_dev_range, orig_heavy_range, orig_light_range)
 	return 1
 
 

--- a/code/modules/mod/modules/modules_science.dm
+++ b/code/modules/mod/modules/modules_science.dm
@@ -35,21 +35,21 @@
 	. = ..()
 	if(!.)
 		return
-	GLOB.doppler_arrays += src
+	RegisterSignal(SSdcs, COMSIG_GLOB_EXPLOSION, PROC_REF(sense_explosion))
 
 /obj/item/mod/module/reagent_scanner/advanced/on_deactivation(display_message = TRUE, deleting = FALSE)
 	. = ..()
 	if(!.)
 		return
-	GLOB.doppler_arrays -= src
+	UnregisterSignal(SSdcs, COMSIG_GLOB_EXPLOSION)
 
-/obj/item/mod/module/reagent_scanner/advanced/proc/sense_explosion(x0, y0, z0, devastation_range, heavy_impact_range,
+/obj/item/mod/module/reagent_scanner/advanced/proc/sense_explosion(datum/source, turf/epicenter, devastation_range, heavy_impact_range,
 		light_impact_range, took, orig_dev_range, orig_heavy_range, orig_light_range)
 	var/turf/T = get_turf(src)
-	var/dx = abs(x0 - T.x)
-	var/dy = abs(y0 - T.y)
+	var/dx = abs(epicenter.x - T.x)
+	var/dy = abs(epicenter.y - T.y)
 	var/distance
-	if(T.z != z0)
+	if(T.z != epicenter.z)
 		return
 	if(dx > dy)
 		distance = dx


### PR DESCRIPTION
## What Does This PR Do
This PR replaces the list of global explosion sensors with a signal that doppler arrays and advanced reagent MOD modules subscribe to.

## Why It's Good For The Game
We have this signal, might as well use it; one less GLOB list; less typecasting and null checks in /proc/explosion.

## Testing
Blew up toxins test range, used Event panel to drop bombs, checked that doppler arrays and advanced reagent scanners reacted to explosions.

<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog
NPFC
