### PR TITLE
Fixes a glowing eye issue and eye overlay issue

### DIFF
--- a/code/__DEFINES/misc_defines.dm
+++ b/code/__DEFINES/misc_defines.dm
@@ -186,52 +186,52 @@
 
 //Human Overlays Indexes/////////
 #define EYES_OVERLAY_LAYER		48
-#define WING_LAYER				47
-#define WING_UNDERLIMBS_LAYER	46
-#define MUTANTRACE_LAYER		45
-#define TAIL_UNDERLIMBS_LAYER	44	//Tail split-rendering.
-#define LIMBS_LAYER				43
-#define MARKINGS_LAYER			42
-#define INTORGAN_LAYER			41
-#define UNDERWEAR_LAYER			40
-#define MUTATIONS_LAYER			39
-#define H_DAMAGE_LAYER			38
-#define UNIFORM_LAYER			37
-#define ID_LAYER				36
-#define HANDS_LAYER				35	//Exists to overlay hands over jumpsuits
-#define SHOES_LAYER				34
-#define L_FOOT_BLOOD_LAYER		33	// Blood overlay separation Left-Foot
-#define R_FOOT_BLOOD_LAYER		32	// Blood overlay separation Right-Foot
-#define GLOVES_LAYER			31
-#define L_HAND_BLOOD_LAYER		30	// Blood overlay separation Left-Hand
-#define R_HAND_BLOOD_LAYER		29	// Blood overlay separation Right-Hand
-#define LEFT_EAR_LAYER			28
-#define RIGHT_EAR_LAYER			27
-#define BELT_LAYER				26	//Possible make this an overlay of something required to wear a belt?
-#define SUIT_LAYER				25
-#define SPECIAL_BELT_LAYER		24
-#define SUIT_STORE_LAYER		23
-#define BACK_LAYER				22
-#define HEAD_ACCESSORY_LAYER	21
-#define FHAIR_LAYER				20
-#define GLASSES_LAYER			19
-#define HAIR_LAYER				18	//TODO: make part of head layer?
-#define HEAD_ACC_OVER_LAYER		17	//Select-layer rendering.
-#define FHAIR_OVER_LAYER		16	//Select-layer rendering.
-#define GLASSES_OVER_LAYER		15	//Select-layer rendering.
-#define TAIL_LAYER				14	//bs12 specific. this hack is probably gonna come back to haunt me
-#define FACEMASK_LAYER			13
-#define OVER_MASK_LAYER			12	//Select-layer rendering.
-#define HEAD_LAYER				11
-#define COLLAR_LAYER			10
-#define HANDCUFF_LAYER			9
-#define LEGCUFF_LAYER			8
-#define L_HAND_LAYER			7
-#define R_HAND_LAYER			6
-#define TARGETED_LAYER			5	//BS12: Layer for the target overlay from weapon targeting system
-#define HALO_LAYER				4	//blood cult ascended halo, because there's currently no better solution for adding/removing
-#define FIRE_LAYER				3	//If you're on fire
-#define MISC_LAYER				2
+#define MISC_LAYER				47 // Handles eye_shine() -> cybernetic eyes, specific eye traits.
+#define WING_LAYER				46
+#define WING_UNDERLIMBS_LAYER	45
+#define MUTANTRACE_LAYER		44
+#define TAIL_UNDERLIMBS_LAYER	43	//Tail split-rendering.
+#define LIMBS_LAYER				42
+#define MARKINGS_LAYER			41
+#define INTORGAN_LAYER			40
+#define UNDERWEAR_LAYER			39
+#define MUTATIONS_LAYER			38
+#define H_DAMAGE_LAYER			37
+#define UNIFORM_LAYER			36
+#define ID_LAYER				35
+#define HANDS_LAYER				34	//Exists to overlay hands over jumpsuits
+#define SHOES_LAYER				33
+#define L_FOOT_BLOOD_LAYER		32	// Blood overlay separation Left-Foot
+#define R_FOOT_BLOOD_LAYER		31	// Blood overlay separation Right-Foot
+#define GLOVES_LAYER			30
+#define L_HAND_BLOOD_LAYER		29	// Blood overlay separation Left-Hand
+#define R_HAND_BLOOD_LAYER		28	// Blood overlay separation Right-Hand
+#define LEFT_EAR_LAYER			27
+#define RIGHT_EAR_LAYER			26
+#define BELT_LAYER				25	//Possible make this an overlay of something required to wear a belt?
+#define SUIT_LAYER				24
+#define SPECIAL_BELT_LAYER		23
+#define SUIT_STORE_LAYER		22
+#define BACK_LAYER				21
+#define HEAD_ACCESSORY_LAYER	20
+#define FHAIR_LAYER				19
+#define GLASSES_LAYER			18
+#define HAIR_LAYER				17	//TODO: make part of head layer?
+#define HEAD_ACC_OVER_LAYER		16	//Select-layer rendering.
+#define FHAIR_OVER_LAYER		15	//Select-layer rendering.
+#define GLASSES_OVER_LAYER		14	//Select-layer rendering.
+#define TAIL_LAYER				13	//bs12 specific. this hack is probably gonna come back to haunt me
+#define FACEMASK_LAYER			12
+#define OVER_MASK_LAYER			11	//Select-layer rendering.
+#define HEAD_LAYER				10
+#define COLLAR_LAYER			9
+#define HANDCUFF_LAYER			8
+#define LEGCUFF_LAYER			7
+#define L_HAND_LAYER			6
+#define R_HAND_LAYER			5
+#define TARGETED_LAYER			4	//BS12: Layer for the target overlay from weapon targeting system
+#define HALO_LAYER				3	//blood cult ascended halo, because there's currently no better solution for adding/removing
+#define FIRE_LAYER				2	//If you're on fire
 #define FROZEN_LAYER			1
 #define TOTAL_LAYERS			48
 

--- a/code/modules/mob/living/carbon/human/human_inventory.dm
+++ b/code/modules/mob/living/carbon/human/human_inventory.dm
@@ -118,6 +118,7 @@
 				update_sight()
 		head_update(I)
 		update_inv_head()
+		update_misc_effects()
 	else if(I == r_ear)
 		r_ear = null
 		update_inv_ears()
@@ -140,6 +141,7 @@
 			internal = null
 		wear_mask_update(I, toggle_off = FALSE)
 		sec_hud_set_ID()
+		update_misc_effects()
 		update_inv_wear_mask()
 	else if(I == wear_id)
 		wear_id = null
@@ -211,6 +213,7 @@
 			if(length(hud_list))
 				sec_hud_set_ID()
 			wear_mask_update(I, toggle_off = TRUE)
+			update_misc_effects()
 			update_inv_wear_mask()
 		if(SLOT_HUD_HANDCUFFED)
 			handcuffed = I
@@ -279,6 +282,7 @@
 				if(hat.vision_flags || hat.see_in_dark || !isnull(hat.lighting_alpha))
 					update_sight()
 			// this calls update_inv_head() on its own
+			update_misc_effects()
 			head_update(I)
 		if(SLOT_HUD_SHOES)
 			shoes = I

--- a/code/modules/mob/living/carbon/human/human_mob.dm
+++ b/code/modules/mob/living/carbon/human/human_mob.dm
@@ -1347,7 +1347,7 @@
 		return
 	var/datum/sprite_accessory/hair/hair_style = GLOB.hair_styles_full_list[head_organ.h_style]
 	var/icon/hair = new /icon("icon" = hair_style.icon, "icon_state" = "[hair_style.icon_state]_s")
-	var/mutable_appearance/MA = mutable_appearance(get_icon_difference(get_eyecon(), hair), layer = EMISSIVE_PLANE)
+	var/mutable_appearance/MA = mutable_appearance(get_icon_difference(get_eyecon(), hair), layer = ABOVE_LIGHTING_LAYER)
 	MA.plane = ABOVE_LIGHTING_PLANE
 	return MA //Cut the hair's pixels from the eyes icon so eyes covered by bangs stay hidden even while on a higher layer.
 

--- a/code/modules/mob/living/carbon/human/human_mob.dm
+++ b/code/modules/mob/living/carbon/human/human_mob.dm
@@ -1347,7 +1347,7 @@
 		return
 	var/datum/sprite_accessory/hair/hair_style = GLOB.hair_styles_full_list[head_organ.h_style]
 	var/icon/hair = new /icon("icon" = hair_style.icon, "icon_state" = "[hair_style.icon_state]_s")
-	var/mutable_appearance/MA = mutable_appearance(get_icon_difference(get_eyecon(), hair), layer = ABOVE_LIGHTING_LAYER)
+	var/mutable_appearance/MA = mutable_appearance(get_icon_difference(get_eyecon(), hair), layer = EMISSIVE_PLANE)
 	MA.plane = ABOVE_LIGHTING_PLANE
 	return MA //Cut the hair's pixels from the eyes icon so eyes covered by bangs stay hidden even while on a higher layer.
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes an issue where cybernetic eyes, xray eyes, and a few other misc eye traits would ignore the overlays and appear over items they shouldn't. (Like a hood or gasmask etc.)

Fixes https://github.com/ParadiseSS13/Paradise/issues/25725

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

Bugs are bad.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Loaded offline, made a nian with cybernetic eyes. Walked into a dark room. Put on a gas mask, took off the gasmask. Smiled!

<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Eye_shine no longer goes over masks and other clothing.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
