### PR TITLE
[s] Fixes shell launch sytem not backfiring right

### DIFF
--- a/code/modules/projectiles/firing.dm
+++ b/code/modules/projectiles/firing.dm
@@ -38,10 +38,12 @@
 
 /obj/item/ammo_casing/proc/throw_proj(atom/target, turf/targloc, mob/living/user, params, spread, atom/firer_source_atom)
 	var/turf/curloc = get_turf(firer_source_atom)
-	if(!istype(curloc)) // False-bottomed briefcase check.
+	if(!istype(curloc)) // False-bottomed briefcase check / shell launch system check.
 		var/obj/item/holding = user.get_active_hand()
 		if(istype(holding, /obj/item/storage/briefcase/false_bottomed))
 			curloc = get_turf(holding)
+		if(istype(firer_source_atom, /obj/item/gun/projectile/revolver/doublebarrel/shell_launcher))
+			curloc = get_turf(user)
 	if(!istype(targloc) || !istype(curloc) || !BB)
 		return
 	BB.ammo_casing = src


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Fixes shell launch system not backfiring properly on emp, after changes in https://github.com/ParadiseSS13/Paradise/pull/25567

## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Bugs are bad

## Testing

<!-- How did you test the PR, if at all? -->
shot the shotgun.
Emped myself with rubbershot and gun deployed, gun retracted and hit my arm.
emped myself with dragonsbreath and gun retracted, gun fired and hit my arm
Emped myself with frag12, hit then arm gibbed
<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Fixes shell launch sytem not backfiring right
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
