### PR TITLE
Datumizes microbatteries

### DIFF
--- a/code/__DEFINES/mob_defines.dm
+++ b/code/__DEFINES/mob_defines.dm
@@ -14,6 +14,7 @@
 // Organ datum defines. Each one of these represents a slot for organ datums in internal_organ_datums
 #define ORGAN_DATUM_HEART	"heart"
 #define ORGAN_DATUM_LUNGS	"lungs"
+#define ORGAN_DATUM_BATTERY "battery"
 
 // For limb resistance flags
 #define CANNOT_BREAK		(1 << 0)

--- a/code/game/gamemodes/miniantags/abduction/gland.dm
+++ b/code/game/gamemodes/miniantags/abduction/gland.dm
@@ -6,7 +6,7 @@
 	dead_icon = null
 	status = ORGAN_ROBOT
 	origin_tech = "materials=4;biotech=7;abductor=3"
-	organ_datums = list(/datum/organ/heart/always_beating, /datum/organ/battery) // alien glands are immune to stopping
+	organ_datums = list(/datum/organ/heart/always_beating, /datum/organ/battery) // alien glands are immune to stopping, and provide power to IPCs
 	tough = TRUE //not easily broken by combat damage
 
 	var/cooldown_low = 300

--- a/code/game/gamemodes/miniantags/abduction/gland.dm
+++ b/code/game/gamemodes/miniantags/abduction/gland.dm
@@ -6,7 +6,7 @@
 	dead_icon = null
 	status = ORGAN_ROBOT
 	origin_tech = "materials=4;biotech=7;abductor=3"
-	organ_datums = list(/datum/organ/heart/always_beating) // alien glands are immune to stopping
+	organ_datums = list(/datum/organ/heart/always_beating, /datum/organ/battery) // alien glands are immune to stopping
 	tough = TRUE //not easily broken by combat damage
 
 	var/cooldown_low = 300

--- a/code/game/gamemodes/miniantags/demons/slaughter_demon/slaughter.dm
+++ b/code/game/gamemodes/miniantags/demons/slaughter_demon/slaughter.dm
@@ -212,7 +212,7 @@
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "demon_heart"
 	origin_tech = "combat=5;biotech=7"
-	organ_datums = list(/datum/organ/heart/always_beating)
+	organ_datums = list(/datum/organ/heart/always_beating, /datum/organ/battery)
 
 /obj/item/organ/internal/heart/demon/update_icon_state()
 	return //always beating visually

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -147,7 +147,7 @@
 			R.cell.charge = min(R.cell.charge + recharge_speed, R.cell.maxcharge)
 	else if(ishuman(occupant))
 		var/mob/living/carbon/human/H = occupant
-		if(H.get_int_organ(/obj/item/organ/internal/cell))
+		if(ismachineperson(H))
 			if(H.nutrition < NUTRITION_LEVEL_FULL - 1)
 				H.set_nutrition(min(H.nutrition + recharge_speed_nutrition, NUTRITION_LEVEL_FULL - 1))
 			if(repairs)

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -206,7 +206,7 @@
 		if(occupant)
 			to_chat(H, "<span class='warning'>The cell is already occupied!</span>")
 			return
-		if(ismodcontrol(H.back) || H.get_int_organ(/obj/item/organ/internal/cell))
+		if(ismodcontrol(H.back) || ismachineperson(H))
 			can_accept_user = TRUE
 
 	if(!can_accept_user)

--- a/code/modules/mob/living/carbon/carbon_update_status.dm
+++ b/code/modules/mob/living/carbon/carbon_update_status.dm
@@ -6,7 +6,7 @@
 			death()
 			create_debug_log("died of damage, trigger reason: [reason]")
 			return
-		if(HAS_TRAIT(src, TRAIT_KNOCKEDOUT) || (check_death_method() && getOxyLoss() > 50) || HAS_TRAIT(src, TRAIT_FAKEDEATH) || health < HEALTH_THRESHOLD_KNOCKOUT && check_death_method() || health <= HEALTH_THRESHOLD_DEAD)
+		if(HAS_TRAIT(src, TRAIT_KNOCKEDOUT) || (check_death_method() && getOxyLoss() > 50) || HAS_TRAIT(src, TRAIT_FAKEDEATH) || health < HEALTH_THRESHOLD_KNOCKOUT && check_death_method() || health <= HEALTH_THRESHOLD_DEAD) // In case anyone is wondering where oldcrit is handled, it's here.
 			if(stat == CONSCIOUS)
 				KnockOut()
 				create_debug_log("fell unconscious, trigger reason: [reason]")

--- a/code/modules/mob/living/carbon/human/human_update_status.dm
+++ b/code/modules/mob/living/carbon/human/human_update_status.dm
@@ -3,10 +3,14 @@
 		return
 	..(reason)
 	if(stat == DEAD)
-		if(dna.species && dna.species.can_revive_by_healing)
+		if(dna.species && dna.species.can_revive_by_healing)  // Here's where IPC revival is handled
 			var/obj/item/organ/internal/brain/B = get_int_organ(/obj/item/organ/internal/brain)
 			if(B)
 				if((health >= (HEALTH_THRESHOLD_DEAD + HEALTH_THRESHOLD_CRIT) * 0.5) && check_vital_organs() && !suiciding)
+					var/mob/dead/observer/ghost = get_ghost()
+					if(ghost)
+						to_chat(ghost, "<span class='ghostalert'>Your chassis has been repaired and repowered, re-enter if you want to continue playing!</span> (Verbs -> Ghost -> Re-enter corpse)")
+						SEND_SOUND(ghost, sound('sound/effects/genetics.ogg'))
 					update_revive()
 					create_debug_log("revived from healing, trigger reason: [reason]")
 

--- a/code/modules/mob/living/carbon/human/human_update_status.dm
+++ b/code/modules/mob/living/carbon/human/human_update_status.dm
@@ -6,7 +6,7 @@
 		if(dna.species && dna.species.can_revive_by_healing)  // Here's where IPC revival is handled
 			var/obj/item/organ/internal/brain/B = get_int_organ(/obj/item/organ/internal/brain)
 			if(B)
-				if((health >= (HEALTH_THRESHOLD_DEAD + HEALTH_THRESHOLD_CRIT) * 0.5) && check_vital_organs() && !suiciding)
+				if((health >= (HEALTH_THRESHOLD_DEAD + HEALTH_THRESHOLD_CRIT) * 0.5) && ipc_vital_organ_check() && !suiciding)
 					var/mob/dead/observer/ghost = get_ghost()
 					if(ghost)
 						to_chat(ghost, "<span class='ghostalert'>Your chassis has been repaired and repowered, re-enter if you want to continue playing!</span> (Verbs -> Ghost -> Re-enter corpse)")

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -417,12 +417,8 @@
 	user.changeNext_move(CLICK_CD_MELEE)
 	var/obj/machinery/power/apc/A = target
 	var/mob/living/carbon/human/H = user
-	if(H.get_int_organ(/obj/item/organ/internal/cell) || H.get_int_organ(/obj/item/organ/internal/heart))
-		var/obj/item/organ/internal/heart/robotic = H.get_int_organ(/obj/item/organ/internal/heart)
-		if(robotic)
-			if(!(robotic.status & ORGAN_ROBOT) && !H.get_int_organ(/obj/item/organ/internal/heart/demon/pulse))
-				to_chat(user, "<span class='warning'>You lack a cell in which to store charge!</span>")
-				return
+	var/datum/organ/battery/power_source = H.get_int_organ_datum(ORGAN_DATUM_BATTERY)
+	if(istype(power_source))
 		if(A.emagged || A.stat & BROKEN)
 			do_sparks(3, 1, A)
 			to_chat(H, "<span class='warning'>The APC power currents surge erratically, damaging your chassis!</span>")
@@ -435,7 +431,7 @@
 		else
 			to_chat(user, "<span class='warning'>There is no charge to draw from that APC.</span>")
 	else
-		to_chat(user, "<span class='warning'>You lack a cell in which to store charge!</span>")
+		to_chat(user, "<span class='warning'>You lack a power source in which to store charge!</span>")
 
 /obj/item/apc_powercord/proc/powerdraw_loop(obj/machinery/power/apc/A, mob/living/carbon/human/H)
 	H.visible_message("<span class='notice'>[H] inserts a power connector into \the [A].</span>", "<span class='notice'>You begin to draw power from \the [A].</span>")

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -36,7 +36,7 @@
 	base_icon_state = "cursedheart"
 	origin_tech = "biotech=6"
 	actions_types = list(/datum/action/item_action/organ_action/cursed_heart)
-	organ_datums = list(/datum/organ/heart, /datum/organ/battery)
+	organ_datums = list(/datum/organ/heart, /datum/organ/battery) // This doesn't actually work for IPCs but it also doesn't kill you, and it's funny
 	var/last_pump = 0
 	var/pump_delay = 30 //you can pump 1 second early, for lag, but no more (otherwise you could spam heal)
 	var/blood_loss = 100 //600 blood is human default, so 5 failures (below 122 blood is where humans die because reasons?)

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -36,6 +36,7 @@
 	base_icon_state = "cursedheart"
 	origin_tech = "biotech=6"
 	actions_types = list(/datum/action/item_action/organ_action/cursed_heart)
+	organ_datums = list(/datum/organ/heart, /datum/organ/battery)
 	var/last_pump = 0
 	var/pump_delay = 30 //you can pump 1 second early, for lag, but no more (otherwise you could spam heal)
 	var/blood_loss = 100 //600 blood is human default, so 5 failures (below 122 blood is where humans die because reasons?)
@@ -191,6 +192,7 @@
 	base_icon_state = "heart-c"
 	dead_icon = "heart-c-off"
 	status = ORGAN_ROBOT
+	organ_datums = list(/datum/organ/heart, /datum/organ/battery)
 
 /obj/item/organ/internal/heart/cybernetic/upgraded
 	name = "upgraded cybernetic heart"

--- a/code/modules/surgery/organs/organ_datums/battery_datum.dm
+++ b/code/modules/surgery/organs/organ_datums/battery_datum.dm
@@ -1,5 +1,5 @@
 /*
-	For any species that doesn't have a heart datum but does have heart-like organs, so just IPCs right now.
+	For any species that doesn't have a heart datum but does have heart-like organs, so just IPCs right now. Microbatteries currently have no behavior.
 */
 /datum/organ/battery
 	organ_tag = ORGAN_DATUM_BATTERY

--- a/code/modules/surgery/organs/organ_datums/battery_datum.dm
+++ b/code/modules/surgery/organs/organ_datums/battery_datum.dm
@@ -1,0 +1,5 @@
+/*
+	For any species that doesn't have a heart datum but does have heart-like organs, so just IPCs right now.
+*/
+/datum/organ/battery
+	organ_tag = ORGAN_DATUM_BATTERY

--- a/code/modules/surgery/organs/organ_helpers.dm
+++ b/code/modules/surgery/organs/organ_helpers.dm
@@ -85,8 +85,13 @@
 			.++
 		if(affecting.body_part == LEG_LEFT)
 			.++
-///Returns true if all the mob's vital organs are functional, otherwise returns false
+/* Returns true if all the mob's vital organs are functional, otherwise returns false.
+*  This proc is only used for checking if IPCs can revive from death, so calling it on a non IPC will always return false (right now)
+*/
 /mob/living/carbon/human/proc/check_vital_organs()
+	var/has_battery = get_int_organ_datum(ORGAN_DATUM_BATTERY)
+	if(!has_battery)
+		return FALSE
 	for(var/obj/item/organ/internal/organ in internal_organs)
 		if(organ.vital && (organ.damage >= organ.max_damage))
 			return FALSE

--- a/code/modules/surgery/organs/organ_helpers.dm
+++ b/code/modules/surgery/organs/organ_helpers.dm
@@ -88,7 +88,7 @@
 /* Returns true if all the mob's vital organs are functional, otherwise returns false.
 *  This proc is only used for checking if IPCs can revive from death, so calling it on a non IPC will always return false (right now)
 */
-/mob/living/carbon/human/proc/check_vital_organs()
+/mob/living/carbon/human/proc/ipc_vital_organ_check()
 	var/has_battery = get_int_organ_datum(ORGAN_DATUM_BATTERY)
 	if(!has_battery)
 		return FALSE

--- a/code/modules/surgery/organs/subtypes/machine_organs.dm
+++ b/code/modules/surgery/organs/subtypes/machine_organs.dm
@@ -112,6 +112,7 @@
 	vital = TRUE
 	status = ORGAN_ROBOT
 	requires_robotic_bodypart = TRUE
+	organ_datums = list(/datum/organ/battery)
 
 /obj/item/organ/internal/eyes/optical_sensor
 	name = "optical sensor"

--- a/paradise.dme
+++ b/paradise.dme
@@ -2869,6 +2869,7 @@
 #include "code\modules\surgery\organs\robolimbs.dm"
 #include "code\modules\surgery\organs\skeleton_organs.dm"
 #include "code\modules\surgery\organs\vocal_cords.dm"
+#include "code\modules\surgery\organs\organ_datums\battery_datum.dm"
 #include "code\modules\surgery\organs\organ_datums\heart_datum.dm"
 #include "code\modules\surgery\organs\organ_datums\lung_datum.dm"
 #include "code\modules\surgery\organs\organ_datums\organ_datum.dm"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #26665 by creating a datum for an organ that powers an IPC. Currently given to cyberhearts, cursed hearts, demon hearts, and abductor glands. Makes it so IPCs can always enter rechargers even if they don't have a standard microbattery. It also adds extra feedback for when an IPC is able to be revived.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Not being able to charge when you should be able to is bad, and datumizing organs also makes them generally easier to work with. The extra feedback when being revived is just a really needed change, and since it works when you get a microbattery replaced now that was enough justification to add it in this PR.

## Testing

<!-- How did you test the PR, if at all? -->
Spawned in without instantly dying as IPC, replaced my battery with various demon hearts and was still able to live/charge. 
Used an organ extractor to replace my demon heart with a cyberheart and briefly died before being immediately revived.
Did the same process with an organic heart and was not revived.
Tried to enter a charger as human, failed.
Tried to enter charger as human with modsuit, succeeded.
Smacked myself to death and left my body, healed the corpse and I got the ghost notification to reenter.
<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
tweak: IPCs now get notified when they can revive
fix: IPCs can enter rechargers when they don't have a microbattery
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
