### PR TITLE
[TWEAK/BALANCE] Destroyed monkey cube box now destroys monkey cubes inside

### DIFF
--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -381,6 +381,15 @@
 	for(var/I in 1 to 5)
 		new monkey_cube_type(src)
 
+/obj/item/storage/box/monkeycubes/obj_destruction(damage_flag)
+	if(damage_flag == ACID)
+		for(var/obj/item/food/monkeycube/mkc in contents)
+			mkc.obj_destruction(ACID)
+	else if(damage_flag == FIRE)
+		for(var/obj/item/food/monkeycube/mkc in contents)
+			mkc.obj_destruction(FIRE)
+	. = ..()
+
 /obj/item/storage/box/monkeycubes/syndicate
 	desc = "Waffle Co. brand monkey cubes. Just add water and a dash of subterfuge!"
 	monkey_cube_type = /obj/item/food/monkeycube/syndicate

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -382,12 +382,9 @@
 		new monkey_cube_type(src)
 
 /obj/item/storage/box/monkeycubes/obj_destruction(damage_flag)
-	if(damage_flag == ACID)
+	if(damage_flag == ACID || damage_flag == FIRE)
 		for(var/obj/item/food/monkeycube/mkc in contents)
-			mkc.obj_destruction(ACID)
-	else if(damage_flag == FIRE)
-		for(var/obj/item/food/monkeycube/mkc in contents)
-			mkc.obj_destruction(FIRE)
+			mkc.obj_destruction(damage_flag)
 	. = ..()
 
 /obj/item/storage/box/monkeycubes/syndicate


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
When a monkey cube box (Or any of their variants) is destroyed by acid/fire, the cubes inside are also destroyed.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Prevents cheesing by biohazards
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Burn a monkey cube box by blowing up a weldertank next to it, monkey cubes are destroyed
Spray acid on monkey cube box as a xeno queen, monkey cubes are destroyed
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

![image](https://github.com/user-attachments/assets/a55a135a-26b5-46f5-a2ab-02d16df55f7a)

  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
tweak: Destroyed monkey cube box now destroys monkey cubes inside.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
