### PR TITLE
fix: duplicate mapped fire-extinguishers

### DIFF
--- a/_maps/map_files/generic/Lavaland.dmm
+++ b/_maps/map_files/generic/Lavaland.dmm
@@ -9158,10 +9158,6 @@
 	name = "south bump";
 	pixel_y = -30
 	},
-/obj/structure/extinguisher_cabinet{
-	name = "south bump";
-	pixel_y = -30
-	},
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/mining)
 "Sd" = (

--- a/_maps/map_files/stations/deltastation.dmm
+++ b/_maps/map_files/stations/deltastation.dmm
@@ -11069,20 +11069,12 @@
 /turf/simulated/wall/r_wall,
 /area/station/security/execution)
 "aMx" = (
-/obj/structure/extinguisher_cabinet{
-	name = "east bump";
-	pixel_x = 30
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable,
-/obj/structure/extinguisher_cabinet{
-	name = "east bump";
-	pixel_x = 30
-	},
 /obj/structure/extinguisher_cabinet{
 	name = "east bump";
 	pixel_x = 30

--- a/tools/maplint/lints/stacked_matching_extinguisher_cabinets.yml
+++ b/tools/maplint/lints/stacked_matching_extinguisher_cabinets.yml
@@ -1,0 +1,4 @@
+/obj/structure/extinguisher_cabinet:
+  banned_neighbors:
+    /obj/structure/extinguisher_cabinet:
+      identical: true


### PR DESCRIPTION
## What Does This PR Do
This PR removes two instances on maps where multiple fire extinguishers were stacked in the same direction, and adds a maplint prohibiting it in the future.
## Why It's Good For The Game
Easy mapping oversight, let's fix it forever.
## Images of changes
![2024_10_14__16_44_45__paradise dme  Lavaland dmm  - StrongDMM](https://github.com/user-attachments/assets/cbcb3c9c-f52f-402a-800b-d0d937245a47)
## Testing
Visual inspection.

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: The mining shuttle no longer has two fire extinguishers stacked on the same wall.
fix: Kerberos: the SMES room no longer has three fire extinguishers stacked on the same wall.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
