### PR TITLE
Fixes a machine analyzer runtime

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -388,7 +388,7 @@ SLIME SCANNER
 	msgs += "<span class='notice'>Chassis Temperature: ???</span>"
 	to_chat(user, chat_box_healthscan(msgs.Join("<br>")))
 
-/obj/item/robotanalyzer/attack_obj(obj/O, mob/living/user) // Scanning a machine object
+/obj/item/robotanalyzer/attack_obj(obj/O, mob/living/user) // Scanning a machine, mech and other structures
 	if((HAS_TRAIT(user, TRAIT_CLUMSY) || user.getBrainLoss() >= 60) && prob(50))
 		handle_clumsy(user)
 		return

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -388,21 +388,23 @@ SLIME SCANNER
 	msgs += "<span class='notice'>Chassis Temperature: ???</span>"
 	to_chat(user, chat_box_healthscan(msgs.Join("<br>")))
 
-/obj/item/robotanalyzer/attack_obj(obj/machinery/M, mob/living/user) // Scanning a machine object
+/obj/item/robotanalyzer/attack_obj(obj/O, mob/living/user) // Scanning a machine object
 	if((HAS_TRAIT(user, TRAIT_CLUMSY) || user.getBrainLoss() >= 60) && prob(50))
 		handle_clumsy(user)
 		return
-	user.visible_message("<span class='notice'>[user] has analyzed [M]'s components with [src].</span>", "<span class='notice'>You analyze [M]'s components with [src].</span>")
-	machine_scan(user, M)
+	user.visible_message("<span class='notice'>[user] has analyzed [O]'s components with [src].</span>", "<span class='notice'>You analyze [O]'s components with [src].</span>")
+	machine_scan(user, O)
 	add_fingerprint(user)
 
-/obj/item/robotanalyzer/proc/machine_scan(mob/user, obj/machinery/M)
-	if(M.obj_integrity == M.max_integrity)
-		to_chat(user, "<span class='notice'>[M] is at full integrity.</span>")
+/obj/item/robotanalyzer/proc/machine_scan(mob/user, obj/O)
+	if(O.obj_integrity == O.max_integrity)
+		to_chat(user, "<span class='notice'>[O] is at full integrity.</span>")
 		return
-	to_chat(user, "<span class='notice'>Structural damage detected! [M]'s overall estimated integrity is [round((M.obj_integrity / M.max_integrity) * 100)]%.</span>")
-	if(ismachinery(M) && M.stat & BROKEN) // Displays alongside above message. Machines with a "broken" state do not become broken at 0% HP - anything that reaches that point is destroyed
-		to_chat(user, "<span class='warning'>Further analysis: Catastrophic component failure detected! [M] requires reconstruction to fully repair.</span>")
+	to_chat(user, "<span class='notice'>Structural damage detected! [O]'s overall estimated integrity is [round((O.obj_integrity / O.max_integrity) * 100)]%.</span>")
+	if(ismachinery(O))
+		var/obj/machinery/M = O
+		if(M.stat & BROKEN) // Displays alongside above message. Machines with a "broken" state do not become broken at 0% HP - anything that reaches that point is destroyed
+			to_chat(user, "<span class='warning'>Further analysis: Catastrophic component failure detected! [M] requires reconstruction to fully repair.</span>")
 
 /obj/item/robotanalyzer/attack(mob/living/M, mob/living/user) // Scanning borgs, IPCs/augmented crew, and AIs
 	if((HAS_TRAIT(user, TRAIT_CLUMSY) || user.getBrainLoss() >= 60) && prob(50))

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -401,7 +401,7 @@ SLIME SCANNER
 		to_chat(user, "<span class='notice'>[M] is at full integrity.</span>")
 		return
 	to_chat(user, "<span class='notice'>Structural damage detected! [M]'s overall estimated integrity is [round((M.obj_integrity / M.max_integrity) * 100)]%.</span>")
