### PR TITLE
reflectors anchor on mapload

### DIFF
--- a/_maps/map_files/stations/boxstation.dmm
+++ b/_maps/map_files/stations/boxstation.dmm
@@ -54610,7 +54610,6 @@
 /area/station/maintenance/apmaint)
 "fdg" = (
 /obj/structure/reflector/single{
-	anchored = 1;
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
@@ -68254,7 +68253,6 @@
 /area/station/aisat/service)
 "lKP" = (
 /obj/structure/reflector/single{
-	anchored = 1;
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -73967,9 +73965,7 @@
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
 "oBR" = (
-/obj/structure/reflector/double{
-	anchored = 1
-	},
+/obj/structure/reflector/double,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -77728,7 +77724,6 @@
 /area/station/maintenance/aft)
 "qpq" = (
 /obj/structure/reflector/box{
-	anchored = 1;
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{

--- a/_maps/map_files/stations/cerestation.dmm
+++ b/_maps/map_files/stations/cerestation.dmm
@@ -26558,25 +26558,21 @@
 /area/station/maintenance/apmaint)
 "cWI" = (
 /obj/structure/reflector/single{
-	dir = 4;
-	anchored = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/station/engineering/control)
 "cWK" = (
-/obj/structure/reflector/box{
-	anchored = 1
-	},
+/obj/structure/reflector/box,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/station/engineering/control)
 "cWO" = (
 /obj/structure/reflector/single{
-	dir = 1;
-	anchored = 1
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"

--- a/_maps/map_files/stations/cerestation.dmm
+++ b/_maps/map_files/stations/cerestation.dmm
@@ -26558,21 +26558,25 @@
 /area/station/maintenance/apmaint)
 "cWI" = (
 /obj/structure/reflector/single{
-	dir = 4
+	dir = 4;
+	anchored = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/station/engineering/control)
 "cWK" = (
-/obj/structure/reflector/box,
+/obj/structure/reflector/box{
+	anchored = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/station/engineering/control)
 "cWO" = (
 /obj/structure/reflector/single{
-	dir = 1
+	dir = 1;
+	anchored = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"

--- a/_maps/map_files/stations/deltastation.dmm
+++ b/_maps/map_files/stations/deltastation.dmm
@@ -4293,15 +4293,12 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/controlroom)
 "aud" = (
-/obj/structure/reflector/box{
-	anchored = 1
-	},
+/obj/structure/reflector/box,
 /obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/controlroom)
 "aue" = (
 /obj/structure/reflector/single{
-	anchored = 1;
 	dir = 4
 	},
 /turf/simulated/floor/plasteel/dark,
@@ -80649,9 +80646,7 @@
 /turf/simulated/floor/wood,
 /area/station/maintenance/library)
 "nvp" = (
-/obj/structure/reflector/double{
-	anchored = 1
-	},
+/obj/structure/reflector/double,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/controlroom)
 "nvr" = (

--- a/_maps/map_files/stations/deltastation.dmm
+++ b/_maps/map_files/stations/deltastation.dmm
@@ -4293,7 +4293,9 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/controlroom)
 "aud" = (
-/obj/structure/reflector/box,
+/obj/structure/reflector/box{
+	anchored = 1
+	},
 /obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/controlroom)
@@ -80647,7 +80649,9 @@
 /turf/simulated/floor/wood,
 /area/station/maintenance/library)
 "nvp" = (
-/obj/structure/reflector/double,
+/obj/structure/reflector/double{
+	anchored = 1
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/controlroom)
 "nvr" = (

--- a/_maps/map_files/stations/metastation.dmm
+++ b/_maps/map_files/stations/metastation.dmm
@@ -9555,7 +9555,6 @@
 /area/station/engineering/engine/supermatter)
 "aSp" = (
 /obj/structure/reflector/box{
-	anchored = 1;
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
@@ -57290,7 +57289,6 @@
 /area/station/service/clown)
 "jbk" = (
 /obj/structure/reflector/double{
-	anchored = 1;
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
@@ -66840,7 +66838,6 @@
 /area/station/legal/courtroom/gallery)
 "mZJ" = (
 /obj/structure/reflector/single{
-	anchored = 1;
 	dir = 8
 	},
 /turf/simulated/floor/plating,
@@ -84731,7 +84728,6 @@
 /area/station/medical/chemistry)
 "uLE" = (
 /obj/structure/reflector/single{
-	anchored = 1;
 	dir = 1
 	},
 /turf/simulated/floor/plating,

--- a/code/game/objects/structures/reflector.dm
+++ b/code/game/objects/structures/reflector.dm
@@ -11,6 +11,10 @@
 	var/obj/item/stack/sheet/build_stack_type
 	var/build_stack_amount
 
+/obj/structure/reflector/Initialize(mapload)
+	. = ..()
+	if(mapload)
+		anchored = TRUE
 
 /obj/structure/reflector/bullet_act(obj/item/projectile/P)
 	var/turf/reflector_turf = get_turf(src)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Makes the maps consistent by having the reflectors by supermatter welded down, so engineers don't get surprised half the time as the emitters just break

## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

See above, you shouldn't be gaslighted half the time as engineering

## Testing
forced map, turned on emitters
reflected without breaking
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Reflectors now anchor on mapload, to avoid sm setups breaking rounstart
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
