### PR TITLE
Removes tech levels from four high risk items

### DIFF
--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -245,8 +245,9 @@
 	hardened = TRUE // EMP-proof (on the component), but not emag-proof.
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF // Objective item, better not have it destroyed.
 	heart_attack_probability = 10
+	origin_tech = null
 	/// To prevent spam from the emagging message on the advanced defibrillator.
-	var/next_emp_message 
+	var/next_emp_message
 
 /obj/item/defibrillator/compact/advanced/examine(mob/user)
 	. = ..()

--- a/code/game/objects/items/weapons/knuckledusters.dm
+++ b/code/game/objects/items/weapons/knuckledusters.dm
@@ -65,7 +65,7 @@
 	icon_state = "knuckleduster_nt"
 	force = 10
 	throwforce = 5
-	origin_tech = "combat=3"
+	origin_tech = null
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF // Steal objectives shouldnt be easy to destroy.
 	materials = list(MAT_GOLD = 500, MAT_TITANIUM = 200, MAT_PLASMA = 200)
 	trauma = 10

--- a/code/game/objects/items/weapons/melee/melee_misc.dm
+++ b/code/game/objects/items/weapons/melee/melee_misc.dm
@@ -34,7 +34,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	armour_penetration_percentage = 75
 	sharp = TRUE
-	origin_tech = "combat=5"
+	origin_tech = null
 	attack_verb = list("lunged at", "stabbed")
 	hitsound = 'sound/weapons/rapierhit.ogg'
 	materials = list(MAT_METAL = 1000)

--- a/code/game/objects/items/weapons/teleportation.dm
+++ b/code/game/objects/items/weapons/teleportation.dm
@@ -17,7 +17,7 @@
 	throw_speed = 3
 	throw_range = 5
 	materials = list(MAT_METAL=10000)
-	origin_tech = "magnets=3;bluespace=4"
+	origin_tech = null
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 30, RAD = 0, FIRE = 100, ACID = 100)
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	var/icon_state_inactive = "hand_tele_inactive"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

This PR removes the tech origins, and by extension the ability to destroyed at RnD, from the hand teleporter, captain's rapier, QM knuckledusters, and CMO defib.

## Why It's Good For The Game

Destroying these items via RND in most cases is a rule break. There is no reason for these items to have a tech origin. No other high risk items have tech origins.

## Testing

Ensured all four items could no longer be deconstructed at RnD

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<details>
<summary> Approval screenie </summary>
![image](https://github.com/user-attachments/assets/901d4b5b-aa5e-45a1-9c04-dd3eeb91595b)
</details>
  <hr>



## Changelog

:cl:
tweak: removed tech origin from hand teleporter, Captain's rapier, QM knuckledusters, and CMO defib
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
