### PR TITLE
[FIX] Animated closet fixes

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -524,13 +524,15 @@
 	for(var/atom/A in location)
 		if(A.density && A != src && A != AM)
 			transparent = TRUE
-			break
+			alpha = 180
+			update_icon()
+			return
+	alpha = 255
 	update_icon()
 
 /obj/structure/closet/bluespace/Crossed(atom/movable/AM, oldloc)
 	if(AM.density)
-		transparent = TRUE
-		update_icon()
+		UpdateTransparency(location = loc)
 
 /obj/structure/closet/bluespace/Move(NewLoc, direct) // Allows for "phasing" throug objects but doesn't allow you to stuff your EOC homebois in one of these and push them through walls.
 	var/turf/T = get_turf(NewLoc)

--- a/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
@@ -60,4 +60,3 @@
 
 	else
 		to_chat(user, "<span class='warning'>Access denied.</span>")
-	

--- a/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
@@ -39,10 +39,6 @@
 	if(opened || !istype(W, /obj/item/card/id))
 		return ..()
 
-	if(broken)
-		to_chat(user, "<span class='warning'>It appears to be broken.</span>")
-		return
-
 	if(istype(W, /obj/item/card/id/guest))
 		to_chat(user, "<span class='warning'>Invalid identification card.</span>")
 		return
@@ -51,24 +47,17 @@
 	if(!I || !I.registered_name)
 		return
 
-	if(src == user.loc)
-		to_chat(user, "<span class='notice'>You can't reach the lock from inside.</span>")
-
 	else if(allowed(user) || !registered_name || (istype(I) && (registered_name == I.registered_name)))
-		cut_overlays()
-
 		//they can open all lockers, or nobody owns this, or they own this locker
-		locked = !locked
-		if(locked)
-			add_overlay("locked")
-		else
-			add_overlay("unlocked")
-			icon_state = icon_closed
+		togglelock(user)
+		if(!locked)
 			registered_name = null
 			desc = initial(desc)
 
 		if(!registered_name && locked)
 			registered_name = I.registered_name
-			desc = "Owned by [I.registered_name]."
+			desc = "Owned by [I.registered_name]." 
+
 	else
 		to_chat(user, "<span class='warning'>Access denied.</span>")
+	


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes some issues with animated closets:

1. Personal closets no longer go invisible when you swipe an ID over them.
2. Bluespace lockers once again go transparent when something moves through them.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Bugs are bad
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Move a bluespace locker through myself, and a table, and open and close it a bunch. It handles transparency fine.
Swipe my ID card over a personal locker. It does not go invisible.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Personal lockers no longer go invisible if you swipe your ID over them.
fix: Bluespace lockers can once again go transparent.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
