### PR TITLE
fix squeak component

### DIFF
--- a/code/datums/components/squeak.dm
+++ b/code/datums/components/squeak.dm
@@ -71,26 +71,34 @@
 	else
 		steps++
 
-/datum/component/squeak/proc/play_squeak_crossed(atom/movable/AM)
-	if(isitem(AM))
-		var/obj/item/I = AM
-		if(I.flags & ABSTRACT)
-			return
-		else if(isprojectile(AM))
-			var/obj/item/projectile/P = AM
-			if(P.original != parent)
-				return
-	if(ismob(AM))
-		var/mob/M = AM
+/datum/component/squeak/proc/play_squeak_crossed(atom/source, atom/movable/crossing)
+	if(istype(crossing, /obj/effect))
+		return
+	if(ismob(crossing))
+		var/mob/M = crossing
 		if(M.flying)
 			return
-		if(isliving(AM))
+		if(isliving(crossing))
 			var/mob/living/L = M
 			if(L.floating)
 				return
-	var/atom/current_parent = parent
-	if(isturf(current_parent.loc))
-		play_squeak()
+	else if(isitem(crossing))
+		var/obj/item/I = source
+		if(I.flags & ABSTRACT)
+			return
+		if(isprojectile(crossing))
+			var/obj/item/projectile/P = crossing
+			if(P.original != parent)
+				return
+	if(ismob(source))
+		var/mob/M = source
+		if(M.flying)
+			return
+		if(isliving(source))
+			var/mob/living/L = M
+			if(L.floating)
+				return
+	play_squeak()
 
 /datum/component/squeak/proc/use_squeak()
 	if(last_use + use_delay < world.time)


### PR DESCRIPTION
Continuation of #26461 because you can't reopen PRs with force-pushed branches, apparently.
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
fixes #10334 "Blood crawling slaughter demons make rubber duckies squeak"
fixes squeak component being confused about what is the crossed and what is the crossing atom
prevents some potential runtimes in play_squeak_crossed
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Less bugs, less runtimes and it is more intuitive if blood crawling demons don't cause things in the normal plane to squeak.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

- Walked normally and
- - Walked over ducky as human. It  squeaked.
- - Walked over a resting jestosterone'd human as human. They squeaked.
- - Walked over ducky as slaughter demon. It  squeaked.
- - Blood crawled below the ducky. It didn't squeak.
- - Threw ducky. (just to be safe.) It  squeaked.
- Mounted a broom as wizard and
- - Flew over ducky as human. It didn't squeak.
- - Flew over jestosterone'd human as human. They didn't squeak.
- - Walked with another human over the flying, jestosterone'd and resting wizard. They didn't squeak.
- Turned off gravity and
- - Floated over the ducky. It didn't squeak.
- - Floated over the resting jestosterone'd human. They didn't squeak.
- - Floated over the resting jestosterone'd human as slaughter  demon. They didn't squeak.

<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Things like blood crawling slaughter demons no longer cause squeaky things to squeak when passing over them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
