### PR TITLE
TWEAK: Love pen now higly peaceful

### DIFF
--- a/code/datums/uplink_items/uplink_traitor.dm
+++ b/code/datums/uplink_items/uplink_traitor.dm
@@ -337,7 +337,7 @@
 //skrell
 /datum/uplink_item/species_restricted/lovepen
 	name = "Aggression Suppression Pen"
-	desc = "A hypospay disguised as a functional pen which is filled with a potent aggression supressing chemical. The pen holds four doses of the mixture, slowly regenerates over time, but cannot be refilled."
+	desc = "A hypospray disguised as a functional pen which is filled with a potent aggression suppressing chemical. The pen holds four doses of the mixture which slowly regenerates over time, but cannot be refilled."
 	reference = "LP"
 	item = /obj/item/pen/sleepy/love
 	cost = 20

--- a/code/datums/uplink_items/uplink_traitor.dm
+++ b/code/datums/uplink_items/uplink_traitor.dm
@@ -337,7 +337,7 @@
 //skrell
 /datum/uplink_item/species_restricted/lovepen
 	name = "Aggression Suppression Pen"
-	desc = "A syringe disguised as a functional pen which is filled with a potent aggression supressing chemical. The pen holds four doses of the mixture and it cannot be refilled."
+	desc = "A hypospay disguised as a functional pen which is filled with a potent aggression supressing chemical. The pen holds four doses of the mixture, slowly regenerates over time, but cannot be refilled."
 	reference = "LP"
 	item = /obj/item/pen/sleepy/love
 	cost = 20

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -179,19 +179,25 @@
 	name = "fancy pen"
 	desc = "A fancy metal pen. An inscription on one side reads, \"L.L. - L.R.\""
 	icon_state = "fancypen"
-	container_type = DRAINABLE //cannot be refilled, love can be extracted for use in other items with syringe
+	container_type = (DRAINABLE | TRANSPARENT) //cannot be refilled, but pax can be extracted for use in other items with syringe
 	origin_tech = "engineering=4;syndicate=2"
 	transfer_amount = 25 // 4 Dosages instead of 2
 
-/obj/item/pen/sleepy/love/attack(mob/living/M, mob/user)
-	var/can_transfer = reagents.total_volume && M.reagents
+/obj/item/pen/sleepy/love/Initialize(mapload)
 	. = ..()
-	if(can_transfer && .)
-		M.apply_status_effect(STATUS_EFFECT_PACIFIED) //pacifies for 40 seconds
-	return TRUE
+	START_PROCESSING(SSobj, src)
+
+/obj/item/pen/sleepy/love/Destroy()
+	STOP_PROCESSING(SSobj, src)
+	return ..()
 
 /obj/item/pen/sleepy/love/fill_pen()
-	reagents.add_reagent("love", 100)
+	reagents.add_reagent("pax", 100) // strong and unique reagent, making you a pacifist for a long time.
+
+/obj/item/pen/sleepy/love/process()
+	if(reagents.total_volume < 100)
+		reagents.add_reagent("pax", 0.5) // slow refill over time. In average 1 dose every 100 seconds.
+
 
 /obj/item/pen/sleepy/undisguised
 	name = "sleepy pen"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Replace Love in love pen with Pax, who give target full pacifism, instead of force status + reagent who just names "love" and doesnt do something to avoid you from death. Added reagent regeneration, so you can use it far more than 4 times for 20 TC.

## Why It's Good For The Game

Cheap stuffs always was the most funny or cursed ones, yet the pen only give you limited time for do something. Now with removing original author restrictions and adding regeneration, you can use it AND for easy kills without resistance AND for trolling sec who cant kill someone. Counter to this is pretty easy to obtain and dont restrict you from stunning opponents, so it will remain niche item. But now you can use it for fun, because it never deplete fully, and more fun = more joy to play. In my opinion, this pen now have all he need to be "niche fun item", without complaints.

## Images of changes

![image](https://github.com/user-attachments/assets/27fc6c17-45eb-4423-af37-69b413109099)

## Testing

Start local server, shot skrell, see how he cant hurt me, Jack. After this, i see how it regenerates inside with 100 second for every full shot.

<hr>

### Declaration

Pre-approve gang rises. After further conversation, original author agree 100 seconds is enough.
![image](https://github.com/user-attachments/assets/1a805893-7fb8-453a-95fe-3806fee01ee7)

## Changelog

:cl:
tweak: Love pen now contain Pax instead of Love and slowly regenerate this reagent over time. In other words, he is usable and fun now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
