### PR TITLE
[s] Fixes eswords reflecting bullets rather than just energy projectiles on parry.

### DIFF
--- a/code/game/objects/items/weapons/melee/energy_melee_weapons.dm
+++ b/code/game/objects/items/weapons/melee/energy_melee_weapons.dm
@@ -311,13 +311,14 @@
 		return
 	if(isprojectile(hitby))
 		var/obj/item/projectile/P = hitby
-		if(P.reflectability == REFLECTABILITY_NEVER) //only 1 magic spell does this, but hey, needed
-			owner.visible_message("<span class='danger'>[owner] blocks [attack_text] with [src]!</span>")
-			playsound(src, 'sound/weapons/effects/ric3.ogg', 100, TRUE)
-			return TRUE
-		owner.visible_message("<span class='danger'>[owner] parries [attack_text] with [src]!</span>")
-		add_attack_logs(P.firer, src, "hit by [P.type] but got parried by [src]")
-		return -1
+		if(P.reflectability == REFLECTABILITY_ENERGY)
+			owner.visible_message("<span class='danger'>[owner] parries [attack_text] with [src]!</span>")
+			add_attack_logs(P.firer, src, "hit by [P.type] but got parried by [src]")
+			return -1
+		owner.visible_message("<span class='danger'>[owner] blocks [attack_text] with [src]!</span>")
+		playsound(src, 'sound/weapons/effects/ric3.ogg', 100, TRUE)
+		return TRUE
+
 	return TRUE
 
 //////////////////////////////


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
fixes eswords reflecting bullets rather than just energy projectiles on parry.

## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
should only be lasers as intended in https://github.com/ParadiseSS13/Paradise/pull/21463

## Testing

<!-- How did you test the PR, if at all? -->

Parried lasers from an energy turret, reflected back.
Parried bullets from  a syndicate turret, blocked.
Parried a terror spider, blocked.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Fixes eswords reflecting bullets rather than just energy projectiles on parry.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
