### PR TITLE
Stops hemo claws runtiming on xenos, makes them become stronger

### DIFF
--- a/code/modules/antagonists/vampire/vampire_powers/hemomancer_powers.dm
+++ b/code/modules/antagonists/vampire/vampire_powers/hemomancer_powers.dm
@@ -55,6 +55,8 @@
 	var/durability = 15
 	var/blood_drain_amount = 15
 	var/blood_absorbed_amount = 5
+	var/xenomorph_acid_boosted = FALSE
+	var/heal_boost = 1
 	var/datum/spell/vampire/self/vamp_claws/parent_spell
 
 /obj/item/vamp_claws/Initialize(mapload, new_parent_spell)
@@ -77,23 +79,43 @@
 
 	var/datum/antagonist/vampire/V = user.mind?.has_antag_datum(/datum/antagonist/vampire)
 	var/mob/living/attacker = user
+	var/is_alien = FALSE
 
 	if(!V)
 		return
-
-	if(iscarbon(target))
-		var/mob/living/carbon/C = target
-		if(C.ckey && C.stat != DEAD && C.affects_vampire() && !(NO_BLOOD in C.dna.species.species_traits))
+	if(xenomorph_acid_boosted)
+		target.acid_act(42, 10) // 42 is the acid power of facid, 10 is equal to 100 units.
+	if(!iscarbon(target))
+		return ..()
+	var/mob/living/carbon/C = target
+	if(isalien(target))
+		is_alien = TRUE
+		if(!xenomorph_acid_boosted)
+			if(C.ckey && C.stat != DEAD)
+				to_chat(user, "<span class='warning'>As [C] bleeds acid, you mix it into your claws!</span>")
+				xenomorph_acid_boosted = TRUE
+				durability += 5 // Small boost in durability once.
+				blood_drain_amount *= 1.5
+				blood_absorbed_amount *= 1.5
+				force *= 1.5 // 15 force
+				heal_boost = 2 //This *might* let you survive xeno disarms. Maybe.
+				damtype = BURN
+				hitsound = 'sound/weapons/sear.ogg'
+				color = list(0.5,1,0,0, 0,1,0,0, 0,0,0.5,0, 0,0,0,1, 0,0,0,0)
+				user.update_inv_r_hand()
+				user.update_inv_l_hand()
+	if(C.ckey && C.stat != DEAD && C.affects_vampire())
+		if(is_alien || !(NO_BLOOD in C.dna.species.species_traits)) // second check runtimes if they are not a xenomorph, but we check xenomorph first
 			C.bleed(blood_drain_amount)
 			V.adjust_blood(C, blood_absorbed_amount)
-			attacker.adjustStaminaLoss(-20) // security is dead
-			attacker.heal_overall_damage(4, 4) // the station is full
-			attacker.AdjustKnockDown(-1 SECONDS) // blood is fuel
-		if(!V.get_ability(/datum/vampire_passive/blood_spill))
-			durability--
-			if(durability <= 0)
-				qdel(src)
-				to_chat(user, "<span class='warning'>Your claws shatter!</span>")
+			attacker.adjustStaminaLoss(-20 * heal_boost) // security is dead
+			attacker.heal_overall_damage(4 * heal_boost, 4 * heal_boost) // the station is full
+			attacker.AdjustKnockDown(-1 SECONDS * heal_boost) // blood is fuel
+	if(!V.get_ability(/datum/vampire_passive/blood_spill))
+		durability--
+		if(durability <= 0)
+			qdel(src)
+			to_chat(user, "<span class='warning'>Your claws shatter!</span>")
 
 /obj/item/vamp_claws/melee_attack_chain(mob/user, atom/target, params)
 	..()

--- a/code/modules/antagonists/vampire/vampire_powers/hemomancer_powers.dm
+++ b/code/modules/antagonists/vampire/vampire_powers/hemomancer_powers.dm
@@ -79,7 +79,6 @@
 
 	var/datum/antagonist/vampire/V = user.mind?.has_antag_datum(/datum/antagonist/vampire)
 	var/mob/living/attacker = user
