### PR TITLE
docs: add generic site description for social cards

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,6 @@
 site_name: Paradise Contributor Documentation
 site_url: https://devdocs.paradisestation.org
+site_description: Paradise Contributor Documentation
 
 theme:
   name: material


### PR DESCRIPTION
## What Does This PR Do
Fixes the "None" text that shows up on social preview cards.
## Why It's Good For The Game
"None" looks bad.
## Images of changes
![2024_09_08__14_08_56__Guide to Testing - Paradise Contributor Documentation](https://github.com/user-attachments/assets/7ca302ec-de2d-48c9-ace4-e9513eab501a)
## Testing
See above
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog
NPFC