### PR TITLE
Fixes Powercell Removal On Modsuits

### DIFF
--- a/code/modules/mod/mod_core.dm
+++ b/code/modules/mod/mod_core.dm
@@ -182,7 +182,7 @@
 	examine_text += cell ? "You could remove the cell while in hand or being worn with <b>Ctrl-Click</b>." : "You could use a <b>cell</b> on it to install one."
 
 /obj/item/mod/core/standard/proc/on_ctrl_click(datum/source, mob/living/user)
-	SIGNAL_HANDLER
+	SIGNAL_HANDLER // COMSIG_CLICK_CTRL
 
 	if(mod.seconds_electrified && charge_amount() && mod.shock(user))
 		return COMPONENT_CANCEL_ATTACK_CHAIN

--- a/code/modules/mod/mod_core.dm
+++ b/code/modules/mod/mod_core.dm
@@ -86,7 +86,7 @@
 	if(cell)
 		install_cell(cell)
 	RegisterSignal(mod, COMSIG_PARENT_EXAMINE, PROC_REF(on_examine))
-	RegisterSignal(mod, COMSIG_CLICK_CTRL, PROC_REF(on_attack_hand))
+	RegisterSignal(mod, COMSIG_CLICK_CTRL, PROC_REF(on_ctrl_click))
 	RegisterSignal(mod, COMSIG_MOD_WEARER_SET, PROC_REF(on_wearer_set))
 	if(mod.wearer)
 		on_wearer_set(mod, mod.wearer)
@@ -181,7 +181,7 @@
 		return
 	examine_text += cell ? "You could remove the cell while in hand or being worn with <b>Ctrl-Click</b>." : "You could use a <b>cell</b> on it to install one."
 
-/obj/item/mod/core/standard/proc/on_attack_hand(datum/source, mob/living/user)
+/obj/item/mod/core/standard/proc/on_ctrl_click(datum/source, mob/living/user)
 	SIGNAL_HANDLER
 
 	if(mod.seconds_electrified && charge_amount() && mod.shock(user))

--- a/code/modules/mod/mod_core.dm
+++ b/code/modules/mod/mod_core.dm
@@ -86,7 +86,7 @@
 	if(cell)
 		install_cell(cell)
 	RegisterSignal(mod, COMSIG_PARENT_EXAMINE, PROC_REF(on_examine))
-	RegisterSignal(mod, COMSIG_ATOM_ATTACK_HAND, PROC_REF(on_attack_hand))
+	RegisterSignal(mod, COMSIG_CLICK_CTRL, PROC_REF(on_attack_hand))
 	RegisterSignal(mod, COMSIG_MOD_WEARER_SET, PROC_REF(on_wearer_set))
 	if(mod.wearer)
 		on_wearer_set(mod, mod.wearer)
@@ -94,7 +94,7 @@
 /obj/item/mod/core/standard/uninstall()
 	if(!QDELETED(cell))
 		cell.forceMove(drop_location())
-	UnregisterSignal(mod, list(COMSIG_PARENT_EXAMINE, COMSIG_ATOM_ATTACK_HAND, COMSIG_MOD_WEARER_SET))
+	UnregisterSignal(mod, list(COMSIG_PARENT_EXAMINE, COMSIG_CLICK_CTRL, COMSIG_MOD_WEARER_SET))
 	if(mod.wearer)
 		on_wearer_unset(mod, mod.wearer)
 	return ..()
@@ -179,7 +179,7 @@
 
 	if(!mod.open)
 		return
-	examine_text += cell ? "You could remove the cell with an empty hand." : "You could use a cell on it to install one."
+	examine_text += cell ? "You could remove the cell while in hand or being worn with <b>Ctrl-Click</b>." : "You could use a <b>cell</b> on it to install one."
 
 /obj/item/mod/core/standard/proc/on_attack_hand(datum/source, mob/living/user)
 	SIGNAL_HANDLER


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Rebinds pulling cells out of modsuits from click to ctrl-click.

It was being overridden by storage modules meaning you could not actually remove a cell with a normal click.

Changed the examine text to reference ctrl-click and bolded both hints. The other hints given for wrench, crowbar and so on were bolded so this is just to match that style.

## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Bug fix.

## Testing

<!-- How did you test the PR, if at all? -->


Spawned myself in and tested ctrl-clicking cells out of modsuits with and without storage.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl: Bmon
fix: Fixed removing cells from modsuits. To remove a cell from a modsuit ctrl-click it while the panel is open.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
