### PR TITLE
Fixes #26844 - Labeled condiment bottle loses its label when contents change

### DIFF
--- a/code/datums/components/label.dm
+++ b/code/datums/components/label.dm
@@ -53,6 +53,7 @@
 	* user: The mob who is wielding the attacking object.
 */
 /datum/component/label/proc/on_attack_by(datum/source, obj/item/attacker, mob/user)
+	SIGNAL_HANDLER // COMSIG_PARENT_ATTACKBY
 	// If the attacking object is not a hand labeler or it's not off (has a label ready to apply), return.
 	// The hand labeler should be off in order to remove a label.
 	var/obj/item/hand_labeler/labeler = attacker

--- a/code/datums/components/label.dm
+++ b/code/datums/components/label.dm
@@ -22,8 +22,8 @@
 	apply_label()
 
 /datum/component/label/RegisterWithParent()
-	RegisterSignal(parent, COMSIG_PARENT_ATTACKBY, PROC_REF(onAttackBy))
-	RegisterSignal(parent, COMSIG_PARENT_EXAMINE, PROC_REF(Examine))
+	RegisterSignal(parent, COMSIG_PARENT_ATTACKBY, PROC_REF(on_attack_by))
+	RegisterSignal(parent, COMSIG_PARENT_EXAMINE, PROC_REF(on_examine))
 	RegisterSignal(parent, COMSIG_ATOM_UPDATE_NAME, PROC_REF(on_update_name))
 
 /datum/component/label/UnregisterFromParent()
@@ -52,7 +52,7 @@
 	* attacker: The object that is hitting the parent.
 	* user: The mob who is wielding the attacking object.
 */
-/datum/component/label/proc/onAttackBy(datum/source, obj/item/attacker, mob/user)
+/datum/component/label/proc/on_attack_by(datum/source, obj/item/attacker, mob/user)
 	// If the attacking object is not a hand labeler or it's not off (has a label ready to apply), return.
 	// The hand labeler should be off in order to remove a label.
 	var/obj/item/hand_labeler/labeler = attacker
@@ -79,7 +79,7 @@
 	remove_label()
 	apply_label()
 
-/datum/component/label/proc/Examine(datum/source, mob/user, list/examine_list)
+/datum/component/label/proc/on_examine(datum/source, mob/user, list/examine_list)
 	examine_list += "<span class='notice'>It has a label with some words written on it. Use a hand labeler to remove it.</span>"
 
 /// Applies a label to the name of the parent in the format of: "parent_name (label)"
@@ -103,7 +103,7 @@
 	return ..()
 
 /// Adds detailed information to the examine text.
-/datum/component/label/goal/Examine(datum/source, mob/user, list/examine_list)
+/datum/component/label/goal/on_examine(datum/source, mob/user, list/examine_list)
 	examine_list += "<span class='notice'>It has a label on it, marking it as part of a secondary goal for [label_name]. Use a hand labeler to remove it.</span>"
 
 /// Applies a static label to the parent's name.

--- a/code/datums/components/label.dm
+++ b/code/datums/components/label.dm
@@ -104,6 +104,7 @@
 
 /// Adds detailed information to the examine text.
 /datum/component/label/goal/on_examine(datum/source, mob/user, list/examine_list)
+	SIGNAL_HANDLER // COMSIG_PARENT_EXAMINE
 	examine_list += "<span class='notice'>It has a label on it, marking it as part of a secondary goal for [label_name]. Use a hand labeler to remove it.</span>"
 
 /// Applies a static label to the parent's name.

--- a/code/datums/components/label.dm
+++ b/code/datums/components/label.dm
@@ -26,7 +26,6 @@
 	RegisterSignal(parent, COMSIG_PARENT_EXAMINE, PROC_REF(Examine))
 	RegisterSignal(parent, COMSIG_ATOM_UPDATE_NAME, PROC_REF(OnUpdateName))
 
-
 /datum/component/label/UnregisterFromParent()
 	UnregisterSignal(parent, list(COMSIG_PARENT_ATTACKBY, COMSIG_PARENT_EXAMINE, COMSIG_ATOM_UPDATE_NAME))
 

--- a/code/datums/components/label.dm
+++ b/code/datums/components/label.dm
@@ -76,6 +76,7 @@
 
 ///Reapplies label when update_name is called on the parent object. Attempts to remove it first just in case.
 /datum/component/label/proc/on_update_name()
