### PR TITLE
fix: handle resizing shelf items from non-player movement

### DIFF
--- a/code/datums/components/shelved.dm
+++ b/code/datums/components/shelved.dm
@@ -227,6 +227,7 @@
 /datum/component/shelved/RegisterWithParent()
 	. = ..()
 	RegisterSignal(parent, COMSIG_ITEM_PICKUP, PROC_REF(on_item_pickup))
+	RegisterSignal(parent, COMSIG_MOVABLE_MOVED, PROC_REF(on_movable_moved))
 	var/obj/shelf = locateUID(shelf_uid)
 	if(shelf)
 		RegisterSignal(shelf, COMSIG_MOVABLE_SHOVE_IMPACT, PROC_REF(on_movable_shove_impact))
@@ -239,6 +240,11 @@
 
 /datum/component/shelved/proc/on_item_pickup(obj/item/I, mob/user)
 	SIGNAL_HANDLER // COMSIG_ITEM_PICKUP
+	qdel(src)
+
+/// Generic handler for if anything moves us off our original shelf position, such as atmos pressure.
+/datum/component/shelved/proc/on_movable_moved()
+	SIGNAL_HANDLER // COMSIG_MOVABLE_MOVED
 	qdel(src)
 
 /datum/component/shelved/UnregisterFromParent()


### PR DESCRIPTION
## What Does This PR Do
This PR fixes an issue with shelved items not regaining their original size when moved by external means such as atmos pressure.
## Why It's Good For The Game
Bugfix.
## Testing
https://github.com/user-attachments/assets/6b36a7dd-debe-4dc1-a03d-8c231da4af29

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Shelved items will properly resize themselves if moved off their shelf tile by external forces such as atmos pressure.
/:cl:
