### PR TITLE
Fixes a runtime caused by stacks accidentally merging twice

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -127,6 +127,8 @@
 	// We don't only use istype here, since that will match subtypes, and stack things that shouldn't stack
 	if(!istype(check, merge_type) || check.merge_type != merge_type)
 		return FALSE
+	if(amount <= 0 || check.amount <= 0) // no merging empty stacks that are in the process of being deleted
+		return FALSE
 	if(is_cyborg) // No merging cyborg stacks into other stacks
 		return FALSE
 	if(ismob(loc) && !inhand) // no merging with items that are on the mob

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -127,7 +127,7 @@
 	// We don't only use istype here, since that will match subtypes, and stack things that shouldn't stack
 	if(!istype(check, merge_type) || check.merge_type != merge_type)
 		return FALSE
-	if(amount <= 0 || check.amount <= 0) // no merging empty stacks that are in the process of being deleted
+	if(amount <= 0 || check.amount <= 0) // no merging empty stacks that are in the process of being qdel'd
 		return FALSE
 	if(is_cyborg) // No merging cyborg stacks into other stacks
 		return FALSE


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Fixes a runtime where a stack that has merge_without_del returns a qdeling stack of 0 items tries to merge with another stack item.
## Why It's Good For The Game
A lot less runtimes
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


## Testing

<!-- How did you test the PR, if at all? -->
Tried to reproduce the bug with a reliable method of crafting floor tiles as a cyborg, it didn't runtime.
Used breakpoints to make sure the guard clause was working
Tried to merge a bunch of other stack items to see if it broke something else.
Made sure cyborgs could still stack items.
<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
NPFC
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
