### PR TITLE
Fixes Autoinjectors and Some Hyposprays Working on Robotic/Missing Limbs

### DIFF
--- a/code/modules/mob/living/carbon/human/human_mob.dm
+++ b/code/modules/mob/living/carbon/human/human_mob.dm
@@ -813,7 +813,7 @@
 			xylophone=0
 	return
 
-/mob/living/carbon/human/can_inject(mob/user, error_msg, target_zone, penetrate_thick = FALSE, piercing = FALSE)
+/mob/living/carbon/human/can_inject(mob/user, error_msg, target_zone, penetrate_thick = FALSE, defeat_all_protection = FALSE)
 	. = TRUE
 
 	if(!target_zone)
@@ -822,12 +822,6 @@
 			CRASH("can_inject() called on a human mob with neither a user nor a targeting zone selected.")
 		else
 			target_zone = user.zone_selected
-
-	if(HAS_TRAIT(src, TRAIT_PIERCEIMMUNE))
-		. = FALSE
-
-	if(wear_suit && HAS_TRAIT(wear_suit, TRAIT_RSG_IMMUNE))
-		return FALSE
 
 	var/obj/item/organ/external/affecting = get_organ(target_zone)
 	var/fail_msg
@@ -838,8 +832,16 @@
 		. = FALSE
 		fail_msg = "That limb is robotic."
 
-	if(piercing)
+	// If there is flesh, inject.
+	if(defeat_all_protection)
 		return TRUE
+
+	if(HAS_TRAIT(src, TRAIT_PIERCEIMMUNE && !penetrate_thick))
+		. = FALSE
+		fail_msg = "[p_their(TRUE)] skin is too tough to inject into!"
+
+	if(wear_suit && HAS_TRAIT(wear_suit, TRAIT_RSG_IMMUNE))
+		return FALSE
 
 	if(target_zone == "head")
 		if((head?.flags & THICKMATERIAL) && !penetrate_thick)

--- a/code/modules/mob/living/carbon/human/human_mob.dm
+++ b/code/modules/mob/living/carbon/human/human_mob.dm
@@ -836,7 +836,7 @@
 	if(defeat_all_protection)
 		return TRUE
 
-	if(HAS_TRAIT(src, TRAIT_PIERCEIMMUNE) && !penetrate_thick)
+	if(HAS_TRAIT(src, TRAIT_PIERCEIMMUNE))
 		. = FALSE
 
 	if(wear_suit && HAS_TRAIT(wear_suit, TRAIT_RSG_IMMUNE))

--- a/code/modules/mob/living/carbon/human/human_mob.dm
+++ b/code/modules/mob/living/carbon/human/human_mob.dm
@@ -836,12 +836,11 @@
 	if(defeat_all_protection)
 		return TRUE
 
-	if(HAS_TRAIT(src, TRAIT_PIERCEIMMUNE && !penetrate_thick))
+	if(HAS_TRAIT(src, TRAIT_PIERCEIMMUNE) && !penetrate_thick)
 		. = FALSE
-		fail_msg = "[p_their(TRUE)] skin is too tough to inject into!"
 
 	if(wear_suit && HAS_TRAIT(wear_suit, TRAIT_RSG_IMMUNE))
-		return FALSE
+		. = FALSE
 
 	if(target_zone == "head")
 		if((head?.flags & THICKMATERIAL) && !penetrate_thick)

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -224,7 +224,7 @@
 	name = "dart"
 	icon_state = "cbbolt"
 	damage = 6
-	var/piercing = FALSE
+	var/penetrate_thick = FALSE
 
 /obj/item/projectile/bullet/dart/New()
 	..()
@@ -235,7 +235,7 @@
 	if(iscarbon(target))
 		var/mob/living/carbon/M = target
 		if(blocked != INFINITY)
-			if(M.can_inject(null, FALSE, hit_zone, piercing)) // Pass the hit zone to see if it can inject by whether it hit the head or the body.
+			if(M.can_inject(null, FALSE, hit_zone, penetrate_thick)) // Pass the hit zone to see if it can inject by whether it hit the head or the body.
 				..()
 
 				reagents.reaction(M, REAGENT_INGEST, 0.1)
@@ -268,7 +268,7 @@
 	damage = 20
 
 /obj/item/projectile/bullet/dart/syringe/pierce_ignore
-	piercing = TRUE
+	penetrate_thick = TRUE
 
 /obj/item/projectile/bullet/dart/syringe/tranquilizer
 

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -18,7 +18,7 @@
 	/// How many SSobj ticks it takes for the reagents to recharge by 10 units
 	var/recharge_time = 3
 	/// Can the autohypo inject through thick materials?
-	var/bypass_protection = 0
+	var/penetrate_thick = FALSE
 	var/choosen_reagent = "salglu_solution"
 	var/list/datum/reagents/reagent_list = list()
 	var/list/reagent_ids = list("salglu_solution", "epinephrine", "spaceacillin", "charcoal", "hydrocodone", "mannitol", "salbutamol")
