### PR TITLE
Updates RPD Auto-Wrenching

### DIFF
--- a/code/game/objects/items/weapons/rpd.dm
+++ b/code/game/objects/items/weapons/rpd.dm
@@ -192,7 +192,13 @@
 	QDEL_NULL(P)
 	activate_rpd()
 
-/// Automatically wrenches down an atmos device/pipe if the user has a wrench equipped in their off-hand (or in an inactive module slot as a robot).
+/**
+* Automatically wrenches down an atmos device/pipe if the user has a wrench equipped in their off-hand (or in an inactive module slot as a robot).
+* Arguments:
+* * user - the user of the RPD.
+* * target - the pipe/device/tube being placed by the RPD.
+* * tool_type - the tool behavour required for the target to be wrenched down (some devices have a different requirement than `TOOL_WRENCH`).
+*/
 /obj/item/rpd/proc/automatic_wrench_down(mob/living/user, obj/item/target, tool_type = TOOL_WRENCH)
 	var/obj/item/off_hand_item = user.get_inactive_hand()
 	if(isrobot(user))

--- a/code/game/objects/items/weapons/rpd.dm
+++ b/code/game/objects/items/weapons/rpd.dm
@@ -114,8 +114,7 @@
 		else if(!iconrotation) //If user selected a rotation
 			P.dir = user.dir
 	to_chat(user, "<span class='notice'>[src] rapidly dispenses [P]!</span>")
-	if(istype(user.get_inactive_hand(), /obj/item/wrench) && (user.can_reach(P, user.get_inactive_hand())))
-		P.wrench_act(user, user.get_inactive_hand())
+	automatic_wrench_down(user, P)
 	activate_rpd(TRUE)
 
 /obj/item/rpd/proc/create_disposals_pipe(mob/user, turf/T) //Make a disposals pipe / construct
@@ -127,8 +126,7 @@
 	if(!iconrotation && whatdpipe != PIPE_DISPOSALS_JUNCTION_RIGHT) //Disposals pipes are in the opposite direction to atmos pipes, so we need to flip them. Junctions don't have this quirk though
 		P.flip()
 	to_chat(user, "<span class='notice'>[src] rapidly dispenses [P]!</span>")
-	if(istype(user.get_inactive_hand(), /obj/item/wrench) && (user.can_reach(P, user.get_inactive_hand())))
-		P.attackby(user.get_inactive_hand(), user)
+	automatic_wrench_down(user, P)
 	activate_rpd(TRUE)
 
 /obj/item/rpd/proc/create_transit_tube(mob/user, turf/dest)
@@ -144,8 +142,7 @@
 			S.dir = iconrotation ? iconrotation : user.dir
 
 			to_chat(user, "<span class='notice'>[src] rapidly dispenses [S]!</span>")
-			if(istype(user.get_inactive_hand(), /obj/item/wrench) && (user.can_reach(S, user.get_inactive_hand())))
-				S.wrench_act(user, user.get_inactive_hand())
+			automatic_wrench_down(user, S)
 			activate_rpd(TRUE)
 
 /obj/item/rpd/proc/rotate_all_pipes(mob/user, turf/T) //Rotate all pipes on a turf
@@ -194,6 +191,21 @@
 	to_chat(user, "<span class='notice'>[src] sucks up [P].</span>")
 	QDEL_NULL(P)
 	activate_rpd()
+
+/// Automatically wrenches down an atmos device/pipe if the user has a wrench equipped in their off-hand (or in an inactive module slot as a robot).
+/obj/item/rpd/proc/automatic_wrench_down(mob/living/user, obj/item/target)
+	var/obj/item/off_hand_item = user.get_inactive_hand()
+	if(isrobot(user))
+		for(var/obj/item/robot_module_item in user.get_all_slots())
+			if(robot_module_item.tool_behaviour == TOOL_WRENCH)
+				off_hand_item = robot_module_item
+				break
+
+	if(!off_hand_item || off_hand_item.tool_behaviour != TOOL_WRENCH)
+		return
+
+	if(user.can_reach(target, off_hand_item))
+		target.wrench_act(user, off_hand_item)
 
 // TGUI stuff
 

--- a/code/game/objects/items/weapons/rpd.dm
+++ b/code/game/objects/items/weapons/rpd.dm
@@ -142,7 +142,6 @@
 			S.dir = iconrotation ? iconrotation : user.dir
 
 			to_chat(user, "<span class='notice'>[src] rapidly dispenses [S]!</span>")
-			automatic_wrench_down(user, S)
 			activate_rpd(TRUE)
 
 /obj/item/rpd/proc/rotate_all_pipes(mob/user, turf/T) //Rotate all pipes on a turf

--- a/code/game/objects/items/weapons/rpd.dm
+++ b/code/game/objects/items/weapons/rpd.dm
@@ -142,6 +142,7 @@
 			S.dir = iconrotation ? iconrotation : user.dir
 
 			to_chat(user, "<span class='notice'>[src] rapidly dispenses [S]!</span>")
+			automatic_wrench_down(user, S, TOOL_SCREWDRIVER)
 			activate_rpd(TRUE)
 
 /obj/item/rpd/proc/rotate_all_pipes(mob/user, turf/T) //Rotate all pipes on a turf
@@ -192,19 +193,19 @@
 	activate_rpd()
 
 /// Automatically wrenches down an atmos device/pipe if the user has a wrench equipped in their off-hand (or in an inactive module slot as a robot).
-/obj/item/rpd/proc/automatic_wrench_down(mob/living/user, obj/item/target)
+/obj/item/rpd/proc/automatic_wrench_down(mob/living/user, obj/item/target, tool_type = TOOL_WRENCH)
 	var/obj/item/off_hand_item = user.get_inactive_hand()
 	if(isrobot(user))
 		for(var/obj/item/robot_module_item in user.get_all_slots())
-			if(robot_module_item.tool_behaviour == TOOL_WRENCH)
+			if(robot_module_item.tool_behaviour == tool_type)
 				off_hand_item = robot_module_item
 				break
 
-	if(!off_hand_item || off_hand_item.tool_behaviour != TOOL_WRENCH)
+	if(!off_hand_item || off_hand_item.tool_behaviour != tool_type)
 		return
 
 	if(user.can_reach(target, off_hand_item))
-		target.wrench_act(user, off_hand_item)
+		target.tool_act(user, off_hand_item, tool_type)
 
 // TGUI stuff
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Auto-wrenching is now a proc.

The user's off-hand tool for automatic RPD wrenching now checks for `TOOL_WRENCH` behaviour instead of type-checking for `obj/item/wrench`.

Cyborgs are now able to auto-wrench with the RPD.

Auto-wrenching now auto-screws transit tubes when a tool with `TOOL_SCREWDRIVER` is held. Previously you'd try to wrench the tubes and destroy them.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Not trying to destroy transit tubes you've just spawned when you have a wrench out is good.

Borgs getting to auto wrench is way better than spam-clicking 500 times on a long pipeline and then having to go back because some sections still didn't wrench.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Spawned in a cyborg and a skrell.

Spawned a bunch of different pipes and devices as both - with and without a wrench equipped. Repeated with a screwdriver.

Every category of item spawnable automatically got wrenched when a wrench was held, except for transit tubes.

Transit tubes got automatically screwed down when a screwdriver was held, no other category interacted with it.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
tweak: Cyborgs can now automatically wrench RPD spawned pipes and devices with a wrench also equipped, just like humans can.
tweak: Auto-wrenching on transit tubes has been replaced with auto-screwing. This means you actually try to secure the tube instead of trying to destroy it. A screwdriver instead of a wrench is required to auto-screw (obviously).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
