### PR TITLE
[FIX] Fixes for xenomorphs

### DIFF
--- a/code/modules/mob/living/carbon/alien/alien_base.dm
+++ b/code/modules/mob/living/carbon/alien/alien_base.dm
@@ -25,6 +25,7 @@
 /mob/living/carbon/alien/Initialize(mapload)
 	. = ..()
 	create_reagents(1000)
+	faction = list("alien")
 
 	for(var/organ_path in get_caste_organs())
 		var/obj/item/organ/internal/organ = new organ_path()

--- a/code/modules/mob/living/carbon/alien/alien_base.dm
+++ b/code/modules/mob/living/carbon/alien/alien_base.dm
@@ -5,6 +5,7 @@
 	bubble_icon = "alien"
 	icon = 'icons/mob/alien.dmi'
 	gender = NEUTER
+	faction = list("alien")
 
 	var/nightvision = TRUE
 	see_in_dark = 4
@@ -25,7 +26,6 @@
 /mob/living/carbon/alien/Initialize(mapload)
 	. = ..()
 	create_reagents(1000)
-	faction = list("alien")
 
 	for(var/organ_path in get_caste_organs())
 		var/obj/item/organ/internal/organ = new organ_path()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -662,7 +662,7 @@
 				if(H.dna.species.blood_color)
 					existing_trail.color = H.dna.species.blood_color
 			else if(isalien(src))
-				existing_trail.color = "#00FF32"
+				existing_trail.color = "#05EE05"
 			else
 				existing_trail.color = "#A10808"
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -661,6 +661,8 @@
 				var/mob/living/carbon/human/H = src
 				if(H.dna.species.blood_color)
 					existing_trail.color = H.dna.species.blood_color
+			else if(isalien(src))
+				existing_trail.color = "#00FF32"
 			else
 				existing_trail.color = "#A10808"
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

- Xenos now bleed with lime blood color, instead of red.
- Xenos now doesnt have neutral fraction, as any other biohazard(blod, spooder, demons). Now its only alien.

## Why It's Good For The Game

Red blood is not good for immersion
Neutral xenos are not exist in this world

## Images of changes
Neutral xenos - the only biohazard you have. This is clearly an oversight
![image](https://github.com/user-attachments/assets/d60208ad-ab40-4e5e-bffb-158f848e13d6)

Before update:
![image](https://github.com/user-attachments/assets/e7007bb9-9389-4ff4-8121-f0104f5989ef)

After fix:
![image](https://github.com/user-attachments/assets/1b24a961-72e5-4534-a7a8-bb564121e9be)



## Testing

Spawn xeno, kill him. drag him, see the green blood as expected.
Spawn goliath, he attack xenos. Kill him, revive him with lazarus, now he is neutral but still attack xenos, as he do with spiders or blobs.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Xenomorph blood is green again
tweak: Neutral mobs are now hostile to xenomorphs, similar to other biohazards
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
