### PR TITLE
Adds functionality for placing hats on top of hats. MODsuit Helmet and Plasma-man hat accessory edition.

### DIFF
--- a/code/modules/clothing/head/misc_hats.dm
+++ b/code/modules/clothing/head/misc_hats.dm
@@ -536,6 +536,7 @@
 	icon_state = "crown"
 	armor = list(MELEE = 10, BULLET = 0, LASER = 0, ENERGY = 10, BOMB = 0, RAD = 0, FIRE = INFINITY, ACID = 50)
 	resistance_flags = FIRE_PROOF
+	can_be_hat = FALSE
 
 /obj/item/clothing/head/crown/fancy
 	name = "magnificent crown"

--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -23,6 +23,7 @@
 	icon = 'icons/obj/clothing/species/plasmaman/hats.dmi'
 	species_restricted = list("Plasmaman")
 	sprite_sheets = list("Plasmaman" = 'icons/mob/clothing/species/plasmaman/helmet.dmi')
+	can_have_hats = TRUE
 
 /obj/item/clothing/head/helmet/space/plasmaman/Initialize(mapload)
 	. = ..()

--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -24,6 +24,7 @@
 	species_restricted = list("Plasmaman")
 	sprite_sheets = list("Plasmaman" = 'icons/mob/clothing/species/plasmaman/helmet.dmi')
 	can_have_hats = TRUE
+	can_be_hat = FALSE
 
 /obj/item/clothing/head/helmet/space/plasmaman/Initialize(mapload)
 	. = ..()

--- a/code/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/code/modules/mob/living/carbon/human/human_update_icons.dm
@@ -869,7 +869,10 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 			var/obj/item/clothing/head/w_hat = head
 			if(length(w_hat.attached_hats))
 				for(var/obj/item/clothing/head/Hat in w_hat:attached_hats)
-					standing.overlays += image("icon" = Hat.icon_override, "icon_state" = "[Hat.icon_state]")
+					if(Hat.sprite_sheets && Hat.sprite_sheets[dna.species.sprite_sheet_name])
+						standing.overlays += image("icon" = Hat.sprite_sheets[dna.species.sprite_sheet_name], "icon_state" = "[Hat.icon_state]")
+					else
+						standing.overlays += image("icon" = Hat.icon_override, "icon_state" = "[Hat.icon_state]")
 
 		if(head.blood_DNA)
 			var/image/bloodsies = image("icon" = dna.species.blood_mask, "icon_state" = "helmetblood")

--- a/code/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/code/modules/mob/living/carbon/human/human_update_icons.dm
@@ -855,14 +855,21 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 		var/mutable_appearance/standing
 		if(head.sprite_sheets && head.sprite_sheets[dna.species.sprite_sheet_name])
 			standing = mutable_appearance(head.sprite_sheets[dna.species.sprite_sheet_name], "[head.icon_state]", layer = -HEAD_LAYER)
-			if(istype(head, /obj/item/clothing/head/helmet/space/plasmaman))
-				var/obj/item/clothing/head/helmet/space/plasmaman/P = head
-				if(!P.up)
-					standing.overlays += P.visor_icon
 		else if(head.icon_override)
 			standing = mutable_appearance(head.icon_override, "[head.icon_state]", layer = -HEAD_LAYER)
 		else
 			standing = mutable_appearance('icons/mob/clothing/head.dmi', "[head.icon_state]", layer = -HEAD_LAYER)
+
+		if(istype(head, /obj/item/clothing/head/helmet/space/plasmaman))
+			var/obj/item/clothing/head/helmet/space/plasmaman/P = head
+			if(!P.up)
+				standing.overlays += P.visor_icon
+
+		if(istype(head, /obj/item/clothing/head))
+			var/obj/item/clothing/head/w_hat = head
+			if(length(w_hat.attached_hats))
+				for(var/obj/item/clothing/head/Hat in w_hat:attached_hats)
+					standing.overlays += image("icon" = Hat.icon_override, "icon_state" = "[Hat.icon_state]")
 
 		if(head.blood_DNA)
 			var/image/bloodsies = image("icon" = dna.species.blood_mask, "icon_state" = "helmetblood")

--- a/code/modules/mod/mod_clothes.dm
+++ b/code/modules/mod/mod_clothes.dm
@@ -18,6 +18,8 @@
 		"Unathi" = 'icons/mob/clothing/modsuit/species/unathi_modsuits.dmi',
 		"Vox" = 'icons/mob/clothing/modsuit/species/vox_modsuits.dmi'
 		)
+	can_have_hats = TRUE
+	can_be_hat = FALSE
 
 /obj/item/clothing/suit/mod
 	name = "MOD chestplate"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Allows for hats to be placed on top of modsuit helmets and plasma-man helmets as accessories. These hats provide no protection bonus and are purely cosmetic. 

Adds functionality for placing hats on hats if that is ever wanted later on.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

Plasma-men are sorely lacking in cosmetic variety. This adds some spice to it.
Placing hats on modsuits also adds some cosmetic variety.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://github.com/user-attachments/assets/08cc8a8b-0697-43c5-954a-2ee1b918f0c8)
![image](https://github.com/user-attachments/assets/d80aa109-0f2d-4c69-9256-9d387ec96157)
![image](https://github.com/user-attachments/assets/08a8062d-0510-4548-94cc-627839c4830b)
![image](https://github.com/user-attachments/assets/33aa6664-d329-462e-8574-b3f93042c4a8)


<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing

Spawned as a plasma-man, placed a hat on the helmet. Ooooo'd and Aaaaa'd.
Deleted the helmet, no runtimes.
Tried to place multiple hats on the helmet, failed to stack many hats!

Tested the modsuit helmets and sprites for such. Hat changes sprite appropriately per species.
Deploying the helmet and placing a hat ontop of the helmet stores the hat inside the helmet for quick usage later.

<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
add: Hat placement on plasma-men helmets.
add: Hat placement on modsuit helmets.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
