### PR TITLE
fix: headphone music notes updating / admin musician outfit

### DIFF
--- a/code/datums/outfits/outfit_admin.dm
+++ b/code/datums/outfits/outfit_admin.dm
@@ -561,9 +561,9 @@
 	if(istype(I))
 		apply_to_card(I, H, list(ACCESS_MAINT_TUNNELS), "Bard")
 
-	var/obj/item/clothing/ears/headphones/P = r_ear
+	var/obj/item/clothing/ears/headphones/P = H.r_ear
 	if(istype(P))
-		P.attack_self(H) // activate them, display musical notes effect
+		P.toggle_visual_notes(H) // activate them, display musical notes effect
 
 // Soviet Military
 

--- a/code/modules/instruments/objs/items/headphones.dm
+++ b/code/modules/instruments/objs/items/headphones.dm
@@ -23,9 +23,17 @@
 /obj/item/clothing/ears/headphones/ui_action_click(mob/user, actiontype)
 	if(actiontype == /datum/action/item_action/change_headphones_song)
 		ui_interact(user)
-	else
-		on = !on
-		update_icon(UPDATE_ICON_STATE)
+	else if(actiontype == /datum/action/item_action/toggle_music_notes)
+		toggle_visual_notes(user)
+
+	for(var/X in actions)
+		var/datum/action/A = X
+		A.UpdateButtons()
+
+/obj/item/clothing/ears/headphones/proc/toggle_visual_notes(mob/user)
+	on = !on
+	update_icon(UPDATE_ICON_STATE)
+	user.regenerate_icons()
 
 /obj/item/clothing/ears/headphones/ui_data(mob/user)
 	return song.ui_data(user)


### PR DESCRIPTION
## What Does This PR Do
This PR fixes player sprites and action buttons not updating when toggling music notes on worn headphones. It also fixes a logic error in the admin "Musician" outfit that was meant to toggle music notes upon equipping, but didn't.
## Why It's Good For The Game
Bug fixes good.
## Testing
Selected musician as admin equipment loadout. Ensured music notes were visible. Pressed UI action button to toggle notes. Ensured they were enabled and disabled on the player icon appropriately.
<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: Worn headphones will now properly update their sprite when music notes are toggled.
fix: The UI buttons for worn headphones will properly update when music notes are toggled.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
