### PR TITLE
Energy field generators Refactor/Tweak

### DIFF
--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -719,7 +719,7 @@ GLOBAL_PROTECT(AdminProcCallSpamPrevention)
 		if(!F.active)
 			F.active = TRUE
 			F.state = 2
-			F.power = 250
+			F.energy = 125
 			F.anchored = TRUE
 			F.warming_up = 3
 			F.start_fields()

--- a/code/modules/power/engines/singularity/containment_field.dm
+++ b/code/modules/power/engines/singularity/containment_field.dm
@@ -15,8 +15,10 @@
 	var/obj/machinery/field/generator/FG2 = null
 
 /obj/machinery/field/containment/Destroy()
-	FG1.fields -= src
-	FG2.fields -= src
+	if(FG1)// These checks are mostly in case a field is spawned in by accident.
+		FG1.fields -= src
+	if(FG2)
+		FG2.fields -= src
 	return ..()
 
 /obj/machinery/field/containment/attack_hand(mob/user)
@@ -50,7 +52,7 @@
 		return
 	if(ismegafauna(M))
 		M.visible_message("<span class='warning'>[M] glows fiercely as the containment field flickers out!</span>")
-		FG1.calc_power(INFINITY) //rip that 'containment' field
+		FG1.calc_energy(INFINITY) //rip that 'containment' field
 		M.adjustHealth(-M.obj_damage)
 	else
 		..()

--- a/code/modules/power/engines/singularity/field_generator.dm
+++ b/code/modules/power/engines/singularity/field_generator.dm
@@ -1,14 +1,14 @@
 /*
-field_generator power level display
- *   The icon used for the field_generator need to have 'num_power_levels' number of icon states
- *   named 'Field_Gen +p[num]' where 'num' ranges from 1 to 'num_power_levels'
- *   The power level is displayed using overlays. The current displayed power level is stored in 'powerlevel'.
- *   The overlay in use and the powerlevel variable must be kept in sync.  A powerlevel equal to 0 means that
- *   no power level overlay is currently in the overlays list.
+field_generator energy level display
+ *   The icon used for the field_generator need to have 'num_energy_levels' number of icon states
+ *   named 'Field_Gen +p[num]' where 'num' ranges from 1 to 'num_energy_levels'
+ *   The energy level is displayed using overlays. The current displayed energy level is stored in 'energylevel'.
+ *   The overlay in use and the energylevel variable must be kept in sync.  A energylevel equal to 0 means that
+ *   no energy level overlay is currently in the overlays list.
  *   -Aygar
 */
 
-#define field_generator_max_power 250
+#define field_generator_max_energy 125
 
 #define FG_UNSECURED 0
 #define FG_SECURED 1
@@ -31,10 +31,10 @@ GLOBAL_LIST_EMPTY(field_generator_fields)
 	max_integrity = 500
 	//100% immune to lasers and energy projectiles since it absorbs their energy.
 	armor = list(MELEE = 25, BULLET = 10, LASER = 100, ENERGY = 100, BOMB = 0, RAD = 0, FIRE = 50, ACID = 70)
-	var/const/num_power_levels = 6	// Total number of power level icon has
-	var/power_level = 0
+	var/const/num_energy_levels = 6	// Total number of power level icon has
+	var/energy_level = 0
 	var/active = FG_OFFLINE
-	var/power = 20  // Current amount of power
+	var/energy = 20  // Current amount of energy
 	var/state = FG_UNSECURED
 	var/warming_up = 0
 	var/list/obj/machinery/field/containment/fields
@@ -47,8 +47,8 @@ GLOBAL_LIST_EMPTY(field_generator_fields)
 		. += "+a[warming_up]"
 	if(length(fields))
 		. += "+on"
-	if(power_level)
-		. += "+p[power_level]"
+	if(energy_level)
+		. += "+p[energy_level]"
 
 /obj/machinery/field/generator/Initialize(mapload)
 	. = ..()
@@ -58,7 +58,7 @@ GLOBAL_LIST_EMPTY(field_generator_fields)
 
 /obj/machinery/field/generator/process()
 	if(active == FG_ONLINE)
-		calc_power()
+		calc_energy()
 
 /obj/machinery/field/generator/attack_hand(mob/user)
 	if(state == FG_WELDED)
@@ -141,8 +141,8 @@ GLOBAL_LIST_EMPTY(field_generator_fields)
 
 /obj/machinery/field/generator/bullet_act(obj/item/projectile/Proj)
 	if(Proj.flag != BULLET && !Proj.nodamage)
-		power = min(power + Proj.damage, field_generator_max_power)
-		check_power_level()
+		energy = min(energy + Proj.damage, field_generator_max_energy)
+		check_energy_level()
 	return 0
 
 
@@ -151,10 +151,10 @@ GLOBAL_LIST_EMPTY(field_generator_fields)
 	return ..()
 
 
-/obj/machinery/field/generator/proc/check_power_level()
-	var/new_level = round(num_power_levels * power / field_generator_max_power)
-	if(new_level != power_level)
-		power_level = new_level
+/obj/machinery/field/generator/proc/check_energy_level()
+	var/new_level = round(num_energy_levels * energy / field_generator_max_energy)
+	if(new_level != energy_level)
+		energy_level = new_level
 		update_icon()
 
 /obj/machinery/field/generator/proc/turn_off()
