### PR TITLE
IPCs are affected by Jestosterone now

### DIFF
--- a/code/modules/reagents/chemistry/reagents/misc_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/misc_reagents.dm
@@ -476,7 +476,7 @@
 			C.AddElement(/datum/element/waddling)
 	C.AddComponent(/datum/component/squeak, null, null, null, null, null, TRUE, falloff_exponent = 20)
 
-/datum/reagent/jestosterone/on_mob_life(mob/living/carbon/M)
+/datum/reagent/jestosterone/on_mob_life(mob/living/human/carbon/M)
 	var/update_flags = STATUS_UPDATE_NONE
 	var/is_robot = (SYNTHETIC) > 0
 	if(prob(10))
@@ -484,7 +484,7 @@
 	if(!M.mind)
 		return ..() | update_flags
 	if(M.mind.assigned_role == "Clown")
-		update_flags |= M.adjustBruteLoss(-1.5 * REAGENTS_EFFECT_MULTIPLIER) //Screw those pesky clown beatings!
+		update_flags |= M.adjustBruteLoss(-1.5 * REAGENTS_EFFECT_MULTIPLIER, robotic = TRUE) //Screw those pesky clown beatings!
 	else
 		M.AdjustDizzy(20 SECONDS, 0, 100 SECONDS)
 		M.Druggy(30 SECONDS)
@@ -507,7 +507,7 @@
 			if(!is_robot)
 				update_flags |= M.adjustToxLoss(1.5 * REAGENTS_EFFECT_MULTIPLIER)
 			else
-				update_flags |= M.adjustFireLoss(1.5 * REAGENTS_EFFECT_MULTIPLIER)
+				update_flags |= M.adjustFireLoss(1.5 * REAGENTS_EFFECT_MULTIPLIER, robotic = TRUE)
 	return ..() | update_flags
 
 /datum/reagent/jestosterone/on_mob_delete(mob/living/M)

--- a/code/modules/reagents/chemistry/reagents/misc_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/misc_reagents.dm
@@ -504,7 +504,7 @@
 			"You feel like telling a pun.")
 			to_chat(M, "<span class='warning'>[pick(clown_message)]</span>")
 		if(M.mind.assigned_role == "Mime")
-			if(!SYNTHETIC)
+			if(!(M.dna.species.reagent_tag & PROCESS_SYN))
 				update_flags |= M.adjustToxLoss(1.5 * REAGENTS_EFFECT_MULTIPLIER)
 			else
 				update_flags |= M.adjustFireLoss(1.5 * REAGENTS_EFFECT_MULTIPLIER, robotic = TRUE)

--- a/code/modules/reagents/chemistry/reagents/misc_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/misc_reagents.dm
@@ -476,7 +476,7 @@
 			C.AddElement(/datum/element/waddling)
 	C.AddComponent(/datum/component/squeak, null, null, null, null, null, TRUE, falloff_exponent = 20)
 
-/datum/reagent/jestosterone/on_mob_life(mob/living/human/carbon/M)
+/datum/reagent/jestosterone/on_mob_life(mob/living/carbon/human/M)
 	var/update_flags = STATUS_UPDATE_NONE
 	var/is_robot = (SYNTHETIC) > 0
 	if(prob(10))

--- a/code/modules/reagents/chemistry/reagents/misc_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/misc_reagents.dm
@@ -503,7 +503,7 @@
 			"You feel like telling a pun.")
 			to_chat(M, "<span class='warning'>[pick(clown_message)]</span>")
 		if(M.mind.assigned_role == "Mime")
-			if(!(M.dna.species.reagent_tag & PROCESS_SYN)) // Ensures the mob that is processing the reagent is Organic
+			if(!(M.dna.species.reagent_tag & PROCESS_SYN)) // Ensures the mob that is processing the reagent is Organic to apply toxin damage
 				update_flags |= M.adjustToxLoss(1.5 * REAGENTS_EFFECT_MULTIPLIER)
 			else // Only activates if the mob that is processing the reagent is Synthetic (IPC)
 				update_flags |= M.adjustFireLoss(1.5 * REAGENTS_EFFECT_MULTIPLIER, robotic = TRUE) // The ", robotic = TRUE" just means it affects robotic limbs, which an IPC is fully robotic

