### PR TITLE
[FIX] Tourist not rolling traitor

### DIFF
--- a/code/game/gamemodes/miniantags/tourist/tourist_arrivals.dm
+++ b/code/game/gamemodes/miniantags/tourist/tourist_arrivals.dm
@@ -78,7 +78,7 @@
 		M.mind.special_role = SPECIAL_ROLE_TOURIST
 		// Rolls a 20% probability, checks if 3 tourists have been made into tot and check if there's space for a new tot!
 		// If any is false, we don't make a new tourist tot
-		if(prob(chance) && tot_number < 3 && antag_count < max_antag && (SPECIAL_ROLE_TRAITOR in M.client.prefs.be_special) && !jobban_isbanned(M, SPECIAL_ROLE_TRAITOR))
+		if(prob(chance) && tot_number < 3 && antag_count < max_antag && (ROLE_TRAITOR in M.client.prefs.be_special) && !jobban_isbanned(M, ROLE_TRAITOR))
 			if(player_old_enough_antag(M.client, ROLE_TRAITOR))
 				tot_number++
 				M.mind.add_antag_datum(/datum/antagonist/traitor)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes a check that didn't allow people to roll tot on tourist.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
It's working as it should again! 
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Logged into test with an improv db, tested and got tot!
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:

fix: Tourists should be able to roll traitor again.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
