### PR TITLE
[FIX] Cult Shadow Shackles can now cuff people who are missing an arm.

### DIFF
--- a/code/game/gamemodes/cult/blood_magic.dm
+++ b/code/game/gamemodes/cult/blood_magic.dm
@@ -566,11 +566,10 @@
 		return
 	if(iscarbon(target) && proximity)
 		var/mob/living/carbon/C = target
-		if(C.canBeHandcuffed() || C.get_arm_ignore())
-			CuffAttack(C, user)
-		else
+		if(!(C.has_left_hand() || C.has_right_hand()))
 			user.visible_message("<span class='cultitalic'>This victim doesn't have enough arms to complete the restraint!</span>")
 			return
+		CuffAttack(C, user)
 		source.UpdateButtons()
 		..()
 

--- a/code/modules/mob/living/carbon/human/human_mob.dm
+++ b/code/modules/mob/living/carbon/human/human_mob.dm
@@ -1608,12 +1608,6 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 #undef CPR_CHEST_COMPRESSION_RESTORATION
 #undef CPR_BREATHS_RESTORATION
 
-/mob/living/carbon/human/canBeHandcuffed()
-	if(get_num_arms() >= 2)
-		return TRUE
-	else
-		return FALSE
-
 /mob/living/carbon/human/has_mutated_organs()
 	for(var/obj/item/organ/external/E in bodyparts)
 		if(E.status & ORGAN_MUTATED)

--- a/code/modules/surgery/organs/organ_helpers.dm
+++ b/code/modules/surgery/organs/organ_helpers.dm
@@ -74,19 +74,6 @@
 		return TRUE
 	return FALSE
 
-//Limb numbers
-/mob/proc/get_num_arms()
-	return 2
-
-/mob/living/carbon/human/get_num_arms()
-	. = 0
-	for(var/X in bodyparts)
-		var/obj/item/organ/external/affecting = X
-		if(affecting.body_part == ARM_RIGHT)
-			.++
-		if(affecting.body_part == ARM_LEFT)
-			.++
-
 /mob/proc/get_num_legs()
 	return 2
 

--- a/code/modules/surgery/organs/organ_helpers.dm
+++ b/code/modules/surgery/organs/organ_helpers.dm
@@ -87,11 +87,6 @@
 		if(affecting.body_part == ARM_LEFT)
 			.++
 
-//sometimes we want to ignore that we don't have the required amount of arms.
-/mob/proc/get_arm_ignore()
-	return FALSE
-
-
 /mob/proc/get_num_legs()
 	return 2
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Gives the Shadow Shackle cult spell the ability to cuff people who are missing an arm.
Fixes #26706
Removes procs that were only used for this one check.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Normal cuffs can do this, so cult cuffs should be able to as well.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Cuffed an IPC with both 2 and 1 arm. Failed to cuff an unarmed (heh) IPC.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Cult Shadow Shackles can now cuff people who are missing an arm.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