+	SIGNAL_HANDLER // COMSIG_ATOM_UPDATE_NAME
 	remove_label()
 	apply_label()
 

--- a/code/datums/components/label.dm
+++ b/code/datums/components/label.dm
@@ -106,7 +106,6 @@
 
 /// Adds detailed information to the examine text.
 /datum/component/label/goal/on_examine(datum/source, mob/user, list/examine_list)
-	SIGNAL_HANDLER // COMSIG_PARENT_EXAMINE
 	examine_list += "<span class='notice'>It has a label on it, marking it as part of a secondary goal for [label_name]. Use a hand labeler to remove it.</span>"
 
 /// Applies a static label to the parent's name.

--- a/code/datums/components/label.dm
+++ b/code/datums/components/label.dm
@@ -24,9 +24,11 @@
 /datum/component/label/RegisterWithParent()
 	RegisterSignal(parent, COMSIG_PARENT_ATTACKBY, PROC_REF(OnAttackby))
 	RegisterSignal(parent, COMSIG_PARENT_EXAMINE, PROC_REF(Examine))
+	RegisterSignal(parent, COMSIG_ATOM_UPDATE_NAME, PROC_REF(OnUpdateName))
+
 
 /datum/component/label/UnregisterFromParent()
-	UnregisterSignal(parent, list(COMSIG_PARENT_ATTACKBY, COMSIG_PARENT_EXAMINE))
+	UnregisterSignal(parent, list(COMSIG_PARENT_ATTACKBY, COMSIG_PARENT_EXAMINE, COMSIG_ATOM_UPDATE_NAME))
 
 /**
 	This proc will fire after the parent is hit by a hand labeler which is trying to apply another label.
@@ -72,6 +74,12 @@
 	* user: The mob exmaining the parent.
 	* examine_list: The current list of text getting passed from the parent's normal examine() proc.
 */
+
+///Reapplies label when update_name() is called on the parent object. Attempts to remove it first just in case.
+/datum/component/label/proc/OnUpdateName()
+	remove_label()
+	apply_label()
+
 /datum/component/label/proc/Examine(datum/source, mob/user, list/examine_list)
 	examine_list += "<span class='notice'>It has a label with some words written on it. Use a hand labeler to remove it.</span>"
 

--- a/code/datums/components/label.dm
+++ b/code/datums/components/label.dm
@@ -19,12 +19,12 @@
 		return COMPONENT_INCOMPATIBLE
 
 	label_name = _label_name
-	applyLabel()
+	apply_label()
 
 /datum/component/label/RegisterWithParent()
 	RegisterSignal(parent, COMSIG_PARENT_ATTACKBY, PROC_REF(onAttackBy))
 	RegisterSignal(parent, COMSIG_PARENT_EXAMINE, PROC_REF(Examine))
-	RegisterSignal(parent, COMSIG_ATOM_UPDATE_NAME, PROC_REF(onUpdateName))
+	RegisterSignal(parent, COMSIG_ATOM_UPDATE_NAME, PROC_REF(on_update_name))
 
 /datum/component/label/UnregisterFromParent()
 	UnregisterSignal(parent, list(COMSIG_PARENT_ATTACKBY, COMSIG_PARENT_EXAMINE, COMSIG_ATOM_UPDATE_NAME))
@@ -34,12 +34,12 @@
 	Since the parent already has a label, it will remove the old one from the parent's name, and apply the new one.
 */
 /datum/component/label/InheritComponent(datum/component/label/new_comp , i_am_original, _label_name)
-	removeLabel()
+	remove_label()
 	if(new_comp)
 		label_name = new_comp.label_name
 	else
 		label_name = _label_name
-	applyLabel()
+	apply_label()
 
 /**
 	This proc will trigger when any object is used to attack the parent.
@@ -59,7 +59,7 @@
 	if(!istype(labeler) || labeler.mode)
 		return
 
-	removeLabel()
+	remove_label()
 	playsound(parent, 'sound/items/poster_ripped.ogg', 20, TRUE)
 	to_chat(user, "<span class='warning'>You remove the label from [parent].</span>")
 	qdel(src) // Remove the component from the object.
@@ -75,20 +75,20 @@
 */
 
 ///Reapplies label when update_name() is called on the parent object. Attempts to remove it first just in case.
