### PR TITLE
Gives all status effects an ID

### DIFF
--- a/code/datums/status_effects/blob_burst.dm
+++ b/code/datums/status_effects/blob_burst.dm
@@ -1,4 +1,5 @@
 /datum/status_effect/blob_burst
+	id = "blob_burst"
 	alert_type = /atom/movable/screen/alert/status_effect/blob_burst
 	var/datum/callback/blob_burst_callback
 

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -275,7 +275,7 @@
 	owner.adjustFireLoss(-5)
 
 /datum/status_effect/blood_rush
-	id = "bloodrush"
+	id = "blood_rush"
 	alert_type = null
 	duration = 10 SECONDS
 

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -275,6 +275,7 @@
 	owner.adjustFireLoss(-5)
 
 /datum/status_effect/blood_rush
+	id = "bloodrush"
 	alert_type = null
 	duration = 10 SECONDS
 
@@ -488,6 +489,7 @@
 	REMOVE_TRAIT(owner, TRAIT_IGNOREDAMAGESLOWDOWN, id)
 
 /datum/status_effect/fleshmend
+	id = "fleshmend"
 	duration = -1
 	status_type = STATUS_EFFECT_REFRESH
 	tick_interval = 1 SECONDS
@@ -536,6 +538,7 @@
 		qdel(src)
 
 /datum/status_effect/speedlegs
+	id = "speedlegs"
 	duration = -1
 	status_type = STATUS_EFFECT_UNIQUE
 	tick_interval = 4 SECONDS
@@ -577,6 +580,7 @@
 	cling = null
 
 /datum/status_effect/panacea
+	id = "panacea"
 	duration = 20 SECONDS
 	tick_interval = 2 SECONDS
 	status_type = STATUS_EFFECT_REFRESH
@@ -702,6 +706,7 @@
 		to_chat(owner, "<span class='cultitalic'>[pick(un_hopeful_messages)]</span>")
 
 /datum/status_effect/drill_payback
+	id = "drill_payback"
 	duration = -1
 	status_type = STATUS_EFFECT_UNIQUE
 	alert_type = null
@@ -797,6 +802,7 @@
 	vamp = null
 
 /datum/status_effect/rev_protection
+	id = "rev_protection"
 	// revs are paralyzed for 10 seconds when they're deconverted, same duration
 	duration = 10 SECONDS
 	alert_type = null
@@ -823,6 +829,7 @@
 	. = ..()
 
 /datum/status_effect/bookwyrm
+	id = "bookworm"
 	duration = BRAIN_DAMAGE_MOB_TIME
 	alert_type = null
 

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -829,7 +829,7 @@
 	. = ..()
 
 /datum/status_effect/bookwyrm
-	id = "bookworm"
+	id = "bookwyrm"
 	duration = BRAIN_DAMAGE_MOB_TIME
 	alert_type = null
 

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -523,6 +523,7 @@
 	id = "cult_slurring"
 
 /datum/status_effect/incapacitating
+	id = "incapacitating"
 	tick_interval = 0
 	status_type = STATUS_EFFECT_REPLACE
 	alert_type = null

--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -249,6 +249,7 @@
 /// A status effect that can have a certain amount of "bonus" duration added, which extends the duration every tick,
 /// although there is a maximum amount of bonus time that can be active at any given time.
 /datum/status_effect/limited_bonus
+	id = "limited_bonus"
 	/// How much extra time has been added
 	var/bonus_time = 0
 	/// How much extra time to apply per tick
@@ -366,6 +367,7 @@
 	expire_proc.Invoke()
 
 /datum/status_effect/action_status_effect
+	id = "action_status_effect"
 	alert_type = null
 	tick_interval = -1
 

--- a/code/datums/status_effects/status_effect.dm
+++ b/code/datums/status_effects/status_effect.dm
@@ -262,6 +262,7 @@
 
 /// Status effect from multiple sources, when all sources are removed, so is the effect
 /datum/status_effect/grouped
