### PR TITLE
Buffs SM Events

### DIFF
--- a/code/modules/power/engines/supermatter/supermatter_event.dm
+++ b/code/modules/power/engines/supermatter/supermatter_event.dm
@@ -66,7 +66,7 @@
 
 /datum/supermatter_event/delta_tier/sleeping_gas/on_start()
 	var/datum/gas_mixture/air = new()
-	air.set_sleeping_agent(200)
+	air.set_sleeping_agent(2000)
 	supermatter_turf.blind_release_air(air)
 
 // nitrogen
@@ -75,7 +75,7 @@
 
 /datum/supermatter_event/delta_tier/nitrogen/on_start()
 	var/datum/gas_mixture/air = new()
-	air.set_nitrogen(200)
+	air.set_nitrogen(2000)
 	supermatter_turf.blind_release_air(air)
 
 // carbon dioxide
@@ -84,7 +84,7 @@
 
 /datum/supermatter_event/delta_tier/carbon_dioxide/on_start()
 	var/datum/gas_mixture/air = new()
-	air.set_carbon_dioxide(250)
+	air.set_carbon_dioxide(2000)
 	supermatter_turf.blind_release_air(air)
 
 
@@ -103,7 +103,7 @@
 
 /datum/supermatter_event/charlie_tier/oxygen/on_start()
 	var/datum/gas_mixture/air = new()
-	air.set_oxygen(250)
+	air.set_oxygen(2000)
 	supermatter_turf.blind_release_air(air)
 
 // plasma
@@ -112,7 +112,7 @@
 
 /datum/supermatter_event/charlie_tier/plasma/on_start()
 	var/datum/gas_mixture/air = new()
-	air.set_toxins(200)
+	air.set_toxins(2000)
 	supermatter_turf.blind_release_air(air)
 
 // lowers the temp required for the SM to take damage.
@@ -121,7 +121,7 @@
 	duration = 5 MINUTES
 
 /datum/supermatter_event/charlie_tier/heat_penalty_threshold/on_start()
-	supermatter.heat_penalty_threshold -= -73
+	supermatter.heat_penalty_threshold -= -173
 
 //Class B events
 /datum/supermatter_event/bravo_tier
@@ -137,14 +137,14 @@
 	name = "B-1"
 
 /datum/supermatter_event/bravo_tier/gas_multiply/on_start()
-	supermatter.gas_multiplier = 1.5
+	supermatter.gas_multiplier = 3
 
 
 /datum/supermatter_event/bravo_tier/heat_multiplier
 	name = "B-2"
 
 /datum/supermatter_event/bravo_tier/heat_multiplier/on_start()
-	supermatter.heat_multiplier = 1.25
+	supermatter.heat_multiplier = 3
 
 /datum/supermatter_event/bravo_tier/power_additive
 	name = "B-3"
@@ -216,4 +216,6 @@
 
 /datum/supermatter_event/sierra_tier/laminate/start_sierra_event()
 	..()
-	supermatter.heat_multiplier = 10
+	supermatter.heat_multiplier = 25
+	supermatter.gas_multiplier = 25
+	empulse(supermatter, 3, 6, TRUE, "S-laminite event")


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Makes previously less impactful SM events more impactful
C/D class events now add MUCH more gas to the engine, heat penalty threshold decease doubled for C3.
B Class events now cause double their original effect
S-Laminate now causes 25x heat output, 25x waste output (not as much as you think) and causes a fairly large EMP pulse upon starting. 

## Why It's Good For The Game

Most of our events you can completely ignore, this makes them slightly more impactful.

## Testing

manually test each modified SM event by commenting out all the others. Cry. regret datumizing them, repeat.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
tweak: Makes some SM events more dangerous
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
