### PR TITLE
tweak: slightly reduce spawn rate of boulders on blocked burrows

### DIFF
--- a/code/modules/lavaland/caves_theme.dm
+++ b/code/modules/lavaland/caves_theme.dm
@@ -137,7 +137,7 @@ GLOBAL_LIST_INIT(caves_default_flora_spawns, list(
 	perlin_upper_range = 0.3
 
 /datum/caves_theme/burrows/on_change(turf/T)
-	if(prob(9))
+	if(prob(7))
 		new /obj/structure/flora/ash/rock/style_random(T)
 	else if(prob(5))
 		lavaland_caves_spawn_flora(T)


### PR DESCRIPTION
## What Does This PR Do
This PR reduces the probability of boulders spawning on Blocked Burrows from prob(9) per cave tile to prob(7). prob(8) did not seem to make a substantial difference, still allowing huge clumps of boulders.
## Why It's Good For The Game
This still presents a challenge for miners in terms of navigation, placing shelters, etc., but is not as ridiculous as the current spawn rate.
## Images of changes
### Before
![2024_10_15__16_46_01__](https://github.com/user-attachments/assets/5b8b53f9-f52b-47fe-9911-fe3fdce55600)

### After
![2024_10_15__17_12_08__](https://github.com/user-attachments/assets/e7c24aea-8096-49a0-92ac-7ec65b7c443c)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
I'm not going to run stats for this, you're just going to have to trust me that 7 is less than 9.
<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

![2024_10_15__17_13_35__#development_discussion _ Paradise Station - Discord](https://github.com/user-attachments/assets/442818e3-5d0c-4aa7-8e00-519e909002cc)


<hr>

## Changelog

:cl:
tweak: The rate of boulder spawns on the Blocked Burrows cave theme has been slightly reduced.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
