### PR TITLE
Fix 3 posibrain / robobrain bugs

### DIFF
--- a/code/modules/mob/living/brain/robotic_brain.dm
+++ b/code/modules/mob/living/brain/robotic_brain.dm
@@ -17,8 +17,7 @@
 	var/mob/living/carbon/human/imprinted_master = null
 	var/ejected_flavor_text = "circuit"
 	/// If this is a posibrain, which will reject attempting to put a new ghost in it, because this a real brain we care about, not a robobrain
-	var/is_posibrain = FALSE
-
+	var/can_be_reinhabited = TRUE
 	dead_icon = "boris_blank"
 
 /obj/item/mmi/robotic_brain/Destroy()
@@ -33,7 +32,7 @@
 		to_chat(user, "<span class='notice'>You press your thumb on [src] and imprint your user information.</span>")
 		imprinted_master = user
 		return
-	if(brainmob && !brainmob.key && !searching && !is_posibrain)
+	if(brainmob && !brainmob.key && !searching && can_be_reinhabited)
 		//Start the process of searching for a new user.
 		to_chat(user, "<span class='notice'>You carefully locate the manual activation switch and start [src]'s boot process.</span>")
 		request_player()
@@ -208,4 +207,4 @@
 	requires_master = FALSE
 	ejected_flavor_text = "metal cube"
 	dead_icon = "posibrain"
-	is_posibrain = TRUE
+	can_be_reinhabited = FALSE

--- a/code/modules/mob/living/brain/robotic_brain.dm
+++ b/code/modules/mob/living/brain/robotic_brain.dm
@@ -16,6 +16,8 @@
 	var/requires_master = TRUE
 	var/mob/living/carbon/human/imprinted_master = null
 	var/ejected_flavor_text = "circuit"
+	/// If this is a posibrain, which will reject attempting to put a new ghost in it, because this a real brain we care about, not a robobrain
+	var/is_posibrain = FALSE
 
 	dead_icon = "boris_blank"
 
@@ -31,7 +33,7 @@
 		to_chat(user, "<span class='notice'>You press your thumb on [src] and imprint your user information.</span>")
 		imprinted_master = user
 		return
-	if(brainmob && !brainmob.key && !searching)
+	if(brainmob && !brainmob.key && !searching && !is_posibrain)
 		//Start the process of searching for a new user.
 		to_chat(user, "<span class='notice'>You carefully locate the manual activation switch and start [src]'s boot process.</span>")
 		request_player()
@@ -93,7 +95,7 @@
 	become_occupied(occupied_icon)
 
 /obj/item/mmi/robotic_brain/proc/reset_search() //We give the players sixty seconds to decide, then reset the timer.
-	if(brainmob && brainmob.key)
+	if(brainmob && brainmob.key || !searching)
 		return
 
 	searching = FALSE
@@ -104,6 +106,8 @@
 /obj/item/mmi/robotic_brain/proc/volunteer(mob/dead/observer/user)
 	if(!searching)
 		return
+	if(brainmob && brainmob.key)
+		return // No, something is wrong, abort.
 	if(!istype(user) && !HAS_TRAIT(user, TRAIT_RESPAWNABLE))
 		to_chat(user, "<span class='warning'>Seems you're not a ghost. Could you please file an exploit report on the forums?</span>")
 		return
@@ -182,11 +186,11 @@
 	..()
 
 /obj/item/mmi/robotic_brain/attack_ghost(mob/dead/observer/O)
+	if(brainmob && brainmob.key)
+		return // No point pinging a posibrain with a player already inside
 	if(searching)
 		volunteer(O)
 		return
-	if(brainmob && brainmob.key)
-		return // No point pinging a posibrain with a player already inside
 	if(validity_checks(O) && (world.time >= next_ping_at))
 		next_ping_at = world.time + (20 SECONDS)
 		playsound(get_turf(src), 'sound/items/posiping.ogg', 80, 0)
@@ -204,3 +208,4 @@
 	requires_master = FALSE
 	ejected_flavor_text = "metal cube"
 	dead_icon = "posibrain"
+	is_posibrain = TRUE


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Robobrains removed from cyborgs no longer look inactive because of them being borged in under 60 seconds from being activated.
Posibrains can no longer be offered to ghosts, they are actual players and far too often get stolen from the actual player because someone tried to turn on their microphone.
Robobrains no longer send the person inside them to the void at times

## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

These bugs were bad. Brains looking inactive, or kicking you out of the game, is bad.
Posibrains now refuse to be offered to ghosts, as 90% of the time it is accidental, and the remaining 10% of the time the brain probably wants back into their body but you offer it before it gets in.

## Testing

<!-- How did you test the PR, if at all? -->

Attempt to activate a ghosted posibrain, fail.
Attempt to join into a robobrain with a mob in it, fail.
Borg a robobrain, its icon is fine when unborged

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Robobrains removed from cyborgs no longer look inactive because of them being borged in under 60 seconds from being activated.
fix: Posibrains can no longer be offered to ghosts, they are actual players and far too often get stolen from the actual player because someone tried to turn on their microphone.
fix: Robobrains no longer send the person inside them to the void at times
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
