### PR TITLE
fix: TESTING-enabled admin rank helper procs

### DIFF
--- a/code/modules/admin/admin_ranks.dm
+++ b/code/modules/admin/admin_ranks.dm
@@ -139,7 +139,7 @@ GLOBAL_PROTECT(admin_ranks) // this shit is being protected for obvious reasons
 		holder.rights = GLOB.admin_ranks[newrank]
 	else
 		holder = new /datum/admins(newrank,GLOB.admin_ranks[newrank],ckey)
-	remove_admin_verbs()
+	hide_verbs()
 	holder.associate(src)
 
 /client/verb/changerights(newrights as num)
@@ -147,7 +147,7 @@ GLOBAL_PROTECT(admin_ranks) // this shit is being protected for obvious reasons
 		holder.rights = newrights
 	else
 		holder = new /datum/admins("testing",newrights,ckey)
-	remove_admin_verbs()
+	hide_verbs()
 	holder.associate(src)
 
 #endif


### PR DESCRIPTION
## What Does This PR Do
This PR fixes two procs guarded by the `TESTING` compiler define to use the new functions introduced in https://github.com/ParadiseSS13/Paradise/pull/24065.

It's pretty clear no one has used this define at *all* since at least March, and who knows how useful they are, and I'm half tempted to remove it completely and migrate some of its other guards to other defines and better logs, but this works for now.
## Why It's Good For The Game
Code should compile with expected compiler flags.
## Testing
Built server with `TESTING`, spawned in, ensured I could Advanced Proccall the two procs that were previously guarded.
<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog
NPFC