### PR TITLE
[s] fixes some walls I missed

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/telecomns_returns.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/telecomns_returns.dmm
@@ -1658,14 +1658,6 @@
 	},
 /turf/simulated/wall/indestructible/riveted,
 /area/ruin/space/telecomms/chamber)
-"zM" = (
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'SERVER ROOM'.";
-	name = "SERVER ROOM";
-	pixel_y = 0
-	},
-/turf/simulated/wall/r_wall,
-/area/ruin/space/telecomms/chamber)
 "zY" = (
 /obj/structure/bed,
 /obj/item/bedsheet/green,
@@ -3011,9 +3003,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/ruin/space/telecomms/computer)
-"To" = (
-/turf/simulated/wall/r_wall,
-/area/ruin/space/telecomms/chamber)
 "Tw" = (
 /obj/machinery/computer/telescience{
 	dir = 4
@@ -7958,7 +7947,7 @@ ux
 Ad
 tF
 iy
-To
+Zu
 mZ
 FA
 EM
@@ -8050,7 +8039,7 @@ ux
 ux
 ux
 ux
-To
+Zu
 ME
 Zj
 EM
@@ -8142,9 +8131,9 @@ pE
 sv
 ia
 kl
-To
-To
-zM
+Zu
+Zu
+FA
 EM
 il
 dn


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Removes some reinforced walls, makes them indestructable
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
No you can not skip the dangerous half of the ruin
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Fixs being able to skip the left side of the dvorak ruin
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
