### PR TITLE
refactor: Eliminate text access fields.

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/abandoned_sec_shuttle.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/abandoned_sec_shuttle.dmm
@@ -9,10 +9,10 @@
 /turf/simulated/floor/plating/airless,
 /area/ruin/space/sec_shuttle)
 "c" = (
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/specops,
 /obj/machinery/door/airlock/external{
 	id_tag = "s_docking_airlock";
-	name = "Shuttle Hatch";
-	req_access_txt = "109"
+	name = "Shuttle Hatch"
 	},
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "dark"
@@ -176,10 +176,10 @@
 	},
 /area/ruin/space/sec_shuttle)
 "T" = (
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/specops,
 /obj/machinery/door/airlock/external{
 	id_tag = "s_docking_airlock";
-	name = "Shuttle Hatch";
-	req_access_txt = "109"
+	name = "Shuttle Hatch"
 	},
 /turf/simulated/floor/plating/airless,
 /area/ruin/space/sec_shuttle)

--- a/_maps/map_files/RandomRuins/SpaceRuins/deepstorage.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/deepstorage.dmm
@@ -275,9 +275,8 @@
 /turf/simulated/floor/catwalk,
 /area/ruin/space/deepstorage)
 "aR" = (
-/obj/machinery/door/airlock/highsecurity{
-	req_access_txt = "512"
-	},
+/obj/effect/mapping_helpers/airlock/access/all/ruins/deepstorage,
+/obj/machinery/door/airlock/highsecurity,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -771,9 +770,8 @@
 	},
 /area/ruin/space/deepstorage)
 "co" = (
-/obj/machinery/door/airlock/hatch{
-	req_access_txt = "512"
-	},
+/obj/effect/mapping_helpers/airlock/access/all/ruins/deepstorage,
+/obj/machinery/door/airlock/hatch,
 /obj/structure/barricade/wooden/crude{
 	layer = 4
 	},
@@ -1029,9 +1027,8 @@
 	},
 /area/ruin/space/deepstorage)
 "eq" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	req_access_txt = "512"
-	},
+/obj/effect/mapping_helpers/airlock/access/all/ruins/deepstorage,
+/obj/machinery/door/airlock/maintenance_hatch,
 /turf/simulated/floor/plating,
 /area/ruin/space/deepstorage)
 "es" = (
@@ -1440,8 +1437,8 @@
 /turf/simulated/floor/plating,
 /area/ruin/space/deepstorage)
 "hp" = (
+/obj/effect/mapping_helpers/airlock/access/all/ruins/deepstorage,
 /obj/machinery/door/airlock/hatch{
-	req_access_txt = "512";
 	name = "Guard Wing"
 	},
 /obj/structure/barricade/wooden/crude{
@@ -1692,8 +1689,8 @@
 /turf/simulated/floor/plasteel,
 /area/ruin/space/deepstorage)
 "jj" = (
+/obj/effect/mapping_helpers/airlock/access/all/ruins/deepstorage,
 /obj/machinery/door/airlock/highsecurity{
-	req_access_txt = "512";
 	name = "Guard Store Room"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -1856,9 +1853,9 @@
 /area/ruin/space/deepstorage)
 "jT" = (
 /obj/structure/fans/tiny,
+/obj/effect/mapping_helpers/airlock/access/all/ruins/deepstorage,
 /obj/machinery/door/airlock/vault{
-	locked = 1;
-	req_access_txt = "512"
+	locked = 1
 	},
 /turf/simulated/floor/catwalk,
 /area/ruin/space/deepstorage)
@@ -2170,9 +2167,8 @@
 /obj/structure/barricade/wooden/crude{
 	layer = 4
 	},
-/obj/machinery/door/airlock/centcom{
-	req_access_txt = "512"
-	},
+/obj/effect/mapping_helpers/airlock/access/all/ruins/deepstorage,
+/obj/machinery/door/airlock/centcom,
 /turf/simulated/floor/catwalk,
 /area/ruin/space/deepstorage)
 "mf" = (
@@ -2689,8 +2685,8 @@
 /turf/simulated/floor/plating/asteroid/basalt/airless,
 /area/ruin/space/unpowered)
 "pz" = (
+/obj/effect/mapping_helpers/airlock/access/all/ruins/deepstorage,
 /obj/machinery/door/airlock/command/glass{
-	req_access_txt = "512";
 	name = "Floor Administrator's Office"
 	},
 /obj/effect/mapping_helpers/airlock/polarized{
@@ -2742,9 +2738,8 @@
 /obj/structure/barricade/wooden/crude{
 	layer = 4
 	},
-/obj/machinery/door/airlock/hatch{
-	req_access_txt = "512"
-	},
+/obj/effect/mapping_helpers/airlock/access/all/ruins/deepstorage,
+/obj/machinery/door/airlock/hatch,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "podfloor"
@@ -2974,9 +2969,8 @@
 /area/ruin/space/deepstorage)
 "rK" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/hatch{
-	req_access_txt = "512"
-	},
+/obj/effect/mapping_helpers/airlock/access/all/ruins/deepstorage,
+/obj/machinery/door/airlock/hatch,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "podfloor"
@@ -3776,9 +3770,8 @@
 /turf/simulated/wall/indestructible/riveted,
 /area/ruin/space/deepstorage)
 "wH" = (
-/obj/machinery/door/airlock/hatch{
-	req_access_txt = "512"
-	},
+/obj/effect/mapping_helpers/airlock/access/all/ruins/deepstorage,
+/obj/machinery/door/airlock/hatch,
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 2;
 	id_tag = "DS_Quartermaster"
@@ -3858,8 +3851,8 @@
 	},
 /area/ruin/space/deepstorage)
 "xC" = (
+/obj/effect/mapping_helpers/airlock/access/all/ruins/deepstorage,
 /obj/machinery/door/airlock/highsecurity{
-	req_access_txt = "512";
 	name = "Interrogation Room"
 	},
 /turf/simulated/floor/plasteel{
@@ -4108,9 +4101,9 @@
 /turf/simulated/floor/mineral/titanium,
 /area/ruin/space/deepstorage)
 "zh" = (
+/obj/effect/mapping_helpers/airlock/access/all/ruins/deepstorage,
 /obj/machinery/door/airlock/highsecurity{
-	name = "Incinerator";
-	req_access_txt = "512"
+	name = "Incinerator"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cult"
@@ -4169,9 +4162,9 @@
 /turf/simulated/floor/plating,
 /area/ruin/space/deepstorage)
 "zy" = (
+/obj/effect/mapping_helpers/airlock/access/all/ruins/deepstorage,
 /obj/machinery/door/airlock/vault{
-	locked = 1;
-	req_access_txt = "512"
+	locked = 1
 	},
 /obj/structure/fans/tiny,
 /turf/simulated/floor/catwalk,
@@ -4192,9 +4185,8 @@
 /obj/structure/barricade/wooden/crude{
 	layer = 4
 	},
-/obj/machinery/door/airlock/hatch{
-	req_access_txt = "512"
-	},
+/obj/effect/mapping_helpers/airlock/access/all/ruins/deepstorage,
+/obj/machinery/door/airlock/hatch,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -4321,9 +4313,9 @@
 /area/ruin/space/deepstorage)
 "As" = (
 /obj/structure/fans/tiny,
+/obj/effect/mapping_helpers/airlock/access/all/ruins/deepstorage,
 /obj/machinery/door/airlock/vault{
-	name = "Auxiliary Power Room";
-	req_access_txt = "512"
+	name = "Auxiliary Power Room"
 	},
 /obj/machinery/door/poddoor/multi_tile/impassable{
 	id_tag = "DS_Engineering"
@@ -4356,8 +4348,8 @@
 	},
 /area/ruin/space/deepstorage)
 "AA" = (
+/obj/effect/mapping_helpers/airlock/access/all/ruins/deepstorage,
 /obj/machinery/door/airlock/highsecurity{
-	req_access_txt = "512";
 	name = "Evidence Storage"
 	},
 /turf/simulated/floor/plasteel{
@@ -5370,9 +5362,8 @@
 	},
 /area/ruin/space/deepstorage)
 "Hx" = (
-/obj/machinery/door/airlock/hatch{
-	req_access_txt = "512"
-	},
+/obj/effect/mapping_helpers/airlock/access/all/ruins/deepstorage,
+/obj/machinery/door/airlock/hatch,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -6899,9 +6890,8 @@
 	},
 /area/ruin/space/deepstorage)
 "To" = (
-/obj/machinery/door/airlock/centcom{
-	req_access_txt = "512"
-	},
+/obj/effect/mapping_helpers/airlock/access/all/ruins/deepstorage,
+/obj/machinery/door/airlock/centcom,
 /turf/simulated/floor/catwalk,
 /area/ruin/space/deepstorage)
 "Tq" = (
@@ -6927,9 +6917,8 @@
 	},
 /area/ruin/space/deepstorage)
 "TK" = (
-/obj/machinery/door/airlock/highsecurity{
-	req_access_txt = "512"
-	},
+/obj/effect/mapping_helpers/airlock/access/all/ruins/deepstorage,
+/obj/machinery/door/airlock/highsecurity,
 /obj/machinery/door/poddoor/multi_tile/impassable{
 	id_tag = "DS_Storage"
 	},
@@ -7005,9 +6994,8 @@
 /obj/structure/barricade/wooden/crude{
 	layer = 4
 	},
-/obj/machinery/door/airlock/highsecurity{
-	req_access_txt = "512"
-	},
+/obj/effect/mapping_helpers/airlock/access/all/ruins/deepstorage,
+/obj/machinery/door/airlock/highsecurity,
 /obj/machinery/door/poddoor/multi_tile/impassable{
 	id_tag = "DS_Storage"
 	},
@@ -7922,9 +7910,8 @@
 /turf/simulated/floor/engine/airless,
 /area/ruin/space/unpowered)
 "ZW" = (
-/obj/machinery/door/airlock/hatch{
-	req_access_txt = "512"
-	},
+/obj/effect/mapping_helpers/airlock/access/all/ruins/deepstorage,
+/obj/machinery/door/airlock/hatch,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "podfloor"

--- a/_maps/map_files/RandomRuins/SpaceRuins/listeningpost.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/listeningpost.dmm
@@ -63,9 +63,9 @@
 /turf/simulated/floor/plating/airless,
 /area/ruin/space/syndicate_listening_station/asteroid)
 "kE" = (
+/obj/effect/mapping_helpers/airlock/access/all/syndicate,
 /obj/machinery/door/airlock/external{
-	id_tag = "sst_away";
-	req_access_txt = "150"
+	id_tag = "sst_away"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -242,9 +242,9 @@
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/syndicate_listening_station)
 "zb" = (
+/obj/effect/mapping_helpers/airlock/access/all/syndicate,
 /obj/machinery/door/airlock/external{
-	id_tag = "sst_away";
-	req_access_txt = "150"
+	id_tag = "sst_away"
 	},
 /obj/structure/fans/tiny,
 /obj/effect/decal/cleanable/dirt,
@@ -472,9 +472,9 @@
 /turf/simulated/floor/mineral/silver,
 /area/ruin/space/syndicate_listening_station)
 "Ow" = (
+/obj/effect/mapping_helpers/airlock/access/all/syndicate,
 /obj/machinery/door/airlock/external{
-	id_tag = "sst_away";
-	req_access_txt = "150"
+	id_tag = "sst_away"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -513,9 +513,9 @@
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/syndicate_listening_station)
 "TS" = (
+/obj/effect/mapping_helpers/airlock/access/all/syndicate,
 /obj/machinery/door/airlock/external{
-	id_tag = "sst_away";
-	req_access_txt = "150"
+	id_tag = "sst_away"
 	},
 /obj/structure/cable{
 	d1 = 4;

--- a/_maps/map_files/RandomRuins/SpaceRuins/moonoutpost19.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/moonoutpost19.dmm
@@ -290,8 +290,8 @@
 /turf/simulated/wall,
 /area/ruin/space/moonbase19)
 "aN" = (
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
 /obj/machinery/door/airlock/medical/glass{
-	req_access_txt = "271";
 	name = "Storage Room"
 	},
 /turf/simulated/floor/plasteel,
@@ -390,16 +390,15 @@
 /obj/machinery/door/poddoor/impassable{
 	id_tag = "awaymlock"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
 /obj/machinery/door/airlock/medical/glass{
-	req_access_txt = "271";
 	name = "Medical Ward"
 	},
 /turf/simulated/floor/catwalk,
 /area/ruin/space/moonbase19)
 "ba" = (
-/obj/machinery/door/airlock/multi_tile/glass{
-	req_access_txt = "271"
-	},
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
+/obj/machinery/door/airlock/multi_tile/glass,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
@@ -846,9 +845,8 @@
 	},
 /area/ruin/space/moonbase19)
 "cx" = (
-/obj/machinery/door/airlock/security/glass{
-	req_access_txt = "271"
-	},
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
+/obj/machinery/door/airlock/security/glass,
 /obj/structure/barricade/wooden/crude{
 	layer = 4
 	},
@@ -909,9 +907,8 @@
 	layer = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
-/obj/machinery/door/airlock/maintenance_hatch{
-	req_access_txt = "271"
-	},
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
+/obj/machinery/door/airlock/maintenance_hatch,
 /turf/simulated/floor/plating,
 /area/ruin/space/moonbase19)
 "cI" = (
@@ -1198,8 +1195,8 @@
 /obj/machinery/door/poddoor/impassable{
 	id_tag = "awaycontlockdown"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
 /obj/machinery/door/airlock/highsecurity{
-	req_access_txt = "271";
 	name = "Specimen Containtment Zone"
 	},
 /turf/simulated/floor/catwalk,
@@ -1394,8 +1391,8 @@
 /obj/machinery/door/poddoor/impassable{
 	id_tag = "awaymlock"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
 /obj/machinery/door/airlock/centcom{
-	req_access_txt = "271";
 	name = "Medical Ward"
 	},
 /turf/simulated/floor/catwalk,
@@ -1574,9 +1571,8 @@
 /obj/structure/barricade/wooden/crude{
 	layer = 4
 	},
-/obj/machinery/door/airlock/external{
-	req_access_txt = "271"
-	},
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
+/obj/machinery/door/airlock/external,
 /turf/simulated/floor/catwalk,
 /area/ruin/space/moonbase19)
 "eZ" = (
@@ -1672,9 +1668,8 @@
 	},
 /area/ruin/space/moonbase19)
 "fn" = (
-/obj/machinery/door/airlock/centcom{
-	req_access_txt = "271"
-	},
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
+/obj/machinery/door/airlock/centcom,
 /turf/simulated/floor/plasteel,
 /area/ruin/space/moonbase19)
 "fp" = (
@@ -1819,8 +1814,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
 /obj/machinery/door/airlock/centcom{
-	req_access_txt = "271";
 	name = "Cafeteria"
 	},
 /turf/simulated/floor/catwalk,
@@ -2934,8 +2929,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
 /obj/machinery/door/airlock/engineering/glass{
-	req_access_txt = "271";
 	name = "Workshop"
 	},
 /turf/simulated/floor/catwalk,
@@ -3335,8 +3330,8 @@
 /obj/machinery/door/poddoor/impassable{
 	id_tag = "awayscilock"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
 /obj/machinery/door/airlock/centcom{
-	req_access_txt = "271";
 	name = "Research Division"
 	},
 /turf/simulated/floor/catwalk,
@@ -3548,9 +3543,8 @@
 /turf/simulated/floor/engine,
 /area/ruin/space/moonbase19)
 "kW" = (
-/obj/machinery/door/airlock/centcom{
-	req_access_txt = "271"
-	},
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
+/obj/machinery/door/airlock/centcom,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "caution"
@@ -3628,9 +3622,8 @@
 	},
 /area/ruin/space/moonbase19)
 "lq" = (
-/obj/machinery/door/airlock{
-	req_access_txt = "271"
-	},
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
+/obj/machinery/door/airlock,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -4181,8 +4174,8 @@
 /turf/simulated/floor/carpet,
 /area/ruin/space/moonbase19)
 "nx" = (
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
 /obj/machinery/door/airlock/centcom{
-	req_access_txt = "271";
 	name = "Engineering Division"
 	},
 /turf/simulated/floor/plasteel,
@@ -4813,8 +4806,8 @@
 /obj/machinery/door/poddoor/impassable{
 	id_tag = "awayscilock"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
 /obj/machinery/door/airlock/centcom{
-	req_access_txt = "271";
 	name = "Research Division"
 	},
 /turf/simulated/floor/catwalk,
@@ -4968,8 +4961,8 @@
 	},
 /area/ruin/space/moonbase19)
 "qx" = (
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
 /obj/machinery/door/airlock/centcom{
-	req_access_txt = "271";
 	name = "Cafeteria"
 	},
 /turf/simulated/floor/catwalk,
@@ -5354,8 +5347,8 @@
 	},
 /area/ruin/space/moonbase19)
 "rV" = (
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
 /obj/machinery/door/airlock{
-	req_access_txt = "271";
 	name = "Dorms"
 	},
 /turf/simulated/floor/plasteel{
@@ -5379,9 +5372,8 @@
 	},
 /area/ruin/space/moonbase19)
 "rZ" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	req_access_txt = "271"
-	},
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
+/obj/machinery/door/airlock/maintenance_hatch,
 /turf/simulated/floor/plating,
 /area/ruin/space/moonbase19)
 "sa" = (
@@ -7074,7 +7066,7 @@
 /area/ruin/space/moonbase19)
 "zV" = (
 /obj/machinery/economy/vending/medical{
-	req_access_txt = "271"
+	req_access = list(271)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitecorner";
@@ -7099,8 +7091,8 @@
 	},
 /area/ruin/space/moonbase19)
 "Af" = (
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
 /obj/machinery/door/airlock/command/glass{
-	req_access_txt = "271";
 	name = "Senior Researcher's Office"
 	},
 /obj/effect/mapping_helpers/airlock/polarized{
@@ -7491,7 +7483,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/reinforced/normal{
 	dir = 4;
-	req_access_txt = "271"
+	req_access = list(271)
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id_tag = "awayscilock2"
@@ -7516,9 +7508,8 @@
 /obj/machinery/door/poddoor/impassable{
 	id_tag = "awayscilock"
 	},
-/obj/machinery/door/airlock/maintenance_hatch{
-	req_access_txt = "271"
-	},
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
+/obj/machinery/door/airlock/maintenance_hatch,
 /turf/simulated/floor/plating,
 /area/ruin/space/moonbase19)
 "BK" = (
@@ -7527,8 +7518,8 @@
 /turf/simulated/floor/catwalk,
 /area/ruin/space/moonbase19)
 "BO" = (
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
 /obj/machinery/door/airlock/engineering/glass{
-	req_access_txt = "271";
 	name = "Engineering Division"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -7606,8 +7597,8 @@
 /obj/machinery/door/poddoor/impassable{
 	id_tag = "awaycontlockdown"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
 /obj/machinery/door/airlock/highsecurity{
-	req_access_txt = "271";
 	name = "Specimen Containtment Zone"
 	},
 /turf/simulated/floor/catwalk,
@@ -7621,9 +7612,8 @@
 	},
 /area/ruin/space/moonbase19)
 "Ct" = (
-/obj/machinery/door/airlock/highsecurity{
-	req_access_txt = "271"
-	},
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
+/obj/machinery/door/airlock/highsecurity,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "awayscilock1"
 	},
@@ -7645,8 +7635,8 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
 /obj/machinery/door/airlock/centcom{
-	req_access_txt = "271";
 	name = "Engineering Division"
 	},
 /turf/simulated/floor/plasteel,
@@ -7882,9 +7872,8 @@
 	},
 /area/ruin/space/moonbase19)
 "Dt" = (
-/obj/machinery/door/airlock/medical/glass{
-	req_access_txt = "271"
-	},
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
+/obj/machinery/door/airlock/medical/glass,
 /obj/effect/decal/cleanable/blood/tracks/mapped,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkfull";
@@ -8496,8 +8485,8 @@
 	},
 /area/ruin/space/moonbase19)
 "Gk" = (
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
 /obj/machinery/door/airlock/medical/glass{
-	req_access_txt = "271";
 	name = "Operation Room"
 	},
 /turf/simulated/floor/plasteel{
@@ -8845,8 +8834,8 @@
 /turf/simulated/floor/engine,
 /area/ruin/space/moonbase19)
 "HO" = (
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
 /obj/machinery/door/airlock/highsecurity{
-	req_access_txt = "271";
 	name = "Chamber #1"
 	},
 /obj/effect/turf_decal/delivery,
@@ -9070,8 +9059,8 @@
 /area/ruin/space/moonbase19)
 "IU" = (
 /obj/effect/turf_decal/delivery,
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
 /obj/machinery/door/airlock/highsecurity{
-	req_access_txt = "271";
 	name = "Chamber #2"
 	},
 /turf/simulated/floor/plasteel{
@@ -9197,9 +9186,8 @@
 	},
 /area/ruin/space/moonbase19)
 "JE" = (
-/obj/machinery/door/airlock/external{
-	req_access_txt = "271"
-	},
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
+/obj/machinery/door/airlock/external,
 /turf/simulated/floor/catwalk,
 /area/ruin/space/moonbase19)
 "JG" = (
@@ -9839,9 +9827,8 @@
 	},
 /area/ruin/space/moonbase19)
 "Mx" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	req_access_txt = "271"
-	},
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
+/obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/ruin/space/moonbase19)
@@ -10578,8 +10565,8 @@
 	},
 /area/ruin/space/moonbase19)
 "PF" = (
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
 /obj/machinery/door/airlock/security{
-	req_access_txt = "271";
 	name = "Security Checkpoint"
 	},
 /turf/simulated/floor/plasteel{
@@ -10888,8 +10875,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
 /obj/machinery/door/airlock/centcom{
-	req_access_txt = "271";
 	name = "Cafeteria"
 	},
 /turf/simulated/floor/catwalk,
@@ -10979,9 +10966,8 @@
 	},
 /area/ruin/space/moonbase19)
 "Rg" = (
-/obj/machinery/door/airlock/freezer{
-	req_access_txt = "271"
-	},
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
+/obj/machinery/door/airlock/freezer,
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor";
 	temperature = 273.15
@@ -11060,9 +11046,8 @@
 /turf/simulated/floor/engine,
 /area/ruin/space/moonbase19)
 "RD" = (
-/obj/machinery/door/airlock/multi_tile/glass{
-	req_access_txt = "271"
-	},
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
+/obj/machinery/door/airlock/multi_tile/glass,
 /obj/structure/barricade/wooden/crude{
 	layer = 4
 	},
@@ -11299,9 +11284,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/airlock/centcom{
-	req_access_txt = "271"
-	},
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
+/obj/machinery/door/airlock/centcom,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "caution"
@@ -11365,8 +11349,8 @@
 	},
 /area/ruin/space/moonbase19)
 "Ti" = (
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
 /obj/machinery/door/airlock/command/glass{
-	req_access_txt = "271";
 	name = "Senior Researcher's Office"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -11591,8 +11575,8 @@
 "Ue" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
 /obj/machinery/door/airlock{
-	req_access_txt = "271";
 	name = "Dorms"
 	},
 /turf/simulated/floor/plasteel{
@@ -11695,9 +11679,8 @@
 /obj/effect/decal/cleanable/blood/tracks/mapped{
 	dir = 8
 	},
-/obj/machinery/door/airlock/maintenance_hatch{
-	req_access_txt = "271"
-	},
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
+/obj/machinery/door/airlock/maintenance_hatch,
 /turf/simulated/floor/plating,
 /area/ruin/space/moonbase19)
 "UA" = (
@@ -12043,9 +12026,8 @@
 /turf/simulated/floor/plating,
 /area/ruin/space/moonbase19)
 "We" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	req_access_txt = "271"
-	},
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
+/obj/machinery/door/airlock/maintenance_hatch,
 /obj/machinery/door/poddoor/impassable{
 	id_tag = "awayscilock"
 	},
@@ -12153,9 +12135,9 @@
 	},
 /area/ruin/space/moonbase19)
 "WG" = (
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
 /obj/machinery/door/airlock/vault{
-	locked = 1;
-	req_access_txt = "271"
+	locked = 1
 	},
 /turf/simulated/floor/catwalk,
 /area/ruin/space/moonbase19)
@@ -12557,8 +12539,8 @@
 /area/ruin/space/moonbase19)
 "Yj" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
 /obj/machinery/door/airlock/engineering/glass{
-	req_access_txt = "271";
 	name = "Engineering Division"
 	},
 /turf/simulated/floor/plasteel,
@@ -12643,8 +12625,8 @@
 	id_tag = "awaymlock"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
 /obj/machinery/door/airlock/centcom{
-	req_access_txt = "271";
 	name = "Medical Ward"
 	},
 /turf/simulated/floor/catwalk,
@@ -12688,8 +12670,8 @@
 	},
 /area/ruin/space/moonbase19)
 "YM" = (
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
 /obj/machinery/door/airlock/engineering/glass{
-	req_access_txt = "271";
 	name = "Workshop"
 	},
 /turf/simulated/floor/catwalk,
@@ -12948,9 +12930,8 @@
 /turf/simulated/floor/engine,
 /area/ruin/space/moonbase19)
 "ZP" = (
-/obj/machinery/door/airlock/medical/glass{
-	req_access_txt = "271"
-	},
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19,
+/obj/machinery/door/airlock/medical/glass,
 /obj/structure/barricade/wooden{
 	layer = 4
 	},

--- a/_maps/map_files/RandomRuins/SpaceRuins/oldstation.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/oldstation.dmm
@@ -1960,9 +1960,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/ruins/theta,
 /obj/machinery/door/airlock/external{
-	name = "Engineering External Access";
-	req_one_access_txt = "301"
+	name = "Engineering External Access"
 	},
 /turf/simulated/floor/plating,
 /area/ruin/ancientstation/engi)
@@ -3013,9 +3013,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/maintenance_hatch{
-	req_one_access_txt = "301"
-	},
+/obj/effect/mapping_helpers/airlock/access/all/ruins/theta,
+/obj/machinery/door/airlock/maintenance_hatch,
 /turf/simulated/floor/plating,
 /area/ruin/ancientstation/thetacorridor)
 "hF" = (
@@ -3090,9 +3089,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/ruins/theta,
 /obj/machinery/door/airlock/external{
-	name = "Engineering External Access";
-	req_one_access_txt = "301"
+	name = "Engineering External Access"
 	},
 /turf/simulated/floor/plating/airless,
 /area/ruin/ancientstation/engi)
@@ -3792,9 +3791,9 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/airlock/access/all/ruins/theta,
 /obj/machinery/door/airlock/highsecurity{
-	name = "Prototype Laboratory";
-	req_access_txt = "301"
+	name = "Prototype Laboratory"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitehall"
@@ -3803,9 +3802,9 @@
 "jv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/airlock/access/all/ruins/theta,
 /obj/machinery/door/airlock/highsecurity{
-	name = "Prototype Laboratory";
-	req_access_txt = "301"
+	name = "Prototype Laboratory"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitehall"

--- a/_maps/map_files/RandomRuins/SpaceRuins/syndicatedruglab.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/syndicatedruglab.dmm
@@ -241,8 +241,7 @@
 	id = "syndicatedruglab";
 	name = "Syndicate Drug Lab Hangar";
 	pixel_x = 24;
-	pixel_y = 4;
-	req_access_txt = null
+	pixel_y = 4
 	},
 /turf/simulated/floor/plating,
 /area/ruin/space/syndicate_druglab)

--- a/_maps/map_files/RandomRuins/SpaceRuins/syndie_space_base.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/syndie_space_base.dmm
@@ -78,8 +78,8 @@
 	name = "Vault Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_x = 24;
-	req_access_txt = "150";
-	specialfunctions = 4
+	specialfunctions = 4;
+	req_access = list(150)
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -1082,7 +1082,7 @@
 	id = "SSBrestricted";
 	name = "Shutters Control";
 	pixel_x = -24;
-	req_access_txt = "151"
+	req_access = list(151)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -1274,8 +1274,7 @@
 "gW" = (
 /obj/machinery/door/window/classic/reversed{
 	name = "Animal Storage";
-	req_access_txt = "150";
-	req_one_access_txt = "150"
+	req_access = list(150)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -1553,7 +1552,7 @@
 	id = "SSBrestricted";
 	name = "Shutters Control";
 	pixel_x = 24;
-	req_access_txt = "151"
+	req_access = list(151)
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -1581,7 +1580,7 @@
 /area/ruin/unpowered/syndicate_space_base/toxtest)
 "iB" = (
 /obj/structure/closet/crate/secure/gear{
-	req_access_txt = "150"
+	req_access = list(150)
 	},
 /obj/item/clothing/suit/space/syndicate,
 /obj/item/clothing/suit/space/syndicate,
@@ -1728,7 +1727,7 @@
 /area/ruin/unpowered/syndicate_space_base/arrivals)
 "je" = (
 /obj/structure/closet/crate/secure/gear{
-	req_access_txt = "150"
+	req_access = list(150)
 	},
 /obj/item/clothing/suit/space/syndicate,
 /obj/item/clothing/suit/space/syndicate,
@@ -4979,7 +4978,7 @@
 	dir = 4;
 	network = list("SyndicateTestLab","SyndicateToxinsTest","SyndicateCaves","SyndicateInterior");
 	name = "syndicate security camera console";
-	req_access_txt = "150"
+	req_access = list(150)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -5290,7 +5289,7 @@
 /area/ruin/unpowered/syndicate_space_base/atmos)
 "Ed" = (
 /obj/structure/closet/crate/secure/gear{
-	req_access_txt = "150"
+	req_access = list(150)
 	},
 /obj/machinery/light{
 	dir = 1
@@ -5332,8 +5331,7 @@
 "Ei" = (
 /obj/machinery/door/window/classic/reversed{
 	name = "Animal Storage";
-	req_access_txt = "150";
-	req_one_access_txt = "150"
+	req_access = list(150)
 	},
 /mob/living/simple_animal/chicken{
 	faction = list("neutral","syndicate")
@@ -5456,10 +5454,10 @@
 	},
 /area/ruin/unpowered/syndicate_space_base/genetics)
 "ES" = (
+/obj/effect/mapping_helpers/airlock/access/all/syndicate,
 /obj/machinery/door/airlock/vault{
 	id_tag = "syndie_lavaland_vault";
-	locked = 1;
-	req_access_txt = "150"
+	locked = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -6140,7 +6138,7 @@
 /area/ruin/unpowered/syndicate_space_base/main)
 "Iz" = (
 /obj/structure/closet/crate/secure/gear{
-	req_access_txt = "150"
+	req_access = list(150)
 	},
 /obj/machinery/light,
 /obj/item/clothing/gloves/combat,
@@ -6396,7 +6394,7 @@
 	pixel_y = -24;
 	name = "Caves Turret Control Panel";
 	control_area = "Syndicate Space Base Cave";
-	req_access_txt = "150"
+	req_access = list(150)
 	},
 /obj/structure/chair{
 	dir = 8
@@ -7028,8 +7026,7 @@
 /area/ruin/unpowered/syndicate_space_base/toxlaunch)
 "NT" = (
 /obj/structure/closet/secure_closet/medical1{
-	req_access = null;
-	req_access_txt = "150"
+	req_access = list(150)
 	},
 /obj/structure/window/reinforced{
 	dir = 1
@@ -7692,7 +7689,7 @@
 /area/ruin/unpowered/syndicate_space_base/engineering)
 "Sv" = (
 /obj/structure/closet/crate/secure/weapon{
-	req_access_txt = "150"
+	req_access = list(150)
 	},
 /obj/item/ammo_box/magazine/m10mm/hp,
 /obj/item/ammo_box/magazine/m10mm/hp,
@@ -7793,7 +7790,7 @@
 /area/ruin/unpowered/syndicate_space_base/storage)
 "SN" = (
 /obj/structure/closet/crate/secure/weapon{
-	req_access_txt = "150"
+	req_access = list(150)
 	},
 /obj/item/ammo_box/magazine/m10mm/hp,
 /obj/item/ammo_box/magazine/m10mm/hp,

--- a/_maps/map_files/RandomRuins/SpaceRuins/syndiedepot.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/syndiedepot.dmm
@@ -448,17 +448,17 @@
 	},
 /area/syndicate_depot/core)
 "bq" = (
+/obj/effect/mapping_helpers/airlock/access/all/syndicate,
 /obj/machinery/door/airlock/external{
-	id_tag = "sst_away";
-	req_access_txt = "150"
+	id_tag = "sst_away"
 	},
 /obj/structure/fans/tiny,
 /turf/simulated/floor/plating,
 /area/syndicate_depot/core)
 "br" = (
+/obj/effect/mapping_helpers/airlock/access/all/syndicate,
 /obj/machinery/door/airlock/external{
-	id_tag = "sst_away";
-	req_access_txt = "150"
+	id_tag = "sst_away"
 	},
 /obj/structure/fans/tiny,
 /turf/simulated/floor/plating,
@@ -568,9 +568,9 @@
 	name = "Sealed Doors";
 	protected = 0
 	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate,
 /obj/machinery/door/airlock/external{
-	id_tag = "sst_away";
-	req_access_txt = "150"
+	id_tag = "sst_away"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -655,8 +655,7 @@
 /obj/machinery/turretid/syndicate{
 	name = "external turret controls";
 	pixel_x = -32;
-	req_access = null;
-	req_access_txt = "150"
+	req_access = list(150)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"

--- a/_maps/map_files/RandomRuins/SpaceRuins/telecomns_returns.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/telecomns_returns.dmm
@@ -157,9 +157,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	req_access_txt = "0"
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/ruin/space/telecomms/tele)
 "cJ" = (
@@ -417,13 +415,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
 /obj/machinery/door/airlock/hatch{
-	name = "Telecoms Satellite";
-	req_access_txt = "61"
+	name = "Telecoms Satellite"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	req_access_txt = "0"
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/ruin/space/telecomms/tele)
@@ -512,9 +508,9 @@
 /turf/simulated/floor/catwalk/airless,
 /area/ruin/space/telecomms/powercontrol)
 "ky" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
 /obj/machinery/door/airlock/hatch{
-	name = "Telecoms Power Control";
-	req_access_txt = "61"
+	name = "Telecoms Power Control"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -1498,9 +1494,9 @@
 /turf/simulated/floor/plasteel,
 /area/ruin/space/telecomms/computer)
 "xL" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
 /obj/machinery/door/airlock/hatch{
-	name = "Telecoms Lounge";
-	req_access_txt = "61"
+	name = "Telecoms Lounge"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor,
@@ -1518,9 +1514,9 @@
 /turf/simulated/floor/plating,
 /area/ruin/space/telecomms)
 "yl" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
 /obj/machinery/door/airlock/maintenance_hatch{
-	name = "Telecoms Storage";
-	req_access_txt = "61"
+	name = "Telecoms Storage"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -1576,9 +1572,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
 /obj/machinery/door/airlock/hatch{
-	name = "Telecoms East Wing";
-	req_access_txt = "61"
+	name = "Telecoms East Wing"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
@@ -1678,9 +1674,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	req_access_txt = "0"
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/telecomms_trap_tank,
 /obj/effect/abstract/cheese_trap,
 /turf/simulated/floor/catwalk,
@@ -1770,9 +1764,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	req_access_txt = "0"
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/abstract/bot_trap,
 /turf/simulated/floor/catwalk,
 /area/ruin/space/telecomms)
@@ -2303,18 +2295,16 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	req_access_txt = "0"
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/ruin/space/telecomms/tele)
 "IL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
 /obj/machinery/door/airlock/hatch{
-	name = "Telecoms West Wing";
-	req_access_txt = "61"
+	name = "Telecoms West Wing"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
@@ -2391,9 +2381,7 @@
 /area/ruin/space/telecomms/computer)
 "JQ" = (
 /obj/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	req_access_txt = "0"
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -2482,9 +2470,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	req_access_txt = "0"
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -2741,9 +2727,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
 /obj/machinery/door/airlock/hatch{
-	name = "Telecoms Satellite";
-	req_access_txt = "61"
+	name = "Telecoms Satellite"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/preopen{
@@ -2847,18 +2833,6 @@
 	temperature = 80
 	},
 /area/ruin/space/telecomms/chamber)
-"QY" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	req_access_txt = "0"
-	},
-/turf/simulated/floor/catwalk,
-/area/ruin/space/telecomms)
 "QZ" = (
 /obj/machinery/power/solar,
 /obj/structure/cable,
@@ -3097,9 +3071,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	req_access_txt = "0"
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/ruin/space/telecomms/foyer)
 "UF" = (
@@ -6860,7 +6832,7 @@ UD
 oB
 BQ
 Zb
-QY
+nL
 ML
 ML
 AX
@@ -8518,12 +8490,12 @@ nL
 vd
 Od
 xj
-QY
-QY
-QY
-QY
-QY
-QY
+nL
+nL
+nL
+nL
+nL
+nL
 vU
 Xf
 Ed

--- a/_maps/map_files/RandomRuins/SpaceRuins/ussp.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/ussp.dmm
@@ -3665,11 +3665,11 @@
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/ruin/space/derelict/arrival)
 "jl" = (
+/obj/effect/mapping_helpers/airlock/access/all/syndicate,
 /obj/machinery/door/airlock/external{
 	id_tag = "s_docking_airlock";
 	locked = 1;
-	name = "Shuttle Airlock";
-	req_access_txt = "150"
+	name = "Shuttle Airlock"
 	},
 /turf/simulated/floor/plating,
 /area/ruin/space/derelict/arrival)

--- a/_maps/map_files/generic/Lavaland.dmm
+++ b/_maps/map_files/generic/Lavaland.dmm
@@ -556,8 +556,8 @@
 /obj/machinery/access_button{
 	autolink_id = "labor_btn_ext";
 	name = "Prison Wing Access Button";
-	req_access_txt = "2";
-	pixel_y = -21
+	pixel_y = -21;
+	req_access = list(2)
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -1155,10 +1155,10 @@
 /obj/effect/turf_decal/delivery/hollow/right,
 /obj/machinery/door_control{
 	id = "mining_mechbay";
-	req_access_txt = "54";
 	name = "Mech Bay Shutters";
 	pixel_x = 24;
-	pixel_y = 5
+	pixel_y = 5;
+	req_access = list(54)
 	},
 /obj/machinery/light_switch{
 	pixel_x = 24;
@@ -2448,9 +2448,9 @@
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/unexplored)
 "fU" = (
+/obj/effect/mapping_helpers/airlock/access/all/supply/mining,
 /obj/machinery/door/airlock/titanium{
-	id_tag = "s_docking_airlock";
-	req_access_txt = "48"
+	id_tag = "s_docking_airlock"
 	},
 /obj/docking_port/mobile/mining,
 /obj/structure/fans/tiny,
@@ -2905,7 +2905,7 @@
 	id = "gulagshuttleflasher";
 	name = "Flash Control";
 	pixel_y = -26;
-	req_access_txt = "1"
+	req_access = list(1)
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/siberia)
@@ -3082,8 +3082,8 @@
 	id = "Labor";
 	name = "Labor Camp Lockdown";
 	pixel_y = -22;
-	req_access_txt = "2";
-	pixel_x = -7
+	pixel_x = -7;
+	req_access = list(2)
 	},
 /obj/machinery/flasher_button{
 	id = "laborairlock";
@@ -3889,7 +3889,7 @@
 /obj/machinery/flasher_button{
 	id = "gulagshuttleflasher";
 	name = "Flash Control";
-	req_access_txt = "1"
+	req_access = list(1)
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/siberia)
@@ -4485,8 +4485,8 @@
 /obj/machinery/access_button{
 	autolink_id = "labor_btn_int";
 	name = "Prison Wing Access Button";
-	req_access_txt = "2";
-	pixel_y = -21
+	pixel_y = -21;
+	req_access = list(2)
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -6014,8 +6014,8 @@
 /obj/machinery/access_button{
 	autolink_id = "labor_btn_ext";
 	name = "Prison Wing Access Button";
-	req_access_txt = "2";
-	pixel_y = 21
+	pixel_y = 21;
+	req_access = list(2)
 	},
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Labor";
@@ -6091,8 +6091,8 @@
 /obj/machinery/access_button{
 	autolink_id = "labor_btn_int";
 	name = "Prison Wing Access Button";
-	req_access_txt = "2";
-	pixel_y = 21
+	pixel_y = 21;
+	req_access = list(2)
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/security/brig,

--- a/_maps/map_files/generic/centcomm.dmm
+++ b/_maps/map_files/generic/centcomm.dmm
@@ -19,9 +19,9 @@
 /turf/simulated/wall/indestructible/fakedoor,
 /area/ninja/holding)
 "ah" = (
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/general,
 /obj/machinery/door/airlock/centcom{
-	name = "CentCom Security";
-	req_access_txt = "101"
+	name = "CentCom Security"
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/evac)
@@ -434,7 +434,7 @@
 /area/ninja/holding)
 "bO" = (
 /obj/structure/closet/secure_closet/bar{
-	req_access_txt = "25"
+	req_access = list(25)
 	},
 /turf/simulated/floor/plasteel/freezer,
 /area/ninja/holding)
@@ -906,12 +906,12 @@
 "dD" = (
 /obj/machinery/airlock_controller/air_cycler{
 	pixel_x = 25;
-	req_access_txt = "150";
 	vent_link_id = "syndishuttle_vent";
 	ext_door_link_id = "syndishuttle_door_ext";
 	int_door_link_id = "syndishuttle_door_int";
 	ext_button_link_id = "syndishuttle_btn_ext";
-	int_button_link_id = "syndishuttle_btn_int"
+	int_button_link_id = "syndishuttle_btn_int";
+	req_access = list(150)
 	},
 /obj/machinery/light{
 	dir = 4
@@ -1069,10 +1069,10 @@
 	},
 /area/ninja/holding)
 "ei" = (
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/general,
 /obj/machinery/door/airlock/centcom{
 	id_tag = "adminshuttle";
-	name = "Workshop";
-	req_access_txt = "101"
+	name = "Workshop"
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/administration)
@@ -1934,10 +1934,10 @@
 /turf/simulated/floor/plasteel,
 /area/tdome/arena)
 "hl" = (
+/obj/effect/mapping_helpers/airlock/access/all/syndicate,
 /obj/machinery/door/airlock/external{
 	id_tag = "s_docking_airlock";
-	name = "Shuttle Airlock";
-	req_access_txt = "150"
+	name = "Shuttle Airlock"
 	},
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -1945,7 +1945,7 @@
 	id_tag = "syndicate_sit_1";
 	name = "Side Hull Door";
 	opacity = 0;
-	req_access_txt = "150"
+	req_access = list(150)
 	},
 /obj/docking_port/mobile{
 	dir = 8;
@@ -1960,7 +1960,7 @@
 	id = "syndicate_sit_1";
 	name = "Blast Doors";
 	pixel_y = -23;
-	req_access_txt = "150"
+	req_access = list(150)
 	},
 /obj/docking_port/stationary{
 	dir = 8;
@@ -1976,9 +1976,9 @@
 "hm" = (
 /obj/machinery/door_control/no_emag/no_cyborg{
 	pixel_y = 24;
-	req_access_txt = "114";
 	name = "Engineering Storage Shutters";
-	id = "SpecopsEngineering"
+	id = "SpecopsEngineering";
+	req_access = list(114)
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -1999,7 +1999,7 @@
 /obj/machinery/door_control/no_emag{
 	id = "tdome1";
 	pixel_x = 24;
-	req_access_txt = "102"
+	req_access = list(102)
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -2016,9 +2016,9 @@
 /turf/simulated/floor/wood,
 /area/ghost_bar)
 "hq" = (
+/obj/effect/mapping_helpers/airlock/access/all/syndicate,
 /obj/machinery/door/airlock/external{
-	id_tag = "sit_away";
-	req_access_txt = "150"
+	id_tag = "sit_away"
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/syndicate_mothership)
@@ -2080,17 +2080,17 @@
 /turf/simulated/floor/wood,
 /area/wizard_station)
 "hA" = (
+/obj/effect/mapping_helpers/airlock/access/all/syndicate,
 /obj/machinery/door/airlock/external{
-	id_tag = "sst_away";
-	req_access_txt = "150"
+	id_tag = "sst_away"
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/syndicate_mothership)
 "hB" = (
+/obj/effect/mapping_helpers/airlock/access/all/syndicate,
 /obj/machinery/door/airlock/external{
 	id_tag = "s_docking_airlock";
-	name = "Shuttle Airlock";
-	req_access_txt = "150"
+	name = "Shuttle Airlock"
 	},
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -2098,7 +2098,7 @@
 	id_tag = "syndicate_elite";
 	name = "Side Hull Door";
 	opacity = 0;
-	req_access_txt = "150"
+	req_access = list(150)
 	},
 /obj/docking_port/mobile{
 	dir = 4;
@@ -2129,10 +2129,10 @@
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/syndicate_sit)
 "hE" = (
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/security,
 /obj/machinery/door/airlock/centcom{
 	id_tag = "adminshuttle";
-	name = "Holding Cell";
-	req_access_txt = "104"
+	name = "Holding Cell"
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/administration)
@@ -2142,7 +2142,7 @@
 	name = "Shuttle Blast Doors";
 	pixel_x = -26;
 	pixel_y = -2;
-	req_access_txt = "150"
+	req_access = list(150)
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/syndicate_mothership)
@@ -2179,7 +2179,7 @@
 	name = "Shuttle Blast Doors";
 	pixel_x = 26;
 	pixel_y = -2;
-	req_access_txt = "150"
+	req_access = list(150)
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/syndicate_mothership)
@@ -2221,7 +2221,7 @@
 /obj/machinery/door_control/no_emag{
 	id = "tdome2";
 	pixel_x = -24;
-	req_access_txt = "102"
+	req_access = list(102)
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -2246,16 +2246,16 @@
 /turf/simulated/floor/plating/abductor,
 /area/abductor_ship)
 "hX" = (
+/obj/effect/mapping_helpers/airlock/access/all/syndicate,
 /obj/machinery/door/airlock/external{
 	id_tag = "s_docking_airlock";
-	name = "Shuttle Airlock";
-	req_access_txt = "150"
+	name = "Shuttle Airlock"
 	},
 /obj/machinery/door_control/no_emag{
 	id = "syndicate_elite";
 	name = "Blast Doors";
 	pixel_x = -25;
-	req_access_txt = "150"
+	req_access = list(150)
 	},
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -2263,22 +2263,22 @@
 	id_tag = "syndicate_elite";
 	name = "Front Hull Door";
 	opacity = 0;
-	req_access_txt = "150"
+	req_access = list(150)
 	},
 /obj/structure/fans/tiny,
 /turf/simulated/floor/plating,
 /area/shuttle/syndicate_elite)
 "hY" = (
+/obj/effect/mapping_helpers/airlock/access/all/syndicate,
 /obj/machinery/door/airlock/external{
 	id_tag = "s_docking_airlock";
-	name = "Shuttle Airlock";
-	req_access_txt = "150"
+	name = "Shuttle Airlock"
 	},
 /obj/machinery/door_control/no_emag{
 	id = "syndicate_sit_1";
 	name = "Blast Doors";
 	pixel_x = -25;
-	req_access_txt = "150"
+	req_access = list(150)
 	},
 /obj/structure/fans/tiny,
 /obj/machinery/door/poddoor{
@@ -2287,7 +2287,7 @@
 	id_tag = "syndicate_sit_1";
 	name = "Front Hull Door";
 	opacity = 0;
-	req_access_txt = "150"
+	req_access = list(150)
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/syndicate_sit)
@@ -2307,9 +2307,9 @@
 	},
 /area/tdome/tdomeobserve)
 "ic" = (
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/specops,
 /obj/machinery/door/airlock/centcom{
-	name = "Administrative Office";
-	req_access_txt = "109"
+	name = "Administrative Office"
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/specops)
@@ -2448,14 +2448,14 @@
 	name = "SIT Base Access";
 	pixel_x = -6;
 	pixel_y = 6;
-	req_access_txt = "153"
+	req_access = list(153)
 	},
 /obj/machinery/door_control/no_emag{
 	id = "sit_tele";
 	name = "SIT Teleporter Access";
 	pixel_x = 6;
 	pixel_y = 6;
-	req_access_txt = "153"
+	req_access = list(153)
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/syndicate_mothership)
@@ -2482,28 +2482,28 @@
 	name = "SST Extra Weapons";
 	pixel_x = -6;
 	pixel_y = -4;
-	req_access_txt = "153"
+	req_access = list(153)
 	},
 /obj/machinery/door_control/no_emag{
 	id = "sst_ready";
 	name = "SST Base Access";
 	pixel_x = -6;
 	pixel_y = 6;
-	req_access_txt = "153"
+	req_access = list(153)
 	},
 /obj/machinery/door_control/no_emag{
 	id = "sst_tele";
 	name = "SST Teleporter Access";
 	pixel_x = 6;
 	pixel_y = 6;
-	req_access_txt = "153"
+	req_access = list(153)
 	},
 /obj/machinery/door_control/no_emag{
 	id = "sst_mechbay";
 	name = "SST Mech Bay";
 	pixel_x = 6;
 	pixel_y = -4;
-	req_access_txt = "153"
+	req_access = list(153)
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/syndicate_mothership)
@@ -2667,11 +2667,11 @@
 /obj/machinery/airlock_controller/access_controller{
 	name = "Syndicate Jail Access Controller";
 	pixel_y = 24;
-	req_access_txt = "150";
 	ext_door_link_id = "syndijail_door_ext";
 	int_door_link_id = "syndijail_door_int";
 	ext_button_link_id = "syndijail_btn_ext";
-	int_button_link_id = "syndijail_btn_int"
+	int_button_link_id = "syndijail_btn_int";
+	req_access = list(150)
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/syndicate_mothership)
@@ -2714,7 +2714,7 @@
 /obj/machinery/door_control/no_emag{
 	id = "commandcenter";
 	name = "Privacy Shutters";
-	req_access_txt = "153"
+	req_access = list(153)
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/syndicate_mothership)
@@ -2803,14 +2803,14 @@
 	name = "Nuclear Base Access";
 	pixel_x = -6;
 	pixel_y = 6;
-	req_access_txt = "153"
+	req_access = list(153)
 	},
 /obj/machinery/door_control/no_emag{
 	id = "nukeop_ready";
 	name = "Nuclear Shuttle Access";
 	pixel_x = 6;
 	pixel_y = 6;
-	req_access_txt = "153"
+	req_access = list(153)
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/syndicate_mothership)
@@ -2926,7 +2926,7 @@
 /area/syndicate_mothership)
 "kk" = (
 /obj/structure/closet/secure_closet{
-	req_access_txt = "150"
+	req_access = list(150)
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/syndicate_mothership)
@@ -3263,16 +3263,16 @@
 	name = "Bolt Cell Doors";
 	normaldoorcontrol = 1;
 	pixel_x = 6;
-	req_access_txt = "150";
-	specialfunctions = 4
+	specialfunctions = 4;
+	req_access = list(150)
 	},
 /obj/machinery/door_control/no_emag{
 	id = "syndicate_jail";
 	name = "Bolt Jail Door";
 	normaldoorcontrol = 1;
 	pixel_x = -5;
-	req_access_txt = "150";
-	specialfunctions = 4
+	specialfunctions = 4;
+	req_access = list(150)
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/syndicate_mothership/jail)
@@ -3459,7 +3459,7 @@
 /obj/machinery/door_control/no_emag{
 	id = "syndieshutters";
 	name = "remote shutter control";
-	req_access_txt = "150"
+	req_access = list(150)
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/syndicate)
@@ -3830,9 +3830,9 @@
 /turf/simulated/floor/carpet/arcade,
 /area/ghost_bar)
 "mT" = (
+/obj/effect/mapping_helpers/airlock/access/all/syndicate,
 /obj/machinery/door/airlock/centcom{
-	name = "Restroom";
-	req_access_txt = "150"
+	name = "Restroom"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
@@ -3869,7 +3869,7 @@
 "mX" = (
 /obj/machinery/door/window{
 	name = "Cockpit";
-	req_access_txt = "150"
+	req_access = list(150)
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/syndicate)
@@ -4153,7 +4153,7 @@
 	dir = 8;
 	name = "Tactical Toilet";
 	opacity = 1;
-	req_access_txt = "150"
+	req_access = list(150)
 	},
 /turf/simulated/floor/plasteel/freezer,
 /area/syndicate_mothership)
@@ -4342,7 +4342,7 @@
 /obj/machinery/door/airlock/centcom{
 	aiControlDisabled = 1;
 	name = "Assault Pod";
-	req_one_access_txt = "150"
+	req_access = list(150)
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/assault_pod)
@@ -4535,9 +4535,9 @@
 /turf/space/transit,
 /area/space/centcomm)
 "pg" = (
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
 /obj/machinery/door/airlock/titanium/glass{
 	name = "trader shuttle airlock";
-	req_access_txt = "160";
 	security_level = 6
 	},
 /turf/simulated/floor/mineral/titanium/blue,
@@ -4662,9 +4662,9 @@
 /turf/simulated/floor/grass/jungle,
 /area/centcom/evac)
 "pK" = (
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/commander,
 /obj/machinery/door/airlock/centcom{
-	name = "Shuttle Control Office";
-	req_access_txt = "114"
+	name = "Shuttle Control Office"
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/gamma)
@@ -4692,14 +4692,14 @@
 	normaldoorcontrol = 1;
 	pixel_x = 24;
 	pixel_y = -8;
-	req_access_txt = "160"
+	req_access = list(160)
 	},
 /obj/machinery/door_control/no_emag{
 	id = "trader_privacy";
 	name = "Privacy Shutters Control";
 	pixel_x = 24;
 	pixel_y = 8;
-	req_access_txt = "160"
+	req_access = list(160)
 	},
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/trade/sol)
@@ -4729,7 +4729,7 @@
 	id = "adminshuttleblast";
 	name = "blast door control";
 	pixel_x = -30;
-	req_access_txt = "101"
+	req_access = list(101)
 	},
 /obj/machinery/light{
 	dir = 8
@@ -4846,10 +4846,10 @@
 	name = "Security Doors";
 	opacity = 0
 	},
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
 /obj/machinery/door/airlock/titanium/glass{
 	id_tag = "soltrader_north";
 	name = "trader shuttle airlock";
-	req_access_txt = "160";
 	security_level = 6
 	},
 /turf/simulated/floor/mineral/titanium/blue,
@@ -4941,7 +4941,7 @@
 	name = "Mission Launch Control";
 	pixel_x = -26;
 	pixel_y = -2;
-	req_access_txt = "151"
+	req_access = list(151)
 	},
 /obj/item/kirbyplants,
 /turf/simulated/floor/plasteel{
@@ -5059,9 +5059,8 @@
 /turf/simulated/floor/wood,
 /area/syndicate_mothership)
 "rc" = (
-/obj/machinery/door/airlock/external{
-	req_access_txt = "150"
-	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate,
+/obj/machinery/door/airlock/external,
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
 	},
@@ -5192,14 +5191,14 @@
 	name = "CentCom Security Shutters";
 	pixel_x = 8;
 	pixel_y = 36;
-	req_access_txt = "101"
+	req_access = list(101)
 	},
 /obj/machinery/door_control/no_emag{
 	id = "CC";
 	name = "Thunderdome Shutters";
 	pixel_x = 8;
 	pixel_y = 24;
-	req_access_txt = "114"
+	req_access = list(114)
 	},
 /obj/machinery/door_control/no_emag{
 	desc = "A remote control switch to connect the ready room to the rest of Centcom.";
@@ -5207,7 +5206,7 @@
 	name = "Nanotrasen Asset Protection Shutters";
 	pixel_x = -8;
 	pixel_y = 30;
-	req_access_txt = "109"
+	req_access = list(109)
 	},
 /turf/simulated/floor/wood,
 /area/centcom/control)
