### PR TITLE
Makes powerfist and wallbashing not ignore armor

### DIFF
--- a/code/game/objects/items/weapons/powerfist.dm
+++ b/code/game/objects/items/weapons/powerfist.dm
@@ -102,6 +102,9 @@
 	user.do_attack_animation(target)
 
 	var/obj/item/organ/external/affecting = target.get_organ(ran_zone(user.zone_selected))
+	if(!affecting)
+		affecting = target.get_organ("chest")
+
 	var/armor_block = target.run_armor_check(affecting, MELEE)
 	target.apply_damage(force * fisto_setting, BRUTE, affecting, armor_block)
 

--- a/code/game/objects/items/weapons/powerfist.dm
+++ b/code/game/objects/items/weapons/powerfist.dm
@@ -101,7 +101,10 @@
 
 	user.do_attack_animation(target)
 
-	target.apply_damage(force * fisto_setting, BRUTE)
+	var/obj/item/organ/external/affecting = target.get_organ(ran_zone(user.zone_selected))
+	var/armor_block = target.run_armor_check(affecting, MELEE)
+	target.apply_damage(force * fisto_setting, BRUTE, affecting, armor_block)
+
 	target.visible_message("<span class='danger'>[user]'s powerfist lets out a loud hiss as [user.p_they()] punch[user.p_es()] [target.name]!</span>", \
 		"<span class='userdanger'>You cry out in pain as [user]'s punch flings you backwards!</span>")
 	new /obj/effect/temp_visual/kinetic_blast(target.loc)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -274,12 +274,16 @@
 	if(mob_hurt) //Density check probably not needed, one should only bump into something if it is dense, and blob tiles are not dense, because of course they are not.
 		return
 	C.visible_message("<span class='danger'>[C] slams into [src]!</span>", "<span class='userdanger'>You slam into [src]!</span>")
-	C.take_organ_damage(damage)
 	if(!self_hurt)
 		take_damage(damage, BRUTE)
+
 	if(issilicon(C))
 		C.Weaken(3 SECONDS)
+		C.adjustBruteLoss(damage)
 	else
+		var/obj/item/organ/external/affecting = C.get_organ(ran_zone(throwingdatum.target_zone))
+		var/armor_block = C.run_armor_check(affecting, MELEE)
+		C.apply_damage(damage, BRUTE, affecting, armor_block)
 		C.KnockDown(3 SECONDS)
 
 /obj/handle_ricochet(obj/item/projectile/P)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -282,8 +282,11 @@
 		C.adjustBruteLoss(damage)
 	else
 		var/obj/item/organ/external/affecting = C.get_organ(ran_zone(throwingdatum.target_zone))
-		var/armor_block = C.run_armor_check(affecting, MELEE)
-		C.apply_damage(damage, BRUTE, affecting, armor_block)
+		if(affecting)
+			var/armor_block = C.run_armor_check(affecting, MELEE)
+			C.apply_damage(damage, BRUTE, affecting, armor_block)
+		else
+			C.adjustBruteLoss(damage)
 		C.KnockDown(3 SECONDS)
 
 /obj/handle_ricochet(obj/item/projectile/P)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -286,7 +286,7 @@
 			var/armor_block = C.run_armor_check(affecting, MELEE)
 			C.apply_damage(damage, BRUTE, affecting, armor_block)
 		else
-			C.adjustBruteLoss(damage)
+			C.take_organ_damage(damage)
 		C.KnockDown(3 SECONDS)
 
 /obj/handle_ricochet(obj/item/projectile/P)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1121,8 +1121,12 @@
 		C.Weaken(3 SECONDS)
 	else
 		var/obj/item/organ/external/affecting = C.get_organ(ran_zone(throwingdatum.target_zone))
-		var/armor_block = C.run_armor_check(affecting, MELEE)
-		C.apply_damage(damage, BRUTE, affecting, armor_block)
+		if(affecting)
+			var/armor_block = C.run_armor_check(affecting, MELEE)
+			C.apply_damage(damage, BRUTE, affecting, armor_block)
+		else
+			C.adjustBruteLoss(damage)
+
 		C.KnockDown(3 SECONDS)
 
 	C.visible_message("<span class='danger'>[C] crashes into [src], knocking them both over!</span>", "<span class='userdanger'>You violently crash into [src]!</span>")

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1120,8 +1120,11 @@
 		C.adjustBruteLoss(damage)
 		C.Weaken(3 SECONDS)
 	else
-		C.take_organ_damage(damage)
+		var/obj/item/organ/external/affecting = C.get_organ(ran_zone(throwingdatum.target_zone))
+		var/armor_block = C.run_armor_check(affecting, MELEE)
+		C.apply_damage(damage, BRUTE, affecting, armor_block)
 		C.KnockDown(3 SECONDS)
+
 	C.visible_message("<span class='danger'>[C] crashes into [src], knocking them both over!</span>", "<span class='userdanger'>You violently crash into [src]!</span>")
 
 /**

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1125,7 +1125,7 @@
 			var/armor_block = C.run_armor_check(affecting, MELEE)
 			C.apply_damage(damage, BRUTE, affecting, armor_block)
 		else
-			C.adjustBruteLoss(damage)
+			C.take_organ_damage(damage)
 
 		C.KnockDown(3 SECONDS)
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
- Makes the powerfist respect armor
- Makes wallbashing respect armor
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
The powerfist fully ignores armor. This makes it just as effective to fight it with riot armor and as if you were naked. This now works intuitively with the rest of the armor system.

The wallbashing change is included here because they go hand in hand with the powerfist changes.

## Testing
![image](https://github.com/user-attachments/assets/c86ccf47-f862-4b07-a231-010adfd429e7)

<!-- How did you test the PR, if at all? -->

<hr>

### Declaration
![image](https://github.com/user-attachments/assets/211b6ac8-b8b0-4452-9d80-412d8e093e76)

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
tweak: the Powerfist now respects armor
tweak: wallbashing now respects armor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
