### PR TITLE
blackbox: Record ghost role spawns.

### DIFF
--- a/code/datums/spawners_menu.dm
+++ b/code/datums/spawners_menu.dm
@@ -57,5 +57,6 @@
 			owner.forceMove(get_turf(MS))
 			. = TRUE
 		if("spawn")
-			MS.attack_ghost(owner)
+			if(MS.attack_ghost(owner))
+				SSblackbox.record_feedback("tally", "ghost_spawns", 1, "[MS.assignedrole]")
 			. = TRUE

--- a/code/modules/awaymissions/mission_code/ghost_role_spawners/golems.dm
+++ b/code/modules/awaymissions/mission_code/ghost_role_spawners/golems.dm
@@ -208,3 +208,4 @@
 	mob_name = "a free golem"
 	can_transfer = FALSE
 	mob_species = /datum/species/golem/adamantine
+	assignedrole = "Free Golem"

--- a/code/modules/awaymissions/mob_spawn.dm
+++ b/code/modules/awaymissions/mob_spawn.dm
@@ -55,6 +55,8 @@
 		return
 	create(ckey = user.ckey, user = user)
 
+	return TRUE
+
 /obj/effect/mob_spawn/Initialize(mapload)
 	. = ..()
 	if(instant || roundstart)	//at some point we should probably re-introduce the (ticker && ticker.current_state > GAME_STATE_SETTING_UP) portion of this check, but for now it was preventing the corpses from spawning at roundstart and resulting in ghost role spawners that made dead bodies.

--- a/code/modules/ruins/lavalandruin_code/seed_vault.dm
+++ b/code/modules/ruins/lavalandruin_code/seed_vault.dm
@@ -22,7 +22,7 @@
 	flavour_text = "You are a sentient ecosystem, an example of the mastery over life that your creators possessed. Your masters, benevolent as they were, created uncounted \
 	seed vaults and spread them across the universe to every planet they could chart. You are in one such seed vault. Your goal is to cultivate and spread life wherever it will go while waiting \
 	for contact from your creators. Estimated time of last contact: Deployment, 5x10^3 millennia ago."
-	assignedrole = "Lifebringer"
+	assignedrole = "Seed Vault Diona"
 
 /obj/effect/mob_spawn/human/alive/seed_vault/special(mob/living/new_spawn)
 	var/plant_name = pick("Tomato", "Potato", "Broccoli", "Carrot", "Ambrosia", "Pumpkin", "Ivy", "Kudzu", "Banana", "Moss", "Flower", "Bloom", "Root", "Bark", "Glowshroom", "Petal", "Leaf", \


### PR DESCRIPTION
## What Does This PR Do
This PR adds blackbox recording for number of ghost roles spawned per round. Despite wanting to, I didn't use the type of ghost spawner as the record name, because a role might have different subtypes (like theta having .../old/eng and .../old/sci) and I didn't think it was worth it this time around to store the whole type.

It also changes the "assigned role" value for seed vault from "Lifebringer" to "Seed Vault Diona" so it's more recognizable. As far as I know this value isn't compared to anything else in-code for this spawner.
## Why It's Good For The Game
Will be good to see how often each role gets used for future changes/improvements.
## Images of changes
![2024_09_26__06_52_51__](https://github.com/user-attachments/assets/9dc27ae0-c063-4cf5-a685-fa5d8132421f)
![2024_09_26__06_53_58__json - Text editor](https://github.com/user-attachments/assets/435ab631-3569-4e6b-b896-bb19060a1f26)
## Testing
Spawned in several times. Ensured that a failed spawn (such as a timeout) wasn't recorded.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog
NPFC
