### PR TITLE
Adds a Collection of Spent Ballistic Casings With Random Rotation and Offsets

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/ussp.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/ussp.dmm
@@ -1844,9 +1844,7 @@
 	name = "custom placement";
 	pixel_x = 30
 	},
-/obj/item/trash/spentcasing{
-	icon_state = "762-casing"
-	},
+/obj/item/trash/spentcasing/bullet/medium,
 /turf/simulated/floor/wood,
 /area/ruin/space/derelict/crew_quarters)
 "eI" = (
@@ -2010,9 +2008,7 @@
 /turf/simulated/floor/plating,
 /area/ruin/space/derelict/hallway/primary)
 "fb" = (
-/obj/item/trash/spentcasing{
-	icon_state = "s-casing"
-	},
+/obj/item/trash/spentcasing/bullet,
 /turf/simulated/floor/wood,
 /area/ruin/space/derelict/crew_quarters)
 "fc" = (
@@ -2247,14 +2243,12 @@
 	},
 /area/ruin/space/derelict/arrival)
 "fB" = (
-/obj/item/trash/spentcasing{
-	icon_state = "762-casing"
-	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/item/trash/spentcasing/bullet/medium,
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/derelict/arrival)
 "fC" = (
@@ -2266,12 +2260,12 @@
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/derelict/arrival)
 "fD" = (
-/obj/item/trash/spentcasing,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/item/trash/spentcasing/shotgun,
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/derelict/arrival)
 "fE" = (
@@ -2399,14 +2393,12 @@
 /turf/simulated/floor/wood,
 /area/ruin/space/derelict/crew_quarters)
 "fU" = (
-/obj/item/trash/spentcasing,
+/obj/item/trash/spentcasing/shotgun,
 /turf/simulated/floor/wood,
 /area/ruin/space/derelict/crew_quarters)
 "fV" = (
 /obj/structure/chair/stool/bar,
-/obj/item/trash/spentcasing{
-	icon_state = "762-casing"
-	},
+/obj/item/trash/spentcasing/bullet/medium,
 /turf/simulated/floor/wood,
 /area/ruin/space/derelict/crew_quarters)
 "fW" = (
@@ -2576,7 +2568,7 @@
 	},
 /area/ruin/space/derelict/arrival)
 "gr" = (
-/obj/item/trash/spentcasing,
+/obj/item/trash/spentcasing/shotgun,
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/derelict/arrival)
 "gs" = (
@@ -2702,7 +2694,7 @@
 /turf/simulated/floor/wood,
 /area/ruin/space/derelict/crew_quarters)
 "gH" = (
-/obj/item/trash/spentcasing,
+/obj/item/trash/spentcasing/shotgun,
 /turf/simulated/floor/plasteel/grimy,
 /area/ruin/space/derelict/crew_quarters)
 "gI" = (
@@ -2732,9 +2724,7 @@
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/derelict/arrival)
 "gM" = (
-/obj/item/trash/spentcasing{
-	icon_state = "762-casing"
-	},
+/obj/item/trash/spentcasing/bullet/medium,
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/derelict/arrival)
 "gN" = (
@@ -3229,7 +3219,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/item/trash/spentcasing,
+/obj/item/trash/spentcasing/shotgun,
 /turf/simulated/floor/plasteel,
 /area/ruin/space/derelict/arrival)
 "ia" = (
@@ -3327,9 +3317,7 @@
 	},
 /area/ruin/space/derelict/crew_quarters)
 "in" = (
-/obj/item/trash/spentcasing{
-	icon_state = "s-casing"
-	},
+/obj/item/trash/spentcasing/bullet,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "chapel"
@@ -3374,9 +3362,7 @@
 /area/ruin/space/derelict/arrival)
 "ix" = (
 /obj/effect/decal/cleanable/blood/splatter,
-/obj/item/trash/spentcasing{
-	icon_state = "s-casing"
-	},
+/obj/item/trash/spentcasing/bullet,
 /turf/simulated/floor/plasteel,
 /area/ruin/space/derelict/arrival)
 "iy" = (
@@ -3477,7 +3463,7 @@
 	},
 /area/ruin/space/derelict/crew_quarters)
 "iL" = (
-/obj/item/trash/spentcasing,
+/obj/item/trash/spentcasing/shotgun,
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/derelict/crew_quarters)
 "iM" = (
@@ -3686,9 +3672,7 @@
 /turf/simulated/floor/plasteel,
 /area/ruin/space/derelict/arrival)
 "jo" = (
-/obj/item/trash/spentcasing{
-	icon_state = "s-casing"
-	},
+/obj/item/trash/spentcasing/bullet,
 /turf/simulated/floor/plasteel,
 /area/ruin/space/derelict/arrival)
 "jp" = (
@@ -3702,9 +3686,7 @@
 /area/ruin/space/derelict/arrival)
 "jq" = (
 /obj/effect/landmark/burnturf,
-/obj/item/trash/spentcasing{
-	icon_state = "s-casing"
-	},
+/obj/item/trash/spentcasing/bullet,
 /turf/simulated/floor/plasteel,
 /area/ruin/space/derelict/arrival)
 "jr" = (
@@ -3722,7 +3704,7 @@
 	},
 /area/ruin/space/derelict/hallway/primary)
 "jt" = (
-/obj/item/trash/spentcasing,
+/obj/item/trash/spentcasing/shotgun,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "rampbottom"
@@ -3931,9 +3913,7 @@
 	},
 /area/ruin/space/derelict/arrival)
 "jX" = (
-/obj/item/trash/spentcasing{
-	icon_state = "762-casing"
-	},
+/obj/item/trash/spentcasing/bullet/medium,
 /turf/simulated/floor/plasteel{
 	icon_state = "derelict14"
 	},
@@ -4009,9 +3989,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/trash/spentcasing{
-	icon_state = "762-casing"
-	},
+/obj/item/trash/spentcasing/bullet/medium,
 /turf/simulated/floor/plasteel,
 /area/ruin/space/derelict/hallway/primary)
 "kf" = (
@@ -4386,7 +4364,7 @@
 	},
 /area/ruin/space/derelict/arrival)
 "kN" = (
-/obj/item/trash/spentcasing,
+/obj/item/trash/spentcasing/shotgun,
 /turf/simulated/floor/plasteel{
 	icon_state = "derelict3"
 	},
@@ -4430,9 +4408,7 @@
 /area/ruin/space/derelict/arrival)
 "kU" = (
 /obj/machinery/light/small,
-/obj/item/trash/spentcasing{
-	icon_state = "762-casing"
-	},
+/obj/item/trash/spentcasing/bullet/medium,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "redblue"
@@ -4557,9 +4533,7 @@
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/derelict/crew_quarters)
 "ll" = (
-/obj/item/trash/spentcasing{
-	icon_state = "s-casing"
-	},
+/obj/item/trash/spentcasing/bullet,
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/derelict/crew_quarters)
 "lm" = (
@@ -4907,9 +4881,7 @@
 	},
 /area/ruin/space/derelict/arrival)
 "mf" = (
-/obj/item/trash/spentcasing{
-	icon_state = "762-casing"
-	},
+/obj/item/trash/spentcasing/bullet/medium,
 /turf/simulated/floor/plasteel,
 /area/ruin/space/derelict/arrival)
 "mg" = (

--- a/code/game/objects/effects/spawners/random/trash_spawners.dm
+++ b/code/game/objects/effects/spawners/random/trash_spawners.dm
@@ -59,7 +59,7 @@
 		// Ammo casings rarely
 		list(
 			/obj/item/ammo_casing/c10mm,
-			/obj/item/trash/spentcasing,
+			/obj/item/trash/spentcasing/shotgun,
 		) = 1,
 	)
 

--- a/code/game/objects/effects/spawners/random/trash_spawners.dm
+++ b/code/game/objects/effects/spawners/random/trash_spawners.dm
@@ -58,8 +58,16 @@
 
 		// Ammo casings rarely
 		list(
-			/obj/item/ammo_casing/c10mm,
 			/obj/item/trash/spentcasing/shotgun,
+			/obj/item/trash/spentcasing/shotgun/rubbershot,
+			/obj/item/trash/spentcasing/shotgun/beanbag,
+			/obj/item/trash/spentcasing/shotgun/slug,
+			/obj/item/trash/spentcasing/shotgun/dragonsbreath,
+			/obj/item/trash/spentcasing/shotgun/stun,
+			/obj/item/trash/spentcasing/bullet,
+			/obj/item/trash/spentcasing/bullet/medium,
+			/obj/item/trash/spentcasing/bullet/large,
+			/obj/item/trash/spentcasing/bullet/lasershot
 		) = 1,
 	)
 

--- a/code/game/objects/items/trash.dm
+++ b/code/game/objects/items/trash.dm
@@ -17,6 +17,9 @@
 		return TRUE
 	return ..()
 
+/obj/item/trash/attack(mob/M as mob, mob/living/user as mob)
+	return
+
 /obj/item/trash/raisins
 	name = "4no raisins"
 	icon_state= "4no_raisins"
