### PR TITLE
Fixes eternal candle boxes appearing empty on spawn

### DIFF
--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -32,9 +32,6 @@
 		else
 			. += "There are [length(contents)] [icon_type]s in the box."
 
-/obj/item/storage/fancy/Initialize(mapload)
-	. = ..()
-	update_icon_state()
 
 /*
  * Donut Box
@@ -107,8 +104,9 @@
 	throwforce = 2
 	slot_flags = SLOT_FLAG_BELT
 
-/obj/item/storage/fancy/candle_box/full
-	icon_state = "candlebox5"
+/obj/item/storage/fancy/candle_box/Initialize(mapload)
+	. = ..()
+	update_icon_state()
 
 /obj/item/storage/fancy/candle_box/full/populate_contents()
 	for(var/I in 1 to storage_slots)

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -106,7 +106,7 @@
 
 /obj/item/storage/fancy/candle_box/Initialize(mapload)
 	. = ..()
-	update_icon_state()
+	update_icon(UPDATE_ICON_STATE)
 
 /obj/item/storage/fancy/candle_box/full/populate_contents()
 	for(var/I in 1 to storage_slots)

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -32,6 +32,10 @@
 		else
 			. += "There are [length(contents)] [icon_type]s in the box."
 
+/obj/item/storage/fancy/Initialize(mapload)
+	. = ..()
+	update_icon_state()
+
 /*
  * Donut Box
  */


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes the eternal candle box appearing empty on spawn, also changes how the normal candle box handles it slightly.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
The boxes looked empty, the whole point of fancy storage is you can /see/ how full/empty it is
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![dreamseeker_W9ywE6r8a7](https://github.com/user-attachments/assets/69fa58d4-6525-4bab-92b5-90b49df99a13)
![dreamseeker_FQwpDC4SAs](https://github.com/user-attachments/assets/59d37afa-d94d-47ad-be5a-e39de51f37db)
(trust me)
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Spawned every candle box type, all appeared correctly. swapped candles around the boxes, no issues seen
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

fix: Fixed eternal candle boxes appearing empty when they spawn
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
