### PR TITLE
[FIX] Prevent Shell Count From Appearing on DL-88 Speedcharger

### DIFF
--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -250,12 +250,7 @@
 
 /obj/item/ammo_box/update_desc()
 	. = ..()
-
-	// Edgecase catch to prevent a shell count from appearing on the DL-88 Speedcharger
-	if(istype(src, /obj/item/ammo_box/magazine/detective/speedcharger))
-		desc = "[initial(desc)]"
-	else
-		desc = "[initial(desc)] There are [length(stored_ammo)] shell\s left!"
+	desc = "[initial(desc)] There are [length(stored_ammo)] shell\s left!"
 
 /obj/item/ammo_box/proc/update_mat_value()
 	var/num_ammo = 0

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -250,7 +250,12 @@
 
 /obj/item/ammo_box/update_desc()
 	. = ..()
-	desc = "[initial(desc)] There are [length(stored_ammo)] shell\s left!"
+
+	// Edgecase catch to prevent a shell count from appearing on the DL-88 Speedcharger
+	if(istype(src, /obj/item/ammo_box/magazine/detective/speedcharger))
+		desc = "[initial(desc)]"
+	else
+		desc = "[initial(desc)] There are [length(stored_ammo)] shell\s left!"
 
 /obj/item/ammo_box/proc/update_mat_value()
 	var/num_ammo = 0

--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -604,6 +604,11 @@
 	materials = list(MAT_METAL = 20000)
 	var/charge = 1000
 
+// Overwrite description so shells aren't displayed
+/obj/item/ammo_box/magazine/detective/speedcharger/update_desc()
+	. = ..()
+	desc = "[initial(desc)]"
+
 /obj/item/ammo_box/magazine/detective/speedcharger/update_icon_state()
 	return
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

This PR adds a check to make sure the default 7 shell count is not appended to the DL-88 speedcharger, which is supposed to be energy-based and single use.

The speedcharger itself is defined in magazines.dm, with the comment `//yes this doesn't really belong here but nowhere else works`, so I've just added a check to make sure the count doesn't appear instead of touching the speedcharger.

Fixes #26874

## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Quality of Life, game is literally unplayable if the speedcharger says it has shells

## Testing

<!-- How did you test the PR, if at all? -->

Spawned the speedcharger, examined it, it showed no shell count. Used it to recharge the DL-88, still no shell count.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
