### PR TITLE
Easier craft for Colorful reagent

### DIFF
--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -172,8 +172,8 @@
 	name = "colorful_reagent"
 	id = "colorful_reagent"
 	result = "colorful_reagent"
-	required_reagents = list("plasma" = 1, "radium" = 1, "space_drugs" = 1, "cryoxadone" = 1, "triple_citrus" = 1, "stabilizing_agent" = 1)
-	result_amount = 6
+	required_reagents = list("plasma" = 1, "radium" = 1, "space_drugs" = 1, "triple_citrus" = 1)
+	result_amount = 4
 	mix_message = "The substance flashes multiple colors and emits the smell of a pocket protector."
 
 /datum/chemical_reaction/corgium


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Facilitates the creation of a color reagent by removing the requirement for cryoxadone and stabilizing agent

## Why It's Good For The Game

The complexity of creating this reagent compared to what it does and what it is for is excessive. It's literally paint, not some hyper-important combat drug or medicine. I find the presence of cryoxadone in it unnecessary, and the stabilizing agent in it is not justified, for the agent is meant (in my opinion) to stabilize explosion reactions, not to be part of any prescription. Now to create paint, you literally have to rob a bar and make a couple clicks to enjoy the confetti, not go to the wiki because you don't remember the recipe for cryoxadone.

## Images of changes

![image](https://github.com/user-attachments/assets/9035037e-22b1-4202-99f6-4d0759cc59d7)

## Testing

log in, do few clicks, make a colorful reagent with ease, go to lavaland and see how a pink necropolis legion eat me alive

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
tweak: Colorful reagent now do not require Cryoxadone and Stabilising agent for crafting.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
