### PR TITLE
fix: move pipe icon manager out of SSair

### DIFF
--- a/code/_globalvars/misc_globals.dm
+++ b/code/_globalvars/misc_globals.dm
@@ -45,8 +45,6 @@ GLOBAL_VAR_INIT(gametime_offset, 432000) // 12:00 in seconds
 
 GLOBAL_DATUM_INIT(data_core, /datum/datacore, new) // Station datacore, manifest, etc
 
-GLOBAL_LIST_INIT(pipe_colors, list("grey" = PIPE_COLOR_GREY, "red" = PIPE_COLOR_RED, "blue" = PIPE_COLOR_BLUE, "cyan" = PIPE_COLOR_CYAN, "green" = PIPE_COLOR_GREEN, "yellow" = PIPE_COLOR_YELLOW, "purple" = PIPE_COLOR_PURPLE))
-
 /// Global list of all /datum/mod_theme
 GLOBAL_LIST_INIT(mod_themes, setup_mod_themes())
 

--- a/code/controllers/subsystem/SSair.dm
+++ b/code/controllers/subsystem/SSair.dm
@@ -57,9 +57,6 @@ SUBSYSTEM_DEF(air)
 	/// A list of atmos machinery to set up in Initialize.
 	var/list/machinery_to_construct = list()
 
-	/// Pipe overlay/underlay icon manager
-	var/datum/pipe_icon_manager/icon_manager
-
 	/// An arbitrary list of stuff currently being processed.
 	var/list/currentrun = list()
 
@@ -138,7 +135,6 @@ SUBSYSTEM_DEF(air)
 	in_milla_safe_code = TRUE
 
 	setup_overlays() // Assign icons and such for gas-turf-overlays
-	icon_manager = new() // Sets up icon manager for pipes
 	setup_allturfs()
 	setup_write_to_milla()
 	setup_atmos_machinery(GLOB.machines)
@@ -154,7 +150,6 @@ SUBSYSTEM_DEF(air)
 	pipenets = SSair.pipenets
 	atmos_machinery = SSair.atmos_machinery
 	machinery_to_construct = SSair.machinery_to_construct
-	icon_manager = SSair.icon_manager
 	currentrun = SSair.currentrun
 	currentpart = SSair.currentpart
 	is_synchronous = SSair.is_synchronous

--- a/code/game/objects/items/devices/painter/pipe_painter.dm
+++ b/code/game/objects/items/devices/painter/pipe_painter.dm
@@ -7,7 +7,7 @@
 /datum/painter/pipe/New()
 	..()
 	if(!length(modes))
-		for(var/C in GLOB.pipe_colors)
+		for(var/C in GLOB.pipe_icon_manager.pipe_colors)
 			modes += "[C]"
 	paint_setting = pick(modes)
 
@@ -25,7 +25,7 @@
 	if(is_type_in_list(P, blacklisted_pipes))
 		return
 
-	if(P.pipe_color == GLOB.pipe_colors[paint_setting])
+	if(P.pipe_color == GLOB.pipe_icon_manager.pipe_colors[paint_setting])
 		to_chat(user, "<span class='notice'>This pipe is aready painted [paint_setting]!</span>")
 		return
 
@@ -34,5 +34,5 @@
 		to_chat(user, "<span class='warning'>You must remove the flooring first.</span>")
 		return
 
-	P.change_color(GLOB.pipe_colors[paint_setting])
+	P.change_color(GLOB.pipe_icon_manager.pipe_colors[paint_setting])
 	return TRUE

--- a/code/game/objects/items/devices/painter/window_painter.dm
+++ b/code/game/objects/items/devices/painter/window_painter.dm
@@ -20,17 +20,17 @@
 	var/obj/structure/window/W = target
 
 	if(is_type_in_list(target, polarized_windows))
-		if((W.opacity && W.old_color == GLOB.pipe_colors[paint_setting]) || (!W.opacity && W.color == GLOB.pipe_colors[paint_setting]))
+		if((W.opacity && W.old_color == GLOB.pipe_icon_manager.pipe_colors[paint_setting]) || (!W.opacity && W.color == GLOB.pipe_icon_manager.pipe_colors[paint_setting]))
 			to_chat(user, "<span class='notice'>This window is aready painted [paint_setting]!</span>")
 			return
 		if(!W.opacity)
