### PR TITLE
Fix heat-proof doors

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -146,6 +146,8 @@
 
 /obj/machinery/door/get_superconductivity(direction)
 	if(density)
+		if(heat_proof)
+			return 0
 		return superconductivity
 	return ..()
 

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -145,11 +145,11 @@
 	return !density
 
 /obj/machinery/door/get_superconductivity(direction)
-	if(density)
-		if(heat_proof)
-			return ZERO_HEAT_TRANSFER_COEFFICIENT
-		return superconductivity
-	return ..()
+	if(!density)
+		return ..()
+	if(heat_proof)
+		return ZERO_HEAT_TRANSFER_COEFFICIENT
+	return superconductivity
 
 /obj/machinery/door/proc/bumpopen(mob/user)
 	if(operating)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -147,7 +147,7 @@
 /obj/machinery/door/get_superconductivity(direction)
 	if(density)
 		if(heat_proof)
-			return 0
+			return ZERO_HEAT_TRANSFER_COEFFICIENT
 		return superconductivity
 	return ..()
 


### PR DESCRIPTION
## What Does This PR Do
Makes heat-proof doors actually heat-proof again.

## Why It's Good For The Game
Bugs bad

## Testing
Successfully contained very hot air with heat-proof doors.
Unleashed heat by opening a heat-proof door despite air flowing the other way.
Melted a non-heat-proof door by putting very hot air on one side.

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog

:cl:
fix: Heat-proof doors will no longer leak heat and melt.
/:cl: