### PR TITLE
The amplified drill actually heals IPCs for more than just stamina damage

### DIFF
--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -730,7 +730,7 @@
 			owner.remove_status_effect(STATUS_EFFECT_DRILL_PAYBACK)
 			return
 	if(owner.stat != DEAD)
-		var/mob/living/carbon/human/H
+		var/mob/living/carbon/human/H = owner // The Brute and Burn heal doesn't work if it doesn't do it at the human level
 		H.adjustBruteLoss(-3, FALSE, robotic = TRUE)
 		H.adjustFireLoss(-3, FALSE, robotic = TRUE)
 		owner.adjustStaminaLoss(-25)

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -722,7 +722,7 @@
 	owner.clear_fullscreen("payback")
 	owner.overlay_fullscreen("payback", /atom/movable/screen/fullscreen/stretch/payback, 1)
 
-/datum/status_effect/drill_payback/tick() //They are not staying down. This will be a fight.
+/datum/status_effect/drill_payback/tick(mob/living/carbon/human/H) //They are not staying down. This will be a fight.
 	if(!drilled_successfully && (get_dist(owner, drilled) >= 9)) //We don't want someone drilling the safe at arivals then raiding bridge with the buff
 		to_chat(owner, "<span class='userdanger'>Get back to the safe, they are going to get the drill!</span>")
 		times_warned++
@@ -730,8 +730,8 @@
 			owner.remove_status_effect(STATUS_EFFECT_DRILL_PAYBACK)
 			return
 	if(owner.stat != DEAD)
-		owner.adjustBruteLoss(-3, robotic = TRUE)
-		owner.adjustFireLoss(-3, robotic = TRUE)
+		H.adjustBruteLoss(-3, robotic = TRUE)
+		H.adjustFireLoss(-3, robotic = TRUE)
 		owner.adjustStaminaLoss(-25)
 
 /datum/status_effect/drill_payback/on_remove()

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -722,7 +722,7 @@
 	owner.clear_fullscreen("payback")
 	owner.overlay_fullscreen("payback", /atom/movable/screen/fullscreen/stretch/payback, 1)
 
-/datum/status_effect/drill_payback/tick(mob/living/carbon/human/H) //They are not staying down. This will be a fight.
+/datum/status_effect/drill_payback/tick() //They are not staying down. This will be a fight.
 	if(!drilled_successfully && (get_dist(owner, drilled) >= 9)) //We don't want someone drilling the safe at arivals then raiding bridge with the buff
 		to_chat(owner, "<span class='userdanger'>Get back to the safe, they are going to get the drill!</span>")
 		times_warned++
@@ -730,8 +730,9 @@
 			owner.remove_status_effect(STATUS_EFFECT_DRILL_PAYBACK)
 			return
 	if(owner.stat != DEAD)
-		H.adjustBruteLoss(-3, robotic = TRUE)
-		H.adjustFireLoss(-3, robotic = TRUE)
+		var/mob/living/carbon/human/H
+		H.adjustBruteLoss(-3, FALSE, robotic = TRUE)
+		H.adjustFireLoss(-3, FALSE, robotic = TRUE)
 		owner.adjustStaminaLoss(-25)
 
 /datum/status_effect/drill_payback/on_remove()

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -730,8 +730,8 @@
 			owner.remove_status_effect(STATUS_EFFECT_DRILL_PAYBACK)
 			return
 	if(owner.stat != DEAD)
-		owner.adjustBruteLoss(-3)
-		owner.adjustFireLoss(-3)
+		owner.adjustBruteLoss(-3, robotic = TRUE)
+		owner.adjustFireLoss(-3, robotic = TRUE)
 		owner.adjustStaminaLoss(-25)
 
 /datum/status_effect/drill_payback/on_remove()

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -722,8 +722,8 @@
 	owner.clear_fullscreen("payback")
 	owner.overlay_fullscreen("payback", /atom/movable/screen/fullscreen/stretch/payback, 1)
 
-/datum/status_effect/drill_payback/tick() //They are not staying down. This will be a fight.
-	if(!drilled_successfully && (get_dist(owner, drilled) >= 9)) //We don't want someone drilling the safe at arivals then raiding bridge with the buff
+/datum/status_effect/drill_payback/tick() // They are not staying down. This will be a fight.
+	if(!drilled_successfully && (get_dist(owner, drilled) >= 9)) // We don't want someone drilling the safe at arrivals then raiding bridge with the buff
 		to_chat(owner, "<span class='userdanger'>Get back to the safe, they are going to get the drill!</span>")
 		times_warned++
 		if(times_warned >= 6)


### PR DESCRIPTION
## What Does This PR Do

Makes it so the drill can actually heal the brute and burn of IPCs too.

## Why It's Good For The Game

Fixing oversights is good, it's an antag item healing.

## Testing

Spawned as a Drask tot Assistant, spawned Payday bundle, opened Vault with C4, aghosted and went back to lobby to then spawn as a Drask HoS, moved HoS just out of sight of the Vault interior, aghosted then controlled Assistant, used drill on safe, walked out enough to spot HoS, got payback effect, dealt brute burn and stamina damage, saw damage got healed, removed drill from safe.

Aghosted and went back to lobby to then spawn as an IPC tot Assistant, spawned Payday bundle, used drill on safe in Vault, walked out enough to spot HoS, got payback effect, dealt brute burn and stamina damage, saw damage got healed.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <hr>

## Changelog

:cl:
fix: Fixed the drill payback buff to properly function with IPCs too
/:cl: