### PR TITLE
refactor: dead signals removal

### DIFF
--- a/code/__DEFINES/dcs/atom_signals.dm
+++ b/code/__DEFINES/dcs/atom_signals.dm
@@ -6,31 +6,18 @@
 
 // /atom
 
-///from base of atom/proc/Initialize(): sent any time a new atom is created
-#define COMSIG_ATOM_CREATED "atom_created"
-//from SSatoms InitAtom - Only if the  atom was not deleted or failed initialization
-#define COMSIG_ATOM_AFTER_SUCCESSFUL_INITIALIZE "atom_init_success"
 ///from base of atom/attackby(): (/obj/item, /mob/living, params)
 #define COMSIG_PARENT_ATTACKBY "atom_attackby"
 ///Return this in response if you don't want afterattack to be called
 	#define COMPONENT_NO_AFTERATTACK (1<<0)
 ///from base of atom/attack_hulk(): (/mob/living/carbon/human)
 #define COMSIG_ATOM_HULK_ATTACK "hulk_attack"
-///from base of atom/animal_attack(): (/mob/user)
-#define COMSIG_ATOM_ATTACK_ANIMAL "attack_animal"
 ///from base of atom/examine(): (examining_user, examine_list)
 #define COMSIG_PARENT_EXAMINE "atom_examine"
 ///from base of atom/examine_more(): (examining_user, examine_list)
 #define COMSIG_PARENT_EXAMINE_MORE "atom_examine_more"
-///from base of atom/get_examine_name(): (/mob, list/overrides)
-#define COMSIG_ATOM_GET_EXAMINE_NAME "atom_examine_name"
-	//Positions for overrides list
-	#define EXAMINE_POSITION_ARTICLE (1<<0)
-	#define EXAMINE_POSITION_BEFORE (1<<1)
-	//End positions
-	#define COMPONENT_EXNAME_CHANGED (1<<0)
-	///from base of [/atom/proc/update_appearance]: (updates)
-	#define COMSIG_ATOM_UPDATE_APPEARANCE "atom_update_appearance"
+///from base of [/atom/proc/update_appearance]: (updates)
+#define COMSIG_ATOM_UPDATE_APPEARANCE "atom_update_appearance"
 	/// If returned from [COMSIG_ATOM_UPDATE_APPEARANCE] it prevents the atom from updating its name.
 	#define COMSIG_ATOM_NO_UPDATE_NAME UPDATE_NAME
 	/// If returned from [COMSIG_ATOM_UPDATE_APPEARANCE] it prevents the atom from updating its desc.
@@ -60,8 +47,6 @@
 	#define COMPONENT_ATOM_BLOCK_EXIT (1<<0)
 ///from base of atom/Exited(): (atom/movable/exiting, atom/newloc)
 #define COMSIG_ATOM_EXITED "atom_exited"
-///from base of atom/Bumped(): (/atom/movable)
-#define COMSIG_ATOM_BUMPED "atom_bumped"
 ///from base of atom/ex_act(): (severity, target)
 #define COMSIG_ATOM_EX_ACT "atom_ex_act"
 ///from base of atom/emp_act(): (severity)
@@ -78,21 +63,12 @@
 #define COMSIG_ATOM_EMAG_ACT "atom_emag_act"
 ///from base of atom/rad_act(intensity)
 #define COMSIG_ATOM_RAD_ACT "atom_rad_act"
-///from base of atom/narsie_act(): ()
-#define COMSIG_ATOM_NARSIE_ACT "atom_narsie_act"
-///from base of atom/rcd_act(): (/mob, /obj/item/construction/rcd, passed_mode)
-#define COMSIG_ATOM_RCD_ACT "atom_rcd_act"
 ///from base of atom/singularity_pull(): (S, current_size)
 #define COMSIG_ATOM_SING_PULL "atom_sing_pull"
-///from obj/machinery/bsa/full/proc/fire(): ()
-#define COMSIG_ATOM_BSA_BEAM "atom_bsa_beam_pass"
-	#define COMSIG_ATOM_BLOCKS_BSA_BEAM (1<<0)
 ///from base of atom/set_light(): (l_range, l_power, l_color)
 #define COMSIG_ATOM_SET_LIGHT "atom_set_light"
 ///from base of atom/setDir(): (old_dir, new_dir)
 #define COMSIG_ATOM_DIR_CHANGE "atom_dir_change"
