### PR TITLE
Replaces Engiborg Meson Goggles With Engineering Scanning Goggles. Removes T-Ray Scanner From Loadout.

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_module_actions.dm
+++ b/code/modules/mob/living/silicon/robot/robot_module_actions.dm
@@ -36,6 +36,56 @@
 	button_overlay_icon = 'icons/obj/clothing/glasses.dmi'
 	button_overlay_icon_state = "meson"
 
+#define MODE_NONE ""
+#define MODE_MESON "meson"
+#define MODE_TRAY "t-ray"
+#define MODE_RAD "radiation"
+#define RAD_RANGE 5
+
+/datum/action/innate/robot_sight/engineering_scanner
+	name = "Engineering Scanner Vision"
+	sight_mode = BORGMESON
+	button_overlay_icon = 'icons/obj/clothing/glasses.dmi'
+	button_overlay_icon_state = "trayson-meson"
+	var/list/mode_list = list(MODE_NONE = MODE_MESON, MODE_MESON = MODE_TRAY, MODE_TRAY = MODE_RAD, MODE_RAD = MODE_NONE)
+	var/mode = MODE_NONE
+
+/datum/action/innate/robot_sight/engineering_scanner/Activate()
+	var/mob/living/silicon/robot/R = owner
+	mode = mode_list[mode]
+	to_chat(owner, "<span class='notice'>You turn your enhanced optics [mode ? "to [mode] mode." : "off."]</span>")
+	button_overlay_icon_state = "trayson-[mode]"
+
+	if(mode == MODE_MESON)
+		R.sight_mode |= sight_mode
+	else
+		R.sight_mode &= ~sight_mode
+	R.update_sight()
+
+	if(mode != (MODE_NONE || MODE_MESON))
+		START_PROCESSING(SSobj, src)
+	else
+		STOP_PROCESSING(SSobj, src)
+
+/datum/action/innate/robot_sight/engineering_scanner/Deactivate()
+	return
+
+/datum/action/innate/robot_sight/engineering_scanner/process()
+	var/mob/living/silicon/robot/user = owner
+	if(!user.client)
+		return
+	switch(mode)
+		if(MODE_TRAY)
+			t_ray_scan(user)
+		if(MODE_RAD)
+			user.show_rads(RAD_RANGE)
+
+#undef MODE_NONE
+#undef MODE_MESON
+#undef MODE_TRAY
+#undef MODE_RAD
+#undef RAD_RANGE
+
 /datum/action/innate/robot_magpulse
 	name = "Magnetic pulse"
 	button_overlay_icon = 'icons/obj/clothing/shoes.dmi'

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -447,7 +447,7 @@
 	name = "engineering robot module"
 	module_type = "Engineer"
 	subsystems = list(/mob/living/silicon/proc/subsystem_power_monitor)
-	module_actions = list(/datum/action/innate/robot_sight/meson, /datum/action/innate/robot_magpulse)
+	module_actions = list(/datum/action/innate/robot_sight/engineering_scanner, /datum/action/innate/robot_magpulse)
 	basic_modules = list(
 		/obj/item/flash/cyborg,
 		/obj/item/rpd,
@@ -458,7 +458,6 @@
 		/obj/item/crowbar/cyborg,
 		/obj/item/wirecutters/cyborg,
 		/obj/item/multitool/cyborg,
-		/obj/item/t_scanner,
 		/obj/item/analyzer,
 		/obj/item/geiger_counter/cyborg,
 		/obj/item/holosign_creator/engineering,


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Replaces an engineering cyborg's meson vision with engineering scanner vision.

Functions like engineering scanner goggles, has 3 modes: meson, T-ray, radiation.

T-Ray scanner is removed from cyborg inventory. The T-ray mode on the goggles has the same range as it used to have.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Removes one item from the tray, slightly reducing clutter.

Actually makes vision mode something to consider rather than turning on once and forgetting about. You can see under the floors, if you sacrifice your seeing through walls, and vice versa.

It's a lot more convenient than fumbling around with the T-ray scanner in the inventory.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

<!-- How did you test the PR, if at all? -->
Spawned in a cyborg. Meson mode gave me meson vision. T-Ray mode let me see under floor tiles. Rad mode showed me radiation.

Spawned in a skrell, equipped engi goggles. Cycled through the modes. They look the same as what the borg saw.
<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
add: Added new things
del: Removed the T-Ray scanner from the engiborg inventory.
tweak: Replaced engiborg meson goggles with engineering scanner goggles.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
