### PR TITLE
fix: R&D rework: convert rest of tgui_alert choices to lists

### DIFF
--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -433,7 +433,7 @@
 		if("unlink")
 			if(!network_manager_uid)
 				return
-			var/choice = tgui_alert(usr, "Are you SURE you want to unlink this fabricator?\nYou wont be able to re-link without the network manager password", "Unlink","Yes","No")
+			var/choice = tgui_alert(usr, "Are you SURE you want to unlink this fabricator?\nYou wont be able to re-link without the network manager password", "Unlink", list("Yes", "No"))
 			if(choice == "Yes")
 				unlink()
 

--- a/code/modules/research/backup_console.dm
+++ b/code/modules/research/backup_console.dm
@@ -156,7 +156,7 @@
 			if(!T)
 				return
 
-			var/choice = tgui_alert(usr, "Do you want to import this level to the network (Network level: [T.level] | Disk level: [inserted_disk.stored_tech_assoc[tech]])", "Data Import", "Yes", "No")
+			var/choice = tgui_alert(usr, "Do you want to import this level to the network (Network level: [T.level] | Disk level: [inserted_disk.stored_tech_assoc[tech]])", "Data Import", list("Yes", "No"))
 			if(choice != "Yes")
 				return FALSE
 
@@ -180,7 +180,7 @@
 			if(!T)
 				return
 
-			var/choice = tgui_alert(usr, "Do you want to export this tech data to the disk (Network level: [T.level] | Disk level: [inserted_disk.stored_tech_assoc[tech]])", "Data Export", "Yes", "No")
+			var/choice = tgui_alert(usr, "Do you want to export this tech data to the disk (Network level: [T.level] | Disk level: [inserted_disk.stored_tech_assoc[tech]])", "Data Export", list("Yes", "No"))
 			if(choice != "Yes")
 				return FALSE
 
@@ -199,7 +199,7 @@
 				network_manager_uid = null
 				return FALSE
 
-			var/choice = tgui_alert(usr, "Are you SURE you want to import all the data on the disk to the network?", "Data Import", "Yes", "No")
+			var/choice = tgui_alert(usr, "Are you SURE you want to import all the data on the disk to the network?", "Data Import", list("Yes", "No"))
 			if(choice != "Yes")
 				return FALSE
 
@@ -220,7 +220,7 @@
 				network_manager_uid = null
 				return FALSE
 
-			var/choice = tgui_alert(usr, "Are you SURE you want to export all the data on the network to the disk?", "Data Export", "Yes", "No")
+			var/choice = tgui_alert(usr, "Are you SURE you want to export all the data on the network to the disk?", "Data Export", list("Yes", "No"))
 			if(choice != "Yes")
 				return FALSE
 


### PR DESCRIPTION
## What Does This PR Do
This PR fixes the tgui_alert calls in the R&D rework refactor to the correct arguments.
## Why It's Good For The Game
Runtimes bad.
## Testing
Visual inspection and prayer.
<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: GUIs for the mech fabricator and backup console now correctly handle unlinking and data disk uploads.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
