### PR TITLE
Candles - Randomized Flicker Duration

### DIFF
--- a/code/game/objects/items/candle.dm
+++ b/code/game/objects/items/candle.dm
@@ -80,10 +80,10 @@
 	return FALSE
 
 /obj/item/candle/proc/start_flickering()
-    flickering = TRUE
-    update_icon(UPDATE_ICON_STATE)
-    var/random_duration = (2 + rand(0, 4)) SECONDS
-    addtimer(CALLBACK(src, PROC_REF(stop_flickering)), random_duration, TIMER_UNIQUE)
+	flickering = TRUE
+	update_icon(UPDATE_ICON_STATE)
+	var/random_duration = (2 + rand(0, 4)) SECONDS
+	addtimer(CALLBACK(src, PROC_REF(stop_flickering)), random_duration, TIMER_UNIQUE)
 
 
 /obj/item/candle/proc/stop_flickering()

--- a/code/game/objects/items/candle.dm
+++ b/code/game/objects/items/candle.dm
@@ -80,9 +80,11 @@
 	return FALSE
 
 /obj/item/candle/proc/start_flickering()
-	flickering = TRUE
-	update_icon(UPDATE_ICON_STATE)
-	addtimer(CALLBACK(src, PROC_REF(stop_flickering)), 4 SECONDS, TIMER_UNIQUE)
+    flickering = TRUE
+    update_icon(UPDATE_ICON_STATE)
+    var/random_duration = (2 + rand(0, 4)) SECONDS
+    addtimer(CALLBACK(src, PROC_REF(stop_flickering)), random_duration, TIMER_UNIQUE)
+
 
 /obj/item/candle/proc/stop_flickering()
 	flickering = FALSE

--- a/code/game/objects/items/candle.dm
+++ b/code/game/objects/items/candle.dm
@@ -82,8 +82,7 @@
 /obj/item/candle/proc/start_flickering()
 	flickering = TRUE
 	update_icon(UPDATE_ICON_STATE)
-	var/random_duration = (2 + rand(0, 4)) SECONDS
-	addtimer(CALLBACK(src, PROC_REF(stop_flickering)), random_duration, TIMER_UNIQUE)
+	addtimer(CALLBACK(src, PROC_REF(stop_flickering)), rand(2, 6)) SECONDS, TIMER_UNIQUE)
 
 
 /obj/item/candle/proc/stop_flickering()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Randomized Flicker Duration: Added a variable random_duration which uses (2 + rand(0, 4)) SECONDS to make the flickering duration randomized between 2 and 6 seconds instead of being fixed at 4 seconds.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Increased Immersion: By adding a randomized flicker duration, the behavior of the candle becomes less predictable and more dynamic. This helps in creating a more realistic, atmospheric environment, making the candle appear alive rather than mechanical and repetitive.

Enhanced Tension and Atmosphere: The flickering of the candle can contribute to a sense of suspense, especially in darker or eerie environments. Randomizing the flicker duration makes the player's experience more engaging, as they can't predict when the candle will flicker, adding to the sense of unease or tension.

Variety in Visual Effects: Repeated, identical flicker durations can become monotonous, reducing the impact of flickering as an atmospheric effect. A randomized duration ensures that flickering remains visually interesting throughout the game, maintaining a fresh experience for the player.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [ ] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

tweak: Made candles flicker for a random amount of time.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
