### PR TITLE
[FIX] Stopped Quantum Entanglement of Original Fax to Fax Panel

### DIFF
--- a/_maps/map_files/generic/centcomm.dmm
+++ b/_maps/map_files/generic/centcomm.dmm
@@ -6360,6 +6360,12 @@
 /obj/item/dice/d20,
 /turf/simulated/floor/wood,
 /area/trader_station/sol)
+"vC" = (
+/obj/machinery/photocopier/faxmachine/longrange{
+	department = "Central Command"
+	},
+/turf/simulated/floor/plasteel,
+/area/admin)
 "vD" = (
 /obj/structure/railing,
 /obj/effect/landmark/spawner/trader,
@@ -6906,6 +6912,12 @@
 	icon_state = "white"
 	},
 /area/centcom/control)
+"xx" = (
+/obj/machinery/photocopier/faxmachine/longrange/syndie{
+	department = "Syndicate"
+	},
+/turf/simulated/floor/plasteel,
+/area/admin)
 "xy" = (
 /obj/structure/bookcase/random,
 /obj/machinery/light/small,
@@ -8994,7 +9006,7 @@
 /obj/structure/table/wood,
 /obj/machinery/photocopier{
 	icon_state = "fax";
-	name = "fax machine"
+	name = "fake fax machine"
 	},
 /obj/item/photo{
 	name = "butts"
@@ -69406,7 +69418,7 @@ vH
 lZ
 wR
 wk
-lZ
+vC
 lZ
 lZ
 lZ
@@ -69663,7 +69675,7 @@ lZ
 lZ
 lZ
 wk
-lZ
+xx
 lZ
 lZ
 lZ

--- a/code/modules/paperwork/fax.dm
+++ b/code/modules/paperwork/fax.dm
@@ -18,7 +18,6 @@ GLOBAL_LIST_EMPTY(adminfaxes)
 	var/list/reply_to = null
 
 /datum/fax/admin/New()
-	GLOB.adminfaxes += src
 
 // Fax panel - lets admins check all faxes sent during the round
 /client/proc/fax_panel()

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -299,22 +299,22 @@ GLOBAL_LIST_EMPTY(fax_blacklist)
 	var/success = 0
 	for(var/obj/machinery/photocopier/faxmachine/F in GLOB.allfaxes)
 		if(F.department == destination)
-			success = F.receivefax(copyitem)
-	if(success)
-		var/datum/fax/F = new /datum/fax()
-		F.name = copyitem.name
-		F.from_department = department
-		F.to_department = destination
-		F.origin = src
-		F.message = copyitem
-		F.sent_by = sender
-		F.sent_at = world.time
+			var/datum/fax/A = new /datum/fax()
+			A.name = copyitem.name
+			A.from_department = department
+			A.to_department = destination
+			A.origin = src
+			A.message = copyitem
+			A.sent_by = sender
+			A.sent_at = world.time
 
+			success = F.receivefax(A)
+	if(success)
 		visible_message("[src] beeps, \"Message transmitted successfully.\"")
 	else
 		visible_message("[src] beeps, \"Error transmitting message.\"")
 
-/obj/machinery/photocopier/faxmachine/proc/receivefax(obj/item/incoming)
+/obj/machinery/photocopier/faxmachine/proc/receivefax(datum/fax/incoming)
 	if(stat & (BROKEN|NOPOWER))
 		return FALSE
 
@@ -327,15 +327,30 @@ GLOBAL_LIST_EMPTY(fax_blacklist)
 	addtimer(CALLBACK(src, PROC_REF(print_fax), incoming), 2 SECONDS)
 	return TRUE
 
-/obj/machinery/photocopier/faxmachine/proc/print_fax(obj/item/incoming)
-	if(istype(incoming, /obj/item/paper))
-		papercopy(incoming)
-	else if(istype(incoming, /obj/item/photo))
-		photocopy(incoming)
-	else if(istype(incoming, /obj/item/paper_bundle))
-		bundlecopy(incoming)
+/obj/machinery/photocopier/faxmachine/proc/print_fax(datum/fax/incoming)
+	var/obj/item/new_copy = null
+	if(istype(incoming.message, /obj/item/paper))
+		new_copy = papercopy(incoming.message)
+	else if(istype(incoming.message, /obj/item/photo))
+		new_copy = photocopy(incoming.message)
+	else if(istype(incoming.message, /obj/item/paper_bundle))
+		new_copy = bundlecopy(incoming.message)
 	else
 		return
+
+	// Store the fax that was received in the admin room in adminfaxes
+	// Fixes issue where deleting the original would make it unreadable in the admin panel
+	if(istype(incoming, /datum/fax/admin))
+		var/datum/fax/admin/A = new /datum/fax/admin()
+		A.name = new_copy.name
+		A.from_department = incoming.from_department
+		A.to_department = incoming.to_department
+		A.origin = incoming.origin
+		A.message = new_copy
+		A.sent_by = incoming.sent_by
+		A.sent_at = incoming.sent_at
+
+		GLOB.adminfaxes += A
 
 	use_power(active_power_consumption)
 
@@ -363,6 +378,8 @@ GLOBAL_LIST_EMPTY(fax_blacklist)
 			page_count ++
 		return
 
+
+
 /obj/machinery/photocopier/faxmachine/proc/send_admin_fax(mob/sender, destination)
 	use_power(active_power_consumption)
 
@@ -387,7 +404,7 @@ GLOBAL_LIST_EMPTY(fax_blacklist)
 			message_admins(sender, "SYNDICATE FAX", destination, copyitem, "#DC143C")
 	for(var/obj/machinery/photocopier/faxmachine/F in GLOB.allfaxes)
 		if(F.department == destination)
-			F.receivefax(copyitem)
+			F.receivefax(A)
 	visible_message("[src] beeps, \"Message transmitted successfully.\"")
 	log_fax(sender, destination)
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

This PR causes admin faxes (faxes sent to CC or Syndies) to be printed in the admin room. The admin fax panel also refers to these printed faxes, instead of the original, solving a problem where burning the original fax would make it unreadable from the fax panel.

Fixes #26760 and #11736

(Faxes are still quantum entangled, however to the received fax now. Killing quantum physics would need a fax rework.)

## Why It's Good For The Game

Admins should be able to read faxes. Also, pieces of paper shouldn't be quantum entangled.


## Testing

<!-- How did you test the PR, if at all? -->

Sent fax to CC, burned it, still legible in the fax panel

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->