-			W.color = GLOB.pipe_colors[paint_setting]
-		W.old_color = GLOB.pipe_colors[paint_setting]
+			W.color = GLOB.pipe_icon_manager.pipe_colors[paint_setting]
+		W.old_color = GLOB.pipe_icon_manager.pipe_colors[paint_setting]
 		return TRUE
 
-	if(W.color == GLOB.pipe_colors[paint_setting])
+	if(W.color == GLOB.pipe_icon_manager.pipe_colors[paint_setting])
 		to_chat(user, "<span class='notice'>This window is aready painted [paint_setting]!</span>")
 		return
 
-	W.color = GLOB.pipe_colors[paint_setting]
+	W.color = GLOB.pipe_icon_manager.pipe_colors[paint_setting]
 	return TRUE

--- a/code/modules/atmospherics/machinery/atmospherics.dm
+++ b/code/modules/atmospherics/machinery/atmospherics.dm
@@ -106,7 +106,7 @@ Pipelines + Other Objects -> Pipe network
 	pipe_image.plane = HUD_PLANE
 
 /obj/machinery/atmospherics/proc/check_icon_cache()
-	if(!istype(SSair.icon_manager))
+	if(!istype(GLOB.pipe_icon_manager))
 		return FALSE
 
 	return TRUE
@@ -121,17 +121,14 @@ Pipelines + Other Objects -> Pipe network
 /obj/machinery/atmospherics/proc/add_underlay(turf/T, obj/machinery/atmospherics/node, direction, icon_connect_type)
 	if(node)
 		if(T.intact && node.level == 1 && istype(node, /obj/machinery/atmospherics/pipe) && !T.transparent_floor)
-			//underlays += SSair.icon_manager.get_atmos_icon("underlay_down", direction, color_cache_name(node))
-			underlays += SSair.icon_manager.get_atmos_icon("underlay", direction, color_cache_name(node), "down" + icon_connect_type)
+			underlays += GLOB.pipe_icon_manager.get_atmos_icon("underlay", direction, color_cache_name(node), "down" + icon_connect_type)
 		else
-			//underlays += SSair.icon_manager.get_atmos_icon("underlay_intact", direction, color_cache_name(node))
-			underlays += SSair.icon_manager.get_atmos_icon("underlay", direction, color_cache_name(node), "intact" + icon_connect_type)
+			underlays += GLOB.pipe_icon_manager.get_atmos_icon("underlay", direction, color_cache_name(node), "intact" + icon_connect_type)
 	else
 		if(T.transparent_floor) //we want to keep pipes under transparent floors connected normally
-			underlays += SSair.icon_manager.get_atmos_icon("underlay", direction, color_cache_name(node), "intact" + icon_connect_type)
+			underlays += GLOB.pipe_icon_manager.get_atmos_icon("underlay", direction, color_cache_name(node), "intact" + icon_connect_type)
 		else
-			//underlays += SSair.icon_manager.get_atmos_icon("underlay_exposed", direction, pipe_color)
-			underlays += SSair.icon_manager.get_atmos_icon("underlay", direction, color_cache_name(node), "exposed" + icon_connect_type)
+			underlays += GLOB.pipe_icon_manager.get_atmos_icon("underlay", direction, color_cache_name(node), "exposed" + icon_connect_type)
 
 /obj/machinery/atmospherics/proc/update_underlays()
 	return check_icon_cache()
@@ -401,14 +398,14 @@ Pipelines + Other Objects -> Pipe network
 /obj/machinery/atmospherics/proc/add_underlay_adapter(turf/T, obj/machinery/atmospherics/node, direction, icon_connect_type) //modified from add_underlay, does not make exposed underlays
 	if(node)
 		if(T.intact && node.level == 1 && istype(node, /obj/machinery/atmospherics/pipe) && !T.transparent_floor)
-			underlays += SSair.icon_manager.get_atmos_icon("underlay", direction, color_cache_name(node), "down" + icon_connect_type)
+			underlays += GLOB.pipe_icon_manager.get_atmos_icon("underlay", direction, color_cache_name(node), "down" + icon_connect_type)
 		else
-			underlays += SSair.icon_manager.get_atmos_icon("underlay", direction, color_cache_name(node), "intact" + icon_connect_type)
+			underlays += GLOB.pipe_icon_manager.get_atmos_icon("underlay", direction, color_cache_name(node), "intact" + icon_connect_type)
 	else
 		if(T.transparent_floor) //we want to keep pipes under transparent floors connected normally
-			underlays += SSair.icon_manager.get_atmos_icon("underlay", direction, color_cache_name(node), "intact" + icon_connect_type)
+			underlays += GLOB.pipe_icon_manager.get_atmos_icon("underlay", direction, color_cache_name(node), "intact" + icon_connect_type)
 		else
