### PR TITLE
Modernizes abductor Baton

### DIFF
--- a/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
@@ -297,7 +297,7 @@ CONTENTS:
 	user.do_attack_animation(L)
 
 	if(isrobot(L))
-		L.apply_damage(120, STAMINA) //Force a reboot instantly
+		L.apply_damage(80, STAMINA) //Force a reboot on two hits for consitancy.
 		return
 
 	if(ishuman(L))
@@ -327,8 +327,8 @@ CONTENTS:
 	L.lastattacker = user.real_name
 	L.lastattackerckey = user.ckey
 
-	L.Stun(14 SECONDS)
-	L.Weaken(14 SECONDS)
+	L.KnockDown(7 SECONDS)
+	L.apply_damage(80, STAMINA)
 	L.Stuttering(14 SECONDS)
 
 	L.visible_message("<span class='danger'>[user] has stunned [L] with [src]!</span>", \
@@ -338,16 +338,20 @@ CONTENTS:
 	add_attack_logs(user, L, "Stunned with [src]")
 
 /obj/item/abductor_baton/proc/SleepAttack(mob/living/L,mob/living/user)
-	if(L.IsStunned() || L.IsSleeping())
-		L.visible_message("<span class='danger'>[user] has induced sleep in [L] with [src]!</span>", \
-							"<span class='userdanger'>You suddenly feel very drowsy!</span>")
-		playsound(loc, 'sound/weapons/egloves.ogg', 50, TRUE, -1)
-		L.Sleeping(120 SECONDS)
-		add_attack_logs(user, L, "Put to sleep with [src]")
-	else
-		L.AdjustDrowsy(2 SECONDS)
-		to_chat(user, "<span class='warning'>Sleep inducement works fully only on stunned specimens!</span>")
-		L.visible_message("<span class='danger'>[user] tried to induce sleep in [L] with [src]!</span>", \
+	if(!iscarbon(L))
+		return
+	var/mob/living/carbon/C = L
+	if(do_mob(user, C, 25))
+		if(C.getStaminaLoss() > 100 || C.IsSleeping())
+			C.visible_message("<span class='danger'>[user] has induced sleep in [L] with [src]!</span>", \
+								"<span class='userdanger'>You suddenly feel very drowsy!</span>")
+			playsound(loc, 'sound/weapons/egloves.ogg', 50, TRUE, -1)
+			C.Sleeping(120 SECONDS)
+			add_attack_logs(user, C, "Put to sleep with [src]")
+		else
+			C.AdjustDrowsy(2 SECONDS)
+			to_chat(user, "<span class='warning'>Sleep inducement works fully only on stunned specimens!</span>")
+			C.visible_message("<span class='danger'>[user] tried to induce sleep in [L] with [src]!</span>", \
 							"<span class='userdanger'>You suddenly feel drowsy!</span>")
 
 /obj/item/abductor_baton/proc/CuffAttack(mob/living/L,mob/living/user)

--- a/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
@@ -297,7 +297,7 @@ CONTENTS:
 	user.do_attack_animation(L)
 
 	if(isrobot(L))
-		L.apply_damage(80, STAMINA) //Force a reboot on two hits for consitancy.
+		L.apply_damage(80, STAMINA) //Force a reboot on two hits for consistency.
 		return
 
 	if(ishuman(L))
@@ -341,7 +341,7 @@ CONTENTS:
 	if(!iscarbon(L))
 		return
 	var/mob/living/carbon/C = L
-	if(do_mob(user, C, 25))
+	if(do_mob(user, C, 2.5 SECONDS))
 		if(C.getStaminaLoss() > 100 || C.IsSleeping())
 			C.visible_message("<span class='danger'>[user] has induced sleep in [L] with [src]!</span>", \
 								"<span class='userdanger'>You suddenly feel very drowsy!</span>")
@@ -362,7 +362,7 @@ CONTENTS:
 		playsound(loc, 'sound/weapons/cablecuff.ogg', 30, TRUE, -2)
 		C.visible_message("<span class='danger'>[user] begins restraining [C] with [src]!</span>", \
 								"<span class='userdanger'>[user] begins shaping an energy field around your hands!</span>")
-		if(do_mob(user, C, 30))
+		if(do_mob(user, C, 3 SECONDS))
 			if(!C.handcuffed)
 				C.handcuffed = new /obj/item/restraints/handcuffs/energy(C)
 				C.update_handcuffed()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

The abductor baton is now a 2 hit stun with knockdown on hit, comparable to the contractor baton. There is now a 2.5 second do-after to put someone to sleep. Cuff and probe modes were unchanged.

## Why It's Good For The Game

This removes the last vestiges of old combat from our codebase, and brings the abductors inline with the combat system used by the rest of the game.


## Testing

Bully a skrell. Ensure baton cannot be used by non-abductors.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>
![image](https://github.com/user-attachments/assets/8cee49d7-593a-4b87-ba0f-2db66bc860d2)

## Changelog

:cl:
tweak: Abductor baton now takes 2 hits to stun, and 2.5 seconds to sleep.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