--- a/code/modules/reagents/chemistry/reagents/misc_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/misc_reagents.dm
@@ -453,6 +453,7 @@
 	id = "jestosterone"
 	description = "Jestosterone is an odd chemical compound that induces a variety of annoying side-effects in the average person. It also causes mild intoxication, and is toxic to mimes."
 	color = "#ff00ff" //Fuchsia, pity we can't do rainbow here
+	process_flags = ORGANIC | SYNTHETIC
 	taste_description = "a funny flavour"
 
 /datum/reagent/jestosterone/on_new()
@@ -477,6 +478,7 @@
 
 /datum/reagent/jestosterone/on_mob_life(mob/living/carbon/M)
 	var/update_flags = STATUS_UPDATE_NONE
+	var/is_robot = (SYNTHETIC) > 0
 	if(prob(10))
 		M.emote("giggle")
 	if(!M.mind)
@@ -502,7 +504,10 @@
 			"You feel like telling a pun.")
 			to_chat(M, "<span class='warning'>[pick(clown_message)]</span>")
 		if(M.mind.assigned_role == "Mime")
-			update_flags |= M.adjustToxLoss(1.5 * REAGENTS_EFFECT_MULTIPLIER)
+			if(!is_robot)
+				update_flags |= M.adjustToxLoss(1.5 * REAGENTS_EFFECT_MULTIPLIER)
+			else
+				update_flags |= M.adjustFireLoss(1.5 * REAGENTS_EFFECT_MULTIPLIER)
 	return ..() | update_flags
 
 /datum/reagent/jestosterone/on_mob_delete(mob/living/M)

--- a/code/modules/reagents/chemistry/reagents/misc_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/misc_reagents.dm
@@ -478,7 +478,6 @@
 
 /datum/reagent/jestosterone/on_mob_life(mob/living/carbon/human/M)
 	var/update_flags = STATUS_UPDATE_NONE
-	var/is_robot = (SYNTHETIC) > 0
 	if(prob(10))
 		M.emote("giggle")
 	if(!M.mind)

--- a/code/modules/reagents/chemistry/reagents/misc_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/misc_reagents.dm
@@ -503,11 +503,11 @@
 			"You feel like telling a pun.")
 			to_chat(M, "<span class='warning'>[pick(clown_message)]</span>")
 		if(M.mind.assigned_role == "Mime")
-			if(!(M.dna.species.reagent_tag & PROCESS_SYN))
+			if(!(M.dna.species.reagent_tag & PROCESS_SYN)) // Ensures the mob that is processing the reagent is Organic
 				update_flags |= M.adjustToxLoss(1.5 * REAGENTS_EFFECT_MULTIPLIER)
-			else
-				update_flags |= M.adjustFireLoss(1.5 * REAGENTS_EFFECT_MULTIPLIER, robotic = TRUE)
-	return ..() | update_flags
+			else // Only activates if the mob that is processing the reagent is Synthetic (IPC)
+				update_flags |= M.adjustFireLoss(1.5 * REAGENTS_EFFECT_MULTIPLIER, robotic = TRUE) // The ", robotic = TRUE" just means it affects robotic limbs, which an IPC is fully robotic
+	return ..() | update_flags 																	   // Using burn instead of toxin for IPCs since IPCs don't suffer toxin and poison can feel similar to burns
 
 /datum/reagent/jestosterone/on_mob_delete(mob/living/M)
 	..()

--- a/code/modules/reagents/chemistry/reagents/misc_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/misc_reagents.dm
@@ -504,7 +504,7 @@
 			"You feel like telling a pun.")
 			to_chat(M, "<span class='warning'>[pick(clown_message)]</span>")
 		if(M.mind.assigned_role == "Mime")
