### PR TITLE
Allows multitile to work with arbitrary list lengths

### DIFF
--- a/code/__DEFINES/misc_defines.dm
+++ b/code/__DEFINES/misc_defines.dm
@@ -105,7 +105,7 @@
 #define STAGE_SIX 11 //From supermatter shard
 
 /// A define for the center of the coordinate map of big machinery
-#define MACH_CENTER 0
+#define MACH_CENTER 2
 
 #define in_range(source, user)		(get_dist(source, user) <= 1)
 

--- a/code/datums/components/multitile.dm
+++ b/code/datums/components/multitile.dm
@@ -47,33 +47,33 @@
 	var/distance_from_center_x = (max_max_width - 1) / 2
 	var/distance_from_center_y = (max_height - 1) / 2
 
-	if(owner.x + offset_x + distance_from_center_x > world.maxx || owner.x + offset_x - distance_from_center_x < 1)
+	if(owner.x - offset_x + distance_from_center_x > world.maxx || owner.x + offset_x - distance_from_center_x < 1)
 		var/obj/machinery/machine = parent
 		machine.deconstruct()
 		return COMPONENT_INCOMPATIBLE
 
-	if(owner.y + offset_y + distance_from_center_y > world.maxy || owner.y + offset_y - distance_from_center_y < 1)
+	if(owner.y + offset_y + distance_from_center_y > world.maxy || owner.y - offset_y - distance_from_center_y < 1)
 		var/obj/machinery/machine = parent
 		machine.deconstruct()
 		return COMPONENT_INCOMPATIBLE
 
 	var/current_height = 0
-	var/current_width = 0
+	var/current_width = 1
 	var/tile_index = 1
 	var/padding = (max_max_width - max_width) / 2
 
 	for(var/turf/filler_turf as anything in block( \
-	owner.x + offset_x - distance_from_center_x, owner.y + offset_y - distance_from_center_y, owner.z, \
-	owner.x + offset_x + distance_from_center_x, owner.y + offset_y + distance_from_center_y, owner.z, \
+	owner.x - offset_x - distance_from_center_x, owner.y + offset_y - distance_from_center_y, owner.z, \
+	owner.x - offset_x + distance_from_center_x, owner.y + offset_y + distance_from_center_y, owner.z, \
 	))
 		//Last check is for filler row lists of length 1.
-		if(!padding || ((tile_index % max_max_width) in (padding + 1) to (max_width - padding)) || (tile_index % max_max_width) == (padding + 1))
-			if((new_filler_map[max_height - current_height][max_width - current_width] % 2) != 0) // Because the `block()` proc always works from the bottom left to the top right, we have to loop through our nested lists in reverse
+		if(!padding || ((tile_index % max_max_width) in (padding + 1) to (max_max_width - padding)) || (tile_index % max_max_width) == (padding + 1))
+			if(new_filler_map[max_height - current_height][current_width] == 1) // Because the `block()` proc always works from the bottom left to the top right, we have to loop through our list in reverse
 				var/obj/structure/filler/new_filler = new(filler_turf)
 				all_fillers += new_filler
 			current_width += 1
-			if(current_width == max_width)
-				current_width = 0
+			if(current_width == (max_width + 1))
+				current_width = 1
 		tile_index++
 		if(tile_index % max_max_width == 1)
 			current_height += 1
@@ -81,6 +81,7 @@
 				break
 			max_width = length(new_filler_map[max_height - current_height])
 			padding = (max_max_width - max_width) / 2
+			current_width = 1
 
 /datum/component/multitile/Destroy(force, silent)
 	QDEL_LIST_CONTENTS(all_fillers)

--- a/code/datums/components/multitile.dm
+++ b/code/datums/components/multitile.dm
@@ -22,11 +22,8 @@
 
 	if(!isatom(parent))
 		return COMPONENT_INCOMPATIBLE
-	if(length(new_filler_map) % 2 == 0)
-		new_filler_map += list(list(0))
 	var/max_height = length(new_filler_map)
 	var/max_width = length(new_filler_map[1]) //it should have the same length on every row
