### PR TITLE
[s] you no longer can instantly husk people as an ERT inquisitor

### DIFF
--- a/code/game/objects/items/weapons/holy_weapons.dm
+++ b/code/game/objects/items/weapons/holy_weapons.dm
@@ -42,6 +42,11 @@
 		if(!V.get_ability(/datum/vampire_passive/full))
 			to_chat(M, "<span class='warning'>The nullrod's power interferes with your own!</span>")
 			V.adjust_nullification(30 + sanctify_force, 15 + sanctify_force)
+	if(!sanctify_force)
+		return
+	if(isliving(M))
+		var/mob/living/L = M
+		L.adjustFireLoss(sanctify_force) // Bonus fire damage for sanctified (ERT) versions of nullrod
 
 /obj/item/nullrod/pickup(mob/living/user)
 	. = ..()
@@ -95,14 +100,6 @@
 	if(!src || !user.is_in_hands(src) || user.incapacitated() || reskinned)
 		return FALSE
 	return TRUE
-
-/obj/item/nullrod/afterattack(atom/movable/AM, mob/user, proximity)
-	. = ..()
-	if(!sanctify_force)
-		return
-	if(isliving(AM))
-		var/mob/living/L = AM
-		L.adjustFireLoss(sanctify_force) // Bonus fire damage for sanctified (ERT) versions of nullrod
 
 /// fluff subtype to be used for all donator nullrods
 /obj/item/nullrod/fluff


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

You can no longer use the full power of god to husk anyone on your screen at range anymore. Sorry.

## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

It was not balanced. (and a bug)

## Testing

<!-- How did you test the PR, if at all? -->
Clicked people from range, failed to do burn damage.
Melee'd, did burn damage.
Used prayer beads, did no burn damage
<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: You can no longer use the full power of god to husk anyone on your screen at range anymore as an ERT inquisitor. Sorry
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