-			if(!is_robot)
+			if(!SYNTHETIC)
 				update_flags |= M.adjustToxLoss(1.5 * REAGENTS_EFFECT_MULTIPLIER)
 			else
 				update_flags |= M.adjustFireLoss(1.5 * REAGENTS_EFFECT_MULTIPLIER, robotic = TRUE)

--- a/code/modules/reagents/chemistry/reagents/misc_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/misc_reagents.dm
@@ -504,8 +504,8 @@
 			to_chat(M, "<span class='warning'>[pick(clown_message)]</span>")
 		if(M.mind.assigned_role == "Mime")
 			if(!M.dna.species.tox_mod) // If they can't take tox damage, make them take burn damage
-				update_flags |= M.adjustFireLoss(1.5 * REAGENTS_EFFECT_MULTIPLIER, robotic = TRUE) // Deal burn instead of toxin for IPCs, since IPCs don't suffer toxin and poison can feel similar to burns
-			else // Ensures the mob that is processing the reagent is Organic to apply toxin damage
+				update_flags |= M.adjustFireLoss(1.5 * REAGENTS_EFFECT_MULTIPLIER, robotic = TRUE)
+			else
 				update_flags |= M.adjustToxLoss(1.5 * REAGENTS_EFFECT_MULTIPLIER)
 	return ..() | update_flags
 

--- a/code/modules/reagents/chemistry/reagents/misc_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/misc_reagents.dm
@@ -503,7 +503,7 @@
 			"You feel like telling a pun.")
 			to_chat(M, "<span class='warning'>[pick(clown_message)]</span>")
 		if(M.mind.assigned_role == "Mime")
-			if(!M.dna.species.tox_mod) // If they can't take tox damage, make them take burn damage
+			if(M.dna.species.tox_mod <= 0) // If they can't take tox damage, make them take burn damage
 				update_flags |= M.adjustFireLoss(1.5 * REAGENTS_EFFECT_MULTIPLIER, robotic = TRUE)
 			else
 				update_flags |= M.adjustToxLoss(1.5 * REAGENTS_EFFECT_MULTIPLIER)

--- a/code/modules/reagents/chemistry/reagents/misc_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/misc_reagents.dm
@@ -503,7 +503,7 @@
 			"You feel like telling a pun.")
 			to_chat(M, "<span class='warning'>[pick(clown_message)]</span>")
 		if(M.mind.assigned_role == "Mime")
-			if(!M.dna.species.tox_mod)) // If they can't take tox damage, make them take burn damage
+			if(!(M.dna.species.reagent_tag & PROCESS_ORG)) // Only activates if the mob that is processing the reagent is Synthetic (IPC)
 				update_flags |= M.adjustFireLoss(1.5 * REAGENTS_EFFECT_MULTIPLIER, robotic = TRUE) // Deal burn instead of toxin for IPCs, since IPCs don't suffer toxin and poison can feel similar to burns
 			else // Ensures the mob that is processing the reagent is Organic to apply toxin damage
 				update_flags |= M.adjustToxLoss(1.5 * REAGENTS_EFFECT_MULTIPLIER)

--- a/code/modules/reagents/chemistry/reagents/misc_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/misc_reagents.dm
@@ -504,7 +504,7 @@
 			to_chat(M, "<span class='warning'>[pick(clown_message)]</span>")
 		if(M.mind.assigned_role == "Mime")
 			if(!(C.dna.species.reagent_tag & PROCESS_ORG)) // Only activates if the mob that is processing the reagent is Synthetic (IPC)
-				update_flags |= M.adjustFireLoss(1.5 * REAGENTS_EFFECT_MULTIPLIER, robotic = TRUE) // The ", robotic = TRUE" just means it affects robotic limbs, which an IPC is fully robotic
+				update_flags |= M.adjustFireLoss(1.5 * REAGENTS_EFFECT_MULTIPLIER, robotic = TRUE)  // The ", robotic = TRUE" just means it affects robotic limbs, which an IPC is fully robotic
 			else // Ensures the mob that is processing the reagent is Organic to apply toxin damage // Using burn instead of toxin for IPCs since IPCs don't suffer toxin and poison can feel similar to burns
 				update_flags |= M.adjustToxLoss(1.5 * REAGENTS_EFFECT_MULTIPLIER)
 	return ..() | update_flags

--- a/code/modules/reagents/chemistry/reagents/misc_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/misc_reagents.dm
@@ -503,7 +503,7 @@
 			"You feel like telling a pun.")
 			to_chat(M, "<span class='warning'>[pick(clown_message)]</span>")
 		if(M.mind.assigned_role == "Mime")
-			if(!(M.dna.species.reagent_tag & PROCESS_ORG)) // Only activates if the mob that is processing the reagent is Synthetic (IPC)
+			if(!M.dna.species.tox_mod)) // If they can't take tox damage, make them take burn damage
 				update_flags |= M.adjustFireLoss(1.5 * REAGENTS_EFFECT_MULTIPLIER, robotic = TRUE) // Deal burn instead of toxin for IPCs, since IPCs don't suffer toxin and poison can feel similar to burns
 			else // Ensures the mob that is processing the reagent is Organic to apply toxin damage
 				update_flags |= M.adjustToxLoss(1.5 * REAGENTS_EFFECT_MULTIPLIER)

--- a/code/modules/reagents/chemistry/reagents/misc_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/misc_reagents.dm
@@ -503,7 +503,7 @@
 			"You feel like telling a pun.")
 			to_chat(M, "<span class='warning'>[pick(clown_message)]</span>")
 		if(M.mind.assigned_role == "Mime")
-			if(!(C.dna.species.reagent_tag & PROCESS_ORG)) // Only activates if the mob that is processing the reagent is Synthetic (IPC)
+			if(!(M.dna.species.reagent_tag & PROCESS_ORG)) // Only activates if the mob that is processing the reagent is Synthetic (IPC)
 				update_flags |= M.adjustFireLoss(1.5 * REAGENTS_EFFECT_MULTIPLIER, robotic = TRUE)  // The ", robotic = TRUE" just means it affects robotic limbs, which an IPC is fully robotic
 			else // Ensures the mob that is processing the reagent is Organic to apply toxin damage // Using burn instead of toxin for IPCs since IPCs don't suffer toxin and poison can feel similar to burns
 				update_flags |= M.adjustToxLoss(1.5 * REAGENTS_EFFECT_MULTIPLIER)

--- a/code/modules/reagents/chemistry/reagents/misc_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/misc_reagents.dm
@@ -503,7 +503,7 @@
 			"You feel like telling a pun.")
 			to_chat(M, "<span class='warning'>[pick(clown_message)]</span>")
 		if(M.mind.assigned_role == "Mime")
-			if(!(M.dna.species.reagent_tag & PROCESS_ORG)) // Only activates if the mob that is processing the reagent is Synthetic (IPC)
+			if(!M.dna.species.tox_mod) // If they can't take tox damage, make them take burn damage
 				update_flags |= M.adjustFireLoss(1.5 * REAGENTS_EFFECT_MULTIPLIER, robotic = TRUE) // Deal burn instead of toxin for IPCs, since IPCs don't suffer toxin and poison can feel similar to burns
 			else // Ensures the mob that is processing the reagent is Organic to apply toxin damage
 				update_flags |= M.adjustToxLoss(1.5 * REAGENTS_EFFECT_MULTIPLIER)

--- a/code/modules/reagents/chemistry/reagents/misc_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/misc_reagents.dm
@@ -503,11 +503,11 @@
 			"You feel like telling a pun.")
 			to_chat(M, "<span class='warning'>[pick(clown_message)]</span>")
 		if(M.mind.assigned_role == "Mime")
-			if(!(M.dna.species.reagent_tag & PROCESS_SYN)) // Ensures the mob that is processing the reagent is Organic to apply toxin damage
-				update_flags |= M.adjustToxLoss(1.5 * REAGENTS_EFFECT_MULTIPLIER)
-			else // Only activates if the mob that is processing the reagent is Synthetic (IPC)
+			if(!(C.dna.species.reagent_tag & PROCESS_ORG)) // Only activates if the mob that is processing the reagent is Synthetic (IPC)
 				update_flags |= M.adjustFireLoss(1.5 * REAGENTS_EFFECT_MULTIPLIER, robotic = TRUE) // The ", robotic = TRUE" just means it affects robotic limbs, which an IPC is fully robotic
-	return ..() | update_flags 																	   // Using burn instead of toxin for IPCs since IPCs don't suffer toxin and poison can feel similar to burns
+			else // Ensures the mob that is processing the reagent is Organic to apply toxin damage // Using burn instead of toxin for IPCs since IPCs don't suffer toxin and poison can feel similar to burns
+				update_flags |= M.adjustToxLoss(1.5 * REAGENTS_EFFECT_MULTIPLIER)
+	return ..() | update_flags
 
 /datum/reagent/jestosterone/on_mob_delete(mob/living/M)
 	..()

--- a/code/modules/reagents/chemistry/reagents/misc_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/misc_reagents.dm
@@ -504,8 +504,8 @@
 			to_chat(M, "<span class='warning'>[pick(clown_message)]</span>")
 		if(M.mind.assigned_role == "Mime")
 			if(!(M.dna.species.reagent_tag & PROCESS_ORG)) // Only activates if the mob that is processing the reagent is Synthetic (IPC)
-				update_flags |= M.adjustFireLoss(1.5 * REAGENTS_EFFECT_MULTIPLIER, robotic = TRUE)  // The ", robotic = TRUE" just means it affects robotic limbs, which an IPC is fully robotic
-			else // Ensures the mob that is processing the reagent is Organic to apply toxin damage // Using burn instead of toxin for IPCs since IPCs don't suffer toxin and poison can feel similar to burns
+				update_flags |= M.adjustFireLoss(1.5 * REAGENTS_EFFECT_MULTIPLIER, robotic = TRUE) // Deal burn instead of toxin for IPCs, since IPCs don't suffer toxin and poison can feel similar to burns
+			else // Ensures the mob that is processing the reagent is Organic to apply toxin damage
 				update_flags |= M.adjustToxLoss(1.5 * REAGENTS_EFFECT_MULTIPLIER)
 	return ..() | update_flags
 


### PR DESCRIPTION
## What Does This PR Do

Makes it so IPCs are affected by Jestosterone relative to their job variable. Mime IPCs are burned instead as IPCs are unaffected by Toxin damage and burns feel somewhat similar to poison with numbness and burning sensations.

## Why It's Good For The Game

Funny Clown chemical should do funny Clown things to all. Also because IPC Clowns and Mimes should be affected as it is part of the chemical's gimmick.

## Testing

Spawned in as a Drask Clown, dealt brute to myself, drank Jestosterone, watched myself get healed.

Spawned in as an IPC Clown, dealt brute to myself, drank Jestosterone, watched myself get healed.

Spawned in as a Drask Assistant, drank Jestosterone, felt and saw the funny effects.

Spawned in as an IPC Assistant, drank Jestosterone, felt and saw the funny effects.

Spawned in as a Drask Mime, drank Jestosterone, felt and saw the funny effects, got Toxin damage.

Spawned in as an IPC Mime, drank Jestosterone, felt and saw the funny effects, got Burn damage.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
![image](https://github.com/user-attachments/assets/6416d4c2-39d5-4885-bf7d-8bdd60b4fcf1)
  <hr>

## Changelog

:cl:
tweak: IPC Clowns now get healed by Jestosterone.
tweak: IPC non-Clowns now get the regular effects of Jestosterone.
tweak: IPC Mimes now take burn damage from Jestosterone.
/:cl:
