### PR TITLE
[REFACTOR] Helper proc for unbuckling a mob

### DIFF
--- a/code/datums/components/zombie_regen.dm
+++ b/code/datums/components/zombie_regen.dm
@@ -82,7 +82,7 @@
 	zomboid.suiciding = 0
 	zomboid.set_nutrition(max(zomboid.nutrition, NUTRITION_LEVEL_HUNGRY))
 	if(zomboid.buckled) //Unbuckle the mob and clear the alerts.
-		zomboid.unbuckle_self(force = TRUE)
+		zomboid.unbuckle(force = TRUE)
 
 	var/datum/organ/heart/heart = zomboid.get_int_organ_datum(ORGAN_DATUM_HEART)
 	var/heart_type = zomboid.dna?.species?.has_organ["heart"]

--- a/code/datums/components/zombie_regen.dm
+++ b/code/datums/components/zombie_regen.dm
@@ -82,7 +82,7 @@
 	zomboid.suiciding = 0
 	zomboid.set_nutrition(max(zomboid.nutrition, NUTRITION_LEVEL_HUNGRY))
 	if(zomboid.buckled) //Unbuckle the mob and clear the alerts.
-		zomboid.buckled.unbuckle_mob(src, force = TRUE)
+		zomboid.unbuckle_self(force = TRUE)
 
 	var/datum/organ/heart/heart = zomboid.get_int_organ_datum(ORGAN_DATUM_HEART)
 	var/heart_type = zomboid.dna?.species?.has_organ["heart"]

--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -140,7 +140,7 @@
 		destturf = safepick(posturfs)
 	else
 		destturf = get_turf(destination)
-	
+
 	// Make sure the target tile does not contain a teleporter on it
 	for(var/teleporter_type in blacklisted)
 		var/teleporters = destturf.search_contents_for(teleporter_type)
@@ -167,7 +167,7 @@
 	if(isliving(teleatom))
 		var/mob/living/target_mob = teleatom
 		if(target_mob.buckled)
-			target_mob.buckled.unbuckle_mob(target_mob, force = TRUE)
+			target_mob.unbuckle_self(force = TRUE)
 		if(target_mob.has_buckled_mobs())
 			target_mob.unbuckle_all_mobs(force = TRUE)
 		if(ismachinery(target_mob.loc) || istype(target_mob.loc, /obj/item/mecha_parts/mecha_equipment/medical/sleeper))

--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -167,7 +167,7 @@
 	if(isliving(teleatom))
 		var/mob/living/target_mob = teleatom
 		if(target_mob.buckled)
-			target_mob.unbuckle_self(force = TRUE)
+			target_mob.unbuckle(force = TRUE)
 		if(target_mob.has_buckled_mobs())
 			target_mob.unbuckle_all_mobs(force = TRUE)
 		if(ismachinery(target_mob.loc) || istype(target_mob.loc, /obj/item/mecha_parts/mecha_equipment/medical/sleeper))

--- a/code/datums/spells/area_teleport.dm
+++ b/code/datums/spells/area_teleport.dm
@@ -54,7 +54,7 @@
 			return
 
 		if(target && target.buckled)
-			target.buckled.unbuckle_mob(target, force = TRUE)
+			target.unbuckle_self(force = TRUE)
 
 		if(target && target.has_buckled_mobs())
 			target.unbuckle_all_mobs(force = TRUE)

--- a/code/datums/spells/area_teleport.dm
+++ b/code/datums/spells/area_teleport.dm
@@ -54,7 +54,7 @@
 			return
 
 		if(target && target.buckled)
-			target.unbuckle_self(force = TRUE)
+			target.unbuckle(force = TRUE)
 
 		if(target && target.has_buckled_mobs())
 			target.unbuckle_all_mobs(force = TRUE)

--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -165,7 +165,7 @@
 
 	// No cheesing with buckling ourselves, this spinning is too fast for seatbelts
 	if(user.buckled)
-		user.buckled.unbuckle_mob(user, force = TRUE)
+		user.unbuckle_self(force = TRUE)
 
 	// Check if the machine and the user are still next to each other
 	if(!do_after(user, delay = 1.2 SECONDS, target = src, use_default_checks = FALSE))

