### PR TITLE
Getting rid of generic first aid kits in mapping

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/listeningpost.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/listeningpost.dmm
@@ -260,8 +260,8 @@
 "Ab" = (
 /obj/structure/closet/syndicate,
 /obj/item/clothing/glasses/regular,
-/obj/item/storage/firstaid,
-/obj/item/storage/firstaid,
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/regular,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/syndicate_listening_station)

--- a/_maps/map_files/RandomRuins/SpaceRuins/onehalf.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/onehalf.dmm
@@ -184,7 +184,7 @@
 	pixel_x = 3;
 	pixel_y = 6
 	},
-/obj/item/storage/firstaid,
+/obj/item/storage/firstaid/regular,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -1106,7 +1106,7 @@
 "de" = (
 /obj/machinery/light,
 /obj/structure/table,
-/obj/item/storage/firstaid,
+/obj/item/storage/firstaid/regular,
 /turf/simulated/floor/plasteel,
 /area/ruin/space/onehalf/abandonedbridge)
 "dg" = (

--- a/_maps/map_files/generic/centcomm.dmm
+++ b/_maps/map_files/generic/centcomm.dmm
@@ -11751,7 +11751,7 @@
 /area/centcom/specops)
 "OZ" = (
 /obj/structure/table,
-/obj/item/storage/firstaid,
+/obj/item/storage/firstaid/regular,
 /obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "bot"

--- a/_maps/map_files/shuttles/admin_armory.dmm
+++ b/_maps/map_files/shuttles/admin_armory.dmm
@@ -24,7 +24,7 @@
 /area/shuttle/administration)
 "bi" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/firstaid,
+/obj/item/storage/firstaid/regular,
 /obj/item/storage/firstaid/brute,
 /obj/item/storage/box/bodybags,
 /obj/item/storage/firstaid/surgery,

--- a/_maps/map_files/shuttles/admin_hospital.dmm
+++ b/_maps/map_files/shuttles/admin_hospital.dmm
@@ -227,8 +227,8 @@
 /area/shuttle/administration)
 "bg" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/firstaid,
-/obj/item/storage/firstaid,
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/regular,
 /obj/item/storage/firstaid/adv,
 /obj/item/storage/firstaid/adv,
 /turf/simulated/floor/mineral/titanium,

--- a/_maps/map_files/shuttles/emergency_cramped.dmm
+++ b/_maps/map_files/shuttles/emergency_cramped.dmm
@@ -47,7 +47,7 @@
 	layer = 2.9
 	},
 /obj/structure/table,
-/obj/item/storage/firstaid,
+/obj/item/storage/firstaid/regular,
 /turf/simulated/floor/plating,
 /area/shuttle/escape)
 "o" = (

--- a/_maps/map_files/shuttles/emergency_cyb.dmm
+++ b/_maps/map_files/shuttles/emergency_cyb.dmm
@@ -442,7 +442,7 @@
 /area/shuttle/escape)
 "by" = (
 /obj/structure/table,
-/obj/item/storage/firstaid,
+/obj/item/storage/firstaid/regular,
 /obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/shuttle/escape)

--- a/_maps/map_files/shuttles/emergency_jungle.dmm
+++ b/_maps/map_files/shuttles/emergency_jungle.dmm
@@ -313,7 +313,7 @@
 /area/shuttle/escape)
 "by" = (
 /obj/structure/table/wood,
-/obj/item/storage/firstaid,
+/obj/item/storage/firstaid/regular,
 /turf/simulated/floor/grass,
 /area/shuttle/escape)
 "bz" = (

--- a/_maps/map_files/shuttles/emergency_lance.dmm
+++ b/_maps/map_files/shuttles/emergency_lance.dmm
@@ -126,7 +126,7 @@
 /area/shuttle/escape)
 "fH" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/firstaid/doctor,
+/obj/item/storage/firstaid/regular/doctor,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkbluecorners"
 	},
@@ -464,7 +464,7 @@
 /area/shuttle/escape)
 "ut" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/firstaid/doctor,
+/obj/item/storage/firstaid/regular/doctor,
 /turf/simulated/floor/plasteel/dark,
 /area/shuttle/escape)
 "uW" = (
@@ -766,7 +766,7 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/item/storage/firstaid/doctor,
+/obj/item/storage/firstaid/regular/doctor,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/escape)
 "HK" = (

--- a/_maps/map_files/shuttles/emergency_raven.dmm
+++ b/_maps/map_files/shuttles/emergency_raven.dmm
@@ -419,7 +419,7 @@
 "bM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
-/obj/item/storage/firstaid/doctor,
+/obj/item/storage/firstaid/regular/doctor,
 /obj/item/storage/firstaid/toxin,
 /turf/simulated/floor/plasteel/white,
 /area/shuttle/escape)

--- a/_maps/map_files/shuttles/emergency_shadow.dmm
+++ b/_maps/map_files/shuttles/emergency_shadow.dmm
@@ -752,7 +752,7 @@
 /area/shuttle/escape)
 "GB" = (
 /obj/structure/table/glass/reinforced/plastitanium,
-/obj/item/storage/firstaid/doctor,
+/obj/item/storage/firstaid/regular/doctor,
 /obj/machinery/light{
 	dir = 8
 	},

--- a/_maps/map_files/stations/boxstation.dmm
+++ b/_maps/map_files/stations/boxstation.dmm
@@ -37502,7 +37502,7 @@
 	pixel_x = 5;
 	pixel_y = 5
 	},
-/obj/item/storage/firstaid,
+/obj/item/storage/firstaid/regular,
 /obj/item/radio/intercom{
 	name = "east bump";
 	pixel_x = 28
@@ -69910,7 +69910,7 @@
 /area/station/maintenance/apmaint)
 "mCO" = (
 /obj/structure/table,
-/obj/item/storage/firstaid,
+/obj/item/storage/firstaid/regular/empty,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitecorner"

--- a/_maps/map_files/stations/cerestation.dmm
+++ b/_maps/map_files/stations/cerestation.dmm
@@ -46066,13 +46066,13 @@
 /area/station/command/office/blueshield)
 "hXD" = (
 /obj/structure/table,
-/obj/item/storage/firstaid{
+/obj/item/storage/firstaid/regular/empty{
 	name = "first-aid kit (empty)"
 	},
-/obj/item/storage/firstaid{
+/obj/item/storage/firstaid/regular/empty{
 	name = "first-aid kit (empty)"
 	},
-/obj/item/storage/firstaid{
+/obj/item/storage/firstaid/regular/empty{
 	name = "first-aid kit (empty)"
 	},
 /obj/item/healthanalyzer,

--- a/_maps/map_files/stations/deltastation.dmm
+++ b/_maps/map_files/stations/deltastation.dmm
@@ -59105,8 +59105,8 @@
 /area/station/science/research)
 "dyM" = (
 /obj/structure/rack,
-/obj/item/storage/firstaid,
-/obj/item/storage/firstaid,
+/obj/item/storage/firstaid/regular/empty,
+/obj/item/storage/firstaid/regular/empty,
 /obj/item/paicard,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/delivery/hollow,

--- a/_maps/map_files/stations/emeraldstation.dmm
+++ b/_maps/map_files/stations/emeraldstation.dmm
@@ -50352,7 +50352,7 @@
 /area/station/maintenance/starboard)
 "jqS" = (
 /obj/structure/closet/crate,
-/obj/item/storage/firstaid,
+/obj/item/storage/firstaid/regular/empty,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint2)
 "jqU" = (
@@ -120950,7 +120950,7 @@
 /area/station/maintenance/starboard)
 "wpd" = (
 /obj/structure/closet/crate,
-/obj/item/storage/firstaid,
+/obj/item/storage/firstaid/regular/empty,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
 "wpk" = (

--- a/_maps/map_files/stations/metastation.dmm
+++ b/_maps/map_files/stations/metastation.dmm
@@ -59475,7 +59475,7 @@
 	pixel_y = 5
 	},
 /obj/item/storage/firstaid/fire,
-/obj/item/storage/firstaid{
+/obj/item/storage/firstaid/regular{
 	pixel_x = -3;
 	pixel_y = -5
 	},

--- a/code/game/jobs/job/medical_jobs.dm
+++ b/code/game/jobs/job/medical_jobs.dm
@@ -45,7 +45,7 @@
 	l_ear = /obj/item/radio/headset/heads/cmo
 	id = /obj/item/card/id/cmo
 	suit_store = /obj/item/flashlight/pen
-	l_hand = /obj/item/storage/firstaid/doctor
+	l_hand = /obj/item/storage/firstaid/regular/doctor
 	pda = /obj/item/pda/heads/cmo
 	backpack_contents = list(
 		/obj/item/melee/classic_baton/telescopic = 1
@@ -86,7 +86,7 @@
 	l_ear = /obj/item/radio/headset/headset_med
 	id = /obj/item/card/id/medical
 	suit_store = /obj/item/flashlight/pen
-	l_hand = /obj/item/storage/firstaid/doctor
+	l_hand = /obj/item/storage/firstaid/regular/doctor
 	pda = /obj/item/pda/medical
 
 	backpack = /obj/item/storage/backpack/medic

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -9,8 +9,8 @@
  * First Aid Kits
  */
 /obj/item/storage/firstaid
-	name = "first-aid kit"
-	desc = "It's an emergency medical kit for those serious boo-boos."
+	name = "generic first-aid kit"
+	desc = "If you can see this, make a bug report on GitHub, something went wrong!"
 	icon_state = "firstaid"
 	throw_speed = 2
 	throw_range = 8
@@ -24,6 +24,34 @@
 	var/syndicate_aligned = FALSE
 	var/robot_arm // This is for robot construction
 
+
+/obj/item/storage/firstaid/regular
+	name = "first-aid kit"
+	desc = "A general medical kit that contains medical patches for both brute damage and burn damage. Also contains an epinephrine syringe for emergency use and a health analyzer"
+
+/obj/item/storage/firstaid/regular/populate_contents()
+	new /obj/item/reagent_containers/patch/styptic(src)
+	new /obj/item/reagent_containers/patch/styptic(src)
+	new /obj/item/reagent_containers/pill/salicylic(src)
+	new /obj/item/reagent_containers/patch/silver_sulf(src)
+	new /obj/item/reagent_containers/patch/silver_sulf(src)
+	new /obj/item/healthanalyzer(src)
+	new /obj/item/reagent_containers/hypospray/autoinjector/epinephrine(src)
+
+/obj/item/storage/firstaid/regular/empty/populate_contents()
+	return
+
+/obj/item/storage/firstaid/regular/doctor
+	desc = "A medical kit designed for Nanotrasen medical personnel"
+
+/obj/item/storage/firstaid/regular/doctor/populate_contents()
+	new /obj/item/reagent_containers/applicator/brute(src)
+	new /obj/item/reagent_containers/applicator/burn(src)
+	new /obj/item/reagent_containers/patch/styptic(src)
+	new /obj/item/reagent_containers/patch/silver_sulf(src)
+	new /obj/item/reagent_containers/pill/salicylic(src)
+	new /obj/item/healthanalyzer/advanced(src)
+	new /obj/item/reagent_containers/hypospray/autoinjector/epinephrine(src)
 
 /obj/item/storage/firstaid/fire
 	name = "fire first-aid kit"
@@ -45,35 +73,6 @@
 
 /obj/item/storage/firstaid/fire/empty/populate_contents()
 	return
-
-/obj/item/storage/firstaid/regular
-	desc = "A general medical kit that contains medical patches for both brute damage and burn damage. Also contains an epinephrine syringe for emergency use and a health analyzer"
-	icon_state = "firstaid"
-
-/obj/item/storage/firstaid/regular/populate_contents()
-	new /obj/item/reagent_containers/patch/styptic(src)
-	new /obj/item/reagent_containers/patch/styptic(src)
-	new /obj/item/reagent_containers/pill/salicylic(src)
-	new /obj/item/reagent_containers/patch/silver_sulf(src)
-	new /obj/item/reagent_containers/patch/silver_sulf(src)
-	new /obj/item/healthanalyzer(src)
-	new /obj/item/reagent_containers/hypospray/autoinjector/epinephrine(src)
-
-/obj/item/storage/firstaid/regular/empty/populate_contents()
-	return
-
-/obj/item/storage/firstaid/doctor
-	desc = "A general medical kit that contains medical patches for both brute damage and burn damage. Also contains an epinephrine syringe for emergency use and a health analyzer"
-	icon_state = "firstaid"
-
-/obj/item/storage/firstaid/doctor/populate_contents()
-	new /obj/item/reagent_containers/applicator/brute(src)
-	new /obj/item/reagent_containers/applicator/burn(src)
-	new /obj/item/reagent_containers/patch/styptic(src)
-	new /obj/item/reagent_containers/patch/silver_sulf(src)
-	new /obj/item/reagent_containers/pill/salicylic(src)
-	new /obj/item/healthanalyzer/advanced(src)
-	new /obj/item/reagent_containers/hypospray/autoinjector/epinephrine(src)
 
 /obj/item/storage/firstaid/toxin
 	name = "toxin first aid kit"
@@ -233,7 +232,6 @@
 
 /obj/item/storage/firstaid/ert_amber
 	name = "amber ert first-aid kit"
-	icon_state = "firstaid"
 	desc = "A medical kit used by Amber level emergency response team personnel."
 
 /obj/item/storage/firstaid/ert_amber/populate_contents()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Makes `/obj/item/storage/firstaid` generic
Removes all `/obj/item/storage/firstaid` from dmm files, replacing them with `/obj/item/storage/firstaid/regular` or `/obj/item/storage/firstaid/regular/empty` if they are in maintenance/robotics area
Also moves `regular`'s code a bit higher so it's more obvious which one to spawn instead of generic
`/obj/item/storage/firstaid/doctor` is now `/obj/item/storage/firstaid/regular/doctor`
This also fixes empty first aid kits in medical storage, some escape shuttles, some ruins and admin areas.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

Mappers like to put `/obj/item/storage/firstaid` somewhere, thinking it has some medicine inside. It's not
Will prevent them from using this type of kit and force them to use `empty` type

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Checked all of them on a local server. Empty are empty, regular are full packaged. Kits spawn properly on shuttles, maps, ruins etc.

<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Fixes empty first aid kits on stations, shuttles, ruins.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