@@ -57,14 +57,14 @@
 	reagent_ids = list("syndicate_nanites", "potass_iodide", "hydrocodone")
 	total_reagents = 30
 	maximum_reagents = 30
-	bypass_protection = TRUE
+	penetrate_thick = TRUE
 	choosen_reagent = "syndicate_nanites"
 
 /obj/item/reagent_containers/borghypo/abductor
 	charge_cost = 40
 	recharge_time = 3
 	reagent_ids = list("salglu_solution", "epinephrine", "hydrocodone", "spaceacillin", "charcoal", "mannitol", "salbutamol", "corazone")
-	bypass_protection = 1
+	penetrate_thick = TRUE
 
 /obj/item/reagent_containers/borghypo/Initialize(mapload)
 	. = ..()
@@ -94,7 +94,7 @@
 		return
 	if(!istype(M))
 		return
-	if(total_reagents && M.can_inject(user, TRUE, user.zone_selected, penetrate_thick = bypass_protection))
+	if(total_reagents && M.can_inject(user, TRUE, user.zone_selected, penetrate_thick))
 		to_chat(user, "<span class='notice'>You inject [M] with the injector.</span>")
 		to_chat(M, "<span class='notice'>You feel a tiny prick!</span>")
 
@@ -127,11 +127,11 @@
 /obj/item/reagent_containers/borghypo/emag_act(mob/user)
 	if(!emagged)
 		emagged = TRUE
-		bypass_protection = TRUE
+		penetrate_thick = TRUE
 		reagent_ids += reagent_ids_emagged
 		return
 	emagged = FALSE
-	bypass_protection = FALSE
+	penetrate_thick = FALSE
 	reagent_ids -= reagent_ids_emagged
 
 /obj/item/reagent_containers/borghypo/basic

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -14,10 +14,12 @@
 	resistance_flags = ACID_PROOF
 	container_type = OPENCONTAINER
 	slot_flags = SLOT_FLAG_BELT
-	/// If TRUE, the hypospray can inject through most hardsuits/modsuits.
-	var/can_pierce_hardsuits = FALSE
+	/// If TRUE, the hypospray can inject through most hardsuits/modsuits and people with the gene that gives TRAIT_PIERCEIMMUNE.
+	var/penetrate_thick = FALSE
 	/// If TRUE, the hypospray isn't blocked by suits with TRAIT_HYPOSPRAY_IMMUNE.
 	var/ignore_hypospray_immunity = FALSE
+	/// if TRUE, the hypospray will always succeed at injecting an organic limb regardless of protective clothing or traits.
+	var/defeat_all_protection = FALSE
 	/// If TRUE, the hypospray will reject any chemicals not on the safe_chem_list.
 	var/safety_hypo = FALSE
 	// List of SOSHA-approved medicines.
@@ -32,6 +34,7 @@
 	if(!reagents.total_volume)
 		to_chat(user, "<span class='warning'>[src] is empty!</span>")
 		return
+
 	if(!iscarbon(M))
 		return
 
@@ -41,7 +44,7 @@
 			to_chat(user, "<span class='warning'>[src] is unable to penetrate the armour of [M] or interface with any injection ports.</span>")
 			return
 
-	if(reagents.total_volume && (can_pierce_hardsuits || M.can_inject(user, TRUE))) // can_pierce_hardsuits should be checked first or there will be an error message.
+	if(reagents.total_volume && M.can_inject(user, TRUE, penetrate_thick, defeat_all_protection))
 		to_chat(M, "<span class='warning'>You feel a tiny prick!</span>")
 		to_chat(user, "<span class='notice'>You inject [M] with [src].</span>")
 
@@ -99,7 +102,7 @@
 /obj/item/reagent_containers/hypospray/emag_act(mob/user)
 	if(safety_hypo && !emagged)
 		emagged = TRUE
-		can_pierce_hardsuits = TRUE
+		penetrate_thick = TRUE
 		to_chat(user, "<span class='warning'>You short out the safeties on [src].</span>")
 		return TRUE
 
@@ -124,7 +127,8 @@
 	possible_transfer_amounts = list(5, 10, 15, 20, 25, 30)
 	icon_state = "combat_hypo"
 	volume = 90
-	can_pierce_hardsuits = TRUE // So they can heal their comrades.
+	penetrate_thick = TRUE // So they can heal their comrades.
+	defeat_all_protection = TRUE
 	ignore_hypospray_immunity = TRUE
 	list_reagents = list("epinephrine" = 30, "weak_omnizine" = 30, "salglu_solution" = 30)
 
@@ -148,7 +152,7 @@
 	desc = "Nanotrasen's own, reverse-engineered and improved version of DeForest's hypospray."
 	list_reagents = list("omnizine" = 30)
 	volume = 100
-	can_pierce_hardsuits = TRUE
+	penetrate_thick = TRUE
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 
 /obj/item/reagent_containers/hypospray/CMO/Initialize(mapload)
@@ -177,8 +181,9 @@
 	amount_per_transfer_from_this = 10
 	possible_transfer_amounts = null
 	volume = 10
