### PR TITLE
Fixes Newscaster Treatment of Wallets

### DIFF
--- a/code/defines/procs/announcer_datum.dm
+++ b/code/defines/procs/announcer_datum.dm
@@ -137,10 +137,6 @@ GLOBAL_DATUM_INIT(major_announcement, /datum/announcer, new(config_type = /datum
 	log_game("[key_name(usr)] has made \a [config.log_name]: [message_title] - [message] - [author]")
 	message_admins("[key_name_admin(usr)] has made \a [config.log_name].", 1)
 
-/proc/GetNameAndAssignmentFromId(obj/item/card/id/I)
-	// Format currently matches that of newscaster feeds: Registered Name (Assigned Rank)
-	return I.assignment ? "[I.registered_name] ([I.assignment])" : I.registered_name
-
 /datum/announcement_configuration/event
 	default_title = ANNOUNCE_KIND_EVENT
 	sound = sound('sound/misc/notice2.ogg')

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -1191,3 +1191,7 @@
 			return "Thunderdome Green"
 		else
 			return capitalize(skin)
+
+/proc/GetNameAndAssignmentFromId(obj/item/card/id/I)
+	// Format currently matches that of newscaster feeds: Registered Name (Assigned Rank)
+	return I.assignment ? "[I.registered_name] ([I.assignment])" : I.registered_name

--- a/code/modules/newscaster/obj/newscaster.dm
+++ b/code/modules/newscaster/obj/newscaster.dm
@@ -645,9 +645,9 @@ GLOBAL_LIST_EMPTY(allNewscasters)
 /obj/machinery/newscaster/proc/get_scanned_user(mob/user)
 	. = list(name = "Unknown", security = user.can_admin_interact())
 	if(ishuman(user))
-		var/mob/living/carbon/human/M = user
+		var/mob/living/carbon/human/human_user = user
 		// No ID, no luck
-		var/obj/item/card/id/ID = M.get_id_card()
+		var/obj/item/card/id/ID = human_user.get_id_card()
 		if(ID)
 			return list(name = "[ID.registered_name] ([ID.assignment])", security = has_access(list(), list(ACCESS_SECURITY), ID.access))
 	else if(issilicon(user))

--- a/code/modules/newscaster/obj/newscaster.dm
+++ b/code/modules/newscaster/obj/newscaster.dm
@@ -646,7 +646,6 @@ GLOBAL_LIST_EMPTY(allNewscasters)
 	. = list(name = "Unknown", security = user.can_admin_interact())
 	if(ishuman(user))
 		var/mob/living/carbon/human/human_user = user
-		// No ID, no luck
 		var/obj/item/card/id/ID = human_user.get_id_card()
 		if(ID)
 			return list(name = "[ID.registered_name] ([ID.assignment])", security = has_access(list(), list(ACCESS_SECURITY), ID.access))

--- a/code/modules/newscaster/obj/newscaster.dm
+++ b/code/modules/newscaster/obj/newscaster.dm
@@ -647,16 +647,8 @@ GLOBAL_LIST_EMPTY(allNewscasters)
 	if(ishuman(user))
 		var/mob/living/carbon/human/M = user
 		// No ID, no luck
-		if(!M.wear_id)
-			return
-		// Try to get the ID
-		var/obj/item/card/id/ID
-		if(istype(M.wear_id, /obj/item/pda))
-			var/obj/item/pda/P = M.wear_id
-			ID = P.id
-		else if(istype(M.wear_id, /obj/item/card/id))
-			ID = M.wear_id
-		if(istype(ID))
+		var/obj/item/card/id/ID = M.get_id_card()
+		if(ID)
 			return list(name = "[ID.registered_name] ([ID.assignment])", security = has_access(list(), list(ACCESS_SECURITY), ID.access))
 	else if(issilicon(user))
 		var/mob/living/silicon/ai_user = user


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #26357 (Newscaster does not recognize IDs inside wallets)
Simplyfies newscaster/proc/get_scanned_user
Moves proc/GetNameAndAssignmentFromId from a comms console related file to the ID card file
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
One less bug
Makes a proc that's universally useful more discoverable
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Created news channel with empty wallet in ID slot. Manage channel was available.
Put on ID directly. Manage channel was greyed out.
Put on ID in wallet. Manage channel was greyed out.
Created news channel with ID in wallet. Manage channel was available.
IIRC put on ID directly and manage channel was available. (I should have written this while I was testing.)
Removed ID. Manage channel was greyed out.

Logged into comms console with debugger ID. Made announcement. Job was shown correctly.
Same with ID in wallet.
Tried logging in with librarian ID. Unable.
Tried loggin in with empty wallet. Unable
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Newscaster now correctly handle wallets.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