-	var/max_max_width = 0
 
 	var/offset_x = 0
 	var/offset_y = 0
@@ -34,17 +31,18 @@
 	var/atom/owner = parent
 
 	for(var/i in 1 to length(new_filler_map))
-		if(length(new_filler_map[i]) % 2 == 0)
-			new_filler_map[i] += list(0)
-		max_width = length(new_filler_map[i])
-		if(max_width > max_max_width)
-			max_max_width = max_width
+		if(length(new_filler_map[i] != max_width))
+			stack_trace("A multitile component was passed a list wich did not have the same length every row. Atom parent is: [parent]")
+			var/obj/machinery/machine = parent
+			machine.deconstruct()
+			return COMPONENT_INCOMPATIBLE
+
 		for(var/j in 1 to length(new_filler_map[i]))
 			if(new_filler_map[i][j] == 2)
 				offset_x = j - ((length(new_filler_map[i]) + 1) / 2)
 				offset_y = i - ((length(new_filler_map) + 1) / 2)
 
-	var/distance_from_center_x = (max_max_width - 1) / 2
+	var/distance_from_center_x = (max_width - 1) / 2
 	var/distance_from_center_y = (max_height - 1) / 2
 
 	if(owner.x - offset_x + distance_from_center_x > world.maxx || owner.x + offset_x - distance_from_center_x < 1)
@@ -60,28 +58,22 @@
 	var/current_height = 0
 	var/current_width = 1
 	var/tile_index = 1
-	var/padding = (max_max_width - max_width) / 2
 
 	for(var/turf/filler_turf as anything in block( \
 	owner.x - offset_x - distance_from_center_x, owner.y + offset_y - distance_from_center_y, owner.z, \
 	owner.x - offset_x + distance_from_center_x, owner.y + offset_y + distance_from_center_y, owner.z, \
 	))
 		//Last check is for filler row lists of length 1.
-		if(!padding || ((tile_index % max_max_width) in (padding + 1) to (max_max_width - padding)) || (tile_index % max_max_width) == (padding + 1))
-			if(new_filler_map[max_height - current_height][current_width] == 1) // Because the `block()` proc always works from the bottom left to the top right, we have to loop through our list in reverse
-				var/obj/structure/filler/new_filler = new(filler_turf)
-				all_fillers += new_filler
-			current_width += 1
-			if(current_width == (max_width + 1))
-				current_width = 1
+		if(new_filler_map[max_height - current_height][current_width] == 1) // Because the `block()` proc always works from the bottom left to the top right, we have to loop through our list in reverse
+			var/obj/structure/filler/new_filler = new(filler_turf)
+			all_fillers += new_filler
+		current_width += 1
 		tile_index++
-		if(tile_index % max_max_width == 1)
+		if(tile_index % max_width == 1)
 			current_height += 1
+			current_width = 1
 			if(current_height == max_height)
 				break
-			max_width = length(new_filler_map[max_height - current_height])
-			padding = (max_max_width - max_width) / 2
-			current_width = 1
 
 /datum/component/multitile/Destroy(force, silent)
 	QDEL_LIST_CONTENTS(all_fillers)

--- a/code/datums/components/multitile.dm
+++ b/code/datums/components/multitile.dm
@@ -16,45 +16,71 @@
  */
 
 //distance_from_center does not include src itself
-/datum/component/multitile/Initialize(distance_from_center, new_filler_map)
-	if(!distance_from_center || !length(new_filler_map))
+/datum/component/multitile/Initialize(new_filler_map)
+	if(!length(new_filler_map))
 		return COMPONENT_INCOMPATIBLE
 
 	if(!isatom(parent))
 		return COMPONENT_INCOMPATIBLE
-
-	var/atom/owner = parent
-	if(owner.x + distance_from_center > world.maxx || owner.x - distance_from_center < 1)
-		var/obj/machinery/machine = parent
-		machine.deconstruct()
-		return COMPONENT_INCOMPATIBLE
-
-	if(owner.y + distance_from_center > world.maxy || owner.y - distance_from_center < 1)
-		var/obj/machinery/machine = parent
-		machine.deconstruct()
-		return COMPONENT_INCOMPATIBLE
-
+	if(length(new_filler_map) % 2 == 0)
+		new_filler_map += list(list(0))
 	var/max_height = length(new_filler_map)
 	var/max_width = length(new_filler_map[1]) //it should have the same length on every row
-	for(var/i in 2 to length(new_filler_map))
-		var/length = length(new_filler_map[i])
-		if(length != max_width)
-			stack_trace("A multitile component was passed a list wich did not have the same length every row. Atom parent is: [parent]")
-			var/obj/machinery/machine = parent
-			machine.deconstruct()
-			return COMPONENT_INCOMPATIBLE
+	var/max_max_width = 0
+
+	var/offset_x = 0
+	var/offset_y = 0
+
+	var/atom/owner = parent
+
+	for(var/i in 1 to length(new_filler_map))
+		if(length(new_filler_map[i]) % 2 == 0)
+			new_filler_map[i] += list(0)
+		max_width = length(new_filler_map[i])
+		if(max_width > max_max_width)
+			max_max_width = max_width
+		for(var/j in 1 to length(new_filler_map[i]))
+			if(new_filler_map[i][j] == 2)
+				offset_x = j - ((length(new_filler_map[i]) + 1) / 2)
+				offset_y = i - ((length(new_filler_map) + 1) / 2)
+
+	var/distance_from_center_x = (max_max_width - 1) / 2
+	var/distance_from_center_y = (max_height - 1) / 2
+
+	if(owner.x + offset_x + distance_from_center_x > world.maxx || owner.x + offset_x - distance_from_center_x < 1)
+		var/obj/machinery/machine = parent
+		machine.deconstruct()
+		return COMPONENT_INCOMPATIBLE
+
+	if(owner.y + offset_y + distance_from_center_y > world.maxy || owner.y + offset_y - distance_from_center_y < 1)
+		var/obj/machinery/machine = parent
+		machine.deconstruct()
+		return COMPONENT_INCOMPATIBLE
 
 	var/current_height = 0
 	var/current_width = 0
+	var/tile_index = 1
+	var/padding = (max_max_width - max_width) / 2
 
-	for(var/turf/filler_turf as anything in RANGE_TURFS(distance_from_center, owner))
-		if(new_filler_map[max_height - current_height][max_width - current_width]) // Because the `block()` proc always works from the bottom left to the top right, we have to loop through our nested lists in reverse
-			var/obj/structure/filler/new_filler = new(filler_turf)
-			all_fillers += new_filler
-		current_width += 1
-		if(current_width == max_width)
+	for(var/turf/filler_turf as anything in block( \
+	owner.x + offset_x - distance_from_center_x, owner.y + offset_y - distance_from_center_y, owner.z, \
+	owner.x + offset_x + distance_from_center_x, owner.y + offset_y + distance_from_center_y, owner.z, \
+	))
+		//Last check is for filler row lists of length 1.
+		if(!padding || ((tile_index % max_max_width) in (padding + 1) to (max_width - padding)) || (tile_index % max_max_width) == (padding + 1))
+			if((new_filler_map[max_height - current_height][max_width - current_width] % 2) != 0) // Because the `block()` proc always works from the bottom left to the top right, we have to loop through our nested lists in reverse
+				var/obj/structure/filler/new_filler = new(filler_turf)
+				all_fillers += new_filler
+			current_width += 1
+			if(current_width == max_width)
+				current_width = 0
+		tile_index++
+		if(tile_index % max_max_width == 1)
 			current_height += 1
-			current_width = 0
+			if(current_height == max_height)
+				break
+			max_width = length(new_filler_map[max_height - current_height])
+			padding = (max_max_width - max_width) / 2
 
 /datum/component/multitile/Destroy(force, silent)
 	QDEL_LIST_CONTENTS(all_fillers)

--- a/code/datums/components/multitile.dm
+++ b/code/datums/components/multitile.dm
@@ -38,7 +38,7 @@
 			return COMPONENT_INCOMPATIBLE
 
 		for(var/j in 1 to length(new_filler_map[i]))
-			if(new_filler_map[i][j] == 2)
+			if(new_filler_map[i][j] == MACH_CENTER)
 				offset_x = j - ((length(new_filler_map[i]) + 1) / 2)
 				offset_y = i - ((length(new_filler_map) + 1) / 2)
 
@@ -59,9 +59,9 @@
 	var/current_width = 1
 	var/tile_index = 1
 
-	for(var/turf/filler_turf as anything in block( \
-	owner.x - offset_x - distance_from_center_x, owner.y + offset_y - distance_from_center_y, owner.z, \
-	owner.x - offset_x + distance_from_center_x, owner.y + offset_y + distance_from_center_y, owner.z, \
+	for(var/turf/filler_turf as anything in block( 
+	owner.x - offset_x - distance_from_center_x, owner.y + offset_y - distance_from_center_y, owner.z,
+	owner.x - offset_x + distance_from_center_x, owner.y + offset_y + distance_from_center_y, owner.z,
 	))
 		//Last check is for filler row lists of length 1.
 		if(new_filler_map[max_height - current_height][current_width] == 1) // Because the `block()` proc always works from the bottom left to the top right, we have to loop through our list in reverse

--- a/code/modules/power/gravitygenerator.dm
+++ b/code/modules/power/gravitygenerator.dm
@@ -58,10 +58,9 @@ GLOBAL_LIST_EMPTY(gravity_generators)
 
 /obj/machinery/gravity_generator/main/station/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/multitile, 1, list(
+	AddComponent(/datum/component/multitile, list(
 		list(1, 1,		   1),
 		list(1, MACH_CENTER, 1),
-		list(0, 0,		   0),
 	))
 	update_gen_list()
 	set_power()

--- a/code/modules/station_goals/bluespace_tap.dm
+++ b/code/modules/station_goals/bluespace_tap.dm
@@ -256,7 +256,7 @@
 	if(!powernet)
 		connect_to_network()
 
-	AddComponent(/datum/component/multitile, 1, list(
+	AddComponent(/datum/component/multitile, list(
 		list(1, 1,		   1),
 		list(1, MACH_CENTER, 1),
 		list(1, 0,		   1),

--- a/code/modules/station_goals/dna_vault.dm
+++ b/code/modules/station_goals/dna_vault.dm
@@ -170,9 +170,7 @@ GLOBAL_LIST_INIT(non_simple_animals, typecacheof(list(/mob/living/carbon/human/m
 			dna_max = G.human_count
 			break
 
-	AddComponent(/datum/component/multitile, 2, list(
-		list(0, 0,		 0,	   0, 0),
-		list(0, 0,		 0,	   0, 0),
+	AddComponent(/datum/component/multitile, list(
 		list(0, 1, MACH_CENTER, 1, 0),
 		list(0, 1,		 0,	   1, 0),
 		list(0, 1,		 0,	   1, 0)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
The multitile component now works with any length of lists and creates all of the fillers relative to MACH_CENTER, rather than the center of the table.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
This makes it easier and more intuitive to create big machines of various shapes while also dramatically reducing the size of the table needed to create shapes of high aspect ratios.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://github.com/user-attachments/assets/17858a42-528b-4817-8f9f-3eca0da9d6ec)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
I tested the following shapes by changing the filler's sprite to that of a wooden table:
Hourglass:


		list(1, 1, 1, 1, 1)

		list(	1, 1, 1)

		list(  MACH_CENTER)

		list(	1, 1, 1)

		list(1, 1, 1, 1, 1)

Hollow Diamond:

		list(		 	1)

		list(	 	1,	0, 	1)

		list(	   1, 0,	0, 	0, 1)

		list(   1, 0,  0,	0, 	0, 0, 1)

		list(        1, 0,	0, 	0, 1)

		list( 		1, 	0, 	1, )

		list(		   MACH_CENTER)

Snake:

		list(	          1, 0, 0, 0, 1, 0, 0),

		list(MACH_CENTER, 0, 1, 0, 1, 0, 1, 0, 1),

		list(	          0, 0, 1, 0, 0, 0, 1),

<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
tweak: Changed the multitile component so that it could work with arbitrary shapes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