-///from base of atom/handle_atom_del(): (atom/deleted)
-#define COMSIG_ATOM_CONTENTS_DEL "atom_contents_del"
 ///from base of atom/has_gravity(): (turf/location, list/forced_gravities)
 #define COMSIG_ATOM_HAS_GRAVITY "atom_has_gravity"
 ///from proc/get_rad_contents(): ()
@@ -104,26 +80,6 @@
 ///from base of datum/radiation_wave/check_obstructions(): (datum/radiation_wave, width)
 #define COMSIG_ATOM_RAD_WAVE_PASSING "atom_rad_wave_pass"
 	#define COMPONENT_RAD_WAVE_HANDLED (1<<0)
-///from base of atom/screwdriver_act(): (mob/living/user, obj/item/I)
-#define COMSIG_ATOM_SCREWDRIVER_ACT "atom_screwdriver_act"
-///from base of atom/wrench_act(): (mob/living/user, obj/item/I)
-#define COMSIG_ATOM_WRENCH_ACT "atom_wrench_act"
-///from base of atom/multitool_act(): (mob/living/user, obj/item/I)
-#define COMSIG_ATOM_MULTITOOL_ACT "atom_multitool_act"
-///from base of atom/welder_act(): (mob/living/user, obj/item/I)
-#define COMSIG_ATOM_WELDER_ACT "atom_welder_act"
-///from base of atom/wirecutter_act(): (mob/living/user, obj/item/I)
-#define COMSIG_ATOM_WIRECUTTER_ACT "atom_wirecutter_act"
-///from base of atom/crowbar_act(): (mob/living/user, obj/item/I)
-#define COMSIG_ATOM_CROWBAR_ACT "atom_crowbar_act"
-///from base of atom/analyser_act(): (mob/living/user, obj/item/I)
-#define COMSIG_ATOM_ANALYSER_ACT "atom_analyser_act"
-	#define COMPONENT_BLOCK_TOOL_ATTACK (1<<0)
-///called when teleporting into a protected turf: (channel, turf/origin)
-#define COMSIG_ATOM_INTERCEPT_TELEPORT "intercept_teleport"
-	#define COMPONENT_BLOCK_TELEPORT (1<<0)
-///called when an atom is added to the hearers on get_hearers_in_view(): (list/processing_list, list/hearers)
-#define COMSIG_ATOM_HEARER_IN_VIEW "atom_hearer_in_view"
 ///called when an atom starts orbiting another atom: (atom)
 #define COMSIG_ATOM_ORBIT_BEGIN "atom_orbit_begin"
 ///called when an atom stops orbiting another atom: (atom)
@@ -158,12 +114,6 @@
 	#define COMPONENT_NO_ATTACK_HAND (1<<0)								//works on all 3.
 //This signal return value bitflags can be found in __DEFINES/misc.dm
 
-///called for each movable in a turf contents on /turf/zImpact(): (atom/movable/A, levels)
-#define COMSIG_ATOM_INTERCEPT_Z_FALL "movable_intercept_z_impact"
-///called on a movable (NOT living) when someone starts pulling it (atom/movable/puller, state, force)
-#define COMSIG_ATOM_START_PULL "movable_start_pull"
-///called on /living when someone starts pulling it (atom/movable/puller, state, force)
-#define COMSIG_LIVING_START_PULL "living_start_pull"
 ///called on /living, when pull is attempted, but before it completes, from base of [/mob/living/start_pulling]: (atom/movable/thing, force)
 #define COMSIG_LIVING_TRY_PULL "living_try_pull"
 	#define COMSIG_LIVING_CANCEL_PULL (1 << 0)

--- a/code/__DEFINES/dcs/basetype_signals.dm
+++ b/code/__DEFINES/dcs/basetype_signals.dm
@@ -16,11 +16,6 @@
 /// from base of client/MouseUp(): (/client, object, location, control, params)
 #define COMSIG_CLIENT_MOUSEDRAG "client_mousedrag"
 
-/// from base of area/Entered(): (/area)
-#define COMSIG_ENTER_AREA "enter_area"
-/// from base of area/Exited(): (/area)
-#define COMSIG_EXIT_AREA "exit_area"
-
 // /area
 
 /// from base of area/Entered(): (atom/movable/M)
@@ -32,10 +27,3 @@
 
 ///from base of turf/ChangeTurf(): (path, list/new_baseturfs, flags, list/transferring_comps)
 #define COMSIG_TURF_CHANGE "turf_change"
-///from base of atom/has_gravity(): (atom/asker, list/forced_gravities)
-#define COMSIG_TURF_HAS_GRAVITY "turf_has_gravity"
-///from base of turf/New(): (turf/source, direction)
-#define COMSIG_TURF_MULTIZ_NEW "turf_multiz_new"
-///from base of /turf/proc/levelupdate(). (intact) true to hide and false to unhide
-#define COMSIG_OBJ_HIDE	"obj_hide"
-

--- a/code/__DEFINES/dcs/carbon_signals.dm
+++ b/code/__DEFINES/dcs/carbon_signals.dm
@@ -4,20 +4,10 @@
  * All signals send the source datum of the signal as the first argument
  */
 
-///from base of mob/living/carbon/soundbang_act(): (list(intensity))
-#define COMSIG_CARBON_SOUNDBANG "carbon_soundbang"
 ///from /item/organ/proc/Insert() (/obj/item/organ/)
 #define COMSIG_CARBON_GAIN_ORGAN "carbon_gain_organ"
 ///from /item/organ/proc/Remove() (/obj/item/organ/)
 #define COMSIG_CARBON_LOSE_ORGAN "carbon_lose_organ"
-///from /mob/living/carbon/doUnEquip(obj/item/I, force, newloc, no_move, invdrop, silent)
-#define COMSIG_CARBON_EQUIP_HAT "carbon_equip_hat"
-///from /mob/living/carbon/doUnEquip(obj/item/I, force, newloc, no_move, invdrop, silent)
-#define COMSIG_CARBON_UNEQUIP_HAT "carbon_unequip_hat"
-///defined twice, in carbon and human's topics, fired when interacting with a valid embedded_object to pull it out (mob/living/carbon/target, /obj/item, /obj/item/bodypart/L)
-#define COMSIG_CARBON_EMBED_RIP "item_embed_start_rip"
-///called when removing a given item from a mob, from mob/living/carbon/remove_embedded_object(mob/living/carbon/target, /obj/item)
-#define COMSIG_CARBON_EMBED_REMOVAL "item_embed_remove_safe"
 /// From /mob/living/carbon/swap_hand(): Called when the user swaps their active hand
 #define COMSIG_CARBON_SWAP_HANDS "carbon_swap_hands"
 /// From /mob/living/carbon/toggle_throw_mode()
@@ -39,15 +29,9 @@
 
 
 ///from mob/living/carbon/human/UnarmedAttack(): (atom/target, proximity)
-#define COMSIG_HUMAN_EARLY_UNARMED_ATTACK "human_early_unarmed_attack"
-///from mob/living/carbon/human/UnarmedAttack(): (atom/target, proximity)
 #define COMSIG_HUMAN_MELEE_UNARMED_ATTACK "human_melee_unarmed_attack"
 ///from mob/living/carbon/human/UnarmedAttack(): (mob/living/carbon/human/attacker)
 #define COMSIG_HUMAN_MELEE_UNARMED_ATTACKBY "human_melee_unarmed_attackby"
-///Hit by successful disarm attack (mob/living/carbon/human/attacker,zone_targeted)
-#define COMSIG_HUMAN_DISARM_HIT	"human_disarm_hit"
-///Whenever EquipRanked is called, called after job is set
-#define COMSIG_JOB_RECEIVED "job_received"
 // called after DNA is updated
 #define COMSIG_HUMAN_UPDATE_DNA "human_update_dna"
 /// From mob/living/carbon/human/change_body_accessory(): (mob/living/carbon/human/H, body_accessory_style)

--- a/code/__DEFINES/dcs/datum_signals.dm
+++ b/code/__DEFINES/dcs/datum_signals.dm
@@ -14,8 +14,6 @@
 #define COMSIG_PARENT_PREQDELETED "parent_preqdeleted"
 /// just before a datum's Destroy() is called: (force), at this point none of the other components chose to interrupt qdel and Destroy will be called
 #define COMSIG_PARENT_QDELETING "parent_qdeleting"
