### PR TITLE
Fixes some unknown tgui change breaking station trait saving

### DIFF
--- a/code/controllers/subsystem/processing/SSstation.dm
+++ b/code/controllers/subsystem/processing/SSstation.dm
@@ -18,9 +18,9 @@ PROCESSING_SUBSYSTEM_DEF(station)
 /datum/controller/subsystem/processing/station/proc/SetupTraits()
 
 	if(fexists("data/next_traits.txt"))
-		var/forced_traits_contents = file2list("data/next_traits.txt")
+		var/forced_traits_contents = file2text("data/next_traits.txt")
 		fdel("data/next_traits.txt")
-		var/list/temp_list = splittext(forced_traits_contents[1], ",")
+		var/list/temp_list = json_decode(forced_traits_contents)
 
 		for(var/trait_text_path in temp_list)
 			var/station_trait_path = text2path(trait_text_path)

--- a/code/datums/station_traits/admin_panel.dm
+++ b/code/datums/station_traits/admin_panel.dm
@@ -101,7 +101,7 @@
 			future_traits = new_future_traits
 			fdel("data/next_traits.txt") //Delete it.
 			var/F = file("data/next_traits.txt")
-			F << params["station_traits"]
+			F << json_encode(params["station_traits"])
 			return TRUE
 
 		if("clear_future_traits")


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Makes station traits saving for next round work again

resolve #26983

## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Bugs are bad, admin tools should work

## Testing

<!-- How did you test the PR, if at all? -->

<hr>

Forced the traits. (Cybernetic, rave, carp.)
Loaded cybernetic, rave, carp next round, verified with breakpoints t hat they were loaded and not random generated

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Fixed admins being unable to force station traits for next round
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
