### PR TITLE
[FIX] Personal lockers fix

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -79,7 +79,7 @@
 			door_overlay.overlays += emissive_blocker(door_overlay.icon, door_overlay.icon_state, alpha = door_overlay.alpha) // If we don't do this the door doesn't block emissives and it looks weird.
 		else if(!opened && has_closed_overlay)
 			. += "[closed_door_sprite || icon_state]_closed"
-	
+
 	if(opened)
 		return
 
@@ -255,7 +255,6 @@
 	if(enable_door_overlay)
 		animate_door(TRUE)
 	update_appearance()
-	playsound(loc, close_sound, close_sound_volume, TRUE, -3)
 	density = TRUE
 
 	return TRUE

--- a/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
@@ -43,13 +43,26 @@
 		to_chat(user, "<span class='warning'>Invalid identification card.</span>")
 		return
 
+	if(opened)
+		to_chat(user, "<span class='notice'>Close the locker first.</span>")
+		return
+
+	if(broken)
+		to_chat(user, "<span class='warning'>The locker appears to be broken.</span>")
+		return
+
+	if(user.loc == src)
+		to_chat(user, "<span class='notice'>You can't reach the lock from inside.</span>")
+		return
+		
 	var/obj/item/card/id/I = W
 	if(!I || !I.registered_name)
 		return
 
 	else if(allowed(user) || !registered_name || (istype(I) && (registered_name == I.registered_name)))
 		//they can open all lockers, or nobody owns this, or they own this locker
-		togglelock(user)
+		locked = !locked
+		update_icon()
 		if(!locked)
 			registered_name = null
 			desc = initial(desc)

--- a/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
@@ -39,10 +39,6 @@
 	if(opened || !istype(W, /obj/item/card/id))
 		return ..()
 
-	if(opened)
-		to_chat(user, "<span class='notice'>Close the locker first.</span>")
-		return
-
 	if(broken)
 		to_chat(user, "<span class='warning'>The locker appears to be broken.</span>")
 		return

--- a/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
@@ -39,10 +39,6 @@
 	if(opened || !istype(W, /obj/item/card/id))
 		return ..()
 
-	if(istype(W, /obj/item/card/id/guest))
-		to_chat(user, "<span class='warning'>Invalid identification card.</span>")
-		return
-
 	if(opened)
 		to_chat(user, "<span class='notice'>Close the locker first.</span>")
 		return
@@ -54,7 +50,11 @@
 	if(user.loc == src)
 		to_chat(user, "<span class='notice'>You can't reach the lock from inside.</span>")
 		return
-		
+
+	if(istype(W, /obj/item/card/id/guest))
+		to_chat(user, "<span class='warning'>Invalid identification card.</span>")
+		return
+
 	var/obj/item/card/id/I = W
 	if(!I || !I.registered_name)
 		return
@@ -69,7 +69,7 @@
 
 		if(!registered_name && locked)
 			registered_name = I.registered_name
-			desc = "Owned by [I.registered_name]." 
+			desc = "Owned by [I.registered_name]."
 
 	else
 		to_chat(user, "<span class='warning'>Access denied.</span>")

--- a/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
@@ -59,7 +59,7 @@
 	if(!I || !I.registered_name)
 		return
 
-	else if(allowed(user) || !registered_name || (istype(I) && (registered_name == I.registered_name)))
+	if(allowed(user) || !registered_name || (istype(I) && (registered_name == I.registered_name)))
 		//they can open all lockers, or nobody owns this, or they own this locker
 		locked = !locked
 		update_icon()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Personal lockers can be locked and unlocked again
Also fixes the closing sound playing twice when closing a closet.

Fixes: #27130
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Bug bad.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Swipe my ID card on a locker, it unlockes.
Swipe it again, it's now locked.
Make sure not to use a captain's ID since it apparently can unlock all personal lockers.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Personal lockers can be opened and closed again.
fix: You can no longer hear a closet close twice.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