--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -165,7 +165,7 @@
 
 	// No cheesing with buckling ourselves, this spinning is too fast for seatbelts
 	if(user.buckled)
-		user.unbuckle_self(force = TRUE)
+		user.unbuckle(force = TRUE)
 
 	// Check if the machine and the user are still next to each other
 	if(!do_after(user, delay = 1.2 SECONDS, target = src, use_default_checks = FALSE))

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -191,4 +191,4 @@
 
 /mob/living/proc/check_buckled()
 	if(buckled && !(buckled in loc))
-		unbuckle_self(force = TRUE)
+		unbuckle(force = TRUE)

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -191,4 +191,4 @@
 
 /mob/living/proc/check_buckled()
 	if(buckled && !(buckled in loc))
-		buckled.unbuckle_mob(src, force = TRUE)
+		unbuckle_self(force = TRUE)

--- a/code/game/objects/items/tools/wirecutters.dm
+++ b/code/game/objects/items/tools/wirecutters.dm
@@ -36,7 +36,7 @@
 		user.visible_message("<span class='notice'>[user] cuts [C]'s restraints with [src]!</span>")
 		QDEL_NULL(C.handcuffed)
 		if(C.buckled && C.buckled.buckle_requires_restraints)
-			C.unbuckle_self()
+			C.unbuckle()
 		C.update_handcuffed()
 		return
 	else

--- a/code/game/objects/items/tools/wirecutters.dm
+++ b/code/game/objects/items/tools/wirecutters.dm
@@ -36,7 +36,7 @@
 		user.visible_message("<span class='notice'>[user] cuts [C]'s restraints with [src]!</span>")
 		QDEL_NULL(C.handcuffed)
 		if(C.buckled && C.buckled.buckle_requires_restraints)
-			C.buckled.unbuckle_mob(C)
+			C.unbuckle_self()
 		C.update_handcuffed()
 		return
 	else

--- a/code/game/objects/items/weapons/scrolls.dm
+++ b/code/game/objects/items/weapons/scrolls.dm
@@ -21,7 +21,7 @@
 	. += "<span class='notice'>Number of uses: [uses]. This scroll will vanish after the final use.</span>"
 	. += "<span class='notice'>P.S. Don't forget to bring your gear, you'll need it to cast most spells.</span>"
 
-/obj/item/teleportation_scroll/attack_self(mob/user)
+/obj/item/teleportation_scroll/attack_self(mob/living/user)
 	if(!uses) //somehow?
 		to_chat(user, "<span class='warning'>You attempt to read the scroll but it disintegrates in your hand, it appears that is has run out of charges!</span>")
 		qdel(src)

--- a/code/game/objects/items/weapons/scrolls.dm
+++ b/code/game/objects/items/weapons/scrolls.dm
@@ -59,7 +59,7 @@
 		return
 
 	if(user && user.buckled)
-		user.unbuckle_self(force = TRUE)
+		user.unbuckle(force = TRUE)
 
 	if(user?.has_buckled_mobs())
 		user.unbuckle_all_mobs(force = TRUE)

--- a/code/game/objects/items/weapons/scrolls.dm
+++ b/code/game/objects/items/weapons/scrolls.dm
@@ -59,7 +59,7 @@
 		return
 
 	if(user && user.buckled)
-		user.buckled.unbuckle_mob(user, force = TRUE)
+		user.unbuckle_self(force = TRUE)
 
 	if(user?.has_buckled_mobs())
 		user.unbuckle_all_mobs(force = TRUE)

--- a/code/modules/mob/living/carbon/carbon_procs.dm
+++ b/code/modules/mob/living/carbon/carbon_procs.dm
@@ -733,7 +733,7 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 	else if(I == handcuffed)
 		handcuffed = null
 		if(buckled && buckled.buckle_requires_restraints)
-			buckled.unbuckle_mob(src)
+			unbuckle_self()
 		update_handcuffed()
 	else if(I == legcuffed)
 		legcuffed = null
@@ -994,7 +994,7 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 
 	handcuffed = null
 	if(buckled && buckled.buckle_requires_restraints)
-		buckled.unbuckle_mob(src)
+		unbuckle_self()
 	update_handcuffed()
 
 	if(client)

--- a/code/modules/mob/living/carbon/carbon_procs.dm
+++ b/code/modules/mob/living/carbon/carbon_procs.dm
@@ -733,7 +733,7 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 	else if(I == handcuffed)
 		handcuffed = null
 		if(buckled && buckled.buckle_requires_restraints)
-			unbuckle_self()
+			unbuckle()
 		update_handcuffed()
 	else if(I == legcuffed)
 		legcuffed = null
@@ -994,7 +994,7 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 
 	handcuffed = null
 	if(buckled && buckled.buckle_requires_restraints)
-		unbuckle_self()
+		unbuckle()
 	update_handcuffed()
 
 	if(client)

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -586,7 +586,7 @@
 	if(target.anchored)
 		return FALSE
 	if(target.buckled)
-		target.buckled.unbuckle_mob(target)
+		target.unbuckle_self()
 
 	var/shove_dir = get_dir(user.loc, target.loc)
 	var/turf/shove_to = get_step(target.loc, shove_dir)

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -586,7 +586,7 @@
 	if(target.anchored)
 		return FALSE
 	if(target.buckled)
-		target.unbuckle_self()
+		target.unbuckle()
 
 	var/shove_dir = get_dir(user.loc, target.loc)
 	var/turf/shove_to = get_step(target.loc, shove_dir)

--- a/code/modules/mob/living/carbon/human/species/golem.dm
+++ b/code/modules/mob/living/carbon/human/species/golem.dm
@@ -454,7 +454,7 @@
 	if(!isturf(picked))
 		return
 	if(H.buckled)
-		H.buckled.unbuckle_mob(H, force = TRUE)
+		H.unbuckle_self(force = TRUE)
 	do_teleport(H, picked)
 	return TRUE
 
@@ -538,7 +538,7 @@
 	if(!isturf(picked))
 		return
 	if(H.buckled)
-		H.buckled.unbuckle_mob(H, force = TRUE)
+		H.unbuckle_self(force = TRUE)
 	do_teleport(H, picked)
 	last_teleport = world.time
 	UpdateButtons() //action icon looks unavailable

--- a/code/modules/mob/living/carbon/human/species/golem.dm
+++ b/code/modules/mob/living/carbon/human/species/golem.dm
@@ -454,7 +454,7 @@
 	if(!isturf(picked))
 		return
 	if(H.buckled)
-		H.unbuckle_self(force = TRUE)
+		H.unbuckle(force = TRUE)
 	do_teleport(H, picked)
 	return TRUE
 
@@ -538,7 +538,7 @@
 	if(!isturf(picked))
 		return
 	if(H.buckled)
-		H.unbuckle_self(force = TRUE)
+		H.unbuckle(force = TRUE)
 	do_teleport(H, picked)
 	last_teleport = world.time
 	UpdateButtons() //action icon looks unavailable

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -537,7 +537,7 @@
 	on_fire = 0
 	suiciding = 0
 	if(buckled) //Unbuckle the mob and clear the alerts.
-		unbuckle_self(force = TRUE)
+		unbuckle(force = TRUE)
 
 	if(iscarbon(src))
 		var/mob/living/carbon/C = src
@@ -802,7 +802,7 @@
 	END RESIST PROCS
 *///////////////////////
 
-/mob/living/proc/unbuckle_self(force)
+/mob/living/proc/unbuckle(force)
 	buckled.unbuckle_mob(src, force)
 
 /mob/living/proc/Exhaust()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -802,6 +802,9 @@
 	END RESIST PROCS
 *///////////////////////
 
+/// Unbuckle the mob from whatever it is buckled to.
+/mob/living/proc/unbuckle(force)
+	buckled.unbuckle_mob(src, force)
 
 /mob/living/proc/Exhaust()
 	to_chat(src, "<span class='notice'>You're too exhausted to keep going...</span>")

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -802,8 +802,6 @@
 	END RESIST PROCS
 *///////////////////////
 
-/mob/living/proc/unbuckle(force)
-	buckled.unbuckle_mob(src, force)
 
 /mob/living/proc/Exhaust()
 	to_chat(src, "<span class='notice'>You're too exhausted to keep going...</span>")

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -537,7 +537,7 @@
 	on_fire = 0
 	suiciding = 0
 	if(buckled) //Unbuckle the mob and clear the alerts.
-		buckled.unbuckle_mob(src, force = TRUE)
+		unbuckle_self(force = TRUE)
 
 	if(iscarbon(src))
 		var/mob/living/carbon/C = src
@@ -801,6 +801,9 @@
 /*//////////////////////
 	END RESIST PROCS
 *///////////////////////
+
+/mob/living/proc/unbuckle_self(force)
+	buckled.unbuckle_mob(src, force)
 
 /mob/living/proc/Exhaust()
 	to_chat(src, "<span class='notice'>You're too exhausted to keep going...</span>")

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -41,6 +41,9 @@
 	var/mob_biotypes = MOB_ORGANIC
 	var/metabolism_efficiency = 1 //more or less efficiency to metabolize helpful/harmful reagents and regulate body temperature..
 
+	/// movable atom we are buckled to
+	var/atom/movable/buckling
+
 	var/ventcrawler = VENTCRAWLER_NONE
 	var/list/icon/pipes_shown = list()
 	var/last_played_vent

--- a/code/modules/mob/living/simple_animal/hostile/floorcluwne.dm
+++ b/code/modules/mob/living/simple_animal/hostile/floorcluwne.dm
@@ -316,7 +316,7 @@
 					if(T.density)
 						forceMove(H.loc)
 					if(H.buckled)
-						H.unbuckle_self(force = TRUE)
+						H.unbuckle(force = TRUE)
 				manifested = TRUE
 				Manifest()
 				to_chat(H, "<span class='userdanger'>You feel the floor closing in on your feet!</span>")

--- a/code/modules/mob/living/simple_animal/hostile/floorcluwne.dm
+++ b/code/modules/mob/living/simple_animal/hostile/floorcluwne.dm
@@ -316,7 +316,7 @@
 					if(T.density)
 						forceMove(H.loc)
 					if(H.buckled)
-						H.buckled.unbuckle_mob(H, force = TRUE)
+						H.unbuckle_self(force = TRUE)
 				manifested = TRUE
 				Manifest()
 				to_chat(H, "<span class='userdanger'>You feel the floor closing in on your feet!</span>")

--- a/code/modules/mob/living/simple_animal/slime/slime_powers.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime_powers.dm
@@ -118,7 +118,7 @@
 			visible_message("<span class='warning'>[src] has let go of [buckled]!</span>", \
 							"<span class='notice'><i>I stopped feeding.</i></span>")
 		layer = initial(layer)
-		buckled.unbuckle(force=TRUE)
+		unbuckle(force=TRUE)
 
 /mob/living/simple_animal/slime/proc/Evolve()
 	if(stat)

--- a/code/modules/mob/living/simple_animal/slime/slime_powers.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime_powers.dm
@@ -118,7 +118,7 @@
 			visible_message("<span class='warning'>[src] has let go of [buckled]!</span>", \
 							"<span class='notice'><i>I stopped feeding.</i></span>")
 		layer = initial(layer)
-		buckled.unbuckle_self(force=TRUE)
+		buckled.unbuckle(force=TRUE)
 
 /mob/living/simple_animal/slime/proc/Evolve()
 	if(stat)

--- a/code/modules/mob/living/simple_animal/slime/slime_powers.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime_powers.dm
@@ -118,7 +118,7 @@
 			visible_message("<span class='warning'>[src] has let go of [buckled]!</span>", \
 							"<span class='notice'><i>I stopped feeding.</i></span>")
 		layer = initial(layer)
-		buckled.unbuckle_mob(src,force=TRUE)
+		buckled.unbuckle_self(force=TRUE)
 
 /mob/living/simple_animal/slime/proc/Evolve()
 	if(stat)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1061,6 +1061,10 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 	if(M.layer < layer)
 		M.layer = layer + 0.1
 
