### PR TITLE
Adds Mimestrogen!

### DIFF
--- a/code/modules/reagents/chemistry/reagents/misc_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/misc_reagents.dm
@@ -518,7 +518,7 @@
 	description = "Mimestrogen is an odd chemical compound that induces a variety of annoying side-effects in the average person. It also causes mild intoxication, and is toxic to mimes."
 	color = "#353535" // Should be dark grey, there are already a fair number of white chemicals
 	process_flags = ORGANIC | SYNTHETIC
-	taste_description = "a funny flavour"
+	taste_description = "an entertaining flavour"
 
 /datum/reagent/mimestrogen/on_new()
 	..()
@@ -536,11 +536,12 @@
 		else
 			to_chat(C, "<span class='warning'>Something doesn't feel right...</span>")
 			C.AdjustDizzy(volume STATUS_EFFECT_CONSTANT)
-			C.mind.miming=!C.mind.miming
+			C.mind.miming=!C.mind.miming // Jestosterone gives comic sans which makes one more clown-like, comic sans also unlocks clown healing, minus Jestoserone. So, mind.miming makes one more like a mime and unlocks mime healing.
 			ADD_TRAIT(C, TRAIT_COLORBLIND, id)
 
 /datum/reagent/mimestrogen/on_mob_life(mob/living/carbon/human/M)
 	var/update_flags = STATUS_UPDATE_NONE
+	// var/list/color_view = null // Overrides client.color
 	if(prob(10))
 		M.emote("giggle")
 	if(!M.mind)
@@ -549,6 +550,8 @@
 		update_flags |= M.adjustBruteLoss(-1.5 * REAGENTS_EFFECT_MULTIPLIER, robotic = TRUE)
 	else
 		M.AdjustDizzy(20 SECONDS, 0, 100 SECONDS)
+		M.client.color = MATRIX_GREYSCALE
+		M.update_client_colour() // TRAIT_COLORBLIND only makes you colourblind for the wires, this fully makes it greyscale
 		if(prob(10))
 			M.EyeBlurry(10 SECONDS)
 		if(prob(6))
@@ -575,6 +578,8 @@
 	..()
 	if(M.mind?.assigned_role != "Mime")
 		M.mind.miming=!M.mind.miming
+		M.client.color = null
+		M.update_client_colour()
 		REMOVE_TRAIT(M, TRAIT_COLORBLIND, id)
 
 /datum/reagent/royal_bee_jelly

--- a/code/modules/reagents/chemistry/reagents/misc_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/misc_reagents.dm
@@ -531,12 +531,12 @@
 		else if(C.mind.assigned_role == "Clown")
 			to_chat(C, "<span class='warning'>You feel nauseous.</span>")
 			C.AdjustDizzy(volume STATUS_EFFECT_CONSTANT)
-			ADD_TRAIT(C, TRAIT_MUTE, id)
+			C.mind.miming=!C.mind.miming
 			ADD_TRAIT(C, TRAIT_COLORBLIND, id)
 		else
 			to_chat(C, "<span class='warning'>Something doesn't feel right...</span>")
 			C.AdjustDizzy(volume STATUS_EFFECT_CONSTANT)
-			ADD_TRAIT(C, TRAIT_MUTE, id)
+			C.mind.miming=!C.mind.miming
 			ADD_TRAIT(C, TRAIT_COLORBLIND, id)
 
 /datum/reagent/mimestrogen/on_mob_life(mob/living/carbon/human/M)
@@ -574,7 +574,7 @@
 /datum/reagent/mimestrogen/on_mob_delete(mob/living/M)
 	..()
 	if(M.mind?.assigned_role != "Mime")
-		REMOVE_TRAIT(M, TRAIT_MUTE, id)
+		M.mind.miming=!M.mind.miming
 		REMOVE_TRAIT(M, TRAIT_COLORBLIND, id)
 
 /datum/reagent/royal_bee_jelly

--- a/code/modules/reagents/chemistry/reagents/misc_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/misc_reagents.dm
@@ -575,7 +575,7 @@
 	..()
 	if(M.mind?.assigned_role != "Mime")
 		REMOVE_TRAIT(M, TRAIT_MUTE, id)
-		REMOVE_TRAIT(C, TRAIT_COLORBLIND, id)
+		REMOVE_TRAIT(M, TRAIT_COLORBLIND, id)
 
 /datum/reagent/royal_bee_jelly
 	name = "Royal bee jelly"

--- a/code/modules/reagents/chemistry/reagents/misc_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/misc_reagents.dm
@@ -579,8 +579,8 @@
 	if(M.mind?.assigned_role != "Mime")
 		M.mind.miming=!M.mind.miming
 		M.client.color = null
-		M.update_client_colour()
 		REMOVE_TRAIT(M, TRAIT_COLORBLIND, id)
+		M.update_client_colour() // You get stuck with permanent greyscale if it's not separated from client.color by at least one line
 
 /datum/reagent/royal_bee_jelly
 	name = "Royal bee jelly"

--- a/code/modules/reagents/chemistry/reagents/misc_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/misc_reagents.dm
@@ -542,7 +542,7 @@
 /datum/reagent/mimestrogen/on_mob_life(mob/living/carbon/human/M)
 	var/update_flags = STATUS_UPDATE_NONE
 	if(prob(10))
-		M.emote("giggles silently")
+		M.emote("giggle")
 	if(!M.mind)
 		return ..() | update_flags
 	if(M.mind.assigned_role == "Mime")

--- a/code/modules/reagents/chemistry/reagents/misc_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/misc_reagents.dm
@@ -532,25 +532,23 @@
 			to_chat(C, "<span class='warning'>You feel nauseous.</span>")
 			C.AdjustDizzy(volume STATUS_EFFECT_CONSTANT)
 			ADD_TRAIT(C, TRAIT_MUTE, id)
-			C.AddElement(/datum/element/waddling)
+			ADD_TRAIT(C, TRAIT_COLORBLIND, id)
 		else
 			to_chat(C, "<span class='warning'>Something doesn't feel right...</span>")
 			C.AdjustDizzy(volume STATUS_EFFECT_CONSTANT)
 			ADD_TRAIT(C, TRAIT_MUTE, id)
-			C.AddElement(/datum/element/waddling)
-	C.AddComponent(/datum/component/squeak, null, null, null, null, null, TRUE, falloff_exponent = 20)
+			ADD_TRAIT(C, TRAIT_COLORBLIND, id)
 
 /datum/reagent/mimestrogen/on_mob_life(mob/living/carbon/human/M)
 	var/update_flags = STATUS_UPDATE_NONE
 	if(prob(10))
-		M.emote("giggle")
+		M.emote("giggles silently")
 	if(!M.mind)
 		return ..() | update_flags
 	if(M.mind.assigned_role == "Mime")
 		update_flags |= M.adjustBruteLoss(-1.5 * REAGENTS_EFFECT_MULTIPLIER, robotic = TRUE)
 	else
 		M.AdjustDizzy(20 SECONDS, 0, 100 SECONDS)
-		M.Druggy(30 SECONDS)
 		if(prob(10))
 			M.EyeBlurry(10 SECONDS)
 		if(prob(6))
@@ -577,8 +575,7 @@
 	..()
 	if(M.mind?.assigned_role != "Mime")
 		REMOVE_TRAIT(M, TRAIT_MUTE, id)
-		M.RemoveElement(/datum/element/waddling)
-	qdel(M.GetComponent(/datum/component/squeak))
+		REMOVE_TRAIT(C, TRAIT_COLORBLIND, id)
 
 /datum/reagent/royal_bee_jelly
 	name = "Royal bee jelly"

--- a/code/modules/reagents/chemistry/reagents/misc_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/misc_reagents.dm
@@ -559,7 +559,7 @@
 			"You can't see straight.",
 			"You feel about as funny as the station mime.",
 			"Muted colours and berets cloud your vision.",
