### PR TITLE
Judo combos fix

### DIFF
--- a/code/modules/martial_arts/combos/judo/judothrow.dm
+++ b/code/modules/martial_arts/combos/judo/judothrow.dm
@@ -4,7 +4,7 @@
 	explaination_text = "Establish a gripset on your opponent and throw them to the floor, inflicting stamina damage"
 	combo_text_override = "Grab, Disarm"
 /datum/martial_combo/judo/judothrow/perform_combo(mob/living/carbon/human/user, mob/living/target, datum/martial_art/MA)
-	if(user.IsKnockedDown() || IS_HORIZONTAL(target))
+	if(IS_HORIZONTAL(user) || IS_HORIZONTAL(target))
 		return MARTIAL_COMBO_FAIL
 	target.visible_message("<span class='warning'>[user] judo throws [target] to ground!</span>", \
 						"<span class='userdanger'>[user] judo throws you to the ground!</span>")

--- a/code/modules/martial_arts/judo.dm
+++ b/code/modules/martial_arts/judo.dm
@@ -75,11 +75,6 @@
 	add_attack_logs(A, D, "Melee attacked with [src]")
 	return TRUE
 
-/datum/martial_art/judo/grab_act(mob/living/carbon/human/attacker, mob/living/carbon/human/defender)
-	if(IS_HORIZONTAL(attacker))
-		return FALSE
-	return ..()
-
 /datum/martial_art/judo/explaination_header(user)
 	to_chat(user, "<b><i>You recall the teachings of Corporate Judo.</i></b>")
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes #26053. You can now perform wheelthrow and armbar being prone. Not judothrow.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

Fixes are good

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Tried to perform an `armbar` and a `wheelthrow` being prone - was able to
Tried to perform a `judothrow` being prone - was unable to

<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Judo combos are now working as it was intended long ago
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