@@ -177,49 +177,60 @@ GLOBAL_LIST_EMPTY(field_generator_fields)
 				start_fields()
 
 
-/obj/machinery/field/generator/proc/calc_power()
+/obj/machinery/field/generator/proc/calc_energy()
 	var/power_draw = 2 + length(fields)
 
 	if(draw_power(round(power_draw/2, 1)))
-		check_power_level()
+		spread_energy()
+		check_energy_level()
 		return 1
 	else
 		visible_message("<span class='danger'>[src] shuts down!</span>", "<span class='italics'>You hear something shutting down.</span>")
 		turn_off()
-		investigate_log("ran out of power and <font color='red'>deactivated</font>","singulo")
-		power = 0
-		check_power_level()
+		investigate_log("ran out of energy and <font color='red'>deactivated</font>","singulo")
+		energy = 0
+		check_energy_level()
 		return 0
 
-//This could likely be better, it tends to start loopin if you have a complex generator loop setup.  Still works well enough to run the engine fields will likely recode the field gens and fields sometime -Mport
-/obj/machinery/field/generator/proc/draw_power(draw = 0, failsafe = 0, obj/machinery/field/generator/G = null, obj/machinery/field/generator/last = null)
-	if((G && (G == src)) || (failsafe >= 8))//Loopin, set fail
+/**
+* Draws power. If there isn't enough energy to sustain the draw, draw from connected generators, up to 3 generators away.
+* We never do a 180, so at most we should be going around 270 degrees, and never loop.
+*
+* Arguments:
+** draw - Amount of energy needed to sustain powerdraw during this cycle
+** failsafe - Current depth of the recursion. We don't let this go above 3.
+** last - should be src of the previous call, we check against this to prevent going back and forth between two field generators.
+*/
+/obj/machinery/field/generator/proc/draw_power(draw = 0, failsafe = 0, obj/machinery/field/generator/last = null)
+	if(failsafe >= 3)// Asking at most 3 gens away so we can't loop.
 		return 0
 	else
 		failsafe++
 
-	if(power >= draw)//We have enough power
-		power -= draw
+	if(energy >= draw)// We have enough energy
+		energy -= draw
 		return 1
 
-	else//Need more power
-		draw -= power
-		power = 0
+	else//Need more energy
+		draw -= energy
+		energy = 0
 		for(var/CG in connected_gens)
 			var/obj/machinery/field/generator/FG = CG
-			if(FG == last)//We just asked you
+			if(FG == last)// We just asked you
 				continue
-			if(G)//Another gen is askin for power and we dont have it
-				if(FG.draw_power(draw,failsafe,G,src))//Can you take the load
-					return 1
-				else
-					return 0
-			else//We are askin another for power
-				if(FG.draw_power(draw,failsafe,src,src))
+			else// We are askin another for energy
+				if(FG.draw_power(draw,failsafe,src))
 					return 1
 				else
 					return 0
 
+/// Sends energy to every neighbour that has less energy
+/obj/machinery/field/generator/proc/spread_energy()
+	for(var/obj/machinery/field/generator/gen in connected_gens)
+		if(energy > gen.energy)
+			var/diff = min(energy - gen.energy, field_generator_max_energy - gen.energy)// We don't want to delete energy
+			gen.energy += diff / 2
+			energy -= diff / 2
 
 /obj/machinery/field/generator/proc/start_fields()
 	if(state != FG_WELDED || !anchored)
@@ -299,8 +310,8 @@ GLOBAL_LIST_EMPTY(field_generator_fields)
 	for(var/CG in connected_gens)
 		var/obj/machinery/field/generator/FG = CG
 		FG.connected_gens -= src
-		if(!FG.clean_up)//Makes the other gens clean up as well
-			FG.cleanup()
+		if(!FG.clean_up)//Makes the other gens clean up and shutdown as well
+			FG.turn_off()
 		connected_gens -= FG
 	clean_up = FALSE
 	update_icon()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Changes the way Energy field generators share energy:
 - Limits the range at which they can directly draw from another generator to 3 neighbors away
 - If a field generator has a neighbor with as less energy, they will equalize by transferring half of the difference.
Also reduces the maximum energy capacity by half so that the overall energy stored in the field generators is about the same as live, so time to containment breach is about the same when turning off the emitters.
Fixes a bug that causes field generators to improperly shut down
Fixes a bug that causes energy field destructor to runtime when the field has no generators(should only happen when admin spawned)
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Field generators behave in an odd way. Most of them remain empty, and only draw power from connected generators, and the method used tends to loop around a lot, which generates a lot of useless calls.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
- Setup a field generator array
- Observed energy being transferred between field generators
- Overloaded the array and made sure it properly shut down
<!-- How did you test the PR, if at all? -->
<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
tweak: Field generators now share their energy and only pull directly from up to 3 neighbors away. Maximum energy capacity reduced by half to maintain the same overall level of energy storage.
fix: Field generators now properly shutdown.
fix: Fields no longer runtime when qdeleted if they have no generators(mostly affects admin spawned ones).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
