### PR TITLE
makes secbots / ed209's not stupid as a fucking rock

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -840,3 +840,5 @@ emp_act
 /mob/living/carbon/human/projectile_hit_check(obj/item/projectile/P)
 	return (HAS_TRAIT(src, TRAIT_FLOORED) || HAS_TRAIT(src, TRAIT_NOKNOCKDOWNSLOWDOWN)) && !density // hit mobs that are intentionally lying down to prevent combat crawling.
 
+/mob/living/carbon/human/canBeHandcuffed()
+	return TRUE

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -841,4 +841,4 @@ emp_act
 	return (HAS_TRAIT(src, TRAIT_FLOORED) || HAS_TRAIT(src, TRAIT_NOKNOCKDOWNSLOWDOWN)) && !density // hit mobs that are intentionally lying down to prevent combat crawling.
 
 /mob/living/carbon/human/canBeHandcuffed()
-	return TRUE
+	return (has_left_hand() || has_right_hand())

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -841,4 +841,4 @@ emp_act
 	return (HAS_TRAIT(src, TRAIT_FLOORED) || HAS_TRAIT(src, TRAIT_NOKNOCKDOWNSLOWDOWN)) && !density // hit mobs that are intentionally lying down to prevent combat crawling.
 
 /mob/living/carbon/human/canBeHandcuffed()
-	return (has_left_hand() || has_right_hand())
+	return has_left_hand() || has_right_hand()

--- a/code/modules/mob/living/simple_animal/bot/ed209bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/ed209bot.dm
@@ -1,4 +1,5 @@
 #define BATON_COOLDOWN 3.5 SECONDS
+#define BOT_REBATON_THRESHOLD 5 SECONDS
 
 /mob/living/simple_animal/bot/ed209
 	name = "\improper ED-209 Security Robot"
@@ -282,7 +283,7 @@
 			if(target.stat == DEAD)
 				back_to_idle() // Stop beating up the dead guy
 				return
-			
+
 			if(Adjacent(target) && isturf(target.loc) && !baton_delayed)	// if right next to perp
 				stun_attack(target)
 				if(!lasercolor)
@@ -300,7 +301,7 @@
 		if(BOT_PREP_ARREST)		// preparing to arrest target
 
 			// see if he got away. If he's no no longer adjacent or inside a closet or about to get up, we hunt again.
-			if(!Adjacent(target) || !isturf(target.loc) || target.stam_regen_start_time - world.time <= 5 SECONDS || target.getStaminaLoss() <= 100)
+			if(!Adjacent(target) || !isturf(target.loc) || target.stam_regen_start_time - world.time <= BOT_REBATON_THRESHOLD || target.getStaminaLoss() <= 100)
 				back_to_hunt()
 				return
 
@@ -325,7 +326,7 @@
 				back_to_idle()
 				return
 
-			if(!Adjacent(target) || !isturf(target.loc) || (target.loc != target_lastloc && target.stam_regen_start_time - world.time <= 5 SECONDS || target.getStaminaLoss() <= 100)) //if he's changed loc and about to get up or not adjacent or got into a closet, we prep arrest again.
+			if(!Adjacent(target) || !isturf(target.loc) || (target.loc != target_lastloc && target.stam_regen_start_time - world.time <= BOT_REBATON_THRESHOLD || target.getStaminaLoss() <= 100)) //if he's changed loc and about to get up or not adjacent or got into a closet, we prep arrest again.
 				back_to_hunt()
 				return
 
@@ -586,3 +587,4 @@
 	back_to_idle()
 
 #undef BATON_COOLDOWN
+#undef BOT_REBATON_THRESHOLD

--- a/code/modules/mob/living/simple_animal/bot/ed209bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/ed209bot.dm
@@ -279,6 +279,10 @@
 				back_to_idle()
 				return
 
+			if(target.stat == DEAD)
+				back_to_idle() // Stop beating up the dead guy
+				return
+			
 			if(Adjacent(target) && isturf(target.loc) && !baton_delayed)	// if right next to perp
 				stun_attack(target)
 				if(!lasercolor)
@@ -296,7 +300,7 @@
 		if(BOT_PREP_ARREST)		// preparing to arrest target
 
 			// see if he got away. If he's no no longer adjacent or inside a closet or about to get up, we hunt again.
-			if(!Adjacent(target) || !isturf(target.loc) || world.time - target.stam_regen_start_time < 4 SECONDS && target.getStaminaLoss() <= 100)
+			if(!Adjacent(target) || !isturf(target.loc) || target.stam_regen_start_time - world.time <= 5 SECONDS || target.getStaminaLoss() <= 100)
 				back_to_hunt()
 				return
 
@@ -321,7 +325,7 @@
 				back_to_idle()
 				return
 
-			if(!Adjacent(target) || !isturf(target.loc) || (target.loc != target_lastloc && world.time - target.stam_regen_start_time < 4 SECONDS && target.getStaminaLoss() <= 100)) //if he's changed loc and about to get up or not adjacent or got into a closet, we prep arrest again.
+			if(!Adjacent(target) || !isturf(target.loc) || (target.loc != target_lastloc && target.stam_regen_start_time - world.time <= 5 SECONDS || target.getStaminaLoss() <= 100)) //if he's changed loc and about to get up or not adjacent or got into a closet, we prep arrest again.
 				back_to_hunt()
 				return
 

--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -330,6 +330,10 @@
 				back_to_idle()
 				return
 
+			if(target.stat == DEAD)
+				back_to_idle() // Stop beating up the dead guy
+				return
+
 			if(Adjacent(target) && isturf(target.loc) && !baton_delayed)	// if right next to perp
 				stun_attack(target)
 				mode = BOT_PREP_ARREST
@@ -341,7 +345,7 @@
 
 		if(BOT_PREP_ARREST)		// preparing to arrest target
 			// see if he got away. If he's no no longer adjacent or inside a closet or about to get up, we hunt again.
-			if(!Adjacent(target) || !isturf(target.loc) || world.time - target.stam_regen_start_time < 4 SECONDS && target.getStaminaLoss() <= 100)
+			if(!Adjacent(target) || !isturf(target.loc) || target.stam_regen_start_time - world.time <= 5 SECONDS || target.getStaminaLoss() <= 100)
 				back_to_hunt()
 				return
 			// target is stunned and nearby
@@ -367,7 +371,7 @@
 				back_to_idle()
 				return
 
-			if(!Adjacent(target) || !isturf(target.loc) || (target.loc != target_lastloc && target.AmountWeakened() < 4 SECONDS)) //if he's changed loc and about to get up or not adjacent or got into a closet, we prep arrest again.
+			if(!Adjacent(target) || !isturf(target.loc) || (target.loc != target_lastloc && target.stam_regen_start_time - world.time <= 5 SECONDS || target.getStaminaLoss() <= 100)) //if he's changed loc and about to get up or not adjacent or got into a closet, we prep arrest again.
 				back_to_hunt()
 				return
 			//Try arresting again if the target escapes.
@@ -407,7 +411,7 @@
 		if((C.stat) || (C.handcuffed))
 			continue
 
-		if((C.name == oldtarget_name) && (world.time < last_found + 100))
+		if((C.name == oldtarget_name) && (world.time < last_found + 5 SECONDS))
 			continue
 
 		threatlevel = C.assess_threat(src)

--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -1,4 +1,5 @@
 #define BATON_COOLDOWN 3.5 SECONDS
+#define BOT_REBATON_THRESHOLD 5 SECONDS
 
 /mob/living/simple_animal/bot/secbot
 	name = "\improper Securitron"
@@ -345,7 +346,7 @@
 
 		if(BOT_PREP_ARREST)		// preparing to arrest target
 			// see if he got away. If he's no no longer adjacent or inside a closet or about to get up, we hunt again.
-			if(!Adjacent(target) || !isturf(target.loc) || target.stam_regen_start_time - world.time <= 5 SECONDS || target.getStaminaLoss() <= 100)
+			if(!Adjacent(target) || !isturf(target.loc) || target.stam_regen_start_time - world.time <= BOT_REBATON_THRESHOLD|| target.getStaminaLoss() <= 100)
 				back_to_hunt()
 				return
 			// target is stunned and nearby
@@ -371,7 +372,7 @@
 				back_to_idle()
 				return
 
-			if(!Adjacent(target) || !isturf(target.loc) || (target.loc != target_lastloc && target.stam_regen_start_time - world.time <= 5 SECONDS || target.getStaminaLoss() <= 100)) //if he's changed loc and about to get up or not adjacent or got into a closet, we prep arrest again.
+			if(!Adjacent(target) || !isturf(target.loc) || (target.loc != target_lastloc && target.stam_regen_start_time - world.time <= BOT_REBATON_THRESHOLD || target.getStaminaLoss() <= 100)) //if he's changed loc and about to get up or not adjacent or got into a closet, we prep arrest again.
 				back_to_hunt()
 				return
 			//Try arresting again if the target escapes.
@@ -474,3 +475,4 @@
 	..()
 
 #undef BATON_COOLDOWN
+#undef BOT_REBATON_THRESHOLD

--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -366,7 +366,7 @@
 
 			back_to_idle()
 
-		if(BOT_ARREST)
+		if(BOT_ARREST) // Fun fact: This is not called
 			if(!target || target.handcuffed)
 				back_to_idle()
 				return


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

secbots no longer try to detain dead people
humans now have canBeHandcuffed() return TRUE. This was problem A.
Switches  world.time - target.stam_regen_start_time < 4 (was giving negative numbers aka always true) to target.stam_regen_start_time - world.time <= 5 SECONDS (also makes it more consistant of batoning people in time) This was problem B
switches  && target.getStaminaLoss() <= 100 to  || target.getStaminaLoss() <= 100, so the bots will actually keep someone detained in stamina crit. This was problem C
Adjusts last target to 5 seconds from 10, so it can still go after people in stamina crit if it decides to recalculate targets for some reason, which lasts around 10 seconds

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
A: Secbots not endlessly beating dead people is good, while funny made them less of a problem when emaged or in ruins.
B: secbots actually fucking working in detainmode is good
C: Secbots in ruins actually killing people vs letting them slowly crawl away is good

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
like 9 message admins and pulling my hair out debugging it till it worked.
Confirmed detain mode worked.
Confirmed it didnt attack dead people
confirmed arrests worked.
Confirmed it worked if the person had some antistun (upgraded cybernetic heart used)
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Secbots no longer endlessly beat dead people ignoring everyone else
fix: Secbots in detain mode actually detain people properly now. You can not escape one without outside help or antistuns again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