-/datum/component/label/proc/onUpdateName()
-	removeLabel()
-	applyLabel()
+/datum/component/label/proc/on_update_name()
+	remove_label()
+	apply_label()
 
 /datum/component/label/proc/Examine(datum/source, mob/user, list/examine_list)
 	examine_list += "<span class='notice'>It has a label with some words written on it. Use a hand labeler to remove it.</span>"
 
 /// Applies a label to the name of the parent in the format of: "parent_name (label)"
-/datum/component/label/proc/applyLabel()
+/datum/component/label/proc/apply_label()
 	var/atom/owner = parent
 	owner.name += " ([label_name])"
 
 /// Removes the label from the parent's name
-/datum/component/label/proc/removeLabel()
+/datum/component/label/proc/remove_label()
 	var/atom/owner = parent
 	owner.name = replacetext(owner.name, "([label_name])", "") // Remove the label text from the parent's name, wherever it's located.
 	owner.name = trim(owner.name) // Shave off any white space from the beginning or end of the parent's name.
@@ -108,12 +108,12 @@
 
 /// Applies a static label to the parent's name.
 /// We do this instead of using label_name so it's easier to identify goal objects at a glance.
-/datum/component/label/goal/applyLabel()
+/datum/component/label/goal/apply_label()
 	var/atom/owner = parent
 	owner.name += " (Secondary Goal)"
 
 /// Removes the label from the parent's name
-/datum/component/label/goal/removeLabel()
+/datum/component/label/goal/remove_label()
 	var/atom/owner = parent
 	owner.name = replacetext(owner.name, "(Secondary Goal)", "") // Remove the label text from the parent's name, wherever it's located.
 	owner.name = trim(owner.name) // Shave off any white space from the beginning or end of the parent's name.

--- a/code/datums/components/label.dm
+++ b/code/datums/components/label.dm
@@ -19,12 +19,12 @@
 		return COMPONENT_INCOMPATIBLE
 
 	label_name = _label_name
-	apply_label()
+	applyLabel()
 
 /datum/component/label/RegisterWithParent()
-	RegisterSignal(parent, COMSIG_PARENT_ATTACKBY, PROC_REF(OnAttackby))
+	RegisterSignal(parent, COMSIG_PARENT_ATTACKBY, PROC_REF(onAttackBy))
 	RegisterSignal(parent, COMSIG_PARENT_EXAMINE, PROC_REF(Examine))
-	RegisterSignal(parent, COMSIG_ATOM_UPDATE_NAME, PROC_REF(OnUpdateName))
+	RegisterSignal(parent, COMSIG_ATOM_UPDATE_NAME, PROC_REF(onUpdateName))
 
 /datum/component/label/UnregisterFromParent()
 	UnregisterSignal(parent, list(COMSIG_PARENT_ATTACKBY, COMSIG_PARENT_EXAMINE, COMSIG_ATOM_UPDATE_NAME))
@@ -34,12 +34,12 @@
 	Since the parent already has a label, it will remove the old one from the parent's name, and apply the new one.
 */
 /datum/component/label/InheritComponent(datum/component/label/new_comp , i_am_original, _label_name)
-	remove_label()
+	removeLabel()
 	if(new_comp)
 		label_name = new_comp.label_name
 	else
 		label_name = _label_name
-	apply_label()
+	applyLabel()
 
 /**
 	This proc will trigger when any object is used to attack the parent.
@@ -52,14 +52,14 @@
 	* attacker: The object that is hitting the parent.
 	* user: The mob who is wielding the attacking object.
 */
-/datum/component/label/proc/OnAttackby(datum/source, obj/item/attacker, mob/user)
+/datum/component/label/proc/onAttackBy(datum/source, obj/item/attacker, mob/user)
 	// If the attacking object is not a hand labeler or it's not off (has a label ready to apply), return.
 	// The hand labeler should be off in order to remove a label.
 	var/obj/item/hand_labeler/labeler = attacker
 	if(!istype(labeler) || labeler.mode)
 		return
 
-	remove_label()
+	removeLabel()
 	playsound(parent, 'sound/items/poster_ripped.ogg', 20, TRUE)
 	to_chat(user, "<span class='warning'>You remove the label from [parent].</span>")
 	qdel(src) // Remove the component from the object.
@@ -75,20 +75,20 @@
 */
 
 ///Reapplies label when update_name() is called on the parent object. Attempts to remove it first just in case.