@@ -5484,10 +5483,10 @@
 /turf/simulated/floor/plasteel/dark,
 /area/tdome/tdomeobserve)
 "su" = (
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/general,
 /obj/machinery/door/airlock/centcom{
 	id_tag = "adminshuttle";
-	name = "Bridge";
-	req_access_txt = "101"
+	name = "Bridge"
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/administration)
@@ -5545,9 +5544,9 @@
 /turf/simulated/floor/wood,
 /area/syndicate_mothership)
 "sE" = (
+/obj/effect/mapping_helpers/airlock/access/all/syndicate,
 /obj/machinery/door/airlock/multi_tile/glass{
-	name = "Equipment Room";
-	req_access_txt = "150"
+	name = "Equipment Room"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
@@ -5641,7 +5640,7 @@
 /obj/machinery/door/airlock/centcom{
 	aiControlDisabled = 1;
 	name = "Assault Pod";
-	req_one_access_txt = "150"
+	req_access = list(150)
 	},
 /obj/docking_port/mobile/assault_pod,
 /turf/simulated/floor/plating,
@@ -5668,8 +5667,8 @@
 "th" = (
 /obj/machinery/door/window/reinforced/normal{
 	color = "#d70000";
-	req_access_txt = "104";
-	dir = 8
+	dir = 8;
+	req_access = list(104)
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/administration)
@@ -5809,7 +5808,7 @@
 	id = "ASSAULT";
 	name = "Mech Storage";
 	pixel_y = -24;
-	req_access_txt = "114"
+	req_access = list(114)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkred"
@@ -5905,7 +5904,7 @@
 /obj/machinery/door/window{
 	dir = 8;
 	name = "Tool Storage";
-	req_access_txt = "150"
+	req_access = list(150)
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/syndicate)
@@ -6015,7 +6014,7 @@
 /obj/machinery/door/window{
 	dir = 1;
 	name = "Secure Storage";
-	req_access_txt = "150"
+	req_access = list(150)
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/syndicate)
@@ -6265,7 +6264,7 @@
 	normaldoorcontrol = 1;
 	pixel_x = 24;
 	pixel_y = 8;
-	req_access_txt = "160"
+	req_access = list(160)
 	},
 /obj/machinery/flasher_button{
 	id = "soltraderflash";
@@ -6285,10 +6284,10 @@
 	name = "Security Doors";
 	opacity = 0
 	},
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
 /obj/machinery/door/airlock/titanium/glass{
 	id_tag = "soltrader_south";
 	name = "trader shuttle airlock";
-	req_access_txt = "160";
 	security_level = 6
 	},
 /turf/simulated/floor/mineral/titanium/blue,
@@ -7148,10 +7147,10 @@
 /turf/simulated/floor/grass,
 /area/centcom/control)
 "yZ" = (
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/shuttles,
 /obj/machinery/door/airlock/external{
 	name = "Supply Shuttle";
-	opacity = 0;
-	req_access_txt = "106"
+	opacity = 0
 	},
 /obj/structure/fans/tiny,
 /turf/simulated/floor/plating,
@@ -7302,9 +7301,9 @@
 "zK" = (
 /obj/machinery/door_control/no_emag/no_cyborg{
 	pixel_x = 24;
-	req_access_txt = "114";
 	name = "Specops Teleporter Shutters";
-	id = "CCTELE"
+	id = "CCTELE";
+	req_access = list(114)
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/specops)
@@ -7347,8 +7346,8 @@
 "zW" = (
 /obj/machinery/door/window{
 	name = "Uplink Management Control";
-	req_access_txt = "151";
-	dir = 4
+	dir = 4;
+	req_access = list(151)
 	},
 /turf/simulated/floor/wood,
 /area/syndicate_mothership)
@@ -7423,8 +7422,8 @@
 "Am" = (
 /obj/machinery/door/window/classic/normal{
 	name = "cell door";
-	req_access_txt = "150";
-	dir = 1
+	dir = 1;
+	req_access = list(150)
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/syndicate_mothership)
@@ -7603,9 +7602,9 @@
 /turf/simulated/wall/mineral/plastitanium/nodiagonal,
 /area/shuttle/supply)
 "AU" = (
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/commander,
 /obj/machinery/door/airlock/centcom{
-	name = "CentCom BSA Control";
-	req_access_txt = "114"
+	name = "CentCom BSA Control"
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/gamma)
@@ -7648,9 +7647,9 @@
 /turf/simulated/floor/catwalk,
 /area/shuttle/supply)
 "Be" = (
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/shuttles,
 /obj/machinery/door/airlock/centcom{
-	name = "CentCom Supply";
-	req_access_txt = "106"
+	name = "CentCom Supply"
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/suppy)
@@ -7692,8 +7691,8 @@
 	base_state = "right";
 	icon_state = "right";
 	name = "Infirmary";
-	req_access_txt = "150";
-	dir = 4
+	dir = 4;
+	req_access = list(150)
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/syndicate)
@@ -7854,9 +7853,9 @@
 /turf/simulated/floor/plasteel/dark,
 /area/tdome/tdomeobserve)
 "BV" = (
+/obj/effect/mapping_helpers/airlock/access/all/syndicate,
 /obj/machinery/door/airlock/external{
-	id_tag = "syndicate_away";
-	req_access_txt = "150"
+	id_tag = "syndicate_away"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bar"
@@ -8044,7 +8043,7 @@
 /obj/machinery/door_control/no_emag{
 	id = "thunderdome";
 	name = "Main Blast Doors Control";
-	req_access_txt = "102"
+	req_access = list(102)
 	},
 /obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel{
@@ -8119,7 +8118,7 @@
 	id = "CCcustoms2";
 	name = "CentCom Inner Customs Shutters";
 	pixel_x = 24;
-	req_access_txt = "101"
+	req_access = list(101)
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -8132,10 +8131,10 @@
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/control)
 "CM" = (
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/shuttles,
 /obj/machinery/door/airlock/external{
 	name = "Supply Shuttle";
-	opacity = 0;
-	req_access_txt = "106"
+	opacity = 0
 	},
 /turf/simulated/floor/plating,
 /area/centcom/suppy)
@@ -8230,14 +8229,14 @@
 	name = "Privacy Shutters";
 	pixel_x = 6;
 	pixel_y = 10;
-	req_access_txt = "114"
+	req_access = list(114)
 	},
 /obj/machinery/door_control/no_emag{
 	pixel_x = -6;
 	pixel_y = -17;
 	name = "Engineering Storage";
 	id = "SpecopsEngineering";
-	req_access_txt = "114"
+	req_access = list(114)
 	},
 /turf/simulated/floor/carpet,
 /area/centcom/specops)
@@ -8426,9 +8425,9 @@
 /turf/simulated/floor/plasteel/freezer,
 /area/ghost_bar)
 "DV" = (
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/commander,
 /obj/machinery/door/airlock/centcom{
-	name = "Administrative Office";
-	req_access_txt = "114"
+	name = "Administrative Office"
 	},
 /obj/machinery/door/poddoor/impassable{
 	id_tag = "specopsoffice";
@@ -8459,9 +8458,9 @@
 	},
 /area/centcom/specops)
 "Ea" = (
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/specops,
 /obj/machinery/door/airlock/centcom{
-	name = "Shuttle Control Office";
-	req_access_txt = "109"
+	name = "Shuttle Control Office"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -8507,7 +8506,7 @@
 "Ej" = (
 /obj/machinery/door/window/reinforced/normal{
 	name = "Cell Door";
-	req_access_txt = "150"
+	req_access = list(150)
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/syndicate_sit)
@@ -8517,13 +8516,13 @@
 /area/shuttle/administration)
 "El" = (
 /obj/effect/mapping_helpers/airlock/unres,
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/general,
 /obj/machinery/door/airlock/centcom{
 	aiControlDisabled = 1;
 	auto_close_time = 25;
 	hackProof = 1;
 	max_integrity = 3000;
-	name = "Escape Pod Dock";
-	req_access_txt = "101"
+	name = "Escape Pod Dock"
 	},
 /turf/simulated/floor/wood,
 /area/centcom/evac)
@@ -8774,8 +8773,8 @@
 "Fp" = (
 /obj/machinery/door/window/classic/reversed{
 	name = "Tool Storage";
-	req_access_txt = "150";
-	dir = 8
+	dir = 8;
+	req_access = list(150)
 	},
 /obj/machinery/light/spot{
 	dir = 1
@@ -8803,8 +8802,8 @@
 "Ft" = (
 /obj/machinery/door/window{
 	name = "Infirmary";
-	req_access_txt = "150";
-	dir = 4
+	dir = 4;
+	req_access = list(150)
 	},
 /obj/machinery/light/spot{
 	dir = 1
@@ -9202,7 +9201,7 @@
 /obj/machinery/door/window{
 	dir = 1;
 	name = "Cell A";
-	req_access_txt = "101"
+	req_access = list(101)
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/admin)
@@ -9212,9 +9211,9 @@
 "GO" = (
 /obj/machinery/door_control/no_emag{
 	pixel_y = -24;
-	req_access_txt = "114";
 	name = "Engineering Storage Shutters";
-	id = "SpecopsEngineering"
+	id = "SpecopsEngineering";
+	req_access = list(114)
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/specops)
@@ -9614,7 +9613,7 @@
 	id = "adminshuttleblast";
 	name = "blast door control";
 	pixel_x = -30;
-	req_access_txt = "101"
+	req_access = list(101)
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/administration)
@@ -9859,10 +9858,10 @@
 	},
 /area/centcom/specops)
 "Jb" = (
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/specops,
 /obj/machinery/door/airlock/external{
 	id_tag = "s_docking_airlock";
-	name = "Shuttle Hatch";
-	req_access_txt = "109"
+	name = "Shuttle Hatch"
 	},
 /obj/structure/fans/tiny,
 /turf/simulated/floor/plating,
@@ -10095,7 +10094,7 @@
 	id = "CCGAMMA";
 	name = "Gamma Lockdown";
 	pixel_x = 32;
-	req_access_txt = "114"
+	req_access = list(114)
 	},
 /obj/structure/filingcabinet/filingcabinet,
 /turf/simulated/floor/plasteel{
@@ -10535,7 +10534,7 @@
 /obj/machinery/door_control/no_emag{
 	id = "thunderdomehea";
 	name = "Heavy Supply Control";
-	req_access_txt = "102"
+	req_access = list(102)
 	},
 /obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel{
@@ -10573,7 +10572,7 @@
 	id = "ASSAULT";
 	name = "Mech Storage";
 	pixel_y = -24;
-	req_access_txt = "114"
+	req_access = list(114)
 	},
 /obj/effect/turf_decal/caution/stand_clear{
 	dir = 4
@@ -10816,7 +10815,7 @@
 /obj/machinery/door_control/no_emag{
 	id = "thunderdomegen";
 	name = "General Supply Control";
-	req_access_txt = "102"
+	req_access = list(102)
 	},
 /obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel{
@@ -10839,9 +10838,9 @@
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/administration)
 "Mn" = (
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/commander,
 /obj/machinery/door/airlock/centcom{
-	name = "Gamma Armory";
-	req_access_txt = "114"
+	name = "Gamma Armory"
 	},
 /obj/machinery/door/poddoor/impassable{
 	id_tag = "CCGAMMA";
@@ -10945,9 +10944,9 @@
 /area/centcom/specops)
 "Mz" = (
 /obj/effect/turf_decal/stripes/line,
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/shuttles,
 /obj/machinery/door/airlock/centcom{
-	name = "CentCom Supply";
-	req_access_txt = "106"
+	name = "CentCom Supply"
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/suppy)
@@ -11039,28 +11038,28 @@
 	name = "Station Access";
 	pixel_x = -6;
 	pixel_y = 6;
-	req_access_txt = "114"
+	req_access = list(114)
 	},
 /obj/machinery/door_control/no_emag{
 	id = "CCGAMMA";
 	name = "Gamma Lockdown";
 	pixel_x = -6;
 	pixel_y = -3;
-	req_access_txt = "114"
+	req_access = list(114)
 	},
 /obj/machinery/door_control/no_emag{
 	id = "ASSAULT";
 	name = "Mech Storage";
 	pixel_x = 6;
 	pixel_y = 6;
-	req_access_txt = "114"
+	req_access = list(114)
 	},
 /obj/machinery/door_control/no_emag{
 	id = "CCDOCK2";
 	name = "Special Operations Secondary Dock";
 	pixel_x = 6;
 	pixel_y = -3;
-	req_access_txt = "114"
+	req_access = list(114)
 	},
 /turf/simulated/floor/carpet,
 /area/centcom/specops)
@@ -11072,10 +11071,10 @@
 	},
 /area/holodeck/source_desert)
 "MS" = (
+/obj/effect/mapping_helpers/airlock/access/all/syndicate,
 /obj/machinery/door/airlock/external{
 	id_tag = "syndishuttle_door_ext";
-	name = "Ship External Access";
-	req_access_txt = "150"
+	name = "Ship External Access"
 	},
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -11089,7 +11088,7 @@
 	name = "External Door Control";
 	pixel_x = -26;
 	pixel_y = 2;
-	req_access_txt = "150"
+	req_access = list(150)
 	},
 /obj/docking_port/mobile{
 	dheight = 9;
@@ -11656,8 +11655,8 @@
 "OM" = (
 /obj/machinery/door/window/classic/reversed{
 	name = "In";
-	req_access_txt = "150";
-	dir = 1
+	dir = 1;
+	req_access = list(150)
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/syndicate_mothership)
@@ -11692,12 +11691,12 @@
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "adminshuttleblast";
 	name = "Blast Doors";
-	req_access_txt = "101"
+	req_access = list(101)
 	},
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/general,
 /obj/machinery/door/airlock/centcom{
 	id_tag = "adminshuttle";
-	name = "General Access";
-	req_access_txt = "101"
+	name = "General Access"
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/administration)
@@ -11719,7 +11718,7 @@
 	id = "CCDOCK2";
 	name = "Special Operations Secondary Dock";
 	pixel_y = 24;
-	req_access_txt = "114"
+	req_access = list(114)
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -12365,8 +12364,8 @@
 "Rl" = (
 /obj/machinery/door/window/classic/normal{
 	name = "Out";
-	req_access_txt = "150";
-	dir = 1
+	dir = 1;
+	req_access = list(150)
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/syndicate_mothership)
@@ -12467,7 +12466,7 @@
 	name = "Hanger Bay Shutters";
 	pixel_x = 24;
 	pixel_y = null;
-	req_access_txt = "101"
+	req_access = list(101)
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/specops)
@@ -12552,7 +12551,7 @@
 	id = "CCcustoms2";
 	name = "CentCom Inner Customs Shutters";
 	pixel_x = -24;
-	req_access_txt = "101"
+	req_access = list(101)
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -12587,7 +12586,7 @@
 	id = "CCcustoms1";
 	name = "CentCom Outer Customs Shutters";
 	pixel_x = 24;
-	req_access_txt = "101"
+	req_access = list(101)
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -12693,7 +12692,7 @@
 	name = "Specops Teleporter Shutters";
 	pixel_x = -24;
 	pixel_y = null;
-	req_access_txt = "114"
+	req_access = list(114)
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -12995,7 +12994,7 @@
 	id = "SpecopsFerry";
 	name = "Hanger Bay Shutters";
 	pixel_y = 24;
-	req_access_txt = "101"
+	req_access = list(101)
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -13090,9 +13089,9 @@
 	},
 /area/centcom/control)
 "Uj" = (
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/specops,
 /obj/machinery/door/airlock/centcom{
-	name = "CentCom Bridge";
-	req_access_txt = "109"
+	name = "CentCom Bridge"
 	},
 /turf/simulated/floor/wood,
 /area/centcom/control)
@@ -13151,10 +13150,10 @@
 	},
 /area/shuttle/escape)
 "Us" = (
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/general,
 /obj/machinery/door/airlock/centcom{
 	id_tag = "adminshuttle";
-	name = "Medbay";
-	req_access_txt = "101"
+	name = "Medbay"
 	},
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/administration)
@@ -13361,8 +13360,8 @@
 	base_state = "right";
 	icon_state = "right";
 	name = "Equipment Room";
-	req_access_txt = "150";
-	dir = 4
+	dir = 4;
+	req_access = list(150)
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/syndicate)
@@ -13592,7 +13591,7 @@
 	id = "CCcustoms1";
 	name = "CentCom Outer Customs Shutters";
 	pixel_x = -24;
-	req_access_txt = "101"
+	req_access = list(101)
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -13696,10 +13695,10 @@
 /turf/simulated/floor/plasteel,
 /area/admin)
 "WD" = (
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/specops,
 /obj/machinery/door/airlock/external{
 	id_tag = "s_docking_airlock";
-	name = "Shuttle Hatch";
-	req_access_txt = "109"
+	name = "Shuttle Hatch"
 	},
 /obj/docking_port/mobile{
 	dir = 8;
@@ -13991,7 +13990,7 @@
 	id = "SPECOPS";
 	name = "Nanotrasen Asset Protection Shutters";
 	pixel_y = -24;
-	req_access_txt = "109"
+	req_access = list(109)
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -14232,7 +14231,7 @@
 	id = "CCDOCK2";
 	name = "Special Operations Secondary Dock";
 	pixel_y = -24;
-	req_access_txt = "114"
+	req_access = list(114)
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/specops)
@@ -14294,8 +14293,8 @@
 "Ys" = (
 /obj/machinery/door/window{
 	name = "Equipment Room";
-	req_access_txt = "150";
-	dir = 4
+	dir = 4;
+	req_access = list(150)
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/syndicate)
@@ -14383,7 +14382,7 @@
 "YJ" = (
 /obj/machinery/door/window/classic/normal{
 	name = "Cell B";
-	req_access_txt = "101"
+	req_access = list(101)
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/admin)
@@ -14423,11 +14422,11 @@
 /turf/simulated/floor/plasteel,
 /area/centcom/evac)
 "YS" = (
+/obj/effect/mapping_helpers/airlock/access/all/syndicate,
 /obj/machinery/door/airlock/external{
 	id_tag = "syndishuttle_door_int";
 	locked = 1;
-	name = "Ship External Access";
-	req_access_txt = "150"
+	name = "Ship External Access"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5

--- a/_maps/map_files/shuttles/admin_admin.dmm
+++ b/_maps/map_files/shuttles/admin_admin.dmm
@@ -6,19 +6,19 @@
 /turf/simulated/wall/mineral/plastitanium/nodiagonal,
 /area/shuttle/administration)
 "ad" = (
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/general,
 /obj/machinery/door/airlock/external{
 	id_tag = "s_docking_airlock";
-	name = "Shuttle Hatch";
-	req_access_txt = "101"
+	name = "Shuttle Hatch"
 	},
 /obj/structure/fans/tiny,
 /turf/simulated/floor/plating,
 /area/shuttle/administration)
 "ae" = (
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/general,
 /obj/machinery/door/airlock/external{
 	id_tag = "s_docking_airlock";
-	name = "Shuttle Hatch";
-	req_access_txt = "101"
+	name = "Shuttle Hatch"
 	},
 /obj/docking_port/mobile{
 	dir = 2;
@@ -60,7 +60,7 @@
 	id = "adminshuttleblast";
 	name = "blast door control";
 	pixel_x = -30;
-	req_access_txt = "101"
+	req_access = list(101)
 	},
 /obj/machinery/light{
 	dir = 8
@@ -98,12 +98,12 @@
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "adminshuttleblast";
 	name = "Blast Doors";
-	req_access_txt = "101"
+	req_access = list(101)
 	},
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/general,
 /obj/machinery/door/airlock/centcom{
 	id_tag = "adminshuttle";
-	name = "General Access";
-	req_access_txt = "101"
+	name = "General Access"
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/administration)
@@ -169,15 +169,15 @@
 	id = "adminshuttleblast";
 	name = "blast door control";
 	pixel_x = -30;
-	req_access_txt = "101"
+	req_access = list(101)
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/administration)
 "aB" = (
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/general,
 /obj/machinery/door/airlock/centcom{
 	id_tag = "adminshuttle";
-	name = "Workshop";
-	req_access_txt = "101"
+	name = "Workshop"
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/administration)
@@ -339,10 +339,10 @@
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/administration)
 "bd" = (
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/general,
 /obj/machinery/door/airlock/centcom{
 	id_tag = "adminshuttle";
-	name = "Bridge";
-	req_access_txt = "101"
+	name = "Bridge"
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/administration)
@@ -357,10 +357,10 @@
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/administration)
 "bh" = (
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/general,
 /obj/machinery/door/airlock/centcom{
 	id_tag = "adminshuttle";
-	name = "Medbay";
-	req_access_txt = "101"
+	name = "Medbay"
 	},
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/administration)
@@ -399,18 +399,18 @@
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/administration)
 "bp" = (
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/security,
 /obj/machinery/door/airlock/centcom{
 	id_tag = "adminshuttle";
-	name = "Holding Cell";
-	req_access_txt = "104"
+	name = "Holding Cell"
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/administration)
 "bq" = (
 /obj/machinery/door/window/reinforced/normal{
 	color = "#d70000";
-	req_access_txt = "104";
-	dir = 8
+	dir = 8;
+	req_access = list(104)
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/administration)

--- a/_maps/map_files/shuttles/admin_armory.dmm
+++ b/_maps/map_files/shuttles/admin_armory.dmm
@@ -221,7 +221,7 @@
 	id = "adminshuttlebridge";
 	name = "Bridge Privacy Shutters";
 	pixel_x = 25;
-	req_access_txt = "19"
+	req_access = list(19)
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/administration)
@@ -267,7 +267,7 @@
 	name = "External Window Shutter Control";
 	pixel_x = -5;
 	pixel_y = 35;
-	req_access_txt = "19"
+	req_access = list(19)
 	},
 /obj/machinery/keycard_auth{
 	pixel_y = 24
@@ -277,7 +277,7 @@
 	name = "Airlock Blast Door Control";
 	pixel_x = 5;
 	pixel_y = 35;
-	req_access_txt = "19"
+	req_access = list(19)
 	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
@@ -789,7 +789,7 @@
 	id = "adminarmoryshutters";
 	name = "Armory Internal Shutters";
 	pixel_x = -26;
-	req_access_txt = "3"
+	req_access = list(3)
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/administration)

--- a/_maps/map_files/shuttles/admin_skipjack.dmm
+++ b/_maps/map_files/shuttles/admin_skipjack.dmm
@@ -13,10 +13,10 @@
 /turf/simulated/floor/mineral/plastitanium/red/nitrogen,
 /area/shuttle/administration)
 "ad" = (
+/obj/effect/mapping_helpers/airlock/access/all/shuttles/vox,
 /obj/machinery/door/airlock/hatch{
 	id_tag = "voxwest_door_ext";
-	locked = 1;
-	req_access_txt = "152"
+	locked = 1
 	},
 /obj/structure/fans/tiny,
 /turf/simulated/floor/mineral/plastitanium/red/nitrogen,
@@ -77,7 +77,7 @@
 "av" = (
 /obj/machinery/access_button{
 	autolink_id = "voxwest_btn_ext";
-	req_one_access_txt = "152"
+	req_access = list(152)
 	},
 /turf/simulated/wall/mineral/plastitanium,
 /area/shuttle/administration)
@@ -97,7 +97,7 @@
 	int_button_link_id = "voxwest_btn_int";
 	int_door_link_id = "voxwest_door_int";
 	pixel_x = 24;
-	req_access_txt = "152"
+	req_access = list(152)
 	},
 /turf/simulated/floor/mineral/plastitanium/red/nitrogen,
 /area/shuttle/administration)
@@ -127,19 +127,19 @@
 /turf/simulated/floor/plating/airless,
 /area/shuttle/administration)
 "aM" = (
+/obj/effect/mapping_helpers/airlock/access/all/shuttles/vox,
 /obj/machinery/door/airlock/hatch{
 	id_tag = "voxeast_door_ext";
-	locked = 1;
-	req_access_txt = "152"
+	locked = 1
 	},
 /obj/structure/fans/tiny,
 /turf/simulated/floor/mineral/plastitanium/red/nitrogen,
 /area/shuttle/administration)
 "aN" = (
+/obj/effect/mapping_helpers/airlock/access/all/shuttles/vox,
 /obj/machinery/door/airlock/hatch{
 	id_tag = "voxwest_door_int";
-	locked = 1;
-	req_access_txt = "152"
+	locked = 1
 	},
 /turf/simulated/floor/mineral/plastitanium/red/nitrogen,
 /area/shuttle/administration)
@@ -162,9 +162,8 @@
 /turf/simulated/floor/mineral/plastitanium/red/nitrogen,
 /area/shuttle/administration)
 "bb" = (
-/obj/machinery/door/airlock/hatch{
-	req_access_txt = "152"
-	},
+/obj/effect/mapping_helpers/airlock/access/all/shuttles/vox,
+/obj/machinery/door/airlock/hatch,
 /turf/simulated/floor/mineral/plastitanium/red/nitrogen,
 /area/shuttle/administration)
 "bd" = (
@@ -232,7 +231,7 @@
 "bO" = (
 /obj/machinery/access_button{
 	autolink_id = "voxeast_btn_ext";
-	req_access_txt = "152"
+	req_access = list(152)
 	},
 /turf/simulated/wall/mineral/plastitanium,
 /area/shuttle/administration)
@@ -277,16 +276,16 @@
 	ext_door_link_id = "voxeast_door_ext";
 	int_door_link_id = "voxeast_door_int";
 	pixel_x = -24;
-	req_access_txt = "152";
 	ext_button_link_id = "voxeast_btn_ext";
-	int_button_link_id = "voxeast_btn_int"
+	int_button_link_id = "voxeast_btn_int";
+	req_access = list(152)
 	},
 /turf/simulated/floor/mineral/plastitanium/red/nitrogen,
 /area/shuttle/administration)
 "cg" = (
 /obj/machinery/access_button{
 	autolink_id = "voxwest_btn_int";
-	req_one_access_txt = "152"
+	req_access = list(152)
 	},
 /turf/simulated/wall/mineral/plastitanium/nodiagonal,
 /area/shuttle/administration)
@@ -325,15 +324,15 @@
 "cn" = (
 /obj/machinery/access_button{
 	autolink_id = "voxeast_btn_int";
-	req_one_access_txt = "152"
+	req_access = list(152)
 	},
 /turf/simulated/wall/mineral/plastitanium/nodiagonal,
 /area/shuttle/administration)
 "co" = (
+/obj/effect/mapping_helpers/airlock/access/all/shuttles/vox,
 /obj/machinery/door/airlock/hatch{
 	id_tag = "voxeast_door_int";
-	locked = 1;
-	req_access_txt = "152"
+	locked = 1
 	},
 /turf/simulated/floor/mineral/plastitanium/red/nitrogen,
 /area/shuttle/administration)
@@ -486,7 +485,7 @@
 /obj/machinery/door_control{
 	id = "voxshutters";
 	name = "remote shutter control";
-	req_access_txt = "152"
+	req_access = list(152)
 	},
 /turf/simulated/floor/mineral/plastitanium/red/nitrogen,
 /area/shuttle/administration)

--- a/_maps/map_files/shuttles/emergency_raven.dmm
+++ b/_maps/map_files/shuttles/emergency_raven.dmm
@@ -693,7 +693,7 @@
 	name = "Warehouse Door Control";
 	pixel_x = -1;
 	pixel_y = 24;
-	req_access_txt = "31"
+	req_access = list(31)
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/shuttle/escape)
@@ -721,7 +721,7 @@
 	name = "Warehouse Door Control";
 	pixel_x = -1;
 	pixel_y = 24;
-	req_access_txt = "31"
+	req_access = list(31)
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/shuttle/escape)
@@ -1303,7 +1303,7 @@
 	name = "Warehouse Door Control";
 	pixel_x = -1;
 	pixel_y = -24;
-	req_access_txt = "31"
+	req_access = list(31)
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/shuttle/escape)
@@ -1458,7 +1458,7 @@
 	name = "Warehouse Door Control";
 	pixel_x = -1;
 	pixel_y = -24;
-	req_access_txt = "31"
+	req_access = list(31)
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/shuttle/escape)

--- a/_maps/map_files/stations/boxstation.dmm
+++ b/_maps/map_files/stations/boxstation.dmm
@@ -813,7 +813,7 @@
 	id = "HoS";
 	pixel_x = 24;
 	pixel_y = -8;
-	req_access_txt = "58"
+	req_access = list(58)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -947,14 +947,14 @@
 	name = "Prison Wing Lockdown";
 	pixel_x = -28;
 	pixel_y = 7;
-	req_access_txt = "2"
+	req_access = list(2)
 	},
 /obj/machinery/door_control{
 	id = "Secure Gate";
 	name = "Brig Lockdown";
 	pixel_x = -28;
 	pixel_y = -3;
-	req_access_txt = "2"
+	req_access = list(2)
 	},
 /obj/machinery/door_control{
 	id = "hosofficedoor";
@@ -962,7 +962,7 @@
 	normaldoorcontrol = 1;
 	pixel_x = -28;
 	pixel_y = 17;
-	req_access_txt = "58"
+	req_access = list(58)
 	},
 /turf/simulated/floor/carpet,
 /area/station/command/office/hos)
@@ -1008,7 +1008,7 @@
 	name = "Brig Lockdown";
 	pixel_x = 3;
 	pixel_y = -28;
-	req_access_txt = "2"
+	req_access = list(2)
 	},
 /obj/machinery/door_control{
 	desc = "A remote control-switch to lock down the prison wing's blast doors";
@@ -1016,7 +1016,7 @@
 	name = "Prison Wing Lockdown";
 	pixel_x = -7;
 	pixel_y = -28;
-	req_access_txt = "2"
+	req_access = list(2)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -1484,7 +1484,7 @@
 	autolink_id = "viro_btn_int";
 	name = "Virology Lab Access Button";
 	pixel_x = -24;
-	req_access_txt = "39"
+	req_access = list(39)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -2824,7 +2824,7 @@
 	name = "Secure Armory Shutter Control";
 	pixel_x = 7;
 	pixel_y = -28;
-	req_access_txt = "3"
+	req_access = list(3)
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -5375,8 +5375,7 @@
 "asO" = (
 /obj/machinery/computer/prisoner{
 	dir = 4;
-	req_access = null;
-	req_access_txt = "2"
+	req_access = list(2)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cult"
@@ -5432,7 +5431,7 @@
 	normaldoorcontrol = 1;
 	pixel_x = 5;
 	pixel_y = -35;
-	req_access_txt = "63"
+	req_access = list(63)
 	},
 /obj/machinery/door_control{
 	desc = "A remote control switch for the brig foyer.";
@@ -5441,7 +5440,7 @@
 	normaldoorcontrol = 1;
 	pixel_x = 5;
 	pixel_y = -25;
-	req_access_txt = "63"
+	req_access = list(63)
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -5455,7 +5454,7 @@
 	normaldoorcontrol = 1;
 	pixel_x = -5;
 	pixel_y = -25;
-	req_access_txt = "63"
+	req_access = list(63)
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -5744,8 +5743,7 @@
 "atN" = (
 /obj/machinery/computer/prisoner{
 	dir = 4;
-	req_access = null;
-	req_access_txt = "2"
+	req_access = list(2)
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -6079,7 +6077,7 @@
 	name = "processing tint control";
 	pixel_x = -24;
 	pixel_y = -8;
-	req_access_txt = "63"
+	req_access = list(63)
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/processing)
@@ -7284,7 +7282,7 @@
 	id = "IAA";
 	pixel_x = -24;
 	pixel_y = 6;
-	req_access_txt = "38"
+	req_access = list(38)
 	},
 /obj/machinery/economy/vending/lawdrobe,
 /turf/simulated/floor/plasteel{
@@ -7652,7 +7650,7 @@
 	id = "brig_courtroom";
 	name = "Brig Courtroom Shutter Control";
 	pixel_x = 25;
-	req_access_txt = "2"
+	req_access = list(2)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -7823,7 +7821,7 @@
 	id = "Interrogation";
 	name = "interrogation tint control";
 	pixel_x = -24;
-	req_access_txt = "63"
+	req_access = list(63)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -8033,15 +8031,15 @@
 	id = "Magistrate";
 	pixel_x = 24;
 	pixel_y = 6;
-	req_access_txt = "74"
+	req_access = list(74)
 	},
 /obj/machinery/door_control{
 	id = "magistrateofficedoor";
 	name = "Office Door";
 	normaldoorcontrol = 1;
 	pixel_x = 25;
-	req_access_txt = "74";
-	pixel_y = -4
+	pixel_y = -4;
+	req_access = list(74)
 	},
 /turf/simulated/floor/carpet,
 /area/station/legal/magistrate)
@@ -8442,8 +8440,7 @@
 	},
 /obj/machinery/alarm/directional/west,
 /obj/machinery/computer/prisoner{
-	req_access = null;
-	req_access_txt = "2"
+	req_access = list(2)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cult"
@@ -8780,7 +8777,7 @@
 	id = "brig_courtroom";
 	name = "Brig Courtroom Shutter Control";
 	pixel_y = 25;
-	req_access_txt = "2"
+	req_access = list(2)
 	},
 /obj/machinery/light{
 	dir = 1
@@ -9184,7 +9181,7 @@
 	id = "Detective";
 	pixel_x = -8;
 	pixel_y = 24;
-	req_access_txt = "4"
+	req_access = list(4)
 	},
 /turf/simulated/floor/carpet,
 /area/station/security/detective)
@@ -11487,7 +11484,7 @@
 /obj/machinery/button/windowtint{
 	id = "Courtroom";
 	pixel_x = -8;
-	req_one_access_txt = "74;3"
+	req_one_access = list(74,3)
 	},
 /turf/simulated/floor/carpet,
 /area/station/legal/courtroom)
@@ -14048,8 +14045,8 @@
 /obj/machinery/door_control{
 	id = "paramedic";
 	name = "Garage Door Control";
-	req_access_txt = "66";
-	pixel_x = -24
+	pixel_x = -24;
+	req_access = list(66)
 	},
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Biohazard_medi";
@@ -19493,7 +19490,7 @@
 /area/station/service/bar)
 "bjc" = (
 /obj/structure/closet/secure_closet/bar{
-	req_access_txt = "25"
+	req_access = list(25)
 	},
 /turf/simulated/floor/wood,
 /area/station/service/bar)
@@ -19552,7 +19549,7 @@
 "bjp" = (
 /obj/machinery/door/morgue{
 	name = "Confession Booth (Chaplain)";
-	req_access_txt = "22"
+	req_access = list(22)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -21482,7 +21479,7 @@
 "boy" = (
 /obj/machinery/door/morgue{
 	name = "Private Study";
-	req_access_txt = "37"
+	req_access = list(37)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cult"
@@ -24012,14 +24009,14 @@
 	name = "Kitchen Bar Shutters Control";
 	pixel_x = -6;
 	pixel_y = -24;
-	req_access_txt = "28"
+	req_access = list(28)
 	},
 /obj/machinery/door_control{
 	id = "kitchenhall";
 	name = "Kitchen Hallway Shutters Control";
 	pixel_x = 6;
 	pixel_y = -24;
-	req_access_txt = "28"
+	req_access = list(28)
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -26103,16 +26100,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/warehouse)
-"bFp" = (
-/obj/machinery/door_control{
-	id = "qm_warehouse";
-	name = "Warehouse Door Control";
-	pixel_x = -1;
-	pixel_y = -24;
-	req_access_txt = "31"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/supply/warehouse)
 "bFq" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = -32
@@ -26970,7 +26957,7 @@
 	name = "Robotics Lab Shutters Control";
 	pixel_x = 24;
 	pixel_y = 32;
-	req_access_txt = "29"
+	req_access = list(29)
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -27767,7 +27754,7 @@
 	name = "Research and Development Lab Shutters Control";
 	pixel_x = -24;
 	pixel_y = 32;
-	req_access_txt = "47"
+	req_access = list(47)
 	},
 /obj/effect/landmark/start/scientist,
 /turf/simulated/floor/plasteel{
@@ -28032,7 +28019,7 @@
 	name = "Warehouse Door Control";
 	pixel_x = -1;
 	pixel_y = 24;
-	req_access_txt = "31"
+	req_access = list(31)
 	},
 /obj/machinery/power/apc/directional/east,
 /obj/structure/cable{
@@ -32738,14 +32725,14 @@
 	name = "Office Door";
 	normaldoorcontrol = 1;
 	pixel_x = 25;
-	req_access_txt = "40"
+	req_access = list(40)
 	},
 /obj/machinery/button/windowtint{
 	id = "CMO";
 	pixel_x = 24;
 	pixel_y = 8;
-	req_access_txt = "40";
-	dir = 8
+	dir = 8;
+	req_access = list(40)
 	},
 /obj/machinery/light_switch{
 	pixel_x = 24;
@@ -32757,7 +32744,7 @@
 	id = "Biohazard_medi";
 	name = "Medical Quarantine";
 	pixel_x = 35;
-	req_access_txt = "40"
+	req_access = list(40)
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -33240,7 +33227,7 @@
 	id = "xenobio4";
 	name = "Chamber 4 Containment Blast Doors";
 	pixel_y = 4;
-	req_access_txt = "55"
+	req_access = list(55)
 	},
 /turf/simulated/floor/plasteel,
 /area/station/science/xenobiology)
@@ -34588,7 +34575,7 @@
 	name = "Biohazard Shutter Control";
 	pixel_x = -4;
 	pixel_y = 6;
-	req_access_txt = "30"
+	req_access = list(30)
 	},
 /obj/item/folder/white{
 	pixel_x = 4
@@ -34604,7 +34591,7 @@
 	normaldoorcontrol = 1;
 	pixel_x = -4;
 	pixel_y = -4;
-	req_access_txt = "30"
+	req_access = list(30)
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -35753,7 +35740,7 @@
 	normaldoorcontrol = 1;
 	pixel_x = 6;
 	pixel_y = 3;
-	req_one_access_txt = "57"
+	req_access = list(57)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -35945,9 +35932,9 @@
 /obj/machinery/button/windowtint{
 	id = "Surgery 1";
 	pixel_y = -24;
-	req_access_txt = "45";
 	dir = 1;
-	pixel_x = 8
+	pixel_x = 8;
+	req_access = list(45)
 	},
 /obj/machinery/iv_drip,
 /turf/simulated/floor/plasteel{
@@ -39869,7 +39856,7 @@
 	id = "disvent";
 	name = "Incinerator Vent Control";
 	pixel_y = -24;
-	req_access_txt = "12"
+	req_access = list(12)
 	},
 /obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -41389,7 +41376,7 @@
 	id = "xenobio6";
 	name = "Chamber 6 Containment Blast Doors";
 	pixel_y = 4;
-	req_access_txt = "55"
+	req_access = list(55)
 	},
 /turf/simulated/floor/plasteel,
 /area/station/science/xenobiology)
@@ -42106,7 +42093,7 @@
 	name = "Atmospherics Lockdown";
 	pixel_x = 24;
 	pixel_y = 8;
-	req_access_txt = "24"
+	req_access = list(24)
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -43279,7 +43266,7 @@
 	name = "Office Door";
 	normaldoorcontrol = 1;
 	pixel_x = -5;
-	req_access_txt = "56"
+	req_access = list(56)
 	},
 /obj/item/clipboard{
 	pixel_x = 5
@@ -44889,7 +44876,7 @@
 	name = "Atmospherics Lockdown";
 	pixel_x = 24;
 	pixel_y = 4;
-	req_access_txt = "24"
+	req_access = list(24)
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/purple,
 /turf/simulated/floor/plasteel,
@@ -45431,7 +45418,7 @@
 	id = "Secure Storage";
 	name = "Engineering Secure Storage";
 	pixel_x = -24;
-	req_access_txt = "56"
+	req_access = list(56)
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -45821,7 +45808,7 @@
 	id = "xenobio7";
 	name = "Chamber 7 Containment Blast Doors";
 	pixel_y = 4;
-	req_access_txt = "55"
+	req_access = list(55)
 	},
 /turf/simulated/floor/plasteel,
 /area/station/science/xenobiology)
@@ -46853,14 +46840,14 @@
 	name = "Auxiliary Vent";
 	pixel_x = 6;
 	pixel_y = -24;
-	req_access_txt = "32"
+	req_access = list(32)
 	},
 /obj/machinery/door_control{
 	id = "turbinevent";
 	name = "Turbine Vent";
 	pixel_x = -6;
 	pixel_y = -24;
-	req_access_txt = "32"
+	req_access = list(32)
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -48211,7 +48198,7 @@
 	id = "teledoor";
 	name = "AI Satellite Teleport Shutters Control";
 	pixel_y = 25;
-	req_access_txt = "17;75"
+	req_access = list(17,75)
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/turf_decal/stripes/line{
@@ -48620,7 +48607,7 @@
 	control_area = "\improper AI Satellite Antechamber";
 	name = "AI Antechamber Turret Control";
 	pixel_y = -24;
-	req_access_txt = "75"
+	req_access = list(75)
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -48732,7 +48719,7 @@
 	control_area = "\improper AI Satellite Atmospherics";
 	name = "AI Satellite Atmospherics Turret Control";
 	pixel_x = -28;
-	req_access_txt = "75"
+	req_access = list(75)
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -48853,7 +48840,7 @@
 	control_area = "\improper AI Satellite Service";
 	name = "AI Satellite Service Bay Turret Control";
 	pixel_x = 24;
-	req_access_txt = "75"
+	req_access = list(75)
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -49170,7 +49157,7 @@
 	name = "AI Chamber Hallway Turret Control";
 	pixel_x = 24;
 	pixel_y = -24;
-	req_access_txt = "75"
+	req_access = list(75)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -50569,7 +50556,7 @@
 	name = "AI Chamber Turret Control";
 	pixel_x = 5;
 	pixel_y = -24;
-	req_access_txt = "75"
+	req_access = list(75)
 	},
 /obj/machinery/flasher{
 	id = "AI";
@@ -51635,7 +51622,7 @@
 	id = "justice_blast";
 	name = "Space Vent";
 	pixel_x = -32;
-	req_access_txt = "2"
+	req_access = list(2)
 	},
 /obj/machinery/flasher_button{
 	id = "Execution";
@@ -52487,7 +52474,7 @@
 	autolink_id = "atmossm_btn_ext";
 	name = "Atmospherics Access Button";
 	pixel_y = -24;
-	req_access_txt = "24"
+	req_access = list(24)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -52729,12 +52716,12 @@
 "ehs" = (
 /obj/machinery/airlock_controller/air_cycler{
 	pixel_x = -25;
-	req_access_txt = "10;13";
 	vent_link_id = "eng_vent";
 	ext_door_link_id = "eng_door_ext";
 	int_door_link_id = "eng_door_int";
 	ext_button_link_id = "eng_btn_ext";
-	int_button_link_id = "eng_btn_int"
+	int_button_link_id = "eng_btn_int";
+	req_access = list(10,13)
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/hardsuitstorage)
@@ -54458,7 +54445,7 @@
 	id = "xenobio2";
 	name = "Chamber 2 Containment Blast Doors";
 	pixel_y = 4;
-	req_access_txt = "55"
+	req_access = list(55)
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -54478,8 +54465,8 @@
 /obj/machinery/door_control{
 	id = "mechbay_outer";
 	name = "Outer Mech Bay Shutters Control";
-	req_access_txt = "29";
-	pixel_x = 24
+	pixel_x = 24;
+	req_access = list(29)
 	},
 /turf/simulated/floor/plasteel,
 /area/station/science/robotics/chargebay)
@@ -54538,8 +54525,8 @@
 /obj/machinery/door_control{
 	id = "mechbay_inner";
 	name = "Inner Mech Bay Shutter Control";
-	req_access_txt = "29";
-	pixel_y = -24
+	pixel_y = -24;
+	req_access = list(29)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -55130,11 +55117,11 @@
 	name = "Turbine Access Console";
 	pixel_x = 6;
 	pixel_y = -26;
-	req_access_txt = "12";
 	ext_door_link_id = "turbine_door_ext";
 	int_door_link_id = "turbine_door_int";
 	ext_button_link_id = "turbine_btn_ext";
-	int_button_link_id = "turbine_btn_int"
+	int_button_link_id = "turbine_btn_int";
+	req_access = list(12)
 	},
 /obj/machinery/ignition_switch{
 	id = "gasturbine";
@@ -55934,7 +55921,7 @@
 	autolink_id = "engsm_btn_int";
 	name = "Supermatter Access Button";
 	pixel_y = -24;
-	req_access_txt = "10"
+	req_access = list(10)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -57685,7 +57672,7 @@
 	name = "Dispossal Vent Control";
 	pixel_x = -24;
 	pixel_y = 8;
-	req_access_txt = "12"
+	req_access = list(12)
 	},
 /obj/machinery/driver_button{
 	id_tag = "trash";
@@ -58511,7 +58498,7 @@
 	autolink_id = "eng_btn_int";
 	pixel_x = -22;
 	pixel_y = -20;
-	req_access_txt = "10;13"
+	req_access = list(10,13)
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/hardsuitstorage)
@@ -58758,8 +58745,8 @@
 /obj/machinery/access_button{
 	autolink_id = "perma_btn_ext";
 	name = "Prison Wing Access Button";
-	req_access_txt = "2";
-	pixel_y = 21
+	pixel_y = 21;
+	req_access = list(2)
 	},
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Prison Gate";
@@ -60360,7 +60347,7 @@
 	id = "xenobio1";
 	name = "Chamber 1 Containment Blast Door";
 	pixel_y = 4;
-	req_access_txt = "55"
+	req_access = list(55)
 	},
 /turf/simulated/floor/plasteel,
 /area/station/science/xenobiology)
@@ -61794,12 +61781,12 @@
 "iDk" = (
 /obj/machinery/airlock_controller/air_cycler{
 	pixel_y = -25;
-	req_access_txt = "13";
 	vent_link_id = "secmaint_vent";
 	ext_door_link_id = "secmaint_door_ext";
 	int_door_link_id = "secmaint_door_int";
 	ext_button_link_id = "secmaint_btn_ext";
-	int_button_link_id = "secmaint_btn_int"
+	int_button_link_id = "secmaint_btn_int";
+	req_access = list(13)
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8;
@@ -61832,26 +61819,26 @@
 	name = "East Bridge Blast Door Control";
 	pixel_x = 6;
 	pixel_y = 2;
-	req_one_access_txt = "19"
+	req_access = list(19)
 	},
 /obj/machinery/door_control{
 	id = "bridge blast west";
 	name = "West Bridge Blast Door Control";
 	pixel_x = -6;
-	req_one_access_txt = "19";
-	pixel_y = 2
+	pixel_y = 2;
+	req_access = list(19)
 	},
 /obj/machinery/door_control{
 	id = "bridge blast south";
 	name = "South Bridge Blast Door Control";
 	pixel_y = -6;
-	req_one_access_txt = "19"
+	req_access = list(19)
 	},
 /obj/machinery/door_control{
 	id = "bridge blast north";
 	name = "North Bridge Blast Door Control";
 	pixel_y = 10;
-	req_one_access_txt = "19"
+	req_access = list(19)
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -63887,8 +63874,7 @@
 /area/station/public/dorms)
 "jFf" = (
 /obj/structure/closet/crate/secure{
-	req_one_access = list(33,41);
-	req_one_access_txt = "33;41"
+	req_one_access = list(33,41)
 	},
 /obj/item/circuitboard/chem_dispenser,
 /obj/item/storage/pill_bottle/random_drug_bottle,
@@ -64159,7 +64145,7 @@
 	id = "teleshutter";
 	name = "Teleporter Shutters Access Control";
 	pixel_x = 24;
-	req_one_access_txt = "62"
+	req_access = list(62)
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel,
@@ -65346,7 +65332,7 @@
 	autolink_id = "engsm_btn_ext";
 	name = "Supermatter Access Button";
 	pixel_y = -24;
-	req_access_txt = "10"
+	req_access = list(10)
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/hardsuitstorage)
@@ -66295,8 +66281,7 @@
 /area/station/engineering/control)
 "kNx" = (
 /obj/machinery/computer/prisoner{
-	req_access = null;
-	req_one_access_txt = "2"
+	req_access = list(2)
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -66825,7 +66810,7 @@
 	id = "CE";
 	pixel_x = -8;
 	pixel_y = 24;
-	req_access_txt = "56"
+	req_access = list(56)
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -67647,7 +67632,7 @@
 	name = "Atmospherics Lockdown";
 	pixel_x = 10;
 	pixel_y = 24;
-	req_access_txt = "24"
+	req_access = list(24)
 	},
 /obj/machinery/door_control{
 	desc = "A remote control-switch for the engineering security doors.";
@@ -67655,14 +67640,14 @@
 	name = "Engineering Lockdown";
 	pixel_x = -10;
 	pixel_y = 24;
-	req_access_txt = "10"
+	req_access = list(10)
 	},
 /obj/machinery/door_control{
 	desc = "A remote control-switch for secure storage.";
 	id = "Secure Storage";
 	name = "Engineering Secure Storage";
 	pixel_y = 24;
-	req_access_txt = "11"
+	req_access = list(11)
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/photocopier/faxmachine{
@@ -67835,7 +67820,7 @@
 	autolink_id = "xeno_btn_ext";
 	name = "Xenobiology Access Button";
 	pixel_x = -24;
-	req_access_txt = "55"
+	req_access = list(55)
 	},
 /obj/effect/turf_decal/stripes,
 /obj/structure/disposalpipe/segment,
@@ -68660,9 +68645,9 @@
 /obj/machinery/button/windowtint{
 	pixel_x = 24;
 	id = "qm";
-	req_access_txt = "41";
 	dir = 8;
-	pixel_y = 5
+	pixel_y = 5;
+	req_access = list(41)
 	},
 /obj/machinery/light_switch{
 	dir = 8;
@@ -71040,7 +71025,7 @@
 	autolink_id = "eng_btn_ext";
 	pixel_x = -22;
 	pixel_y = 20;
-	req_access_txt = "10;13"
+	req_access = list(10,13)
 	},
 /turf/space,
 /area/space/nearstation)
@@ -71441,7 +71426,7 @@
 	autolink_id = "engsm_btn_ext";
 	name = "Supermatter Access Button";
 	pixel_y = 24;
-	req_access_txt = "10"
+	req_access = list(10)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -71854,7 +71839,7 @@
 	id = "xenobio3";
 	name = "Chamber 3 Containment Blast Doors";
 	pixel_y = 4;
-	req_access_txt = "55"
+	req_access = list(55)
 	},
 /turf/simulated/floor/plasteel,
 /area/station/science/xenobiology)
@@ -71908,7 +71893,7 @@
 	id = "xenobio5";
 	name = "Chamber 5 Containment Blast Doors";
 	pixel_y = 4;
-	req_access_txt = "55"
+	req_access = list(55)
 	},
 /turf/simulated/floor/plasteel,
 /area/station/science/xenobiology)
@@ -71962,6 +71947,16 @@
 	icon_state = "purple"
 	},
 /area/station/science/rnd)
+"nGo" = (
+/obj/machinery/door_control{
+	id = "qm_warehouse";
+	name = "Warehouse Door Control";
+	pixel_x = -1;
+	pixel_y = -24;
+	req_access = list(31)
+	},
+/turf/simulated/floor/plasteel,
+/area/station/supply/warehouse)
 "nGC" = (
 /obj/structure/disposalpipe/segment/corner,
 /obj/structure/cable{
@@ -72915,11 +72910,11 @@
 	name = "Incinerator Access Console";
 	pixel_x = -26;
 	pixel_y = 6;
-	req_access_txt = "12";
 	ext_door_link_id = "incinerator_door_ext";
 	int_door_link_id = "incinerator_door_int";
 	ext_button_link_id = "incinerator_btn_ext";
-	int_button_link_id = "incinerator_btn_int"
+	int_button_link_id = "incinerator_btn_int";
+	req_access = list(12)
 	},
 /obj/machinery/ignition_switch{
 	id = "Incinerator";
@@ -73231,7 +73226,7 @@
 	autolink_id = "secmaint_btn_ext";
 	pixel_x = -25;
 	pixel_y = -25;
-	req_access_txt = "13"
+	req_access = list(13)
 	},
 /obj/structure/lattice/catwalk,
 /turf/space,
@@ -76026,8 +76021,8 @@
 /obj/machinery/access_button{
 	autolink_id = "perma_btn_int";
 	name = "Prison Wing Access Button";
-	req_access_txt = "2";
-	pixel_y = -21
+	pixel_y = -21;
+	req_access = list(2)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
@@ -76263,7 +76258,7 @@
 	autolink_id = "atmossm_btn_int";
 	name = "Atmospherics Access Button";
 	pixel_y = -24;
-	req_access_txt = "24"
+	req_access = list(24)
 	},
 /obj/machinery/door/airlock/atmos/glass{
 	autoclose = 0;
@@ -76728,7 +76723,7 @@
 	control_area = "\improper AI Upload Chamber";
 	name = "AI Upload Turret Control";
 	pixel_x = -28;
-	req_access_txt = "75"
+	req_access = list(75)
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -77370,8 +77365,8 @@
 	layer = 3.6;
 	autolink_id = "viro_btn_ext";
 	name = "Virology Lab Access Button";
-	req_access_txt = "39";
-	pixel_y = -24
+	pixel_y = -24;
+	req_access = list(39)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -77985,7 +77980,7 @@
 	name = "interior access button";
 	pixel_x = 9;
 	pixel_y = -25;
-	req_access_txt = "13"
+	req_access = list(13)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
@@ -78455,7 +78450,7 @@
 	name = "Prison Wing Lockdown";
 	pixel_x = -32;
 	pixel_y = 22;
-	req_access_txt = "2"
+	req_access = list(2)
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -78884,8 +78879,8 @@
 /obj/machinery/access_button{
 	autolink_id = "perma_btn_int";
 	name = "Prison Wing Access Button";
-	req_access_txt = "2";
-	pixel_y = 21
+	pixel_y = 21;
+	req_access = list(2)
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -80711,7 +80706,7 @@
 	name = "Office Door";
 	normaldoorcontrol = 1;
 	pixel_y = -3;
-	req_one_access_txt = "20"
+	req_access = list(20)
 	},
 /turf/simulated/floor/carpet/royalblue,
 /area/station/command/office/captain)
@@ -80994,7 +80989,7 @@
 	id = "engsm";
 	name = "Radiation Shutters Control";
 	pixel_y = -24;
-	req_access_txt = "32"
+	req_access = list(32)
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/engine,
@@ -81845,8 +81840,7 @@
 /area/station/supply/storage)
 "snE" = (
 /obj/structure/closet/crate/secure{
-	req_one_access = list(33,41);
-	req_one_access_txt = "33;41"
+	req_one_access = list(33,41)
 	},
 /obj/effect/spawner/random/maintenance,
 /mob/living/simple_animal/hostile/scarybat,
@@ -84679,7 +84673,7 @@
 	name = "Xenobiology Access Button";
 	pixel_x = 8;
 	pixel_y = 28;
-	req_access_txt = "55"
+	req_access = list(55)
 	},
 /obj/effect/turf_decal/stripes,
 /obj/structure/disposalpipe/segment{
@@ -86382,8 +86376,8 @@
 /obj/machinery/access_button{
 	autolink_id = "perma_btn_ext";
 	name = "Prison Wing Access Button";
-	req_access_txt = "2";
-	pixel_y = -21
+	pixel_y = -21;
+	req_access = list(2)
 	},
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Prison Gate";
@@ -86700,14 +86694,14 @@
 	name = "Queue Privacy Shutters Control";
 	pixel_x = 6;
 	pixel_y = 25;
-	req_one_access_txt = "57"
+	req_access = list(57)
 	},
 /obj/machinery/door_control{
 	id = "hop";
 	name = "Privacy Shutters Control";
 	pixel_x = -6;
 	pixel_y = 25;
-	req_one_access_txt = "57"
+	req_access = list(57)
 	},
 /obj/machinery/flasher_button{
 	id = "hopflash";
@@ -86983,8 +86977,8 @@
 /obj/machinery/door_control{
 	id = "janitor";
 	name = "Janitor Shutters Door Control";
-	req_access_txt = "26";
-	pixel_x = 24
+	pixel_x = 24;
+	req_access = list(26)
 	},
 /turf/simulated/floor/plasteel,
 /area/station/service/janitor)
@@ -90892,11 +90886,11 @@
 /obj/machinery/airlock_controller/access_controller{
 	name = "Virology Lab Access Console";
 	pixel_y = 24;
-	req_one_access_txt = "39";
 	ext_door_link_id = "viro_door_ext";
 	int_door_link_id = "viro_door_int";
 	ext_button_link_id = "viro_btn_ext";
-	int_button_link_id = "viro_btn_int"
+	int_button_link_id = "viro_btn_int";
+	req_access = list(39)
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -115077,7 +115071,7 @@ bEB
 bGY
 bIz
 cCh
-bFp
+nGo
 qsc
 bMi
 bKz

--- a/_maps/map_files/stations/cerestation.dmm
+++ b/_maps/map_files/stations/cerestation.dmm
@@ -1309,15 +1309,15 @@
 	id = "ailockdown";
 	name = "AI Asteroid Lockdown";
 	pixel_y = 32;
-	req_access_txt = "56";
-	pixel_x = -5
+	pixel_x = -5;
+	req_access = list(56)
 	},
 /obj/machinery/door_control{
 	id = "aisat";
 	name = "AI Core Lockdown";
 	pixel_y = 32;
-	req_access_txt = "56";
-	pixel_x = 5
+	pixel_x = 5;
+	req_access = list(56)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bcircuit"
@@ -1378,7 +1378,7 @@
 	check_synth = 1;
 	name = "AI Chamber Turret Control";
 	pixel_y = 28;
-	req_access_txt = "75"
+	req_access = list(75)
 	},
 /obj/machinery/requests_console/directional/south,
 /turf/simulated/floor/plasteel{
@@ -3849,7 +3849,7 @@
 	name = "AI Asteroid Teleport Shutters Control";
 	pixel_x = 25;
 	pixel_y = 25;
-	req_one_access_txt = "17;75"
+	req_one_access = list(17,75)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -4940,7 +4940,7 @@
 	id = "bridge_lower";
 	name = "Lower Bridge Lockdown";
 	pixel_y = 24;
-	req_one_access_txt = "19;14"
+	req_one_access = list(19,14)
 	},
 /obj/structure/cable/orange{
 	d1 = 4;
@@ -4951,7 +4951,7 @@
 	id = "bridge_upper";
 	name = "Upper Bridge Lockdown";
 	pixel_y = 32;
-	req_one_access_txt = "19;14"
+	req_one_access = list(19,14)
 	},
 /turf/simulated/floor/carpet/black,
 /area/station/command/bridge)
