### PR TITLE
Makes chemical flamethrowers more efficient

### DIFF
--- a/code/game/objects/items/weapons/chemical_flamethrower/chemical_flamethrower.dm
+++ b/code/game/objects/items/weapons/chemical_flamethrower/chemical_flamethrower.dm
@@ -29,6 +29,8 @@
 	var/canister_burn_duration = 10 SECONDS
 	/// How many firestacks will our reagent apply
 	var/canister_fire_applications = 1
+	/// How much ammo do we use per tile?
+	var/ammo_usage = 2
 	/// Is this a syndicate flamethrower
 	var/syndicate = FALSE
 
@@ -138,7 +140,7 @@
 	for(var/turf/simulated/T in turflist)
 		if(iswallturf(T)) // No going through walls
 			break
-		if(!use_ammo(3))
+		if(!use_ammo(ammo_usage))
 			to_chat(user, "<span class='warning'>You hear a click!</span>")
 			playsound(user, 'sound/weapons/empty.ogg', 100, TRUE)
 			break // Whoops! No ammo!


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Chemical flamethrowers now use 2 ammo per tile of fire, instead of 3. This increases the effective ammo of a flamethrower by about 50%. Sounds like a lot, but the basic canister goes from 34 tiles to 50. Extended canisters go from 60-ish to 100.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
While the flamethrower feels good, it definitely has some ammo issues. You'll eat through extended canisters like candy - also partially because there isn't anything to show if you use a flamethrower again on already burning tiles.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Shot a flamethrower, I could shoot more tiles than before
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration
![image](https://github.com/user-attachments/assets/b3bbfa62-3f6e-42fa-a88a-401af1f2f6f1)

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
tweak: Chemical flamethrowers now use slightly less ammo
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
