### PR TITLE
Creates the Ruin of Lust

### DIFF
--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_lust.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_lust.dmm
@@ -1,0 +1,147 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"c" = (
+/turf/simulated/floor/lava/mapping_lava,
+/area/lavaland/surface/outdoors)
+"i" = (
+/obj/structure/table/wood/fancy/purple,
+/turf/simulated/floor/carpet/purple,
+/area/ruin/powered/lust)
+"j" = (
+/obj/structure/fans/tiny/invisible,
+/obj/machinery/door/airlock/wood/glass,
+/turf/simulated/floor/carpet/purple,
+/area/ruin/powered/lust)
+"o" = (
+/turf/simulated/floor/carpet/purple,
+/area/ruin/powered/lust)
+"p" = (
+/turf/simulated/wall/indestructible/wood{
+	desc = "This building looks cozy. You WANT to go in."
+	},
+/area/ruin/powered/lust)
+"w" = (
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/purple,
+/area/ruin/powered/lust)
+"A" = (
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"G" = (
+/obj/effect/baseturf_helper/lava/mapping_lava,
+/turf/simulated/floor/carpet/purple,
+/area/ruin/powered/lust)
+
+(1,1,1) = {"
+a
+a
+c
+c
+c
+c
+c
+c
+a
+a
+"}
+(2,1,1) = {"
+a
+c
+c
+p
+p
+p
+p
+c
+c
+a
+"}
+(3,1,1) = {"
+c
+c
+p
+p
+o
+o
+p
+p
+c
+a
+"}
+(4,1,1) = {"
+c
+p
+p
+o
+o
+o
+o
+p
+p
+A
+"}
+(5,1,1) = {"
+c
+p
+i
+w
+o
+G
+o
+o
+j
+A
+"}
+(6,1,1) = {"
+c
+p
+p
+o
+o
+o
+o
+p
+p
+A
+"}
+(7,1,1) = {"
+c
+c
+p
+p
+o
+o
+p
+p
+c
+a
+"}
+(8,1,1) = {"
+a
+c
+c
+p
+p
+p
+p
+c
+c
+a
+"}
+(9,1,1) = {"
+a
+a
+c
+c
+c
+c
+c
+c
+a
+a
+"}

--- a/code/datums/ruins/lavaland.dm
+++ b/code/datums/ruins/lavaland.dm
@@ -82,6 +82,12 @@
 	description = "If you eat enough, then eating will be all that you do."
 	suffix = "lavaland_surface_gluttony.dmm"
 
+/datum/map_template/ruin/lavaland/sin/lust
+	name = "Ruin of Lust"
+	id = "lust"
+	description = "Despite all rational thought, you really WANT to read it..."
+	suffix = "lavaland_surface_lust.dmm"
+
 /datum/map_template/ruin/lavaland/sin/greed
 	name = "Ruin of Greed"
 	id = "greed"

--- a/code/game/area/areas/ruins/lavaland_areas.dm
+++ b/code/game/area/areas/ruins/lavaland_areas.dm
@@ -46,7 +46,8 @@
 /area/ruin/powered/seedvault
 	icon_state = "yellow"
 
-
+/area/ruin/powered/lust
+	icon_state = "yellow"
 //Xeno Nest
 
 /area/ruin/unpowered/xenonest

--- a/config/example/config.toml
+++ b/config/example/config.toml
@@ -726,6 +726,7 @@ active_lava_ruins = [
 	##SIN
 	"_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_envy.dmm",
 	"_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_gluttony.dmm",
+	"_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_lust.dmm",
 	# Greed blacklisted on production because its reward (dice) has a 1/20 chance of making you a wizard
 	"_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_greed.dmm",
 	"_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_pride.dmm",


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

This PR adds the Lust Ruin, the sixth Sin ruin. The intention here is to fill the void of the sin ruins (Wrath coming Soon™) while avoiding the breaking of Rule 9 and inspiration of players to break Rule 9 via this ruin. 
It's a small, wooden library. It's carpeted and stocked with books. One stands out: The Unholy Compendium, a dreadful collection of **thankfully forgotten** literature.  Complete a bookcase related minigame (Current iteration: sorting random, book database books into the categories they were assigned by the author.) and the tome is yours, but the price isn't physical in this ruin...

Current relic effects: Upon reading the book, gain a unique spell that knockdowns sentient creatures you can see for a very short amount of time in a very flavor texty way. Has negligible effects on sentient Megafauna (since it's miners that find it, they should be able to use it on more than the crew as a funny haha.)

To Do (Keep drafted until done!): 

- [x] Create the structure and observe it spawning in a lavaland generation.
- [ ] Sprite the Unholy Compendium (Working title!).
- [ ] Create the Unholy Compendium.
- [ ] Create book minigame.
- [ ] Final polishing.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

It's always irked me that the sin ruins are incomplete. [The person who created them in 2016 was planning on adding more, but went inactive.](https://github.com/tgstation/tgstation/pull/15708) More content in Lavaland is great on it's own. Those guys are starving down there!
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
As seen in map editor, pre-bookshelves + loot
![image_2024-10-27_172337989](https://github.com/user-attachments/assets/ce35e9bc-3bed-4884-bbf4-b5af3d905664)
As seen in game, pre-bookshelves + loot
![image_2024-10-27_222503651](https://github.com/user-attachments/assets/b496d87d-f518-4d1e-9d02-74384e83eb22)
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing

Ruin generates in Lavaland (see above screenshot.)
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

![image_2024-10-27_151545749](https://github.com/user-attachments/assets/345d2634-b74b-4d01-bf4f-0cefcbf04467)

  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
add: The Ruin of Lust is manifested! It took on the form of the previously well-hidden past of the Librarians. Find it in lavaland!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
### SUGGESTIONS VERY WELCOME!

The nature of this ruin is obviously that of dancing around the rules and keeping it silly, so the current iteration is that of a community reference most are familiar with. However, I would be glad to change things. The Unholy Compendium is the main WIP aspect of this; balance perspectives are extremely welcome.