### PR TITLE
Conveyer belts and Disposals units no longer steal items on nonhelp intents

### DIFF
--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -55,7 +55,8 @@ GLOBAL_LIST_EMPTY(conveyor_switches)
 /obj/machinery/conveyor/attackby(obj/item/I, mob/user)
 	if(stat & BROKEN)
 		return ..()
-	else if(istype(I, /obj/item/conveyor_switch_construct))
+
+	if(istype(I, /obj/item/conveyor_switch_construct))
 		var/obj/item/conveyor_switch_construct/S = I
 		if(S.id == id)
 			return ..()
@@ -64,11 +65,14 @@ GLOBAL_LIST_EMPTY(conveyor_switches)
 				CS.conveyors -= src
 		id = S.id
 		to_chat(user, "<span class='notice'>You link [I] with [src].</span>")
-	else if(user.a_intent != INTENT_HARM)
+		return
+
+	if(user.a_intent == INTENT_HELP)
 		if(user.drop_item())
 			I.forceMove(loc)
-	else
-		return ..()
+		return
+
+	return ..()
 
 
 /obj/machinery/conveyor/crowbar_act(mob/user, obj/item/I)

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -127,6 +127,9 @@
 	if(stat & BROKEN || !user || I.flags & ABSTRACT)
 		return
 
+	if(user.a_intent != INTENT_HELP)
+		return
+
 	src.add_fingerprint(user)
 
 	if(istype(I, /obj/item/melee/energy/blade))

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -128,7 +128,7 @@
 		return
 
 	if(user.a_intent != INTENT_HELP)
-		return
+		return ..()
 
 	src.add_fingerprint(user)
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
This PR fixes behaviour of coveyer belts and disposal units, making you place an item on/in it only on help intent so you dont randomly loose your baton

## Why It's Good For The Game
Fixes are good, Something that stores items acting like everything else storing items is good.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

<!-- How did you test the PR, if at all? -->
Compiled, put items on belt, in disposals unit, made sure you're not doing this on disarm
<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Conveyer belts and Disposals units will only place your item in on help intent
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