+///unbuckle the mob from whatever it is buckled to.
+/mob/proc/unbuckle(force)
+	buckled.unbuckle_mob(src, force)
+
 ///Call back post unbuckle from a mob, (reset your visual height here)
 /mob/post_unbuckle_mob(mob/living/M)
 	M.layer = initial(M.layer)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1061,10 +1061,6 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 	if(M.layer < layer)
 		M.layer = layer + 0.1
 
-///unbuckle the mob from whatever it is buckled to.
-/mob/proc/unbuckle(force)
-	buckled.unbuckle_mob(src, force)
-
 ///Call back post unbuckle from a mob, (reset your visual height here)
 /mob/post_unbuckle_mob(mob/living/M)
 	M.layer = initial(M.layer)

--- a/code/modules/mob/mob_vars.dm
+++ b/code/modules/mob/mob_vars.dm
@@ -75,8 +75,6 @@
 	var/lastKnownIP = null
 	/// movable atoms buckled to this mob
 	var/atom/movable/buckled = null //Living
-	/// movable atom we are buckled to
-	var/atom/movable/buckling
 
 	var/obj/item/l_hand = null //Living
 	var/obj/item/r_hand = null //Living

--- a/code/modules/research/experimentor.dm
+++ b/code/modules/research/experimentor.dm
@@ -487,7 +487,7 @@
 				throwSmoke(tracked_ian.loc)
 				tracked_ian.loc = loc
 				if(tracked_ian.buckled)
-					tracked_ian.unbuckle_self(force = TRUE)
+					tracked_ian.unbuckle(force = TRUE)
 				investigate_log("Experimentor has stolen Ian!", "experimentor") //...if anyone ever fixes it...
 			else
 				new /mob/living/simple_animal/pet/dog/corgi(loc)
@@ -501,7 +501,7 @@
 				throwSmoke(tracked_runtime.loc)
 				tracked_runtime.loc = loc
 				if(tracked_runtime.buckled)
-					tracked_runtime.unbuckle_self(force = TRUE)
+					tracked_runtime.unbuckle(force = TRUE)
 				investigate_log("Experimentor has stolen Runtime!", "experimentor")
 			else
 				new /mob/living/simple_animal/pet/cat(loc)

--- a/code/modules/research/experimentor.dm
+++ b/code/modules/research/experimentor.dm
@@ -487,7 +487,7 @@
 				throwSmoke(tracked_ian.loc)
 				tracked_ian.loc = loc
 				if(tracked_ian.buckled)
-					tracked_ian.buckled.unbuckle_mob(tracked_ian, TRUE)
+					tracked_ian.unbuckle_self(force = TRUE)
 				investigate_log("Experimentor has stolen Ian!", "experimentor") //...if anyone ever fixes it...
 			else
 				new /mob/living/simple_animal/pet/dog/corgi(loc)
@@ -501,7 +501,7 @@
 				throwSmoke(tracked_runtime.loc)
 				tracked_runtime.loc = loc
 				if(tracked_runtime.buckled)
-					tracked_runtime.buckled.unbuckle_mob(tracked_runtime, TRUE)
+					tracked_runtime.unbuckle_self(force = TRUE)
 				investigate_log("Experimentor has stolen Runtime!", "experimentor")
 			else
 				new /mob/living/simple_animal/pet/cat(loc)

--- a/code/modules/research/experimentor.dm
+++ b/code/modules/research/experimentor.dm
@@ -482,7 +482,7 @@
 		if(globalMalf > 16 && globalMalf < 35)
 			visible_message("<span class='warning'>[src] melts [exp_on], ian-izing the air around it!</span>")
 			throwSmoke(loc)
-			var/mob/tracked_ian = locate(/mob/living/simple_animal/pet/dog/corgi/Ian) in GLOB.mob_living_list
+			var/mob/living/tracked_ian = locate(/mob/living/simple_animal/pet/dog/corgi/Ian) in GLOB.mob_living_list
 			if(tracked_ian)
 				throwSmoke(tracked_ian.loc)
 				tracked_ian.loc = loc
