### PR TITLE
[s] Makes powerfists a bit more sane

### DIFF
--- a/code/game/objects/items/weapons/powerfist.dm
+++ b/code/game/objects/items/weapons/powerfist.dm
@@ -129,5 +129,4 @@
 		amount_to_remove = 0.1 * pressure_in_tank
 
 	var/moles_to_remove = (amount_to_remove * tank.air_contents.volume) / (R_IDEAL_GAS_EQUATION * tank.air_contents.temperature())
-	if(tank.air_contents.boolean_remove(moles_to_remove))
-		return TRUE
+	return tank.air_contents.boolean_remove(moles_to_remove)

--- a/code/game/objects/items/weapons/powerfist.dm
+++ b/code/game/objects/items/weapons/powerfist.dm
@@ -14,8 +14,9 @@
 	origin_tech = "combat=5;powerstorage=3;syndicate=3"
 	var/click_delay = 1.5
 	var/fisto_setting = 1
-	///base pressure in kpa used by the powerfist per hit
+	/// Base pressure in kpa used by the powerfist per hit
 	var/gasperfist = 17.5
+
 	var/obj/item/tank/internals/tank = null //Tank used for the gauntlet's piston-ram.
 
 /obj/item/melee/powerfist/Destroy()
@@ -93,7 +94,7 @@
 	if(!tank)
 		to_chat(user, "<span class='warning'>[src] can't operate without a source of gas!</span>")
 		return
-	if(tank && !tank.air_contents.boolean_remove(((gasperfist * fisto_setting) * tank.air_contents.return_volume()) / (R_IDEAL_GAS_EQUATION * tank.air_contents.temperature())))
+	if(!use_air())
 		to_chat(user, "<span class='warning'>[src]'s piston-ram lets out a weak hiss, it needs more gas!</span>")
 		playsound(loc, 'sound/effects/refill.ogg', 50, 1)
 		return
@@ -114,3 +115,19 @@
 	add_attack_logs(user, target, "POWER FISTED with [src]")
 
 	user.changeNext_move(CLICK_CD_MELEE * click_delay)
+
+/obj/item/melee/powerfist/proc/use_air()
+	if(!tank)
+		return FALSE
+
+	var/amount_to_remove = gasperfist * fisto_setting
+	var/pressure_in_tank = tank.air_contents.return_pressure()
+
+	// So this check is here to see if the amount of pressure currently in the tank is higher than 10 atmospheres
+	// If it is higher, we instead take 10% out of the tank so it'll deplete a lot faster, but is still a bit more ammo
+	if(pressure_in_tank > (ONE_ATMOSPHERE * 10))
+		amount_to_remove = 0.1 * pressure_in_tank
+
+	var/moles_to_remove = (amount_to_remove * tank.air_contents.volume) / (R_IDEAL_GAS_EQUATION * tank.air_contents.temperature())
+	if(tank.air_contents.boolean_remove(moles_to_remove))
+		return TRUE


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes fists
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
This should not work like this
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Tested to see if high and low pressure worked
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog
NPFC
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
