### PR TITLE
fix: only blackbox maintloot spawners

### DIFF
--- a/code/game/objects/effects/spawners/random/engineering_spawners.dm
+++ b/code/game/objects/effects/spawners/random/engineering_spawners.dm
@@ -1,6 +1,7 @@
 /obj/effect/spawner/random/engineering
 	icon = 'icons/effects/random_spawners.dmi'
 	icon_state = "wrench"
+	record_spawn = TRUE
 
 /obj/effect/spawner/random/engineering/tools
 	name = "Tool spawner"

--- a/code/game/objects/effects/spawners/random/food_spawners.dm
+++ b/code/game/objects/effects/spawners/random/food_spawners.dm
@@ -18,3 +18,4 @@
 
 		/obj/item/food/stroopwafel = 1,
 	)
+	record_spawn = TRUE

--- a/code/game/objects/effects/spawners/random/maint_loot_spawners.dm
+++ b/code/game/objects/effects/spawners/random/maint_loot_spawners.dm
@@ -4,6 +4,7 @@
 	name = "Maintenance loot spawner"
 	spawn_loot_chance = 65
 	spawn_random_offset_max_pixels = 8
+	record_spawn = TRUE
 
 /obj/effect/spawner/random/maintenance/Initialize(mapload)
 	loot = GLOB.maintenance_loot_tables

--- a/code/game/objects/effects/spawners/random/misc_spawners.dm
+++ b/code/game/objects/effects/spawners/random/misc_spawners.dm
@@ -6,6 +6,7 @@
 		/obj/item/dice/d10,
 		/obj/item/dice/d12,
 	)
+	record_spawn = TRUE
 
 /obj/effect/spawner/random/dice/Initialize()
 	. = ..()
@@ -28,6 +29,7 @@
 		/obj/item/folder/yellow,
 		/obj/item/clipboard,
 	)
+	record_spawn = TRUE
 
 /obj/effect/spawner/random/book
 	icon = 'icons/effects/random_spawners.dmi'
@@ -67,6 +69,7 @@
 		/obj/item/book/manual/wiki/sop_supply,
 		/obj/item/book/manual/zombie_manual,
 	)
+	record_spawn = TRUE
 
 /obj/effect/spawner/random/book/record_item(type_path_to_make)
 	SSblackbox.record_feedback("tally", "random_spawners", 1, "[/obj/item/book]")
@@ -78,6 +81,7 @@
 		/obj/item/mod/module/balloon = 1,
 		/obj/item/mod/module/stamp = 1
 	)
+	record_spawn = TRUE
 
 /obj/effect/spawner/random/janitor/supplies
 	icon = 'icons/effects/random_spawners.dmi'
@@ -89,4 +93,5 @@
 		/obj/item/storage/box/lights/mixed,
 		/obj/item/storage/box/lights/bulbs,
 	)
+	record_spawn = TRUE
 

--- a/code/game/objects/effects/spawners/random/random_spawner.dm
+++ b/code/game/objects/effects/spawners/random/random_spawner.dm
@@ -33,6 +33,8 @@
 	var/spawn_random_offset_max_pixels = 16
 	/// Whether the spawned items should be rotated randomly.
 	var/spawn_random_angle = FALSE
+	/// Whether blackbox should record when the spawner spawns.
+	var/record_spawn = FALSE
 
 // Brief explanation:
 // Rather then setting up and then deleting spawners, we block all atomlike setup
@@ -96,7 +98,8 @@
 			loot_spawned++
 
 /**
- *  Makes the actual item related to our spawner.
+ *  Makes the actual item related to our spawner. If `record_spawn` is `TRUE`,
+ *  this is when the items spawned are recorded to blackbox (except for `/obj/effect`s).
  *
  * spawn_loc - where are we spawning it?
  * type_path_to_make - what are we spawning?
@@ -104,7 +107,8 @@
 /obj/effect/spawner/random/proc/make_item(spawn_loc, type_path_to_make)
 	var/result = new type_path_to_make(spawn_loc)
 
-	record_item(type_path_to_make)
+	if(record_spawn)
+		record_item(type_path_to_make)
 
 	var/atom/item = result
 	if(spawn_random_angle && istype(item))

--- a/code/game/objects/effects/spawners/random/trash_spawners.dm
+++ b/code/game/objects/effects/spawners/random/trash_spawners.dm
@@ -30,6 +30,7 @@
 	)
 
 	spawn_random_angle = TRUE
+	record_spawn = TRUE
 
 /obj/effect/spawner/random/food_trash/record_item(type_path_to_make)
 	SSblackbox.record_feedback("tally", "random_spawners", 1, "[/obj/item/trash]")


### PR DESCRIPTION
## What Does This PR Do
This PR disables blackbox recording of random spawner spawns by default for new subtypes, and explicitly enables them for spawners that are part of maintenance loot tables.

I'd prefer having the toggle var as opposed to just having the base type's `/record_item` do nothing, because the default format of the blackbox row is still worth not having to reimplement for other subtypes.
## Why It's Good For The Game
I need to start moving all the old random_spawners over to the new type, and we don't need to know every time fungus spawned somewhere in the galaxy.
## Testing
Manually stepped through logic.
<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog
NPFC