-	var/is_alien = FALSE
 
 	if(!V)
 		return
@@ -89,7 +88,6 @@
 		return ..()
 	var/mob/living/carbon/C = target
 	if(isalien(target))
-		is_alien = TRUE
 		if(!xenomorph_acid_boosted)
 			if(C.ckey && C.stat != DEAD)
 				to_chat(user, "<span class='warning'>As [C] bleeds acid, you mix it into your claws!</span>")
@@ -101,11 +99,11 @@
 				heal_boost = 2 // This *might* let you survive xeno disarms. Maybe.
 				damtype = BURN
 				hitsound = 'sound/weapons/sear.ogg'
-				color = list(0.5,1,0,0, 0,1,0,0, 0,0,0.5,0, 0,0,0,1, 0,0,0,0)
+				color = list(0.5,1,0,0, 0,1,0,0, 0,0,0.5,0, 0,0,0,1, 0,0,0,0) // This makes it coloured acidic green
 				user.update_inv_r_hand()
 				user.update_inv_l_hand()
 	if(C.ckey && C.stat != DEAD && C.affects_vampire())
-		if(is_alien || !(NO_BLOOD in C.dna.species.species_traits)) // second check runtimes if they are not a xenomorph, but we check xenomorph first
+		if(isalien(C) || !(NO_BLOOD in C.dna.species.species_traits)) // second check runtimes if they are not a xenomorph, but we check xenomorph first
 			C.bleed(blood_drain_amount)
 			V.adjust_blood(C, blood_absorbed_amount)
 			attacker.adjustStaminaLoss(-20 * heal_boost) // security is dead

--- a/code/modules/antagonists/vampire/vampire_powers/hemomancer_powers.dm
+++ b/code/modules/antagonists/vampire/vampire_powers/hemomancer_powers.dm
@@ -98,7 +98,7 @@
 				blood_drain_amount *= 1.5
 				blood_absorbed_amount *= 1.5
 				force *= 1.5 // 15 force
-				heal_boost = 2 //This *might* let you survive xeno disarms. Maybe.
+				heal_boost = 2 // This *might* let you survive xeno disarms. Maybe.
 				damtype = BURN
 				hitsound = 'sound/weapons/sear.ogg'
 				color = list(0.5,1,0,0, 0,1,0,0, 0,0,0.5,0, 0,0,0,1, 0,0,0,0)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Hemomancer claws no longer runtimes on hitting a xenomorph.
Instead, they become stronger due to the acid blood _**UNTIL THE CLAWS RUN OUT OF DURABILITY!**_ Recasting the claws afterwords, will be *back to normal*

When empowered by acid, the claws do an acid act similar to dumping facid on someone, but:
Less damage because its not the chemical, it's acid act
Clothing protects you.
Aditionally, the claws heal the user twice as much so they *might* survive using them on a xenomorph, and now do 50% more damage / blood collection, and become burn for the duration.
Remember. You need a live xenomorph, you need to engage them in melee, and it only lasts 20 hits (2 handed, if you drop it you lose it) Good luck!

## Why It's Good For The Game

Sure, I could have just made it not runtime, but this is cooler. Might make a vampire feel awesome, sorta able to fight one xenomorph in melee. Fighting multiple will not end well, though you'll at least get a fun melee weapon for a short period of time.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![image](https://github.com/user-attachments/assets/bbd6d12e-0250-4cbe-94dc-54ddc3e63c01)
g r e e n

## Testing
Video for it in dev discussion, slashed xenomorph to get the acid claws, started slashing people and things, getting acid everywhere. Fun fun fun. After recasting, back to normal
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>
![image](https://github.com/user-attachments/assets/7c27fe91-300e-409a-88cd-41b3793a435c)

## Changelog

:cl:
tweak: Hemomancer vampires can now temporarily enhance their vampiric claws with xenomorph blood... if they can survive using the claws on a living xenomorph.
fix: Hemo claws will work and no longer runtime on hitting xenomorphs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
