### PR TITLE
Prevent sleeps in key handling from blocking SSinput

### DIFF
--- a/code/controllers/subsystem/SSinput.dm
+++ b/code/controllers/subsystem/SSinput.dm
@@ -29,7 +29,7 @@ SUBSYSTEM_DEF(input)
 				LAZYADD(to_cull, C)
 			else
 				continue // they fell asleep on their keyboard or w/e, let them
-		C.key_loop()
+		INVOKE_ASYNC(C, TYPE_PROC_REF(/datum, key_loop))
 
 	if(to_cull)
 		processing -= to_cull


### PR DESCRIPTION
## What Does This PR Do
Makes SSinput run key presses asynchronously.

## Why It's Good For The Game
If something sleeps during the handling, it no longer makes SSinput stop working.

## Testing
I could move.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog

:cl:
fix: Prevented the input subsystem from freezing and making everyone unable to move.
/:cl: