### PR TITLE
Fix SMES not working after recharge

### DIFF
--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -293,7 +293,7 @@
 			if(output_used < 0.0001)		// Either from no charge or set to 0
 				outputting = FALSE
 				investigate_log("lost power and turned <font color='red'>off</font>", "singulo")
-		else if(output_attempt && charge > output_level && output_level > 0)
+		else if(output_attempt && charge > 0 && output_level > 0)
 			outputting = TRUE
 		else
 			output_used = 0


### PR DESCRIPTION
## What Does This PR Do
Fixes SMES not outputting if it has been recharged.

## Why It's Good For The Game
The current check makes SMES not working. The `charge` should not be compared to `output_level`, because these values have different sense (the first one is *kinda* charge, the second one is power). Low charge will just lead to low output.

## Testing
1. Discharge a SMES.
2. Set output to something > 0. Provide some power to it. 
3. Start recharging.
4. SMES provides power.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl: Maxiemar
fix: SMES now recharges correctly providing power.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
