### PR TITLE
Non fulltile windows don't get blood on them, spacecleaner cleans blood more reliably

### DIFF
--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -55,7 +55,7 @@
 	var/turf/T = get_turf(src)
 	check_gravity(T)
 
-	if((T && (T.density)) || !gravity_check || locate(/obj/structure/window/) in T || locate(/obj/structure/grille/) in T)
+	if(!istype(src, /obj/effect/decal/cleanable/blood/footprints) && ((T && (T.density)) || !gravity_check || locate(/obj/structure/window/full) in T || locate(/obj/structure/grille/) in T))
 		off_floor = TRUE
 		layer = ABOVE_MOB_LAYER
 		plane = GAME_PLANE

--- a/code/modules/reagents/chemistry/reagents/water.dm
+++ b/code/modules/reagents/chemistry/reagents/water.dm
@@ -61,9 +61,7 @@
 	if(iseffect(O))
 		var/obj/effect/E = O
 		if(E.is_cleanable())
-			var/obj/effect/decal/cleanable/blood/B = E
-			if(!(istype(B) && B.off_floor))
-				qdel(E)
+			qdel(E)
 	else
 		if(O.simulated)
 			O.color = initial(O.color)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Blood no longer layers on non fulltile windows. This helps, as it's sprite doesn't line up correctly, and it only visually makes sense on fulltile ones.
Footprints no longer layer above windows or grills. You are stepping on the floor, not on the windows. This shouldn't be an issue anymore anyway with the above window check, but safety first is good
Spacecleaner foam now cleans windows or grills of blood, much like the floor

## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Buggy blood that doesnt visually look sense or is nearly impossible to clean isn't good. This fixes this.
Spacecleaner foam covering a window with space cleaner should clean it, much like it cleans every other object in the game

## Testing

<!-- How did you test the PR, if at all? -->
Attempted to bleed on non fulltile windows, blood layered the floor.
Attempted to splatter blood on fulltile windows, layered properly.
Deployed spacecleaner foam beside window, cleaned window.
Removed window, applied spacecleaner to turf, blood cleaned.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Blood no longer layers above non fulltile glass. This means you wont see blood above people and chairs in faragus medbay.
fix: Footsteps specifically are targeted as well, so you won't have bloody foodsteps above the mobs making them.
fix: Spacecleaning foam cleans blood on walls and windows now, much like everything else. Removing the windows and spraycleaning the  turf also works now, rather than the blood only be cleanable with soap even if there is nothing there but blood
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