-	can_pierce_hardsuits = TRUE //so you can medipen through hardsuits
+	penetrate_thick = TRUE
 	ignore_hypospray_immunity = TRUE
+	defeat_all_protection = TRUE // Autoinjectors bypass everything.
 	container_type = DRAWABLE
 	flags = null
 

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -14,7 +14,7 @@
 	resistance_flags = ACID_PROOF
 	container_type = OPENCONTAINER
 	slot_flags = SLOT_FLAG_BELT
-	/// If TRUE, the hypospray can inject through most hardsuits/modsuits and people with the gene that gives TRAIT_PIERCEIMMUNE.
+	/// If TRUE, the hypospray can inject through most hardsuits/modsuits.
 	var/penetrate_thick = FALSE
 	/// If TRUE, the hypospray isn't blocked by suits with TRAIT_HYPOSPRAY_IMMUNE.
 	var/ignore_hypospray_immunity = FALSE

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -18,7 +18,7 @@
 	var/penetrate_thick = FALSE
 	/// If TRUE, the hypospray isn't blocked by suits with TRAIT_HYPOSPRAY_IMMUNE.
 	var/ignore_hypospray_immunity = FALSE
-	/// if TRUE, the hypospray will always succeed at injecting an organic limb regardless of protective clothing or traits.
+	/// if TRUE, the hypospray will always succeed at injecting an organic limb regardless of protective clothing or traits (except for TRAIT_HYPOSPRAY_IMMUNE).
 	var/defeat_all_protection = FALSE
 	/// If TRUE, the hypospray will reject any chemicals not on the safe_chem_list.
 	var/safety_hypo = FALSE
@@ -40,11 +40,12 @@
 
 	var/mob/living/carbon/human/H = M
 	if(H.wear_suit)
-		if(HAS_TRAIT(H.wear_suit, TRAIT_HYPOSPRAY_IMMUNE) && !ignore_hypospray_immunity)	// This check is here entirely to stop goobers injecting nukies with meme chems
+		// This check is here entirely to stop goobers injecting Nukies, the SST, and the Deathsquad with meme chems.
+		if(HAS_TRAIT(H.wear_suit, TRAIT_HYPOSPRAY_IMMUNE) && !ignore_hypospray_immunity)
 			to_chat(user, "<span class='warning'>[src] is unable to penetrate the armour of [M] or interface with any injection ports.</span>")
 			return
 
-	if(reagents.total_volume && M.can_inject(user, TRUE, penetrate_thick, defeat_all_protection))
+	if(reagents.total_volume && M.can_inject(user, TRUE, user.zone_selected, penetrate_thick, defeat_all_protection))
 		to_chat(M, "<span class='warning'>You feel a tiny prick!</span>")
 		to_chat(user, "<span class='notice'>You inject [M] with [src].</span>")
 
@@ -103,6 +104,7 @@
 	if(safety_hypo && !emagged)
 		emagged = TRUE
 		penetrate_thick = TRUE
+		defeat_all_protection = TRUE
 		to_chat(user, "<span class='warning'>You short out the safeties on [src].</span>")
 		return TRUE
 
@@ -128,8 +130,8 @@
 	icon_state = "combat_hypo"
 	volume = 90
 	penetrate_thick = TRUE // So they can heal their comrades.
-	defeat_all_protection = TRUE
 	ignore_hypospray_immunity = TRUE
+	defeat_all_protection = TRUE
 	list_reagents = list("epinephrine" = 30, "weak_omnizine" = 30, "salglu_solution" = 30)
 
 /obj/item/reagent_containers/hypospray/combat/nanites


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Hyposprays (and by extension autoinjectors) no longer ignore `can_inject()` if they are piercing hyposprays, and `can_inject()` now checks for robotic/missing limbs before anything else. This prevents hyposprays and autoinjectors from injecting robotic and missing limbs.

Hyposprays now check for targeted body zones like other handheld injectors do.

Several injection items have had their local variables name changed so they obviously are referring to the ability to defeat thick clothing.

The unused `piercing` variable has been renamed `always_defeat_protection` so it's immediately obvious that it will always return `TRUE` if the missing/robotics limb checks succeed. Autoinjectors and piercing hyposprays (CMO/emagged/Syndicate/Deathsquad) have been given this characteristic due to it being how they currently behave on live, but it's now very easy to change the behaviour for individual hyposprays and injectors.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
You're not supposed to be able to inject into robotic/missing body parts.

There is now more granular control over the piercing behaviours of hyposprays and autoinjectors.

There is now a single variable that can be tweaked for tems doing an injection check if we want them to be able to bypass all injection protection without fuss.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Spawned a bunch of syringes, a dart gun, an RSG, hypospray, CMO hypospray, DS hypospray, and some autoinjectors.
Used them on test skrell with various protections (or lack thereof) to check that nothing got broken.

Everything worked good.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.


  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Hyposprays and autoinjectors no longer inject into missing or robotic limbs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
