### PR TITLE
blackbox: improve lathe production feedback

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -416,6 +416,8 @@
 			new_item.materials[MAT_GLASS] /= coeff
 			new_item.pixel_y = rand(-5, 5)
 			new_item.pixel_x = rand(-5, 5)
+		if(is_station_level(z))
+			SSblackbox.record_feedback("tally", "station_autolathe_production", 1, "[D.type]")
 	SStgui.update_uis(src)
 	desc = initial(desc)
 

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -246,6 +246,8 @@
 /obj/machinery/mecha_part_fabricator/proc/build_design_timer_finish(datum/design/D, list/final_cost)
 	// Spawn the item (in a lockbox if restricted) OR mob (e.g. IRC body)
 	var/atom/A = new D.build_path(get_step(src, output_dir))
+	if(is_station_level(z))
+		SSblackbox.record_feedback("tally", "station_mechfab_production", 1, "[D.type]")
 	if(isitem(A))
 		var/obj/item/I = A
 		I.materials = final_cost

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -419,7 +419,8 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 /obj/machinery/computer/rdconsole/proc/finish_machine(key, amount, enough_materials,  obj/machinery/r_n_d/machine, datum/design/being_built, list/efficient_mats)
 	if(machine)
 		if(enough_materials && being_built)
-			SSblackbox.record_feedback("nested tally", "RND Production List", amount, list("[being_built.category]", "[being_built.name]"))
+			if(is_station_level(z))
+				SSblackbox.record_feedback("tally", "station_protolathe_production", amount, "[being_built.type]")
 			for(var/i in 1 to amount)
 				var/obj/item/new_item = new being_built.build_path(src)
 				if(istype(new_item)) // Only want a random pixel offset if it IS actually an item, and not a structure like a bluespace closet


### PR DESCRIPTION
## What Does This PR Do
This PR removes the "RND Production List" feedback key, and replaces it with "station_protolathe_production", only recording production on the station level. It also adds commensurate "station_autolathe_production" and "station_mechfab_production" keys that record their respective machine output.
## Why It's Good For The Game
The original "RND Production List" key was poorly named, incorrectly nested (usually ending up in a key called, literally, `/list`), and wasn't restricted to station level. The lack of similar feedback for other production machines seemed like an oversight. Recording names of output instead of using their types is bad because it makes reverse lookups extremely painful (e.g. trying to find the amount of materials used for "C-Foam cartridge" instead of `/datum/design/c_foam_ammo`).
## Images of changes
![2024_10_05__13_10_29__](https://github.com/user-attachments/assets/9ea8379a-7312-434e-99c5-11e162517dc8)
## Testing
See above. Also tested building things on golem ship to ensure they weren't recorded.
<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog
NPFC