@@ -496,7 +496,7 @@
 		if(globalMalf > 36 && globalMalf < 59)
 			visible_message("<span class='warning'>[src] encounters a run-time error!</span>")
 			throwSmoke(loc)
-			var/mob/tracked_runtime = locate(/mob/living/simple_animal/pet/cat/Runtime) in GLOB.mob_living_list
+			var/mob/living/tracked_runtime = locate(/mob/living/simple_animal/pet/cat/Runtime) in GLOB.mob_living_list
 			if(tracked_runtime)
 				throwSmoke(tracked_runtime.loc)
 				tracked_runtime.loc = loc

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -645,20 +645,18 @@
 				var/obj/mecha/mech = AM
 				if(mech.occupant)
 					INVOKE_ASYNC(mech, TYPE_PROC_REF(/obj/mecha, get_out_and_die))
-			if(ismob(AM))
-				var/mob/M = AM
-				if(M.buckled)
-					M.unbuckle(force = TRUE)
-				if(isliving(AM))
-					var/mob/living/L = AM
-					if(L.incorporeal_move || L.status_flags & GODMODE)
-						continue
-					L.stop_pulling()
-					L.visible_message("<span class='warning'>[L] is hit by \
-									a hyperspace ripple!</span>",
-									"<span class='userdanger'>You feel an immense \
-									crushing pressure as the space around you ripples.</span>")
-					L.gib()
+			if(isliving(AM))
+				var/mob/living/L = AM
+				if(L.buckled)
+					L.unbuckle(force = TRUE)
+				if(L.incorporeal_move || L.status_flags & GODMODE)
+					continue
+				L.stop_pulling()
+				L.visible_message("<span class='warning'>[L] is hit by \
+								a hyperspace ripple!</span>",
+								"<span class='userdanger'>You feel an immense \
+								crushing pressure as the space around you ripples.</span>")
+				L.gib()
 			else if(lance_docking) //corrupt the child, destroy them all
 				if(!AM.simulated)
 					continue

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -648,7 +648,7 @@
 			if(ismob(AM))
 				var/mob/M = AM
 				if(M.buckled)
-					M.unbuckle_self(force = TRUE)
+					M.unbuckle(force = TRUE)
 				if(isliving(AM))
 					var/mob/living/L = AM
 					if(L.incorporeal_move || L.status_flags & GODMODE)

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -648,7 +648,7 @@
 			if(ismob(AM))
 				var/mob/M = AM
 				if(M.buckled)
-					M.buckled.unbuckle_mob(M, force = TRUE)
+					M.unbuckle_self(force = TRUE)
 				if(isliving(AM))
 					var/mob/living/L = AM
 					if(L.incorporeal_move || L.status_flags & GODMODE)

--- a/code/modules/surgery/organs/vocal_cords.dm
+++ b/code/modules/surgery/organs/vocal_cords.dm
@@ -433,7 +433,7 @@ GLOBAL_DATUM_INIT(multispin_words, /regex, regex("like a record baby"))
 		for(var/V in listeners)
 			var/mob/living/L = V
 			if(L.buckled && istype(L.buckled, /obj/structure/chair))
-				L.unbuckle_self()
+				L.unbuckle()
 		next_command = world.time + cooldown_meme
 
 	//DANCE

--- a/code/modules/surgery/organs/vocal_cords.dm
+++ b/code/modules/surgery/organs/vocal_cords.dm
@@ -433,7 +433,7 @@ GLOBAL_DATUM_INIT(multispin_words, /regex, regex("like a record baby"))
 		for(var/V in listeners)
 			var/mob/living/L = V
 			if(L.buckled && istype(L.buckled, /obj/structure/chair))
-				L.buckled.unbuckle_mob(L)
+				L.unbuckle_self()
 		next_command = world.time + cooldown_meme
 
 	//DANCE


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds a helper proc `unbuckle` to `mob` that handles unbuckling and replaces all instances of `buckled.unbuckle_mob()` with the helper proc instead.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
A single proc for this is simpler and more readable
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Buckle myself to a chair
Unbuckle myself from a chair
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

NPFC

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
