### PR TITLE
Fix: Prevent Mech Fabricator output into the wall

### DIFF
--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -197,7 +197,6 @@
 /obj/machinery/mecha_part_fabricator/proc/build_design(datum/design/D)
 	. = FALSE
 
-	var/turf_to_print_on = get_step(src, output_dir)
 	var/datum/research/files = get_files()
 	if(!files)
 		atom_say("Error - No research network linked.")
@@ -214,6 +213,8 @@
 	if(stat & NOPOWER)
 		atom_say("Error: Insufficient power!")
 		return
+
+	var/turf_to_print_on = get_step(src, output_dir)
 	if(iswallturf(turf_to_print_on))
 		atom_say("Error: Output blocked by a wall!")
 		return

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -83,6 +83,7 @@
 		"Misc"
 	)
 
+	output_dir = dir
 	return INITIALIZE_HINT_LATELOAD
 
 /obj/machinery/mecha_part_fabricator/LateInitialize()
@@ -196,6 +197,7 @@
 /obj/machinery/mecha_part_fabricator/proc/build_design(datum/design/D)
 	. = FALSE
 
+	var/turf_to_print_on = get_step(src, output_dir)
 	var/datum/research/files = get_files()
 	if(!files)
 		atom_say("Error - No research network linked.")
@@ -211,6 +213,9 @@
 		return
 	if(stat & NOPOWER)
 		atom_say("Error: Insufficient power!")
+		return
+	if(iswallturf(turf_to_print_on))
+		atom_say("Error: Output blocked by a wall!")
 		return
 
 	// Subtract the materials from the holder


### PR DESCRIPTION
## What Does This PR Do
Prevents things made in Mech Fabricator from going straight into the wall
Also sets the output_dir depending on the dir of the machine itself during init, which fix issue on Emerald Station on screenshot bellow
![image](https://github.com/user-attachments/assets/3514b8a3-e1b7-4bec-aaf7-cc26002655e9)

## Why It's Good For The Game
Mech Fabricator doesn't print thing into the wall, which funny but bad

## Testing
Started local with Emerald Station, print some MOD storage and see it doesn't stuck into the wall.
Turned output dir via multitool and make sure it doesn't print into the wall.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Mech Fabricator no longer prints things into the wall
/:cl:
