### PR TITLE
[s] AI can no longer see through camera bugs or to the syndicate research base

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/syndie_space_base.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/syndie_space_base.dmm
@@ -1347,7 +1347,8 @@
 /obj/machinery/camera/emp_proof{
 	c_tag = "Test Lab South";
 	network = list("SyndicateTestLab");
-	dir = 10
+	dir = 10;
+	non_chunking_camera = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -1944,7 +1945,8 @@
 /obj/machinery/camera/emp_proof{
 	c_tag = "Test Lab East";
 	network = list("SyndicateTestLab");
-	dir = 8
+	dir = 8;
+	non_chunking_camera = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -3538,7 +3540,8 @@
 "tS" = (
 /obj/machinery/camera/emp_proof{
 	c_tag = "Test Lab North";
-	network = list("SyndicateTestLab")
+	network = list("SyndicateTestLab");
+	non_chunking_camera = 1
 	},
 /turf/simulated/floor/engine,
 /area/ruin/unpowered/syndicate_space_base/testlab)
@@ -4639,7 +4642,8 @@
 /obj/machinery/camera/emp_proof{
 	c_tag = "Test Lab West";
 	dir = 5;
-	network = list("SyndicateTestLab")
+	network = list("SyndicateTestLab");
+	non_chunking_camera = 1
 	},
 /turf/simulated/floor/engine,
 /area/ruin/unpowered/syndicate_space_base/testlab)

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -40,6 +40,8 @@
 	var/detectTime = 0
 	var/area/station/ai_monitored/area_motion = null
 	var/alarm_delay = 30 // Don't forget, there's another 3 seconds in queueAlarm()
+	/// If this camera doesnt add to camera chunks. Used by camera bugs.
+	var/non_chunking_camera = FALSE
 
 /obj/machinery/camera/Initialize(mapload, should_add_to_cameranet = TRUE)
 	. = ..()

--- a/code/game/objects/items/devices/camera_bug.dm
+++ b/code/game/objects/items/devices/camera_bug.dm
@@ -55,7 +55,7 @@
 	icon = 'icons/obj/device.dmi'
 	icon_state = "wall_bug"
 	w_class = WEIGHT_CLASS_TINY
-	var/obj/machinery/camera/portable/camera
+	var/obj/machinery/camera/portable/camera_bug/camera
 	var/index = "REPORT THIS TO CODERS"
 
 /obj/item/wall_bug/Initialize(mapload, obj/item/camera_bug/the_bug)
@@ -81,9 +81,12 @@
 	camera_bug.connections++
 	index = camera_bug.connections
 
-	camera = new /obj/machinery/camera/portable(src)
+	camera = new /obj/machinery/camera/portable/camera_bug(src)
 	camera.network = list("camera_bug[camera_bug.UID()]")
 	camera.c_tag = "Hidden Camera [index]"
+
+/obj/machinery/camera/portable/camera_bug
+	non_chunking_camera = TRUE
 
 /obj/item/paper/camera_bug
 	name = "Camera Bug Guide"

--- a/code/modules/mob/living/silicon/ai/freelook/chunk.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/chunk.dm
@@ -20,6 +20,8 @@
 /datum/camerachunk/proc/add_camera(obj/machinery/camera/cam)
 	if(active_cameras[cam] || inactive_cameras[cam])
 		return
+	if(cam.non_chunking_camera)
+		return
 	// Register all even though it is active/inactive. Won't get called incorrectly
 	RegisterSignal(cam, COMSIG_CAMERA_OFF, PROC_REF(deactivate_camera), TRUE)
 	RegisterSignal(cam, COMSIG_CAMERA_ON, PROC_REF(activate_camera), TRUE)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

AI can no longer see through camera bugs.
Add a variable to cameras that prevent cameras being added to the camera chunk system. Use this on cameras you don't want the AI to see through
AI can no longer see through cameras on the syndicate space base.

## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Please sir let us use camera bugs without instantly outing ourselves.

## Testing

<!-- How did you test the PR, if at all? -->
tested camera bugs worked
tested could see through them
tested ai could not see
tested advanced camera console could not see
tested that normal cameras worked
tested could not track through camea bug cameras as AI
<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: AI can no longer see through camera bugs or to the syndicate research base
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
