### PR TITLE
Fixes heat_proof vairables of doors

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -148,7 +148,7 @@
 	if(!density)
 		return ..()
 	if(heat_proof)
-		return ZERO_HEAT_TRANSFER_COEFFICIENT
+		return 0 //ZERO_HEAT_TRANSFER_COEFFICIENT not used here as DM did not like "0.0" as a direction
 	return superconductivity
 
 /obj/machinery/door/proc/bumpopen(mob/user)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes #26389. Turbine doors are now heatproof again
## Why It's Good For The Game

I dislike becoming fried calamari when messing with the turbine.

## Testing

Ran a turbine before changes, was fried by heat. Ran a turbine after changes, was not fried by heat. 

<hr>

### Declaration

- [x ] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Turbine doors are once again heatproof
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