@@ -5405,8 +5405,7 @@
 "aLe" = (
 /obj/machinery/computer/prisoner{
 	dir = 4;
-	req_access = null;
-	req_access_txt = "2"
+	req_access = list(2)
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -6713,8 +6712,7 @@
 "aTR" = (
 /obj/machinery/computer/prisoner{
 	dir = 4;
-	req_access = null;
-	req_access_txt = "2"
+	req_access = list(2)
 	},
 /turf/simulated/floor/carpet,
 /area/station/legal/magistrate)
@@ -7100,8 +7098,7 @@
 /area/station/hallway/primary/fore/west)
 "aWm" = (
 /obj/machinery/computer/prisoner{
-	req_access = null;
-	req_access_txt = "2"
+	req_access = list(2)
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/prisonershuttle)
@@ -9717,7 +9714,7 @@
 	name = "Medical Asteroid Lockdown";
 	pixel_x = 10;
 	pixel_y = 39;
-	req_access_txt = "40"
+	req_access = list(40)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -12627,8 +12624,8 @@
 /obj/machinery/access_button{
 	autolink_id = "viro_btn_int";
 	name = "Virology Lab Access Button";
-	req_access_txt = "39";
-	pixel_y = -24
+	pixel_y = -24;
+	req_access = list(39)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitegreenfull"
@@ -13465,8 +13462,7 @@
 	name = "Command EVA shutter control";
 	pixel_x = 25;
 	pixel_y = 24;
-	req_access_txt = null;
-	req_one_access_txt = "19;41"
+	req_one_access = list(19,41)
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -13821,7 +13817,7 @@
 	autolink_id = "engsm_btn_int";
 	name = "Supermatter Access Button";
 	pixel_y = 24;
-	req_access_txt = "10"
+	req_access = list(10)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -14251,7 +14247,7 @@
 	autolink_id = "engsm_btn_ext";
 	name = "Supermatter Access Button";
 	pixel_y = -24;
-	req_access_txt = "10"
+	req_access = list(10)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -14870,7 +14866,7 @@
 	autolink_id = "engsm_btn_ext";
 	name = "Supermatter Access Button";
 	pixel_y = 24;
-	req_access_txt = "10"
+	req_access = list(10)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -15110,7 +15106,7 @@
 	name = "Secure Armory Shutter Control";
 	pixel_x = 12;
 	pixel_y = 28;
-	req_access_txt = "3"
+	req_access = list(3)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -15616,21 +15612,21 @@
 	id = "engiestoragesmes";
 	name = "Secure Storage Blast Door Control";
 	pixel_x = -24;
-	req_access_txt = "10;11"
+	req_access = list(10,11)
 	},
 /obj/machinery/door_control{
 	id = "engineeringlockdown";
 	name = "Engineering Emergency Lockdown Control";
 	pixel_x = -24;
 	pixel_y = 8;
-	req_access_txt = "10;11"
+	req_access = list(10,11)
 	},
 /obj/machinery/door_control{
 	id = "ceoffice";
 	name = "Office Emergency Lockdown";
 	pixel_x = -24;
 	pixel_y = -8;
-	req_access_txt = "10;11"
+	req_access = list(10,11)
 	},
 /obj/structure/cable{
 	d2 = 4;
@@ -20431,14 +20427,14 @@
 	name = "Prison Wing Lockdown";
 	pixel_x = -7;
 	pixel_y = -28;
-	req_access_txt = "2"
+	req_access = list(2)
 	},
 /obj/machinery/door_control{
 	id = "Secure Gate";
 	name = "Brig Lockdown";
 	pixel_x = 3;
 	pixel_y = -28;
-	req_access_txt = "2"
+	req_access = list(2)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -21326,7 +21322,7 @@
 	name = "Arrivals EVA shutter control";
 	pixel_x = 25;
 	pixel_y = 6;
-	req_one_access_txt = "19;41"
+	req_one_access = list(19,41)
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -24081,7 +24077,7 @@
 	id = "servlockdown";
 	name = "Service Asteroid Lockdown";
 	pixel_y = 32;
-	req_access_txt = "57"
+	req_access = list(57)
 	},
 /obj/machinery/computer/guestpass/hop{
 	pixel_x = 28
@@ -25046,13 +25042,13 @@
 	name = "Desk Shutters";
 	pixel_x = 24;
 	pixel_y = 8;
-	req_access_txt = "57"
+	req_access = list(57)
 	},
 /obj/machinery/door_control{
 	id = "hopexternal";
 	name = "External Lockdown";
 	pixel_x = 24;
-	req_access_txt = "57"
+	req_access = list(57)
 	},
 /obj/machinery/door_control/ticket_machine_button{
 	pixel_x = 24;
@@ -25963,14 +25959,14 @@
 	name = "Auxiliary Vent Control";
 	pixel_x = 6;
 	pixel_y = -24;
-	req_access_txt = "32"
+	req_access = list(32)
 	},
 /obj/machinery/door_control{
 	id = "turbinevent";
 	name = "Turbine Vent Control";
 	pixel_x = -6;
 	pixel_y = -24;
-	req_access_txt = "32"
+	req_access = list(32)
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/meter,
@@ -26005,11 +26001,11 @@
 	name = "Turbine Access Console";
 	pixel_x = 6;
 	pixel_y = -26;
-	req_access_txt = "12";
 	ext_door_link_id = "turbine_door_ext";
 	int_door_link_id = "turbine_door_int";
 	ext_button_link_id = "turbine_btn_ext";
-	int_button_link_id = "turbine_btn_int"
+	int_button_link_id = "turbine_btn_int";
+	req_access = list(12)
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/turbine)
@@ -26316,7 +26312,7 @@
 	name = "Civilian EVA shutter control";
 	pixel_x = 25;
 	pixel_y = 24;
-	req_one_access_txt = "19;41"
+	req_one_access = list(19,41)
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -27585,7 +27581,7 @@
 	control_area = "\improper AI Satellite Secondary Antechamber";
 	name = "AI Satellite Secondary Antechamber Turret Control";
 	pixel_y = 32;
-	req_access_txt = "75"
+	req_access = list(75)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -30912,8 +30908,8 @@
 	layer = 3.6;
 	autolink_id = "viro_btn_ext";
 	name = "Virology Lab Access Button";
-	req_access_txt = "39";
-	pixel_y = -24
+	pixel_y = -24;
+	req_access = list(39)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitegreenfull"
@@ -32507,7 +32503,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/morgue{
 	name = "Private Study";
-	req_access_txt = "37"
+	req_access = list(37)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -33239,7 +33235,7 @@
 	name = "Garage Door Control";
 	pixel_x = 24;
 	pixel_y = 1;
-	req_access_txt = "66"
+	req_access = list(66)
 	},
 /obj/structure/sink{
 	dir = 4;
@@ -33774,7 +33770,7 @@
 "enw" = (
 /obj/machinery/smartfridge/secure{
 	name = "\improper Kitchen Delivery SmartFridge";
-	req_one_access_txt = "28;35"
+	req_one_access = list(28,35)
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/classic/normal{
@@ -41979,8 +41975,8 @@
 /obj/machinery/door_control{
 	id = "qm_warehouse";
 	name = "Warehouse Door Control";
-	req_access_txt = "31";
-	pixel_x = 24
+	pixel_x = 24;
+	req_access = list(31)
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -45721,7 +45717,7 @@
 	autolink_id = "atmossm_btn_ext";
 	name = "Atmospherics Access Button";
 	pixel_y = -24;
-	req_access_txt = "24"
+	req_access = list(24)
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
@@ -49492,7 +49488,7 @@
 	id = "mixvent";
 	name = "Mixing Room Vent Control";
 	pixel_x = -24;
-	req_access_txt = "7"
+	req_access = list(7)
 	},
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 8
@@ -52237,7 +52233,7 @@
 	name = "Science Asteroid Lockdown";
 	pixel_x = -24;
 	pixel_y = -5;
-	req_access_txt = "30"
+	req_access = list(30)
 	},
 /obj/structure/table,
 /obj/item/book/manual/wiki/sop_science{
@@ -52308,7 +52304,7 @@
 	name = "AI Sat EVA shutter control";
 	pixel_x = 24;
 	pixel_y = 25;
-	req_one_access_txt = "19;41"
+	req_one_access = list(19,41)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -52690,7 +52686,7 @@
 	normaldoorcontrol = 1;
 	pixel_x = 6;
 	pixel_y = -24;
-	req_access_txt = "67"
+	req_access = list(67)
 	},
 /obj/machinery/button/windowtint{
 	dir = 1;
@@ -56721,7 +56717,7 @@
 	normaldoorcontrol = 1;
 	pixel_x = 6;
 	pixel_y = -24;
-	req_access_txt = "73"
+	req_access = list(73)
 	},
 /obj/machinery/button/windowtint{
 	dir = 1;
@@ -57660,7 +57656,7 @@
 	name = "Garage Door Control";
 	pixel_x = -24;
 	pixel_y = 1;
-	req_access_txt = "66"
+	req_access = list(66)
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -61809,7 +61805,7 @@
 	name = "Dispossal Vent Control";
 	pixel_x = 24;
 	pixel_y = 8;
-	req_access_txt = "12"
+	req_access = list(12)
 	},
 /obj/effect/spawner/random_spawners/dirt_frequent,
 /turf/simulated/floor/plating,
@@ -64342,7 +64338,7 @@
 /area/station/security/prison/cell_block/A)
 "mYT" = (
 /obj/structure/closet/secure_closet/bar{
-	req_access_txt = "25"
+	req_access = list(25)
 	},
 /obj/item/radio/intercom{
 	name = "north bump";
@@ -65183,9 +65179,9 @@
 /obj/machinery/button/windowtint{
 	id = "Courtroom";
 	pixel_x = -24;
-	req_one_access_txt = "74;3";
 	dir = 4;
-	pixel_y = -8
+	pixel_y = -8;
+	req_one_access = list(74,3)
 	},
 /turf/simulated/floor/carpet,
 /area/station/legal/courtroom)
@@ -66380,8 +66376,8 @@
 /obj/machinery/button/windowtint{
 	id = "Detective";
 	pixel_x = -24;
-	req_access_txt = "4";
-	dir = 4
+	dir = 4;
+	req_access = list(4)
 	},
 /turf/simulated/floor/carpet,
 /area/station/security/detective)
@@ -68146,8 +68142,8 @@
 /obj/machinery/door_control{
 	id = "engiestoragesmes";
 	name = "Secure Storage Blast Door Control";
-	req_access_txt = "56";
-	pixel_x = -24
+	pixel_x = -24;
+	req_access = list(56)
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/smes)
@@ -68442,7 +68438,7 @@
 	name = "Science EVA shutter control";
 	pixel_x = -25;
 	pixel_y = 24;
-	req_one_access_txt = "19;41"
+	req_one_access = list(19,41)
 	},
 /obj/structure/sign/directions/security{
 	dir = 1;
@@ -69083,11 +69079,11 @@
 	name = "Mixing Room Access Console";
 	pixel_x = -26;
 	pixel_y = 6;
-	req_access_txt = "12";
 	ext_door_link_id = "incinerator_door_ext";
 	int_door_link_id = "incinerator_door_int";
 	ext_button_link_id = "incinerator_btn_ext";
-	int_button_link_id = "incinerator_btn_int"
+	int_button_link_id = "incinerator_btn_int";
+	req_access = list(12)
 	},
 /obj/machinery/ignition_switch{
 	id = "Incinerator";
@@ -72493,8 +72489,8 @@
 /obj/machinery/door_control{
 	id = "RoboticsShutters";
 	name = "Robotics Privacy Shutters";
-	req_access_txt = "29";
-	pixel_y = -24
+	pixel_y = -24;
+	req_access = list(29)
 	},
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -73839,7 +73835,7 @@
 	name = "Prison Wing Lockdown";
 	pixel_x = 1;
 	pixel_y = -28;
-	req_access_txt = "2"
+	req_access = list(2)
 	},
 /obj/machinery/door_control{
 	id = "hosofficedoor";
@@ -73847,14 +73843,14 @@
 	normaldoorcontrol = 1;
 	pixel_x = 11;
 	pixel_y = -28;
-	req_access_txt = "58"
+	req_access = list(58)
 	},
 /obj/machinery/door_control{
 	id = "Secure Gate";
 	name = "Brig Lockdown";
 	pixel_x = -9;
 	pixel_y = -28;
-	req_access_txt = "2"
+	req_access = list(2)
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -76389,7 +76385,7 @@
 	id = "teleshutter";
 	name = "Teleporter Shutters Access Control";
 	pixel_y = -24;
-	req_access_txt = "62"
+	req_access = list(62)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -80241,8 +80237,8 @@
 /obj/machinery/door_control{
 	id = "qm_warehouse";
 	name = "Warehouse Door Control";
-	req_access_txt = "31";
-	pixel_x = -24
+	pixel_x = -24;
+	req_access = list(31)
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/corner{
@@ -81404,7 +81400,7 @@
 	id = "MechbayShutters2";
 	name = "Mechbay Shutters";
 	pixel_y = 24;
-	req_access_txt = "29"
+	req_access = list(29)
 	},
 /obj/machinery/door/poddoor/shutters{
 	dir = 8;
@@ -81482,7 +81478,7 @@
 	name = "Chemistry Shutter Control";
 	pixel_x = 24;
 	pixel_y = 22;
-	req_access_txt = "33"
+	req_access = list(33)
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -84232,7 +84228,7 @@
 	name = "AI Asteroid Teleport Shutters Control";
 	pixel_x = -25;
 	pixel_y = 25;
-	req_one_access_txt = "17;75"
+	req_one_access = list(17,75)
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
@@ -84555,7 +84551,7 @@
 	id = "RnDShutters";
 	name = "Research Privacy Shutters";
 	pixel_y = 24;
-	req_access_txt = "47"
+	req_access = list(47)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -85452,8 +85448,7 @@
 "sZS" = (
 /obj/machinery/computer/prisoner{
 	dir = 1;
-	req_access = null;
-	req_access_txt = "2"
+	req_access = list(2)
 	},
 /obj/machinery/light_switch{
 	dir = 1;
@@ -85466,7 +85461,7 @@
 	name = "Prison Wing Lockdown";
 	pixel_x = -9;
 	pixel_y = -24;
-	req_access_txt = "2"
+	req_access = list(2)
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -88597,41 +88592,41 @@
 	id = "ailockdown";
 	name = "AI Asteroid Lockdown";
 	pixel_y = 40;
-	req_access_txt = "56"
+	req_access = list(56)
 	},
 /obj/machinery/door_control{
 	id = "servlockdown";
 	name = "Service Lockdown";
 	pixel_x = -10;
 	pixel_y = 32;
-	req_access_txt = "57"
+	req_access = list(57)
 	},
 /obj/machinery/door_control{
 	id = "medlockdown";
 	name = "Medical Lockdown";
 	pixel_x = 10;
 	pixel_y = 32;
-	req_access_txt = "40"
+	req_access = list(40)
 	},
 /obj/machinery/door_control{
 	id = "cargolockdown";
 	name = "Cargo Lockdown";
 	pixel_x = 10;
 	pixel_y = 40;
-	req_access_txt = "41"
+	req_access = list(41)
 	},
 /obj/machinery/door_control{
 	id = "scilockdown";
 	name = "Science Lockdown";
 	pixel_x = -10;
 	pixel_y = 24;
-	req_access_txt = "30"
+	req_access = list(30)
 	},
 /obj/machinery/door_control{
 	id = "engilockdown";
 	name = "Engineering Lockdown";
 	pixel_y = 32;
-	req_access_txt = "56"
+	req_access = list(56)
 	},
 /turf/simulated/floor/carpet/black,
 /area/station/command/bridge)
@@ -89386,7 +89381,7 @@
 	name = "Cargo EVA shutter control";
 	pixel_x = -25;
 	pixel_y = 24;
-	req_one_access_txt = "19;41"
+	req_one_access = list(19,41)
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -89470,7 +89465,7 @@
 	id = "engilockdown";
 	name = "Engineering Lockdown";
 	pixel_y = 24;
-	req_access_txt = "56"
+	req_access = list(56)
 	},
 /obj/machinery/photocopier/faxmachine{
 	department = "Chief Engineer's Office"
@@ -89644,12 +89639,12 @@
 	},
 /obj/machinery/airlock_controller/access_controller{
 	name = "Virology Lab Access Console";
-	req_one_access_txt = "39";
 	ext_door_link_id = "viro_door_ext";
 	int_door_link_id = "viro_door_int";
 	ext_button_link_id = "viro_btn_ext";
 	int_button_link_id = "viro_btn_int";
-	pixel_x = -24
+	pixel_x = -24;
+	req_access = list(39)
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -99145,7 +99140,7 @@
 	id = "bridge";
 	dir = 1;
 	pixel_y = 7;
-	req_one_access_txt = "19;41"
+	req_one_access = list(19,41)
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -100461,7 +100456,7 @@
 	id = "engsm";
 	name = "Radiation Shutters Control";
 	pixel_y = 24;
-	req_access_txt = "10"
+	req_access = list(10)
 	},
 /obj/machinery/camera{
 	c_tag = "SM South";
@@ -101488,8 +101483,7 @@
 /area/station/hallway/spacebridge/dockmed)
 "xwQ" = (
 /obj/structure/closet/crate/secure{
-	req_one_access = list(33,41);
-	req_one_access_txt = "33;41"
+	req_one_access = list(33,41)
 	},
 /obj/item/circuitboard/chem_dispenser,
 /obj/item/storage/pill_bottle/random_drug_bottle,
@@ -102329,7 +102323,7 @@
 	autolink_id = "atmossm_btn_int";
 	name = "Atmospherics Access Button";
 	pixel_y = -24;
-	req_access_txt = "24"
+	req_access = list(24)
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
@@ -104201,8 +104195,8 @@
 /obj/machinery/door_control{
 	id = "medeva";
 	name = "Medical EVA shutter control";
-	req_one_access_txt = "19;41";
-	pixel_y = 24
+	pixel_y = 24;
+	req_one_access = list(19,41)
 	},
 /obj/effect/spawner/random_spawners/dirt_often,
 /turf/simulated/floor/plating,
@@ -104585,7 +104579,7 @@
 	id = "MechbayShutters";
 	name = "Mechbay Shutters";
 	pixel_x = 25;
-	req_access_txt = "29"
+	req_access = list(29)
 	},
 /obj/machinery/door/poddoor/shutters{
 	dir = 2;

--- a/_maps/map_files/stations/deltastation.dmm
+++ b/_maps/map_files/stations/deltastation.dmm
@@ -6353,17 +6353,6 @@
 	icon_state = "brown"
 	},
 /area/station/supply/warehouse)
-"azF" = (
-/obj/machinery/door_control{
-	id = "qm_warehouse";
-	name = "Warehouse Door Control";
-	pixel_x = 24;
-	pixel_y = -3;
-	req_access_txt = "31"
-	},
-/obj/effect/decal/cleanable/cobweb2,
-/turf/simulated/floor/plating,
-/area/station/supply/warehouse)
 "azG" = (
 /obj/structure/table,
 /obj/item/stack/packageWrap,
@@ -6373,7 +6362,7 @@
 	name = "Warehouse Door Control";
 	pixel_x = -24;
 	pixel_y = -3;
-	req_access_txt = "31"
+	req_access = list(31)
 	},
 /obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
@@ -9915,7 +9904,7 @@
 	id = "engsm";
 	name = "Radiation Shutters Control";
 	pixel_y = 24;
-	req_access_txt = "24"
+	req_access = list(24)
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -12250,7 +12239,7 @@
 	id = "janitorshutters";
 	name = "Janitor Shutters Control";
 	pixel_x = 25;
-	req_access_txt = "26"
+	req_access = list(26)
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -16261,7 +16250,7 @@
 	id = "cell1lockdown";
 	name = "Cell Lockdown";
 	pixel_y = 32;
-	req_access_txt = "2"
+	req_access = list(2)
 	},
 /obj/machinery/flasher_button{
 	id = "Cell 1";
@@ -16302,7 +16291,7 @@
 	id = "cell2lockdown";
 	name = "Cell Lockdown";
 	pixel_y = 32;
-	req_access_txt = "2"
+	req_access = list(2)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkredcorners"
@@ -23165,7 +23154,7 @@
 	id = "bridge blast north";
 	name = "North Bridge Blast Door Control";
 	pixel_y = 32;
-	req_access_txt = "19"
+	req_access = list(19)
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/bridge)
@@ -24389,14 +24378,14 @@
 	name = "Prison Wing Lockdown";
 	pixel_x = -7;
 	pixel_y = -28;
-	req_access_txt = "2"
+	req_access = list(2)
 	},
 /obj/machinery/door_control{
 	id = "Secure Gate";
 	name = "Brig Lockdown";
 	pixel_x = 3;
 	pixel_y = -28;
-	req_access_txt = "2"
+	req_access = list(2)
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -25734,7 +25723,7 @@
 	id = "bridge blast east";
 	name = "East Bridge Blast Door Control";
 	pixel_x = 26;
-	req_access_txt = "19"
+	req_access = list(19)
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/bridge)
@@ -26922,7 +26911,7 @@
 	name = "West Bridge Blast Door Control";
 	pixel_x = null;
 	pixel_y = 24;
-	req_access_txt = "19"
+	req_access = list(19)
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -27122,7 +27111,7 @@
 	name = "East Bridge Blast Door Control";
 	pixel_x = null;
 	pixel_y = 24;
-	req_access_txt = "19"
+	req_access = list(19)
 	},
 /obj/item/kirbyplants,
 /obj/structure/cable{
@@ -29302,7 +29291,7 @@
 	control_area = "\improper AI Upload Chamber";
 	name = "AI Upload Turret Control";
 	pixel_y = -24;
-	req_one_access_txt = "75"
+	req_access = list(75)
 	},
 /turf/simulated/floor/carpet,
 /area/station/command/bridge)
@@ -29312,14 +29301,14 @@
 	name = "Expedition Shutters Access Control";
 	pixel_x = 7;
 	pixel_y = -26;
-	req_access_txt = "62"
+	req_access = list(62)
 	},
 /obj/machinery/door_control{
 	id = "eva-shutters";
 	name = "Auxilary E.V.A. Storage";
 	pixel_x = -7;
 	pixel_y = -26;
-	req_one_access_txt = "18"
+	req_access = list(18)
 	},
 /obj/machinery/keycard_auth{
 	pixel_y = -38
@@ -30361,7 +30350,7 @@
 	id = "transitlock";
 	name = "Transit Tube Lockdown Control";
 	pixel_y = 24;
-	req_access_txt = "11"
+	req_access = list(11)
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -30581,7 +30570,7 @@
 	name = "Privacy Shutters";
 	pixel_x = 5;
 	pixel_y = -4;
-	req_one_access_txt = "18"
+	req_access = list(18)
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -32646,7 +32635,7 @@
 	name = "Office Door";
 	normaldoorcontrol = 1;
 	pixel_x = -5;
-	req_access_txt = "56"
+	req_access = list(56)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -34609,7 +34598,7 @@
 	control_area = "\improper AI Satellite";
 	name = "AI Antechamber Turret Control";
 	pixel_x = -28;
-	req_access_txt = "75"
+	req_access = list(75)
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
@@ -34914,14 +34903,14 @@
 	name = "Engineering Secure Storage Control";
 	pixel_x = -38;
 	pixel_y = 8;
-	req_access_txt = "11"
+	req_access = list(11)
 	},
 /obj/machinery/door_control{
 	id = "transitlock";
 	name = "Transit Tube Lockdown Control";
 	pixel_x = -38;
 	pixel_y = -8;
-	req_access_txt = "11"
+	req_access = list(11)
 	},
 /obj/machinery/computer/security/engineering{
 	dir = 4
@@ -34932,7 +34921,7 @@
 	pixel_x = -24;
 	pixel_y = 9;
 	range = 12;
-	req_access_txt = "56"
+	req_access = list(56)
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/office/ce)
@@ -36427,8 +36416,7 @@
 /area/station/legal/lawoffice)
 "caM" = (
 /obj/machinery/computer/prisoner{
-	req_access = null;
-	req_access_txt = "2"
+	req_access = list(2)
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -36494,13 +36482,13 @@
 	name = "Privacy Shutters";
 	pixel_x = -24;
 	pixel_y = -8;
-	req_one_access_txt = "18"
+	req_access = list(18)
 	},
 /obj/machinery/door_control{
 	id = "hopqueueshutters";
 	name = "Queue Shutters";
 	pixel_x = -24;
-	req_one_access_txt = "18"
+	req_access = list(18)
 	},
 /obj/machinery/door_control/ticket_machine_button{
 	pixel_x = -24;
@@ -36960,7 +36948,7 @@
 	normaldoorcontrol = 1;
 	pixel_x = -24;
 	pixel_y = -8;
-	req_access_txt = "73"
+	req_access = list(73)
 	},
 /obj/machinery/light_switch{
 	dir = 4;
@@ -37052,7 +37040,7 @@
 	normaldoorcontrol = 1;
 	pixel_x = 24;
 	pixel_y = -24;
-	req_access_txt = "67"
+	req_access = list(67)
 	},
 /turf/simulated/floor/wood,
 /area/station/command/office/blueshield)
@@ -38432,7 +38420,7 @@
 /obj/machinery/button/windowtint{
 	id = "Courtroom";
 	pixel_x = -8;
-	req_one_access_txt = "74;3"
+	req_one_access = list(74,3)
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -38491,7 +38479,7 @@
 	normaldoorcontrol = 1;
 	pixel_x = 6;
 	pixel_y = -25;
-	req_access_txt = "74"
+	req_access = list(74)
 	},
 /turf/simulated/floor/carpet,
 /area/station/legal/magistrate)
@@ -38780,7 +38768,7 @@
 	name = "Office Door";
 	normaldoorcontrol = 1;
 	pixel_x = -8;
-	req_access_txt = "57"
+	req_access = list(57)
 	},
 /turf/simulated/floor/carpet,
 /area/station/command/office/hop)
@@ -38827,7 +38815,7 @@
 	id = "BS";
 	pixel_x = -24;
 	pixel_y = -8;
-	req_access_txt = "67"
+	req_access = list(67)
 	},
 /turf/simulated/floor/wood,
 /area/station/command/office/blueshield)
@@ -39946,7 +39934,7 @@
 	id = "teleaccessshutter";
 	name = "Teleporter Shutters Access Control";
 	pixel_y = 24;
-	req_access_txt = "17"
+	req_access = list(17)
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -41466,7 +41454,7 @@
 	id = "teleportershutter";
 	name = "Teleporter Shutters Access Control";
 	pixel_x = -24;
