### PR TITLE
Fix: Syndie depot locker is only spawned when there is a loot

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/syndiedepot.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/syndiedepot.dmm
@@ -147,14 +147,12 @@
 	on = 1
 	},
 /obj/effect/spawner/random/syndicate/loot/common,
-/obj/structure/closet/secure_closet/syndicate/depot,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/syndicate_depot/core)
 "aB" = (
 /obj/effect/spawner/random/syndicate/loot/common,
-/obj/structure/closet/secure_closet/syndicate/depot,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -345,7 +343,6 @@
 /area/syndicate_depot/core)
 "bc" = (
 /obj/effect/spawner/random/syndicate/loot/rare,
-/obj/structure/closet/secure_closet/syndicate/depot,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -371,7 +368,6 @@
 	on = 1
 	},
 /obj/effect/spawner/random/syndicate/loot/rare,
-/obj/structure/closet/secure_closet/syndicate/depot,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -418,7 +414,6 @@
 	dir = 8
 	},
 /obj/effect/spawner/random/syndicate/loot/common,
-/obj/structure/closet/secure_closet/syndicate/depot,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -428,7 +423,6 @@
 	dir = 4
 	},
 /obj/effect/spawner/random/syndicate/loot/common,
-/obj/structure/closet/secure_closet/syndicate/depot,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -539,7 +533,6 @@
 /area/syndicate_depot/core)
 "bE" = (
 /obj/effect/spawner/random/syndicate/loot/officer,
-/obj/structure/closet/secure_closet/syndicate/depot,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -577,7 +570,6 @@
 	},
 /area/syndicate_depot/outer)
 "bJ" = (
-/obj/structure/closet/secure_closet/syndicate/depot,
 /obj/effect/spawner/random/syndicate/trapped_documents,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -800,7 +792,6 @@
 /area/syndicate_depot/core)
 "cm" = (
 /obj/effect/spawner/random/syndicate/loot/armory,
-/obj/structure/closet/secure_closet/syndicate/depot/armory,
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -812,14 +803,12 @@
 	on = 1
 	},
 /obj/effect/spawner/random/syndicate/loot/armory,
-/obj/structure/closet/secure_closet/syndicate/depot/armory,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/syndicate_depot/core)
 "co" = (
 /obj/effect/spawner/random/syndicate/loot/armory,
-/obj/structure/closet/secure_closet/syndicate/depot/armory,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -1129,7 +1118,6 @@
 	dir = 8
 	},
 /obj/effect/spawner/random/syndicate/loot/rare,
-/obj/structure/closet/secure_closet/syndicate/depot,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},

--- a/code/game/objects/effects/spawners/depot_spawners.dm
+++ b/code/game/objects/effects/spawners/depot_spawners.dm
@@ -58,12 +58,16 @@
 /obj/effect/spawner/random/syndicate/trapped_documents
 	name = "50pc trapped documents"
 	icon_state = "folder"
+	spawn_inside = /obj/structure/closet/secure_closet/syndicate/depot
 	loot = list(
 		/obj/item/documents/syndicate/yellow,
 		/obj/item/documents/syndicate/yellow/trapped,
 	)
 
 // Loot
+/obj/effect/spawner/random/syndicate/loot
+	spawn_inside = /obj/structure/closet/secure_closet/syndicate/depot
+
 /obj/effect/spawner/random/syndicate/loot/common
 	name = "syndicate depot loot, common"
 	icon_state = "loot"
@@ -87,6 +91,7 @@
 /obj/effect/spawner/random/syndicate/loot/stetchkin
 	name = "syndicate depot loot, 20pct stetchkin"
 	icon_state = "stetchkin"
+	spawn_inside = null
 	spawn_loot_chance = 80
 	loot = list(
 		/obj/item/gun/projectile/automatic/pistol,
@@ -155,6 +160,7 @@
 
 /obj/effect/spawner/random/syndicate/loot/armory
 	name = "syndicate depot loot, armory"
+	spawn_inside = /obj/structure/closet/secure_closet/syndicate/depot/armory
 	// Combat orientated items that could give the player an advantage if an antag messes with them.
 	loot = list(
 		/obj/item/autosurgeon/organ/syndicate/oneuse/razorwire,

--- a/code/game/objects/effects/spawners/random/random_spawner.dm
+++ b/code/game/objects/effects/spawners/random/random_spawner.dm
@@ -36,7 +36,7 @@
 	/// Whether blackbox should record when the spawner spawns.
 	var/record_spawn = FALSE
 	/// Where do we want to spawn an item (closet, safe etc.)
-	var/obj/spawn_inside = null
+	var/spawn_inside
 
 // Brief explanation:
 // Rather then setting up and then deleting spawners, we block all atomlike setup

--- a/code/game/objects/effects/spawners/random/random_spawner.dm
+++ b/code/game/objects/effects/spawners/random/random_spawner.dm
@@ -35,6 +35,8 @@
 	var/spawn_random_angle = FALSE
 	/// Whether blackbox should record when the spawner spawns.
 	var/record_spawn = FALSE
+	/// Where do we want to spawn an item (closet, safe etc.)
+	var/obj/spawn_inside = null
 
 // Brief explanation:
 // Rather then setting up and then deleting spawners, we block all atomlike setup
@@ -56,6 +58,9 @@
 
 	var/list/spawn_locations = get_spawn_locations(spawn_scatter_radius)
 	var/spawn_loot_count = isnull(lootcount_override) ? src.spawn_loot_count : lootcount_override
+
+	if(spawn_inside)
+		new spawn_inside(loc)
 
 	if(spawn_all_loot)
 		spawn_loot_count = INFINITY


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes #26975
Adds new var, `spawn_inside` for random spawners' code (I just stole it from old one).

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

Fix. Hope i'm not breaking something with this.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

![image](https://github.com/user-attachments/assets/0f5e0fa2-f3b4-4994-a809-00299bff13d6)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing

On a local. Checked out depot, no issues.

<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Depot now properly spawns lockers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
