### PR TITLE
[s] Blocks any doubled wall mount placement

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1150,10 +1150,10 @@ GLOBAL_LIST_INIT(wall_items, typecacheof(list(/obj/machinery/power/apc, /obj/mac
 
 /proc/gotwallitem(loc, dir)
 	for(var/obj/O in loc)
-		if(is_type_in_typecache(O, GLOB.wall_items) && dir == REVERSE_DIR(O.dir))
+		if(is_type_in_typecache(O, GLOB.wall_items) && dir == O.dir)
 			return TRUE
 
-	//Some stuff is placed directly on the wallturf (signs)
+	// Some stuff is placed directly on the wallturf (signs)
 	for(var/obj/O in get_step(loc, dir))
 		if(is_type_in_typecache(O, GLOB.wall_items))
 			return TRUE

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1141,41 +1141,23 @@ Checks if that loc and dir has a item on the wall
 */
 GLOBAL_LIST_INIT(wall_items, typecacheof(list(/obj/machinery/power/apc, /obj/machinery/alarm,
 	/obj/item/radio/intercom, /obj/structure/extinguisher_cabinet, /obj/structure/reagent_dispensers/peppertank,
-	/obj/machinery/status_display, /obj/machinery/requests_console, /obj/machinery/light_switch, /obj/structure/sign,
+	/obj/machinery/status_display, /obj/machinery/requests_console, /obj/structure/sign,
 	/obj/machinery/newscaster, /obj/machinery/firealarm, /obj/structure/noticeboard, /obj/machinery/door_control,
 	/obj/machinery/computer/security/telescreen, /obj/machinery/airlock_controller,
 	/obj/item/storage/secure/safe, /obj/machinery/door_timer, /obj/machinery/flasher, /obj/machinery/keycard_auth,
 	/obj/structure/mirror, /obj/structure/closet/fireaxecabinet, /obj/machinery/computer/security/telescreen/entertainment,
-	/obj/structure/sign, /obj/machinery/barsign)))
+	/obj/structure/sign, /obj/machinery/barsign, /obj/machinery/light, /obj/machinery/light_construct)))
 
 /proc/gotwallitem(loc, dir)
 	for(var/obj/O in loc)
-		if(is_type_in_typecache(O, GLOB.wall_items))
-			//Direction works sometimes
-			if(O.dir == dir)
-				return 1
-
-			//Some stuff doesn't use dir properly, so we need to check pixel instead
-			switch(dir)
-				if(SOUTH)
-					if(O.pixel_y > 10)
-						return 1
-				if(NORTH)
-					if(O.pixel_y < -10)
-						return 1
-				if(WEST)
-					if(O.pixel_x > 10)
-						return 1
-				if(EAST)
-					if(O.pixel_x < -10)
-						return 1
+		if(is_type_in_typecache(O, GLOB.wall_items) && dir == REVERSE_DIR(O.dir))
+			return TRUE
 
 	//Some stuff is placed directly on the wallturf (signs)
 	for(var/obj/O in get_step(loc, dir))
 		if(is_type_in_typecache(O, GLOB.wall_items))
-			if(abs(O.pixel_x) <= 10 && abs(O.pixel_y) <= 10)
-				return 1
-	return 0
+			return TRUE
+	return FALSE
 
 /proc/atan2(x, y)
 	if(!x && !y) return 0

--- a/code/game/objects/items/mountable_frames/frames.dm
+++ b/code/game/objects/items/mountable_frames/frames.dm
@@ -22,15 +22,15 @@
 
 /obj/item/mounted/frame/try_build(turf/on_wall, mob/user)
 	if(!..())
-		return
+		return FALSE
 
 	var/turf/build_turf = get_turf(user)
 	if((mount_requirements & MOUNTED_FRAME_SIMFLOOR) && !isfloorturf(build_turf))
 		to_chat(user, "<span class='warning'>[src] cannot be placed on this spot.</span>")
-		return
+		return FALSE
 	if(mount_requirements & MOUNTED_FRAME_NOSPACE)
 		var/area/my_area = get_area(build_turf)
 		if(!istype(my_area) || !my_area.requires_power || isspacearea(my_area))
 			to_chat(user, "<span class='warning'>[src] cannot be placed in this area.</span>")
-			return
+			return FALSE
 	return TRUE

--- a/code/game/objects/items/mountable_frames/light_frames.dm
+++ b/code/game/objects/items/mountable_frames/light_frames.dm
@@ -9,17 +9,6 @@
 	///specifies which type of light fixture this frame will build
 	var/fixture_type = "tube"
 
-/obj/item/mounted/frame/light_fixture/try_build(turf/on_wall, mob/user)
-	. = ..()
-	if(!.)
-		return FALSE
-
-	for(var/obj/machinery/possible_fixture as anything in get_turf(user))
-		if(istype(possible_fixture, /obj/machinery/light) || istype(possible_fixture, /obj/machinery/light_construct))
-			to_chat(user, "<span class='warning'>There is already a light here!</span>")
-			return FALSE
-	return TRUE
-
 /obj/item/mounted/frame/light_fixture/do_build(turf/on_wall, mob/user)
 	to_chat(user, "You begin attaching [src] to \the [on_wall].")
 	playsound(get_turf(src), 'sound/machines/click.ogg', 75, 1)

--- a/code/game/objects/items/mountable_frames/light_frames.dm
+++ b/code/game/objects/items/mountable_frames/light_frames.dm
@@ -9,6 +9,17 @@
 	///specifies which type of light fixture this frame will build
 	var/fixture_type = "tube"
 
+/obj/item/mounted/frame/light_fixture/try_build(turf/on_wall, mob/user)
+	. = ..()
+	if(!.)
+		return FALSE
+
+	for(var/obj/machinery/possible_fixture as anything in get_turf(user))
+		if(istype(possible_fixture, /obj/machinery/light) || istype(possible_fixture, /obj/machinery/light_construct))
+			to_chat(user, "<span class='warning'>There is already a light here!</span>")
+			return FALSE
+	return TRUE
+
 /obj/item/mounted/frame/light_fixture/do_build(turf/on_wall, mob/user)
 	to_chat(user, "You begin attaching [src] to \the [on_wall].")
 	playsound(get_turf(src), 'sound/machines/click.ogg', 75, 1)

--- a/code/game/objects/items/mountable_frames/mountables.dm
+++ b/code/game/objects/items/mountable_frames/mountables.dm
@@ -14,17 +14,18 @@
 
 /obj/item/mounted/proc/try_build(turf/on_wall, mob/user, proximity_flag) //checks
 	if(!on_wall || !user)
-		return
+		return FALSE
 	if(!proximity_flag) //if we aren't next to the turf
-		return
+		return FALSE
+
 	if(!allow_floor_mounting)
 		if(!(get_dir(on_wall, user) in GLOB.cardinal))
 			to_chat(user, "<span class='warning'>You need to be standing next to [on_wall] to place [src].</span>")
-			return
+			return FALSE
 
 		if(gotwallitem(get_turf(user), get_dir(on_wall, user)))
 			to_chat(user, "<span class='warning'>There's already an item on this wall!</span>")
-			return
+			return FALSE
 
 	return TRUE
 

--- a/code/game/objects/items/mountable_frames/mountables.dm
+++ b/code/game/objects/items/mountable_frames/mountables.dm
@@ -23,7 +23,7 @@
 			to_chat(user, "<span class='warning'>You need to be standing next to [on_wall] to place [src].</span>")
 			return FALSE
 
-		if(gotwallitem(get_turf(user), get_dir(on_wall, user)))
+		if(gotwallitem(get_turf(user), get_dir(user, on_wall)))
 			to_chat(user, "<span class='warning'>There's already an item on this wall!</span>")
 			return FALSE
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes sure that you can't put anythin on a wall that already has a wall object
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
This is for consistency and the view of the mapping team that every wall should have only a single wall object (excluding switches)
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Tried putting a lot of frames on walls, they only could when there wasn't anything on the wall
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
tweak: Lights now respect wall objects
tweak: Switches now can be placed on a wall regardless of any other wall objects
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
