### PR TITLE
Disable encoding for tcomms filter input

### DIFF
--- a/code/game/machinery/tcomms/tcomms_core.dm
+++ b/code/game/machinery/tcomms/tcomms_core.dm
@@ -323,7 +323,7 @@
 
 		if("add_filter")
 			// This is a stripped input because I did NOT come this far for this system to be abused by HTML injection
-			var/name_to_add = tgui_input_text(usr, "Enter a name to add to the filtering list", "Name Entry")
+			var/name_to_add = tgui_input_text(usr, "Enter a name to add to the filtering list", "Name Entry", encode = FALSE)
 			if(!name_to_add)
 				return
 			if(name_to_add in nttc.filtering)


### PR DESCRIPTION
## What Does This PR Do
Disables encoding for tcomms filter input via `html_encode`. It was accidentally enabled when TGUI input was used.

## Why It's Good For The Game
The names of some characters contain special symbols such as `'` (Apostrophe 39, replaced with `&#39;`) that cannot be filtered.

## Testing
The filter allows special symbols now.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<hr>

## Changelog

:cl: Maxiemar
fix: Telecommunications Core filter allows special symbols in names now.
/:cl:
