### PR TITLE
fix: remove two unused vardecls

### DIFF
--- a/code/game/objects/items/weapons/shards.dm
+++ b/code/game/objects/items/weapons/shards.dm
@@ -66,7 +66,7 @@
 	. = TRUE
 	if(!I.use_tool(src, user, volume = I.tool_volume))
 		return
-	var/obj/item/stack/sheet/new_glass = new welded_type(user.loc)
+	new welded_type(user.loc)
 	to_chat(user, "<span class='notice'>You add the newly-formed glass to the stack.</span>")
 	qdel(src)
 

--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -61,7 +61,7 @@
 		var/seed_modifier = 0
 		if(seed)
 			seed_modifier = round(seed.potency / 25)
-		var/obj/item/stack/plank = new plank_type(user.loc, 1 + seed_modifier)
+		new plank_type(user.loc, 1 + seed_modifier)
 		to_chat(user, "<span class='notice'>You add the newly-formed [plank_name] to the stack.</span>")
 		qdel(src)
 


### PR DESCRIPTION
## What Does This PR Do
This PR removes two unused vardecls introduced in #26633.
## Why It's Good For The Game
Compiler warnings bad. Surprised CI didn't yell about this.
## Testing
Compiled project.
<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog
NPFC