### PR TITLE
Warden gloves made indestructible

### DIFF
--- a/code/modules/martial_arts/krav_maga.dm
+++ b/code/modules/martial_arts/krav_maga.dm
@@ -172,6 +172,7 @@
 	icon_state = "fightgloves"
 	item_state = "fightgloves"
 	dyeable = FALSE
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 
 /obj/item/clothing/gloves/color/black/krav_maga/sec/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
Added indestructible flags to warden gloves, since they're a high-value target

## What Does This PR Do

The Warden's Krav Maga gloves can no longer be destroyed by explosives, lava, acid, or other methods of removing items without dusting them.

## Why It's Good For The Game

We've decided that high-value items should be difficult to destroy, only allowing them to be dusted in the Supermatter Crystal or via Supermatter Shard. This prevents someone from redtexting if the Warden is blown up via maxcap, killed via acid tomato, or otherwise falls afoul of a hijacker.

## Testing

Opened up local, blew up all high-value target storage machines with C4, verified that all high-value items survived the blast except for the Krav Maga gloves, which were destroyed. Also maxcapped the CMO office and Warden office to verify that this was not a C4-specific interaction. Made change. Used C4 to destroy Warden's locker, got gloves back.

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  
## Changelog

:cl:
fix: Warden's Krav Maga are now resistant to destruction, similar to other high-value items
/:cl:

## Comments

Tried blowing up all the other high-value items, and I found out that while the secret documents are themselves bombproof, if the folder containing them is destroyed, the secret documents inside are destroyed. Going to need a more detailed dive into the code to make folders act like regular item holders and destroy only destructible items when they're destroyed.