### PR TITLE
[FIX] You can no longer put your cyborg gripper in a display case

### DIFF
--- a/code/game/objects/items/robot/cyborg_gripper.dm
+++ b/code/game/objects/items/robot/cyborg_gripper.dm
@@ -15,6 +15,7 @@
 	icon = 'icons/obj/device.dmi'
 	icon_state = "gripper"
 	actions_types = list(/datum/action/item_action/drop_gripped_item)
+	flags = ABSTRACT
 	/// Set to TRUE to removal of cells/lights from machine objects containing them.
 	var/engineering_machine_interaction = FALSE
 	/// Defines what items the gripper can carry.
@@ -50,11 +51,12 @@
 /obj/item/gripper/proc/drop_gripped_item(mob/user, silent = FALSE)
 	if(!gripped_item)
 		to_chat(user, "<span class='warning'>[src] is empty.</span>")
-		return
+		return FALSE
 	if(!silent)
 		to_chat(user, "<span class='warning'>You drop [gripped_item].</span>")
 	gripped_item.forceMove(get_turf(src))
 	gripped_item = null
+	return TRUE
 
 /obj/item/gripper/attack_self(mob/user)
 	if(!gripped_item)

--- a/code/modules/mob/living/silicon/robot/robot_inventory.dm
+++ b/code/modules/mob/living/silicon/robot/robot_inventory.dm
@@ -119,9 +119,8 @@
 
 /mob/living/silicon/robot/drop_item()
 	var/obj/item/gripper/G = get_active_hand()
-	if(istype(G))
-		G.drop_gripped_item(silent = TRUE)
-		return TRUE // The gripper is special because it has a normal item inside that we can drop.
+	if(istype(G)) // The gripper is special because it has a normal item inside that we can drop.
+		return G.drop_gripped_item(silent = TRUE) // This only returns true if there's actually an item to drop so we don't drop the gripper accidentaly.
 	return FALSE // All robot inventory items have NODROP, so they should return FALSE.
 
 //Helper procs for cyborg modules on the UI.


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
You can no longer put your cyborg gripper in a display case
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Place items you're not supposed to drop, and that become undroppable for others is less than desirable.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

https://github.com/user-attachments/assets/10c0c49b-7c93-4a06-bdc8-b1e1ed88d6e4


<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Try to put the gripper in a display case
Grab airlock electronics
Put those in the display case
Put them in the trash
Drop them
Use them in hand
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: You can no longer put your cyborg gripper in a display case
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