@@ -117,10 +120,22 @@
 	name = "bread tube"
 	icon_state = "tastybread"
 
+/obj/item/trash/tapetrash
+	name = "old duct tape"
+	icon_state = "tape"
+	desc = "Not sticky anymore."
+	throw_range = 1
+
+/obj/item/trash/popsicle_stick
+	name = "used popsicle stick"
+	icon_state = "popsicle_stick_s"
+	desc = "Still tastes sweet."
+
+// Ammo casings
 /obj/item/trash/spentcasing
 	icon = 'icons/obj/ammo.dmi'
-	name = "arbitrary spent ammunition"
-	desc = "This is an arbitrary item, if you see it in normal play, please make an issue report on GitHub."
+	name = "arbitrary spent casing item"
+	desc = "If you can see this and didn't spawn it, make an issue report on GitHub."
 	icon_state = "gshell"
 
 /obj/item/trash/spentcasing/Initialize(mapload)
@@ -131,7 +146,7 @@
 
 /obj/item/trash/spentcasing/shotgun
 	name = "spent buckshot shell"
-	desc = "A spent shotgun shell. It smells like cordite."
+	desc = "A spent shotgun shell. It smells like cordite and singed rubber."
 	icon_state = "gshell"
 
 /obj/item/trash/spentcasing/shotgun/rubbershot
@@ -157,31 +172,20 @@
 	icon_state = "stunshell"
 
 /obj/item/trash/spentcasing/bullet
-	desc = "A spent small-caliber bullet casing. It smells of brass and cordite."
+	name = "spent bullet casing"
+	desc = "A spent bullet casing. It smells of brass and cordite."
 	icon_state = "s-casing"
 
 /obj/item/trash/spentcasing/bullet/medium
-	desc = "A spent rifle-caliber bullet casing. It smells of brass and cordite."
+	name = "spent large bullet casing"
+	desc = "A spent high-caliber bullet casing. It smells of brass and cordite."
 	icon_state = "762-casing"
 
 /obj/item/trash/spentcasing/bullet/large
+	name = "spent .50 BMG bullet casing"
 	desc = "A spent .50 BMG bullet casing. It smells of brass and cordite."
 	icon_state = ".50"
 
 /obj/item/trash/spentcasing/bullet/lasershot
 	desc = "A spent IK-series single-use lasershot cell. It smells of burnt plastic with a metallic-chemical undertone."
 	icon_state = "lasercasing"
-
-/obj/item/trash/tapetrash
-	name = "old duct tape"
-	icon_state = "tape"
-	desc = "Not sticky anymore."
-	throw_range = 1
-
-/obj/item/trash/popsicle_stick
-	name = "used popsicle stick"
-	icon_state = "popsicle_stick_s"
-	desc = "Still tastes sweet."
-
-/obj/item/trash/attack(mob/M as mob, mob/living/user as mob)
-	return

--- a/code/game/objects/items/trash.dm
+++ b/code/game/objects/items/trash.dm
@@ -164,7 +164,7 @@
 
 /obj/item/trash/spentcasing/shotgun/dragonsbreath
 	name = "spent dragonsbreath shell"
-	desc = "A spent shotgun shell. It smells like cordite, burnt plastic, and a hint of petrolium."
+	desc = "A spent shotgun shell. It smells like cordite, burnt plastic, and a hint of petroleum."
 	icon_state = "ishell"
 
 /obj/item/trash/spentcasing/shotgun/stun

--- a/code/game/objects/items/trash.dm
+++ b/code/game/objects/items/trash.dm
@@ -146,7 +146,7 @@
 
 /obj/item/trash/spentcasing/shotgun
 	name = "spent buckshot shell"
-	desc = "A spent shotgun shell. It smells like cordite and singed rubber."
+	desc = "A spent shotgun shell. It smells like cordite."
 	icon_state = "gshell"
 
 /obj/item/trash/spentcasing/shotgun/rubbershot

--- a/code/game/objects/items/trash.dm
+++ b/code/game/objects/items/trash.dm
@@ -119,9 +119,58 @@
 
 /obj/item/trash/spentcasing
 	icon = 'icons/obj/ammo.dmi'
-	name = "bullet casing"
-	desc = "A spent bullet casing. Smells like cordite."
+	name = "arbitrary spent ammunition"
+	desc = "This is an arbitrary item, if you see it in normal play, please make an issue report on GitHub."
 	icon_state = "gshell"
+
+/obj/item/trash/spentcasing/Initialize(mapload)
+	. = ..()
+	pixel_x = rand(-10, 10)
+	pixel_y = rand(-10, 10)
+	transform = turn(transform, rand(0, 360))
+
+/obj/item/trash/spentcasing/shotgun
+	name = "spent buckshot shell"
+	desc = "A spent shotgun shell. It smells like cordite."
+	icon_state = "gshell"
+
+/obj/item/trash/spentcasing/shotgun/rubbershot
+	name = "spent rubbershot shell"
+	desc = "A spent shotgun shell. It smells like cordite and singed rubber."
+	icon_state = "cshell"
+
+/obj/item/trash/spentcasing/shotgun/beanbag
+	name = "spent beanbag shell"
+	icon_state = "bshell"
+
+/obj/item/trash/spentcasing/shotgun/slug
+	name = "spent slug shell"
+	icon_state = "blshell"
+
+/obj/item/trash/spentcasing/shotgun/dragonsbreath
+	name = "spent dragonsbreath shell"
+	desc = "A spent shotgun shell. It smells like cordite, burnt plastic, and a hint of petrolium."
+	icon_state = "ishell"
+
+/obj/item/trash/spentcasing/shotgun/stun
+	name = "spent stun shell"
+	icon_state = "stunshell"
+
+/obj/item/trash/spentcasing/bullet
+	desc = "A spent small-caliber bullet casing. It smells of brass and cordite."
+	icon_state = "s-casing"
+
+/obj/item/trash/spentcasing/bullet/medium
+	desc = "A spent rifle-caliber bullet casing. It smells of brass and cordite."
+	icon_state = "762-casing"
+
+/obj/item/trash/spentcasing/bullet/large
+	desc = "A spent .50 BMG bullet casing. It smells of brass and cordite."
+	icon_state = ".50"
+
+/obj/item/trash/spentcasing/bullet/lasershot
+	desc = "A spent IK-series single-use lasershot cell. It smells of burnt plastic with a metallic-chemical undertone."
+	icon_state = "lasercasing"
 
 /obj/item/trash/tapetrash
 	name = "old duct tape"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds a selection of casings for use in mapping:
* Buckshot, slugs, rubbershot, beanbag, dragonsbreath, stun.
* small, large, and .50 cal bullet casings.
* Spent IK casings.

The USSP station ruin has been remapped with these new spent casings, replacing the varedits it was previously using.

Trash spawners can spawn any of the new casings.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Allows mappers to place down randomly scattered casings without needing to varedit. The random offset and rotation makes them actually look like they've been shot. Good for environmental storytelling.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://github.com/user-attachments/assets/e87266f4-b056-49c9-b1e6-7aeec9f04f97)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Spawned into USSP ruin, saw the cartridges were now randomly scattered.
Mapped in a pile of all the casing types, they all got scattered on their tiles randomly.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
tweak: mapped-in spent casings are now randomly scattered.
add: Trash spawners can spawn a wider range of spent casings if they roll to spawn a spent ammo casing.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
