### PR TITLE
fix: AI Eye movement runtimes

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -129,10 +129,9 @@
 /obj/structure/table/CanPass(atom/movable/mover, turf/target)
 	if(istype(mover,/obj/item/projectile))
 		return (check_cover(mover,target))
-	if(ismob(mover))
-		var/mob/living/M = mover
-		if(M.flying || (IS_HORIZONTAL(M) && HAS_TRAIT(M, TRAIT_CONTORTED_BODY)))
-			return TRUE
+	var/mob/living/living_mover = mover
+	if(istype(living_mover) && (living_mover.flying || (IS_HORIZONTAL(living_mover) && HAS_TRAIT(living_mover, TRAIT_CONTORTED_BODY))))
+		return TRUE
 	if(istype(mover) && mover.checkpass(PASSTABLE))
 		return TRUE
 	if(mover.throwing)

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -42,6 +42,10 @@
 /mob/camera/aiEye/Move()
 	return 0
 
+/mob/camera/aiEye/Process_Spacemove(movement_dir)
+	// Nothing in space can stop us from moving.
+	return 1
+
 /mob/camera/aiEye/proc/GetViewerClient()
 	if(ai)
 		return ai.client


### PR DESCRIPTION
## What Does This PR Do
This PR:

- Fixes a check in /obj/structure/table/CanPass which checks for ismob but then casts to /mob/living, accessing variables that don't exist on `/mob` and runtiming
- Overrides `Process_Spacemove` on `/mob/camera/aiEye` to always return `TRUE`, since it cannot be blocked by anything it passes over in the first place

These runtimes were exposed by #26700 though I can't fathom how.
## Why It's Good For The Game
Less runtimes good, correct logic good.
## Testing
Spawned in as AI, observed runtime while passing over a table constructed in space. Made change, observed no runtimes while doing the same.

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog
NPFC