-	if(M.stat & BROKEN) // Displays alongside above message. Machines with a "broken" state do not become broken at 0% HP - anything that reaches that point is destroyed
+	if(ismachinery(M) && M.stat & BROKEN) // Displays alongside above message. Machines with a "broken" state do not become broken at 0% HP - anything that reaches that point is destroyed
 		to_chat(user, "<span class='warning'>Further analysis: Catastrophic component failure detected! [M] requires reconstruction to fully repair.</span>")
 
 /obj/item/robotanalyzer/attack(mob/living/M, mob/living/user) // Scanning borgs, IPCs/augmented crew, and AIs

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -388,23 +388,23 @@ SLIME SCANNER
 	msgs += "<span class='notice'>Chassis Temperature: ???</span>"
 	to_chat(user, chat_box_healthscan(msgs.Join("<br>")))
 
-/obj/item/robotanalyzer/attack_obj(obj/O, mob/living/user) // Scanning a machine, mech and other structures
+/obj/item/robotanalyzer/attack_obj(obj/machinery/M, mob/living/user) // Scanning a machine object
+	if(!ismachinery(M))
+		return
 	if((HAS_TRAIT(user, TRAIT_CLUMSY) || user.getBrainLoss() >= 60) && prob(50))
 		handle_clumsy(user)
 		return
-	user.visible_message("<span class='notice'>[user] has analyzed [O]'s components with [src].</span>", "<span class='notice'>You analyze [O]'s components with [src].</span>")
-	machine_scan(user, O)
+	user.visible_message("<span class='notice'>[user] has analyzed [M]'s components with [src].</span>", "<span class='notice'>You analyze [M]'s components with [src].</span>")
+	machine_scan(user, M)
 	add_fingerprint(user)
 
-/obj/item/robotanalyzer/proc/machine_scan(mob/user, obj/O)
-	if(O.obj_integrity == O.max_integrity)
-		to_chat(user, "<span class='notice'>[O] is at full integrity.</span>")
+/obj/item/robotanalyzer/proc/machine_scan(mob/user, obj/machinery/M)
+	if(M.obj_integrity == M.max_integrity)
+		to_chat(user, "<span class='notice'>[M] is at full integrity.</span>")
 		return
-	to_chat(user, "<span class='notice'>Structural damage detected! [O]'s overall estimated integrity is [round((O.obj_integrity / O.max_integrity) * 100)]%.</span>")
-	if(ismachinery(O))
-		var/obj/machinery/M = O
-		if(M.stat & BROKEN) // Displays alongside above message. Machines with a "broken" state do not become broken at 0% HP - anything that reaches that point is destroyed
-			to_chat(user, "<span class='warning'>Further analysis: Catastrophic component failure detected! [M] requires reconstruction to fully repair.</span>")
+	to_chat(user, "<span class='notice'>Structural damage detected! [M]'s overall estimated integrity is [round((M.obj_integrity / M.max_integrity) * 100)]%.</span>")
+	if(M.stat & BROKEN) // Displays alongside above message. Machines with a "broken" state do not become broken at 0% HP - anything that reaches that point is destroyed
+		to_chat(user, "<span class='warning'>Further analysis: Catastrophic component failure detected! [M] requires reconstruction to fully repair.</span>")
 
 /obj/item/robotanalyzer/attack(mob/living/M, mob/living/user) // Scanning borgs, IPCs/augmented crew, and AIs
 	if((HAS_TRAIT(user, TRAIT_CLUMSY) || user.getBrainLoss() >= 60) && prob(50))


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Fixes a machine analyzer runtime that happens when you use it on a mech/structure that has less than 100% obj_integrity.
You can no longer use the machine analyzer on mechs/structures as it was unintended.
## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Fixes the following runtime:

![ruuun](https://github.com/user-attachments/assets/21b47bf4-9f28-48e0-ad72-0f42cfa30046)

## Testing

<!-- How did you test the PR, if at all? -->
- Tried to use the machine analyzer on mechs and structures, couldnt.
<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: You can no longer use the machine analyzer on structures/mechs, as it was unintended
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