-/// generic topic handler (usr, href_list)
-#define COMSIG_TOPIC "handle_topic"
 
 /// fires on the target datum when an element is attached to it (/datum/element)
 #define COMSIG_ELEMENT_ATTACH "element_attach"
@@ -37,12 +35,6 @@
 	/// If returned from this signal, will prevent any surgery splashing.
 	#define COMPONENT_BLOOD_SPLASH_HANDLED (1<<0)
 
-// Sent from a surgery step when organs are being spread from an incision
-#define COMSIG_SURGERY_GERM_SPREAD "surgery_germ_spread"
-	/// If returned from this signal, germ spread will be blocked.
-	#define COMPONENT_GERM_SPREAD_BLOCK (1<<0)
-
-
 // /datum/species
 
 ///from datum/species/on_species_gain(): (datum/species/new_species, datum/species/old_species)
@@ -63,10 +55,6 @@
 
 // /datum/component/decal
 
-///(): Returns bitflags of wet values.
-#define COMSIG_TURF_IS_WET "check_turf_wet"
-///(max_strength, immediate, duration_decrease = INFINITY): Returns bool.
-#define COMSIG_TURF_MAKE_DRY "make_turf_try"
 ///called on an object to clean it of cleanables. Usualy with soap: (num/strength)
 #define COMSIG_COMPONENT_CLEAN_ACT "clean_act"
 
@@ -126,16 +114,9 @@
 
 // other subtypes
 
-/// called by datum/cinematic/play() : (datum/cinematic/new_cinematic)
-#define COMSIG_GLOB_PLAY_CINEMATIC "!play_cinematic"
-	#define COMPONENT_GLOB_BLOCK_CINEMATIC (1<<0)
-
 ///from base of /datum/local_powernet/proc/power_change()
 #define COMSIG_POWERNET_POWER_CHANGE "powernet_power_change"
 
 /// Sent when bodies transfer between shades/shards and constructs
 /// from base of /datum/component/construct_held_body/proc/transfer_held_body()
 #define COMSIG_SHADE_TO_CONSTRUCT_TRANSFER "shade_to_construct_transfer"
-
-///called when you wash your face at a sink: (num/strength)
-#define COMSIG_COMPONENT_CLEAN_FACE_ACT "clean_face_act"

--- a/code/__DEFINES/dcs/dcs_flags.dm
+++ b/code/__DEFINES/dcs/dcs_flags.dm
@@ -29,13 +29,6 @@
 /// each component of the same type is consulted as to whether the duplicate should be allowed
 #define COMPONENT_DUPE_SELECTIVE		5
 
-//Redirection component init flags
-#define REDIRECT_TRANSFER_WITH_TURF 1
-
-//Arch
-#define ARCH_PROB "probability"					//Probability for each item
-#define ARCH_MAXDROP "max_drop_amount"				//each item's max drop amount
-
 //Ouch my toes!
 #define CALTROP_BYPASS_SHOES 1
 #define CALTROP_IGNORE_WALKERS 2

--- a/code/__DEFINES/dcs/global_signals.dm
+++ b/code/__DEFINES/dcs/global_signals.dm
@@ -12,19 +12,12 @@
 #define COMSIG_GLOB_EXPLOSION "!explosion"
 /// job subsystem has spawned and equipped a new mob
 #define COMSIG_GLOB_JOB_AFTER_SPAWN "!job_after_spawn"
-///from SSsun when the sun changes position : (azimuth)
-#define COMSIG_SUN_MOVED "sun_moved"
 ///from SSsecurity_level on planning security level change : (previous_level_number, new_level_number)
 #define COMSIG_SECURITY_LEVEL_CHANGE_PLANNED "security_level_change_planned"
 ///from SSsecurity_level when the security level changes : (previous_level_number, new_level_number)
 #define COMSIG_SECURITY_LEVEL_CHANGED "security_level_changed"
-
-/// mob was created somewhere : (mob)
-#define COMSIG_GLOB_MOB_CREATED "!mob_created"
-/// mob died somewhere : (mob , gibbed)
-#define COMSIG_GLOB_MOB_DEATH "!mob_death"
-/// global living say plug - use sparingly: (mob/speaker , message)
-#define COMSIG_GLOB_LIVING_SAY_SPECIAL "!say_special"
+/// cable was placed or joined somewhere : (turf)
+#define COMSIG_GLOB_CABLE_UPDATED "!cable_updated"
 
 /// Called when the round has started, but before GAME_STATE_PLAYING.
 #define COMSIG_TICKER_ROUND_STARTING "comsig_ticker_round_starting"

--- a/code/__DEFINES/dcs/item_signals.dm
+++ b/code/__DEFINES/dcs/item_signals.dm
@@ -21,73 +21,33 @@
 #define COMSIG_ITEM_BEING_ATTACKED "item_being_attacked"
 ///from base of obj/item/afterattack(): (atom/target, mob/user, params)
 #define COMSIG_ITEM_AFTERATTACK "item_afterattack"
-///from base of obj/item/attack_qdeleted(): (atom/target, mob/user, params)
-#define COMSIG_ITEM_ATTACK_QDELETED "item_attack_qdeleted"
-///from base of obj/item/equipped(): (/mob/equipper, slot)
 ///called on [/obj/item] before unequip from base of [mob/proc/doUnEquip]: (force, atom/newloc, no_move, invdrop, silent)
 #define COMSIG_ITEM_PRE_UNEQUIP "item_pre_unequip"
 	///only the pre unequip can be cancelled
 	#define COMPONENT_ITEM_BLOCK_UNEQUIP (1<<0)
+///from base of obj/item/equipped(): (/mob/equipper, slot)
 #define COMSIG_ITEM_EQUIPPED "item_equip"
 ///from base of obj/item/dropped(): (mob/user)
 #define COMSIG_ITEM_DROPPED "item_drop"
 ///from base of obj/item/pickup(): (/mob/taker)
 #define COMSIG_ITEM_PICKUP "item_pickup"
-///from base of mob/living/carbon/attacked_by(): (mob/living/carbon/target, mob/living/user, hit_zone)
-#define COMSIG_ITEM_ATTACK_ZONE "item_attack_zone"
-///return a truthy value to prevent ensouling, checked in /datum/spell/lichdom/cast(): (mob/user)
-#define COMSIG_ITEM_IMBUE_SOUL "item_imbue_soul"
-///called before marking an object for retrieval, checked in /datum/spell/summonitem/cast() : (mob/user)
-#define COMSIG_ITEM_MARK_RETRIEVAL "item_mark_retrieval"
-	#define COMPONENT_BLOCK_MARK_RETRIEVAL (1<<0)
 ///from base of obj/item/hit_reaction(): (list/args)
 #define COMSIG_ITEM_HIT_REACT "item_hit_react"
 	#define COMPONENT_BLOCK_SUCCESSFUL (1 << 0)
 	#define COMPONENT_BLOCK_PERFECT (1 << 2)
-///called on item when crossed by something (): (/atom/movable, mob/living/crossed)
-#define COMSIG_ITEM_WEARERCROSSED "wearer_crossed"
-///called on item when microwaved (): (obj/machinery/microwave/M)
-#define COMSIG_ITEM_MICROWAVE_ACT "microwave_act"
 ///from base of item/sharpener/attackby(): (amount, max)
 #define COMSIG_ITEM_SHARPEN_ACT "sharpen_act"
 	#define COMPONENT_SHARPEN_APPLIED (1<<0)
 	#define COMPONENT_BLOCK_SHARPEN_BLOCKED (1<<1)
 	#define COMPONENT_BLOCK_SHARPEN_ALREADY (1<<2)
 	#define COMPONENT_BLOCK_SHARPEN_MAXED (1<<3)
-///from base of [/obj/item/proc/tool_check_callback]: (mob/living/user)
-#define COMSIG_TOOL_IN_USE "tool_in_use"
-///from base of [/obj/item/proc/tool_start_check]: (mob/living/user)
-#define COMSIG_TOOL_START_USE "tool_start_use"
 ///from base of [/obj/item/proc/tool_attack_chain]: (atom/tool, mob/user)
 #define COMSIG_TOOL_ATTACK "tool_attack"
 	#define COMPONENT_CANCEL_TOOLACT (1<<0)
-///from [/obj/item/proc/disableEmbedding]:
-#define COMSIG_ITEM_DISABLE_EMBED "item_disable_embed"
-///from [/obj/effect/mine/proc/triggermine]:
-#define COMSIG_MINE_TRIGGERED "minegoboom"
-/// Called by /obj/item/proc/worn_overlays(list/overlays, mutable_appearance/standing, isinhands, icon_file)
-#define COMSIG_ITEM_GET_WORN_OVERLAYS "item_get_worn_overlays"
 /// Called by /obj/item/assembly/signaler(called_from_radio)
 #define COMSIG_ASSEMBLY_PULSED "item_assembly_pulsed"
-
-///called when an item is sold by the exports subsystem
-#define COMSIG_ITEM_SOLD "item_sold"
-///called when a wrapped up structure is opened by hand
-#define COMSIG_STRUCTURE_UNWRAPPED "structure_unwrapped"
-#define COMSIG_ITEM_UNWRAPPED "item_unwrapped"
-///called when a wrapped up item is opened by hand
-	#define COMSIG_ITEM_SPLIT_VALUE  (1<<0)
-///called when getting the item's exact ratio for cargo's profit.
-#define COMSIG_ITEM_SPLIT_PROFIT "item_split_profits"
-///called when getting the item's exact ratio for cargo's profit, without selling the item.
-#define COMSIG_ITEM_SPLIT_PROFIT_DRY "item_split_profits_dry"
-
-// /obj/item/clothing
-
 ///from [/mob/living/carbon/human/Move]: ()
 #define COMSIG_SHOES_STEP_ACTION "shoes_step_action"
-///from base of /obj/item/clothing/suit/space/proc/toggle_spacesuit(): (obj/item/clothing/suit/space/suit)
-#define COMSIG_SUIT_SPACE_TOGGLE "suit_space_toggle"
 
 // /obj/item/implant
 
@@ -112,27 +72,6 @@
 #define COMSIG_IMPLANT_REMOVED "implant_removed"
 
 
-// /obj/item/pda
-
-///called on pda when the user changes the ringtone: (mob/living/user, new_ringtone)
-#define COMSIG_PDA_CHANGE_RINGTONE "pda_change_ringtone"
-	#define COMPONENT_STOP_RINGTONE_CHANGE (1<<0)
-#define COMSIG_PDA_CHECK_DETONATE "pda_check_detonate"
-	#define COMPONENT_PDA_NO_DETONATE (1<<0)
-
-
-// /obj/item/radio
-
-///called from base of /obj/item/radio/proc/set_frequency(): (list/args)
-#define COMSIG_RADIO_NEW_FREQUENCY "radio_new_frequency"
-
-
-// /obj/item/pen
-
-///called after rotation in /obj/item/pen/attack_self(): (rotation, mob/living/carbon/user)
-#define COMSIG_PEN_ROTATED "pen_rotated"
-
-
 // /obj/item/gun
 
 ///called in /obj/item/gun/fire_gun (user, target, flag, params)
@@ -148,14 +87,6 @@
 /// called in /datum/component/automatic_fire/proc/process_shot(): (atom/target, mob/living/shooter, allow_akimbo, params)
 #define COMSIG_AUTOFIRE_SHOT "autofire_shot"
 	#define COMPONENT_AUTOFIRE_SHOT_SUCCESS (1<<0)
-
-
-// /obj/item/grenade
-
-///called in /obj/item/gun/process_fire (user, target, params, zone_override)
-#define COMSIG_GRENADE_PRIME "grenade_prime"
-///called in /obj/item/gun/process_fire (user, target, params, zone_override)
-#define COMSIG_GRENADE_ARMED "grenade_armed"
 
 
 // /obj/item/mod
@@ -196,10 +127,7 @@
 #define COMSIG_MOD_WEARER_UNSET "mod_wearer_unset"
 
 
-// /obj/item/food
-
-///from base of obj/item/food/attack(): (mob/living/eater, mob/feeder)
-#define COMSIG_FOOD_EATEN "food_eaten"
+// other items
 
 /// from base of /obj/item/slimepotion/speed/afterattack(): (obj/target, /obj/src, mob/user)
 #define COMSIG_SPEED_POTION_APPLIED "speed_potion"

--- a/code/__DEFINES/dcs/machinery_signals.dm
+++ b/code/__DEFINES/dcs/machinery_signals.dm
@@ -4,31 +4,28 @@
  * All signals send the source datum of the signal as the first argument
  */
 
