### PR TITLE
Fixes holo stretcher misspelling

### DIFF
--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -63,7 +63,7 @@
 	category = list("Medical")
 
 /datum/design/holostretcher
-	name = "Holo Strecher"
+	name = "Holo Stretcher"
 	desc = "A hardlight projector for transporting patients."
 	id = "holo_stretcher"
 	req_tech = list("magnets" = 5, "powerstorage" = 4)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #26718
Makes the RnD console call holo stretcher for holo stretcher and not holo strecher

## Why It's Good For The Game

Spelling mistake bad

## Images of changes

![image](https://github.com/user-attachments/assets/ea6ad7e9-b059-43a5-ba99-fa17ee313bc2)

## Testing

I did RnD, then searched for "holo". I saw "holo stretcher" as an option and not "holo strecher"

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:

spellcheck: Fixed a typo in holo stretcher name

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
