### PR TITLE
Morphs that have a perfected form can no longer be seen via health huds. And if a morph mimics a non dense object(like a cigarette) the morph will become non dense

### DIFF
--- a/code/datums/spells/mimic.dm
+++ b/code/datums/spells/mimic.dm
@@ -120,6 +120,7 @@
 		user.pixel_y = initial(user.pixel_y)
 		user.pixel_x = initial(user.pixel_x)
 		user.layer = MOB_LAYER // Avoids weirdness when mimicing something below the vent layer
+		user.density = form.density
 
 	playsound(user, "bonebreak", 75, TRUE)
 	show_change_form_message(user, old_name, "[user]")
@@ -145,6 +146,7 @@
 	user.cut_overlays()
 	user.icon = initial(user.icon)
 	user.icon_state = initial(user.icon_state)
+	user.density = TRUE
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		H.name_override = null
@@ -193,11 +195,14 @@
 	var/examine_text
 	/// What the name of the form is
 	var/name
+	/// If the form has density
+	var/density
 
 /datum/mimic_form/New(atom/movable/form, mob/user)
 	appearance = form.appearance
 	examine_text = form.examine(user)
 	name = form.name
+	density = form.density
 
 /datum/spell/mimic/morph
 	action_background_icon_state = "bg_morph"

--- a/code/game/gamemodes/miniantags/morph/morph.dm
+++ b/code/game/gamemodes/miniantags/morph/morph.dm
@@ -188,19 +188,20 @@
 	mimic_spell.perfect_disguise = FALSE // Reset the perfect disguise
 	remove_status_effect(/datum/status_effect/morph_ambush)
 	UnregisterSignal(src, COMSIG_MOVABLE_MOVED)
+	add_to_all_human_data_huds()
 
 /mob/living/simple_animal/hostile/morph/proc/perfect_ambush()
 	mimic_spell.perfect_disguise = TRUE // Reset the perfect disguise
 	to_chat(src, "<span class='sinister'>You've perfected your disguise. Making you indistinguishable from the real form!</span>")
-
+	remove_from_all_data_huds()
 
 /mob/living/simple_animal/hostile/morph/proc/on_move()
 	failed_ambush()
 	to_chat(src, "<span class='warning'>You moved out of your ambush spot!</span>")
 
-
 /mob/living/simple_animal/hostile/morph/death(gibbed)
 	. = ..()
+	add_to_all_human_data_huds()
 	if(stat == DEAD && gibbed)
 		for(var/atom/movable/AM in src)
 			AM.forceMove(loc)
@@ -273,15 +274,17 @@
 	. = ..()
 	if(. && !morphed)
 		var/list/things = list()
-		for(var/atom/movable/A in view(src))
+		for(var/atom/movable/A in oview(src))
 			if(mimic_spell.valid_target(A, src))
 				things += A
+		if(!length(things))
+			return
 		var/atom/movable/T = pick(things)
 		mimic_spell.take_form(new /datum/mimic_form(T, src), src)
 		prepare_ambush() // They cheat okay
 
 /mob/living/simple_animal/hostile/morph/AttackingTarget()
-	if(isliving(target)) // Eat Corpses to regen health
+	if(!isliving(target)) // Eat Corpses to regen health
 		var/mob/living/L = target
 		if(L.stat == DEAD)
 			try_eat(L)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Buffs morphs so they're not so easily found when hiding.
I've done this by making it so while a morph has its form perfected(~8 seconds of sitting still in ambush mode) it'll loose its health hud. 
I've also made it so if a morph copies something like a cigarette, it'll become non dense, so you don't bump into some trash on the floor.
Also fixed morphs hiding themselves if they're ai controlled
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Morphs currently are very easy to find with a very common hud, this allows the morph to setup better ambushes.
Same deal with them being dense, if you bumped into a morph in a perfected ambush, you'd break their ambush. I'm sure you can see why thats bad.

Also bugs bad.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
## Testing

<!-- How did you test the PR, if at all? -->
Tested the health hud chances, killing, breaking forms, alot of various things.
Same with the density.
Also spawned morphs in a empty room with nothing to copy, and it didn't copy itself.
Then filled that room with stuff, and it copied/attacked items/mobs in that room.
<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>
![Discord_CNc7SwYDfZ](https://github.com/user-attachments/assets/04fccb9f-9898-4438-8000-03c3bd85580d)

## Changelog

:cl:
tweak: Morphs are more sneaky when in ambush mode. very much soif they've perfected their form.
fix: Fixed Ai morphs being able to copy themselves
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
