### PR TITLE
Clarifies Unique AI station trait printout

### DIFF
--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -18,7 +18,8 @@
 	weight = 15
 	show_in_report = TRUE
 	report_message = "For experimental purposes, this station AI might show divergence from default lawset. Do not meddle with this experiment, we've removed \
-		access to your set of alternative upload modules because we know you're already thinking about meddling with this experiment."
+		access to your set of alternative upload modules because we know you're already thinking about meddling with this experiment. If the lawset proves \
+		dangerous, or impedes station efficiency, fax or message Central Command to request permission to alter it."
 	trait_to_give = STATION_TRAIT_UNIQUE_AI
 	blacklist = list(/datum/station_trait/random_event_weight_modifier/ion_storms)
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Modifies the Unique AI station trait printout to include "If the lawset proves dangerous, or impedes station efficiency, fax or message Central Command to request permission to alter it."

## Why It's Good For The Game

Qwerty thought he included this when he was implementing it, didn't realize the paper had no mention of contacting CC for permission to remove it. Thus, people were putting up with obstructive AIs far longer than they had to because they thought they were _forced_ to keep it around forever.

## Testing

Built successfully, it's a two-line change altering what an already existing piece of paper says, following the proper format for such a paper. If this somehow buggers itself I'll eat my hat.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
![image](https://github.com/user-attachments/assets/f6d11e70-94d1-43c6-9969-e875730ae089)
![image](https://github.com/user-attachments/assets/c32d6f0f-020c-4e1d-a4ee-f9cd231a2707)
Thus I'm considering this to be a fix, as it was what was intended.
<hr>

## Changelog

:cl:
fix: The Unique AI station trait now informs the Crew that they can fax CC to ask permission to change the AI's lawset.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