-///from /obj/machinery/obj_break(damage_flag): (damage_flag)
-#define COMSIG_MACHINERY_BROKEN "machinery_broken"
-///from base power_change() when power is lost
-#define COMSIG_MACHINERY_POWER_LOST "machinery_power_lost"
-///from base power_change() when power is restored
-#define COMSIG_MACHINERY_POWER_RESTORED "machinery_power_restored"
-
 
 // /obj/machinery/camera
 
+/// called on cameras after activation: (mob/user, display_message)
 #define COMSIG_CAMERA_ON "camera_on"
+/// called on cameras after deactivation: (mob/user, display_message, emped)
 #define COMSIG_CAMERA_OFF "camera_off"
+/// called on cameras when moved, such as ones inside helmets: (turf/prev_turf)
 #define COMSIG_CAMERA_MOVED "camera_moved"
 
 
 // /obj/machinery/door
 
+/// called on doors when opened: ()
 #define COMSIG_DOOR_OPEN "door_open"
+/// called on doors when closed: ()
 #define COMSIG_DOOR_CLOSE "door_close"
 
 
 // /obj/machinery/door/airlock
 
+/// called on airlocks when opened: ()
 #define COMSIG_AIRLOCK_OPEN "airlock_open"
+/// called on airlocks when closed: ()
 #define COMSIG_AIRLOCK_CLOSE "airlock_close"
-
-/// ingame button pressed (/obj/machinery/button/button)
-#define COMSIG_GLOB_BUTTON_PRESSED "!button_pressed"

--- a/code/__DEFINES/dcs/mob_signals.dm
+++ b/code/__DEFINES/dcs/mob_signals.dm
@@ -38,8 +38,6 @@
 #define COMSIG_MOB_APPLY_DAMAGE	"mob_apply_damage"
 ///from base of obj/item/afterattack(): (atom/target, mob/user, proximity_flag, click_parameters)
 #define COMSIG_MOB_ITEM_AFTERATTACK "mob_item_afterattack"
-///from base of obj/item/attack_qdeleted(): (atom/target, mob/user, proxiumity_flag, click_parameters)
-#define COMSIG_MOB_ITEM_ATTACK_QDELETED "mob_item_attack_qdeleted"
 ///from base of mob/RangedAttack(): (atom/A, params)
 #define COMSIG_MOB_ATTACK_RANGED "mob_attack_ranged"
 ///from base of /mob/throw_item(): (atom/target)
@@ -202,4 +200,7 @@
 /// from observer_base/do_observe(): (mob/no_longer_following)
 #define COMSIG_GHOST_STOP_OBSERVING "ghost_stop_observing"
 
+// other signals
+
+/// called when a living mob's stun status is cleared: ()
 #define COMSIG_LIVING_CLEAR_STUNS "living_clear_stuns"

--- a/code/__DEFINES/dcs/movable_signals.dm
+++ b/code/__DEFINES/dcs/movable_signals.dm
@@ -4,9 +4,6 @@
  * All signals send the source datum of the signal as the first argument
  */
 
-///from base of atom/movable/Moved(): (/atom)
-#define COMSIG_MOVABLE_PRE_MOVE "movable_pre_move"
-	#define COMPONENT_MOVABLE_BLOCK_PRE_MOVE (1<<0)
 ///from base of atom/movable/Moved(): (/atom, dir)
 #define COMSIG_MOVABLE_MOVED "movable_moved"
 ///from base of atom/movable/Cross(): (/atom/movable)
@@ -38,22 +35,12 @@
 ///from /obj/vehicle/proc/driver_move, caught by the riding component to check and execute the driver trying to drive the vehicle
 #define COMSIG_RIDDEN_DRIVER_MOVE "driver_move"
 	#define COMPONENT_DRIVER_BLOCK_MOVE (1<<0)
-///from base of atom/movable/throw_at(): (list/args)
-#define COMSIG_MOVABLE_PRE_THROW "movable_pre_throw"
-	#define COMPONENT_CANCEL_THROW (1<<0)
 ///from base of atom/movable/throw_at(): (datum/thrownthing, spin)
 #define COMSIG_MOVABLE_POST_THROW "movable_post_throw"
 ///from base of datum/thrownthing/finalize(): (obj/thrown_object, datum/thrownthing) used for when a throw is finished
 #define COMSIG_MOVABLE_THROW_LANDED "movable_throw_landed"
 ///from base of atom/movable/onTransitZ(): (old_z, new_z)
 #define COMSIG_MOVABLE_Z_CHANGED "movable_ztransit"
