### PR TITLE
feat: Pizza bombs now disguise as any flavor.

### DIFF
--- a/code/game/objects/effects/spawners/depot_spawners.dm
+++ b/code/game/objects/effects/spawners/depot_spawners.dm
@@ -37,14 +37,14 @@
 	name = "33pc trap pizza"
 	icon_state = "pizzabox"
 	loot = list(
-		/obj/item/pizzabox/pepperoni = 7, // Higher weight as a pizza bomb looks like pepperoni by default
-		/obj/item/pizzabox/pizza_bomb/autoarm = 7,
 		/obj/item/pizzabox/firecracker = 1,
 		/obj/item/pizzabox/garlic = 1,
 		/obj/item/pizzabox/hawaiian = 1,
 		/obj/item/pizzabox/margherita = 1,
 		/obj/item/pizzabox/meat = 1,
 		/obj/item/pizzabox/mushroom = 1,
+		/obj/item/pizzabox/pepperoni = 1,
+		/obj/item/pizzabox/pizza_bomb/autoarm = 5,
 		/obj/item/pizzabox/vegetable = 1,
 	)
 

--- a/code/game/objects/effects/spawners/depot_spawners.dm
+++ b/code/game/objects/effects/spawners/depot_spawners.dm
@@ -37,6 +37,8 @@
 	name = "33pc trap pizza"
 	icon_state = "pizzabox"
 	loot = list(
+		/obj/item/pizzabox/pizza_bomb/autoarm = 4,
+
 		/obj/item/pizzabox/firecracker = 1,
 		/obj/item/pizzabox/garlic = 1,
 		/obj/item/pizzabox/hawaiian = 1,
@@ -44,7 +46,6 @@
 		/obj/item/pizzabox/meat = 1,
 		/obj/item/pizzabox/mushroom = 1,
 		/obj/item/pizzabox/pepperoni = 1,
-		/obj/item/pizzabox/pizza_bomb/autoarm = 5,
 		/obj/item/pizzabox/vegetable = 1,
 	)
 

--- a/code/game/objects/effects/spawners/depot_spawners.dm
+++ b/code/game/objects/effects/spawners/depot_spawners.dm
@@ -38,7 +38,6 @@
 	icon_state = "pizzabox"
 	loot = list(
 		/obj/item/pizzabox/pizza_bomb/autoarm = 4,
-
 		/obj/item/pizzabox/firecracker = 1,
 		/obj/item/pizzabox/garlic = 1,
 		/obj/item/pizzabox/hawaiian = 1,

--- a/code/modules/food_and_drinks/food/foods/pizza.dm
+++ b/code/modules/food_and_drinks/food/foods/pizza.dm
@@ -271,10 +271,16 @@
 	var/is_messy = FALSE // Fancy mess on the lid
 	var/obj/item/food/sliceable/pizza/pizza // Content pizza
 	var/list/boxes = list() // If the boxes are stacked, they come here
+	/// The name that shows on the box lid, describing the pizza type.
 	var/box_tag = ""
+	/// The type of pizza that's spawned in the box.
+	var/pizza_type = /obj/item/food/sliceable/pizza/pepperonipizza // pepperoni as default because there is no generic pizza
 
 /obj/item/pizzabox/Initialize(mapload)
 	. = ..()
+	if(!isnull(pizza_type))
+		pizza = new pizza_type(src)
+
 	update_appearance(UPDATE_DESC|UPDATE_ICON)
 
 /obj/item/pizzabox/update_desc()
@@ -409,46 +415,37 @@
 		return
 	..()
 
-
-/obj/item/pizzabox/margherita/Initialize(mapload)
-	pizza = new /obj/item/food/sliceable/pizza/margheritapizza(src)
+/obj/item/pizzabox/margherita
 	box_tag = "margherita deluxe"
-	. = ..()
+	pizza_type = /obj/item/food/sliceable/pizza/margheritapizza
 
-/obj/item/pizzabox/vegetable/Initialize(mapload)
-	pizza = new /obj/item/food/sliceable/pizza/vegetablepizza(src)
+/obj/item/pizzabox/vegetable
+	pizza_type = /obj/item/food/sliceable/pizza/vegetablepizza
 	box_tag = "gourmet vegetable"
-	. = ..()
 
-/obj/item/pizzabox/mushroom/Initialize(mapload)
-	pizza = new /obj/item/food/sliceable/pizza/mushroompizza(src)
+/obj/item/pizzabox/mushroom
+	pizza_type = /obj/item/food/sliceable/pizza/mushroompizza
 	box_tag = "mushroom special"
-	. = ..()
 
-/obj/item/pizzabox/meat/Initialize(mapload)
-	pizza = new /obj/item/food/sliceable/pizza/meatpizza(src)
+/obj/item/pizzabox/meat
+	pizza_type = /obj/item/food/sliceable/pizza/meatpizza
 	box_tag = "meatlover's supreme"
-	. = ..()
 
-/obj/item/pizzabox/hawaiian/Initialize(mapload)
-	pizza = new /obj/item/food/sliceable/pizza/hawaiianpizza(src)
+/obj/item/pizzabox/hawaiian
+	pizza = /obj/item/food/sliceable/pizza/hawaiianpizza
 	box_tag = "Hawaiian feast"
-	. = ..()
 
-/obj/item/pizzabox/pepperoni/Initialize(mapload)
-	pizza = new /obj/item/food/sliceable/pizza/pepperonipizza(src)
+/obj/item/pizzabox/pepperoni
+	pizza_type = /obj/item/food/sliceable/pizza/pepperonipizza
 	box_tag = "classic pepperoni"
-	. = ..()
 
-/obj/item/pizzabox/garlic/Initialize(mapload)
-	pizza = new /obj/item/food/sliceable/pizza/garlicpizza(src)
+/obj/item/pizzabox/garlic
+	pizza = /obj/item/food/sliceable/pizza/garlicpizza
 	box_tag = "triple garlic"
-	. = ..()
 
-/obj/item/pizzabox/firecracker/Initialize(mapload)
-	pizza = new /obj/item/food/sliceable/pizza/firecrackerpizza(src)
+/obj/item/pizzabox/firecracker
+	pizza_type = /obj/item/food/sliceable/pizza/firecrackerpizza
 	box_tag = "extra spicy pie"
-	. = ..()
 
 //////////////////////////
 //		Pizza bombs		//
@@ -582,7 +579,8 @@
 
 /obj/item/pizzabox/pizza_bomb/Initialize(mapload)
 	correct_wire = pick(wires)
-	box_tag = "classic pepperoni"
+	var/obj/item/pizzabox/mimic_box = pick(subtypesof(/obj/item/pizzabox) - /obj/item/pizzabox/pizza_bomb)
+	box_tag = mimic_box.box_tag
 	. = ..()
 
 /obj/item/pizzabox/pizza_bomb/autoarm

--- a/code/modules/food_and_drinks/food/foods/pizza.dm
+++ b/code/modules/food_and_drinks/food/foods/pizza.dm
@@ -274,7 +274,7 @@
 	/// The name that shows on the box lid, describing the pizza type.
 	var/box_tag = ""
 	/// The type of pizza that's spawned in the box.
-	var/pizza_type = /obj/item/food/sliceable/pizza/pepperonipizza // pepperoni as default because there is no generic pizza
+	var/pizza_type
 
 /obj/item/pizzabox/Initialize(mapload)
 	. = ..()

--- a/code/modules/food_and_drinks/food/foods/pizza.dm
+++ b/code/modules/food_and_drinks/food/foods/pizza.dm
@@ -432,7 +432,7 @@
 	box_tag = "meatlover's supreme"
 
 /obj/item/pizzabox/hawaiian
-	pizza = /obj/item/food/sliceable/pizza/hawaiianpizza
+	pizza_type = /obj/item/food/sliceable/pizza/hawaiianpizza
 	box_tag = "Hawaiian feast"
 
 /obj/item/pizzabox/pepperoni
@@ -440,7 +440,7 @@
 	box_tag = "classic pepperoni"
 
 /obj/item/pizzabox/garlic
-	pizza = /obj/item/food/sliceable/pizza/garlicpizza
+	pizza_type = /obj/item/food/sliceable/pizza/garlicpizza
 	box_tag = "triple garlic"
 
 /obj/item/pizzabox/firecracker

--- a/code/modules/food_and_drinks/food/foods/pizza.dm
+++ b/code/modules/food_and_drinks/food/foods/pizza.dm
@@ -579,7 +579,7 @@
 
 /obj/item/pizzabox/pizza_bomb/Initialize(mapload)
 	correct_wire = pick(wires)
-	var/obj/item/pizzabox/mimic_box = pick(subtypesof(/obj/item/pizzabox) - /obj/item/pizzabox/pizza_bomb)
+	var/obj/item/pizzabox/mimic_box = pick(subtypesof(/obj/item/pizzabox) - typesof(/obj/item/pizzabox/pizza_bomb))
 	box_tag = mimic_box.box_tag
 	. = ..()
 

--- a/code/modules/food_and_drinks/food/foods/pizza.dm
+++ b/code/modules/food_and_drinks/food/foods/pizza.dm
@@ -416,8 +416,8 @@
 	..()
 
 /obj/item/pizzabox/margherita
-	box_tag = "margherita deluxe"
 	pizza_type = /obj/item/food/sliceable/pizza/margheritapizza
+	box_tag = "margherita deluxe"
 
 /obj/item/pizzabox/vegetable
 	pizza_type = /obj/item/food/sliceable/pizza/vegetablepizza


### PR DESCRIPTION
## What Does This PR Do
This PR randomizes the pizza variety on pizza bombs so it's not always "pepperoni". It also refactors the relevant code.
## Why It's Good For The Game
No more predicting if the pizza is a bomb just by its toppings.
## Images of changes
![2024_10_06__22_44_15__Paradise Station 13](https://github.com/user-attachments/assets/f8a30db3-5070-4f63-88d9-c0d9d67891c1)
![2024_10_06__22_44_19__Paradise Station 13](https://github.com/user-attachments/assets/97dd24d5-c7ca-4f80-be61-6b5e9d112734)
![2024_10_06__22_45_09__Paradise Station 13](https://github.com/user-attachments/assets/2a614677-6608-48cd-91b7-9ecaaf14428c)
![2024_10_06__22_45_11__](https://github.com/user-attachments/assets/1053de26-535a-4923-a46f-d69884edc6a0)
## Testing

Ensured boxes spawned with varied labels, ensured stacking them worked, ensured getting blown up worked.

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

![2024_10_03__15_34_18__#development_discussion _ Paradise Station - Discord](https://github.com/user-attachments/assets/f7e62005-d17e-4b07-9f04-e9c1840d4956)

![2024_10_03__15_34_36__#development_discussion _ Paradise Station - Discord](https://github.com/user-attachments/assets/57d104f5-2d4d-41c6-9c61-d3023a01645c)


## Changelog

:cl:
tweak: Pizza bombs now can be labelled as any pizza topping.
/:cl:
