### PR TITLE
blackbox: Record biohazard pop at intervals.

### DIFF
--- a/code/__DEFINES/antag_defines.dm
+++ b/code/__DEFINES/antag_defines.dm
@@ -106,3 +106,8 @@ GLOBAL_LIST(contractors)
 
 // Chance that a traitor will receive a 'You are being targeted by another syndicate agent' notification regardless of being an actual target
 #define ORG_PROB_PARANOIA 5
+
+/// How often a biohazard's population is recorded after the event fires.
+#define BIOHAZARD_POP_INTERVAL 5 MINUTES
+/// The string version of the interval for use in blackbox key names.
+#define BIOHAZARD_POP_INTERVAL_STR "5min"

--- a/code/modules/events/alien_infestation.dm
+++ b/code/modules/events/alien_infestation.dm
@@ -41,4 +41,5 @@
 
 			spawncount--
 			successSpawn = TRUE
-	SSevents.biohazards_this_round += "Xenomorphs"
+	SSticker.record_biohazard_start(BIOHAZARD_XENO)
+	SSevents.biohazards_this_round += BIOHAZARD_XENO

--- a/code/modules/events/blob_spawn.dm
+++ b/code/modules/events/blob_spawn.dm
@@ -39,4 +39,4 @@
 	to_chat(B, "<span class='motd'>For more information, check the wiki page: ([GLOB.configuration.url.wiki_url]/index.php/Blob)</span>")
 	notify_ghosts("Infected Mouse has appeared in [get_area(B)].", source = B, action = NOTIFY_FOLLOW)
 	successSpawn = TRUE
-	SSevents.biohazards_this_round += "Blob"
+	SSevents.biohazards_this_round += BIOHAZARD_BLOB

--- a/code/modules/events/spider_terror.dm
+++ b/code/modules/events/spider_terror.dm
@@ -66,6 +66,7 @@
 		S.give_intro_text()
 		spawncount--
 		successSpawn = TRUE
+	SSticker.record_biohazard_start(infestation_type)
 	SSevents.biohazards_this_round += infestation_type
 
 #undef TS_HIGHPOP_TRIGGER

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -217,6 +217,8 @@
 	if(!gibbed)
 		gib()
 
+	SSticker.record_biohazard_start(BIOHAZARD_BLOB)
+
 /mob/living/simple_animal/mouse/blobinfected/get_scooped(mob/living/carbon/grabber)
 	to_chat(grabber, "<span class='warning'>You try to pick up [src], but they slip out of your grasp!</span>")
 	to_chat(src, "<span class='warning'>[src] tries to pick you up, but you wriggle free of their grasp!</span>")


### PR DESCRIPTION
## What Does This PR Do
This PR adds two new feedback rows:
- `biohazard_start_times_ds`, which keeps track of the number of deciseconds since round start that a biohazard was spawned (immediately for terrors/xenos, after blob burst for blob).
- `biohazard_pop_5min_interval`, a ledger of the total number of biohazard mobs taken every 5 minutes.
## Why It's Good For The Game
While we currently track biohazard winrate, what we don't track is how quickly/slowly a win/loss occurs. By tracking the biohazard population over time we can get a better sense of crew success throughout the threat, not just at the end.
## Testing
Spawned several biohazards, ensured feedback for population was continuously recorded.

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog
NPFC