-/datum/component/label/proc/OnUpdateName()
-	remove_label()
-	apply_label()
+/datum/component/label/proc/onUpdateName()
+	removeLabel()
+	applyLabel()
 
 /datum/component/label/proc/Examine(datum/source, mob/user, list/examine_list)
 	examine_list += "<span class='notice'>It has a label with some words written on it. Use a hand labeler to remove it.</span>"
 
 /// Applies a label to the name of the parent in the format of: "parent_name (label)"
-/datum/component/label/proc/apply_label()
+/datum/component/label/proc/applyLabel()
 	var/atom/owner = parent
 	owner.name += " ([label_name])"
 
 /// Removes the label from the parent's name
-/datum/component/label/proc/remove_label()
+/datum/component/label/proc/removeLabel()
 	var/atom/owner = parent
 	owner.name = replacetext(owner.name, "([label_name])", "") // Remove the label text from the parent's name, wherever it's located.
 	owner.name = trim(owner.name) // Shave off any white space from the beginning or end of the parent's name.
@@ -108,12 +108,12 @@
 
 /// Applies a static label to the parent's name.
 /// We do this instead of using label_name so it's easier to identify goal objects at a glance.
-/datum/component/label/goal/apply_label()
+/datum/component/label/goal/applyLabel()
 	var/atom/owner = parent
 	owner.name += " (Secondary Goal)"
 
 /// Removes the label from the parent's name
-/datum/component/label/goal/remove_label()
+/datum/component/label/goal/removeLabel()
 	var/atom/owner = parent
 	owner.name = replacetext(owner.name, "(Secondary Goal)", "") // Remove the label text from the parent's name, wherever it's located.
 	owner.name = trim(owner.name) // Shave off any white space from the beginning or end of the parent's name.

--- a/code/modules/food_and_drinks/food/condiment.dm
+++ b/code/modules/food_and_drinks/food/condiment.dm
@@ -117,7 +117,7 @@
 		icon_state = "emptycondiment"
 		name = "condiment bottle"
 		desc = "An empty condiment bottle."
-	update_name()
+	update_appearance(UPDATE_NAME)
 
 /obj/item/reagent_containers/condiment/enzyme
 	name = "universal enzyme"

--- a/code/modules/food_and_drinks/food/condiment.dm
+++ b/code/modules/food_and_drinks/food/condiment.dm
@@ -117,6 +117,7 @@
 		icon_state = "emptycondiment"
 		name = "condiment bottle"
 		desc = "An empty condiment bottle."
+	update_name()
 
 /obj/item/reagent_containers/condiment/enzyme
 	name = "universal enzyme"

--- a/code/modules/food_and_drinks/food/foods/candy.dm
+++ b/code/modules/food_and_drinks/food/foods/candy.dm
@@ -13,7 +13,7 @@
 	icon = 'icons/obj/food/candy.dmi'
 	icon_state = "candy"
 	tastes = list("candy" = 1)
-	goal_difficulty = FOOD_GOAL_NORMAL
+	goal_difficulty = FOOD_GOAL_SKIP
 
 // ***********************************************************
 // Candy Ingredients / Flavorings / Byproduct

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -427,8 +427,7 @@
 	if(copytext(name, 1, 13) == "experimental") // Don't delete 'experimental'
 		N = "experimental " + N
 	name = N + V
-	if(GetComponent(/datum/component/label))
-		GetComponent(/datum/component/label).apply_label() // Don't delete labels
+	update_name() //Append name additives such as from labels
 
 
 

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -427,7 +427,7 @@
 	if(copytext(name, 1, 13) == "experimental") // Don't delete 'experimental'
 		N = "experimental " + N
 	name = N + V
-	update_name() //Append name additives such as from labels
+	update_appearance(UPDATE_NAME) //Append name additives such as from labels
 
 
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes #26844, allows condiment bottles to retain their labels, adds COMSIG_ATOM_UPDATE_NAME to the label's signal list.

## Why It's Good For The Game

Bugs should be squished.

## Testing

1. Get hand labeller.
2. Create new bottle with milk cream using the condimaster.
3. Label the bottle.
4. Transfer reagents in and out of the bottle. Add different reagents, empty the bottle.
5. Ensure the label is maintained throughout the process.

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <hr>

## Changelog

:cl:
fix: Condiment bottles now retain their labels when reagents are moved in or out of them.
/:cl: