### PR TITLE
blackbox: mark biohazard events affected by admin spawns

### DIFF
--- a/code/controllers/subsystem/SSticker.dm
+++ b/code/controllers/subsystem/SSticker.dm
@@ -69,6 +69,7 @@ SUBSYSTEM_DEF(ticker)
 	var/list/flagged_antag_rollers = list()
 	/// List of biohazards keyed to the last time their population was sampled.
 	var/list/biohazard_pop_times = list()
+	var/list/biohazard_included_admin_spawns = list()
 
 /datum/controller/subsystem/ticker/Initialize()
 	login_music = pick(\
@@ -828,6 +829,9 @@ SUBSYSTEM_DEF(ticker)
 		else
 			SSblackbox.record_feedback("nested tally", "biohazards", 1, list("defeated", biohazard))
 
+	for(var/biohazard in SSticker.biohazard_included_admin_spawns)
+		SSblackbox.record_feedback("nested tally", "biohazards", 1, list("included_admin_spawns", biohazard))
+
 /datum/controller/subsystem/ticker/proc/count_xenomorps()
 	. = 0
 	for(var/datum/mind/xeno_mind in SSticker.mode.xenos)
@@ -837,12 +841,33 @@ SUBSYSTEM_DEF(ticker)
 
 /datum/controller/subsystem/ticker/proc/sample_biohazard_population(biohazard)
 	SSblackbox.record_feedback("ledger", "biohazard_pop_[BIOHAZARD_POP_INTERVAL_STR]_interval", biohazard_count(biohazard), biohazard)
+	if(any_admin_spawned_mobs(biohazard) && !(biohazard in biohazard_included_admin_spawns))
+		biohazard_included_admin_spawns[biohazard] = TRUE
+
 	biohazard_pop_times[biohazard] = world.time
 
 /// Record the initial time that a biohazard spawned.
 /datum/controller/subsystem/ticker/proc/record_biohazard_start(biohazard)
 	SSblackbox.record_feedback("associative", "biohazard_starts", 1, list("type" = biohazard, "time_ds" = world.time - time_game_started))
 	sample_biohazard_population(biohazard)
+
+/// Returns whether the given biohazard includes mobs that were admin spawned.
+/// Only returns TRUE or FALSE, does not attempt to track which mobs were
+/// admin-spawned and which ones weren't.
+/datum/controller/subsystem/ticker/proc/any_admin_spawned_mobs(biohazard)
+	switch(biohazard)
+		if(TS_INFESTATION_GREEN_SPIDER, TS_INFESTATION_WHITE_SPIDER, TS_INFESTATION_PRINCESS_SPIDER, TS_INFESTATION_QUEEN_SPIDER, TS_INFESTATION_PRINCE_SPIDER)
+			for(var/mob/living/simple_animal/hostile/poison/terror_spider/S in GLOB.ts_spiderlist)
+				if(S.admin_spawned)
+					return TRUE
+		if(BIOHAZARD_XENO)
+			for(var/datum/mind/xeno_mind in SSticker.mode.xenos)
+				if(xeno_mind.current?.admin_spawned)
+					return TRUE
+		if(BIOHAZARD_BLOB)
+			for(var/atom/blob_overmind in SSticker.mode.blob_overminds)
+				if(blob_overmind.admin_spawned)
+					return TRUE
 
 /datum/controller/subsystem/ticker/proc/biohazard_count(biohazard)
 	switch(biohazard)

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -205,17 +205,21 @@
 		return FALSE
 	var/datum/mind/blobmind = mind
 	var/client/C = client
+	var/obj/structure/blob/core/core
 	if(istype(blobmind) && istype(C))
-		var/obj/structure/blob/core/core = new(T, C, 3)
+		core = new(T, C, 3)
 		core.lateblobtimer()
 		qdel(blobmind) // Delete the old mind. THe blob will make a new one
 	else
-		new /obj/structure/blob/core(T) // Ghosts will be prompted to control it.
+		core = new(T) // Ghosts will be prompted to control it.
 	if(ismob(loc)) // in case some taj/etc ate the mouse.
 		var/mob/M = loc
 		M.gib()
 	if(!gibbed)
 		gib()
+
+	if(core)
+		core.admin_spawned = admin_spawned
 
 	SSticker.record_biohazard_start(BIOHAZARD_BLOB)
 


### PR DESCRIPTION
## What Does This PR Do
This PR marks biohazard events which include admin-spawned mobs in the "biohazards" feedback key. It checks the mobs that are sampled for population: blob cores, terrors, and xenos, and adds a single key if any of them were admin-spawned. It also copies over the "admin_spawned" flag from infected mice to their blob cores on the off-chance admins do that, but it would have to be during an existing biohazard to have any effect.

Note for admins: This is not meant to "bust" or call out admins which add spawns to a biohazard event. It is purely so that when analyzing the biohazard data, we know which events shouldn't be considered part of their balance as designed directly from the event spawns.
## Why It's Good For The Game
It's important for statistical analysis as above.
## Images of changes
![2024_10_24__14_25_50__Unnamed_paradise_gamedb_feedback_ - HeidiSQL 11 0 0 5919](https://github.com/user-attachments/assets/d9b36ad6-e6b5-4e78-b618-6426d1770c93)
## Testing
Trigged terror event which spawned a green terror, admin-spawned a red terror, ended round, ensured that biohazard feedback had the proper key.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog
NPFC