### PR TITLE
fix: Farragus disposal outlet direction

### DIFF
--- a/_maps/map_files/stations/cerestation.dmm
+++ b/_maps/map_files/stations/cerestation.dmm
@@ -74137,7 +74137,7 @@
 /area/station/hallway/primary/aft/east)
 "pRl" = (
 /obj/structure/disposaloutlet{
-	dir = 4
+	dir = 8
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 4


### PR DESCRIPTION
## What Does This PR Do
This PR fixes the direction of a disposal outlet in the farragus west waste belt loop.
## Why It's Good For The Game
Shit getting stuck
## Images of changes
### Before
![2024_09_19__06_17_09__paradise dme  cerestation dmm  - StrongDMM](https://github.com/user-attachments/assets/5dfc6c5d-5589-4257-a41a-8bee2a97a661)
### After
![2024_09_19__06_17_15__paradise dme  cerestation dmm  - StrongDMM](https://github.com/user-attachments/assets/f87dbccf-1212-4eeb-ab75-4fa76cff3f43)
## Testing
Visual inspection.

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Farragus: A disposal outlet on the west waste belt loop is now facing the correct direction.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
