### PR TITLE
[FIX] Guncabinet overlay fix

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/guncabinet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/guncabinet.dm
@@ -23,7 +23,7 @@
 		return TRUE
 
 /obj/structure/closet/secure_closet/guncabinet/update_overlays()
-	. = ..()
+	. = list()
 	if(!opened)
 		var/lasers = 0
 		var/ballistics = 0
@@ -48,6 +48,7 @@
 				. += gun
 		if(broken)
 			. += "off"
+	. += ..()
 
 /obj/structure/closet/secure_closet/guncabinet/cc
 	req_access = list(ACCESS_CENT_SPECOPS_COMMANDER)

--- a/code/game/objects/structures/crates_lockers/closets/secure/guncabinet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/guncabinet.dm
@@ -48,7 +48,7 @@
 				. += gun
 		if(broken)
 			. += "off"
-	. += ..()
+	. += ..() // Parent call at the end instead of the beginning because we need the gun overlays to be drawn first, then the door.
 
 /obj/structure/closet/secure_closet/guncabinet/cc
 	req_access = list(ACCESS_CENT_SPECOPS_COMMANDER)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes a bug introduced by animated closets where the gun overlays were drawn before the door overlay on gun cabinets
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Bugs bad
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://github.com/user-attachments/assets/02de54fa-b8f9-4631-b3bf-ff230467b7bf)
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Look at a gun cabinet, open a gun cabinet, close a gun cabinet.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Guncabinets no longer show the gun overlays above their doors.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