+	id = "grouped"
 	status_type = STATUS_EFFECT_MULTIPLE //! Adds itself to sources and destroys itself if one exists already, there are never multiple
 	var/list/sources = list()
 

--- a/code/datums/status_effects/status_effect.dm
+++ b/code/datums/status_effects/status_effect.dm
@@ -3,7 +3,8 @@
 //When making a new status effect, add a define to status_effects.dm in __DEFINES for ease of use!
 
 /datum/status_effect
-	var/id = "effect" //Used for screen alerts.
+	/// A unique ID that is used to see if there is already a status effect of the same type on something. Also used for screen alerts
+	var/id
 	var/duration = -1 //How long the status effect lasts in DECISECONDS. Enter -1 for an effect that never ends unless removed through some means.
 	var/tick_interval = 10 //How many deciseconds between ticks, approximately. Leave at 10 for every second. Setting this to -1 will stop processing if duration is also unlimited.
 	var/mob/living/owner //The mob affected by the status effect.
@@ -14,6 +15,10 @@
 	var/atom/movable/screen/alert/status_effect/linked_alert = null //the alert itself, if it exists
 
 /datum/status_effect/New(list/arguments)
+	if(!id)
+		stack_trace("[src] was created but did not have an unique ID. Deleting.")
+		return
+
 	on_creation(arglist(arguments))
 
 /datum/status_effect/proc/on_creation(mob/living/new_owner, ...)
@@ -280,6 +285,7 @@
  * This allows for a more precise tweaking of status durations at runtime (e.g. paralysis).
  */
 /datum/status_effect/transient
+	id = "transient"
 	tick_interval = 0.2 SECONDS // SSfastprocess interval
 	alert_type = null
 	/// How much strength left before expiring? time in deciseconds.

--- a/code/datums/status_effects/status_effect.dm
+++ b/code/datums/status_effects/status_effect.dm
@@ -17,6 +17,7 @@
 /datum/status_effect/New(list/arguments)
 	if(!id)
 		stack_trace("[src] was created but did not have an unique ID. Deleting.")
+		qdel(src)
 		return
 
 	on_creation(arglist(arguments))

--- a/code/modules/projectiles/guns/chaos_bolt.dm
+++ b/code/modules/projectiles/guns/chaos_bolt.dm
@@ -247,6 +247,7 @@
 			H.electrocute_act(CHAOS_STAFF_DAMAGE, src)
 
 /datum/status_effect/teleport_roulette
+	id = "teleport_roulette"
 	duration = 16 SECONDS
 	status_type = STATUS_EFFECT_REPLACE
 	tick_interval = 2 SECONDS

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -24,6 +24,7 @@
 #include "spawn_humans.dm"
 #include "spell_targeting_test.dm"
 #include "sql.dm"
+#include "status_effect_ids.dm"
 #include "subsystem_init.dm"
 #include "subsystem_metric_sanity.dm"
 #include "test_runner.dm"

--- a/code/modules/unit_tests/status_effect_ids.dm
+++ b/code/modules/unit_tests/status_effect_ids.dm
@@ -1,0 +1,8 @@
+/datum/unit_test/status_effect_ids/Run()
+	var/list/bad_statuses = list()
+	for(var/datum/status_effect/effect as anything in subtypesof(/datum/status_effect))
+		if(initial(effect.id) == null)
+			bad_statuses += effect
+
+	if(length(bad_statuses))
+		Fail("STatus effects found without an unique ID: [bad_statuses.Join(", ")]")


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds some sanity to see if status effects have an ID
Adds missing IDs to status effects
`transient` and `incapacitating` technically didn't require an ID but they got one anyways
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
This makes it easier to see if someone forgot to set an ID for a status effect which could cause some unintended behaviour (looking at you cling)
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Gave myself all status effects without any runtimes
![image](https://github.com/user-attachments/assets/27a0068e-d58e-4d13-a17c-b3248ed36297)
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

NPFC

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
