### PR TITLE
fix: cere jani closet disposal pipe

### DIFF
--- a/_maps/map_files/stations/cerestation.dmm
+++ b/_maps/map_files/stations/cerestation.dmm
@@ -51920,6 +51920,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
+/obj/structure/disposalpipe/segment/corner{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel,
 /area/station/service/janitor)
 "jxd" = (


### PR DESCRIPTION
## What Does This PR Do
This PR adds a missing disposals junction in Cere janitor's closet.
## Why It's Good For The Game
Without this trash just shoots right back out via a hole in the floor.
## Images of changes
### Before
![2024_09_14__00_24_57__paradise dme  cerestation dmm  - StrongDMM](https://github.com/user-attachments/assets/16d725ca-094e-4472-a81d-664d9ba06609)

### After
![2024_09_14__00_25_11__paradise dme  cerestation dmm  - StrongDMM](https://github.com/user-attachments/assets/d834b821-c09c-4cce-b15e-234400ebac9e)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Put trash in trash.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: Farragus: Disposals unit in Janitor Closet now functions properly.
/:cl:
