### PR TITLE
Bungo Fruit is now growable.

### DIFF
--- a/code/modules/hydroponics/grown/cocoa_vanilla.dm
+++ b/code/modules/hydroponics/grown/cocoa_vanilla.dm
@@ -15,7 +15,7 @@
 	icon_grow = "cocoapod-grow"
 	icon_dead = "cocoapod-dead"
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
-	mutatelist = list(/obj/item/seeds/cocoapod/vanillapod)
+	mutatelist = list(/obj/item/seeds/cocoapod/vanillapod, /obj/item/seeds/cocoapod/bungotree)
 	reagents_add = list("cocoa" = 0.25, "plantmatter" = 0.1)
 
 /obj/item/food/grown/cocoapod


### PR DESCRIPTION
## What Does This PR Do

Allows you to now mutate Bungo Fruit seeds from Cocoa, as was intended.

## Why It's Good For The Game

Actually being able to create things with Bungo Juice is a good thing.

## Testing

It mutated.
<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <hr>

## Changelog

:cl:
fix: Bungo Fruit can now be mutated from Cocoa
/:cl:
