### PR TITLE
Ant Popsicle Now Drops Proper Trash when Eaten

### DIFF
--- a/code/modules/food_and_drinks/food/foods/frozen.dm
+++ b/code/modules/food_and_drinks/food/foods/frozen.dm
@@ -360,5 +360,5 @@
 	desc = "A colony of ants suspended in hardened sugar. Those things are dead, right?"
 	icon_state = "ant_pop"
 	trash = /obj/item/trash/popsicle_stick
-	list_reagents = list("nutriment" = 1, "vitamin" = 1, "sugar" = 5, "ants" = 3,)
+	list_reagents = list("nutriment" = 1, "vitamin" = 1, "sugar" = 5, "ants" = 3)
 	tastes = list("candy" = 1, "ants" = 2)

--- a/code/modules/food_and_drinks/food/foods/frozen.dm
+++ b/code/modules/food_and_drinks/food/foods/frozen.dm
@@ -359,6 +359,6 @@
 	name = "ant popsicle"
 	desc = "A colony of ants suspended in hardened sugar. Those things are dead, right?"
 	icon_state = "ant_pop"
-	trash = /obj/item/stack/rods
+	trash = /obj/item/trash/popsicle_stick
 	list_reagents = list("nutriment" = 1, "vitamin" = 1, "sugar" = 5, "ants" = 3,)
 	tastes = list("candy" = 1, "ants" = 2)


### PR DESCRIPTION
## What Does This PR Do
Changes the trash that is dropped when tating an Ant Popsicle from a Metal Rod to a Used Popsicle Stick.
Fixes #26841

## Why It's Good For The Game
Puts the trash in line with what the recipe calls for. 

## Images of changes
![image](https://github.com/user-attachments/assets/095eeb40-689d-41ee-a97a-acb6434445c5)


## Testing
Spawned in Ant Popsicle
Consumed

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog

:cl:
tweak: Changed the trash that drops when consuming Ant Popsicles from Rod to Popsicle Stick.
/:cl: