### PR TITLE
Fixes magboot fuckery

### DIFF
--- a/code/__HELPERS/trait_helpers.dm
+++ b/code/__HELPERS/trait_helpers.dm
@@ -225,7 +225,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_IPC_JOINTS_SEALED "ipc_joints_sealed" // The IPC's limbs will not pop off bar sharp damage (aka like a human), but will take slightly more stamina damage
 #define TRAIT_HAS_GPS "has_gps" // used for /Stat
 #define TRAIT_CAN_VIEW_HEALTH "can_view_health" // Also used for /Stat
-#define TRAIT_MAGPULSE "magnetificent" // Used for anything that is magboot related
+#define TRAIT_MAGPULSE "magpulse" // Used for anything that is magboot related
 #define TRAIT_NOSLIP "noslip"
 #define TRAIT_SCOPED "user_scoped"
 #define TRAIT_MEPHEDRONE_ADAPTED "mephedrone_adapted" // Trait that changes the ending effects of twitch leaving your system

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -66,7 +66,6 @@
 		return
 	if(HAS_TRAIT(user, TRAIT_MAGPULSE)) // User has trait and the magboots were turned off, remove trait
 		REMOVE_TRAIT(user, TRAIT_MAGPULSE, "magboots[UID()]")
-		// REMOVE_TRAIT(H, TRAIT_NOSLIP, UID()) // have to shove this in because
 
 /obj/item/clothing/shoes/magboots/examine(mob/user)
 	. = ..()

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -26,45 +26,47 @@
 	. = ..()
 	if(slot != SLOT_HUD_SHOES || !ishuman(user))
 		return
-	check_mag_pulse()
+	check_mag_pulse(user)
 
 /obj/item/clothing/shoes/magboots/dropped(mob/user, silent)
 	. = ..()
 	if(!ishuman(user))
 		return
-	check_mag_pulse()
+	check_mag_pulse(user, removing = TRUE)
 
-/obj/item/clothing/shoes/magboots/attack_self(mob/user, forced = FALSE)
-	toggle_magpulse(user, forced)
+/obj/item/clothing/shoes/magboots/attack_self(mob/user)
+	toggle_magpulse(user)
 
-/obj/item/clothing/shoes/magboots/proc/toggle_magpulse(mob/user, forced)
+/obj/item/clothing/shoes/magboots/proc/toggle_magpulse(mob/user, no_message)
 	if(magpulse) //magpulse and no_slip will always be the same value unless VV happens
 		REMOVE_TRAIT(user, TRAIT_NOSLIP, UID())
 		slowdown = slowdown_passive
 	else
-		ADD_TRAIT(user, TRAIT_NOSLIP, UID())
+		if(user.get_item_by_slot(SLOT_HUD_SHOES) == src)
+			ADD_TRAIT(user, TRAIT_NOSLIP, UID())
 		slowdown = slowdown_active
 	magpulse = !magpulse
 	no_slip = !no_slip
 	if(multiple_icons)
 		icon_state = "[magboot_state][magpulse]"
-	if(!forced)
+	if(!no_message)
 		to_chat(user, "You [magpulse ? "enable" : "disable"] the [magpulse_name].")
 	user.update_inv_shoes()	//so our mob-overlays update
 	user.update_gravity(user.mob_has_gravity())
 	for(var/X in actions)
 		var/datum/action/A = X
 		A.UpdateButtons()
-	check_mag_pulse(user)
+	check_mag_pulse(user, removing = (user.get_item_by_slot(SLOT_HUD_SHOES) != src))
 
-/obj/item/clothing/shoes/magboots/proc/check_mag_pulse(mob/user)
+/obj/item/clothing/shoes/magboots/proc/check_mag_pulse(mob/user, removing = FALSE)
 	if(!user)
 		return
-	if(magpulse)
-		ADD_TRAIT(user, TRAIT_MAGPULSE, "magboots")
+	if(magpulse && !removing)
+		ADD_TRAIT(user, TRAIT_MAGPULSE, "magboots[UID()]")
 		return
 	if(HAS_TRAIT(user, TRAIT_MAGPULSE)) // User has trait and the magboots were turned off, remove trait
-		REMOVE_TRAIT(user, TRAIT_MAGPULSE, "magboots")
+		REMOVE_TRAIT(user, TRAIT_MAGPULSE, "magboots[UID()]")
+		// REMOVE_TRAIT(H, TRAIT_NOSLIP, UID()) // have to shove this in because
 
 /obj/item/clothing/shoes/magboots/examine(mob/user)
 	. = ..()
@@ -173,17 +175,17 @@
 	magpulse_name = "gripping ability"
 	magical = TRUE
 
-/obj/item/clothing/shoes/magboots/wizard/attack_self(mob/user)
+/obj/item/clothing/shoes/magboots/wizard/toggle_magpulse(mob/user, no_message)
 	if(!user)
 		return
 	if(!iswizard(user))
 		to_chat(user, "<span class='notice'>You poke the gem on [src]. Nothing happens.</span>")
 		return
-	if(magpulse) //faint blue light when shoes are turned on gives a reason to turn them off when not needed in maint
-		set_light(0)
-	else
-		set_light(2, 1, LIGHT_COLOR_LIGHTBLUE)
 	..()
+	if(magpulse) //faint blue light when shoes are turned on gives a reason to turn them off when not needed in maint
+		set_light(2, 1, LIGHT_COLOR_LIGHTBLUE)
+	else
+		set_light(0)
 
 
 /obj/item/clothing/shoes/magboots/gravity
@@ -229,7 +231,7 @@
 	else
 		. += "<span class='warning'>It is missing a gravitational anomaly core and a power cell.</span>"
 
-/obj/item/clothing/shoes/magboots/gravity/attack_self(mob/user)
+/obj/item/clothing/shoes/magboots/gravity/toggle_magpulse(mob/user, no_message)
 	if(!cell)
 		to_chat(user, "<span class='warning'>Your boots do not have a power cell!</span>")
 		return
@@ -249,7 +251,7 @@
 		if(ishuman(loc))
 			var/mob/living/carbon/human/user = loc
 			to_chat(user, "<span class='warning'>[src] has ran out of charge, and turned off!</span>")
-			attack_self(user, TRUE)
+			toggle_magpulse(user, TRUE)
 	else
 		cell.use(power_consumption_rate)
 
@@ -313,7 +315,7 @@
 		style.remove(H)
 		if(magpulse)
 			to_chat(user, "<span class='notice'>As [src] are removed, they deactivate.</span>")
-			attack_self(user, TRUE)
+			toggle_magpulse(user, TRUE)
 
 /obj/item/clothing/shoes/magboots/gravity/item_action_slot_check(slot)
 	if(slot == SLOT_HUD_SHOES)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Fixes magboot fuckery. Specifically fixes #26740 as an alternate PR to #26788 with permission of the author.
Also renames the internal magpulse trait from "magnetificent" to "magpulse" (its funny but without codediving its harder to tell what it is)

## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Fixes a bug

## Testing

<!-- How did you test the PR, if at all? -->
Picked up the boots, turned them on (magpulse not active)
Put the boots on my feet (magpulse active)
took the boots off my feet (magpulse not active)
turned the magboots off (magpulse not active)
put the boots on my feet (magpulse not active)
turned the magboots on (magpulse active)
took the magboots off (magpulse not active)

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Magboots only work when equipped
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
