### PR TITLE
Vaporizes NT Supreme Court

### DIFF
--- a/code/game/jobs/job/supervisor.dm
+++ b/code/game/jobs/job/supervisor.dm
@@ -265,7 +265,7 @@
 	department_flag = JOBCAT_ENGSEC
 	total_positions = 1
 	spawn_positions = 1
-	supervisors = "Central Command"
+	supervisors = "Nanotrasen Asset Protection"
 	department_head = list("Captain")
 	selection_color = "#ddddff"
 	req_admin_notify = TRUE

--- a/code/game/jobs/job/supervisor.dm
+++ b/code/game/jobs/job/supervisor.dm
@@ -265,7 +265,7 @@
 	department_flag = JOBCAT_ENGSEC
 	total_positions = 1
 	spawn_positions = 1
-	supervisors = "the Nanotrasen Supreme Court"
+	supervisors = "Central Command"
 	department_head = list("Captain")
 	selection_color = "#ddddff"
 	req_admin_notify = TRUE


### PR DESCRIPTION
## What Does This PR Do
Title.

Removes the one (1) singular reference to the NT Supreme Court existing in the game.

Makes the Magi now answer to Nanotrasen Asset Protection, the place where their legal team is.

## Why It's Good For The Game
NT has no reason to have a supreme court. It is a company.

It makes much more sense for the legal rep on station to answer to the legal team in Asset Protection.

## Testing

- Joined game as Magi
- I answer to NAP now

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  
  <hr>

## Changelog

:cl:
tweak: Magistrate now answers to NAP as the station arbiter of Space Law
/:cl: