### PR TITLE
Fixes borg cameras

### DIFF
--- a/code/datums/wires/robot_wires.dm
+++ b/code/datums/wires/robot_wires.dm
@@ -36,7 +36,7 @@
 
 		if(WIRE_BORG_CAMERA)
 			if(!isnull(R.camera) && !R.scrambledcodes)
-				R.camera.status = mend
+				R.camera.status = !mend //If we are mending, we set the status to false, and toggle cam. Otherwise, we set it to true, and cut. It's silly, I know
 				R.camera.toggle_cam(usr, 0) // Will kick anyone who is watching the Cyborg's camera.
 
 		if(WIRE_BORG_LOCKED)

--- a/code/modules/mob/living/silicon/robot/robot_death.dm
+++ b/code/modules/mob/living/silicon/robot/robot_death.dm
@@ -58,7 +58,7 @@
 	diag_hud_set_status()
 	diag_hud_set_health()
 	if(camera)
-		camera.status = FALSE
+		camera.turn_off(src, FALSE)
 	update_headlamp(1) //So borg lights are disabled when killed.
 
 	if(in_contents_of(/obj/machinery/recharge_station))//exit the recharge station

--- a/code/modules/mob/living/silicon/robot/robot_life.dm
+++ b/code/modules/mob/living/silicon/robot/robot_life.dm
@@ -45,11 +45,9 @@
 	handle_no_power()
 
 /mob/living/silicon/robot/proc/handle_equipment()
-	if(camera && !scrambledcodes)
+	if(camera && camera.status && !scrambledcodes) //Don't turn off cameras already off
 		if(stat == DEAD || wires.is_cut(WIRE_BORG_CAMERA))
-			camera.status = FALSE
-		else
-			camera.status = TRUE
+			camera.turn_off(src, FALSE)
 
 	//update the state of modules and components here
 	if(stat != CONSCIOUS)

--- a/code/modules/mob/living/silicon/robot/robot_mob.dm
+++ b/code/modules/mob/living/silicon/robot/robot_mob.dm
@@ -185,7 +185,7 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 		camera.c_tag = real_name
 		camera.network = list("SS13","Robots")
 		if(wires.is_cut(WIRE_BORG_CAMERA)) // 5 = BORG CAMERA
-			camera.status = FALSE
+			camera.turn_off(src, FALSE)
 
 	if(mmi == null)
 		mmi = new /obj/item/mmi/robotic_brain(src)	//Give the borg an MMI if he spawns without for some reason. (probably not the correct way to spawn a robotic brain, but it works)

--- a/code/modules/mob/living/silicon/robot/robot_update_status.dm
+++ b/code/modules/mob/living/silicon/robot/robot_update_status.dm
@@ -25,6 +25,9 @@
 	else
 		if(health > 0 && !suiciding && has_power_source())
 			update_revive()
+			if(camera)
+				if(!wires.is_cut(WIRE_BORG_CAMERA))
+					camera.turn_on(src, FALSE)
 			var/mob/dead/observer/ghost = get_ghost()
 			if(ghost)
 				to_chat(ghost, "<span class='ghostalert'>Your cyborg shell has been repaired and repowered, re-enter if you want to continue!</span> (Verbs -> Ghost -> Re-enter corpse)")


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes borg code to not try to toggle it's camera on every tick.
Borgs actually turn off their camera when they die, this was broken.
Borgs turn on their camera when they are revived, if the wire is not cut. This is re-added, replacing the life check.
Pulsing a borgs camera turns it off.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
This fixes many problems, but yes, a dead borg should have it's camera off, and it should be done properly, not by setting camera status to false, which creates other issues.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
killed borgs, revived borgs, pulsed wires, cut wires, mended wires.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Fixed borg cameras not turning off when they died.
fix: Fixed borg cameras not turning on or off half the time you try to toggle them.
fix: Pulsing a borg's camera turns it off properly now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