-	req_access_txt = "17"
+	req_access = list(17)
 	},
 /obj/machinery/door/poddoor/shutters{
 	dir = 2;
@@ -41593,7 +41581,7 @@
 /obj/structure/closet/secure_closet{
 	anchored = 1;
 	name = "Evidence Storage";
-	req_access_txt = "4"
+	req_access = list(4)
 	},
 /obj/item/restraints/handcuffs/pinkcuffs,
 /obj/item/clothing/under/rank/security/officer,
@@ -43024,7 +43012,7 @@
 "csI" = (
 /obj/machinery/door/morgue{
 	name = "Private Study";
-	req_access_txt = "37"
+	req_access = list(37)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -47173,7 +47161,7 @@
 	id = "eva-shutters";
 	name = "Auxilary E.V.A. Storage";
 	pixel_x = 26;
-	req_one_access_txt = "18"
+	req_access = list(18)
 	},
 /obj/machinery/door/poddoor/shutters{
 	dir = 2;
@@ -50475,7 +50463,7 @@
 /obj/machinery/door_control{
 	id = "xeno6";
 	name = "Containment Control";
-	req_access_txt = "55"
+	req_access = list(55)
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -50905,7 +50893,7 @@
 /obj/machinery/door_control{
 	id = "xeno4";
 	name = "Containment Control";
-	req_access_txt = "55"
+	req_access = list(55)
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -50991,7 +50979,7 @@
 /obj/machinery/door_control{
 	id = "xeno5";
 	name = "Containment Control";
-	req_access_txt = "55"
+	req_access = list(55)
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -51267,7 +51255,7 @@
 	id = "xenosecure";
 	name = "Containment Control";
 	pixel_y = -3;
-	req_access_txt = "55"
+	req_access = list(55)
 	},
 /obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel/white,
@@ -51821,7 +51809,7 @@
 /obj/machinery/door_control{
 	id = "xeno2";
 	name = "Containment Control";
-	req_access_txt = "55"
+	req_access = list(55)
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -51834,7 +51822,7 @@
 /obj/machinery/door_control{
 	id = "xeno3";
 	name = "Containment Control";
-	req_access_txt = "55"
+	req_access = list(55)
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -56658,7 +56646,7 @@
 	normaldoorcontrol = 1;
 	pixel_x = -4;
 	pixel_y = -4;
-	req_access_txt = "30"
+	req_access = list(30)
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/command/office/rd)
@@ -57022,7 +57010,7 @@
 	id = "roboticsshutters";
 	name = "Mech Bay Door Control";
 	pixel_y = 24;
-	req_access_txt = "29"
+	req_access = list(29)
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -57234,7 +57222,7 @@
 	id = "RD";
 	pixel_x = 24;
 	pixel_y = -36;
-	req_access_txt = "30"
+	req_access = list(30)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurplecorner"
@@ -63706,7 +63694,7 @@
 /obj/machinery/door_control{
 	id = "xeno1";
 	name = "Containment Control";
-	req_access_txt = "55"
+	req_access = list(55)
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -65181,7 +65169,7 @@
 	name = "exterior access button";
 	pixel_x = 20;
 	pixel_y = 20;
-	req_access_txt = "10;13"
+	req_access = list(10,13)
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -65213,7 +65201,7 @@
 	id = "sr2";
 	pixel_x = 24;
 	pixel_y = -7;
-	req_access_txt = "45"
+	req_access = list(45)
 	},
 /obj/machinery/light_switch{
 	dir = 8;
@@ -65747,7 +65735,7 @@
 	name = "AI Chamber Turret Control";
 	pixel_x = -5;
 	pixel_y = 24;
-	req_access_txt = "75"
+	req_access = list(75)
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -66091,7 +66079,7 @@
 	layer = 3.6;
 	name = "Virology Lab Access Button";
 	pixel_x = -24;
-	req_access_txt = "39"
+	req_access = list(39)
 	},
 /obj/machinery/door/airlock/virology{
 	autoclose = 0;
@@ -66865,7 +66853,7 @@
 	name = "Secure Armory Shutter Control";
 	pixel_x = 7;
 	pixel_y = -28;
-	req_access_txt = "3"
+	req_access = list(3)
 	},
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical,
@@ -67186,7 +67174,7 @@
 	autolink_id = "virolab_btn_int";
 	name = "Virology Lab Access Button";
 	pixel_y = -24;
-	req_access_txt = "39"
+	req_access = list(39)
 	},
 /obj/machinery/door/airlock/virology{
 	autoclose = 0;
@@ -69963,7 +69951,7 @@
 	name = "exterior access button";
 	pixel_x = 20;
 	pixel_y = 20;
-	req_access_txt = "10;13"
+	req_access = list(10,13)
 	},
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -70548,7 +70536,7 @@
 	id = "justice_blast";
 	name = "Space Vent";
 	pixel_x = 32;
-	req_access_txt = "2"
+	req_access = list(2)
 	},
 /obj/structure/closet/secure_closet/injection,
 /obj/machinery/light{
@@ -70914,8 +70902,8 @@
 	int_button_link_id = "enginen_btn_int";
 	int_door_link_id = "enginen_door_int";
 	pixel_y = -25;
-	req_access_txt = "10;13";
-	vent_link_id = "enginen_vent"
+	vent_link_id = "enginen_vent";
+	req_access = list(10,13)
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -74539,7 +74527,7 @@
 	name = "interior access button";
 	pixel_x = -20;
 	pixel_y = 20;
-	req_access_txt = "10;13"
+	req_access = list(10,13)
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -74626,7 +74614,7 @@
 	id = "cell3lockdown";
 	name = "Cell Lockdown";
 	pixel_y = 32;
-	req_access_txt = "2"
+	req_access = list(2)
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -76271,7 +76259,7 @@
 	int_door_link_id = "virolab_door_int";
 	name = "Virology Lab Access Console";
 	pixel_x = -24;
-	req_one_access_txt = "39"
+	req_access = list(39)
 	},
 /obj/item/kirbyplants,
 /turf/simulated/floor/plasteel{
@@ -76665,7 +76653,7 @@
 	id = "paramedic";
 	name = "Garage Door Control";
 	pixel_x = -24;
-	req_access_txt = "66"
+	req_access = list(66)
 	},
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Biohazard_medi";
@@ -79454,7 +79442,7 @@
 	name = "Turbine Access Console";
 	pixel_x = 8;
 	pixel_y = -26;
-	req_access_txt = "12"
+	req_access = list(12)
 	},
 /obj/machinery/ignition_switch{
 	id = "Incinerator";
@@ -79466,7 +79454,7 @@
 	name = "Turbine Vent Control";
 	pixel_x = -8;
 	pixel_y = -36;
-	req_access_txt = "12"
+	req_access = list(12)
 	},
 /obj/machinery/door_control{
 	id = "auxincineratorvent";
@@ -82419,14 +82407,14 @@
 	name = "Kitchen Bar Shutters Control";
 	pixel_x = 6;
 	pixel_y = 24;
-	req_access_txt = "28"
+	req_access = list(28)
 	},
 /obj/machinery/door_control{
 	id = "kitchenhall";
 	name = "Kitchen Hallway Shutters Control";
 	pixel_x = -8;
 	pixel_y = 24;
-	req_access_txt = "28"
+	req_access = list(28)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -83410,7 +83398,7 @@
 	id = "sr1";
 	pixel_x = -24;
 	pixel_y = -7;
-	req_access_txt = "45"
+	req_access = list(45)
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -86768,7 +86756,7 @@
 	dir = 4;
 	id = "qm";
 	pixel_x = -28;
-	req_access_txt = "41"
+	req_access = list(41)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -92821,14 +92809,14 @@
 	name = "Office Door";
 	normaldoorcontrol = 1;
 	pixel_x = 25;
-	req_access_txt = "40"
+	req_access = list(40)
 	},
 /obj/machinery/button/windowtint{
 	dir = 8;
 	id = "CMO";
 	pixel_x = 24;
 	pixel_y = 8;
-	req_access_txt = "40"
+	req_access = list(40)
 	},
 /obj/machinery/light_switch{
 	dir = 8;
@@ -92840,7 +92828,7 @@
 	id = "Biohazard_medi";
 	name = "Medical Quarantine";
 	pixel_x = 35;
-	req_access_txt = "40"
+	req_access = list(40)
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -94210,8 +94198,8 @@
 	int_button_link_id = "engines_btn_int";
 	int_door_link_id = "engines_door_int";
 	pixel_y = 25;
-	req_access_txt = "10;13";
-	vent_link_id = "engines_vent"
+	vent_link_id = "engines_vent";
+	req_access = list(10,13)
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -97610,7 +97598,7 @@
 	name = "interior access button";
 	pixel_x = -20;
 	pixel_y = -20;
-	req_access_txt = "10;13"
+	req_access = list(10,13)
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -98431,6 +98419,17 @@
 	icon_state = "redyellowfull"
 	},
 /area/station/medical/break_room)
+"xtw" = (
+/obj/machinery/door_control{
+	id = "qm_warehouse";
+	name = "Warehouse Door Control";
+	pixel_x = 24;
+	pixel_y = -3;
+	req_access = list(31)
+	},
+/obj/effect/decal/cleanable/cobweb2,
+/turf/simulated/floor/plating,
+/area/station/supply/warehouse)
 "xtS" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
@@ -98479,7 +98478,7 @@
 	name = "Brig Lockdown";
 	pixel_x = 3;
 	pixel_y = -28;
-	req_access_txt = "2"
+	req_access = list(2)
 	},
 /obj/machinery/door_control{
 	desc = "A remote control-switch to lock down the prison wing's blast doors";
@@ -98487,14 +98486,14 @@
 	name = "Prison Wing Lockdown";
 	pixel_x = -7;
 	pixel_y = -28;
-	req_access_txt = "2"
+	req_access = list(2)
 	},
 /obj/machinery/door_control{
 	id = "Secure Armory";
 	name = "Secure Armory Shutter Control";
 	pixel_x = -2;
 	pixel_y = -36;
-	req_access_txt = "3"
+	req_access = list(3)
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -142657,7 +142656,7 @@ axm
 axm
 axt
 kXQ
-azF
+xtw
 aAR
 aCH
 aCH

--- a/_maps/map_files/stations/emeraldstation.dmm
+++ b/_maps/map_files/stations/emeraldstation.dmm
@@ -38,14 +38,14 @@
 	id = "Secure Storage";
 	name = "Engineering Secure Storage";
 	pixel_x = -24;
-	req_access_txt = "56"
+	req_access = list(56)
 	},
 /obj/machinery/door_control{
 	id = "atmos";
 	name = "Atmospherics Lockdown";
 	pixel_x = -24;
 	pixel_y = 7;
-	req_access_txt = "24"
+	req_access = list(24)
 	},
 /obj/machinery/computer/security/telescreen/engine,
 /turf/simulated/floor/plasteel{
@@ -1697,22 +1697,22 @@
 	name = "Office Door";
 	normaldoorcontrol = 1;
 	pixel_x = -24;
-	req_access_txt = "40";
-	pixel_y = 24
+	pixel_y = 24;
+	req_access = list(40)
 	},
 /obj/machinery/door_control{
 	id = "Biohazard_medi";
 	name = "Medical Quarantine";
 	pixel_x = -24;
-	req_access_txt = "40";
-	pixel_y = 33
+	pixel_y = 33;
+	req_access = list(40)
 	},
 /obj/machinery/button/windowtint{
 	id = "CMO";
 	pixel_x = -23;
 	pixel_y = 42;
-	req_access_txt = "40";
-	dir = 4
+	dir = 4;
+	req_access = list(40)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkbluecorners";
@@ -2217,8 +2217,8 @@
 /obj/machinery/access_button{
 	autolink_id = "engsm_btn_ext";
 	name = "Supermatter Access Button";
-	req_access_txt = "32";
-	pixel_x = 24
+	pixel_x = 24;
+	req_access = list(32)
 	},
 /obj/machinery/light{
 	dir = 4
@@ -2320,8 +2320,8 @@
 	id = "disvent";
 	name = "Incinerator Vent Control";
 	pixel_y = -24;
-	req_access_txt = "12";
-	pixel_x = 26
+	pixel_x = 26;
+	req_access = list(12)
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/incinerator)
@@ -2418,7 +2418,7 @@
 	autolink_id = "viro_btn_ext";
 	name = "Virology Lab Access Button";
 	pixel_x = -24;
-	req_access_txt = "39"
+	req_access = list(39)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -4898,7 +4898,7 @@
 	id = "CE";
 	pixel_x = -8;
 	pixel_y = 24;
-	req_access_txt = "56"
+	req_access = list(56)
 	},
 /obj/machinery/button/windowtint{
 	dir = 4;
@@ -4906,7 +4906,7 @@
 	pixel_x = -24;
 	pixel_y = 9;
 	range = 12;
-	req_access_txt = "56"
+	req_access = list(56)
 	},
 /obj/machinery/light_switch{
 	dir = 4;
@@ -5993,7 +5993,7 @@
 	normaldoorcontrol = 1;
 	pixel_x = 37;
 	pixel_y = -25;
-	req_access_txt = "63"
+	req_access = list(63)
 	},
 /obj/machinery/door_control{
 	desc = "A remote control switch for the brig foyer.";
@@ -6002,7 +6002,7 @@
 	normaldoorcontrol = 1;
 	pixel_x = 27;
 	pixel_y = -25;
-	req_access_txt = "63"
+	req_access = list(63)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkredfull"
@@ -8762,8 +8762,8 @@
 /obj/machinery/door_control{
 	id = "paramedic";
 	name = "Garage Door Control";
-	req_access_txt = "66";
-	pixel_x = 24
+	pixel_x = 24;
+	req_access = list(66)
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/preopen{
@@ -10880,7 +10880,7 @@
 	name = "AI Chamber Turret Control";
 	pixel_x = 5;
 	pixel_y = -24;
-	req_access_txt = "75"
+	req_access = list(75)
 	},
 /obj/machinery/flasher{
 	id = "AI";
@@ -11509,8 +11509,8 @@
 /obj/machinery/access_button{
 	autolink_id = "engsm_btn_ext";
 	name = "Supermatter Access Button";
-	req_access_txt = "32";
-	pixel_x = -24
+	pixel_x = -24;
+	req_access = list(32)
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -11919,7 +11919,7 @@
 	id = "xenobio3";
 	name = "Chamber 3 Containment Blast Doors";
 	pixel_y = 4;
-	req_access_txt = "55"
+	req_access = list(55)
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -13422,12 +13422,12 @@
 "cyf" = (
 /obj/machinery/airlock_controller/air_cycler{
 	pixel_x = 25;
-	req_access_txt = "10;13";
 	vent_link_id = "eng_vent";
 	ext_door_link_id = "eng_door_ext";
 	int_door_link_id = "eng_door_int";
 	ext_button_link_id = "eng_btn_ext";
-	int_button_link_id = "eng_btn_int"
+	int_button_link_id = "eng_btn_int";
+	req_access = list(10,13)
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/control)
@@ -13739,7 +13739,7 @@
 	name = "Research and Development Lab Shutters Control";
 	pixel_x = 24;
 	pixel_y = 23;
-	req_access_txt = "47"
+	req_access = list(47)
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -15512,7 +15512,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 8;
-	req_access_txt = null;
 	sort_type_txt = "1"
 	},
 /turf/simulated/floor/plasteel,
@@ -18989,7 +18988,7 @@
 	id = "xenobio4";
 	name = "Chamber 4 Containment Blast Doors";
 	pixel_y = 4;
-	req_access_txt = "55"
+	req_access = list(55)
 	},
 /obj/item/radio/intercom{
 	name = "west bump";
@@ -20990,7 +20989,7 @@
 	autolink_id = "eng_btn_int";
 	pixel_x = -22;
 	pixel_y = -20;
-	req_access_txt = "10;13"
+	req_access = list(10,13)
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -23593,7 +23592,7 @@
 	id = "xenobio5";
 	name = "Chamber 5 Containment Blast Doors";
 	pixel_y = 4;
-	req_access_txt = "55"
+	req_access = list(55)
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -24768,8 +24767,7 @@
 /area/station/engineering/break_room/secondary)
 "eHF" = (
 /obj/machinery/computer/prisoner{
-	req_access = null;
-	req_one_access_txt = "2"
+	req_access = list(2)
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -25261,9 +25259,9 @@
 	id = "Prison Perma Cell 3";
 	name = "Cell Lockdown";
 	pixel_y = 31;
-	req_access_txt = "2";
 	specialfunctions = 4;
-	normaldoorcontrol = 1
+	normaldoorcontrol = 1;
+	req_access = list(2)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -26469,7 +26467,7 @@
 	id = "eva-shutters";
 	name = "Auxilary E.V.A. Storage";
 	pixel_x = -24;
-	req_one_access_txt = "18"
+	req_access = list(18)
 	},
 /turf/simulated/floor/plasteel,
 /area/station/ai_monitored/storage/eva)
@@ -26621,9 +26619,9 @@
 	id = "Prison Perma Cell 1";
 	name = "Cell Lockdown";
 	pixel_y = 31;
-	req_access_txt = "2";
 	specialfunctions = 4;
-	normaldoorcontrol = 1
+	normaldoorcontrol = 1;
+	req_access = list(2)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -27571,7 +27569,7 @@
 	ext_button_link_id = "engsm_btn_ext";
 	int_button_link_id = "engsm_btn_int";
 	pixel_x = 22;
-	req_access_txt = "32"
+	req_access = list(32)
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -29025,11 +29023,11 @@
 	name = "Turbine Access Console";
 	pixel_x = 6;
 	pixel_y = -26;
-	req_access_txt = "12";
 	ext_door_link_id = "turbine_door_ext";
 	int_door_link_id = "turbine_door_int";
 	ext_button_link_id = "turbine_btn_ext";
-	int_button_link_id = "turbine_btn_int"
+	int_button_link_id = "turbine_btn_int";
+	req_access = list(12)
 	},
 /obj/machinery/atmospherics/binary/pump/on,
 /turf/simulated/floor/plasteel{
@@ -29149,7 +29147,7 @@
 	name = "processing tint control";
 	pixel_x = -6;
 	pixel_y = 24;
-	req_access_txt = "63"
+	req_access = list(63)
 	},
 /obj/machinery/light_switch{
 	name = "north bump";
@@ -31399,8 +31397,7 @@
 "fPs" = (
 /obj/machinery/computer/prisoner{
 	dir = 8;
-	req_access = null;
-	req_access_txt = "2"
+	req_access = list(2)
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -35412,11 +35409,11 @@
 	name = "Incinerator Access Console";
 	pixel_x = 6;
 	pixel_y = -25;
-	req_access_txt = "12";
 	ext_door_link_id = "incinerator_door_ext";
 	int_door_link_id = "incinerator_door_int";
 	ext_button_link_id = "incinerator_btn_ext";
-	int_button_link_id = "incinerator_btn_int"
+	int_button_link_id = "incinerator_btn_int";
+	req_access = list(12)
 	},
 /obj/machinery/ignition_switch{
 	id = "Incinerator";
@@ -35713,7 +35710,7 @@
 	autolink_id = "viro_btn_int";
 	name = "Virology Lab Access Button";
 	pixel_x = -24;
-	req_access_txt = "39"
+	req_access = list(39)
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -35903,9 +35900,9 @@
 /obj/machinery/button/windowtint{
 	id = "Surgery 1";
 	pixel_y = 8;
-	req_access_txt = "45";
 	dir = 4;
-	pixel_x = -24
+	pixel_x = -24;
+	req_access = list(45)
 	},
 /obj/machinery/light_switch{
 	dir = 4;
@@ -38641,7 +38638,7 @@
 	normaldoorcontrol = 1;
 	pixel_x = 28;
 	pixel_y = 17;
-	req_access_txt = "58"
+	req_access = list(58)
 	},
 /obj/machinery/door_control{
 	desc = "A remote control-switch to lock down the prison wing's blast doors";
@@ -38649,14 +38646,14 @@
 	name = "Prison Wing Lockdown";
 	pixel_x = 28;
 	pixel_y = 7;
-	req_access_txt = "2"
+	req_access = list(2)
 	},
 /obj/machinery/door_control{
 	id = "Secure Gate";
 	name = "Brig Lockdown";
 	pixel_x = 28;
 	pixel_y = -3;
-	req_access_txt = "2"
+	req_access = list(2)
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -38706,7 +38703,7 @@
 	name = "Secure Armory Shutter Control";
 	pixel_x = -2;
 	pixel_y = -36;
-	req_access_txt = "3"
+	req_access = list(3)
 	},
 /obj/machinery/door_control{
 	desc = "A remote control-switch to lock down the prison wing's blast doors";
@@ -38714,14 +38711,14 @@
 	name = "Prison Wing Lockdown";
 	pixel_x = -7;
 	pixel_y = -28;
-	req_access_txt = "2"
+	req_access = list(2)
 	},
 /obj/machinery/door_control{
 	id = "Secure Gate";
 	name = "Brig Lockdown";
 	pixel_x = 3;
 	pixel_y = -28;
-	req_access_txt = "2"
+	req_access = list(2)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkred"
@@ -41245,14 +41242,14 @@
 	id = "hopqueueshutters";
 	name = "Queue Shutters";
 	pixel_x = -24;
-	req_one_access_txt = "18"
+	req_access = list(18)
 	},
 /obj/machinery/door_control{
 	id = "hop";
 	name = "Privacy Shutters";
 	pixel_x = -24;
 	pixel_y = -8;
-	req_one_access_txt = "18"
+	req_access = list(18)
 	},
 /obj/machinery/flasher_button{
 	id = "hopflash";
@@ -41974,7 +41971,7 @@
 /obj/structure/barricade/wooden/crude,
 /obj/machinery/door/morgue{
 	name = "Private Study";
-	req_access_txt = "37"
+	req_access = list(37)
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint2)
@@ -45943,8 +45940,8 @@
 	id = "justice_blast";
 	name = "Space Vent";
 	pixel_x = 2;
-	req_access_txt = "2";
-	pixel_y = 22
+	pixel_y = 22;
+	req_access = list(2)
 	},
 /obj/structure/table/reinforced,
 /obj/item/taperecorder{
@@ -49958,19 +49955,19 @@
 	id = "bridge blast entrance";
 	name = "Bridge Lobby Blast Door Control";
 	pixel_y = -9;
-	req_one_access_txt = "19"
+	req_access = list(19)
 	},
 /obj/machinery/door_control{
 	id = "bridge blast south";
 	name = "Bridge Entrance Blast Door Control";
 	pixel_y = -1;
-	req_one_access_txt = "19"
+	req_access = list(19)
 	},
 /obj/machinery/door_control{
 	id = "bridge blast north";
 	name = "Bridge Space Blast Door Control";
 	pixel_y = 7;
-	req_one_access_txt = "19"
+	req_access = list(19)
 	},
 /turf/simulated/floor/plasteel,
 /area/station/command/bridge)
@@ -50365,7 +50362,7 @@
 	autolink_id = "xeno_btn_int";
 	name = "Xenobiology Access Button";
 	pixel_x = -24;
-	req_access_txt = "55"
+	req_access = list(55)
 	},
 /obj/machinery/door/airlock/research{
 	autoclose = 0;
@@ -51188,8 +51185,8 @@
 /obj/machinery/turretid/stun{
 	control_area = "\improper AI Satellite Atmospherics";
 	name = "AI Satellite Atmospherics Turret Control";
-	req_access_txt = "75";
-	pixel_y = -26
+	pixel_y = -26;
+	req_access = list(75)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -51840,8 +51837,8 @@
 	id = "engsm";
 	name = "Radiation Shutters Control";
 	pixel_y = -1;
-	req_access_txt = "10";
-	pixel_x = -22
+	pixel_x = -22;
+	req_access = list(10)
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/effect/turf_decal/stripes/line{
@@ -54375,15 +54372,14 @@
 "kcA" = (
 /obj/machinery/computer/prisoner{
 	dir = 4;
-	req_access = null;
-	req_access_txt = "2"
+	req_access = list(2)
 	},
 /obj/machinery/button/windowtint{
 	dir = 4;
 	id = "IAA";
 	pixel_x = -24;
 	pixel_y = 6;
-	req_access_txt = "38"
+	req_access = list(38)
 	},
 /obj/machinery/camera{
 	c_tag = "Internal Affairs Office";
@@ -54766,9 +54762,9 @@
 	id = "Prison Perma Cell 4";
 	name = "Cell Lockdown";
 	pixel_y = 31;
-	req_access_txt = "2";
 	specialfunctions = 4;
-	normaldoorcontrol = 1
+	normaldoorcontrol = 1;
+	req_access = list(2)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -56400,9 +56396,9 @@
 /obj/machinery/door_control{
 	id = "robotics_surgery";
 	name = "Robotics Privacy Shutters";
-	req_access_txt = "29";
 	pixel_y = 24;
-	pixel_x = -24
+	pixel_x = -24;
+	req_access = list(29)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -59959,18 +59955,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
-"lhw" = (
-/obj/structure/closet/cardboard,
-/obj/effect/decal/cleanable/cobweb,
-/obj/machinery/door_control{
-	id = "qm_warehouse";
-	name = "Warehouse Door Control";
-	pixel_x = -1;
-	pixel_y = 24;
-	req_access_txt = "31"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/supply/warehouse)
 "lhR" = (
 /obj/item/decorations/sticky_decorations/flammable/singleeye{
 	pixel_y = 20
@@ -60056,7 +60040,7 @@
 	id = "HoS";
 	pixel_x = 7;
 	pixel_y = -25;
-	req_access_txt = "58"
+	req_access = list(58)
 	},
 /obj/machinery/light_switch{
 	dir = 1;
@@ -60403,14 +60387,14 @@
 	name = "Auxiliary Vent";
 	pixel_x = 6;
 	pixel_y = -24;
-	req_access_txt = "32"
+	req_access = list(32)
 	},
 /obj/machinery/door_control{
 	id = "turbinevent";
 	name = "Turbine Vent";
 	pixel_x = -6;
 	pixel_y = -24;
-	req_access_txt = "32"
+	req_access = list(32)
 	},
 /obj/machinery/atmospherics/binary/pump/on{
 	dir = 1
@@ -60835,7 +60819,7 @@
 	name = "Engineering Lockdown";
 	pixel_x = 8;
 	pixel_y = -7;
-	req_access_txt = "10"
+	req_access = list(10)
 	},
 /turf/simulated/wall/r_wall,
 /area/station/command/office/ce)
@@ -61497,8 +61481,8 @@
 	name = "Office Door";
 	normaldoorcontrol = 1;
 	pixel_x = 9;
-	req_access_txt = "74";
-	pixel_y = 25
+	pixel_y = 25;
+	req_access = list(74)
 	},
 /obj/machinery/light{
 	dir = 1
@@ -62684,8 +62668,7 @@
 /area/station/command/bridge)
 "lFR" = (
 /obj/structure/closet/crate/secure{
-	req_one_access = list(33,41);
-	req_one_access_txt = "33;41"
+	req_one_access = list(33,41)
 	},
 /obj/item/circuitboard/thermomachine{
 	pixel_x = -5
@@ -68160,7 +68143,7 @@
 	control_area = "\improper AI Satellite Antechamber";
 	name = "AI Antechamber Turret Control";
 	pixel_x = -28;
-	req_access_txt = "75"
+	req_access = list(75)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -68781,8 +68764,7 @@
 "mSw" = (
 /obj/machinery/computer/prisoner{
 	dir = 1;
-	req_access = null;
-	req_access_txt = "2"
+	req_access = list(2)
 	},
 /obj/item/radio/intercom{
 	name = "south bump";
@@ -69555,7 +69537,7 @@
 	control_area = "\improper AI Satellite Service";
 	name = "AI Satellite Service Bay Turret Control";
 	pixel_x = -29;
-	req_access_txt = "75"
+	req_access = list(75)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -71524,7 +71506,7 @@
 	name = "Chemistry Privacy Shutter Control";
 	pixel_x = -24;
 	pixel_y = 24;
-	req_access_txt = "33"
+	req_access = list(33)
 	},
 /obj/machinery/firealarm/directional/west,
 /turf/simulated/floor/plasteel{
@@ -72436,7 +72418,7 @@
 "nAB" = (
 /obj/machinery/door/morgue{
 	name = "Confession Booth (Chaplain)";
-	req_access_txt = "22"
+	req_access = list(22)
 	},
 /turf/simulated/floor/plating,
 /area/station/service/chapel)
@@ -73101,8 +73083,8 @@
 	id = "Secure Storage";
 	name = "Engineering Secure Storage";
 	pixel_x = 7;
-	req_access_txt = "56";
-	pixel_y = 24
+	pixel_y = 24;
+	req_access = list(56)
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
@@ -73181,8 +73163,8 @@
 /obj/machinery/button/windowtint{
 	id = "Courtroom";
 	pixel_x = -6;
-	req_one_access_txt = "74;3";
-	range = 10
+	range = 10;
+	req_one_access = list(74,3)
 	},
 /obj/item/megaphone{
 	pixel_y = -11
@@ -73209,8 +73191,8 @@
 	name = "Court Entrance Control";
 	normaldoorcontrol = 1;
 	pixel_x = 1;
-	req_access_txt = "74";
-	pixel_y = 10
+	pixel_y = 10;
+	req_access = list(74)
 	},
 /turf/simulated/floor/carpet,
 /area/station/legal/courtroom)
@@ -75142,8 +75124,7 @@
 "nYy" = (
 /obj/machinery/computer/prisoner{
 	dir = 4;
-	req_access = null;
-	req_access_txt = "2"
+	req_access = list(2)
 	},
 /obj/machinery/light{
 	dir = 8
@@ -77687,9 +77668,9 @@
 /obj/machinery/door_control{
 	id = "mechbay_inner";
 	name = "Inner Mech Bay Shutter Control";
-	req_access_txt = "29";
 	pixel_y = -24;
-	pixel_x = 25
+	pixel_x = 25;
+	req_access = list(29)
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel{
@@ -80934,9 +80915,9 @@
 /obj/machinery/button/windowtint{
 	id = "Surgery 2";
 	pixel_y = 8;
-	req_access_txt = "45";
 	dir = 8;
-	pixel_x = 24
+	pixel_x = 24;
+	req_access = list(45)
 	},
 /obj/machinery/light_switch{
 	dir = 8;
@@ -82687,7 +82668,7 @@
 	id = "teleshutter";
 	name = "Teleporter Shutters Access Control";
 	pixel_x = 24;
-	req_one_access_txt = "62"
+	req_access = list(62)
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -84621,7 +84602,7 @@
 "pHY" = (
 /obj/machinery/door/morgue{
 	name = "Private Study";
-	req_access_txt = "37"
+	req_access = list(37)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -85630,7 +85611,7 @@
 	id = "Detective";
 	pixel_x = -8;
 	pixel_y = 24;
-	req_access_txt = "4"
+	req_access = list(4)
 	},
 /obj/machinery/computer/med_data,
 /obj/machinery/light{
@@ -86352,7 +86333,7 @@
 	id = "xenobio6";
 	name = "Chamber 6 Containment Blast Doors";
 	pixel_y = 4;
-	req_access_txt = "55"
+	req_access = list(55)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
@@ -88096,7 +88077,7 @@
 	id = "xenobio1";
 	name = "Chamber 1 Containment Blast Door";
 	pixel_y = 4;
-	req_access_txt = "55"
+	req_access = list(55)
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -91374,8 +91355,8 @@
 	name = "Jury Entrance Control";
 	normaldoorcontrol = 1;
 	pixel_x = 1;
-	req_access_txt = "74";
-	pixel_y = 10
+	pixel_y = 10;
+	req_access = list(74)
 	},
 /obj/item/reagent_containers/glass/beaker/waterbottle{
 	pixel_x = 5
@@ -92300,7 +92281,7 @@
 	id = "xenobio2";
 	name = "Chamber 2 Containment Blast Doors";
 	pixel_y = 4;
-	req_access_txt = "55"
+	req_access = list(55)
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -94909,8 +94890,8 @@
 /obj/machinery/door_control{
 	id = "mechbay_outer";
 	name = "Outer Mech Bay Shutters Control";
-	req_access_txt = "29";
-	pixel_y = 24
+	pixel_y = 24;
+	req_access = list(29)
 	},
 /turf/simulated/floor/plasteel,
 /area/station/science/robotics/chargebay)
@@ -95508,7 +95489,7 @@
 	id = "Interrogation";
 	name = "interrogation tint control";
 	pixel_x = -24;
-	req_access_txt = "63"
+	req_access = list(63)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -95977,7 +95958,7 @@
 	name = "Atmospherics Lockdown";
 	pixel_x = -24;
 	pixel_y = 5;
-	req_access_txt = "24"
+	req_access = list(24)
 	},
 /obj/machinery/light{
 	dir = 8
@@ -96471,7 +96452,7 @@
 	name = "Atmospherics Lockdown";
 	pixel_x = -8;
 	pixel_y = 10;
-	req_access_txt = "24"
+	req_access = list(24)
 	},
 /obj/item/book/manual/atmospipes,
 /obj/machinery/computer/security/telescreen/engine{
@@ -99644,7 +99625,7 @@
 	name = "Warehouse Door Control";
 	pixel_x = -1;
 	pixel_y = -24;
-	req_access_txt = "31"
+	req_access = list(31)
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -100056,7 +100037,7 @@
 	autolink_id = "xeno_btn_ext";
 	name = "Xenobiology Access Button";
 	pixel_x = -24;
-	req_access_txt = "55"
+	req_access = list(55)
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -100927,9 +100908,9 @@
 	id = "Prison Perma Cell 2";
 	name = "Cell Lockdown";
 	pixel_y = 31;
-	req_access_txt = "2";
 	specialfunctions = 4;
-	normaldoorcontrol = 1
+	normaldoorcontrol = 1;
+	req_access = list(2)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -102448,11 +102429,11 @@
 /obj/machinery/airlock_controller/access_controller{
 	name = "Virology Lab Access Console";
 	pixel_y = 24;
-	req_one_access_txt = "39";
 	ext_door_link_id = "viro_door_ext";
 	int_door_link_id = "viro_door_int";
 	ext_button_link_id = "viro_btn_ext";
-	int_button_link_id = "viro_btn_int"
+	int_button_link_id = "viro_btn_int";
+	req_access = list(39)
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -108441,9 +108422,9 @@
 /obj/machinery/button/windowtint{
 	pixel_x = 24;
 	id = "qm";
-	req_access_txt = "41";
 	dir = 8;
-	pixel_y = 5
+	pixel_y = 5;
+	req_access = list(41)
 	},
 /obj/machinery/light_switch{
 	dir = 8;
@@ -115849,8 +115830,8 @@
 /obj/machinery/access_button{
 	autolink_id = "engsm_btn_int";
 	name = "Supermatter Access Button";
-	req_access_txt = "32";
-	pixel_x = -24
+	pixel_x = -24;
+	req_access = list(32)
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -122352,7 +122333,7 @@
 /area/station/hallway/primary/starboard/south)
 "wFX" = (
 /obj/structure/closet/secure_closet/bar{
-	req_access_txt = "25"
+	req_access = list(25)
 	},
 /obj/item/ammo_box/shotgun/beanbag,
 /turf/simulated/floor/wood,
@@ -122725,7 +122706,7 @@
 	name = "Secure Armory Shutter Control";
 	pixel_x = -24;
 	pixel_y = -28;
-	req_access_txt = "3"
+	req_access = list(3)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkgrey"
@@ -124966,7 +124947,7 @@
 	name = "Office Door";
 	normaldoorcontrol = 1;
 	pixel_x = -8;
-	req_access_txt = "57"
+	req_access = list(57)
 	},
 /obj/item/pen{
 	pixel_x = -8;
@@ -125508,14 +125489,14 @@
 	name = "Kitchen Diner Shutters Control";
 	pixel_x = 26;
 	pixel_y = 7;
-	req_access_txt = "28"
+	req_access = list(28)
 	},
 /obj/machinery/door_control{
 	id = "kitchenhall";
 	name = "Kitchen Hallway Shutters Control";
 	pixel_x = 26;
 	pixel_y = -3;
-	req_access_txt = "28"
+	req_access = list(28)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
@@ -125963,7 +125944,7 @@
 	autolink_id = "eng_btn_ext";
 	pixel_x = -22;
 	pixel_y = 20;
-	req_access_txt = "10;13"
+	req_access = list(10,13)
 	},
 /turf/space,
 /area/space/nearstation)
@@ -126213,14 +126194,14 @@
 	normaldoorcontrol = 1;
 	pixel_x = -4;
 	pixel_y = -4;
-	req_access_txt = "30"
+	req_access = list(30)
 	},
 /obj/machinery/door_control{
 	id = "Biohazard";
 	name = "Biohazard Shutter Control";
 	pixel_x = -4;
 	pixel_y = 6;
-	req_access_txt = "30"
+	req_access = list(30)
 	},
 /obj/item/reagent_containers/drinks/coffee{
 	pixel_x = 8;
@@ -126794,9 +126775,9 @@
 /obj/machinery/door_control{
 	id = "robotics";
 	name = "Robotics Privacy Shutters";
-	req_access_txt = "29";
 	pixel_y = 8;
-	pixel_x = 25
+	pixel_x = 25;
+	req_access = list(29)
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -128761,6 +128742,18 @@
 /obj/effect/spawner/random_spawners/oil_maybe,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint)
+"xRf" = (
+/obj/structure/closet/cardboard,
+/obj/effect/decal/cleanable/cobweb,
+/obj/machinery/door_control{
+	id = "qm_warehouse";
+	name = "Warehouse Door Control";
+	pixel_x = -1;
+	pixel_y = 24;
+	req_access = list(31)
+	},
+/turf/simulated/floor/plasteel,
+/area/station/supply/warehouse)
 "xRh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -128817,7 +128810,7 @@
 	name = "AI Chamber Hallway Turret Control";
 	pixel_x = 24;
 	pixel_y = -24;
-	req_access_txt = "75"
+	req_access = list(75)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -148812,7 +148805,7 @@ qxw
 tKR
 svJ
 wRe
-lhw
+xRf
 gAx
 vTT
 mYq

--- a/_maps/map_files/stations/metastation.dmm
+++ b/_maps/map_files/stations/metastation.dmm
@@ -160,7 +160,7 @@
 	dir = 8;
 	id = "Detective";
 	pixel_x = 24;
-	req_access_txt = "4"
+	req_access = list(4)
 	},
 /turf/simulated/floor/carpet,
 /area/station/security/detective)
@@ -212,8 +212,7 @@
 /obj/machinery/alarm/directional/west,
 /obj/machinery/computer/prisoner{
 	dir = 4;
-	req_access = null;
-	req_access_txt = "2"
+	req_access = list(2)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cult"
@@ -631,7 +630,7 @@
 	name = "exterior access button";
 	pixel_x = 25;
 	pixel_y = 7;
-	req_access_txt = "75;13"
+	req_access = list(75,13)
 	},
 /turf/space,
 /area/space/nearstation)
@@ -1395,7 +1394,7 @@
 	name = "Disposal Vent Control";
 	pixel_x = -25;
 	pixel_y = 4;
-	req_access_txt = "12"
+	req_access = list(12)
 	},
 /obj/machinery/driver_button{
 	id_tag = "trash";
@@ -1499,12 +1498,12 @@
 /obj/machinery/airlock_controller/air_cycler{
 	pixel_x = -25;
 	pixel_y = 4;
-	req_access_txt = "13";
 	vent_link_id = "arrivalsmaint_vent";
 	ext_door_link_id = "arrivalsmaint_door_ext";
 	int_door_link_id = "arrivalsmaint_door_int";
 	ext_button_link_id = "arrivalsmaint_btn_ext";
-	int_button_link_id = "arrivalsmaint_btn_int"
+	int_button_link_id = "arrivalsmaint_btn_int";
+	req_access = list(13)
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
@@ -4169,7 +4168,7 @@
 	id = "qm_warehouse";
 	name = "Warehouse Door Control";
 	pixel_x = 24;
-	req_access_txt = "31"
+	req_access = list(31)
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -6155,7 +6154,7 @@
 	id = "xenobio2";
 	name = "Xenobio Pen 2 Blast Doors";
 	pixel_y = 1;
-	req_access_txt = "55"
+	req_access = list(55)
 	},
 /turf/simulated/floor/plasteel,
 /area/station/science/xenobiology)
@@ -8535,7 +8534,7 @@
 	dir = 1;
 	id = "Courtroom";
 	pixel_y = 8;
-	req_one_access_txt = "74;3"
+	req_one_access = list(74,3)
 	},
 /turf/simulated/floor/carpet,
 /area/station/legal/courtroom)
@@ -8718,7 +8717,7 @@
 	id = "engsm";
 	name = "Radiation Shutters Control";
 	pixel_x = 24;
-	req_access_txt = "32"
+	req_access = list(32)
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -8847,26 +8846,6 @@
 /obj/machinery/firealarm/directional/west,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
-"aPR" = (
-/obj/machinery/door_control{
-	id = "qm_warehouse";
-	name = "Warehouse Door Control";
-	pixel_x = -24;
-	req_access_txt = "31"
-	},
-/obj/structure/table,
-/obj/machinery/kitchen_machine/microwave{
-	pixel_y = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light_switch{
-	dir = 4;
-	name = "custom placement";
-	pixel_x = -24;
-	pixel_y = -8
-	},
-/turf/simulated/floor/plasteel,
-/area/station/supply/warehouse)
 "aPS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -13945,14 +13924,14 @@
 	name = "Engineering Lockdown";
 	pixel_x = -24;
 	pixel_y = -5;
-	req_access_txt = "10"
+	req_access = list(10)
 	},
 /obj/machinery/door_control{
 	id = "atmos";
 	name = "Atmospherics Lockdown";
 	pixel_x = -24;
 	pixel_y = 5;
-	req_access_txt = "24"
+	req_access = list(24)
 	},
 /obj/machinery/light{
 	dir = 8
@@ -14607,7 +14586,7 @@
 	name = "Transit Tube Lockdown";
 	pixel_x = -24;
 	pixel_y = -5;
-	req_access_txt = "19"
+	req_access = list(19)
 	},
 /obj/machinery/door_control{
 	desc = "A remote control-switch for secure storage.";
@@ -14615,7 +14594,7 @@
 	name = "Engineering Secure Storage";
 	pixel_x = -24;
 	pixel_y = 5;
-	req_access_txt = "11"
+	req_access = list(11)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkgrey"
@@ -17499,7 +17478,7 @@
 /obj/machinery/button/windowtint{
 	id = "CE";
 	pixel_y = -24;
-	req_access_txt = "56"
+	req_access = list(56)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkgrey"
@@ -19894,7 +19873,7 @@
 /area/station/service/barber)
 "buI" = (
 /obj/structure/closet/secure_closet/bar{
-	req_access_txt = "25"
+	req_access = list(25)
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -20096,7 +20075,7 @@
 	id = "hop";
 	name = "Privacy Shutters Control";
 	pixel_y = 25;
-	req_access_txt = "28"
+	req_access = list(28)
 	},
 /obj/machinery/computer/account_database,
 /turf/simulated/floor/wood,
@@ -20201,7 +20180,7 @@
 	control_area = "\improper AI Satellite Antechamber";
 	name = "AI Antechamber Turret Control";
 	pixel_x = 24;
-	req_access_txt = "75"
+	req_access = list(75)
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -21257,7 +21236,7 @@
 	id = "hop";
 	name = "Privacy Shutters Control";
 	pixel_x = -24;
-	req_access_txt = "28"
+	req_access = list(28)
 	},
 /turf/simulated/floor/carpet,
 /area/station/command/office/hop)
@@ -21339,14 +21318,14 @@
 	name = "Bridge Access Blast Door Control";
 	pixel_x = -1;
 	pixel_y = -24;
-	req_access_txt = "19"
+	req_access = list(19)
 	},
 /obj/machinery/door_control{
 	id = "council blast";
 	name = "Council Chamber Blast Door Control";
 	pixel_x = -1;
 	pixel_y = -34;
-	req_access_txt = "19"
+	req_access = list(19)
 	},
 /obj/machinery/camera{
 	c_tag = "Bridge - Command Chair";
@@ -22456,13 +22435,13 @@
 	id = "evashutter";
 	name = "E.V.A. Storage Shutter Control";
 	pixel_y = -24;
-	req_access_txt = "19"
+	req_access = list(19)
 	},
 /obj/machinery/door_control{
 	id = "gateshutter";
 	name = "Expedition Shutter Control";
 	pixel_y = -34;
-	req_access_txt = "62"
+	req_access = list(62)
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -22515,14 +22494,14 @@
 	name = "Queue Shutters Control";
 	pixel_x = -6;
 	pixel_y = -35;
-	req_access_txt = "28"
+	req_access = list(28)
 	},
 /obj/machinery/door_control{
 	id = "hop";
 	name = "Privacy Shutters Control";
 	pixel_x = -6;
 	pixel_y = -24;
-	req_access_txt = "28"
+	req_access = list(28)
 	},
 /obj/machinery/flasher_button{
 	id = "hopflash";
@@ -23559,7 +23538,7 @@
 	id = "council blast";
 	name = "Council Chamber Blast Door Control";
 	pixel_x = -24;
-	req_access_txt = "19"
+	req_access = list(19)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -23633,7 +23612,7 @@
 	id = "bridge blast";
 	name = "Bridge Access Blast Door Control";
 	pixel_x = -24;
-	req_access_txt = "19"
+	req_access = list(19)
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -23969,7 +23948,7 @@
 	id = "bridge blast";
 	name = "Bridge Access Blast Door Control";
 	pixel_x = 24;
-	req_access_txt = "19"
+	req_access = list(19)
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -24117,7 +24096,7 @@
 	name = "Kitchen Counter Shutters";
 	pixel_x = -6;
 	pixel_y = 24;
-	req_access_txt = "28"
+	req_access = list(28)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
@@ -26232,7 +26211,7 @@
 	name = "exterior access button";
 	pixel_x = -25;
 	pixel_y = -7;
-	req_access_txt = "75;13"
+	req_access = list(75,13)
 	},
 /turf/space,
 /area/space/nearstation)
@@ -26284,7 +26263,7 @@
 	id = "xenobio5";
 	name = "Xenobio Pen 5 Blast Doors";
 	pixel_y = 4;
-	req_access_txt = "55"
+	req_access = list(55)
 	},
 /turf/simulated/floor/plasteel,
 /area/station/science/xenobiology)
@@ -27485,7 +27464,7 @@
 "bUK" = (
 /obj/machinery/door/morgue{
 	name = "Private Study";
-	req_access_txt = "37"
+	req_access = list(37)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cult"
@@ -28351,7 +28330,7 @@
 	id = "mechbay";
 	name = "Mech Bay Shutters Control";
 	pixel_y = -24;
-	req_access_txt = "29"
+	req_access = list(29)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
@@ -28629,7 +28608,7 @@
 	normaldoorcontrol = 1;
 	pixel_x = 6;
 	pixel_y = -24;
-	req_access_txt = "73"
+	req_access = list(73)
 	},
 /obj/structure/table/wood,
 /obj/machinery/photocopier/faxmachine/longrange{
@@ -28769,7 +28748,7 @@
 	id = "evashutter";
 	name = "E.V.A. Storage Shutter Control";
 	pixel_y = -26;
-	req_access_txt = "19"
+	req_access = list(19)
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -30946,20 +30925,20 @@
 	name = "Xenobiology Containment Control";
 	pixel_x = 7;
 	pixel_y = 24;
-	req_access_txt = "30"
+	req_access = list(30)
 	},
 /obj/machinery/door_control{
 	id = "rdtoxins";
 	name = "Toxins Containment Control";
 	pixel_x = -7;
 	pixel_y = 24;
-	req_access_txt = "30"
+	req_access = list(30)
 	},
 /obj/machinery/door_control{
 	id = "rdrnd";
 	name = "Experi-mentor shutters";
 	pixel_y = 34;
-	req_access_txt = "30"
+	req_access = list(30)
 	},
 /obj/machinery/computer/security/telescreen/rd{
 	pixel_x = 31;
@@ -30969,7 +30948,7 @@
 	id = "RD";
 	pixel_x = -24;
 	pixel_y = 26;
-	req_access_txt = "30"
+	req_access = list(30)
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -31240,7 +31219,7 @@
 	id = "paramedic";
 	name = "Garage Door Control";
 	pixel_y = 24;
-	req_access_txt = "66"
+	req_access = list(66)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -31872,8 +31851,7 @@
 "ckx" = (
 /obj/machinery/mecha_part_fabricator{
 	id = "0";
-	name = "forgotten exosuit fabricator";
-	req_access = "0"
+	name = "forgotten exosuit fabricator"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
@@ -32288,7 +32266,7 @@
 "cmn" = (
 /obj/machinery/door/morgue{
 	name = "Confession Booth (Chaplain)";
-	req_access_txt = "22"
+	req_access = list(22)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -32745,7 +32723,7 @@
 	id = "turbinevent";
 	name = "Turbine Vent Control";
 	pixel_y = -24;
-	req_access_txt = "12"
+	req_access = list(12)
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/extinguisher_cabinet{
@@ -32787,14 +32765,14 @@
 	name = "Turbine Vent Control";
 	pixel_x = -8;
 	pixel_y = -36;
-	req_access_txt = "12"
+	req_access = list(12)
 	},
 /obj/machinery/door_control{
 	id = "auxincineratorvent";
 	name = "Auxiliary Vent Control";
 	pixel_x = -8;
 	pixel_y = -24;
-	req_access_txt = "12"
+	req_access = list(12)
 	},
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plasteel,
@@ -32911,7 +32889,7 @@
 	id = "mechbay";
 	name = "Mech Bay Shutters Control";
 	pixel_y = 24;
-	req_access_txt = "29"
+	req_access = list(29)
 	},
 /turf/simulated/floor/plasteel,
 /area/station/science/robotics/chargebay)
@@ -34508,7 +34486,7 @@
 	id = "Surgery 1";
 	pixel_x = -24;
 	pixel_y = -4;
-	req_access_txt = "45"
+	req_access = list(45)
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -35915,7 +35893,7 @@
 	dir = 1;
 	id = "BS";
 	pixel_y = -22;
-	req_access_txt = "67"
+	req_access = list(67)
 	},
 /turf/simulated/floor/carpet/blue,
 /area/station/command/office/blueshield)
@@ -37790,7 +37768,7 @@
 	id = "imnotmakingyoulubepissoff";
 	name = "Chemistry Privacy Shutter Control";
 	pixel_y = -24;
-	req_access_txt = "33"
+	req_access = list(33)
 	},
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
@@ -38910,7 +38888,7 @@
 "cMz" = (
 /obj/machinery/door/morgue{
 	name = "Relic Closet";
-	req_access_txt = "22"
+	req_access = list(22)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cult"
@@ -39212,7 +39190,7 @@
 	id = "XenoPens";
 	name = "Xenobiology Shutters";
 	pixel_x = 24;
-	req_access_txt = "55"
+	req_access = list(55)
 	},
 /obj/machinery/camera{
 	c_tag = "Xenobiology Lab - Central Port";
@@ -39417,7 +39395,7 @@
 "cOA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/secure_closet/bar{
-	req_access_txt = "25"
+	req_access = list(25)
 	},
 /obj/machinery/light_switch{
 	name = "north bump";
@@ -41507,7 +41485,7 @@
 	id = "Psych";
 	pixel_x = -24;
 	pixel_y = 8;
-	req_access_txt = "64"
+	req_access = list(64)
 	},
 /obj/machinery/light_switch{
 	dir = 4;
@@ -43561,7 +43539,7 @@
 /obj/structure/closet/crate/secure{
 	desc = "A secure crate containing various materials for building a customised test-site.";
 	name = "Test Site Materials Crate";
-	req_access_txt = "8"
+	req_access = list(8)
 	},
 /obj/item/target/alien,
 /obj/item/target/syndicate,
@@ -44087,9 +44065,9 @@
 /obj/machinery/button/windowtint{
 	pixel_x = 24;
 	id = "qm";
-	req_access_txt = "41";
 	dir = 8;
-	pixel_y = 5
+	pixel_y = 5;
+	req_access = list(41)
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/qm)
@@ -44377,7 +44355,7 @@
 	id = "evashutter";
 	name = "E.V.A. Storage Shutter Control";
 	pixel_y = 26;
-	req_access_txt = "19"
+	req_access = list(19)
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -44668,7 +44646,7 @@
 	pixel_x = -6;
 	pixel_y = 24;
 	range = 4;
-	req_access_txt = "63"
+	req_access = list(63)
 	},
 /obj/machinery/light_switch{
 	name = "custom placement";
@@ -44919,8 +44897,8 @@
 /obj/machinery/access_button{
 	autolink_id = "enginesm_btn_ext";
 	name = "Supermatter Access Button";
-	req_access_txt = "10";
-	pixel_x = 24
+	pixel_x = 24;
+	req_access = list(10)
 	},
 /obj/machinery/camera{
 	c_tag = "Engineering - Central";
@@ -45447,7 +45425,6 @@
 /obj/machinery/airlock_controller/air_cycler{
 	pixel_x = 9;
 	pixel_y = -25;
-	req_access_txt = null;
 	vent_link_id = "atmossouth_vent";
 	ext_door_link_id = "atmossouth_door_ext";
 	int_door_link_id = "atmossouth_door_int";
@@ -46267,7 +46244,7 @@
 	name = "Brig Lockdown";
 	pixel_x = -26;
 	pixel_y = 7;
-	req_access_txt = "2"
+	req_access = list(2)
 	},
 /obj/machinery/camera{
 	c_tag = "Warden's Office";
@@ -47187,8 +47164,8 @@
 /obj/machinery/access_button{
 	autolink_id = "atmossm_btn_ext";
 	name = "Atmospherics Access Button";
-	req_access_txt = "24";
-	pixel_x = 24
+	pixel_x = 24;
+	req_access = list(24)
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
 /turf/simulated/floor/plasteel{
@@ -50838,7 +50815,7 @@
 	name = "interior access button";
 	pixel_x = 25;
 	pixel_y = -7;
-	req_access_txt = "13"
+	req_access = list(13)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/plasteel{
@@ -51033,6 +51010,26 @@
 /obj/machinery/firealarm/directional/south,
 /turf/simulated/floor/plasteel,
 /area/station/security/main)
+"gvz" = (
+/obj/machinery/door_control{
+	id = "qm_warehouse";
+	name = "Warehouse Door Control";
+	pixel_x = -24;
+	req_access = list(31)
+	},
+/obj/structure/table,
+/obj/machinery/kitchen_machine/microwave{
+	pixel_y = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light_switch{
+	dir = 4;
+	name = "custom placement";
+	pixel_x = -24;
+	pixel_y = -8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/supply/warehouse)
 "gvJ" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -51959,7 +51956,7 @@
 	id = "xenobio7";
 	name = "Xenobio Pen 7 Blast Doors";
 	pixel_y = 4;
-	req_access_txt = "55"
+	req_access = list(55)
 	},
 /turf/simulated/floor/plasteel,
 /area/station/science/xenobiology)
@@ -52453,7 +52450,7 @@
 	id = "armory";
 	name = "Armory Shutter";
 	pixel_y = -24;
-	req_access_txt = "3"
+	req_access = list(3)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -54341,7 +54338,7 @@
 	id = "paramedic";
 	name = "Garage Door Control";
 	pixel_y = -24;
-	req_access_txt = "66"
+	req_access = list(66)
 	},
 /obj/effect/turf_decal/stripes/corner,
 /obj/structure/disposalpipe/junction/reversed{
@@ -54679,7 +54676,7 @@
 	name = "Service Shutter Control";
 	pixel_x = 24;
 	pixel_y = 24;
-	req_access_txt = "35"
+	req_access = list(35)
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -54698,7 +54695,7 @@
 	id = "xenobio8";
 	name = "Xenobio Pen 8 Blast Doors";
 	pixel_y = 4;
-	req_access_txt = "55"
+	req_access = list(55)
 	},
 /obj/item/reagent_containers/spray/cleaner{
 	pixel_x = 5
@@ -56430,7 +56427,7 @@
 	id = "xenobio6";
 	name = "Xenobio Pen 6 Blast Doors";
 	pixel_y = 1;
-	req_access_txt = "55"
+	req_access = list(55)
 	},
 /turf/simulated/floor/plasteel,
 /area/station/science/xenobiology)
@@ -57528,7 +57525,7 @@
 	name = "Xenobiology Access Button";
 	pixel_x = -3;
 	pixel_y = 26;
-	req_access_txt = "55"
+	req_access = list(55)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurplefull"
@@ -58289,7 +58286,7 @@
 	autolink_id = "xeno_btn_ext";
 	name = "Xenobiology Access Button";
 	pixel_y = -24;
-	req_access_txt = "55"
+	req_access = list(55)
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -59431,8 +59428,8 @@
 /obj/machinery/access_button{
 	autolink_id = "atmossm_btn_int";
 	name = "Atmospherics Access Button";
-	req_access_txt = "24";
-	pixel_x = -24
+	pixel_x = -24;
+	req_access = list(24)
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
 /turf/simulated/floor/plating,
@@ -59594,15 +59591,15 @@
 	id = "Magistrate";
 	pixel_x = -24;
 	pixel_y = 6;
-	req_access_txt = "74"
+	req_access = list(74)
 	},
 /obj/machinery/door_control{
 	id = "magistrateofficedoor";
 	name = "Office Door";
 	normaldoorcontrol = 1;
 	pixel_x = -25;
-	req_access_txt = "74";
-	pixel_y = -4
+	pixel_y = -4;
+	req_access = list(74)
 	},
 /turf/simulated/floor/carpet,
 /area/station/legal/magistrate)
@@ -61039,13 +61036,13 @@
 	normaldoorcontrol = 1;
 	pixel_x = 6;
 	pixel_y = 7;
-	req_access_txt = "63"
+	req_access = list(63)
 	},
 /obj/machinery/flasher_button{
 	id = "secentranceflasher";
 	name = "Brig Entrance Flash Control";
 	pixel_y = -3;
-	req_access_txt = "1"
+	req_access = list(1)
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/warden)
@@ -61154,7 +61151,7 @@
 	name = "Atmospherics Lockdown";
 	pixel_x = -4;
 	pixel_y = 24;
-	req_access_txt = "24"
+	req_access = list(24)
 	},
 /obj/machinery/light_switch{
 	name = "custom placement";
@@ -61268,7 +61265,7 @@
 	id = "xenobio4";
 	name = "Xenobio Pen 4 Blast Doors";
 	pixel_y = 4;
-	req_access_txt = "55"
+	req_access = list(55)
 	},
 /turf/simulated/floor/plasteel,
 /area/station/science/xenobiology)
@@ -62112,7 +62109,7 @@
 	id = "XenoPens";
 	name = "Xenobiology Shutters";
 	pixel_y = -24;
-	req_access_txt = "55"
+	req_access = list(55)
 	},
 /obj/item/book/manual/wiki/sop_science{
 	pixel_y = 4
@@ -62739,13 +62736,13 @@
 /area/station/hallway/secondary/bridge)
 "lnd" = (
 /obj/machinery/airlock_controller/air_cycler{
-	req_access_txt = "10;13";
 	vent_link_id = "engine_vent";
 	ext_door_link_id = "engine_door_ext";
 	int_door_link_id = "engine_door_int";
 	pixel_y = 24;
 	ext_button_link_id = "engine_btn_ext";
-	int_button_link_id = "engine_btn_int"
+	int_button_link_id = "engine_btn_int";
+	req_access = list(10,13)
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/control)
@@ -63516,7 +63513,7 @@
 	name = "interior access button";
 	pixel_x = -22;
 	pixel_y = 20;
-	req_access_txt = "10;13"
+	req_access = list(10,13)
 	},
 /obj/structure/lattice/catwalk,
 /turf/space,
@@ -64206,7 +64203,7 @@
 	id = "xenobio1";
 	name = "Xenobio Pen 1 Blast Doors";
 	pixel_y = 1;
-	req_access_txt = "55"
+	req_access = list(55)
 	},
 /turf/simulated/floor/plasteel,
 /area/station/science/xenobiology)
@@ -65605,7 +65602,7 @@
 	id = "CMO";
 	pixel_x = -7;
 	pixel_y = -24;
-	req_access_txt = "40"
+	req_access = list(40)
 	},
 /obj/machinery/keycard_auth{
 	pixel_x = 7;
@@ -67309,7 +67306,7 @@
 	name = "interior access button";
 	pixel_x = -22;
 	pixel_y = -20;
-	req_access_txt = "10;13"
+	req_access = list(10,13)
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
@@ -68226,7 +68223,7 @@
 	name = "Service Shutter Control";
 	pixel_x = -24;
 	pixel_y = -24;
-	req_access_txt = "28"
+	req_access = list(28)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
@@ -71892,7 +71889,7 @@
 	name = "interior access button";
 	pixel_x = 25;
 	pixel_y = -25;
-	req_access_txt = "13"
+	req_access = list(13)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -71978,11 +71975,11 @@
 	name = "Virology Lab Access Console";
 	pixel_x = 24;
 	pixel_y = -24;
-	req_one_access_txt = "39";
 	ext_door_link_id = "viro_door_ext";
 	int_door_link_id = "viro_door_int";
 	ext_button_link_id = "viro_btn_ext";
-	int_button_link_id = "viro_btn_int"
+	int_button_link_id = "viro_btn_int";
+	req_access = list(39)
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -74848,7 +74845,7 @@
 	id = "HoS";
 	pixel_x = -24;
 	pixel_y = 6;
-	req_access_txt = "58"
+	req_access = list(58)
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -75261,7 +75258,7 @@
 	id = "Surgery 2";
 	pixel_x = 24;
 	pixel_y = -4;
-	req_access_txt = "45"
+	req_access = list(45)
 	},
 /obj/machinery/holosign_switch{
 	dir = 8;
@@ -75657,7 +75654,7 @@
 	id = "xenobio3";
 	name = "Xenobio Pen 3 Blast Doors";
 	pixel_y = 4;
-	req_access_txt = "55"
+	req_access = list(55)
 	},
 /turf/simulated/floor/plasteel,
 /area/station/science/xenobiology)
@@ -75846,7 +75843,7 @@
 	name = "interrogation tint control";
 	pixel_x = -24;
 	pixel_y = 6;
-	req_access_txt = "63"
+	req_access = list(63)
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -78680,7 +78677,7 @@
 	id = "roboticsprivacy2";
 	name = "Robotics Shutters";
 	pixel_x = 24;
-	req_access_txt = "29"
+	req_access = list(29)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkgrey"
@@ -79608,7 +79605,7 @@
 	name = "AI Chamber Turret Control";
 	pixel_x = 5;
 	pixel_y = -24;
-	req_access_txt = "75"
+	req_access = list(75)
 	},
 /obj/machinery/flasher{
 	id = "AI";
@@ -80105,7 +80102,7 @@
 	name = "Robotics Privacy Control";
 	pixel_x = -26;
 	pixel_y = 26;
-	req_access_txt = "29"
+	req_access = list(29)
 	},
 /turf/simulated/floor/plasteel,
 /area/station/science/robotics)
@@ -80341,21 +80338,21 @@
 	name = "Justice Vent Control";
 	pixel_x = -26;
 	pixel_y = 25;
-	req_access_txt = "3"
+	req_access = list(3)
 	},
 /obj/machinery/door_control{
 	id = "executionfireblast";
 	name = "Justice Area Lockdown";
 	pixel_x = -38;
 	pixel_y = 25;
-	req_access_txt = "2"
+	req_access = list(2)
 	},
 /obj/machinery/ignition_switch{
 	id = "executionburn";
 	name = "Justice Ignition Switch";
 	pixel_x = -25;
 	pixel_y = 36;
-	req_access_txt = "1"
+	req_access = list(1)
 	},
 /obj/machinery/flasher_button{
 	id = "justiceflash";
@@ -81642,7 +81639,7 @@
 	name = "exterior access button";
 	pixel_x = 25;
 	pixel_y = -25;
-	req_access_txt = "13"
+	req_access = list(13)
 	},
 /turf/space,
 /area/space/nearstation)
@@ -82328,8 +82325,7 @@
 "tAF" = (
 /obj/machinery/computer/prisoner{
 	dir = 1;
-	req_access = null;
-	req_access_txt = "2"
+	req_access = list(2)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cult"
@@ -82874,7 +82870,7 @@
 	id = "IAA";
 	pixel_x = 24;
 	pixel_y = 8;
-	req_access_txt = "38"
+	req_access = list(38)
 	},
 /turf/simulated/floor/carpet,
 /area/station/legal/lawoffice)
@@ -85620,7 +85616,7 @@
 	name = "Chemistry Privacy Shutter Control";
 	pixel_x = 24;
 	pixel_y = 24;
-	req_access_txt = "33"
+	req_access = list(33)
 	},
 /obj/machinery/chem_master,
 /turf/simulated/floor/plasteel{
@@ -85836,7 +85832,7 @@
 	name = "interior access button";
 	pixel_x = -25;
 	pixel_y = -25;
-	req_access_txt = "13"
+	req_access = list(13)
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -85852,7 +85848,7 @@
 	name = "Toxins Access";
 	pixel_x = -27;
 	pixel_y = 8;
-	req_access_txt = "8"
+	req_access = list(8)
 	},
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plasteel,
@@ -86440,7 +86436,7 @@
 	name = "exterior access button";
 	pixel_x = -25;
 	pixel_y = 7;
-	req_access_txt = "24;13"
+	req_access = list(24,13)
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/atmos)
@@ -88785,8 +88781,7 @@
 "wAJ" = (
 /obj/machinery/computer/prisoner{
 	dir = 8;
-	req_access = null;
-	req_access_txt = "2"
+	req_access = list(2)
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -89676,7 +89671,7 @@
 	name = "Virology Lab Access Button";
 	pixel_x = 8;
 	pixel_y = -24;
-	req_access_txt = "39"
+	req_access = list(39)
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -89751,7 +89746,7 @@
 	name = "Special Containment Blast Doors";
 	pixel_x = 4;
 	pixel_y = -3;
-	req_access_txt = "55"
+	req_access = list(55)
 	},
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the special containment chamber.";
@@ -89942,8 +89937,8 @@
 /obj/machinery/access_button{
 	autolink_id = "enginesm_btn_int";
 	name = "Supermatter Access Button";
-	req_access_txt = "10";
-	pixel_x = 24
+	pixel_x = 24;
+	req_access = list(10)
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -91697,7 +91692,7 @@
 	name = "Research Shutters Control";
 	pixel_x = 24;
 	pixel_y = null;
-	req_access_txt = "7"
+	req_access = list(7)
 	},
 /obj/machinery/cell_charger,
 /turf/simulated/floor/plasteel{
@@ -91806,7 +91801,7 @@
 	name = "Experi-mentor shutters";
 	pixel_x = -25;
 	pixel_y = null;
-	req_access_txt = "7"
+	req_access = list(7)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -92002,8 +91997,8 @@
 /obj/machinery/access_button{
 	autolink_id = "enginesm_btn_ext";
 	name = "Supermatter Access Button";
-	req_access_txt = "10";
-	pixel_x = -24
+	pixel_x = -24;
+	req_access = list(10)
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -92228,7 +92223,7 @@
 	autolink_id = "viro_btn_ext";
 	name = "Virology Lab Access Button";
 	pixel_y = -24;
-	req_access_txt = "39"
+	req_access = list(39)
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -92285,7 +92280,7 @@
 	id = "teleshutter";
 	name = "Teleporter Shutters Access Control";
 	pixel_x = -24;
-	req_access_txt = "62"
+	req_access = list(62)
 	},
 /turf/simulated/floor/plasteel,
 /area/station/command/teleporter)
@@ -112394,7 +112389,7 @@ frx
 frx
 tWP
 aOB
-aPR
+gvz
 aWt
 gqF
 aTW

--- a/_maps/map_files/templates/shelter_2.dmm
+++ b/_maps/map_files/templates/shelter_2.dmm
@@ -123,8 +123,8 @@
 	alert = 0;
 	desc = "A display case containing an expensive forgery, probably.";
 	pixel_y = -4;
-	req_access_txt = "48";
-	start_showpiece_type = /obj/item/fakeartefact
+	start_showpiece_type = /obj/item/fakeartefact;
+	req_access = list(48)
 	},
 /turf/simulated/floor/carpet/black{
 	dir = 1

--- a/code/__DEFINES/access_defines.dm
+++ b/code/__DEFINES/access_defines.dm
@@ -88,3 +88,4 @@
 #define ACCESS_AWAY01					271	//! Access used for moonoutpost19 ruin.
 #define ACCESS_FREE_GOLEMS				300	//! Ghost role: free golems.
 #define ACCESS_THETA_STATION			301	//! Ghost role: Theta station.
+#define ACCESS_DEEPSTORAGE				512	//! Space ruin: Deep Storage

--- a/code/datums/status_effects/magic_disguise.dm
+++ b/code/datums/status_effects/magic_disguise.dm
@@ -44,7 +44,7 @@
 
 	caster_area = get_area(owner)
 	for(var/obj/machinery/door/airlock/tmp in view(owner))
-		if(get_area(tmp) == caster_area && !(tmp.req_access_txt == "0" && tmp.req_one_access_txt == "0")) //Ignore airlocks that arent in area or are public airlocks
+		if(get_area(tmp) == caster_area && (length(tmp.req_access) || length(tmp.req_one_access))) //Ignore airlocks that arent in area or are public airlocks
 			AL = tmp
 			break
 	for(var/mob/living/carbon/human/disguise_source in shuffle(GLOB.player_list)) //Pick a random crewmember with access to this room

--- a/code/game/area/areas/depot-areas.dm
+++ b/code/game/area/areas/depot-areas.dm
@@ -183,7 +183,7 @@
 		for(var/mob/living/simple_animal/hostile/syndicate/N in src)
 			N.a_intent = INTENT_HARM
 		for(var/obj/machinery/door/airlock/A in src)
-			A.req_access_txt = "[ACCESS_SYNDICATE_LEADER]"
+			A.req_access = list(ACCESS_SYNDICATE_LEADER)
 		for(var/obj/structure/closet/secure_closet/syndicate/depot/L in src)
 			if(L.locked)
 				L.locked = !L.locked

--- a/code/game/jobs/access.dm
+++ b/code/game/jobs/access.dm
@@ -15,26 +15,6 @@
 	else
 		return check_access_list(acc)
 
-/obj/proc/generate_req_lists()
-	//These generations have been moved out of /obj/New() because they were slowing down the creation of objects that never even used the access system.
-	if(!req_access)
-		req_access = list()
-		if(req_access_txt)
-			var/list/req_access_str = splittext(req_access_txt, ";")
-			for(var/x in req_access_str)
-				var/n = text2num(x)
-				if(n)
-					req_access += n
-
-	if(!req_one_access)
-		req_one_access = list()
-		if(req_one_access_txt)
-			var/list/req_one_access_str = splittext(req_one_access_txt,";")
-			for(var/x in req_one_access_str)
-				var/n = text2num(x)
-				if(n)
-					req_one_access += n
-
 /obj/proc/check_access(obj/item/I)
 	var/list/L
 	if(I)
@@ -44,8 +24,6 @@
 	return check_access_list(L)
 
 /obj/proc/check_access_list(list/L)
-	generate_req_lists()
-
 	if(!L)
 		return 0
 	if(!istype(L, /list))

--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -367,11 +367,11 @@
 
 /obj/machinery/door/airlock/hatch/syndicate
 	name = "syndicate hatch"
-	req_access_txt = "150"
+	req_access = list(ACCESS_SYNDICATE)
 
 /obj/machinery/door/airlock/hatch/syndicate/command
 	name = "Command Center"
-	req_access_txt = "153"
+	req_access = list(ACCESS_SYNDICATE_COMMAND)
 	explosion_block = 2
 	normal_integrity = 1000
 	security_level = 6
@@ -398,7 +398,7 @@
 
 /obj/machinery/door/airlock/hatch/syndicate/vault
 	name = "syndicate vault hatch"
-	req_access_txt = "151"
+	req_access = list(ACCESS_SYNDICATE)
 	icon = 'icons/obj/doors/airlocks/vault/vault.dmi'
 	overlays_file = 'icons/obj/doors/airlocks/vault/overlays.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_vault

--- a/code/game/machinery/vendors/contraband_vendors.dm
+++ b/code/game/machinery/vendors/contraband_vendors.dm
@@ -13,7 +13,7 @@
 					"Don't you want some?",
 					"Ping!")
 
-	req_access_txt = "150"
+	req_access = list(ACCESS_SYNDICATE)
 	products = list(/obj/item/stack/medical/bruise_pack = 2,
 					/obj/item/stack/medical/ointment = 2,
 					/obj/item/reagent_containers/syringe/charcoal = 4,
@@ -107,7 +107,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/economy/vending/wallmed/syndicate, 32
 	desc = "An overwhelming amount of <b>ancient patriotism</b> washes over you just by looking at the machine."
 	icon_state = "liberationstation"
 	icon_lightmask = "liberationstation"
-	req_access_txt = "1"
+	req_access = list(ACCESS_SECURITY)
 	slogan_list = list("Liberation Station: Your one-stop shop for all things second amendment!",
 					"Be a patriot today, pick up a gun!",
 					"Quality weapons for cheap prices!",

--- a/code/game/machinery/vendors/departmental_vendors.dm
+++ b/code/game/machinery/vendors/departmental_vendors.dm
@@ -5,7 +5,7 @@
 	icon_deny = "engivend_deny"
 	icon_panel = "generic"
 	category = VENDOR_TYPE_DEPARTMENTAL
-	req_one_access_txt = "11;24" // Engineers and atmos techs can use this
+	req_one_access = list(ACCESS_ENGINE_EQUIP, ACCESS_ATMOSPHERICS)
 	products = list(/obj/item/clothing/glasses/meson/engine = 2,
 					/obj/item/clothing/glasses/meson/engine/tray = 4,
 					/obj/item/multitool = 4,
@@ -28,7 +28,7 @@
 	icon_state = "engi"
 	icon_deny = "engi_deny"
 	category = VENDOR_TYPE_DEPARTMENTAL
-	req_access_txt = "11"
+	req_access = list(ACCESS_ENGINE_EQUIP)
 	products = list(/obj/item/clothing/under/rank/engineering/chief_engineer = 4,
 					/obj/item/clothing/under/rank/engineering/engineer = 40,
 					/obj/item/clothing/shoes/workboots = 4,
@@ -62,7 +62,7 @@
 	icon_deny = "robotics_deny"
 	category = VENDOR_TYPE_DEPARTMENTAL
 	icon_lightmask = "robotics"
-	req_access_txt = "29"
+	req_access = list(ACCESS_ROBOTICS)
 	products = list(/obj/item/clothing/suit/storage/labcoat = 4,
 					/obj/item/clothing/under/rank/rnd/roboticist = 4,
 					/obj/item/stack/cable_coil = 4, /obj/item/flash = 4,
@@ -252,7 +252,7 @@
 					"Don't you want some?",
 					"Ping!")
 
-	req_access_txt = "5"
+	req_access = list(ACCESS_MEDICAL)
 	category = VENDOR_TYPE_DEPARTMENTAL
 	products = list(/obj/item/reagent_containers/hypospray/autoinjector/epinephrine = 4,
 					/obj/item/stack/medical/bruise_pack/advanced = 2,
@@ -330,7 +330,7 @@
 	icon_deny = "sec_deny"
 	icon_panel = "wide_vendor"
 	category = VENDOR_TYPE_DEPARTMENTAL
-	req_access_txt = "1"
+	req_access = list(ACCESS_SECURITY)
 	products = list(/obj/item/restraints/handcuffs = 8,
 					/obj/item/restraints/handcuffs/cable/zipties = 8,
 					/obj/item/grenade/flashbang = 4,

--- a/code/game/objects/effects/spawners/airlock_spawner.dm
+++ b/code/game/objects/effects/spawners/airlock_spawner.dm
@@ -207,14 +207,10 @@ This spawner places pipe leading up to the interior door, you will need to finis
 		// Since airlocks are created first, we steal the payload logic
 		// to apply to the controls later
 		req_access = airlock.req_access
-		req_access_txt = airlock.req_access_txt
 		req_one_access = airlock.req_one_access
-		req_one_access_txt = airlock.req_one_access_txt
 	else
 		I.req_access = req_access
-		I.req_access_txt = req_access_txt
 		I.req_one_access = req_one_access
-		I.req_one_access_txt = req_one_access_txt
 
 // MARK: AIRLOCK HELPERS
 

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -34,10 +34,11 @@
 	var/emagged = FALSE
 
 	// Access-related fields
+
+	/// A list of accesses as defined by `code/__DEFINES/access_defines.dm`. All accesses are required when checking.
 	var/list/req_access = null
-	var/req_access_txt = "0"
+	/// A list of accesses as defined by `code/__DEFINES/access_defines.dm`. At least one access is required when checking.
 	var/list/req_one_access = null
-	var/req_one_access_txt = "0"
 
 /obj/Initialize(mapload)
 	. = ..()

--- a/code/modules/atmospherics/machinery/components/binary_devices/valve.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/valve.dm
@@ -10,7 +10,7 @@
 	var/open = FALSE
 	var/animating = FALSE
 
-	req_one_access_txt = "24;10"
+	req_one_access = list(ACCESS_ENGINE, ACCESS_ATMOSPHERICS)
 
 /obj/machinery/atmospherics/binary/valve/examine(mob/user)
 	. = ..()

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -545,7 +545,7 @@
 
 /obj/machinery/smartfridge/secure/circuits/aiupload/Initialize(mapload)
 	. = ..()
-	req_access_txt = "[ACCESS_AI_UPLOAD]"
+	req_access = list(ACCESS_AI_UPLOAD)
 	if(mapload && HAS_TRAIT(SSstation, STATION_TRAIT_UNIQUE_AI) && is_station_level(z))
 		drop_contents_on_delete = FALSE
 		return INITIALIZE_HINT_QDEL
@@ -564,7 +564,7 @@
 
 /obj/machinery/smartfridge/secure/circuits/aiupload/experimental/Initialize(mapload)
 	. = ..()
-	req_access_txt = "[ACCESS_RD]"
+	req_access = list(ACCESS_RD)
 
 /obj/machinery/smartfridge/secure/circuits/aiupload/highrisk
 	name = "\improper High-Risk Laws Storage"
@@ -580,7 +580,7 @@
 
 /obj/machinery/smartfridge/secure/circuits/aiupload/highrisk/Initialize(mapload)
 	. = ..()
-	req_access_txt = "[ACCESS_CAPTAIN]"
+	req_access = list(ACCESS_CAPTAIN)
 
 /**
   * # Refrigerated Medicine Storage
@@ -617,7 +617,7 @@
 
 /obj/machinery/smartfridge/secure/extract/Initialize(mapload)
 	. = ..()
-	req_access_txt = "[ACCESS_RESEARCH]"
+	req_access = list(ACCESS_RESEARCH)
 	accepted_items_typecache = typecacheof(list(
 		/obj/item/slime_extract
 	))
@@ -631,7 +631,7 @@
 	name = "\improper Secure Refrigerated Medicine Storage"
 	desc = "A refrigerated storage unit for storing medicine and chemicals."
 	icon_state = "smartfridge" //To fix the icon in the map editor.
-	req_one_access_txt = "5;33"
+	req_one_access = list(ACCESS_MEDICAL, ACCESS_CHEMISTRY)
 	board_type = /obj/machinery/smartfridge/secure/medbay
 
 /obj/machinery/smartfridge/secure/medbay/Initialize(mapload)
@@ -659,7 +659,7 @@
 
 /obj/machinery/smartfridge/secure/chemistry/Initialize(mapload)
 	. = ..()
-	req_access_txt = "[ACCESS_CHEMISTRY]"
+	req_access = list(ACCESS_CHEMISTRY)
 	// Accepted items
 	accepted_items_typecache = typecacheof(list(
 		/obj/item/storage/pill_bottle,
@@ -689,10 +689,6 @@
   * A [Smart Chemical Storage (Preloaded)][/obj/machinery/smartfridge/secure/chemistry/preloaded] but with exclusive access to Syndicate.
   */
 /obj/machinery/smartfridge/secure/chemistry/preloaded/syndicate
-	req_access_txt = null
-
-/obj/machinery/smartfridge/secure/chemistry/preloaded/syndicate/Initialize(mapload)
-	. = ..()
 	req_access = list(ACCESS_SYNDICATE)
 
 /**
@@ -755,10 +751,10 @@
 	desc = "A refrigerated storage unit for volatile sample storage."
 	board_type = /obj/machinery/smartfridge/secure/chemistry/virology
 	icon_addon = "smartfridge_virology"
+	req_access = list(ACCESS_VIROLOGY)
 
 /obj/machinery/smartfridge/secure/chemistry/virology/Initialize(mapload)
 	. = ..()
-	req_access_txt = "[ACCESS_VIROLOGY]"
 	accepted_items_typecache = typecacheof(list(
 		/obj/item/reagent_containers/syringe,
 		/obj/item/reagent_containers/glass/bottle,
@@ -791,7 +787,7 @@
   * A [Smart Virus Storage (Preloaded)][/obj/machinery/smartfridge/secure/chemistry/virology/preloaded] but with exclusive access to Syndicate.
   */
 /obj/machinery/smartfridge/secure/chemistry/virology/preloaded/syndicate
-	req_access_txt = null
+	req_access = list(ACCESS_SYNDICATE)
 
 /obj/machinery/smartfridge/secure/chemistry/virology/preloaded/syndicate/Initialize(mapload)
 	starting_items = list(
@@ -804,7 +800,6 @@
 		/obj/item/reagent_containers/glass/bottle/reagent/formaldehyde = 1
 	)
 	. = ..()
-	req_access = list(ACCESS_SYNDICATE)
 
 /**
   * # Drink Showcase

--- a/code/modules/mapping/access_helpers.dm
+++ b/code/modules/mapping/access_helpers.dm
@@ -8,26 +8,23 @@
 	if(is_type_in_list(airlock, blacklist))
 		return
 
-	if(airlock.req_access_txt == "0")
-		// Overwrite if there is no access set, otherwise add onto existing access
-		if(airlock.req_one_access_txt == "0")
-			airlock.req_one_access_txt = "[access]"
-		else
-			airlock.req_one_access_txt += ";[access]"
-	else
+	if(length(airlock.req_access))
 		log_world("[src] at [AREACOORD(src)] tried to set req_one_access, but req_access was already set!")
+		return
+
+	LAZYINITLIST(airlock.req_one_access)
+	airlock.req_one_access |= access
 
 /obj/effect/mapping_helpers/airlock/access/all/payload(obj/machinery/door/airlock/airlock)
 	if(is_type_in_list(airlock, blacklist))
 		return
 
-	if(airlock.req_one_access_txt == "0")
-		if(airlock.req_access_txt == "0")
-			airlock.req_access_txt = "[access]"
-		else
-			airlock.req_access_txt += ";[access]"
-	else
+	if(length(airlock.req_one_access))
 		log_world("[src] at [AREACOORD(src)] tried to set req_access, but req_one_access was already set!")
+		return
+
+	LAZYINITLIST(airlock.req_access)
+	airlock.req_access |= access
 
 // -------------------- Req Any (Only requires ONE of the given accesses to open)
 // -------------------- Command access helpers
@@ -467,3 +464,38 @@
 
 /obj/effect/mapping_helpers/airlock/access/all/supply/mule_bot
 	access = ACCESS_CARGO_BOT
+
+// Miscellaneous access helpers
+
+/obj/effect/mapping_helpers/airlock/access/all/ruins/deepstorage
+	access = ACCESS_DEEPSTORAGE
+
+/obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19
+	access = ACCESS_AWAY01
+
+/obj/effect/mapping_helpers/airlock/access/all/ruins/theta
+	access = ACCESS_THETA_STATION
+
+/obj/effect/mapping_helpers/airlock/access/all/syndicate
+	access = ACCESS_SYNDICATE
+
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/general
+	access = ACCESS_CENT_GENERAL
+
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/security
+	access = ACCESS_CENT_SECURITY
+
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/shuttles
+	access = ACCESS_CENT_SHUTTLES
+
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/specops
+	access = ACCESS_CENT_SPECOPS
+
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/commander
+	access = ACCESS_CENT_COMMANDER
+
+/obj/effect/mapping_helpers/airlock/access/all/shuttles/vox
+	access = ACCESS_VOX
+
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders
+	access = ACCESS_TRADE_SOL

--- a/code/modules/mapping/windoor_access_helpers.dm
+++ b/code/modules/mapping/windoor_access_helpers.dm
@@ -11,30 +11,23 @@
 		return
 
 	// Access already set in map edit
-	if(windoor.req_access_txt != "0")
+	if(length(windoor.req_access))
 		log_world("[src] at [AREACOORD(src)] tried to set req_one_access, but req_access was already set!")
 		return
 
-	// Overwrite if there is no access set, otherwise add onto existing access
-	if(windoor.req_one_access_txt == "0")
-		windoor.req_one_access_txt = "[access]"
-		return
-
-	windoor.req_one_access_txt += ";[access]"
+	LAZYINITLIST(windoor.req_one_access)
+	windoor.req_one_access |= access
 
 /obj/effect/mapping_helpers/airlock/windoor/access/all/payload(obj/machinery/door/window/windoor)
 	if(windoor.dir != dir)
 		return
 
-	if(windoor.req_one_access_txt != "0")
+	if(length(windoor.req_one_access))
 		log_world("[src] at [AREACOORD(src)] tried to set req_access, but req_one_access was already set!")
 		return
 
-	if(windoor.req_access_txt == "0")
-		windoor.req_access_txt = "[access]"
-		return
-
-	windoor.req_access_txt += ";[access]"
+	LAZYINITLIST(windoor.req_access)
+	windoor.req_access |= access
 
 // -------------------- Req Any (Only requires ONE of the given accesses to open)
 // -------------------- Command access helpers

--- a/tools/UpdatePaths/Scripts/XXXXX_req_access_refactor.txt
+++ b/tools/UpdatePaths/Scripts/XXXXX_req_access_refactor.txt
@@ -1,0 +1,96 @@
+/obj/machinery/door/airlock/@SUBTYPES{req_access_txt="101"} : /obj/effect/mapping_helpers/airlock/access/all/centcomm/general, /obj/machinery/door/airlock/@SUBTYPES{@OLD;req_access_txt=@SKIP}
+/obj/machinery/door/airlock/@SUBTYPES{req_access_txt="104"} : /obj/effect/mapping_helpers/airlock/access/all/centcomm/security, /obj/machinery/door/airlock/@SUBTYPES{@OLD;req_access_txt=@SKIP}
+/obj/machinery/door/airlock/@SUBTYPES{req_access_txt="106"} : /obj/effect/mapping_helpers/airlock/access/all/centcomm/shuttles, /obj/machinery/door/airlock/@SUBTYPES{@OLD;req_access_txt=@SKIP}
+/obj/machinery/door/airlock/@SUBTYPES{req_access_txt="109"} : /obj/effect/mapping_helpers/airlock/access/all/centcomm/specops, /obj/machinery/door/airlock/@SUBTYPES{@OLD;req_access_txt=@SKIP}
+/obj/machinery/door/airlock/@SUBTYPES{req_access_txt="114"} : /obj/effect/mapping_helpers/airlock/access/all/centcomm/commander, /obj/machinery/door/airlock/@SUBTYPES{@OLD;req_access_txt=@SKIP}
+/obj/machinery/door/airlock/@SUBTYPES{req_access_txt="48"} : /obj/effect/mapping_helpers/airlock/access/all/supply/mining, /obj/machinery/door/airlock/@SUBTYPES{@OLD;req_access_txt=@SKIP}
+/obj/machinery/door/airlock/@SUBTYPES{req_access_txt="61"} : /obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms, /obj/machinery/door/airlock/@SUBTYPES{@OLD;req_access_txt=@SKIP}
+/obj/machinery/door/airlock/@SUBTYPES{req_access_txt="150"} : /obj/effect/mapping_helpers/airlock/access/all/syndicate, /obj/machinery/door/airlock/@SUBTYPES{@OLD;req_access_txt=@SKIP}
+/obj/machinery/door/airlock/@SUBTYPES{req_access_txt="152"} : /obj/effect/mapping_helpers/airlock/access/all/shuttles/vox, /obj/machinery/door/airlock/@SUBTYPES{@OLD;req_access_txt=@SKIP}
+/obj/machinery/door/airlock/@SUBTYPES{req_access_txt="160"} : /obj/effect/mapping_helpers/airlock/access/all/centcomm/traders, /obj/machinery/door/airlock/@SUBTYPES{@OLD;req_access_txt=@SKIP}
+/obj/machinery/door/airlock/@SUBTYPES{req_access_txt="271"} : /obj/effect/mapping_helpers/airlock/access/all/ruins/moonoutpost19, /obj/machinery/door/airlock/@SUBTYPES{@OLD;req_access_txt=@SKIP}
+/obj/machinery/door/airlock/@SUBTYPES{req_access_txt="301"} : /obj/effect/mapping_helpers/airlock/access/all/ruins/theta, /obj/machinery/door/airlock/@SUBTYPES{@OLD;req_access_txt=@SKIP}
+/obj/machinery/door/airlock/@SUBTYPES{req_access_txt="512"} : /obj/effect/mapping_helpers/airlock/access/all/ruins/deepstorage, /obj/machinery/door/airlock/@SUBTYPES{@OLD;req_access_txt=@SKIP}
+/obj/machinery/door/airlock/@SUBTYPES{req_one_access_txt="301"} : /obj/effect/mapping_helpers/airlock/access/all/ruins/theta, /obj/machinery/door/airlock/@SUBTYPES{@OLD;req_one_access_txt=@SKIP}
+
+/obj/@SUBTYPES{req_access_txt="0"} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP}
+/obj/@SUBTYPES{req_access_txt="1"} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP;req_access=list(1)}
+/obj/@SUBTYPES{req_access_txt="10;11"} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP;req_access=list(10,11)}
+/obj/@SUBTYPES{req_access_txt="10;13"} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP;req_access=list(10,13)}
+/obj/@SUBTYPES{req_access_txt="10"} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP;req_access=list(10)}
+/obj/@SUBTYPES{req_access_txt="101"} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP;req_access=list(101)}
+/obj/@SUBTYPES{req_access_txt="102"} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP;req_access=list(102)}
+/obj/@SUBTYPES{req_access_txt="104"} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP;req_access=list(104)}
+/obj/@SUBTYPES{req_access_txt="109"} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP;req_access=list(109)}
+/obj/@SUBTYPES{req_access_txt="11"} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP;req_access=list(11)}
+/obj/@SUBTYPES{req_access_txt="114"} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP;req_access=list(114)}
+/obj/@SUBTYPES{req_access_txt="12"} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP;req_access=list(12)}
+/obj/@SUBTYPES{req_access_txt="13"} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP;req_access=list(13)}
+/obj/@SUBTYPES{req_access_txt="150"} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP;req_access=list(150)}
+/obj/@SUBTYPES{req_access_txt="151"} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP;req_access=list(151)}
+/obj/@SUBTYPES{req_access_txt="152"} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP;req_access=list(152)}
+/obj/@SUBTYPES{req_access_txt="153"} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP;req_access=list(153)}
+/obj/@SUBTYPES{req_access_txt="160"} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP;req_access=list(160)}
+/obj/@SUBTYPES{req_access_txt="17;75"} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP;req_access=list(17,75)}
+/obj/@SUBTYPES{req_access_txt="17"} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP;req_access=list(17)}
+/obj/@SUBTYPES{req_access_txt="19"} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP;req_access=list(19)}
+/obj/@SUBTYPES{req_access_txt="2"} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP;req_access=list(2)}
+/obj/@SUBTYPES{req_access_txt="22"} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP;req_access=list(22)}
+/obj/@SUBTYPES{req_access_txt="24;13"} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP;req_access=list(24,13)}
+/obj/@SUBTYPES{req_access_txt="24"} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP;req_access=list(24)}
+/obj/@SUBTYPES{req_access_txt="25"} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP;req_access=list(25)}
+/obj/@SUBTYPES{req_access_txt="26"} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP;req_access=list(26)}
+/obj/@SUBTYPES{req_access_txt="271"} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP;req_access=list(271)}
+/obj/@SUBTYPES{req_access_txt="28"} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP;req_access=list(28)}
+/obj/@SUBTYPES{req_access_txt="29"} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP;req_access=list(29)}
+/obj/@SUBTYPES{req_access_txt="3"} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP;req_access=list(3)}
+/obj/@SUBTYPES{req_access_txt="30"} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP;req_access=list(30)}
+/obj/@SUBTYPES{req_access_txt="31"} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP;req_access=list(31)}
+/obj/@SUBTYPES{req_access_txt="32"} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP;req_access=list(32)}
+/obj/@SUBTYPES{req_access_txt="33"} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP;req_access=list(33)}
+/obj/@SUBTYPES{req_access_txt="35"} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP;req_access=list(35)}
+/obj/@SUBTYPES{req_access_txt="37"} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP;req_access=list(37)}
+/obj/@SUBTYPES{req_access_txt="38"} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP;req_access=list(38)}
+/obj/@SUBTYPES{req_access_txt="39"} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP;req_access=list(39)}
+/obj/@SUBTYPES{req_access_txt="4"} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP;req_access=list(4)}
+/obj/@SUBTYPES{req_access_txt="40"} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP;req_access=list(40)}
+/obj/@SUBTYPES{req_access_txt="41"} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP;req_access=list(41)}
+/obj/@SUBTYPES{req_access_txt="45"} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP;req_access=list(45)}
+/obj/@SUBTYPES{req_access_txt="47"} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP;req_access=list(47)}
+/obj/@SUBTYPES{req_access_txt="48"} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP;req_access=list(48)}
+/obj/@SUBTYPES{req_access_txt="54"} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP;req_access=list(54)}
+/obj/@SUBTYPES{req_access_txt="55"} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP;req_access=list(55)}
+/obj/@SUBTYPES{req_access_txt="56"} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP;req_access=list(56)}
+/obj/@SUBTYPES{req_access_txt="57"} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP;req_access=list(57)}
+/obj/@SUBTYPES{req_access_txt="58"} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP;req_access=list(58)}
+/obj/@SUBTYPES{req_access_txt="62"} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP;req_access=list(62)}
+/obj/@SUBTYPES{req_access_txt="63"} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP;req_access=list(63)}
+/obj/@SUBTYPES{req_access_txt="64"} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP;req_access=list(64)}
+/obj/@SUBTYPES{req_access_txt="66"} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP;req_access=list(66)}
+/obj/@SUBTYPES{req_access_txt="67"} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP;req_access=list(67)}
+/obj/@SUBTYPES{req_access_txt="7"} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP;req_access=list(7)}
+/obj/@SUBTYPES{req_access_txt="73"} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP;req_access=list(73)}
+/obj/@SUBTYPES{req_access_txt="74"} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP;req_access=list(74)}
+/obj/@SUBTYPES{req_access_txt="75;13"} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP;req_access=list(75,13)}
+/obj/@SUBTYPES{req_access_txt="75"} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP;req_access=list(75)}
+/obj/@SUBTYPES{req_access_txt="8"} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP;req_access=list(8)}
+/obj/@SUBTYPES{req_access_txt=null} : /obj/@SUBTYPES{@OLD;req_access_txt=@SKIP}
+/obj/@SUBTYPES{req_access="0"} : /obj/@SUBTYPES{@OLD;req_access=@SKIP}
+/obj/@SUBTYPES{req_one_access_txt="150"} : /obj/@SUBTYPES{@OLD;req_one_access_txt=@SKIP;req_access=list(150)}
+/obj/@SUBTYPES{req_one_access_txt="150"} : /obj/@SUBTYPES{@OLD;req_one_access_txt=@SKIP;req_access=list(150)}
+/obj/@SUBTYPES{req_one_access_txt="152"} : /obj/@SUBTYPES{@OLD;req_one_access_txt=@SKIP;req_access=list(152)}
+/obj/@SUBTYPES{req_one_access_txt="152"} : /obj/@SUBTYPES{@OLD;req_one_access_txt=@SKIP;req_access=list(152)}
+/obj/@SUBTYPES{req_one_access_txt="17;75"} : /obj/@SUBTYPES{@OLD;req_one_access_txt=@SKIP;req_one_access=list(17,75)}
+/obj/@SUBTYPES{req_one_access_txt="18"} : /obj/@SUBTYPES{@OLD;req_one_access_txt=@SKIP;req_access=list(18)}
+/obj/@SUBTYPES{req_one_access_txt="19;14"} : /obj/@SUBTYPES{@OLD;req_one_access_txt=@SKIP;req_one_access=list(19,14)}
+/obj/@SUBTYPES{req_one_access_txt="19;41"} : /obj/@SUBTYPES{@OLD;req_one_access_txt=@SKIP;req_one_access=list(19,41)}
+/obj/@SUBTYPES{req_one_access_txt="19"} : /obj/@SUBTYPES{@OLD;req_one_access_txt=@SKIP;req_access=list(19)}
+/obj/@SUBTYPES{req_one_access_txt="2"} : /obj/@SUBTYPES{@OLD;req_one_access_txt=@SKIP;req_access=list(2)}
+/obj/@SUBTYPES{req_one_access_txt="20"} : /obj/@SUBTYPES{@OLD;req_one_access_txt=@SKIP;req_access=list(20)}
+/obj/@SUBTYPES{req_one_access_txt="28;35"} : /obj/@SUBTYPES{@OLD;req_one_access_txt=@SKIP;req_one_access=list(28,35)}
+/obj/@SUBTYPES{req_one_access_txt="33;41"} : /obj/@SUBTYPES{@OLD;req_one_access_txt=@SKIP;req_one_access=list(33,41)}
+/obj/@SUBTYPES{req_one_access_txt="39"} : /obj/@SUBTYPES{@OLD;req_one_access_txt=@SKIP;req_access=list(39)}
+/obj/@SUBTYPES{req_one_access_txt="57"} : /obj/@SUBTYPES{@OLD;req_one_access_txt=@SKIP;req_access=list(57)}
+/obj/@SUBTYPES{req_one_access_txt="62"} : /obj/@SUBTYPES{@OLD;req_one_access_txt=@SKIP;req_access=list(62)}
+/obj/@SUBTYPES{req_one_access_txt="74;3"} : /obj/@SUBTYPES{@OLD;req_one_access_txt=@SKIP;req_one_access=list(74,3)}
+/obj/@SUBTYPES{req_one_access_txt="75"} : /obj/@SUBTYPES{@OLD;req_one_access_txt=@SKIP;req_access=list(75)}

--- a/tools/UpdatePaths/__main__.py
+++ b/tools/UpdatePaths/__main__.py
@@ -32,6 +32,10 @@ Old paths properties:
 default_map_directory = "../../_maps"
 replacement_re = re.compile(r'\s*(?P<path>[^{]*)\s*(\{(?P<props>.*)\})?')
 
+# Specifically for separating out new paths once split from the line
+# This was originally done by splitting on commas but that's not great
+new_paths_re = re.compile(r'(?:\/[@\w]+)+\/?(?:{.*?})?')
+
 #urgent todo: replace with actual parser, this is slow as janitor in crit
 split_re = re.compile(r'((?:[A-Za-z0-9_\-$]+)\s*=\s*(?:"(?:.+?)"|[^";][^;]*)|@OLD);?')
 
@@ -68,8 +72,8 @@ def update_path(dmm_data, replacement_string, verbose=False):
     old_path_part, new_path_part = replacement_string.split(':', maxsplit=1)
     old_path, old_path_props = parse_rep_string(old_path_part, verbose)
     new_paths = list()
-    for replacement_def in new_path_part.split(','):
-        new_path, new_path_props = parse_rep_string(replacement_def, verbose)
+    for match in new_paths_re.finditer(new_path_part):
+        new_path, new_path_props = parse_rep_string(match.group(), verbose)
         new_paths.append((new_path, new_path_props))
 
     subtypes = ""

--- a/tools/maplint/lints/airlock_spawner_varedits.yml
+++ b/tools/maplint/lints/airlock_spawner_varedits.yml
@@ -1,7 +1,5 @@
-help: "Please use access helpers for airlock spawners, placed one tile north and east of the spawner itself."
+help: 'Please use access helpers for airlock spawners, placed one tile north and east of the spawner itself.'
 /obj/effect/spawner/airlock:
   banned_variables:
-  - req_access
-  - req_access_txt
-  - req_one_access
-  - req_one_access_txt
+    - req_access
+    - req_one_access


### PR DESCRIPTION
## What Does This PR Do
This PR eliminates the `req_access_txt` and `req_one_access_txt` fields, relying solely on their list equivalents for all uses. It adds several mapping helpers for Z-1 airlocks. It makes a change to UpdatePaths to properly deal with replacements that have commas in them. It provides an UpdatePaths script to fix all maps for this change, and applies it.

## Why It's Good For The Game
Two less fields on every single object. There was a bunch of places where the logic for access would check e.g. the text field but not the list. To be balanced: the way check_access would work was it wouldn't instantiate these lists until it actually needed to for a given object. With this implementation, these lists are always created, but I suspect it's a wash overall, since most airlocks on station will be bumped into at some point during a round, and there's not too many objects relying on these lists off-station for it to be a serious memory concern.

## Testing
In progress.

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog
NPFC