-			"Your funny bone aches.",
+			"Your voice box feels numb.",
 			"What was that?!",
 			"You can hear silence in the distance, somehow.",
 			"You feel like miming.",

--- a/code/modules/reagents/chemistry/reagents/misc_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/misc_reagents.dm
@@ -572,7 +572,7 @@
 			"You feel like miming a performance.")
 			to_chat(M, "<span class='warning'>[pick(mime_message)]</span>")
 		if(M.mind.assigned_role == "Clown")
-			if(!M.dna.species.tox_mod) // If they can't take tox damage, make them take burn damage
+			if(M.dna.species.tox_mod <= 0) // If they can't take tox damage, make them take burn damage
 				update_flags |= M.adjustFireLoss(1.5 * REAGENTS_EFFECT_MULTIPLIER, robotic = TRUE)
 			else
 				update_flags |= M.adjustToxLoss(1.5 * REAGENTS_EFFECT_MULTIPLIER)

--- a/code/modules/reagents/chemistry/reagents/misc_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/misc_reagents.dm
@@ -453,6 +453,7 @@
 	id = "jestosterone"
 	description = "Jestosterone is an odd chemical compound that induces a variety of annoying side-effects in the average person. It also causes mild intoxication, and is toxic to mimes."
 	color = "#ff00ff" //Fuchsia, pity we can't do rainbow here
+	process_flags = ORGANIC | SYNTHETIC
 	taste_description = "a funny flavour"
 
 /datum/reagent/jestosterone/on_new()
@@ -475,14 +476,14 @@
 			C.AddElement(/datum/element/waddling)
 	C.AddComponent(/datum/component/squeak, null, null, null, null, null, TRUE, falloff_exponent = 20)
 
-/datum/reagent/jestosterone/on_mob_life(mob/living/carbon/M)
+/datum/reagent/jestosterone/on_mob_life(mob/living/carbon/human/M)
 	var/update_flags = STATUS_UPDATE_NONE
 	if(prob(10))
 		M.emote("giggle")
 	if(!M.mind)
 		return ..() | update_flags
 	if(M.mind.assigned_role == "Clown")
-		update_flags |= M.adjustBruteLoss(-1.5 * REAGENTS_EFFECT_MULTIPLIER) //Screw those pesky clown beatings!
+		update_flags |= M.adjustBruteLoss(-1.5 * REAGENTS_EFFECT_MULTIPLIER, robotic = TRUE) //Screw those pesky clown beatings!
 	else
 		M.AdjustDizzy(20 SECONDS, 0, 100 SECONDS)
 		M.Druggy(30 SECONDS)
@@ -502,7 +503,10 @@
 			"You feel like telling a pun.")
 			to_chat(M, "<span class='warning'>[pick(clown_message)]</span>")
 		if(M.mind.assigned_role == "Mime")
-			update_flags |= M.adjustToxLoss(1.5 * REAGENTS_EFFECT_MULTIPLIER)
+			if(!M.dna.species.tox_mod) // If they can't take tox damage, make them take burn damage
+				update_flags |= M.adjustFireLoss(1.5 * REAGENTS_EFFECT_MULTIPLIER, robotic = TRUE)
+			else
+				update_flags |= M.adjustToxLoss(1.5 * REAGENTS_EFFECT_MULTIPLIER)
 	return ..() | update_flags
 
 /datum/reagent/jestosterone/on_mob_delete(mob/living/M)

--- a/code/modules/reagents/chemistry/reagents/misc_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/misc_reagents.dm
@@ -569,7 +569,7 @@
 			to_chat(M, "<span class='warning'>[pick(mime_message)]</span>")
 		if(M.mind.assigned_role == "Clown")
 			if(!(C.dna.species.reagent_tag & PROCESS_ORG)) // Only activates if the mob that is processing the reagent is Synthetic (IPC)
-				update_flags |= M.adjustFireLoss(1.5 * REAGENTS_EFFECT_MULTIPLIER, robotic = TRUE) // The ", robotic = TRUE" just means it affects robotic limbs, which an IPC is fully robotic
+				update_flags |= M.adjustFireLoss(1.5 * REAGENTS_EFFECT_MULTIPLIER, robotic = TRUE)  // The ", robotic = TRUE" just means it affects robotic limbs, which an IPC is fully robotic
 			else // Ensures the mob that is processing the reagent is Organic to apply toxin damage // Using burn instead of toxin for IPCs since IPCs don't suffer toxin and poison can feel similar to burns
 				update_flags |= M.adjustToxLoss(1.5 * REAGENTS_EFFECT_MULTIPLIER)
 	return ..() | update_flags

--- a/code/modules/reagents/chemistry/reagents/misc_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/misc_reagents.dm
@@ -568,9 +568,9 @@
 			"You feel like miming a performance.")
 			to_chat(M, "<span class='warning'>[pick(mime_message)]</span>")
 		if(M.mind.assigned_role == "Clown")
-			if(!(M.dna.species.reagent_tag & PROCESS_ORG)) // Only activates if the mob that is processing the reagent is Synthetic (IPC)
-				update_flags |= M.adjustFireLoss(1.5 * REAGENTS_EFFECT_MULTIPLIER, robotic = TRUE)  // The ", robotic = TRUE" just means it affects robotic limbs, which an IPC is fully robotic
-			else // Ensures the mob that is processing the reagent is Organic to apply toxin damage // Using burn instead of toxin for IPCs since IPCs don't suffer toxin and poison can feel similar to burns
+			if(!M.dna.species.tox_mod) // If they can't take tox damage, make them take burn damage
+				update_flags |= M.adjustFireLoss(1.5 * REAGENTS_EFFECT_MULTIPLIER, robotic = TRUE)
+			else
 				update_flags |= M.adjustToxLoss(1.5 * REAGENTS_EFFECT_MULTIPLIER)
 	return ..() | update_flags
 

--- a/code/modules/reagents/chemistry/reagents/misc_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/misc_reagents.dm
@@ -541,7 +541,6 @@
 
 /datum/reagent/mimestrogen/on_mob_life(mob/living/carbon/human/M)
 	var/update_flags = STATUS_UPDATE_NONE
-	// var/list/color_view = null // Overrides client.color
 	if(prob(10))
 		M.emote("giggle")
 	if(!M.mind)

--- a/code/modules/reagents/chemistry/reagents/misc_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/misc_reagents.dm
@@ -568,7 +568,7 @@
 			"You feel like miming a performance.")
 			to_chat(M, "<span class='warning'>[pick(mime_message)]</span>")
 		if(M.mind.assigned_role == "Clown")
-			if(!(C.dna.species.reagent_tag & PROCESS_ORG)) // Only activates if the mob that is processing the reagent is Synthetic (IPC)
+			if(!(M.dna.species.reagent_tag & PROCESS_ORG)) // Only activates if the mob that is processing the reagent is Synthetic (IPC)
 				update_flags |= M.adjustFireLoss(1.5 * REAGENTS_EFFECT_MULTIPLIER, robotic = TRUE)  // The ", robotic = TRUE" just means it affects robotic limbs, which an IPC is fully robotic
 			else // Ensures the mob that is processing the reagent is Organic to apply toxin damage // Using burn instead of toxin for IPCs since IPCs don't suffer toxin and poison can feel similar to burns
 				update_flags |= M.adjustToxLoss(1.5 * REAGENTS_EFFECT_MULTIPLIER)

--- a/code/modules/reagents/chemistry/reagents/misc_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/misc_reagents.dm
@@ -536,7 +536,7 @@
 		else
 			to_chat(C, "<span class='warning'>Something doesn't feel right...</span>")
 			C.AdjustDizzy(volume STATUS_EFFECT_CONSTANT)
-			C.mind.miming=!C.mind.miming // Jestosterone gives comic sans which makes one more clown-like, comic sans also unlocks clown healing, minus Jestoserone. So, mind.miming makes one more like a mime and unlocks mime healing.
+			C.mind.miming=!C.mind.miming // Jestosterone gives comic sans which makes one more clown-like, comic sans also unlocks clown healing, minus Jestoserone. So, mind.miming makes one more like a mime and unlocks mime healing, minus Mimestrogen.
 			ADD_TRAIT(C, TRAIT_COLORBLIND, id)
 
 /datum/reagent/mimestrogen/on_mob_life(mob/living/carbon/human/M)

--- a/code/modules/reagents/chemistry/reagents/misc_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/misc_reagents.dm
@@ -515,9 +515,10 @@
 /datum/reagent/mimestrogen
 	name = "Mimestrogen"
 	id = "mimestrogen"
-	description = "Mimestrogen is an odd chemical compound that induces a variety of annoying side-effects in the average person. It also causes mild intoxication, and is toxic to mimes."
+	description = "Mimestrogen is an odd chemical compound that induces a variety of annoying side-effects in the average person. It also causes mild intoxication, and is toxic to clowns."
 	color = "#353535" // Should be dark grey, there are already a fair number of white chemicals
 	process_flags = ORGANIC | SYNTHETIC
+	drink_desc = "The colour of the glass' surroundings seem to drain as you look at it."
 	taste_description = "an entertaining flavour"
 
 /datum/reagent/mimestrogen/on_new()

--- a/code/modules/reagents/chemistry/reagents/misc_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/misc_reagents.dm
@@ -568,11 +568,11 @@
 			"You feel like miming a performance.")
 			to_chat(M, "<span class='warning'>[pick(mime_message)]</span>")
 		if(M.mind.assigned_role == "Clown")
-			if(!(M.dna.species.reagent_tag & PROCESS_SYN)) // Ensures the mob that is processing the reagent is Organic to apply toxin damage
-				update_flags |= M.adjustToxLoss(1.5 * REAGENTS_EFFECT_MULTIPLIER)
-			else // Only activates if the mob that is processing the reagent is Synthetic (IPC)
+			if(!(C.dna.species.reagent_tag & PROCESS_ORG)) // Only activates if the mob that is processing the reagent is Synthetic (IPC)
 				update_flags |= M.adjustFireLoss(1.5 * REAGENTS_EFFECT_MULTIPLIER, robotic = TRUE) // The ", robotic = TRUE" just means it affects robotic limbs, which an IPC is fully robotic
-	return ..() | update_flags 																	   // Using burn instead of toxin for IPCs since IPCs don't suffer toxin and poison can feel similar to burns
+			else // Ensures the mob that is processing the reagent is Organic to apply toxin damage // Using burn instead of toxin for IPCs since IPCs don't suffer toxin and poison can feel similar to burns
+				update_flags |= M.adjustToxLoss(1.5 * REAGENTS_EFFECT_MULTIPLIER)
+	return ..() | update_flags
 
 /datum/reagent/mimestrogen/on_mob_delete(mob/living/M)
 	..()

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -293,16 +293,7 @@
 	name = "Mimestrogen"
 	id = "mimestrogen"
 	result = "mimestrogen"
-	required_reagents = list("blood" = 1, "sodiumchloride" = 1, "nothing" = 1, "formaldehyde" = 1, "neurotoxin2" = 1) //Or one freshly-squeezed mime
-	min_temp = T0C + 100
-	result_amount = 5
-	mix_message = "The mixture seems to drain of colour before stopping at a dark grey."
-
-/datum/chemical_reaction/mimestrogen2
-	name = "Mimestrogen"
-	id = "mimestrogen"
-	result = "mimestrogen"
-	required_reagents = list("blood" = 1, "sodiumchloride" = 1, "nothing" = 1, "capulettium_plus" = 1) //Or one freshly-squeezed mime
+	required_reagents = list("blood" = 1, "sodiumchloride" = 1, "nothing" = 1, "capulettium_plus" = 1) // Or one freshly-squeezed mime
 	min_temp = T0C + 100
 	result_amount = 5
 	mix_message = "The mixture seems to drain of colour before stopping at a dark grey."

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -289,6 +289,24 @@
 /datum/chemical_reaction/jestosterone/on_reaction(datum/reagents/holder, created_volume)
 	playsound(get_turf(holder.my_atom), 'sound/items/bikehorn.ogg', 50, 1)
 
+/datum/chemical_reaction/mimestrogen
+	name = "Mimestrogen"
+	id = "mimestrogen"
+	result = "mimestrogen"
+	required_reagents = list("blood" = 1, "sodiumchloride" = 1, "nothing" = 1, "formaldehyde" = 1, "neurotoxin2" = 1) //Or one freshly-squeezed mime
+	min_temp = T0C + 100
+	result_amount = 5
+	mix_message = "The mixture seems to drain of colour before stopping at a dark grey."
+
+/datum/chemical_reaction/mimestrogen2
+	name = "Mimestrogen"
+	id = "mimestrogen"
+	result = "mimestrogen"
+	required_reagents = list("blood" = 1, "sodiumchloride" = 1, "nothing" = 1, "capulettium_plus" = 1) //Or one freshly-squeezed mime
+	min_temp = T0C + 100
+	result_amount = 5
+	mix_message = "The mixture seems to drain of colour before stopping at a dark grey."
+
 /datum/chemical_reaction/royal_bee_jelly
 	name = "royal bee jelly"
 	id = "royal_bee_jelly"


### PR DESCRIPTION
## What Does This PR Do

Add Mimestrogen and a recipe for it. Acts as a counterpart chemical to Jestosterone, working like Jestosterone but Mime-like instead. Has the taste of "an entertaining flavour" and is dark grey.

Mimestrogen heals Mimes for 1.5 brute per cycle and sends a chat message of "Whatever that was, it feels great!" upon ingestion.

Mimestrogen has the following effects to non-mimes (including clowns): makes the character see fully in greyscale, makes the user be under the effects of mind.miming (emotes do the mime-like aspect such as *silently giggles., mutes, causes mime healing drinks to work), sends a mime message to chat every so often, sometimes blurs the vision for 10 seconds, sometimes makes the user dizzy, sometimes makes the user giggle. Non-mimes who aren't clowns get the chat message "Something doesn't feel right..." upon ingestion. All specified effects for non-mimes dissipate upon the reagent leaving the body.

Mimestrogen has the same effects on clowns as it does for non-mimes but with the addition of: 1.5 toxin per cycle if the character is able to take damage from toxin or 1.5 burn per cycle if the character cannot take damage from toxin (the burning sensation and numbness of burning is somewhat similar to feelings of poison), sends a chat message "You feel nauseous."

## Why It's Good For The Game

As the Mime is the counterpart of the Clown, the Mime should have a counterpart chemical to the Clown's Jestosterone.

## Testing

Spawned as a Drask Mime, dealt brute to myself, drank Mimestrogen, got specified effects for Mimes.

Spawned as an IPC Mime, dealt brute to myself, drank Mimestrogen, got specified effects for Mimes.

Spawned as a Drask Assistant, drank Mimestrogen, got specified effects for non-Mimes.

Spawned as an IPC Assistant, drank Mimestrogen, got specified effects for non-Mimes.

Spawned as a Drask Clown, drank Mimestrogen, got specified effects for Clowns.

Spawned as an IPC Clown, drank Mimestrogen, got specified effects for Clowns.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
![image](https://github.com/user-attachments/assets/ff7e54e4-a239-4bfd-87d9-c5afc907ad61)
![image](https://github.com/user-attachments/assets/91f1cc7c-bfd4-42bd-8004-58d96d077e0c)
  <hr>

## Changelog

:cl:
add: Mimestrogen
add: Mimestrogen recipe
/:cl:
