### PR TITLE
Disambiguate jelly donuts

### DIFF
--- a/code/modules/food_and_drinks/food/foods/baked_goods.dm
+++ b/code/modules/food_and_drinks/food/foods/baked_goods.dm
@@ -500,14 +500,14 @@
 		filling_color = "#FF69B4"
 
 /obj/item/food/donut/jelly/slimejelly
-	name = "jelly donut"
+	name = "slime jelly donut"
 	desc = "You jelly?"
 	icon_state = "jdonut1"
 	extra_reagent = "slimejelly"
 	goal_difficulty = FOOD_GOAL_HARD
 
 /obj/item/food/donut/jelly/cherryjelly
-	name = "jelly donut"
+	name = "cherry jelly donut"
 	desc = "You jelly?"
 	icon_state = "jdonut1"
 	extra_reagent = "cherryjelly"


### PR DESCRIPTION
## What Does This PR Do
Gives cherry and slime jelly donuts a unique name, rather then all three kinds being "jelly donut".

## Why It's Good For The Game
It's really annoying if a secondary goal asks you to make jelly donuts, then turns up its nose at you because you didn't read its mind and send the correct type.

## Testing
It compiled. If changing their names manages to break something, I will be completely shocked.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog

:cl:
fix: CC has decided that requesting "jelly donuts" without specifying which type was kind of mean, so all three types now have unique names.
/:cl: