### PR TITLE
Deltastation Arrivals Remap

### DIFF
--- a/_maps/map_files/stations/deltastation.dmm
+++ b/_maps/map_files/stations/deltastation.dmm
@@ -216,8 +216,9 @@
 	},
 /area/station/security/execution)
 "adb" = (
+/obj/structure/lattice,
 /turf/simulated/wall,
-/area/station/hallway/secondary/entry/west)
+/area/station/hallway/secondary/entry/north)
 "add" = (
 /turf/simulated/wall/mineral/titanium,
 /area/shuttle/pod_1)
@@ -248,49 +249,63 @@
 	},
 /area/station/hallway/primary/central)
 "adt" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/west)
+/obj/effect/spawner/airlock/s_to_n,
+/turf/simulated/wall,
+/area/station/hallway/secondary/entry/south)
 "adu" = (
-/obj/machinery/atmospherics/portable/canister/air,
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 8
-	},
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/west)
-"adx" = (
-/obj/machinery/status_display{
-	pixel_x = 32
-	},
-/obj/machinery/light{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/chair/comfy/shuttle{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/ai_status_display{
+	pixel_y = 32
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/secondary/entry/south)
+"adx" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/pod_1)
+/obj/item/radio/intercom{
+	name = "south bump";
+	pixel_y = -28
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "arrival"
+	},
+/area/station/hallway/secondary/entry/north)
 "adL" = (
-/obj/structure/shuttle/engine/propulsion/burst,
-/turf/simulated/wall/mineral/titanium,
-/area/shuttle/pod_1)
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "arrival"
+	},
+/area/station/hallway/secondary/entry/east)
 "adN" = (
-/turf/simulated/wall/r_wall,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
 /area/station/hallway/secondary/entry/north)
 "adO" = (
-/obj/item/radio/intercom{
-	name = "east bump";
-	pixel_x = 28
-	},
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
-	},
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/pod_1)
+/obj/structure/marker_beacon/dock_marker,
+/turf/simulated/floor/plating,
+/area/space/nearstation)
 "adU" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -308,60 +323,51 @@
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/virology)
 "adZ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/machinery/firealarm/directional/north,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "arrival"
 	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/west)
+/area/station/hallway/secondary/entry/south)
 "aea" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/entry/lounge)
 "aeb" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/west)
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry/north)
 "aec" = (
-/obj/item/kirbyplants,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
+/obj/effect/turf_decal/delivery/hollow,
+/obj/structure/closet/crate,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light,
+/turf/simulated/floor/plasteel{
+	icon_state = "brown"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/east)
 "aed" = (
-/obj/docking_port/mobile/pod{
-	id = "pod1";
-	name = "escape pod 1"
-	},
-/obj/machinery/door/airlock/titanium{
-	id_tag = "s_docking_airlock";
-	name = "Escape Pod Hatch"
-	},
-/obj/structure/fans/tiny,
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/pod_1)
+/obj/structure/table,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry/east)
 "aee" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 1
-	},
-/turf/simulated/floor/plating/airless,
-/area/shuttle/arrival/station)
-"aef" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "admin_home";
-	locked = 1
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/window/basic{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/west)
+/obj/structure/window/basic,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/sunnybush,
+/obj/structure/flora/ausbushes/reedbush,
+/obj/structure/flora/ausbushes/grassybush,
+/turf/simulated/floor/grass/no_creep,
+/area/station/hallway/secondary/entry/north)
+"aef" = (
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "brown"
+	},
+/area/station/hallway/secondary/entry/east)
 "aek" = (
 /obj/structure/table,
 /obj/machinery/kitchen_machine/microwave,
@@ -375,29 +381,32 @@
 /turf/space,
 /area/space/nearstation)
 "aey" = (
-/obj/machinery/light/small{
-	dir = 8
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "arrival"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry/north)
 "aez" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry/north)
-"aeA" = (
-/obj/machinery/light/small{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
 	},
-/turf/simulated/floor/plating,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
 /area/station/hallway/secondary/entry/north)
+"aeA" = (
+/obj/effect/landmark/damageturf,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/station/hallway/secondary/entry/east)
 "aeC" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -410,13 +419,17 @@
 /turf/simulated/floor/wood,
 /area/station/medical/psych)
 "aeI" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/window/basic{
+	dir = 1
+	},
+/obj/structure/window/basic{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/west)
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/pointybush,
+/turf/simulated/floor/grass/no_creep,
+/area/station/hallway/secondary/entry/north)
 "aeJ" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/delivery,
@@ -438,25 +451,44 @@
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry/east)
 "aeN" = (
-/turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry/west)
-"aeO" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/item/radio/intercom{
-	name = "east bump";
-	pixel_x = 28
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/west)
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/secondary/entry/south)
+"aeO" = (
+/obj/effect/turf_decal/delivery/hollow,
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 4
+	},
+/obj/machinery/atmospherics/portable/canister/air,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/secondary/entry/south)
 "aeP" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/external,
-/obj/effect/turf_decal/stripes/line,
-/turf/simulated/floor/plasteel,
+/obj/structure/sign/vacuum/external{
+	pixel_y = 32
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "arrival"
+	},
 /area/station/hallway/secondary/entry/north)
 "aeQ" = (
 /obj/docking_port/mobile/pod{
@@ -490,18 +522,21 @@
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/pod_4)
 "afb" = (
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/north)
-"afc" = (
-/obj/structure/sign/pods{
-	pixel_x = -32
+/obj/machinery/door/airlock/external,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 9
+	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry/north)
+"afc" = (
+/obj/machinery/alarm/directional/south,
+/turf/simulated/floor/plasteel{
+	icon_state = "arrival"
+	},
+/area/station/hallway/secondary/entry/south)
 "afd" = (
 /obj/machinery/status_display{
 	pixel_y = 32
@@ -528,21 +563,15 @@
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/solar_maintenance/fore_starboard)
 "afh" = (
-/obj/effect/turf_decal/stripes/line{
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry/east)
+"afj" = (
+/obj/structure/chair/sofa/bench/left{
 	dir = 1
 	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/west)
-"afj" = (
-/obj/item/kirbyplants,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
+/turf/simulated/floor/plasteel{
+	icon_state = "barber"
 	},
-/obj/item/radio/intercom{
-	name = "east bump";
-	pixel_x = 28
-	},
-/turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/north)
 "afk" = (
 /obj/item/kirbyplants,
@@ -641,14 +670,13 @@
 	},
 /area/station/hallway/secondary/entry/east)
 "afJ" = (
-/obj/machinery/status_display{
-	pixel_x = -32
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
 	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/west)
+/area/station/hallway/secondary/entry/south)
 "afL" = (
 /turf/simulated/floor/plasteel/white,
 /area/station/science/misc_lab)
@@ -693,62 +721,44 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/fore_starboard)
 "agd" = (
-/obj/machinery/light{
-	dir = 8
+/obj/structure/chair/sofa/bench,
+/obj/effect/landmark/start/assistant,
+/turf/simulated/floor/plasteel{
+	icon_state = "barber"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/alarm/directional/west,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/west)
-"age" = (
-/obj/structure/sign/vacuum{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/west)
-"agg" = (
-/obj/machinery/status_display{
-	pixel_x = -32
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/west)
-"agh" = (
-/obj/machinery/status_display{
-	pixel_x = 32
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Arrivals Center Fore";
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/north)
+"age" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "arrival"
+	},
+/area/station/hallway/secondary/entry/south)
+"agg" = (
+/obj/machinery/light,
+/turf/simulated/floor/plasteel{
+	icon_state = "arrival"
+	},
+/area/station/hallway/secondary/entry/north)
+"agh" = (
+/obj/docking_port/stationary{
+	dwidth = 2;
+	height = 11;
+	id = "specops_home";
+	name = "port bay 2";
+	width = 5
+	},
+/turf/space,
+/area/space)
 "agk" = (
-/obj/structure/window/reinforced,
-/obj/structure/shuttle/engine/heater{
-	dir = 1
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "arrival"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/simulated/floor/plating/airless,
-/area/shuttle/arrival/station)
+/area/station/hallway/secondary/entry/north)
 "ago" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/fueltank,
@@ -782,34 +792,34 @@
 	},
 /area/station/hallway/secondary/entry/east)
 "agA" = (
-/obj/structure/sign/vacuum{
-	pixel_x = -32
+/obj/structure/chair{
+	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/assistant,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "brown"
 	},
-/turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/east)
 "agB" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/structure/chair{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/effect/landmark/start/assistant,
+/turf/simulated/floor/plasteel{
+	icon_state = "barber"
 	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/west)
+/area/station/hallway/secondary/entry/south)
 "agC" = (
-/obj/structure/sign/vacuum{
-	pixel_x = 32
+/obj/item/radio/intercom{
+	name = "north bump";
+	pixel_y = 28
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "arrival"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/north)
 "agD" = (
 /turf/simulated/wall/mineral/titanium/nodiagonal,
@@ -828,42 +838,65 @@
 	},
 /area/station/hallway/secondary/entry/east)
 "agJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/machinery/ai_status_display{
+	pixel_y = 32
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "arrival"
+	},
+/area/station/hallway/secondary/entry/north)
+"agT" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/entry/north)
-"agT" = (
-/obj/item/clothing/suit/storage/hazardvest,
-/obj/item/clothing/suit/storage/hazardvest,
-/obj/item/tank/internals/emergency_oxygen/double,
-/obj/item/tank/internals/emergency_oxygen/double,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/head/hardhat/orange,
-/obj/item/clothing/head/hardhat/orange,
-/obj/structure/closet/crate/internals,
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/arrival/station)
 "agU" = (
-/obj/structure/closet/wardrobe/mixed,
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/arrival/station)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/secondary/entry/north)
 "agV" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/toolbox/emergency,
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/arrival/station)
+/obj/structure/sign/pods,
+/turf/simulated/wall,
+/area/station/maintenance/fore2)
 "agW" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/firstaid/regular,
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/arrival/station)
+/obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/secondary/entry/north)
 "agX" = (
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
@@ -886,12 +919,12 @@
 	},
 /area/station/medical/storage/secondary)
 "ahg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
+/obj/machinery/door/airlock/external,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/area/station/hallway/secondary/entry/west)
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry/north)
 "ahh" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -899,59 +932,39 @@
 	},
 /area/station/maintenance/fsmaint)
 "ahi" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
+/obj/machinery/economy/vending/cola,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
+	dir = 8;
+	icon_state = "arrival"
 	},
-/area/station/hallway/secondary/entry/east)
+/area/station/hallway/secondary/entry/north)
 "ahm" = (
 /obj/structure/table/glass,
 /obj/machinery/computer/med_data/laptop,
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/office/cmo)
 "ahz" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/sign/nanotrasen,
+/obj/effect/spawner/random_spawners/wall_rusted_always,
+/turf/simulated/wall,
+/area/station/hallway/secondary/entry/east)
+"ahA" = (
+/obj/structure/chair{
 	dir = 8
 	},
-/obj/machinery/door/airlock/external{
-	id_tag = "ferry_home";
-	locked = 1
+/obj/machinery/newscaster{
+	dir = 8;
+	name = "east bump";
+	pixel_x = 28
 	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/north)
-"ahA" = (
-/obj/machinery/door/airlock/external{
-	name = "Arrival Airlock"
+/obj/effect/landmark/start/assistant,
+/turf/simulated/floor/plasteel{
+	icon_state = "barber"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/north)
 "ahB" = (
-/obj/machinery/door/airlock/titanium{
-	id_tag = "s_docking_airlock"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/fans/tiny,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/mineral/titanium,
 /area/shuttle/arrival/station)
 "ahC" = (
 /turf/simulated/floor/mineral/titanium/blue,
@@ -972,56 +985,51 @@
 /turf/simulated/floor/engine,
 /area/station/engineering/controlroom)
 "ahE" = (
-/obj/machinery/door/airlock/titanium{
-	id_tag = "s_docking_airlock"
+/obj/machinery/camera/autoname{
+	dir = 10
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/turf/simulated/floor/plasteel{
+	icon_state = "arrival"
 	},
-/obj/structure/fans/tiny,
-/turf/simulated/floor/plasteel,
-/area/shuttle/arrival/station)
+/area/station/hallway/secondary/entry/north)
 "ahF" = (
-/obj/machinery/door/airlock/external{
-	name = "Arrival Airlock"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/east)
+/area/station/hallway/secondary/entry/north)
 "ahQ" = (
-/obj/machinery/airlock_controller/air_cycler{
-	pixel_y = -25;
-	vent_link_id = "enginen_vent";
-	ext_door_link_id = "enginen_door_ext";
-	int_door_link_id = "enginen_door_int";
-	ext_button_link_id = "enginen_btn_ext";
-	int_button_link_id = "enginen_btn_int"
+/obj/structure/chair/sofa/bench/right,
+/turf/simulated/floor/plasteel{
+	icon_state = "barber"
 	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4;
-	autolink_id = "enginen_vent"
-	},
-/turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry/west)
+/area/station/hallway/secondary/entry/south)
 "ahV" = (
-/obj/item/kirbyplants,
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/arrival/station)
+/obj/structure/window/basic,
+/obj/structure/window/basic{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/stalkybush,
+/obj/structure/flora/ausbushes/leafybush,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/simulated/floor/grass/no_creep,
+/area/station/hallway/secondary/entry/north)
 "ahW" = (
-/obj/machinery/light,
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/arrival/station)
-"aik" = (
-/obj/machinery/light{
+/obj/structure/chair/sofa/bench{
 	dir = 1
 	},
-/obj/structure/closet/emcloset,
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/west)
+/turf/simulated/floor/plasteel{
+	icon_state = "barber"
+	},
+/area/station/hallway/secondary/entry/north)
+"aik" = (
+/obj/effect/turf_decal/delivery/hollow,
+/obj/structure/closet/crate,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "brown"
+	},
+/area/station/hallway/secondary/entry/east)
 "ail" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -1030,33 +1038,18 @@
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/arrival/station)
 "aim" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 8
-	},
-/obj/effect/landmark/spawner/late/crew,
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/arrival/station)
-"aio" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/item/kirbyplants,
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/north)
-"aip" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/spawner/random/storage,
+/obj/item/storage/box/donkpockets,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/east)
-"ait" = (
-/obj/machinery/economy/atm/directional/south,
+"aio" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -1064,43 +1057,79 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/secondary/entry/south)
+"aip" = (
+/obj/machinery/ai_status_display{
+	pixel_y = 32
+	},
+/obj/machinery/newscaster{
+	dir = 4;
+	name = "west bump";
+	pixel_x = -28
+	},
+/obj/effect/turf_decal/delivery/hollow,
+/obj/structure/closet/emcloset,
+/turf/simulated/floor/plasteel{
+	dir = 9;
 	icon_state = "arrival"
+	},
+/area/station/hallway/secondary/entry/north)
+"ait" = (
+/obj/structure/chair/sofa/bench,
+/obj/effect/landmark/start/assistant,
+/turf/simulated/floor/plasteel{
+	icon_state = "barber"
 	},
 /area/station/hallway/secondary/entry/south)
 "aiE" = (
-/obj/structure/closet/emcloset,
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/west)
-"aiF" = (
-/obj/structure/chair{
-	dir = 8
+/obj/machinery/door/airlock/titanium{
+	id_tag = "s_docking_airlock"
 	},
-/obj/effect/landmark/start/assistant,
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/west)
-"aiG" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/stalkybush,
-/obj/structure/window/full/shuttle,
-/turf/simulated/floor/grass/no_creep,
+/turf/simulated/floor/mineral/titanium,
 /area/shuttle/arrival/station)
-"aiH" = (
+"aiF" = (
 /obj/structure/chair{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/north)
-"aiI" = (
-/obj/structure/chair{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "brown"
 	},
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/west)
+/area/station/hallway/secondary/entry/east)
+"aiG" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/machinery/newscaster{
+	dir = 4;
+	name = "west bump";
+	pixel_x = -28
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "barber"
+	},
+/area/station/hallway/secondary/entry/south)
+"aiH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/secondary/entry/south)
+"aiI" = (
+/obj/machinery/ai_status_display{
+	pixel_y = 32
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "arrival"
+	},
+/area/station/hallway/secondary/entry/south)
 "aiL" = (
 /obj/structure/chair{
 	dir = 4
@@ -1112,23 +1141,18 @@
 /turf/simulated/floor/carpet/black,
 /area/station/service/chapel)
 "aiX" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/landmark/start/assistant,
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/north)
+/obj/structure/closet/wardrobe/mixed,
+/obj/effect/turf_decal/delivery/hollow,
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/arrival/station)
 "ajd" = (
-/obj/item/beacon,
-/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/east)
 "ajf" = (
-/obj/structure/closet/firecloset,
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/west)
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry/south)
 "ajq" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -1143,22 +1167,22 @@
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
 "ajy" = (
-/obj/item/kirbyplants,
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/north)
+/obj/effect/turf_decal/delivery/hollow,
+/obj/structure/rack,
+/obj/item/storage/secure/briefcase,
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/arrival/station)
 "ajD" = (
-/obj/structure/table/reinforced,
-/obj/item/clipboard,
-/obj/item/toy/figure/crew/assistant,
+/obj/structure/computerframe{
+	dir = 8
+	},
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/arrival/station)
 "ajF" = (
-/obj/structure/table/reinforced,
-/obj/item/folder,
-/obj/item/storage/bag/dice,
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/arrival/station)
+/obj/structure/table,
+/obj/effect/spawner/random/food_trash,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry/east)
 "ajI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -1206,16 +1230,21 @@
 	},
 /area/station/maintenance/fore2)
 "ajX" = (
-/obj/docking_port/stationary{
-	dir = 8;
-	dwidth = 2;
-	height = 11;
-	id = "specops_home";
-	name = "port bay 2";
-	width = 5
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
-/turf/space,
-/area/space)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/secondary/entry/east)
 "ajY" = (
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -1225,33 +1254,33 @@
 	},
 /area/station/maintenance/fore2)
 "ajZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/chair{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
+	icon_state = "barber"
 	},
 /area/station/hallway/secondary/entry/north)
 "aka" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/arrival/station)
+/obj/structure/chair/stool,
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry/east)
 "akb" = (
-/obj/machinery/status_display{
-	pixel_x = 32
+/obj/machinery/alarm/directional/east,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "arrival"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/east)
 "akw" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen,
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/machinery/status_display{
+	pixel_y = -32
+	},
 /turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/arrival/station)
+/area/shuttle/pod_1)
 "akx" = (
 /obj/structure/closet/wardrobe/black,
 /turf/simulated/floor/mineral/titanium/blue,
@@ -1265,20 +1294,16 @@
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/arrival/station)
 "akA" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/secure/briefcase,
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/arrival/station)
+/obj/effect/spawner/random_spawners/wall_rusted_always,
+/turf/simulated/wall,
+/area/station/hallway/secondary/entry/east)
 "akB" = (
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/fore2)
 "akG" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "arrival"
-	},
-/area/station/hallway/secondary/entry/south)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry/east)
 "akQ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mining/glass{
@@ -1288,130 +1313,111 @@
 /turf/simulated/floor/plating,
 /area/station/supply/break_room)
 "akY" = (
-/obj/machinery/status_display,
-/turf/simulated/wall/mineral/titanium,
-/area/shuttle/arrival/station)
-"akZ" = (
-/obj/machinery/door/airlock/titanium{
-	id_tag = "s_docking_airlock"
+/obj/effect/turf_decal/delivery/hollow,
+/obj/structure/closet/firecloset,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "brown"
 	},
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/arrival/station)
-"ala" = (
-/obj/machinery/ai_status_display,
-/turf/simulated/wall/mineral/titanium,
-/area/shuttle/arrival/station)
-"alk" = (
-/obj/effect/spawner/random_spawners/wall_rusted_maybe,
+/area/station/hallway/secondary/entry/east)
+"akZ" = (
+/obj/structure/sign/pods,
 /turf/simulated/wall,
-/area/station/maintenance/fore2)
-"alm" = (
+/area/station/hallway/secondary/entry/east)
+"ala" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /turf/simulated/floor/plasteel{
-	icon_state = "arrival"
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/secondary/entry/south)
+"alk" = (
+/obj/effect/spawner/random_spawners/wall_rusted_maybe,
+/turf/simulated/wall,
+/area/station/maintenance/fore2)
+"alm" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/entry/south)
 "als" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/camera/autoname{
+	dir = 10
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "arrival"
 	},
-/area/station/hallway/secondary/entry/south)
+/area/station/hallway/secondary/entry/east)
 "alt" = (
-/obj/structure/sign/vacuum{
-	pixel_x = 32
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/north)
-"alv" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/turf/simulated/floor/mineral/titanium/blue,
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry/east)
+"alv" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/shuttle/engine/heater{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
 /area/shuttle/arrival/station)
 "alw" = (
-/obj/structure/chair/comfy/shuttle,
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/arrival/station)
-"alx" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/area/station/hallway/secondary/entry/north)
+"alx" = (
+/obj/machinery/status_display{
+	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "arrival"
 	},
 /area/station/hallway/secondary/entry/south)
 "aly" = (
-/obj/machinery/status_display{
-	pixel_x = 32
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Arrivals Center Aft";
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/machinery/light,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
 	},
-/turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/north)
 "alG" = (
-/obj/machinery/status_display{
-	pixel_x = -32
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Arrivals Aft Starboard";
-	dir = 4;
-	pixel_y = -22
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
 /area/station/hallway/secondary/entry/east)
 "alH" = (
-/obj/structure/computerframe,
-/turf/simulated/floor/mineral/titanium/blue,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/structure/closet/crate/internals,
+/turf/simulated/floor/mineral/titanium,
 /area/shuttle/arrival/station)
 "alJ" = (
 /obj/structure/closet/emcloset,
@@ -1561,27 +1567,35 @@
 	},
 /area/station/medical/morgue)
 "amz" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
 	},
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/machinery/power/apc/important/directional/west,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "arrival"
+	},
 /area/station/hallway/secondary/entry/east)
 "amA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/west)
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/simulated/floor/plasteel{
+	icon_state = "arrival"
+	},
+/area/station/hallway/secondary/entry/north)
 "amB" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
 /obj/machinery/firealarm/directional/east,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "arrival"
+	},
 /area/station/hallway/secondary/entry/east)
 "amC" = (
 /obj/machinery/light/small,
@@ -1637,21 +1651,15 @@
 	},
 /area/station/maintenance/fore2)
 "amL" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/south)
-"amM" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/turf_decal/delivery,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
 	},
-/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry/east)
+"amM" = (
+/obj/structure/chair/sofa/bench,
+/turf/simulated/floor/plasteel{
+	icon_state = "barber"
+	},
 /area/station/hallway/secondary/entry/south)
 "amN" = (
 /obj/structure/sign/pods,
@@ -1735,10 +1743,17 @@
 	},
 /area/station/maintenance/fore2)
 "ani" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/firealarm/directional/west,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/sign/vacuum/external{
+	pixel_y = 32
+	},
 /turf/simulated/floor/plasteel{
-	dir = 9;
+	dir = 1;
 	icon_state = "arrival"
 	},
 /area/station/hallway/secondary/entry/south)
@@ -1748,10 +1763,29 @@
 	},
 /area/station/hallway/primary/aft/south)
 "anl" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "arrival"
+	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/entry/south)
 "ann" = (
@@ -1764,17 +1798,22 @@
 	},
 /area/station/hallway/secondary/entry/south)
 "anp" = (
-/obj/machinery/camera{
-	c_tag = "Arrivals Hall Center"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/power/apc/important/directional/north,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "arrival"
+	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/entry/south)
 "anr" = (
@@ -1788,18 +1827,9 @@
 /turf/simulated/floor/plating,
 /area/station/supply/qm)
 "ans" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/item/radio/intercom{
-	name = "north bump";
-	pixel_y = 28
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "arrival"
-	},
-/area/station/hallway/secondary/entry/south)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/catwalk,
+/area/station/hallway/secondary/entry/east)
 "ant" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -1807,23 +1837,15 @@
 	},
 /area/station/hallway/secondary/entry/south)
 "anu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/south)
+/obj/structure/marker_beacon/dock_marker/collision,
+/turf/simulated/floor/plating,
+/area/space/nearstation)
 "anv" = (
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "arrival"
 	},
-/area/station/hallway/secondary/entry/south)
+/area/station/hallway/secondary/entry/east)
 "any" = (
 /turf/simulated/wall/r_wall,
 /area/station/science/explab/chamber)
@@ -1834,7 +1856,7 @@
 	},
 /obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/south)
+/area/station/hallway/secondary/entry/east)
 "anA" = (
 /obj/structure/table/reinforced,
 /obj/item/food/meat/slab{
@@ -1874,128 +1896,54 @@
 /turf/simulated/floor/plasteel/white,
 /area/station/science/rnd)
 "anJ" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	icon_state = "arrival"
+	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/entry/south)
 "anK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/window/basic{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/item/radio/intercom{
-	name = "south bump";
-	pixel_y = -28
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "arrival"
-	},
+/obj/structure/window/basic,
+/obj/structure/flora/ausbushes/stalkybush,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/pointybush,
+/turf/simulated/floor/grass/no_creep,
 /area/station/hallway/secondary/entry/south)
 "anL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "arrival"
 	},
 /area/station/hallway/secondary/entry/south)
 "anO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "arrival"
+	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/entry/south)
 "anP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/firealarm/directional/south,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "arrival"
 	},
 /area/station/hallway/secondary/entry/south)
 "anQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel/white/corner{
-	dir = 8
-	},
+/turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/south)
 "anR" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/secondary/entry/south)
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry/east)
 "anT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2013,63 +1961,25 @@
 	},
 /area/station/hallway/secondary/entry/south)
 "anU" = (
-/obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/landmark/lightsout,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/secondary/entry/south)
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry/north)
 "anW" = (
-/obj/machinery/camera{
-	c_tag = "Arrivals Hall Starboard";
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "arrival"
 	},
-/area/station/hallway/secondary/entry/south)
+/area/station/hallway/secondary/entry/east)
 "anX" = (
 /obj/structure/extinguisher_cabinet{
 	name = "south bump";
 	pixel_y = -30
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "arrival"
 	},
-/area/station/hallway/secondary/entry/south)
+/area/station/hallway/secondary/entry/east)
 "anY" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "arrival"
@@ -2080,7 +1990,7 @@
 	dir = 6;
 	icon_state = "arrival"
 	},
-/area/station/hallway/secondary/entry/south)
+/area/station/hallway/secondary/entry/east)
 "aoa" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/condiment/saltshaker,
@@ -2120,7 +2030,7 @@
 	},
 /obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/south)
+/area/station/hallway/secondary/entry/east)
 "aof" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/white/side,
@@ -2203,8 +2113,7 @@
 "aoA" = (
 /obj/item/kirbyplants,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "arrival"
 	},
 /area/station/hallway/secondary/entry/south)
 "aoB" = (
@@ -2392,13 +2301,14 @@
 /turf/simulated/floor/plasteel/white,
 /area/station/maintenance/fore2)
 "api" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "bluecorner"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/area/station/hallway/secondary/entry/south)
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/secondary/entry/north)
 "apj" = (
 /obj/machinery/ai_status_display,
 /turf/simulated/wall,
@@ -2508,12 +2418,11 @@
 	},
 /area/station/hallway/secondary/entry/lounge)
 "apv" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel{
-	icon_state = "redcorner"
+/obj/structure/shuttle/engine/propulsion{
+	dir = 8
 	},
-/area/station/hallway/secondary/entry/south)
+/turf/simulated/floor/plating,
+/area/shuttle/arrival/station)
 "apw" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -8510,16 +8419,11 @@
 /turf/simulated/wall,
 /area/station/service/bar)
 "aFB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/secondary/entry/east)
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry/north)
 "aFC" = (
 /obj/structure/extinguisher_cabinet{
 	name = "east bump";
@@ -20447,16 +20351,24 @@
 /turf/simulated/floor/plasteel,
 /area/station/service/hydroponics)
 "blc" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
 /area/station/hallway/secondary/entry/north)
 "bld" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/machinery/status_display{
+	pixel_x = 32
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "arrival"
+	},
 /area/station/hallway/secondary/entry/east)
 "ble" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -49820,13 +49732,19 @@
 /turf/simulated/floor/mineral/tranquillite,
 /area/station/service/mime)
 "cMP" = (
-/obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/camera/autoname{
+	dir = 10
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/station/hallway/secondary/entry/west)
+/area/station/hallway/secondary/entry/north)
 "cMR" = (
 /obj/structure/chair{
 	dir = 4
@@ -57570,6 +57488,12 @@
 	icon_state = "whiteyellow"
 	},
 /area/station/medical/chemistry)
+"dqC" = (
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "arrival"
+	},
+/area/station/hallway/secondary/entry/north)
 "dqL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -61277,6 +61201,16 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
+"dKW" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/status_display{
+	pixel_y = 32
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "arrival"
+	},
+/area/station/hallway/secondary/entry/north)
 "dKX" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -61400,6 +61334,19 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central/south)
+"dMg" = (
+/obj/effect/turf_decal/delivery/hollow,
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 1
+	},
+/obj/machinery/atmospherics/portable/canister/air,
+/obj/structure/sign/vacuum/external{
+	pixel_x = -32
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/secondary/entry/north)
 "dMh" = (
 /obj/effect/landmark/start/chaplain,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -63772,10 +63719,12 @@
 	},
 /area/station/hallway/primary/aft/south)
 "dWL" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/effect/spawner/random/storage,
+/obj/item/storage/box/survival,
+/obj/item/flashlight/flare/glowstick/emergency,
+/turf/simulated/floor/plasteel{
+	icon_state = "barber"
 	},
-/turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/north)
 "dWP" = (
 /turf/simulated/floor/plasteel/white,
@@ -64688,6 +64637,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/supply/qm)
+"eiT" = (
+/obj/machinery/firealarm/directional/south,
+/turf/simulated/floor/plasteel{
+	icon_state = "arrival"
+	},
+/area/station/hallway/secondary/entry/south)
 "ejr" = (
 /obj/machinery/newscaster/security_unit{
 	dir = 4;
@@ -65427,14 +65382,11 @@
 /turf/simulated/floor/engine,
 /area/station/science/explab/chamber)
 "ezV" = (
-/obj/machinery/camera{
-	c_tag = "Arrivals Hall Port"
+/obj/machinery/door/airlock/titanium{
+	id_tag = "s_docking_airlock"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "arrival"
-	},
-/area/station/hallway/secondary/entry/south)
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/pod_1)
 "eAi" = (
 /obj/structure/railing/corner,
 /turf/simulated/floor/plasteel{
@@ -65478,19 +65430,18 @@
 /obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
+"eBn" = (
+/obj/structure/table,
+/obj/item/reagent_containers/drinks/coffee,
+/turf/simulated/floor/plasteel{
+	icon_state = "brown"
+	},
+/area/station/hallway/secondary/entry/east)
 "eCj" = (
-/obj/machinery/status_display{
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Arrivals Port Fore";
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/west)
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/airlock/maintenance,
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry/east)
 "eCn" = (
 /obj/structure/closet/secure_closet/medical3,
 /obj/effect/turf_decal/delivery/white/hollow,
@@ -65754,14 +65705,11 @@
 	},
 /area/station/public/fitness)
 "eKO" = (
-/obj/machinery/door/airlock/external{
-	name = "Arrival Airlock"
+/obj/structure/chair{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry/west)
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry/east)
 "eKP" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/disposalpipe/segment{
@@ -66310,14 +66258,13 @@
 /turf/simulated/floor/engine/o2,
 /area/station/engineering/atmos)
 "eYW" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
+/obj/machinery/door/airlock/external,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/area/station/hallway/secondary/entry/west)
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry/north)
 "eZE" = (
 /obj/machinery/door/airlock,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -66526,13 +66473,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/aft_starboard)
 "ffG" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+/obj/machinery/alarm/directional/north,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "arrival"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/north)
 "ffJ" = (
 /obj/structure/cable{
@@ -66659,9 +66604,10 @@
 	},
 /area/station/maintenance/port)
 "fiu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/table,
+/obj/machinery/light,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
+	icon_state = "brown"
 	},
 /area/station/hallway/secondary/entry/east)
 "fiV" = (
@@ -66946,17 +66892,10 @@
 	},
 /area/station/security/main)
 "fqF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/light,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/newscaster{
+	dir = 1;
+	name = "south bump";
+	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "arrival"
@@ -67276,16 +67215,12 @@
 	},
 /area/station/medical/virology)
 "fCA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
+	name = "KEEP CLEAR: DOCKING AREA"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/secondary/entry/west)
+/turf/simulated/wall,
+/area/station/hallway/secondary/entry/north)
 "fCT" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -67823,20 +67758,20 @@
 	},
 /area/station/hallway/primary/port/west)
 "fPG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
 	},
-/turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/east)
 "fPJ" = (
 /obj/effect/spawner/random_spawners/oil_maybe,
@@ -68126,6 +68061,15 @@
 /obj/structure/lattice/catwalk,
 /turf/space,
 /area/space/nearstation)
+"fZc" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "arrival"
+	},
+/area/station/hallway/secondary/entry/north)
 "fZU" = (
 /obj/structure/chair/stool/bar{
 	dir = 1
@@ -68435,10 +68379,15 @@
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/reception)
 "giE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -68619,15 +68568,16 @@
 	},
 /area/station/security/main)
 "gpy" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
 	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-4"
+/obj/machinery/light,
+/obj/structure/sign/vacuum/external{
+	pixel_y = -32
 	},
-/obj/machinery/power/apc/important/directional/west,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "arrival"
+	},
 /area/station/hallway/secondary/entry/north)
 "gpU" = (
 /turf/simulated/floor/plasteel{
@@ -68729,12 +68679,12 @@
 	},
 /area/station/science/research)
 "gtZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/door/airlock/external,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/west)
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry/north)
 "gua" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel/dark,
@@ -69000,22 +68950,10 @@
 /turf/simulated/floor/wood,
 /area/station/public/pet_store)
 "gEs" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/light,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "arrival"
-	},
-/area/station/hallway/secondary/entry/south)
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry/east)
 "gEy" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -69565,15 +69503,11 @@
 	},
 /area/station/public/sleep)
 "gVk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/structure/chair/sofa/bench/right,
+/obj/effect/landmark/start/assistant,
+/turf/simulated/floor/plasteel{
+	icon_state = "barber"
 	},
-/turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/north)
 "gVm" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -69595,6 +69529,13 @@
 	icon_state = "whitegreen"
 	},
 /area/station/medical/virology)
+"gVr" = (
+/obj/effect/decal/cleanable/blood/oil,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "brown"
+	},
+/area/station/hallway/secondary/entry/east)
 "gVE" = (
 /obj/machinery/light{
 	dir = 1
@@ -69788,16 +69729,21 @@
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/medbay)
 "hbv" = (
-/obj/machinery/newscaster{
-	name = "north bump";
-	pixel_y = 28
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "arrival"
+	icon_state = "neutralfull"
 	},
-/area/station/hallway/secondary/entry/south)
+/area/station/hallway/secondary/entry/east)
 "hbB" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
@@ -69926,16 +69872,22 @@
 /turf/simulated/floor/plating,
 /area/station/command/office/rd)
 "hhn" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/effect/turf_decal/delivery/hollow,
+/obj/structure/closet/crate/trashcart,
+/obj/effect/spawner/random/trash,
+/obj/effect/spawner/random/trash,
+/obj/effect/spawner/random/trash,
+/obj/effect/spawner/random/trash,
+/obj/effect/spawner/random/trash,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/official/cleanliness{
+	pixel_y = 32
 	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/west)
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "brown"
+	},
+/area/station/hallway/secondary/entry/east)
 "hhz" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable{
@@ -70505,10 +70457,14 @@
 /turf/simulated/floor/plating,
 /area/station/supply/break_room)
 "hyL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/west)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = 32
+	},
+/obj/structure/rack,
+/obj/effect/spawner/random/maintenance,
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry/east)
 "hyX" = (
 /obj/structure/transit_tube/curved/flipped{
 	dir = 4
@@ -71829,13 +71785,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
 "inH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/structure/cable{
@@ -71843,7 +71796,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "arrival"
+	},
 /area/station/hallway/secondary/entry/east)
 "inM" = (
 /obj/structure/cable{
@@ -72081,20 +72037,18 @@
 /turf/simulated/floor/engine,
 /area/station/science/toxins/mixing)
 "ivG" = (
-/obj/machinery/status_display{
-	pixel_x = 32
-	},
-/obj/machinery/light{
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/status_display{
-	pixel_x = 32
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
 	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/east)
+/area/station/hallway/secondary/entry/south)
 "ivR" = (
 /obj/machinery/camera{
 	c_tag = "Supermatter Emitter Chamber";
@@ -72904,9 +72858,9 @@
 	},
 /area/station/service/bar)
 "iUU" = (
-/obj/effect/spawner/window/reinforced/grilled,
-/turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry/west)
+/obj/effect/spawner/airlock/e_to_w,
+/turf/simulated/wall,
+/area/station/hallway/secondary/entry/north)
 "iUZ" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -73335,6 +73289,12 @@
 	icon_state = "whitegreen"
 	},
 /area/station/medical/virology)
+"jhz" = (
+/obj/structure/chair/sofa/bench/right,
+/turf/simulated/floor/plasteel{
+	icon_state = "barber"
+	},
+/area/station/hallway/secondary/entry/north)
 "jid" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -73569,15 +73529,13 @@
 /obj/machinery/economy/vending/cigarette,
 /obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutral"
+	icon_state = "arrival"
 	},
 /area/station/hallway/secondary/entry/south)
 "jpa" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/north)
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/wood,
+/area/station/hallway/secondary/entry/east)
 "jpk" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -74345,23 +74303,9 @@
 /turf/simulated/wall,
 /area/station/hallway/secondary/entry/lounge)
 "jOW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/camera/autoname{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/alarm/directional/south,
 /turf/simulated/floor/plasteel{
 	icon_state = "arrival"
 	},
@@ -74686,16 +74630,10 @@
 	},
 /area/station/engineering/atmos)
 "jWY" = (
-/obj/docking_port/stationary{
-	dir = 8;
-	dwidth = 2;
-	height = 12;
-	id = "ferry_home";
-	name = "port bay 3";
-	width = 5
+/turf/simulated/floor/plasteel{
+	icon_state = "arrival"
 	},
-/turf/space,
-/area/space)
+/area/station/hallway/secondary/entry/north)
 "jXz" = (
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/aft/south)
@@ -74703,6 +74641,24 @@
 /obj/effect/spawner/random_spawners/blood_maybe,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
+"jZc" = (
+/obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/landmark/lightsout,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/secondary/entry/south)
 "jZh" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -75211,17 +75167,12 @@
 	},
 /area/station/security/main)
 "knM" = (
-/obj/docking_port/stationary{
-	dir = 8;
-	dwidth = 9;
-	height = 18;
-	id = "admin_home";
-	name = "port bay 1";
-	timid = 1;
-	width = 19
+/obj/structure/table,
+/obj/item/storage/briefcase,
+/turf/simulated/floor/plasteel{
+	icon_state = "barber"
 	},
-/turf/space,
-/area/space)
+/area/station/hallway/secondary/entry/north)
 "knY" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -75965,11 +75916,16 @@
 	},
 /area/station/engineering/atmos)
 "kLd" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -76007,12 +75963,17 @@
 /turf/simulated/floor/plasteel/white,
 /area/station/science/break_room)
 "kNa" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -76888,20 +76849,14 @@
 /turf/simulated/wall,
 /area/station/medical/paramedic)
 "lpL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/door/airlock/external,
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "bluecorner"
-	},
+/turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry/south)
 "lpX" = (
 /obj/structure/disposalpipe/segment/corner{
@@ -77032,14 +76987,16 @@
 	},
 /area/station/engineering/atmos)
 "ltw" = (
-/obj/machinery/light{
-	dir = 4
+/obj/structure/table,
+/obj/item/reagent_containers/drinks/cans/beer{
+	pixel_x = 7;
+	pixel_y = 5
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/item/ashtray/plastic{
+	pixel_x = -9
 	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/west)
+/turf/simulated/floor/wood,
+/area/station/hallway/secondary/entry/east)
 "ltX" = (
 /obj/structure/plasticflaps{
 	opacity = 1
@@ -77659,7 +77616,7 @@
 /obj/machinery/economy/vending/clothing,
 /obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutral"
+	icon_state = "arrival"
 	},
 /area/station/hallway/secondary/entry/south)
 "lMM" = (
@@ -77795,6 +77752,17 @@
 	icon_state = "neutralfull"
 	},
 /area/station/public/locker)
+"lQG" = (
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/spawner/random/storage,
+/obj/effect/spawner/random/engineering/tools,
+/obj/effect/spawner/random/engineering/toolbox,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "brown"
+	},
+/area/station/hallway/secondary/entry/east)
 "lQN" = (
 /obj/machinery/status_display{
 	pixel_y = 32
@@ -77990,6 +77958,14 @@
 /obj/structure/girder,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
+"lXG" = (
+/obj/machinery/status_display{
+	pixel_y = -32
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "arrival"
+	},
+/area/station/hallway/secondary/entry/north)
 "lYp" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -78194,12 +78170,17 @@
 	},
 /area/station/hallway/primary/starboard/north)
 "meH" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/structure/window/basic{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/west)
+/obj/structure/window/basic,
+/obj/structure/flora/ausbushes/fernybush,
+/obj/structure/flora/ausbushes/reedbush,
+/obj/structure/flora/ausbushes/palebush,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/brflowers,
+/turf/simulated/floor/grass/no_creep,
+/area/station/hallway/secondary/entry/north)
 "meU" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -79087,17 +79068,14 @@
 	},
 /area/station/security/prison/cell_block)
 "mFy" = (
-/obj/machinery/status_display{
-	pixel_x = 32
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10;
+	initialize_directions = 10
 	},
-/obj/machinery/light{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/west)
+/area/station/hallway/secondary/entry/north)
 "mFK" = (
 /obj/machinery/light,
 /obj/machinery/economy/vending/bardrobe,
@@ -80000,12 +79978,9 @@
 	},
 /area/station/security/brig)
 "ndb" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/north)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/station/hallway/secondary/entry/east)
 "neb" = (
 /obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
@@ -80966,13 +80941,13 @@
 /turf/simulated/floor/plasteel,
 /area/station/science/research)
 "nEp" = (
-/obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/station/hallway/secondary/entry/north)
+/area/station/hallway/secondary/entry/south)
 "nEq" = (
 /obj/machinery/door/airlock/hatch{
 	name = "MiniSat Transit Tube"
@@ -81513,6 +81488,11 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/toxins/mixing)
+"nWU" = (
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry/east)
 "nXf" = (
 /obj/machinery/computer/security/wooden_tv,
 /turf/simulated/floor/carpet,
@@ -82113,6 +82093,15 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/fore/south)
+"onX" = (
+/obj/effect/turf_decal/delivery/hollow,
+/obj/structure/closet/emcloset,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "brown"
+	},
+/area/station/hallway/secondary/entry/east)
 "ooc" = (
 /obj/effect/spawner/window/reinforced/plasma/grilled,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
@@ -82615,6 +82604,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/medical/coldroom)
+"oCh" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
+	name = "KEEP CLEAR: DOCKING AREA"
+	},
+/turf/simulated/wall,
+/area/station/hallway/secondary/entry/east)
 "oCp" = (
 /obj/machinery/economy/vending/virodrobe,
 /turf/simulated/floor/plasteel{
@@ -82991,13 +82987,17 @@
 /turf/simulated/wall/r_wall,
 /area/station/telecomms/chamber)
 "oMA" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
+/obj/structure/chair/sofa/bench/left,
+/turf/simulated/floor/plasteel{
+	icon_state = "barber"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/firealarm/directional/west,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/west)
+/area/station/hallway/secondary/entry/north)
+"oMB" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/emergency,
+/obj/item/storage/firstaid/regular,
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/arrival/station)
 "oMI" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 2
@@ -83522,6 +83522,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
+"pam" = (
+/turf/simulated/floor/plating,
+/area/space/nearstation)
 "pax" = (
 /obj/structure/sink{
 	dir = 1;
@@ -83712,16 +83715,13 @@
 /turf/simulated/floor/carpet/black,
 /area/station/service/chapel/office)
 "pfO" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
+/obj/structure/closet/emcloset,
+/obj/item/radio/intercom{
+	name = "east bump";
+	pixel_x = 28
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/secondary/entry/north)
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry/south)
 "pgx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -83822,13 +83822,16 @@
 /turf/simulated/floor/grass/jungle,
 /area/station/maintenance/fsmaint)
 "pjO" = (
-/obj/machinery/light{
-	dir = 1
+/obj/docking_port/stationary{
+	dir = 8;
+	dwidth = 4;
+	height = 11;
+	id = "trade_dock";
+	name = "port bay 4 at Kerberos";
+	width = 9
 	},
-/obj/item/kirbyplants,
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/west)
+/turf/space,
+/area/space)
 "pkg" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
@@ -84131,10 +84134,15 @@
 /turf/simulated/floor/plasteel,
 /area/station/public/toilet/lockerroom)
 "pvf" = (
-/obj/item/kirbyplants,
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/west)
+/obj/machinery/camera/autoname,
+/obj/structure/sign/vacuum/external{
+	pixel_y = 32
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "arrival"
+	},
+/area/station/hallway/secondary/entry/north)
 "pvg" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -84176,17 +84184,21 @@
 	},
 /area/station/security/main)
 "pvQ" = (
-/obj/machinery/status_display{
-	pixel_x = -32
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/north)
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/secondary/entry/south)
 "pwd" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Science Maintenance"
@@ -84416,14 +84428,13 @@
 /turf/simulated/floor/plating,
 /area/station/command/office/rd)
 "pCM" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/machinery/camera/autoname{
+	dir = 8
 	},
-/obj/item/radio/intercom{
-	name = "east bump";
-	pixel_x = 28
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "arrival"
 	},
-/turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/east)
 "pDw" = (
 /obj/effect/turf_decal/stripes/line,
@@ -84524,9 +84535,21 @@
 	},
 /area/station/science/break_room)
 "pGg" = (
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/west)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/secondary/entry/east)
 "pGi" = (
 /obj/structure/sign/electricshock{
 	pixel_y = -32
@@ -84599,15 +84622,9 @@
 	},
 /area/station/security/permabrig)
 "pHg" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external{
-	id_tag = "specops_home";
-	locked = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/north)
+/obj/item/kirbyplants,
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/arrival/station)
 "pIn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -84782,8 +84799,12 @@
 /turf/simulated/floor/plasteel/white,
 /area/station/science/toxins/mixing)
 "pMq" = (
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/structure/rack,
+/obj/item/clothing/head/welding,
+/turf/simulated/floor/plasteel{
+	icon_state = "brown"
+	},
 /area/station/hallway/secondary/entry/east)
 "pMx" = (
 /obj/machinery/door/firedoor,
@@ -84962,6 +84983,14 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
+"pQv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/secondary/entry/south)
 "pRI" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -85090,11 +85119,11 @@
 	},
 /area/station/science/toxins/mixing)
 "pUC" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/shuttle/engine/propulsion{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry/west)
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/pod_1)
 "pVI" = (
 /obj/structure/plasticflaps{
 	opacity = 1
@@ -85154,12 +85183,16 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "pWw" = (
-/obj/machinery/economy/vending/snack,
-/obj/machinery/light{
-	dir = 1
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/newscaster{
+	name = "north bump";
+	pixel_y = 28
 	},
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "brown"
+	},
 /area/station/hallway/secondary/entry/east)
 "pWz" = (
 /obj/machinery/optable,
@@ -85348,22 +85381,9 @@
 	},
 /area/station/medical/break_room)
 "qcA" = (
-/obj/docking_port/stationary{
-	dir = 8;
-	dwidth = 4;
-	height = 11;
-	id = "trade_dock";
-	name = "port bay 4 at Kerberos";
-	width = 9
-	},
-/obj/machinery/access_button{
-	autolink_id = "enginen_btn_ext";
-	name = "exterior access button";
-	pixel_x = 23;
-	pixel_y = -23
-	},
-/turf/space,
-/area/space)
+/obj/effect/spawner/airlock,
+/turf/simulated/wall,
+/area/station/hallway/secondary/entry/north)
 "qcR" = (
 /obj/machinery/door/airlock/medical,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -85584,11 +85604,14 @@
 	},
 /area/station/hallway/primary/central/ne)
 "qke" = (
-/obj/machinery/door/airlock/external{
-	name = "Arrival Airlock"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/newscaster{
+	dir = 8;
+	name = "east bump";
+	pixel_x = 28
 	},
 /turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry/west)
+/area/station/hallway/secondary/entry/east)
 "qkH" = (
 /obj/structure/chair/sofa/corner{
 	color = "#A30FAF";
@@ -85744,11 +85767,14 @@
 	},
 /area/station/command/bridge)
 "qtk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/south)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry/north)
 "qtC" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	autolink_id = "co2_out";
@@ -86407,15 +86433,12 @@
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/cryo)
 "qQS" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "arrival"
 	},
-/obj/machinery/camera{
-	c_tag = "Arrivals Port Aft";
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/west)
+/area/station/hallway/secondary/entry/north)
 "qRe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -87092,15 +87115,15 @@
 	},
 /area/station/security/brig)
 "reW" = (
-/obj/item/radio/intercom{
-	name = "east bump";
-	pixel_x = 28
-	},
+/obj/machinery/door/airlock/external,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/west)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry/east)
 "rfw" = (
 /obj/machinery/alarm/directional/north,
 /turf/simulated/floor/plasteel{
@@ -87172,6 +87195,14 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/break_room)
+"rhX" = (
+/obj/machinery/economy/vending/snack,
+/obj/effect/turf_decal/delivery/hollow,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "arrival"
+	},
+/area/station/hallway/secondary/entry/north)
 "riq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -87728,14 +87759,11 @@
 /turf/simulated/wall,
 /area/station/service/barber)
 "rwY" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+/obj/structure/chair/sofa/bench,
+/turf/simulated/floor/plasteel{
+	icon_state = "barber"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/west)
+/area/station/hallway/secondary/entry/north)
 "rwZ" = (
 /obj/structure/table/reinforced,
 /obj/item/desk_bell{
@@ -87812,14 +87840,14 @@
 	},
 /area/station/hallway/primary/central/sw)
 "ryh" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/structure/chair/sofa/bench/right{
+	dir = 1
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
+/obj/effect/landmark/start/assistant,
+/turf/simulated/floor/plasteel{
+	icon_state = "barber"
 	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/west)
+/area/station/hallway/secondary/entry/north)
 "ryp" = (
 /obj/effect/spawner/random/fungus/maybe,
 /turf/simulated/wall,
@@ -87891,18 +87919,7 @@
 	},
 /area/station/medical/medbay)
 "rBP" = (
-/obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/plasteel{
 	icon_state = "arrival"
 	},
@@ -88132,22 +88149,24 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
 "rJk" = (
-/obj/effect/spawner/window/reinforced/grilled,
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
-	name = "KEEP CLEAR: DOCKING AREA"
+/obj/docking_port/stationary{
+	dwidth = 9;
+	height = 18;
+	id = "admin_home";
+	name = "port bay 1";
+	timid = 1;
+	width = 19
 	},
-/turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry/west)
+/turf/space,
+/area/space)
 "rJF" = (
-/obj/structure/sign/vacuum{
-	pixel_x = -32
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/simulated/floor/plasteel{
+	icon_state = "barber"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/north)
+/area/station/hallway/secondary/entry/south)
 "rKJ" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -88369,16 +88388,16 @@
 	},
 /area/station/medical/virology)
 "rPU" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/station/hallway/secondary/entry/west)
+/area/station/hallway/secondary/entry/south)
 "rQj" = (
 /obj/machinery/firealarm/directional/west,
 /obj/structure/table/reinforced,
@@ -88402,21 +88421,10 @@
 	},
 /area/station/medical/reception)
 "rQS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "arrival"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/east)
 "rRw" = (
 /obj/structure/table,
@@ -88794,13 +88802,13 @@
 /area/station/security/processing)
 "san" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/west)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry/south)
 "saq" = (
 /obj/machinery/atmospherics/portable/canister/air,
 /obj/machinery/atmospherics/unary/portables_connector{
@@ -88831,16 +88839,23 @@
 /turf/simulated/floor/plating,
 /area/station/medical/virology)
 "saK" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /obj/structure/cable{
+	d1 = 4;
 	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "4-8"
 	},
-/obj/machinery/power/apc/important/directional/east,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/west)
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/secondary/entry/south)
 "sbe" = (
 /obj/structure/extinguisher_cabinet{
 	name = "east bump";
@@ -89088,16 +89103,15 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft2)
 "sgZ" = (
-/obj/machinery/newscaster{
-	name = "north bump";
-	pixel_y = 28
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "arrival"
+/obj/item/radio/intercom{
+	name = "south bump";
+	pixel_y = -28
 	},
-/area/station/hallway/secondary/entry/south)
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/pod_1)
 "shb" = (
 /obj/machinery/light,
 /obj/machinery/light_switch{
@@ -90426,14 +90440,11 @@
 	},
 /area/station/medical/storage)
 "sMV" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/west)
+/obj/effect/decal/cleanable/dirt,
+/obj/item/kirbyplants,
+/obj/effect/decal/cleanable/cobweb,
+/turf/simulated/floor/wood,
+/area/station/hallway/secondary/entry/east)
 "sNF" = (
 /obj/machinery/firealarm/directional/south,
 /turf/simulated/floor/plasteel{
@@ -90824,9 +90835,7 @@
 /turf/simulated/wall,
 /area/station/engineering/ai_transit_tube)
 "sWI" = (
-/obj/item/kirbyplants,
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/catwalk,
 /area/station/hallway/secondary/entry/east)
 "sXr" = (
 /obj/effect/spawner/window/reinforced/polarized/grilled{
@@ -91335,10 +91344,23 @@
 /turf/simulated/floor/plasteel,
 /area/station/science/toxins/mixing)
 "tnU" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
-/area/station/hallway/secondary/entry/west)
+/area/station/hallway/secondary/entry/north)
 "tod" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Internal Medbay Maintenance"
@@ -92013,11 +92035,11 @@
 	},
 /area/station/maintenance/port)
 "tIM" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+/obj/machinery/firealarm/directional/north,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "arrival"
 	},
-/obj/machinery/alarm/directional/east,
-/turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/north)
 "tIT" = (
 /obj/machinery/door/firedoor,
@@ -92263,10 +92285,12 @@
 	},
 /area/station/medical/medbay)
 "tRa" = (
-/obj/machinery/economy/vending/cola,
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/east)
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry/north)
 "tRn" = (
 /obj/machinery/light,
 /obj/structure/disposalpipe/segment{
@@ -92519,14 +92543,15 @@
 	},
 /area/station/medical/cloning)
 "tXb" = (
-/obj/machinery/light{
-	dir = 8
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/spawner/random/storage,
+/obj/item/storage/box/beakers,
+/obj/item/storage/box/lights/mixed,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "brown"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/west)
+/area/station/hallway/secondary/entry/east)
 "tXj" = (
 /obj/machinery/cryopod/right,
 /obj/machinery/light_switch{
@@ -92751,10 +92776,16 @@
 	},
 /area/station/service/chapel/office)
 "uci" = (
-/obj/effect/spawner/window/reinforced/grilled,
-/obj/effect/spawner/airlock/s_to_n,
-/turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry/west)
+/obj/machinery/power/apc/directional/north,
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "arrival"
+	},
+/area/station/hallway/secondary/entry/south)
 "ucl" = (
 /obj/machinery/economy/vending/cigarette,
 /turf/simulated/floor/plating,
@@ -93051,6 +93082,14 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/armory/secure)
+"uiL" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/firealarm/directional/north,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "arrival"
+	},
+/area/station/hallway/secondary/entry/south)
 "uje" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -93270,13 +93309,17 @@
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/reception)
 "upw" = (
-/obj/item/radio/intercom{
-	name = "north bump";
-	pixel_y = 28
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "arrival"
+	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/entry/south)
 "upI" = (
@@ -93335,6 +93378,13 @@
 	icon_state = "neutral"
 	},
 /area/station/maintenance/starboard)
+"urr" = (
+/obj/effect/turf_decal/delivery/hollow,
+/obj/structure/closet/emcloset,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/secondary/entry/south)
 "usf" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -94079,6 +94129,14 @@
 	icon_state = "neutralfull"
 	},
 /area/station/engineering/atmos)
+"uQW" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/secondary/entry/south)
 "uRn" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable,
@@ -94129,6 +94187,31 @@
 	icon_state = "whitebluecorner"
 	},
 /area/station/medical/reception)
+"uTN" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/assistant,
+/obj/machinery/newscaster{
+	dir = 1;
+	name = "south bump";
+	pixel_y = -28
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "brown"
+	},
+/area/station/hallway/secondary/entry/east)
+"uTX" = (
+/obj/effect/turf_decal/delivery/hollow,
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 4
+	},
+/obj/machinery/atmospherics/portable/canister/air,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/secondary/entry/north)
 "uUk" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/classic/normal{
@@ -94485,8 +94568,13 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/ai_transit_tube)
 "vcE" = (
-/obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -94744,11 +94832,13 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "vmP" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/structure/extinguisher_cabinet{
+	name = "south bump";
+	pixel_y = -30
 	},
-/obj/machinery/firealarm/directional/east,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "arrival"
+	},
 /area/station/hallway/secondary/entry/north)
 "vnm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -94849,14 +94939,16 @@
 /turf/simulated/floor/grass/jungle,
 /area/station/maintenance/fsmaint)
 "vrP" = (
-/obj/machinery/status_display{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/window/basic{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/east)
+/obj/structure/window/basic,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/fernybush,
+/obj/structure/flora/ausbushes/palebush,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/simulated/floor/grass/no_creep,
+/area/station/hallway/secondary/entry/north)
 "vsw" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -94878,6 +94970,14 @@
 	icon_state = "dark"
 	},
 /area/station/security/execution)
+"vsP" = (
+/obj/effect/turf_decal/delivery/hollow,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "brown"
+	},
+/area/station/hallway/secondary/entry/east)
 "vtp" = (
 /obj/structure/sign/electricshock{
 	pixel_y = -32
@@ -95124,6 +95224,16 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/sleeper)
+"vBL" = (
+/obj/structure/sink/kitchen/old{
+	pixel_y = 25
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "brown"
+	},
+/area/station/hallway/secondary/entry/east)
 "vBO" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 9
@@ -95420,6 +95530,15 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port/west)
+"vHl" = (
+/obj/structure/sign/vacuum/external{
+	pixel_y = 32
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "arrival"
+	},
+/area/station/hallway/secondary/entry/east)
 "vHE" = (
 /obj/machinery/mass_driver{
 	dir = 8;
@@ -95791,12 +95910,11 @@
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/virology)
 "vTw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/chair/sofa/bench/left,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
+	icon_state = "barber"
 	},
-/area/station/hallway/secondary/entry/west)
+/area/station/hallway/secondary/entry/south)
 "vTx" = (
 /obj/item/radio/intercom{
 	name = "north bump";
@@ -95943,11 +96061,13 @@
 /turf/simulated/floor/engine/co2,
 /area/station/engineering/atmos)
 "vYz" = (
-/obj/item/kirbyplants,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/firealarm/directional/north,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner"
+	dir = 1;
+	icon_state = "arrival"
 	},
-/area/station/hallway/secondary/entry/south)
+/area/station/hallway/secondary/entry/north)
 "vYF" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-18"
@@ -96277,14 +96397,12 @@
 	},
 /area/station/hallway/secondary/exit)
 "whp" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "brown"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/north)
+/area/station/hallway/secondary/entry/east)
 "why" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -96672,14 +96790,8 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/office/ce)
 "wsg" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/west)
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry/south)
 "wsl" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -96871,18 +96983,21 @@
 	},
 /area/station/hallway/primary/central/se)
 "wvH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "arrival"
+	icon_state = "neutralfull"
 	},
-/area/station/hallway/secondary/entry/south)
+/area/station/hallway/secondary/entry/east)
 "wvM" = (
 /obj/machinery/door/airlock{
 	name = "Internal Affairs Office"
@@ -97139,7 +97254,7 @@
 /obj/machinery/economy/vending/coffee,
 /obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutral"
+	icon_state = "arrival"
 	},
 /area/station/hallway/secondary/entry/south)
 "wER" = (
@@ -97476,18 +97591,16 @@
 /turf/simulated/floor/engine,
 /area/station/engineering/controlroom)
 "wSO" = (
-/obj/structure/sign/vacuum/external{
-	pixel_y = -32
+/obj/machinery/power/apc/directional/north,
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 1
-	},
-/obj/machinery/atmospherics/portable/canister/air,
 /turf/simulated/floor/plasteel{
-	dir = 10;
+	dir = 1;
 	icon_state = "arrival"
 	},
-/area/station/hallway/secondary/entry/south)
+/area/station/hallway/secondary/entry/north)
 "wSU" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -97860,6 +97973,12 @@
 /obj/effect/spawner/random/fungus/frequent,
 /turf/simulated/wall,
 /area/station/maintenance/aft)
+"xch" = (
+/obj/effect/turf_decal/delivery/hollow,
+/turf/simulated/floor/plasteel{
+	icon_state = "brown"
+	},
+/area/station/hallway/secondary/entry/east)
 "xcs" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
@@ -97901,21 +98020,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
 "xcL" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/access_button{
-	autolink_id = "engines_btn_int";
-	name = "interior access button";
-	pixel_x = -25;
-	pixel_y = -25
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10;
-	initialize_directions = 10
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry/west)
+/obj/machinery/door/airlock/external,
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry/south)
 "xcR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -97990,6 +98097,16 @@
 "xgm" = (
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/armory/secure)
+"xgt" = (
+/obj/docking_port/stationary{
+	dwidth = 2;
+	height = 12;
+	id = "ferry_home";
+	name = "port bay 3";
+	width = 5
+	},
+/turf/space,
+/area/space)
 "xgF" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
@@ -98177,6 +98294,9 @@
 	icon_state = "vault"
 	},
 /area/station/turret_protected/ai)
+"xlP" = (
+/turf/simulated/floor/wood,
+/area/station/hallway/secondary/entry/east)
 "xlS" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/barricade/wooden,
@@ -98309,6 +98429,17 @@
 /obj/effect/spawner/random_spawners/dirt_often,
 /turf/simulated/floor/plasteel,
 /area/station/supply/expedition)
+"xpm" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/secondary/entry/north)
 "xpq" = (
 /obj/machinery/economy/vending/snack,
 /turf/simulated/floor/plasteel{
@@ -98583,11 +98714,15 @@
 	},
 /area/station/service/chapel)
 "xyI" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/machinery/power/apc/directional/east,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/obj/machinery/alarm/directional/east,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "arrival"
+	},
 /area/station/hallway/secondary/entry/east)
 "xzp" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -98983,13 +99118,11 @@
 /turf/simulated/floor/plating,
 /area/station/security/range)
 "xHN" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/east)
 "xIm" = (
 /obj/structure/closet/walllocker/emerglocker/west,
@@ -99276,10 +99409,14 @@
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/storage/eva)
 "xPh" = (
-/obj/item/kirbyplants,
-/obj/machinery/requests_console/directional/east,
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/arrival/station)
+/obj/item/radio/intercom{
+	name = "south bump";
+	pixel_y = -28
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "arrival"
+	},
+/area/station/hallway/secondary/entry/south)
 "xPn" = (
 /obj/effect/spawner/random_spawners/wall_rusted_always,
 /turf/simulated/wall,
@@ -130036,7 +130173,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+dZi
 aaa
 aaa
 aaa
@@ -130535,7 +130672,6 @@ aaa
 aaa
 aaa
 aaa
-knM
 aaa
 aaa
 aaa
@@ -130552,7 +130688,8 @@ aaa
 aaa
 aaa
 aaa
-qcA
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -130787,36 +130924,36 @@ aaa
 aaa
 aaa
 aaa
-abj
-abj
-abj
-iUU
-aef
-aef
-iUU
-abj
-abj
-abj
-abj
-abj
-abj
-abj
-abj
-abj
-abj
-abj
-abj
-abj
-abj
-iUU
-qke
-rJk
-abj
-abj
-abj
-abj
-abj
-abj
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 abj
 abj
 uzN
@@ -131043,38 +131180,38 @@ aaa
 aaa
 aaa
 aaa
-abj
-abj
-aaa
-aaa
-iUU
-pGg
-pGg
-iUU
-aaa
-aaa
-abj
-aaa
-iUU
-iUU
-iUU
-iUU
-iUU
-iUU
-aaa
-aaa
-aaa
-abj
-iUU
-ahQ
-iUU
-aaa
-abj
 aaa
 aaa
 aaa
 aaa
-abj
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+anu
 aaa
 uzN
 aqB
@@ -131298,39 +131435,39 @@ aaa
 aaa
 aaa
 aaa
-adb
-iUU
-adb
-iUU
-iUU
-iUU
-iUU
-aef
-aef
-adb
-iUU
-iUU
-adb
-iUU
-iUU
-aik
-aiE
-pGg
-ajf
-iUU
-iUU
-iUU
-iUU
-adb
-iUU
-eKO
-iUU
-adb
-adb
-adb
-aAr
-aAr
-aAr
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aAr
 aaa
 uzN
@@ -131553,41 +131690,41 @@ aaa
 aaa
 aaa
 aaa
-iUU
-iUU
-uci
-pGg
-tXb
-adZ
-san
-adZ
-aeI
-adZ
-adZ
-afJ
-adZ
-adZ
-agd
-age
-adZ
-adZ
-adZ
-adZ
-adZ
-adZ
-adZ
-rwY
-age
-agg
-adZ
-xcL
-gtZ
-gtZ
-meH
-oMA
-qtk
-ani
-wSO
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aAr
 aaa
 uzN
@@ -131810,41 +131947,41 @@ aaa
 aaa
 aaa
 aaa
-aeN
-pUC
-aeN
-adt
-afh
-tnU
-fCA
-ahg
-eYW
-ahg
-ahg
-ahg
-ahg
-ahg
-ahg
-ahg
-vTw
-vTw
-cMP
-vTw
-vTw
-vTw
-vTw
-rPU
-vTw
-vTw
-vTw
-amA
-amA
-hyL
-hyL
-hhn
-anu
-wvH
-gEs
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaZ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+add
+ade
+add
 aAr
 aaa
 apG
@@ -132067,41 +132204,41 @@ aaa
 aaa
 aaa
 aaa
-iUU
-iUU
-iUU
-adu
-sMV
-aeb
-ryh
-aeb
-aeO
-aeb
-aeb
-eCj
-aeb
-aeb
-ltw
-aeb
-aeb
-aeb
-aeb
-aeb
-aeb
-qQS
-aeb
-agB
-aeb
-mFy
-aeb
-reW
-aeb
-wsg
-aeb
-saK
-kWK
-ant
-anL
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+add
+akw
+add
 aAr
 aaa
 uzN
@@ -132326,39 +132463,39 @@ aaa
 aaa
 aaa
 aaa
-adb
-iUU
-adb
-iUU
-iUU
-iUU
-adb
-iUU
-iUU
-adb
-iUU
-iUU
-adb
-iUU
-iUU
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 pjO
-aiF
-aiI
-pvf
-iUU
-iUU
-iUU
-iUU
-adb
-adb
-adb
-adb
-adb
-adb
-adb
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aAr
+add
 sgZ
-anK
+add
 aAr
 aaa
 uzN
@@ -132585,37 +132722,37 @@ aaa
 aaa
 aaa
 aaa
-abj
-abj
 aaa
 aaa
-abj
 aaa
 aaa
-abj
 aaa
 aaa
-abj
 aaa
-iUU
-iUU
-iUU
-iUU
-iUU
+aaa
+aaa
+aaa
+aaa
+aaa
+ovL
+eYW
 iUU
 aaa
 aaa
 aaa
-abj
 aaa
 aaa
 aaa
 aaa
-abj
+aaa
+aaa
+aaa
+aaa
 aaa
 aAr
+pUC
 ezV
-anL
+pUC
 aAr
 abj
 abj
@@ -132843,36 +132980,36 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+anu
 abj
+doS
+tRa
+doS
 abj
-abj
-abj
-abj
-abj
-abj
-abj
-abj
-abj
-abj
-abj
-abj
-abj
-abj
-abj
-abj
-abj
-abj
-abj
-abj
-abj
-abj
-abj
-abj
-abj
-abj
-dGS
-ant
-anL
+anu
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+anu
+aAr
+pfO
+wsg
+ajf
 aAr
 awX
 awX
@@ -133103,9 +133240,18 @@ aaa
 aaa
 aaa
 aaa
+abj
+abj
+abj
 aaa
-acF
 aaa
+aaa
+abj
+ovL
+ovL
+eYW
+ovL
+ovL
 abj
 aaa
 aaa
@@ -133116,20 +133262,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 abj
-aaa
-dGS
-ant
-anL
+aAr
+aAr
+xcL
+amN
 aAr
 aor
 aoR
@@ -133358,34 +133495,34 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-acF
-aaa
-abj
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+adO
+fCA
+ovL
+aeb
+aeb
+aeb
+aeb
+ovL
+ovL
+ovL
+aip
+mFy
+dMg
+ovL
+anu
 aaa
 aaa
 aaa
 aaa
 aaa
-abj
 aaa
-dGS
-ant
+aaa
+aaa
+aaa
+anu
+aAr
+urr
+nEp
 anJ
 rxD
 apJ
@@ -133618,8 +133755,17 @@ aaa
 aaa
 aaa
 aaa
-acF
 aaa
+aaa
+aaa
+aaa
+abj
+aaa
+doS
+aey
+qGl
+uTX
+ovL
 abj
 aaa
 aaa
@@ -133630,20 +133776,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 abj
-aaa
-dGS
-ant
-anL
+aAr
+aeO
+afJ
+xPh
 aAr
 aoS
 apK
@@ -133875,32 +134012,32 @@ aaa
 aaa
 aaa
 aaa
-acF
+aaa
+aaa
+aaa
+aaa
+ovL
+doS
+ovL
+pvf
+qGl
+gpy
+ovL
+doS
+qcA
 abj
-abj
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
 aaa
 aaa
 abj
-aaa
+aAr
 dGS
-ant
-anL
+adt
+ani
+afJ
+alx
 aoo
 aoo
 aoo
@@ -134123,6 +134260,7 @@ aaa
 aaa
 aaa
 aaa
+aaZ
 aaa
 aaa
 aaa
@@ -134132,32 +134270,31 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+xgt
+afb
+qtk
+afb
+qGl
+qGl
+mFy
+afb
+qtk
+afb
 acF
-aaa
-abj
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-abj
-aaa
-dGS
-ant
-anL
+acF
+acF
+acF
+acF
+acF
+acF
+lpL
+san
+lpL
+pQv
+afJ
+jOW
 aoo
 aoT
 apL
@@ -134380,7 +134517,6 @@ aaa
 aaa
 aaa
 aaa
-aaZ
 aaa
 aaa
 aaa
@@ -134389,32 +134525,33 @@ aaa
 aaa
 aaa
 aaa
-acF
 aaa
+aaa
+aaa
+aaa
+aaa
+adb
+doS
+ovL
+vYz
+xpm
+adx
+ovL
+doS
+ovL
 abj
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 abj
-aaa
 aAr
-ant
-anL
+dGS
+aAr
+uiL
+aiH
+anP
 aoo
 imf
 apM
@@ -134642,23 +134779,6 @@ aaa
 aaa
 aaa
 aaa
-dZi
-aaa
-aaa
-aaa
-acF
-aaa
-abj
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -134669,8 +134789,25 @@ aaa
 aaa
 abj
 aaa
+doS
+aey
+blc
+lXG
+ovL
+abj
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+abj
 aAr
-ant
+aiI
+rPU
 fqF
 aoo
 aoV
@@ -134897,38 +135034,38 @@ aaa
 aaa
 aaa
 aaa
+adO
+fCA
+ovL
+aeb
+aeb
+aeb
+aeb
+aeb
+aeb
+aeb
+ovL
+ovL
+ovL
+ahF
+adN
+ahF
+ovL
+adO
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-acF
-aaa
-abj
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-abj
-aaa
-dGS
-ant
-anL
+adO
+aAr
+kWK
+ivG
+kWK
 aoo
 vET
 apM
@@ -135156,35 +135293,35 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-acF
+abj
 abj
 abj
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 abj
+abj
+abj
+ovL
+fZc
+blc
+jWY
+doS
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 dGS
 ant
+rPU
 rBP
 aoo
 aoX
@@ -135417,32 +135554,32 @@ aaa
 aaa
 aaa
 aaa
-acF
-aaa
-abj
 aaa
 aaa
 aaa
 aaa
+ovL
+doS
+ovL
+tIM
+blc
+jWY
+doS
 aaa
 aaa
+apv
+apv
+apv
+agE
+apv
+apv
+apv
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-abj
 aaa
 dGS
 ant
-anL
+rPU
+eiT
 aoo
 aoY
 ast
@@ -135674,31 +135811,31 @@ aaa
 aaa
 aaa
 aaa
-acF
-aaa
-abj
 aaa
 aaa
 aaa
 aaa
+doS
+ahV
+dqC
+qGl
+blc
+jWY
+doS
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-abj
+agE
+agE
+alv
+alv
+agE
+alv
+alv
+agE
+agE
 aaa
 dGS
 ant
+ala
 alm
 nmr
 apQ
@@ -135931,32 +136068,32 @@ aaa
 aaa
 aaa
 aaa
-acF
-aaa
-abj
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+doS
+jhz
+qGl
+qGl
+blc
 jWY
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-ajX
-aaa
-aaa
-aaa
-aaa
+doS
 abj
-aaa
+agD
+agE
+agF
+agF
+agD
+agF
+agF
+agE
+agD
+abj
 dGS
-akG
-als
+ant
+anT
+anY
 aoo
 apa
 apR
@@ -136188,31 +136325,31 @@ aaa
 aaa
 aaa
 aaa
-abj
-abj
-abj
-abj
-abj
-abj
-abj
-abj
+aaa
+aaa
+aaa
+aaa
 doS
-ahz
+agd
+qGl
+qGl
+cMP
+ovL
+ovL
 doS
-abj
-abj
-abj
-abj
-doS
+agE
+ail
+ail
+ail
 pHg
-doS
-abj
-abj
-abj
-abj
-abj
+ail
+ail
+ail
+agE
 dGS
-ant
+aAr
+aAr
+pvQ
 anL
 aoo
 apb
@@ -136444,33 +136581,33 @@ aaa
 aaa
 aaa
 aaa
-abj
-abj
 aaa
 aaa
-abj
 aaa
 aaa
-abj
 aaa
 doS
+oMA
+qGl
+qGl
+blc
 afb
-doS
-doS
-doS
-doS
-doS
-doS
+qtk
 afb
-doS
-aaa
-abj
-aaa
-aaa
-aaa
-aAr
-upw
-fqF
+aiE
+ahB
+ahB
+ahB
+ahB
+ahB
+ahB
+ahB
+aiE
+lpL
+san
+lpL
+anT
+afc
 aoo
 apc
 apT
@@ -136701,30 +136838,30 @@ aaa
 aaa
 aaa
 aaa
-adN
-ovL
-ovL
+aaa
+aaa
+aaa
+aaa
+aaa
+doS
+vrP
+rhX
+alw
+aly
 ovL
 ovL
 doS
-doS
-ovL
-doS
-doS
-ahz
-doS
-aio
-aiH
+agE
 aiX
 ajy
-doS
-pHg
-doS
-doS
-ovL
-doS
-doS
-ovL
+ahB
+agD
+ahB
+alH
+aiX
+agE
+dGS
+aAr
 aAr
 anp
 jOW
@@ -136956,34 +137093,34 @@ aaa
 aaa
 aaa
 aaa
-add
-add
-add
-adL
-aey
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+ovL
 doS
-afc
-dWL
-dWL
-pvQ
+ovL
 ffG
-rJF
+blc
 dWL
-dWL
-dWL
-dWL
-dWL
-dWL
-dWL
-dWL
-ffG
-rJF
-pvQ
-dWL
-dWL
-gpy
-amL
-ant
+doS
+abj
+agF
+ail
+ail
+ahB
+agF
+ahB
+ail
+ail
+agF
+abj
+dGS
+ahQ
+aeN
 anO
 jzs
 aoq
@@ -137213,34 +137350,34 @@ aaa
 aaa
 aaa
 aaa
-ade
-adx
-adO
-aed
-aez
-aeP
-jpa
-qGl
-qGl
-qGl
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+abj
+abj
+ovL
 agJ
+blc
 ajZ
-ajZ
-ajZ
-ajZ
-nEp
-ajZ
-ajZ
-ajZ
-ajZ
-pfO
-ajZ
-ajZ
-ajZ
-ajZ
-gVk
+doS
+aaa
+agF
+ahC
+ahC
+ahB
+agF
+ahB
+ahC
+ahC
+agF
+aaa
+dGS
 amM
-wvH
+anT
 alx
 aop
 aop
@@ -137470,35 +137607,35 @@ aaa
 aaa
 aaa
 aaa
-add
-add
-add
-adL
-aeA
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+ovL
 doS
-afj
-blc
-blc
-agh
+doS
+ovL
 agC
 blc
-blc
-blc
-blc
-blc
-blc
-blc
-blc
-blc
-whp
-alt
-aly
-blc
-vmP
-tIM
-amL
-ant
+knM
+doS
+aaa
+agF
+ail
+ail
+ahB
+agF
+ahB
+ail
+ail
+agF
+aaa
+dGS
 ait
+anT
+anY
 aop
 ape
 apV
@@ -137729,33 +137866,33 @@ aaa
 aaa
 aaa
 aaa
-adN
-ovL
-ovL
-ovL
-ovL
-doS
-doS
-ovL
-doS
-doS
+aaa
+aaa
+aaa
+rJk
+gtZ
+anU
+anU
+gtZ
+qGl
+blc
 ahA
 doS
-aio
-ndb
-ndb
-ajy
-doS
-ahA
-doS
-doS
-ovL
-doS
-ovL
-ovL
-amN
-ant
-anL
+abj
+agF
+ahC
+ahC
+ahB
+agD
+ahB
+ahC
+ahC
+agF
+abj
+dGS
+vTw
+anT
+anY
 xVF
 apf
 aqg
@@ -137986,32 +138123,32 @@ aaa
 aaa
 aaa
 aaa
-abj
-abj
-abj
-aaa
-abj
-aaa
-aaa
-abj
-aaa
-doS
-afb
-doS
-doS
-doS
-doS
-doS
-doS
-afb
-doS
-aaa
-abj
 aaa
 aaa
 aaa
+aaa
+ahg
+aFB
+aFB
+ahg
+qGl
+blc
+ovL
+ovL
+doS
+agE
+ail
+ail
+ahB
+pHg
+ahB
+ail
+ail
+agE
+dGS
 aAr
-ant
+aAr
+aio
 anP
 aop
 apg
@@ -138245,31 +138382,31 @@ aaa
 aaa
 aaa
 aaa
-abj
-abj
-abj
-abj
-abj
-abj
-abj
-doS
-ahA
-doS
-abj
 aaa
 aaa
-abj
+ovL
 doS
-ahA
 doS
-abj
-abj
-abj
-abj
-abj
-dGS
-ant
-anL
+ovL
+aeP
+blc
+afb
+qtk
+afb
+aiE
+ahB
+ahB
+ahB
+ahB
+ahB
+ahB
+ahB
+aiE
+lpL
+san
+lpL
+anT
+anY
 aop
 aop
 fih
@@ -138502,33 +138639,33 @@ aaa
 aaa
 aaa
 aaa
-acF
+aaa
+aaa
 aaa
 abj
-aaa
-aaa
+abj
+ovL
+dKW
+api
+ovL
+ovL
+doS
 agE
-agD
-agE
+akz
+aky
+agX
 ahB
+oMB
+aky
+akx
 agE
-agF
-agF
-agF
-agF
-agE
-ahB
-agE
-agE
-aaa
-aaa
-aaa
-aaa
+dGS
 aAr
-ann
+aAr
+adu
 anQ
 aou
-api
+aeJ
 apZ
 aqU
 asA
@@ -138759,31 +138896,31 @@ aaa
 aaa
 aaa
 aaa
-acF
 aaa
+aaa
+aaa
+ovL
+doS
+ovL
+wSO
+aez
+vmP
+ovL
 abj
-aaa
-aee
 agE
 agE
-agT
-ahC
-ahV
-ail
-ail
-ail
-ail
-ahV
-ahC
-akw
 agE
-aaa
-aaa
-aaa
-aaa
-dGS
+agE
+aiE
+agE
+agE
+agE
+agE
+abj
+aAr
+uci
 anl
-anR
+oTa
 oTa
 dhh
 aqX
@@ -139016,32 +139153,32 @@ aaa
 aaa
 aaa
 aaa
-acF
 aaa
-abj
 aaa
-aee
-agk
-agF
+aaa
+doS
+meH
+ahi
+qGl
 agU
-ahC
-ahC
-ahC
-ahC
-ahC
-ahC
-ahC
-ahC
-akx
+agg
+ovL
+ovL
+aaa
+aaa
 agE
-agE
-agF
+ahB
+ail
+ahB
 agE
 aaa
-dGS
-ant
+aaa
+aAr
+aAr
+ann
 anT
-vYz
+eDE
+aoA
 apj
 aqa
 aqV
@@ -139273,31 +139410,31 @@ aaa
 aaa
 aaa
 aaa
-acF
 aaa
-abj
 aaa
-aee
-agk
-agF
-agV
-ahC
-ahC
-aim
-aim
-aim
-aim
+aaa
+doS
+gVk
+qGl
+qGl
+agU
+qGl
+afj
+doS
+aaa
+aaa
+agE
 ajD
-ahC
-aky
-akY
-alv
-alH
-agF
+ajD
+ajD
+agE
+aaa
 aaa
 dGS
-ant
+aiG
+eDE
 anT
+eDE
 joU
 acC
 aqb
@@ -139530,31 +139667,31 @@ aaa
 aaa
 aaa
 aaa
-acF
-abj
-abj
 aaa
-agE
-agE
-agD
+aaa
+aaa
+doS
+rwY
+qGl
+qGl
 agW
-ahC
+qGl
 ahW
-agD
-aiG
-aiG
-aiG
-agD
-aka
-ahC
-akZ
-alw
-alH
-agF
+doS
+abj
 aaa
+agE
+agF
+agF
+agF
+agE
+aaa
+abj
 dGS
-ant
-anU
+rJF
+eDE
+jZc
+eDE
 lML
 acC
 aqc
@@ -139787,31 +139924,31 @@ aaa
 aaa
 aaa
 aaa
-acF
 aaa
+aaa
+aaa
+doS
+oMA
+qGl
+qGl
+agU
+qGl
+ryh
+doS
 abj
 aaa
-aee
-agk
-agF
-agX
-ahC
-ahC
-ail
-ail
-ail
-ail
-ajF
-ahC
-aky
-ala
-alv
-alH
-agF
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+abj
 dGS
-ant
+agB
+eDE
 anT
+eDE
 wEA
 acC
 aqd
@@ -140044,31 +140181,31 @@ aaa
 aaa
 aaa
 aaa
-acF
 aaa
-abj
 aaa
+aaa
+doS
 aee
 agk
-agF
+qGl
 agU
-ahC
-ahC
-ahC
-ahC
-ahC
-ahC
-ahC
-ahC
-akz
-agE
-agE
-agF
-agE
+qGl
+aeI
+doS
+abj
+abj
+abj
 aaa
+anu
+aaa
+abj
+abj
+abj
 dGS
+anK
 ant
 anT
+eDE
 aoA
 tCW
 aqe
@@ -140301,31 +140438,31 @@ aaa
 aaa
 aaa
 aaa
-acF
 aaa
-abj
 aaa
-aee
-agE
-agE
+aaa
+ovL
+doS
+ovL
+qQS
 agT
-ahC
-ahV
-aim
-aim
-aim
-aim
-xPh
-ahC
+amA
+slc
 akA
-agE
-aaa
-aaa
-aaa
-aaa
-dGS
-ant
-anT
+grB
+grB
+grB
+slc
+ahz
+akA
+grB
+grB
+grB
+slc
+slc
+age
+upw
+uQW
 eDE
 aeJ
 aea
@@ -140553,38 +140690,38 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-acF
-aaa
+abj
+abj
 abj
 aaa
 aaa
-agE
-agD
-agE
+aaa
+aaa
+abj
+abj
+abj
+ovL
+tIM
+agU
 ahE
-agE
-agF
-agF
-agF
-agF
-agE
-ahE
-agE
-agE
-aaa
-aaa
-aaa
-aaa
-aAr
+slc
+onX
 ans
-lpL
+aik
+sWI
+pMq
+akA
+vsP
+aef
+gVr
+agA
+aiF
+slc
+adZ
+anT
+eDE
 aoB
-apv
+aeJ
 aqZ
 aqZ
 asW
@@ -140808,38 +140945,38 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-abj
-abj
-abj
-abj
-abj
-abj
-abj
-grB
+adO
+fCA
+ovL
+aeb
+aeb
+aeb
+aeb
+aeb
+aeb
+aeb
+ovL
+ovL
+ovL
 ahF
-grB
-abj
-aaa
-aaa
-abj
-grB
+tnU
 ahF
-grB
-abj
-abj
-abj
-abj
-abj
-dGS
-ant
-anL
+akA
+tXb
+ans
+gEs
+sWI
+aec
+slc
+lQG
+akG
+akG
+ajF
+fiu
+akA
+aeJ
+saK
+aeJ
 aoC
 aoC
 hTD
@@ -141074,27 +141211,27 @@ aaa
 aaa
 aaa
 aaa
-abj
-abj
-aaa
-aaa
-aaa
-grB
-pMq
-grB
-grB
-grB
-grB
-grB
-grB
-pMq
-grB
 aaa
 abj
 aaa
-aaa
-aaa
-aAr
+grB
+adL
+pGg
+anW
+slc
+akY
+sWI
+aim
+sWI
+xch
+slc
+hhn
+akG
+akG
+aed
+eBn
+akA
+adL
 hbv
 als
 aoC
@@ -141332,28 +141469,28 @@ aaa
 aaa
 aaa
 aaa
-aaa
-abj
-abj
-aaa
+slc
 grB
-ahF
-grB
+slc
+adL
+pGg
+anW
+slc
 pWw
-tRa
+sWI
 ajd
 sWI
-grB
-ahF
-grB
-grB
+whp
 slc
-grB
-grB
+vBL
+afh
+afh
+eKO
+uTN
 slc
-amN
-ant
-anL
+adL
+hbv
+anW
 jJl
 apm
 arM
@@ -141588,28 +141725,28 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-abj
-grB
-aip
-vrP
-aip
-aip
-aip
-aip
-aip
-xHN
-aip
-agA
+agh
+reW
+alt
+reW
+amL
+pGg
+amL
+amz
 alG
-aip
-aip
+alG
+alG
+alG
+alG
+xHN
+alG
+alG
+alG
+alG
+alG
 amz
 amL
-ant
+hbv
 anW
 aoC
 apn
@@ -141846,26 +141983,26 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+slc
 grB
-aFB
-fiu
-fiu
+slc
+vHl
+ajX
 vcE
-fiu
-fiu
-fiu
+fPG
+vcE
+vcE
+vcE
+vcE
+vcE
 giE
 kLd
 kNa
-kNa
-kNa
-ahi
+vcE
+vcE
+vcE
 fPG
-amM
+vcE
 wvH
 anX
 aoC
@@ -142103,28 +142240,28 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+abj
 aaa
 grB
-aec
+anv
+amL
+rQS
+amB
+rQS
+pCM
+bld
+rQS
 akb
-bld
-bld
-bld
-bld
-akb
-bld
+xHN
 inH
 xyI
-ivG
+rQS
 pCM
 rQS
 amB
-amL
-ant
-anY
+rQS
+afh
+anW
 axm
 apo
 apo
@@ -142353,24 +142490,24 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+adO
+oCh
 slc
+anR
+anR
+anR
+anR
+slc
+slc
+slc
+slc
+eCj
 slc
 slc
 aeM
 slc
 slc
-slc
+akZ
 slc
 slc
 mqP
@@ -142379,7 +142516,7 @@ axm
 axm
 awY
 axm
-axm
+agV
 anv
 anZ
 axm
@@ -142612,16 +142749,16 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+abj
+abj
+abj
+abj
+pam
+akA
+sMV
+aeA
+hhG
+xlP
 slc
 aeC
 hhG
@@ -142873,13 +143010,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-slc
+abj
+grB
+jpa
+ndb
+jpa
+nWU
+akA
 aeK
 aeQ
 aeK
@@ -143130,13 +143267,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+abj
 slc
+hyL
+aka
+ltw
+qke
+akA
 aeL
 afa
 aeL
@@ -143387,13 +143524,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+abj
+akA
+slc
+grB
+grB
+akA
+akA
 aeL
 afd
 aeL
@@ -143644,11 +143781,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+anu
+abj
+abj
+abj
+anu
 aaa
 aaa
 aeL

--- a/_maps/map_files/stations/deltastation.dmm
+++ b/_maps/map_files/stations/deltastation.dmm
@@ -991,8 +991,9 @@
 /turf/simulated/floor/engine,
 /area/station/engineering/controlroom)
 "ahE" = (
-/obj/machinery/camera/autoname{
-	dir = 10
+/obj/machinery/camera{
+	c_tag = "Arrivals Fore Central";
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "arrival"
@@ -1366,8 +1367,9 @@
 	},
 /area/station/hallway/secondary/entry/south)
 "als" = (
-/obj/machinery/camera/autoname{
-	dir = 10
+/obj/machinery/camera{
+	c_tag = "Arrivals Aft Starboard";
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "arrival"
@@ -49770,8 +49772,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
-/obj/machinery/camera/autoname{
-	dir = 10
+/obj/machinery/camera{
+	c_tag = "Arrivals Fore Starboard";
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -74359,8 +74362,9 @@
 /turf/simulated/wall,
 /area/station/hallway/secondary/entry/lounge)
 "jOW" = (
-/obj/machinery/camera/autoname{
-	dir = 10
+/obj/machinery/camera{
+	c_tag = "Arrivals Aft Port";
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "arrival"
@@ -76071,6 +76075,15 @@
 	icon_state = "red"
 	},
 /area/station/security/permabrig)
+"kOD" = (
+/obj/machinery/camera{
+	c_tag = "Arrivals Aft Central";
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "arrival"
+	},
+/area/station/hallway/secondary/entry/south)
 "kPl" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -84257,9 +84270,11 @@
 /turf/simulated/floor/plasteel,
 /area/station/public/toilet/lockerroom)
 "pvf" = (
-/obj/machinery/camera/autoname,
 /obj/structure/sign/vacuum/external{
 	pixel_y = 32
+	},
+/obj/machinery/camera{
+	c_tag = "Arrivals Fore Port"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -84554,7 +84569,8 @@
 /turf/simulated/floor/plating,
 /area/station/command/office/rd)
 "pCM" = (
-/obj/machinery/camera/autoname{
+/obj/machinery/camera{
+	c_tag = "Arrivals Hall Aft";
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
@@ -88692,6 +88708,16 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/service/kitchen)
+"rVD" = (
+/obj/machinery/camera{
+	c_tag = "Arrivals Hall Fore";
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "arrival"
+	},
+/area/station/hallway/secondary/entry/east)
 "rVL" = (
 /obj/machinery/economy/vending/coffee,
 /obj/effect/turf_decal/delivery,
@@ -137057,7 +137083,7 @@ dGS
 aAr
 aAr
 anp
-jOW
+kOD
 aoo
 aoo
 aoo
@@ -142441,7 +142467,7 @@ amL
 rQS
 amB
 rQS
-pCM
+rVD
 bld
 rQS
 akb

--- a/_maps/map_files/stations/deltastation.dmm
+++ b/_maps/map_files/stations/deltastation.dmm
@@ -85248,7 +85248,7 @@
 /obj/structure/shuttle/engine/propulsion{
 	dir = 4
 	},
-/turf/simulated/floor/mineral/titanium/blue,
+/turf/simulated/wall/mineral/titanium,
 /area/shuttle/pod_1)
 "pVI" = (
 /obj/structure/plasticflaps{

--- a/_maps/map_files/stations/deltastation.dmm
+++ b/_maps/map_files/stations/deltastation.dmm
@@ -477,6 +477,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/portable/canister/air,
+/obj/structure/sign/vacuum/external{
+	pixel_y = 32
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -919,9 +922,12 @@
 	},
 /area/station/medical/storage/secondary)
 "ahg" = (
-/obj/machinery/door/airlock/external,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	id_tag = "admin_home";
+	locked = 1
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry/north)
@@ -995,7 +1001,9 @@
 "ahF" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "arrival"
+	},
 /area/station/hallway/secondary/entry/north)
 "ahQ" = (
 /obj/structure/chair/sofa/bench/right,
@@ -1064,16 +1072,13 @@
 /obj/machinery/ai_status_display{
 	pixel_y = 32
 	},
-/obj/machinery/newscaster{
-	dir = 4;
-	name = "west bump";
-	pixel_x = -28
-	},
 /obj/effect/turf_decal/delivery/hollow,
 /obj/structure/closet/emcloset,
+/obj/structure/sign/vacuum/external{
+	pixel_x = -32
+	},
 /turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "arrival"
+	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/entry/north)
 "ait" = (
@@ -1143,6 +1148,7 @@
 "aiX" = (
 /obj/structure/closet/wardrobe/mixed,
 /obj/effect/turf_decal/delivery/hollow,
+/obj/machinery/light,
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/arrival/station)
 "ajd" = (
@@ -1279,6 +1285,9 @@
 /obj/machinery/status_display{
 	pixel_y = -32
 	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/pod_1)
 "akx" = (
@@ -1371,6 +1380,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry/east)
 "alv" = (
@@ -1417,6 +1429,14 @@
 "alH" = (
 /obj/effect/turf_decal/delivery/hollow,
 /obj/structure/closet/crate/internals,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/clothing/suit/storage/hazardvest,
+/obj/item/clothing/suit/storage/hazardvest,
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/arrival/station)
 "alJ" = (
@@ -1749,9 +1769,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/sign/vacuum/external{
-	pixel_y = 32
-	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "arrival"
@@ -1855,7 +1872,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
 /area/station/hallway/secondary/entry/east)
 "anA" = (
 /obj/structure/table/reinforced,
@@ -2029,7 +2048,9 @@
 	pixel_x = 28
 	},
 /obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
 /area/station/hallway/secondary/entry/east)
 "aof" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2305,6 +2326,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -33094,6 +33118,14 @@
 	icon_state = "grimy"
 	},
 /area/station/turret_protected/aisat)
+"bRC" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/effect/landmark/spawner/late/crew,
+/obj/machinery/light,
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/arrival/station)
 "bRD" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
@@ -53801,6 +53833,13 @@
 /obj/effect/spawner/random_spawners/wall_rusted_always,
 /turf/simulated/wall,
 /area/station/maintenance/port2)
+"dbN" = (
+/obj/machinery/door/airlock/titanium{
+	id_tag = "s_docking_airlock"
+	},
+/obj/structure/fans/tiny,
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/arrival/station)
 "dbR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -61340,9 +61379,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/portable/canister/air,
-/obj/structure/sign/vacuum/external{
-	pixel_x = -32
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -65385,6 +65421,9 @@
 /obj/machinery/door/airlock/titanium{
 	id_tag = "s_docking_airlock"
 	},
+/obj/docking_port/mobile/pod{
+	dir = 8
+	},
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/pod_1)
 "eAi" = (
@@ -66257,14 +66296,6 @@
 	},
 /turf/simulated/floor/engine/o2,
 /area/station/engineering/atmos)
-"eYW" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry/north)
 "eZE" = (
 /obj/machinery/door/airlock,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -68572,9 +68603,6 @@
 	dir = 4
 	},
 /obj/machinery/light,
-/obj/structure/sign/vacuum/external{
-	pixel_y = -32
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "arrival"
 	},
@@ -68679,9 +68707,12 @@
 	},
 /area/station/science/research)
 "gtZ" = (
-/obj/machinery/door/airlock/external,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	id_tag = "admin_home";
+	locked = 1
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry/north)
@@ -69091,6 +69122,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/prison/cell_block)
+"gHk" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	locked = 1;
+	id_tag = "ferry_home"
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry/north)
 "gHB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random_spawners/oil_maybe,