-///called when the movable is placed in an unaccessible area, used for stationloving: ()
-#define COMSIG_MOVABLE_SECLUDED_LOCATION "movable_secluded"
-///from base of atom/movable/Hear(): (proc args list(message, atom/movable/speaker, message_language, raw_message, radio_freq, list/spans, message_mode))
-#define COMSIG_MOVABLE_HEAR "movable_hear"
-	#define HEARING_MESSAGE 1
-	#define HEARING_SPEAKER 2
-	#define HEARING_RAW_MESSAGE 4
 
 /// Called just before something gets untilted
 #define COMSIG_MOVABLE_TRY_UNTILT "movable_try_untilt"

--- a/code/__DEFINES/dcs/obj_signals.dm
+++ b/code/__DEFINES/dcs/obj_signals.dm
@@ -8,41 +8,6 @@
 
 ///from base of obj/deconstruct(): (disassembled)
 #define COMSIG_OBJ_DECONSTRUCT "obj_deconstruct"
-///called in /obj/structure/setAnchored(): (value)
-#define COMSIG_OBJ_SETANCHORED "obj_setanchored"
-///from base of code/game/machinery
-#define COMSIG_OBJ_DEFAULT_UNFASTEN_WRENCH "obj_default_unfasten_wrench"
-///called in /obj/update_icon()
-#define COMSIG_OBJ_UPDATE_ICON "obj_update_icon"
-
-
-// /obj/projectile (sent to the firer)
-
-///from base of /obj/projectile/proc/on_hit(): (atom/movable/firer, atom/target, Angle)
-#define COMSIG_PROJECTILE_SELF_ON_HIT "projectile_self_on_hit"
-///from base of /obj/projectile/proc/on_hit(): (atom/movable/firer, atom/target, Angle)
-#define COMSIG_PROJECTILE_ON_HIT "projectile_on_hit"
-///from base of /obj/projectile/proc/fire(): (obj/projectile, atom/original_target)
-#define COMSIG_PROJECTILE_BEFORE_FIRE "projectile_before_fire"
-///from the base of /obj/projectile/proc/fire(): ()
-#define COMSIG_PROJECTILE_FIRE "projectile_fire"
-///sent to targets during the process_hit proc of projectiles
-#define COMSIG_PROJECTILE_PREHIT "com_proj_prehit"
-///sent to targets during the process_hit proc of projectiles
-#define COMSIG_PROJECTILE_RANGE_OUT "projectile_range_out"
-///sent when trying to force an embed (mainly for projectiles, only used in the embed element)
-#define COMSIG_EMBED_TRY_FORCE "item_try_embed"
-///sent to targets during the process_hit proc of projectiles
-#define COMSIG_PELLET_CLOUD_INIT "pellet_cloud_init"
-
-
-// /obj/mecha
-
-///sent from mecha action buttons to the mecha they're linked to
-#define COMSIG_MECHA_ACTION_ACTIVATE "mecha_action_activate"
-
-/// cable was placed or joined somewhere : (turf)
-#define COMSIG_GLOB_CABLE_UPDATED "!cable_updated"
 
 
 // /obj/structure/cursed_slot_machine
@@ -55,9 +20,3 @@
 #define COMSIG_CURSED_SLOT_MACHINE_LOST "cursed_slot_machine_lost"
 /// from /obj/structure/cursed_slot_machine/determine_victor() when someone finally wins.
 #define COMSIG_GLOB_CURSED_SLOT_MACHINE_WON "cursed_slot_machine_won"
-
-
-// other subtypes
-
-///from base of /obj/effect/decal/cleanable/blood/gibs/streak(): (list/directions, list/diseases)
-#define COMSIG_GIBS_STREAK "gibs_streak"


### PR DESCRIPTION
**What Does This PR Do:** This PR removes all unused signals from the signal defines. Only signals that are never sent are removed. Sent signals with no registrars remain. Many of them are obsolete, many of them never applied to our codebase, many of them refer to being fired in procs that don't exist. Some of them could be useful, if one were to take the time to implement them (see #26703). If someone wants to do that, they're welcome to, and add the signal back in. But until then, it's pointless having them around.

**Why It's Good For The Game:** Less code, less confusion about what signals are actually being used.

**Testing:** Built code and ran CI.

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog
NPFC