### PR TITLE
Morphs now spawn in vents

### DIFF
--- a/code/game/gamemodes/miniantags/morph/morph_event.dm
+++ b/code/game/gamemodes/miniantags/morph/morph_event.dm
@@ -17,12 +17,16 @@
 
 		var/datum/mind/player_mind = new /datum/mind(key_of_morph)
 		player_mind.active = TRUE
-		if(!GLOB.xeno_spawn)
-			kill()
-			return
-		var/mob/living/simple_animal/hostile/morph/S = new /mob/living/simple_animal/hostile/morph(pick(GLOB.xeno_spawn))
+		var/list/vents = get_valid_vent_spawns(exclude_mobs_nearby = TRUE)
+		if(!length(vents))
+			message_admins("Warning: No suitable vents detected for spawning morphs. Force picking from station vents regardless of state!")
+			vents = get_valid_vent_spawns(unwelded_only = FALSE, min_network_size = 0)
+		var/obj/vent = pick(vents)
+		var/mob/living/simple_animal/hostile/morph/S = new /mob/living/simple_animal/hostile/morph(vent.loc)
 		player_mind.transfer_to(S)
 		S.make_morph_antag()
+		S.forceMove(vent)
+		S.add_ventcrawl(vent)
 		dust_if_respawnable(C)
 		message_admins("[key_of_morph] has been made into morph by an event.")
 		log_game("[key_of_morph] was spawned as a morph by an event.")

--- a/code/game/gamemodes/miniantags/morph/morph_event.dm
+++ b/code/game/gamemodes/miniantags/morph/morph_event.dm
@@ -21,6 +21,9 @@
 		if(!length(vents))
 			message_admins("Warning: No suitable vents detected for spawning morphs. Force picking from station vents regardless of state!")
 			vents = get_valid_vent_spawns(unwelded_only = FALSE, min_network_size = 0)
+			if(!length(vents))
+				message_admins("Warning: No vents detected for spawning morphs at all!")
+				return
 		var/obj/vent = pick(vents)
 		var/mob/living/simple_animal/hostile/morph/S = new /mob/living/simple_animal/hostile/morph(vent.loc)
 		player_mind.transfer_to(S)

--- a/code/modules/antagonists/_common/antag_spawner.dm
+++ b/code/modules/antagonists/_common/antag_spawner.dm
@@ -310,11 +310,11 @@
 		message_admins("Warning: No suitable vents detected for spawning morphs. Force picking from station vents regardless of state!")
 		vents = get_valid_vent_spawns(unwelded_only = FALSE, min_network_size = 0)
 	var/obj/vent = pick(vents)
-	var/mob/living/simple_animal/hostile/morph/wizard/M = new /mob/living/simple_animal/hostile/morph/wizard(pick(GLOB.xeno_spawn))
+	var/mob/living/simple_animal/hostile/morph/wizard/M = new /mob/living/simple_animal/hostile/morph/wizard(vent)
 	M.key = C.key
 	M.make_morph_antag(FALSE)
-	S.forceMove(vent)
-	S.add_ventcrawl(vent)
+	M.forceMove(vent)
+	M.add_ventcrawl(vent)
 
 	var/list/messages = list()
 	var/datum/objective/assassinate/KillDaWiz = new /datum/objective/assassinate

--- a/code/modules/antagonists/_common/antag_spawner.dm
+++ b/code/modules/antagonists/_common/antag_spawner.dm
@@ -305,9 +305,16 @@
 		to_chat(user, "<span class='notice'>The sludge does not respond to your attempt to awake it. Perhaps you should try again later.</span>")
 
 /obj/item/antag_spawner/morph/spawn_antag(client/C, turf/T, type = "", mob/user)
+	var/list/vents = get_valid_vent_spawns(exclude_mobs_nearby = TRUE)
+	if(!length(vents))
+		message_admins("Warning: No suitable vents detected for spawning morphs. Force picking from station vents regardless of state!")
+		vents = get_valid_vent_spawns(unwelded_only = FALSE, min_network_size = 0)
+	var/obj/vent = pick(vents)
 	var/mob/living/simple_animal/hostile/morph/wizard/M = new /mob/living/simple_animal/hostile/morph/wizard(pick(GLOB.xeno_spawn))
 	M.key = C.key
 	M.make_morph_antag(FALSE)
+	S.forceMove(vent)
+	S.add_ventcrawl(vent)
 
 	var/list/messages = list()
 	var/datum/objective/assassinate/KillDaWiz = new /datum/objective/assassinate

--- a/code/modules/antagonists/_common/antag_spawner.dm
+++ b/code/modules/antagonists/_common/antag_spawner.dm
@@ -309,6 +309,9 @@
 	if(!length(vents))
 		message_admins("Warning: No suitable vents detected for spawning morphs. Force picking from station vents regardless of state!")
 		vents = get_valid_vent_spawns(unwelded_only = FALSE, min_network_size = 0)
+		if(!length(vents))
+			message_admins("Warning: No vents detected for spawning morphs at all!")
+			return
 	var/obj/vent = pick(vents)
 	var/mob/living/simple_animal/hostile/morph/wizard/M = new /mob/living/simple_animal/hostile/morph/wizard(vent)
 	M.key = C.key


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
This PR makes morphs spawn inside vents, instead of the pre-mapped spawn points used for old xenomorphs. It uses basically the exact same code as terror spiders and blob mice.
## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
It's how all the other ventcrawling antagonists work since #19391, and with the otherwise unused xeno spawns it uses now I've seen a morph spawn in an enclosed maintenance room with no way to safely get out. I imagine it was just a small oversight of the original PR.

## Testing

<!-- How did you test the PR, if at all? -->
Forced a morph midround, it spawned in a vent.
Used a wizard morph summoner, it spawned in a vent.
<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Morphs now properly spawn inside vents
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
