### PR TITLE
[FIX] Dead cats no longer chase mice

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -172,7 +172,7 @@
 				break
 	if(movement_target)
 		stop_automated_movement = TRUE
-		walk(src,movement_target,0,3)
+		walk(src, movement_target, 0, 3)
 
 /mob/living/simple_animal/pet/cat/Proc
 	name = "Proc"

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -142,7 +142,7 @@
 				M.death()
 				M.splat()
 				movement_target = null
-				walk(src, 0)
+				walk_to(src, 0)
 				stop_automated_movement = FALSE
 				break
 		for(var/obj/item/toy/cattoy/T in view(1, src))
@@ -165,6 +165,7 @@
 	if(!movement_target || !(movement_target.loc in oview(src, 3)))
 		movement_target = null
 		stop_automated_movement = FALSE
+		walk_to(src, 0)
 		for(var/mob/living/simple_animal/mouse/snack in oview(src,3))
 			if(isturf(snack.loc) && !snack.stat)
 				movement_target = snack

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -157,7 +157,7 @@
 
 	turns_since_scan++
 	if(turns_since_scan > 5)
-		walk(src,0)
+		walk(src, 0)
 		turns_since_scan = 0
 	if((movement_target) && !(isturf(movement_target.loc) || ishuman(movement_target.loc)))
 		movement_target = null

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -142,6 +142,7 @@
 				M.death()
 				M.splat()
 				movement_target = null
+				walk(src, 0)
 				stop_automated_movement = FALSE
 				break
 		for(var/obj/item/toy/cattoy/T in view(1, src))

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -142,7 +142,7 @@
 				M.death()
 				M.splat()
 				movement_target = null
-				walk_to(src, 0)
+				walk(src, 0)
 				stop_automated_movement = FALSE
 				break
 		for(var/obj/item/toy/cattoy/T in view(1, src))
@@ -157,7 +157,7 @@
 
 	turns_since_scan++
 	if(turns_since_scan > 5)
-		walk_to(src,0)
+		walk(src,0)
 		turns_since_scan = 0
 	if((movement_target) && !(isturf(movement_target.loc) || ishuman(movement_target.loc)))
 		movement_target = null
@@ -165,14 +165,14 @@
 	if(!movement_target || !(movement_target.loc in oview(src, 3)))
 		movement_target = null
 		stop_automated_movement = FALSE
-		walk_to(src, 0)
+		walk(src, 0)
 		for(var/mob/living/simple_animal/mouse/snack in oview(src,3))
 			if(isturf(snack.loc) && !snack.stat)
 				movement_target = snack
 				break
 	if(movement_target)
 		stop_automated_movement = TRUE
-		walk_to(src,movement_target,0,3)
+		walk(src,movement_target,0,3)
 
 /mob/living/simple_animal/pet/cat/Proc
 	name = "Proc"

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -365,6 +365,7 @@
 	if(!.)
 		return FALSE
 	flying = FALSE
+	walk(src, 0)
 	if(nest)
 		nest.spawned_mobs -= src
 		nest = null


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Dead cats no longer try to chase mice. Cats also stop chasing the mouse after the mouse is dead

Fixes: #25610
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Dead cats chase no mice.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Spawn in a mouse, cat starts chasing it, I kill the cat before they reach the mouse, they stop moving.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Dead cats no longer chase mice
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
