### PR TITLE
[FIX] Guardian health HUD now updates properly when host health changes

### DIFF
--- a/code/__DEFINES/dcs/mob_signals.dm
+++ b/code/__DEFINES/dcs/mob_signals.dm
@@ -131,6 +131,8 @@
 ///from base of /obj/item/bodypart/proc/attach_limb(): (new_limb, special) allows you to fail limb attachment
 #define COMSIG_LIVING_ATTACH_LIMB "living_attach_limb"
 	#define COMPONENT_NO_ATTACH (1<<0)
+///from base of mob/living/health_update()
+#define COMSIG_LIVING_HEALTH_UPDATE "living_health_update"
 ///sent from borg recharge stations: (amount, repairs)
 #define COMSIG_PROCESS_BORGCHARGER_OCCUPANT "living_charge"
 ///sent when a mob enters a borg charger

--- a/code/game/gamemodes/miniantags/guardian/guardian.dm
+++ b/code/game/gamemodes/miniantags/guardian/guardian.dm
@@ -53,7 +53,6 @@
 		return
 	summoner = host
 	host.grant_guardian_actions(src)
-	update_health_hud()
 	RegisterSignal(summoner, COMSIG_LIVING_HEALTH_UPDATE, PROC_REF(update_health_hud))
 
 /mob/living/simple_animal/hostile/guardian/can_buckle()

--- a/code/game/gamemodes/miniantags/guardian/guardian.dm
+++ b/code/game/gamemodes/miniantags/guardian/guardian.dm
@@ -54,7 +54,7 @@
 	summoner = host
 	host.grant_guardian_actions(src)
 	update_health_hud()
-	RegisterSignal(summoner, COMSIG_MOB_APPLY_DAMAGE, PROC_REF(update_health_hud))
+	RegisterSignal(summoner, COMSIG_LIVING_HEALTH_UPDATE, PROC_REF(update_health_hud))
 
 /mob/living/simple_animal/hostile/guardian/can_buckle()
 	return FALSE
@@ -135,7 +135,7 @@
 	if(!.)
 		return FALSE
 	to_chat(summoner, "<span class='danger'>Your [name] died somehow!</span>")
-	UnregisterSignal(summoner, COMSIG_MOB_APPLY_DAMAGE)
+	UnregisterSignal(summoner, COMSIG_LIVING_HEALTH_UPDATE)
 	summoner.death()
 
 

--- a/code/game/gamemodes/miniantags/guardian/guardian.dm
+++ b/code/game/gamemodes/miniantags/guardian/guardian.dm
@@ -143,7 +143,7 @@
 	if(summoner)
 		var/resulthealth
 		if(iscarbon(summoner))
-			resulthealth = round((abs(HEALTH_THRESHOLD_DEAD - summoner.health) / abs(HEALTH_THRESHOLD_DEAD - summoner.maxHealth)) * 100)
+			resulthealth = round(((summoner.health - HEALTH_THRESHOLD_CRIT) / abs(HEALTH_THRESHOLD_CRIT - summoner.maxHealth)) * 100)
 		else
 			resulthealth = round((summoner.health / (summoner.maxHealth/2)) * 100)
 		if(hud_used)

--- a/code/game/gamemodes/miniantags/guardian/guardian.dm
+++ b/code/game/gamemodes/miniantags/guardian/guardian.dm
@@ -53,6 +53,8 @@
 		return
 	summoner = host
 	host.grant_guardian_actions(src)
+	update_health_hud()
+	RegisterSignal(summoner, COMSIG_MOB_APPLY_DAMAGE, PROC_REF(update_health_hud))
 
 /mob/living/simple_animal/hostile/guardian/can_buckle()
 	return FALSE
@@ -133,6 +135,7 @@
 	if(!.)
 		return FALSE
 	to_chat(summoner, "<span class='danger'>Your [name] died somehow!</span>")
+	UnregisterSignal(summoner, COMSIG_MOB_APPLY_DAMAGE)
 	summoner.death()
 
 
@@ -142,9 +145,9 @@
 		if(iscarbon(summoner))
 			resulthealth = round((abs(HEALTH_THRESHOLD_DEAD - summoner.health) / abs(HEALTH_THRESHOLD_DEAD - summoner.maxHealth)) * 100)
 		else
-			resulthealth = round((summoner.health / summoner.maxHealth) * 100)
+			resulthealth = round((summoner.health / (summoner.maxHealth/2)) * 100)
 		if(hud_used)
-			hud_used.guardianhealthdisplay.maptext = "<div align='center' valign='middle' style='position:relative; top:0px; left:6px'><font face='Small Fonts' color='#efeeef'>[resulthealth]%</font></div>"
+			hud_used.guardianhealthdisplay.maptext = "<div align='center' valign='middle' style='position:relative; top:0px; left:6px'><font face='Small Fonts' color=[summoner.health < HEALTH_THRESHOLD_CRIT ? "#db2828" : "#efeeef"]>[resulthealth]%</font></div>"
 
 /mob/living/simple_animal/hostile/guardian/adjustHealth(amount, updating_health = TRUE) //The spirit is invincible, but passes on damage/healing to the summoner
 	var/damage = amount * damage_transfer

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -12,6 +12,7 @@
 
 	health = maxHealth - getOxyLoss() - getToxLoss() - getCloneLoss() - total_limb_damage
 
+	SEND_SIGNAL(src, COMSIG_LIVING_HEALTH_UPDATE)
 	update_stat("updatehealth([reason])")
 	med_hud_set_health()
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -359,6 +359,7 @@
 		return
 	health = maxHealth - getOxyLoss() - getToxLoss() - getFireLoss() - getBruteLoss() - getCloneLoss()
 
+	SEND_SIGNAL(src, COMSIG_LIVING_HEALTH_UPDATE)
 	update_stat("updatehealth([reason])")
 	med_hud_set_health()
 	med_hud_set_status()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes it so that the health hud for a guardian updates when the host is hurt/healed
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
It's quite useful for the guardian to know when their host is hurt.

Fixes: #14464
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Get a guardian, hit myself a bunch, their health hud updates
Heal myself, their health hud updates.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Guardian health HUD now updates properly when host health changes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