-			underlays += SSair.icon_manager.get_atmos_icon("underlay", direction, color_cache_name(node), "retracted" + icon_connect_type)
+			underlays += GLOB.pipe_icon_manager.get_atmos_icon("underlay", direction, color_cache_name(node), "retracted" + icon_connect_type)
 
 /obj/machinery/atmospherics/singularity_pull(S, current_size)
 	if(current_size >= STAGE_FIVE)

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -87,7 +87,7 @@
 	else
 		vent_icon += "[on ? "[releasing ? "out" : "in"]" : "off"]"
 
-	. += SSair.icon_manager.get_atmos_icon("device", state = vent_icon)
+	. += GLOB.pipe_icon_manager.get_atmos_icon("device", state = vent_icon)
 
 	update_pipe_image()
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -82,7 +82,7 @@
 	if(welded)
 		scrubber_icon = "scrubberweld"
 
-	. += SSair.icon_manager.get_atmos_icon("device", state = scrubber_icon)
+	. += GLOB.pipe_icon_manager.get_atmos_icon("device", state = scrubber_icon)
 	update_pipe_image()
 
 /obj/machinery/atmospherics/unary/vent_scrubber/update_underlays()

--- a/code/modules/atmospherics/machinery/datum_icon_manager.dm
+++ b/code/modules/atmospherics/machinery/datum_icon_manager.dm
@@ -1,3 +1,4 @@
+GLOBAL_DATUM_INIT(pipe_icon_manager, /datum/pipe_icon_manager, new)
 //--------------------------------------------
 // Pipe colors
 //
@@ -7,15 +8,15 @@
 //--------------------------------------------
 
 /proc/pipe_color_lookup(color)
-	for(var/C in GLOB.pipe_colors)
-		if(color == GLOB.pipe_colors[C])
+	for(var/C in GLOB.pipe_icon_manager.pipe_colors)
+		if(color == GLOB.pipe_icon_manager.pipe_colors[C])
 			return "[C]"
 
 /proc/pipe_color_check(color)
 	if(!color)
 		return 1
-	for(var/C in GLOB.pipe_colors)
-		if(color == GLOB.pipe_colors[C])
+	for(var/C in GLOB.pipe_icon_manager.pipe_colors)
+		if(color == GLOB.pipe_icon_manager.pipe_colors[C])
 			return 1
 	return 0
 
@@ -28,11 +29,16 @@
 	var/list/manifold_icons[]
 	var/list/device_icons[]
 	var/list/underlays[]
-	//var/list/underlays_down[]
-	//var/list/underlays_exposed[]
-	//var/list/underlays_intact[]
-	//var/list/pipe_underlays_exposed[]
-	//var/list/pipe_underlays_intact[]
+
+	var/list/pipe_colors = list(
+		"blue" = PIPE_COLOR_BLUE,
+		"cyan" = PIPE_COLOR_CYAN,
+		"green" = PIPE_COLOR_GREEN,
+		"grey" = PIPE_COLOR_GREY,
+		"purple" = PIPE_COLOR_PURPLE,
+		"red" = PIPE_COLOR_RED,
+		"yellow" = PIPE_COLOR_YELLOW,
+	)
 
 /datum/pipe_icon_manager/New()
 	check_icons()
@@ -54,16 +60,6 @@
 			return device_icons[state]
 		if("underlay")
 			return underlays[state + dir + color]
-		//if("underlay_intact")
-		//	return underlays_intact[state + dir + color]
-	//	if("underlay_exposed")
-	//		return underlays_exposed[state + dir + color]
-	//	if("underlay_down")
-	//		return underlays_down[state + dir + color]
-	//	if("pipe_underlay_exposed")
-	//		return pipe_underlays_exposed[state + dir + color]
-	//	if("pipe_underlay_intact")
-	//		return pipe_underlays_intact[state + dir + color]
 
 /datum/pipe_icon_manager/proc/check_icons()
 	if(!pipe_icons)
@@ -72,7 +68,6 @@
 		gen_manifold_icons()
 	if(!device_icons)
 		gen_device_icons()
-	//if(!underlays_intact || !underlays_down || !underlays_exposed || !pipe_underlays_exposed || !pipe_underlays_intact)
 	if(!underlays)
 		gen_underlay_icons()
 
@@ -90,10 +85,10 @@
 		var/image/I = image('icons/atmos/pipes.dmi', icon_state = state)
 		pipe_icons[cache_name] = I
 
-		for(var/pipe_color in GLOB.pipe_colors)
+		for(var/pipe_color in pipe_colors)
 			I = image('icons/atmos/pipes.dmi', icon_state = state)
-			I.color = GLOB.pipe_colors[pipe_color]
-			pipe_icons[state + "[GLOB.pipe_colors[pipe_color]]"] = I
+			I.color = pipe_colors[pipe_color]
+			pipe_icons[state + "[pipe_colors[pipe_color]]"] = I
 
 	pipe = new ('icons/atmos/heat.dmi')
 	for(var/state in pipe.IconStates())
@@ -122,10 +117,10 @@
 		if(findtext(state, "core") || findtext(state, "4way"))
 			var/image/I = image('icons/atmos/manifold.dmi', icon_state = state)
 			manifold_icons[state] = I
-			for(var/pipe_color in GLOB.pipe_colors)
+			for(var/pipe_color in pipe_colors)
 				I = image('icons/atmos/manifold.dmi', icon_state = state)
-				I.color = GLOB.pipe_colors[pipe_color]
-				manifold_icons[state + GLOB.pipe_colors[pipe_color]] = I
+				I.color = pipe_colors[pipe_color]
+				manifold_icons[state + pipe_colors[pipe_color]] = I
 
 /datum/pipe_icon_manager/proc/gen_device_icons()
 	if(!device_icons)
@@ -161,7 +156,7 @@
 		for(var/D in GLOB.cardinal)
 			var/image/I = image(icon('icons/atmos/pipe_underlays.dmi', icon_state = state, dir = D), layer = GAS_PIPE_HIDDEN_LAYER)
 			underlays[cache_name + "[D]"] = I
-			for(var/pipe_color in GLOB.pipe_colors)
+			for(var/pipe_color in pipe_colors)
 				I = image(icon('icons/atmos/pipe_underlays.dmi', icon_state = state, dir = D), layer = GAS_PIPE_HIDDEN_LAYER)
-				I.color = GLOB.pipe_colors[pipe_color]
-				underlays[state + "[D]" + "[GLOB.pipe_colors[pipe_color]]"] = I
+				I.color = pipe_colors[pipe_color]
+				underlays[state + "[D]" + "[pipe_colors[pipe_color]]"] = I

--- a/code/modules/atmospherics/machinery/pipes/cap.dm
+++ b/code/modules/atmospherics/machinery/pipes/cap.dm
@@ -60,7 +60,7 @@
 /obj/machinery/atmospherics/pipe/cap/update_overlays()
 	. = ..()
 	alpha = 255
-	. += SSair.icon_manager.get_atmos_icon("pipe", null, pipe_color, "cap" + icon_connect_type)
+	. += GLOB.pipe_icon_manager.get_atmos_icon("pipe", null, pipe_color, "cap" + icon_connect_type)
 
 /obj/machinery/atmospherics/pipe/cap/atmos_init()
 	..()

--- a/code/modules/atmospherics/machinery/pipes/manifold.dm
+++ b/code/modules/atmospherics/machinery/pipes/manifold.dm
@@ -116,8 +116,8 @@
 /obj/machinery/atmospherics/pipe/manifold/update_overlays()
 	. = ..()
 	alpha = 255
-	. += SSair.icon_manager.get_atmos_icon("manifold", null, pipe_color, "core" + icon_connect_type)
-	. += SSair.icon_manager.get_atmos_icon("manifold", null, null, "clamps" + icon_connect_type)
+	. += GLOB.pipe_icon_manager.get_atmos_icon("manifold", null, pipe_color, "core" + icon_connect_type)
+	. += GLOB.pipe_icon_manager.get_atmos_icon("manifold", null, null, "clamps" + icon_connect_type)
 	update_underlays()
 
 /obj/machinery/atmospherics/pipe/manifold/update_underlays()

--- a/code/modules/atmospherics/machinery/pipes/manifold4w.dm
+++ b/code/modules/atmospherics/machinery/pipes/manifold4w.dm
@@ -89,8 +89,8 @@
 /obj/machinery/atmospherics/pipe/manifold4w/update_overlays()
 	. = ..()
 	alpha = 255
-	. += SSair.icon_manager.get_atmos_icon("manifold", null, pipe_color, "4way" + icon_connect_type)
-	. += SSair.icon_manager.get_atmos_icon("manifold", null, null, "clamps_4way" + icon_connect_type)
+	. += GLOB.pipe_icon_manager.get_atmos_icon("manifold", null, pipe_color, "4way" + icon_connect_type)
+	. += GLOB.pipe_icon_manager.get_atmos_icon("manifold", null, null, "clamps_4way" + icon_connect_type)
 	update_underlays()
 
 /obj/machinery/atmospherics/pipe/manifold4w/update_underlays()

--- a/code/modules/atmospherics/machinery/pipes/simple/pipe_simple.dm
+++ b/code/modules/atmospherics/machinery/pipes/simple/pipe_simple.dm
@@ -122,9 +122,9 @@
 	. = ..()
 	alpha = 255
 	if(node1 && node2)
-		. += SSair.icon_manager.get_atmos_icon("pipe", null, pipe_color, pipe_icon + "intact" + icon_connect_type)
+		. += GLOB.pipe_icon_manager.get_atmos_icon("pipe", null, pipe_color, pipe_icon + "intact" + icon_connect_type)
 	else
-		. += SSair.icon_manager.get_atmos_icon("pipe", null, pipe_color, pipe_icon + "exposed[node1?1:0][node2?1:0]" + icon_connect_type)
+		. += GLOB.pipe_icon_manager.get_atmos_icon("pipe", null, pipe_color, pipe_icon + "exposed[node1?1:0][node2?1:0]" + icon_connect_type)
 
 // A check to make sure both nodes exist - self-delete if they aren't present
 /obj/machinery/atmospherics/pipe/simple/check_nodes_exist()

--- a/code/modules/atmospherics/machinery/pipes/simple/pipe_simple_hidden.dm
+++ b/code/modules/atmospherics/machinery/pipes/simple/pipe_simple_hidden.dm
@@ -49,7 +49,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/universal/update_overlays()
 	. = list()
 	alpha = 255
-	. += SSair.icon_manager.get_atmos_icon("pipe", color = pipe_color, state = "universal")
+	. += GLOB.pipe_icon_manager.get_atmos_icon("pipe", color = pipe_color, state = "universal")
 	update_underlays()
 
 /obj/machinery/atmospherics/pipe/simple/hidden/universal/update_underlays()

--- a/code/modules/atmospherics/machinery/pipes/simple/pipe_simple_visible.dm
+++ b/code/modules/atmospherics/machinery/pipes/simple/pipe_simple_visible.dm
@@ -66,7 +66,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/universal/update_overlays()
 	. = list()
 	alpha = 255
-	. += SSair.icon_manager.get_atmos_icon("pipe", color = pipe_color, state = "universal")
+	. += GLOB.pipe_icon_manager.get_atmos_icon("pipe", color = pipe_color, state = "universal")
 	update_underlays()
 
 /obj/machinery/atmospherics/pipe/simple/visible/universal/update_underlays()


### PR DESCRIPTION
## What Does This PR Do
This PR removes the pipe icon manager from SSair and makes it a global datum. It also moves GLOB.pipe_colors into the new GLOB.pipe_icon_manager as a field, which seems more sensible. SSair really doesn't need to be responsible for tracking what pipes look like. It's the atmos subsystem. It doesn't even call update_icon or anything.

Also deletes a bunch of code that had been commented out for literally ten years, I don't think we need it anymore.

Fixes #26670.
## Why It's Good For The Game
Anything that called ChangeTurf on a tile with a manifold during SSatoms init would cause a runtime. This was first exposed by the mess spawner trait but has come to include grille spawners on top of manifolds which make many appearances on Emeraldstation.

## Testing
Created test map with grille spawners, ensured no runtimes on init:

![2024_09_21__03_10_01__paradise dme  test_tiny dmm  - StrongDMM](https://github.com/user-attachments/assets/38b4d848-78b1-46f5-9cfc-400f660808fc)

![2024_09_21__03_10_15__paradise dme  test_tiny dmm  - StrongDMM](https://github.com/user-attachments/assets/1e59583f-7d48-4340-b274-2eeb331b0ddc)

### Before

Actually somehow broke during DMM atom instancing so the map didn't fucking load at all, which is comforting

![2024_09_21__03_22_13__Paradise Station 13](https://github.com/user-attachments/assets/fe1907a9-b93c-4e36-b150-c5f5ad96a2ba)

### After

![2024_09_21__03_18_13__Paradise Station 13](https://github.com/user-attachments/assets/89d0f126-8b81-4475-8b77-f0b0c7117129)


<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog
NPFC
