### PR TITLE
BSA now checks if the APC has enough power to reload

### DIFF
--- a/code/modules/station_goals/bsa.dm
+++ b/code/modules/station_goals/bsa.dm
@@ -223,7 +223,7 @@
 	reload()
 
 /obj/machinery/bsa/full/proc/reload()
-	if(machine_powernet && machine_powernet.powernet_apc && machine_powernet.powernet_apc.cell.charge KJ >= energy_used_per_shot)
+	if(machine_powernet?.powernet_apc?.cell?.charge KJ >= energy_used_per_shot)
 		try_reload = FALSE
 		use_power(energy_used_per_shot)
 		COOLDOWN_START(src, firing_cooldown, reload_cooldown_time)

--- a/code/modules/station_goals/bsa.dm
+++ b/code/modules/station_goals/bsa.dm
@@ -115,9 +115,12 @@
 	var/cannon_direction = WEST
 	var/static/image/top_layer = null
 	var/ex_power = 3
-	var/power_used_per_shot = 2000000 //enough to kil standard apc - todo : make this use wires instead and scale explosion power with it
+	/// Amount of energy required to reload the BSA (Joules)
+	var/energy_used_per_shot = 2000000 //enough to kil standard apc - todo : make this use wires instead and scale explosion power with it
 	/// The gun's cooldown
-	var/reload_cooldown_time = 10 MINUTES 
+	var/reload_cooldown_time = 10 MINUTES
+	/// Are we trying to reload? Should only be true if we failed to reload due to lack of power.
+	var/try_reload = FALSE
 	COOLDOWN_DECLARE(firing_cooldown)
 
 	pixel_y = -32
@@ -136,7 +139,7 @@
 	cannon_direction = EAST
 
 /obj/machinery/bsa/full/admin
-	power_used_per_shot = 0
+	energy_used_per_shot = 0
 	reload_cooldown_time = 100 SECONDS
 
 /obj/machinery/bsa/full/admin/east
@@ -220,8 +223,18 @@
 	reload()
 
 /obj/machinery/bsa/full/proc/reload()
-	use_power(power_used_per_shot)
-	COOLDOWN_START(src, firing_cooldown, reload_cooldown_time)
+	if(machine_powernet && machine_powernet.powernet_apc && machine_powernet.powernet_apc.cell.charge KJ >= energy_used_per_shot)
+		try_reload = FALSE
+		use_power(energy_used_per_shot)
+		COOLDOWN_START(src, firing_cooldown, reload_cooldown_time)
+	else
+		firing_cooldown = reload_cooldown_time
+		try_reload = TRUE
+
+/// If we failed a reload keep trying until the APC has enough energy available.
+/obj/machinery/bsa/full/process()
+	if(try_reload)
+		reload()
 
 /obj/item/circuitboard/machine/bsa/back
 	board_name = "Bluespace Artillery Generator"
@@ -329,8 +342,8 @@
 	if(target)
 		data["target"] = get_target_name()
 	if(cannon)
-		data["reloadtime_text"] = seconds_to_clock(round(COOLDOWN_TIMELEFT(cannon, firing_cooldown) / 10))
-		data["ready"] = COOLDOWN_FINISHED(cannon, firing_cooldown)
+		data["reloadtime_text"] = cannon.try_reload ? "Insufficient Energy For Reloading" : seconds_to_clock(round(COOLDOWN_TIMELEFT(cannon, firing_cooldown) / 10))
+		data["ready"] = !cannon.try_reload && COOLDOWN_FINISHED(cannon, firing_cooldown)
 	else
 		data["ready"] = FALSE
 	return data

--- a/code/modules/station_goals/bsa.dm
+++ b/code/modules/station_goals/bsa.dm
@@ -228,7 +228,6 @@
 		use_power(energy_used_per_shot)
 		COOLDOWN_START(src, firing_cooldown, reload_cooldown_time)
 	else
-		firing_cooldown = reload_cooldown_time
 		try_reload = TRUE
 
 /// If we failed a reload keep trying until the APC has enough energy available.

--- a/code/modules/station_goals/bsa.dm
+++ b/code/modules/station_goals/bsa.dm
@@ -116,7 +116,7 @@
 	var/static/image/top_layer = null
 	var/ex_power = 3
 	/// Amount of energy required to reload the BSA (Joules)
-	var/energy_used_per_shot = 2000000 //enough to kil standard apc - todo : make this use wires instead and scale explosion power with it
+	var/energy_used_per_shot = 2 MJ //enough to kil standard apc - todo : make this use wires instead and scale explosion power with it
 	/// The gun's cooldown
 	var/reload_cooldown_time = 10 MINUTES
 	/// Are we trying to reload? Should only be true if we failed to reload due to lack of power.


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
BSA will no longer reload if the APC powering it doesn't have enough energy, or if the APC doesn't exist.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Less bug more good
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
- Made a BSA in an area where the APC didn't have enough energy to reload it and the BSA did not reload
- Gave the APC cell enough energy to reload the BSA. BSA reloaded
- Demonstrated the power of flextape
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: BSA now checks if it has enough energy for a reload before reloading
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
