### PR TITLE
Fix: No more burnt hermit

### DIFF
--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_hermit.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_hermit.dmm
@@ -9,12 +9,7 @@
 /turf/simulated/wall/mineral/iron,
 /area/ruin/powered)
 "d" = (
-/obj/item/clothing/head/helmet/space/syndicate/orange,
 /obj/item/clothing/mask/breath,
-/turf/simulated/floor/plating,
-/area/ruin/powered)
-"e" = (
-/obj/item/clothing/suit/space/syndicate/orange,
 /turf/simulated/floor/plating,
 /area/ruin/powered)
 "g" = (
@@ -363,7 +358,7 @@ s
 "}
 (11,1,1) = {"
 c
-e
+o
 h
 g
 l

--- a/code/modules/ruins/lavalandruin_code/hermit.dm
+++ b/code/modules/ruins/lavalandruin_code/hermit.dm
@@ -25,6 +25,8 @@
 			only one pod left when you got to the escape bay. You took it and launched it alone, and the crowd of terrified faces crowding at the airlock door as your pod's engines burst to \
 			life and sent you to this hell are forever branded into your memory."
 			outfit.uniform = /obj/item/clothing/under/misc/assistantformal
+			outfit.suit = /obj/item/clothing/suit/space/syndicate/orange
+			outfit.head = /obj/item/clothing/head/helmet/space/syndicate/orange
 			outfit.shoes = /obj/item/clothing/shoes/black
 			outfit.back = /obj/item/storage/backpack
 		if(2)
@@ -32,13 +34,16 @@
 			heretic and subjected you to hours of horrible torture. You were hours away from execution when a high-ranking friend of yours in the Cooperative managed to secure you a pod, \
 			scrambled its destination's coordinates, and launched it. You awoke from stasis when you landed and have been surviving - barely - ever since."
 			outfit.uniform = /obj/item/clothing/under/color/orange
+			outfit.suit = /obj/item/clothing/suit/space/syndicate/orange
+			outfit.head = /obj/item/clothing/head/helmet/space/syndicate/orange
 			outfit.shoes = /obj/item/clothing/shoes/orange
 			outfit.back = /obj/item/storage/backpack
 		if(3)
 			flavour_text += "you were a doctor on one of Nanotrasen's space stations, but you left behind that damn corporation's tyranny and everything it stood for. From a metaphorical hell \
 			to a literal one, you find yourself nonetheless missing the recycled air and warm floors of what you left behind... but you'd still rather be here than there."
 			outfit.uniform = /obj/item/clothing/under/rank/medical/doctor
-			outfit.suit = /obj/item/clothing/suit/storage/labcoat
+			outfit.suit = /obj/item/clothing/suit/space/syndicate/orange
+			outfit.head = /obj/item/clothing/head/helmet/space/syndicate/orange
 			outfit.back = /obj/item/storage/backpack/medic
 			outfit.shoes = /obj/item/clothing/shoes/black
 		if(4)
@@ -46,6 +51,8 @@
 			at one of Nanotrasen's state-of-the-art research facilities, were in one of the escape pods alone and saw the red button. It was big and shiny, and it caught your eye. You pressed \
 			it, and after a terrifying and fast ride for days, you landed here. You've had time to wisen up since then, and you think that your old friends wouldn't be laughing now."
 			outfit.uniform = /obj/item/clothing/under/color/grey/glorf
+			outfit.suit = /obj/item/clothing/suit/space/syndicate/orange
+			outfit.head = /obj/item/clothing/head/helmet/space/syndicate/orange
 			outfit.shoes = /obj/item/clothing/shoes/black
 			outfit.back = /obj/item/storage/backpack
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

By taking the lavaland hermit's spacesuit and spawning them with it already on, it fixes #25469 

## Why It's Good For The Game

Hermits should, optimally, not burn to death when they spawn.

## Images of changes
![image](https://github.com/user-attachments/assets/c0419177-4404-41d0-aa03-76b1f8c21ea6)

## Testing

Spawned as a hermit. Was already wearing my space suit. Did not immediately start taking burn damage from atmos.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
tweak: Moves hermit's spacesuit from the map to being automatically equipped
fix: Hermit no longer boils alive on spawn
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
