### PR TITLE
Fixes a thurible runtime

### DIFF
--- a/code/game/objects/items/weapons/thurible.dm
+++ b/code/game/objects/items/weapons/thurible.dm
@@ -164,11 +164,11 @@
 			var/mob/living/carbon/C = A
 			if(C.can_breathe_gas())
 				mobs_to_smoke += C
+	if(mobs_to_smoke)
+		var/percentage_to_add = released_reagents.reagents.total_volume / length(mobs_to_smoke) // Divide the amount of reagents spread around by the number of people inhaling it
 
-	var/percentage_to_add = released_reagents.reagents.total_volume / length(mobs_to_smoke) // Divide the amount of reagents spread around by the number of people inhaling it
-
-	for(var/mob/living/carbon/smoker as anything in mobs_to_smoke)
-		released_reagents.reagents.copy_to(smoker, percentage_to_add)
+		for(var/mob/living/carbon/smoker as anything in mobs_to_smoke)
+			released_reagents.reagents.copy_to(smoker, percentage_to_add)
 
 	if(reagents.total_volume <= 0)
 		put_out()

--- a/code/game/objects/items/weapons/thurible.dm
+++ b/code/game/objects/items/weapons/thurible.dm
@@ -164,7 +164,7 @@
 			var/mob/living/carbon/C = A
 			if(C.can_breathe_gas())
 				mobs_to_smoke += C
-	if(mobs_to_smoke)
+	if(length(mobs_to_smoke))
 		var/percentage_to_add = released_reagents.reagents.total_volume / length(mobs_to_smoke) // Divide the amount of reagents spread around by the number of people inhaling it
 
 		for(var/mob/living/carbon/smoker as anything in mobs_to_smoke)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Makes sure that a division by zero does not happen, since mobs_to_smoke length can be zero if you swing the thurible next to no one.
## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Fixes the following runtime.

![thurible](https://github.com/user-attachments/assets/4042b4f9-4c02-426e-a581-12d07f68930a)

## Testing

<!-- How did you test the PR, if at all? -->
* Ignited the thurible (full of holy water) and swung it next to a skrell for a while, then went to a place without any carbons nearby, no runtime noticed.
<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

NPFC

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
