### PR TITLE
lint: forbid whitespace in empty list decls

### DIFF
--- a/code/__HELPERS/bitflag_lists.dm
+++ b/code/__HELPERS/bitflag_lists.dm
@@ -4,7 +4,7 @@ GLOBAL_LIST_EMPTY(bitflag_lists)
   * System for storing bitflags past the 24 limit, making use of an associative list.
   *
   * Macro converts a list of integers into an associative list of bitflag entries for quicker comparison.
-  * Example: list(0, 4, 26, 32)) => list( "0" = ( (1<<0) | (1<<4) ), "1" = ( (1<<2) | (1<<8) ) )
+  * Example: list(0, 4, 26, 32)) => list("0" = ( (1<<0) | (1<<4) ), "1" = ( (1<<2) | (1<<8) ))
   * Lists are cached into a global list of lists to avoid identical duplicates.
   * This system makes value comparisons faster than pairing every element of one list with every element of the other for evaluation.
   *

--- a/code/datums/mixed.dm
+++ b/code/datums/mixed.dm
@@ -19,7 +19,7 @@
 /datum/data/record
 	name = "record"
 	size = 5.0
-	var/list/fields = list(  )
+	var/list/fields = list()
 
 /datum/data/record/Destroy()
 	if(src in GLOB.data_core.medical)

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -625,11 +625,13 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/chem_dispenser
 	board_type = "machine"
 	origin_tech = "materials=4;programming=4;plasmatech=4;biotech=3"
-	req_components = list(	/obj/item/stock_parts/matter_bin = 2,
-							/obj/item/stock_parts/capacitor = 1,
-							/obj/item/stock_parts/manipulator = 1,
-							/obj/item/stack/sheet/glass = 1,
-							/obj/item/stock_parts/cell = 1)
+	req_components = list(
+		/obj/item/stock_parts/matter_bin = 2,
+		/obj/item/stock_parts/capacitor = 1,
+		/obj/item/stock_parts/manipulator = 1,
+		/obj/item/stack/sheet/glass = 1,
+		/obj/item/stock_parts/cell = 1
+	)
 
 /obj/item/circuitboard/chem_master
 	board_name = "ChemMaster 3000"

--- a/code/game/objects/effects/misc_effects.dm
+++ b/code/game/objects/effects/misc_effects.dm
@@ -58,7 +58,7 @@
 /obj/effect/shut_controller
 	name = "shut controller"
 	var/moving = null
-	var/list/parts = list(  )
+	var/list/parts = list()
 
 /obj/structure/showcase
 	name = "Showcase"
@@ -86,7 +86,7 @@
 	name = "mobl"
 	var/master = null
 
-	var/list/container = list(  )
+	var/list/container = list()
 
 
 /obj/structure/showcase/horrific_experiment

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -116,10 +116,11 @@
 
 /obj/item/taperecorder/AltClick(mob/user)
 	if(in_range(user, src) && mytape && !HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
-		var/list/options = list( "Playback Tape" = image(icon = 'icons/obj/device.dmi', icon_state = "taperecorder_playing"),
-						"Print Transcript" = image(icon = 'icons/obj/bureaucracy.dmi', icon_state = "paper_words"),
-						"Eject Tape" = image(icon = 'icons/obj/device.dmi', icon_state = "[mytape.icon_state]")
-						)
+		var/list/options = list(
+			"Playback Tape" = image(icon = 'icons/obj/device.dmi', icon_state = "taperecorder_playing"),
+			"Print Transcript" = image(icon = 'icons/obj/bureaucracy.dmi', icon_state = "paper_words"),
+			"Eject Tape" = image(icon = 'icons/obj/device.dmi', icon_state = "[mytape.icon_state]")
+		)
 		var/choice = show_radial_menu(user, src, options)
 		if(user.incapacitated())
 			return

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -13,7 +13,7 @@
 	w_class = WEIGHT_CLASS_TINY
 	var/associated_account_number = 0
 
-	var/list/files = list(  )
+	var/list/files = list()
 
 /obj/item/card/proc/get_card_account()
 	return GLOB.station_money_database.find_user_account(associated_account_number)

--- a/code/game/objects/items/weapons/teleportation.dm
+++ b/code/game/objects/items/weapons/teleportation.dm
@@ -52,14 +52,14 @@
 	if(!current_location||!is_teleport_allowed(current_location.z))//If turf was not found or they're somewhere teleproof
 		to_chat(user, "<span class='notice'>\The [src] is malfunctioning.</span>")
 		return
-	var/list/L = list(  )
+	var/list/L = list()
 	for(var/obj/machinery/computer/teleporter/com in GLOB.machines)
 		if(com.target)
 			if(com.power_station && com.power_station.teleporter_hub && com.power_station.engaged)
 				L["[com.id] (Active)"] = com.target
 			else
 				L["[com.id] (Inactive)"] = com.target
-	var/list/turfs = list(	)
+	var/list/turfs = list()
 	var/area/A
 	for(var/turf/T in orange(10))
 		if(T.x>world.maxx-8 || T.x<8)

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -1,5 +1,7 @@
 /datum/canister_icons
-	var/list/possiblemaincolor = list( //these lists contain the possible colors of a canister
+	// these lists contain the possible colors of a canister
+
+	var/list/possiblemaincolor = list(
 		list("name" = "\[N2O\]", "icon" = "redws"),
 		list("name" = "\[N2\]", "icon" = "red"),
 		list("name" = "\[O2\]", "icon" = "blue"),
@@ -10,7 +12,8 @@
 		list("name" = "\[SPECIAL\]", "icon" = "whiters")
 	)
 
-	var/list/possibleseccolor = list( // no point in having the N2O and "whiters" ones in these lists
+	// no point in having the N2O and "whiters" ones in these lists
+	var/list/possibleseccolor = list(
 		list("name" = "\[None\]", "icon" = "none"),
 		list("name" = "\[N2\]", "icon" = "red-c"),
 		list("name" = "\[O2\]", "icon" = "blue-c"),

--- a/code/modules/client/preference/link_processing.dm
+++ b/code/modules/client/preference/link_processing.dm
@@ -322,7 +322,7 @@
 					active_character.metadata = new_metadata
 
 				if("b_type")
-					var/new_b_type = tgui_input_list(user, "Choose your character's blood-type", "Character Preference", list( "A+", "A-", "B+", "B-", "AB+", "AB-", "O+", "O-"))
+					var/new_b_type = tgui_input_list(user, "Choose your character's blood-type", "Character Preference", list("A+", "A-", "B+", "B-", "AB+", "AB-", "O+", "O-"))
 					if(!new_b_type)
 						return
 					active_character.b_type = new_b_type

--- a/code/modules/client/preference/preferences.dm
+++ b/code/modules/client/preference/preferences.dm
@@ -1,4 +1,5 @@
-GLOBAL_LIST_INIT(special_role_times, list( //minimum age (in days) for accounts to play these roles
+/// Minimum age (in days) for accounts to play these roles.
+GLOBAL_LIST_INIT(special_role_times, list(
 	ROLE_PAI = 0,
 	ROLE_GUARDIAN = 0,
 	ROLE_TRAITOR = 7,

--- a/code/modules/clothing/suits/armor_suits.dm
+++ b/code/modules/clothing/suits/armor_suits.dm
@@ -248,7 +248,8 @@
 	desc = "An old style captain tunic. Makes you look and feel like you're wearing a cardboard box with arm holes cut in it but looks like it would be great for a wedding... or a funeral."
 	icon_state = "captain_white"
 
-	sprite_sheets = list( //Drask look fine in the regular human version
+	// Drask look fine in the regular human version
+	sprite_sheets = list(
 		"Vox" = 'icons/mob/clothing/species/vox/suit.dmi',
 		"Grey" = 'icons/mob/clothing/species/grey/suit.dmi',
 		"Kidan" = 'icons/mob/clothing/species/kidan/suit.dmi',

--- a/code/modules/clothing/suits/suit_storage.dm
+++ b/code/modules/clothing/suits/suit_storage.dm
@@ -62,7 +62,7 @@
 
 /obj/item/clothing/suit/storage/proc/return_inv()
 
-	var/list/L = list(  )
+	var/list/L = list()
 
 	L += src.contents
 

--- a/code/modules/clothing/under/accessories/storage_accessories.dm
+++ b/code/modules/clothing/under/accessories/storage_accessories.dm
@@ -50,7 +50,7 @@
 
 /obj/item/clothing/accessory/storage/proc/return_inv()
 
-	var/list/L = list(  )
+	var/list/L = list()
 
 	L += src.contents
 

--- a/code/modules/clothing/under/costumes.dm
+++ b/code/modules/clothing/under/costumes.dm
@@ -139,12 +139,13 @@
 	item_state = "psysuit"
 	item_color = "psysuit"
 
-	sprite_sheets = list( //it is what it is
+	//it is what it is
+	sprite_sheets = list(
 		"Human" = 'icons/mob/clothing/under/costumes.dmi',
 		"Vox" = 'icons/mob/clothing/species/vox/under/costumes.dmi',
 		"Drask" = 'icons/mob/clothing/species/drask/under/costumes.dmi',
 		"Grey" = 'icons/mob/clothing/species/grey/under/costumes.dmi'
-		)
+	)
 
 /obj/item/clothing/under/costume/redcoat
 	name = "redcoat uniform"

--- a/code/modules/crafting/craft.dm
+++ b/code/modules/crafting/craft.dm
@@ -11,20 +11,26 @@
 				CAT_DECORATIONS,
 				CAT_CLOTHING)
 	var/list/subcategories = list(
-						list(	//Weapon subcategories
+						//Weapon subcategories
+						list(
 							CAT_WEAPON,
-							CAT_AMMO),
+							CAT_AMMO
+						),
 						CAT_NONE, //Robot subcategories
 						CAT_NONE, //Misc subcategories
 						CAT_NONE, //Tribal subcategories
-						list(	//Food subcategories
+						// Food subcategories
+						list(
 							CAT_CAKE,
 							CAT_SUSHI,
-							CAT_SANDWICH),
-						list(	//Decoration subcategories
+							CAT_SANDWICH
+						),
+						// Decoration subcategories
+						list(
 							CAT_DECORATION,
 							CAT_HOLIDAY,
-							CAT_LARGE_DECORATIONS),
+							CAT_LARGE_DECORATIONS
+						),
 						CAT_CLOTHING) //Clothing subcategories
 	var/display_craftable_only = FALSE
 	var/display_compact = TRUE

--- a/code/modules/library/library_catalog.dm
+++ b/code/modules/library/library_catalog.dm
@@ -452,7 +452,8 @@
 	var/list/flag_json = list()
 	//Flagged book json is stored as such: "[[reporter_ckey1, report_id1],[reporter_ckey2, report_id2]]""
 	for(var/datum/flagged_book/book in reportedbook.reports)
-		flag_json += list(list( //yes this is intentional
+		//yes this is intentional
+		flag_json += list(list(
 			book.reporter,
 			book.category_id,
 		))

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -159,16 +159,16 @@
 	//Defining lists of icon skin tones for species that have them.
 	var/list/icon_skin_tones = list()
 
-								// Determines the organs that the species spawns with and
-	var/list/has_organ = list(  // which required-organ checks are conducted.
-		"heart" =    /obj/item/organ/internal/heart,
-		"lungs" =    /obj/item/organ/internal/lungs,
-		"liver" =    /obj/item/organ/internal/liver,
-		"kidneys" =  /obj/item/organ/internal/kidneys,
-		"brain" =    /obj/item/organ/internal/brain,
-		"appendix" = /obj/item/organ/internal/appendix,
-		"eyes" =     /obj/item/organ/internal/eyes
-		)
+	/// Determines the organs that the species spawns with and which required-organ checks are conducted.
+	var/list/has_organ = list(
+		"heart"		= /obj/item/organ/internal/heart,
+		"lungs"		= /obj/item/organ/internal/lungs,
+		"liver"		= /obj/item/organ/internal/liver,
+		"kidneys"	= /obj/item/organ/internal/kidneys,
+		"brain"		= /obj/item/organ/internal/brain,
+		"appendix"	= /obj/item/organ/internal/appendix,
+		"eyes"		= /obj/item/organ/internal/eyes
+	)
 	var/vision_organ = /obj/item/organ/internal/eyes // If set, this organ is required for vision.
 	var/list/has_limbs = list(
 		"chest" =  list("path" = /obj/item/organ/external/chest, "descriptor" = "chest"),

--- a/code/modules/mob/living/carbon/human/species/human_species.dm
+++ b/code/modules/mob/living/carbon/human/species/human_species.dm
@@ -14,7 +14,8 @@
 	With a constant desire to colonize and spread their influence onto other species, they have begun to develop alliances and enemies, \
 	making humans one of the most recognizable and socially diverse species in the sector."
 
-	icon_skin_tones = list( //Organized to be from Light to Dark.
+	/// Organized to be from Light to Dark.
+	icon_skin_tones = list(
 		1 = "Default White",
 		2 = "Pale",
 		3 = "Classic",
@@ -28,7 +29,7 @@
 		11 = "Caramel",
 		12 = "Coffee",
 		13 = "Chestnut"
-		)
+	)
 	reagent_tag = PROCESS_ORG
 
 

--- a/code/modules/mob/living/carbon/human/species/unathi.dm
+++ b/code/modules/mob/living/carbon/human/species/unathi.dm
@@ -121,15 +121,16 @@
 	species_traits = list(LIPS, NOT_SELECTABLE)
 	inherent_traits = list(TRAIT_CHUNKYFINGERS)
 
-	has_organ = list( // same as unathi's organs, aside for the lungs as they need to be able to breathe on lavaland.
-		"heart" =    /obj/item/organ/internal/heart/unathi,
-		"lungs" =    /obj/item/organ/internal/lungs/unathi/ash_walker,
-		"liver" =    /obj/item/organ/internal/liver/unathi,
-		"kidneys" =  /obj/item/organ/internal/kidneys/unathi,
-		"brain" =    /obj/item/organ/internal/brain/unathi,
-		"appendix" = /obj/item/organ/internal/appendix,
-		"eyes" =     /obj/item/organ/internal/eyes/unathi
-		)
+	// same as unathi's organs, aside for the lungs as they need to be able to breathe on lavaland.
+	has_organ = list(
+		"heart"		= /obj/item/organ/internal/heart/unathi,
+		"lungs"		= /obj/item/organ/internal/lungs/unathi/ash_walker,
+		"liver"		= /obj/item/organ/internal/liver/unathi,
+		"kidneys"	= /obj/item/organ/internal/kidneys/unathi,
+		"brain"		= /obj/item/organ/internal/brain/unathi,
+		"appendix"	= /obj/item/organ/internal/appendix,
+		"eyes"		= /obj/item/organ/internal/eyes/unathi
+	)
 
 /datum/species/unathi/ashwalker/on_species_gain(mob/living/carbon/human/H)
 	..()

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -166,10 +166,12 @@
 		spawn(rand(20,50))
 			if(stat == CONSCIOUS && M)
 				icon_state = icon_living
-				var/list/responses = list(	"[src] looks at you imploringly.",
-											"[src] looks at you pleadingly",
-											"[src] looks at you with a resigned expression.",
-											"[src] seems resigned to its fate.")
+				var/list/responses = list(
+					"[src] looks at you imploringly.",
+					"[src] looks at you pleadingly",
+					"[src] looks at you with a resigned expression.",
+					"[src] seems resigned to its fate."
+				)
 				to_chat(M, pick(responses))
 	else
 		..()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -670,7 +670,7 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 					G.affecting.ret_grab(L, 1)
 		if(!flag)
 			if(L.master == src)
-				var/list/temp = list(  )
+				var/list/temp = list()
 				temp += L.container
 				//L = null
 				qdel(L)

--- a/code/modules/mob/mob_vars.dm
+++ b/code/modules/mob/mob_vars.dm
@@ -35,7 +35,7 @@
 	var/computer_id = null
 	var/lastattacker = null // real name of the person  doing the attacking
 	var/lastattackerckey = null // their ckey
-	var/list/attack_log_old = list( )
+	var/list/attack_log_old = list()
 	var/list/debug_log = null
 
 	var/last_known_ckey = null	// Used in logging

--- a/code/modules/mod/mod_types.dm
+++ b/code/modules/mod/mod_types.dm
@@ -484,7 +484,8 @@
 /obj/item/mod/control/pre_equipped/debug
 	theme = /datum/mod_theme/debug
 	applied_core = /obj/item/mod/core/infinite
-	applied_modules = list( //one of every type of module, for testing if they all work correctly // boy this isn't even 25% the modules
+	/// One of every type of module, for testing if they all work correctly // boy this isn't even 25% the modules
+	applied_modules = list(
 		/obj/item/mod/module/storage/bluespace,
 		/obj/item/mod/module/welding,
 		/obj/item/mod/module/flashlight,

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -1611,7 +1611,7 @@
 /obj/effect/decal/cleanable/blood/gibs/pipe_eject(direction)
 	var/list/dirs
 	if(direction)
-		dirs = list( direction, turn(direction, -45), turn(direction, 45))
+		dirs = list(direction, turn(direction, -45), turn(direction, 45))
 	else
 		dirs = GLOB.alldirs.Copy()
 
@@ -1620,7 +1620,7 @@
 /obj/effect/decal/cleanable/blood/gibs/robot/gib/pipe_eject(direction)
 	var/list/dirs
 	if(direction)
-		dirs = list( direction, turn(direction, -45), turn(direction, 45))
+		dirs = list(direction, turn(direction, -45), turn(direction, 45))
 	else
 		dirs = GLOB.alldirs.Copy()
 

--- a/tools/ci/check_grep2.py
+++ b/tools/ci/check_grep2.py
@@ -151,7 +151,7 @@ def check_href_styles(idx, line):
     if HREF_OLD_STYLE.search(line):
         return [(idx + 1, "BYOND requires internal href links to begin with \"byond://\"")]
 
-EMPTY_LIST_WHITESPACE = re.compile(r"list\(\s+\)")
+EMPTY_LIST_WHITESPACE = re.compile(r"list\(\s+")
 def check_empty_list_whitespace(idx, line):
     if EMPTY_LIST_WHITESPACE.search(line):
         return [(idx + 1, "Empty list declarations should not have any whitespace within their parentheses.")]

--- a/tools/ci/check_grep2.py
+++ b/tools/ci/check_grep2.py
@@ -151,7 +151,10 @@ def check_href_styles(idx, line):
     if HREF_OLD_STYLE.search(line):
         return [(idx + 1, "BYOND requires internal href links to begin with \"byond://\"")]
 
-EMPTY_LIST_WHITESPACE = re.compile(r"list\(\s+")
+# TODO: This finds most cases except for e.g. `list(1, 2, 3 )`
+# Find a way to include this without breaking macro/tab-aligned versions such as `list(		\`
+# Maybe even make sure it doesn't include comments, idk
+EMPTY_LIST_WHITESPACE = re.compile(r"list\([^\S\n\r\f]+.*?[^\\]\n")
 def check_empty_list_whitespace(idx, line):
     if EMPTY_LIST_WHITESPACE.search(line):
         return [(idx + 1, "Empty list declarations should not have any whitespace within their parentheses.")]

--- a/tools/ci/check_grep2.py
+++ b/tools/ci/check_grep2.py
@@ -151,6 +151,11 @@ def check_href_styles(idx, line):
     if HREF_OLD_STYLE.search(line):
         return [(idx + 1, "BYOND requires internal href links to begin with \"byond://\"")]
 
+EMPTY_LIST_WHITESPACE = re.compile(r"list\(\s+\)")
+def check_empty_list_whitespace(idx, line):
+    if EMPTY_LIST_WHITESPACE.search(line):
+        return [(idx + 1, "Empty list declarations should not have any whitespace within their parentheses.")]
+
 CODE_CHECKS = [
     check_space_indentation,
     check_mixed_indentation,
@@ -164,6 +169,7 @@ CODE_CHECKS = [
     check_tgui_ui_new_argument,
     check_datum_loops,
     check_href_styles,
+    check_empty_list_whitespace,
 ]
 
 


### PR DESCRIPTION
## What Does This PR Do
This PR fixes cases where empty list declarations had whitespace in their parentheses, and adds a check_grep lint to forbid it.
## Why It's Good For The Game
Shit's dumb
## Testing
Visual inspection
<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog
NPFC