@@ -69565,6 +69609,19 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/west)
+"gWD" = (
+/obj/machinery/door/airlock/external{
+	locked = 1;
+	id_tag = "ferry_home"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry/north)
 "gXp" = (
 /obj/machinery/door/airlock/security{
 	name = "Detective"
@@ -71797,8 +71854,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "arrival"
+	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/entry/east)
 "inM" = (
@@ -76563,6 +76619,18 @@
 "lfg" = (
 /turf/simulated/wall,
 /area/station/public/pet_store)
+"lfH" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry/south)
 "lfU" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1;
@@ -77566,6 +77634,15 @@
 /obj/machinery/atmospherics/portable/pump,
 /turf/simulated/floor/plasteel,
 /area/station/science/toxins/mixing)
+"lKr" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry/north)
 "lKI" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
@@ -77758,6 +77835,7 @@
 /obj/effect/spawner/random/engineering/tools,
 /obj/effect/spawner/random/engineering/toolbox,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/suit/storage/hazardvest,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "brown"
@@ -78595,6 +78673,14 @@
 /obj/machinery/suit_storage_unit/security/secure,
 /turf/simulated/floor/plasteel,
 /area/station/security/armory/secure)
+"mra" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "arrival"
+	},
+/area/station/hallway/secondary/entry/south)
 "mrs" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -79646,6 +79732,18 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/command/office/ntrep)
+"mUk" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry/north)
 "mUz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -80784,6 +80882,13 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central/se)
+"nAP" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
+/turf/simulated/floor/plasteel{
+	icon_state = "arrival"
+	},
+/area/station/hallway/secondary/entry/south)
 "nBa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -80886,6 +80991,12 @@
 	icon_state = "whitepurple"
 	},
 /area/station/science/toxins/mixing)
+"nDl" = (
+/obj/item/beacon,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/secondary/entry/south)
 "nDu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -83070,6 +83181,18 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/medical/cloning)
+"oOV" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry/north)
 "oOW" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/delivery,
@@ -84194,6 +84317,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -86424,6 +86550,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
+"qQv" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "arrival"
+	},
+/area/station/hallway/secondary/entry/north)
 "qQx" = (
 /obj/machinery/economy/vending/plasmaresearch,
 /turf/simulated/floor/plasteel,
@@ -87115,12 +87249,15 @@
 	},
 /area/station/security/brig)
 "reW" = (
-/obj/machinery/door/airlock/external,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	id_tag = "specops_home";
+	locked = 1
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry/east)
@@ -89021,6 +89158,14 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/supermatter)
+"seh" = (
+/obj/structure/closet/wardrobe/mixed,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/arrival/station)
 "seH" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -91880,6 +92025,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/reception)
+"tEQ" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/arrival/station)
 "tFK" = (
 /obj/item/soap/nanotrasen,
 /obj/machinery/light/small{
@@ -94154,6 +94305,14 @@
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/command/customs)
+"uSO" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "arrival"
+	},
+/area/station/hallway/secondary/entry/east)
 "uTw" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 6
@@ -94208,6 +94367,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/portable/canister/air,
+/obj/structure/sign/vacuum/external{
+	pixel_y = -32
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -95711,6 +95873,14 @@
 	icon_state = "neutral"
 	},
 /area/station/maintenance/starboard)
+"vNK" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry/north)
 "vNM" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
@@ -98556,6 +98726,18 @@
 	icon_state = "redyellowfull"
 	},
 /area/station/medical/break_room)
+"xty" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry/south)
 "xtS" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
@@ -99121,7 +99303,8 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralfull"
+	dir = 8;
+	icon_state = "arrival"
 	},
 /area/station/hallway/secondary/entry/east)
 "xIm" = (
@@ -99220,6 +99403,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/gravitygenerator)
+"xJy" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/effect/landmark/spawner/late/crew,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/arrival/station)
 "xJD" = (
 /obj/machinery/newscaster{
 	dir = 4;
@@ -132735,7 +132928,7 @@ aaa
 aaa
 aaa
 ovL
-eYW
+tRa
 iUU
 aaa
 aaa
@@ -132992,7 +133185,7 @@ aaa
 anu
 abj
 doS
-tRa
+vNK
 doS
 abj
 anu
@@ -133249,7 +133442,7 @@ aaa
 abj
 ovL
 ovL
-eYW
+tRa
 ovL
 ovL
 abj
@@ -134273,15 +134466,15 @@ aaa
 aaa
 aaa
 xgt
-afb
-qtk
-afb
+gHk
+mUk
+gWD
 qGl
 qGl
 mFy
-afb
 qtk
-afb
+mUk
+qtk
 acF
 acF
 acF
@@ -134289,9 +134482,9 @@ acF
 acF
 acF
 acF
-lpL
 san
-lpL
+lfH
+san
 pQv
 afJ
 jOW
@@ -135047,7 +135240,7 @@ aeb
 ovL
 ovL
 ovL
-ahF
+qQv
 adN
 ahF
 ovL
@@ -136592,9 +136785,9 @@ qGl
 qGl
 blc
 afb
-qtk
+mUk
 afb
-aiE
+dbN
 ahB
 ahB
 ahB
@@ -136602,9 +136795,9 @@ ahB
 ahB
 ahB
 ahB
-aiE
+dbN
 lpL
-san
+lfH
 lpL
 anT
 afc
@@ -136852,7 +137045,7 @@ ovL
 ovL
 doS
 agE
-aiX
+seh
 ajy
 ahB
 agD
@@ -137871,7 +138064,7 @@ aaa
 aaa
 rJk
 gtZ
-anU
+lKr
 anU
 gtZ
 qGl
@@ -138137,13 +138330,13 @@ ovL
 ovL
 doS
 agE
-ail
+xJy
 ail
 ahB
 pHg
 ahB
 ail
-ail
+bRC
 agE
 dGS
 aAr
@@ -138391,9 +138584,9 @@ ovL
 aeP
 blc
 afb
-qtk
+oOV
 afb
-aiE
+dbN
 ahB
 ahB
 ahB
@@ -138401,9 +138594,9 @@ ahB
 ahB
 ahB
 ahB
-aiE
+dbN
 lpL
-san
+xty
 lpL
 anT
 anY
@@ -139167,9 +139360,9 @@ ovL
 aaa
 aaa
 agE
-ahB
+tEQ
 ail
-ahB
+tEQ
 agE
 aaa
 aaa
@@ -139689,7 +139882,7 @@ aaa
 abj
 dGS
 rJF
-eDE
+nDl
 jZc
 eDE
 lML
@@ -140196,7 +140389,7 @@ abj
 abj
 abj
 aaa
-anu
+adO
 aaa
 abj
 abj
@@ -140958,7 +141151,7 @@ aeb
 ovL
 ovL
 ovL
-ahF
+qQv
 tnU
 ahF
 akA
@@ -140974,9 +141167,9 @@ akG
 ajF
 fiu
 akA
-aeJ
+mra
 saK
-aeJ
+nAP
 aoC
 aoC
 hTD
@@ -142252,12 +142445,12 @@ pCM
 bld
 rQS
 akb
-xHN
+uSO
 inH
 xyI
 rQS
 pCM
-rQS
+amL
 amB
 rQS
 afh

--- a/_maps/map_files/stations/deltastation.dmm
+++ b/_maps/map_files/stations/deltastation.dmm
@@ -65425,6 +65425,8 @@
 	id_tag = "s_docking_airlock"
 	},
 /obj/docking_port/mobile/pod{
+	id = "pod1";
+	name = "escape pod 1";
 	dir = 8
 	},
 /turf/simulated/floor/mineral/titanium/blue,


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Updates and remaps the Arrivals section of Deltastation, completely replacing the majority of it with a new layout, look, and feel.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

I, and at least a few others, consider Delta's arrivals to be the worst of all the stations currently in the game. It takes up an absurd amount of space, and the docking arms are just glass tubes full of atrocious wallbumps and far too many hazard decals. This addresses those concerns, making the arrivals area visually smaller, while adding a new aesthetic and making it more useful, while retaining all the features the previous version had. (If there are any wallbumps in here that I made, please yell at me.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

The entirety of Arrivals
![image](https://github.com/user-attachments/assets/f46eff15-4c6e-443c-a9b4-25e2a671fa74)

North Arrivals
![image](https://github.com/user-attachments/assets/87b054a7-853c-4c91-b18e-45f0b80ae731)

Arrivals East
![image](https://github.com/user-attachments/assets/8fc460a3-8b40-401f-8119-38bfbc4fef41)

South Arrivals
![image](https://github.com/user-attachments/assets/99649f70-fc07-412b-8bc3-c4c19c30e205)

Arrivals Shuttle
![image](https://github.com/user-attachments/assets/b4101205-d5b3-4785-94fc-43fd19aa4b81)


<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing

Spun up a server, ran around arrivals and marvelled at how it wasn't all dangerous glass tubes. Lit command on fire so they would call every shuttle, and I saw them dock and undock properly. Confirmed I could flee in terror on the escape pod.

<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [ X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
tweak: Almost completely remapped Deltastation arrivals.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->