### PR TITLE
fix: make food on shelves ant-proof

### DIFF
--- a/code/modules/food_and_drinks/food_base.dm
+++ b/code/modules/food_and_drinks/food_base.dm
@@ -64,7 +64,8 @@
 		ant_suppressors = typecacheof(list(
 			/obj/structure/table,
 			/obj/structure/rack,
-			/obj/structure/closet
+			/obj/structure/closet,
+			/obj/structure/shelf,
 		))
 	START_PROCESSING(SSobj, src)
 	ant_location = get_turf(src)


### PR DESCRIPTION
## What Does This PR Do
This PR adds shelves to the list of structures which prevent ants from spawning on tiles with food.
## Why It's Good For The Game
Food on shelves should be safe from ants.
## Testing
Put burgers on shelves, waited. Ensured no ants spawned.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Food on shelves will no longer spawn ants.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
