### PR TITLE
[Fix] GC issue of multi-tile airlocks

### DIFF
--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -675,7 +675,7 @@
 		stack_trace("Attempted to pair an airlock filler with no parent airlock specified!")
 
 	filled_airlock = parent_airlock
-	RegisterSignal(filled_airlock, PROC_REF(no_airlock))
+	RegisterSignal(filled_airlock, COMSIG_PARENT_QDELETING, PROC_REF(no_airlock))
 
 /obj/airlock_filler_object/proc/no_airlock()
 	UnregisterSignal(filled_airlock)


### PR DESCRIPTION
## What Does This PR Do
Adds a signal type to RegisterSignal() of pair_airlock proc

## Why It's Good For The Game
No more GC issue from filler objects

## Testing
Tried to assemble / disassemble multi-tile airlock on localhost. Checked GC queue from debug menu

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: filler_objects doesn't get stuck in GC queue anymore
/:cl: