### PR TITLE
[FIX] Cargo console entry for critter crates now show their contents

### DIFF
--- a/code/modules/supply/supply_packs/pack_organic.dm
+++ b/code/modules/supply/supply_packs/pack_organic.dm
@@ -152,18 +152,27 @@
 /datum/supply_packs/organic/cow
 	name = "Cow Crate"
 	cost = 100
+	contains_special = list(
+		"Cow"
+	)
 	containertype = /obj/structure/closet/critter/cow
 	containername = "cow crate"
 
 /datum/supply_packs/organic/pig
 	name = "Pig Crate"
 	cost = 100
+	contains_special = list(
+		"Pig"
+	)
 	containertype = /obj/structure/closet/critter/pig
 	containername = "pig crate"
 
 /datum/supply_packs/organic/goat
 	name = "Goat Crate"
 	cost = 100
+	contains_special = list(
+		"Goat"
+	)
 	containertype = /obj/structure/closet/critter/goat
 	containername = "goat crate"
 
@@ -179,12 +188,18 @@
 /datum/supply_packs/organic/turkey
 	name = "Turkey Crate"
 	cost = 100
+	contains_special = list(
+		"Turkey"
+	)
 	containertype = /obj/structure/closet/critter/turkey
 	containername = "turkey crate"
 
 /datum/supply_packs/organic/corgi
 	name = "Corgi Crate"
 	cost = 300
+	contains_special = list(
+		"Corgi"
+	)
 	containertype = /obj/structure/closet/critter/corgi
 	contains = list(/obj/item/petcollar)
 	containername = "corgi crate"
@@ -193,6 +208,9 @@
 	name = "Cat Crate"
 	cost = 300 //Cats are worth as much as corgis.
 	containertype = /obj/structure/closet/critter/cat
+	contains_special = list(
+		"Cat"
+	)
 	contains = list(/obj/item/petcollar,
 					/obj/item/toy/cattoy)
 	containername = "cat crate"
@@ -200,6 +218,9 @@
 /datum/supply_packs/organic/pug
 	name = "Pug Crate"
 	cost = 300
+	contains_special = list(
+		"Pug"
+	)
 	containertype = /obj/structure/closet/critter/pug
 	contains = list(/obj/item/petcollar)
 	containername = "pug crate"
@@ -207,6 +228,9 @@
 /datum/supply_packs/organic/fox
 	name = "Fox Crate"
 	cost = 300 //Foxes are cool.
+	contains_special = list(
+		"Fox"
+	)
 	containertype = /obj/structure/closet/critter/fox
 	contains = list(/obj/item/petcollar)
 	containername = "fox crate"
@@ -214,12 +238,18 @@
 /datum/supply_packs/organic/butterfly
 	name = "Butterfly Crate"
 	cost = 300
+	contains_special = list(
+		"Butterfly"
+	)
 	containertype = /obj/structure/closet/critter/butterfly
 	containername = "butterfly crate"
 
 /datum/supply_packs/organic/nian_caterpillar
 	name = "Nian Caterpillar Crate"
 	cost = 150
+	contains_special = list(
+		"Nian citterpillar"
+	)
 	containertype = /obj/structure/closet/critter/nian_caterpillar
 	contains = list(/obj/item/petcollar)
 	containername = "nian caterpillar crate"
@@ -227,12 +257,18 @@
 /datum/supply_packs/organic/deer
 	name = "Deer Crate"
 	cost = 350 //Deer are best.
+	contains_special = list(
+		"Deer"
+	)
 	containertype = /obj/structure/closet/critter/deer
 	containername = "deer crate"
 
 /datum/supply_packs/organic/bunny
 	name = "Bunny Crate"
 	cost = 200
+	contains_special = list(
+		"Bunny"
+	)
 	containertype = /obj/structure/closet/critter/bunny
 	contains = list(/obj/item/petcollar)
 	containername = "bunny crate"
@@ -240,6 +276,9 @@
 /datum/supply_packs/organic/gorilla
 	name = "Gorilla Crate"
 	cost = 1000
+	contains_special = list(
+		"Gorilla"
+	)
 	containertype = /obj/structure/closet/critter/gorilla
 	containername = "gorilla crate"
 	department_restrictions = list(DEPARTMENT_SCIENCE)
@@ -247,6 +286,9 @@
 /datum/supply_packs/organic/gorilla/cargo
 	name = "Cargorilla Crate"
 	cost = 250
+	contains_special = list(
+		"Cargorilla"
+	)
 	containertype = /obj/structure/closet/critter/gorilla/cargo
 	containername = "cargorilla crate"
 	department_restrictions = list(DEPARTMENT_SUPPLY)


### PR DESCRIPTION

<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
The manifests for critter crates now show their contents

Fixes: #26843
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Should be able to tell what is in a crate before you order it
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://github.com/user-attachments/assets/76648c06-5dc5-4339-9031-f67708a4b7ef)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Look at the cargo console
View contents on a cow crate
I can order cows
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Cargo console entry for critter crates now show their contents
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
