### PR TITLE
dmdoc: Some cleanups.

### DIFF
--- a/code/__DEFINES/dcs/atom_signals.dm
+++ b/code/__DEFINES/dcs/atom_signals.dm
@@ -28,17 +28,17 @@
 #define COMSIG_ATOM_UPDATE_NAME "atom_update_name"
 ///from base of [/atom/proc/update_desc]: (updates)
 #define COMSIG_ATOM_UPDATE_DESC "atom_update_desc"
-///from base of [/atom/update_icon]: ()
+///from base of [/atom/proc/update_icon]: ()
 #define COMSIG_ATOM_UPDATE_ICON "atom_update_icon"
 	/// If returned from [COMSIG_ATOM_UPDATE_ICON] it prevents the atom from updating its icon state.
 	#define COMSIG_ATOM_NO_UPDATE_ICON_STATE UPDATE_ICON_STATE
 	/// If returned from [COMSIG_ATOM_UPDATE_ICON] it prevents the atom from updating its overlays.
 	#define COMSIG_ATOM_NO_UPDATE_OVERLAYS UPDATE_OVERLAYS
-///Sent after [atom/update_icon_state] is called by [/atom/update_icon]: ()
+///Sent after [/atom/proc/update_icon_state] is called by [/atom/proc/update_icon]: ()
 #define COMSIG_ATOM_UPDATE_ICON_STATE "atom_update_icon_state"
-///Sent after [atom/update_overlays] is called by [/atom/update_icon]: (list/new_overlays)
+///Sent after [/atom/proc/update_overlays] is called by [/atom/proc/update_icon]: (list/new_overlays)
 #define COMSIG_ATOM_UPDATE_OVERLAYS "atom_update_overlays"
-///from base of [/atom/update_icon]: (signalOut, did_anything)
+///from base of [/atom/proc/update_icon]: (signalOut, did_anything)
 #define COMSIG_ATOM_UPDATED_ICON "atom_updated_icon"
 ///from base of atom/Entered(): (atom/movable/entering, /atom)
 #define COMSIG_ATOM_ENTERED "atom_entered"
@@ -114,7 +114,7 @@
 	#define COMPONENT_NO_ATTACK_HAND (1<<0)								//works on all 3.
 //This signal return value bitflags can be found in __DEFINES/misc.dm
 
-///called on /living, when pull is attempted, but before it completes, from base of [/mob/living/start_pulling]: (atom/movable/thing, force)
+///called on /living, when pull is attempted, but before it completes, from base of [/mob/living/proc/start_pulling]: (atom/movable/thing, force)
 #define COMSIG_LIVING_TRY_PULL "living_try_pull"
 	#define COMSIG_LIVING_CANCEL_PULL (1 << 0)
 

--- a/code/__DEFINES/dcs/item_signals.dm
+++ b/code/__DEFINES/dcs/item_signals.dm
@@ -21,7 +21,7 @@
 #define COMSIG_ITEM_BEING_ATTACKED "item_being_attacked"
 ///from base of obj/item/afterattack(): (atom/target, mob/user, params)
 #define COMSIG_ITEM_AFTERATTACK "item_afterattack"
-///called on [/obj/item] before unequip from base of [mob/proc/doUnEquip]: (force, atom/newloc, no_move, invdrop, silent)
+///called on [/obj/item] before unequip from base of [/mob/proc/unEquip]: (force, atom/newloc, no_move, invdrop, silent)
 #define COMSIG_ITEM_PRE_UNEQUIP "item_pre_unequip"
 	///only the pre unequip can be cancelled
 	#define COMPONENT_ITEM_BLOCK_UNEQUIP (1<<0)
@@ -44,9 +44,9 @@
 ///from base of [/obj/item/proc/tool_attack_chain]: (atom/tool, mob/user)
 #define COMSIG_TOOL_ATTACK "tool_attack"
 	#define COMPONENT_CANCEL_TOOLACT (1<<0)
-/// Called by /obj/item/assembly/signaler(called_from_radio)
+/// Called by [/obj/item/assembly/proc/pulse]
 #define COMSIG_ASSEMBLY_PULSED "item_assembly_pulsed"
-///from [/mob/living/carbon/human/Move]: ()
+///from [/mob/living/carbon/human/proc/Move]: ()
 #define COMSIG_SHOES_STEP_ACTION "shoes_step_action"
 
 // /obj/item/implant

--- a/code/__DEFINES/tgs.dm
+++ b/code/__DEFINES/tgs.dm
@@ -83,7 +83,7 @@
 #define TGS_EVENT_COMPILE_START 8
 /// When a compile is cancelled. No parameters.
 #define TGS_EVENT_COMPILE_CANCELLED 9
-/// When a compile fails. Parameters: Game directory path, [TRUE]/[FALSE] based on if the cause for failure was DMAPI validation.
+/// When a compile fails. Parameters: Game directory path, `TRUE`/`FALSE` based on if the cause for failure was DMAPI validation.
 #define TGS_EVENT_COMPILE_FAILURE 10
 /// When a compile operation completes. Note, this event fires before the new .dmb is loaded into the watchdog. Consider using the [TGS_EVENT_DEPLOYMENT_COMPLETE] instead. Parameters: Game directory path.
 #define TGS_EVENT_COMPILE_COMPLETE 11
@@ -242,13 +242,13 @@
 	var/friendly_name
 	/// Name of the chat connection. This is the IRC server address or the Discord guild.
 	var/connection_name
-	/// [TRUE]/[FALSE] based on if the server operator has marked this channel for game admins only.
+	/// `TRUE`/`FALSE` based on if the server operator has marked this channel for game admins only.
 	var/is_admin_channel
-	/// [TRUE]/[FALSE] if the channel is a private message channel for a [/datum/tgs_chat_user].
+	/// `TRUE`/`FALSE` if the channel is a private message channel for a [/datum/tgs_chat_user].
 	var/is_private_channel
 	/// Tag string associated with the channel in TGS.
 	var/custom_tag
-	/// [TRUE]/[FALSE] if the channel supports embeds.
+	/// `TRUE`/`FALSE` if the channel supports embeds.
 	var/embeds_supported
 
 // Represents a chat user

--- a/code/__DEFINES/turfs.dm
+++ b/code/__DEFINES/turfs.dm
@@ -1,6 +1,6 @@
 /// Turf will be passable if density is 0
 #define TURF_PATHING_PASS_DENSITY 0
-/// Turf will be passable depending on [CanPathfindPass] return value
+/// Turf will be passable depending on [/atom/proc/CanPathfindPass] return value
 #define TURF_PATHING_PASS_PROC 1
 /// Turf is never passable
 #define TURF_PATHING_PASS_NO 2

--- a/code/__HELPERS/paths/path.dm
+++ b/code/__HELPERS/paths/path.dm
@@ -41,7 +41,7 @@
  * * end: What we're trying to path to. It doesn't matter if this is a turf or some other atom, we're gonna just path to the turf it's on anyway
  * * max_distance: The maximum number of steps we can take in a given path to search (default: 30, 0 = infinite)
  * * mintargetdistance: Minimum distance to the target before path returns, could be used to get near a target, but not right to it - for an AI mob with a gun, for example.
- * * age: How old a path map can be before we'll avoid reusing it. Use the defines found in [code/__DEFINES/path.dm], values larger then MAP_REUSE_SLOWEST will be discarded
+ * * age: How old a path map can be before we'll avoid reusing it. Use the defines found in [code/__DEFINES/path_defines.dm], values larger then MAP_REUSE_SLOWEST will be discarded
  * * access: A list representing what access we have and what doors we can open.
  * * simulated_only: Whether we consider tur fs without atmos simulation (AKA do we want to ignore space)
  * * exclude: If we want to avoid a specific turf, like if we're a mulebot who already got blocked by some turf

--- a/code/__HELPERS/sorts/__main.dm
+++ b/code/__HELPERS/sorts/__main.dm
@@ -306,14 +306,15 @@ reverse a descending sequence without violating stability.
  * Like gallopLeft, except that if the range contains an element equal to
  * key, gallopRight returns the index after the rightmost equal element.
  *
- * @param key the key whose insertion point to search for
- * @param a the array in which to search
- * @param base the index of the first element in the range
- * @param len the length of the range; must be > 0
- * @param hint the index at which to begin the search, 0 <= hint < n.
- *	 The closer hint is to the result, the faster this method will run.
- * @param c the comparator used to order the range, and to search
- * @return the int k,  0 <= k <= n such that a[b + k - 1] <= key < a[b + k]
+ * Returns the int `k`, `0 <= k <= n` such that `a[b + k - 1] <= key < a[b + k]`.
+ *
+ * Arguments:
+ * - key: the key whose insertion point to search for
+ * - a: the array in which to search
+ * - base: the index of the first element in the range
+ * - len: the length of the range; must be > 0
+ * - hint: the index at which to begin the search, `0 <= hint < n`. The closer hint is to the result, the faster this method will run.
+ * - c: the comparator used to order the range, and to search
  */
 /datum/sortInstance/proc/gallopRight(key, base, len, hint)
 	//ASSERT(len > 0 && hint >= 0 && hint < len)

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1984,11 +1984,11 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 /**
   * HTTP Get (Powered by RUSTG)
   *
-  * This proc should be used as a replacement for [world.Export()] due to an underlying issue with it.
+  * This proc should be used as a replacement for [/world/proc/Export] due to an underlying issue with it.
   * See: https://www.byond.com/forum/post/2772166
   * The one thing you will need to be aware of is that this no longer wraps the response inside a "file", so anything that relies on a file2text() unwrap will need tweaking.
   * RUST HTTP also has better support for HTTPS as well as weird quirks with modern webservers.
-  * Returns an assoc list that follows the standard [world.Export()] format (https://secure.byond.com/docs/ref/index.html#/world/proc/Export), with the above exception
+  * Returns an assoc list that follows the standard [/world/proc/Export] format (https://secure.byond.com/docs/ref/index.html#/world/proc/Export), with the above exception
   *
   * Arguments:
   * * url - URL to GET

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -752,7 +752,7 @@
 
 #define HALLUCINATE_COOLDOWN_MIN 20 SECONDS
 #define HALLUCINATE_COOLDOWN_MAX 50 SECONDS
-/// This is multiplied with [/mob/var/hallucination] to determine the final cooldown. A higher hallucination value means shorter cooldown.
+/// This is multiplied with [/datum/status_effect/transient/var/strength] to determine the final cooldown. A higher hallucination value means shorter cooldown.
 #define HALLUCINATE_COOLDOWN_FACTOR 0.003
 /// Percentage defining the chance at which an hallucination may spawn past the cooldown.
 #define HALLUCINATE_CHANCE 80

--- a/code/game/machinery/computer/robot_control.dm
+++ b/code/game/machinery/computer/robot_control.dm
@@ -38,7 +38,7 @@
   * Returns TRUE if a robot will show up in the console
   * Returns FALSE if a robot will not show up in the console
   * Arguments:
-  * * R - The [mob/living/silicon/robot] to be checked
+  * * R - The [/mob/living/silicon/robot] to be checked
   */
 /obj/machinery/computer/robotics/proc/console_shows(mob/living/silicon/robot/R)
 	if(!istype(R))
@@ -57,8 +57,8 @@
   * Returns TRUE if a user can send the command (does not guarantee it will work)
   * Returns FALSE if a user cannot
   * Arguments:
-  * * user - The [mob/user] to be checked
-  * * R - The [mob/living/silicon/robot] to be checked
+  * * user - The [/mob] to be checked
+  * * R - The [/mob/living/silicon/robot] to be checked
   * * telluserwhy - Bool of whether the user should be sent a to_chat message if they don't have access
   */
 /obj/machinery/computer/robotics/proc/can_control(mob/user, mob/living/silicon/robot/R, telluserwhy = FALSE)
@@ -100,7 +100,7 @@
   * Returns TRUE if a user is a traitor AI, or aghost
   * Returns FALSE otherwise
   * Arguments:
-  * * user - The [mob/user] to be checked
+  * * user - The [/mob] to be checked
   */
 /obj/machinery/computer/robotics/proc/can_hack_any(mob/user)
 	if(!istype(user))
@@ -117,8 +117,8 @@
   * Returns TRUE if a user can hack the specific cyborg
   * Returns FALSE if a user cannot
   * Arguments:
-  * * user - The [mob/user] to be checked
-  * * R - The [mob/living/silicon/robot] to be checked
+  * * user - The [/mob] to be checked
+  * * R - The [/mob/living/silicon/robot] to be checked
   */
 /obj/machinery/computer/robotics/proc/can_hack(mob/user, mob/living/silicon/robot/R)
 	if(!can_hack_any(user))

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -44,7 +44,7 @@ GLOBAL_DATUM_INIT(welding_sparks, /mutable_appearance, mutable_appearance('icons
 	var/stealthy_audio = FALSE
 	/// Allows you to override the attack animation with an attack effect
 	var/attack_effect_override
-	/// Used in attackby() to say how something was attacked "[x] has been [z.attack_verb] by [y] with [z]"
+	/// Used in attackby() to say how something was attacked `"[x] has been [z.attack_verb] by [y] with [z]"`
 	var/list/attack_verb
 	/// Determines how big/small items are to fit in storage containers
 	var/w_class = WEIGHT_CLASS_NORMAL

--- a/code/game/objects/items/dyeing.dm
+++ b/code/game/objects/items/dyeing.dm
@@ -2,7 +2,7 @@
  * Updates an item's appearance to mimic the appearance of another item in the dye_registry's dictionary
  * what types of items (beanie, jumpsuit, shoes, etc) src is dyed into depends on the dye_key unless an
  * overidden dye_key is specified. For example if our dye_key is DYE_REGISTRY_UNDER and we specify to dye to
- * DYE_RED, our item's appearance would then mimic /obj/item/clothing/under/color/red; see [dye_registry.dm] for this dictionary
+ * DYE_RED, our item's appearance would then mimic /obj/item/clothing/under/color/red; see [code/_globalvars/lists/dye_registry.dm] for this dictionary
  *
  * once everything is updated, the target type path that we dyed the item into is returned
  *

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -120,8 +120,8 @@
 /** Checks whether this stack can merge itself into another stack.
  *
  * Arguments:
- * - [check][/obj/item/stack]: The stack to check for mergeability.
- * - [inhand][boolean]: Whether or not the stack to check should act like it's in a mob's hand.
+ * - check: The [/obj/item/stack] to check for mergeability.
+ * - inhand: `TRUE` if the stack should check should act like it's in a mob's hand, `FALSE` otherwise.
  */
 /obj/item/stack/proc/can_merge(obj/item/stack/check, inhand = FALSE)
 	// We don't only use istype here, since that will match subtypes, and stack things that shouldn't stack

--- a/code/game/objects/items/weapons/batons.dm
+++ b/code/game/objects/items/weapons/batons.dm
@@ -1,7 +1,7 @@
 /**
   * # Police Baton
   *
-  * Knocks down the hit mob when not on harm intent and when [/obj/item/melee/classic_baton/on] is TRUE
+  * Knocks down the hit mob when not on harm intent and when [/obj/item/melee/classic_baton/var/on] is `TRUE`.
   *
   * A non-lethal attack has a cooldown to avoid spamming
   */

--- a/code/game/objects/items/weapons/lighters.dm
+++ b/code/game/objects/items/weapons/lighters.dm
@@ -18,7 +18,7 @@
 	var/next_on_message
 	/// Cooldown until the next turned off message/sound can be activated
 	var/next_off_message
-	/// Our lighter color suffix. => [base_icon_state]-[lightercolor] => lighter-r
+	/// Our lighter color suffix. => `[base_icon_state]-[lightercolor]` => `lighter-r`
 	var/lighter_color
 	var/is_a_zippo = FALSE
 
@@ -383,7 +383,7 @@
 	lit = TRUE
 	w_class = WEIGHT_CLASS_BULKY //to prevent it going to pockets
 	is_unathi_fire = TRUE
-	
+
 /obj/item/match/unathi/cigarette_lighter_act(mob/living/target, mob/living/user, obj/item/direct_attackby_item)
 	var/obj/item/clothing/mask/cigarette/cig = ..()
 	if(!cig)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -42,7 +42,7 @@
 	var/door_hinge_x = -6.5
 	/// Amount of time it takes for the door animation to play
 	var/door_anim_time = 2.0 // set to 0 to make the door not animate at all
-	/// Whether this closet uses a door overlay at all. If FALSE, it'll switch to a system where the entire icon_state is replaced with [icon_state]_open instead.
+	/// Whether this closet uses a door overlay at all. If `FALSE`, it'll switch to a system where the entire icon_state is replaced with `[icon_state]_open` instead.
 	var/enable_door_overlay = TRUE
 	/// Whether this closet uses a door overlay for when it is opened
 	var/has_opened_overlay = TRUE

--- a/code/modules/antagonists/cult/team_cult.dm
+++ b/code/modules/antagonists/cult/team_cult.dm
@@ -102,7 +102,7 @@ RESTRICT_TYPE(/datum/team/cult)
 /**
   * Returns the current number of cultists and constructs.
   *
-  * Returns the number of cultists and constructs in a list ([1] = Cultists, [2] = Constructs), or as one combined number.
+  * Returns the number of cultists and constructs in the format `list(number of Cultists, number of Constructs)`, or as one combined number.
   *
   * * separate - Should the number be returned as a list with two separate values (Humans and Constructs) or as one number.
   */

--- a/code/modules/antagonists/traitor/contractor/datums/objective_contract.dm
+++ b/code/modules/antagonists/traitor/contractor/datums/objective_contract.dm
@@ -157,7 +157,7 @@
 	var/list/datum/mind/target_blacklist = null
 	/// Static list that is basically [/datum/objective/contract/var/possible_zone_names] but with area names replaced by /area objects if available.
 	var/static/list/possible_zones = null
-	/// The owning [/datum/syndicatce_contract].
+	/// The owning [/datum/syndicate_contract].
 	var/datum/syndicate_contract/owning_contract = null
 	/// Name fixer regex because area names have rogue characters sometimes.
 	var/static/regex/name_fixer = regex("(\[a-z0-9 \\'\]+)$", "ig")

--- a/code/modules/asset_cache/asset_list.dm
+++ b/code/modules/asset_cache/asset_list.dm
@@ -311,9 +311,9 @@ GLOBAL_LIST_EMPTY(asset_datums)
 	var/frame = 1
 	var/movement_states = FALSE
 
-	/// Used in asset name generation, (asset_name = "[prefix].[icon_state_name].png")
+	/// Used in asset name generation, (asset_name = `"[prefix].[icon_state_name].png"`)
 	var/prefix = "default"
-	/// Generate icon filenames using GENERATE_ASSET_NAME instead the "[prefix].[icon_state_name].png" format
+	/// Generate icon filenames using GENERATE_ASSET_NAME instead the `"[prefix].[icon_state_name].png"` format
 	var/generic_icon_names = FALSE
 
 /datum/asset/simple/icon_states/register(_icon = icon)

--- a/code/modules/client/login_processing/__client_login_processor.dm
+++ b/code/modules/client/login_processing/__client_login_processor.dm
@@ -14,7 +14,8 @@
   * This makes it easier to track stuff down -AA07
   *
   * Also if you have used other languages before with "interface" types (Java, C# (Microsoft Java), etc),
-  * treat this class as one of those. [get_query(client/C)] and [process_result(datum/db_query/Q, client/C)] MUST be overriden
+  * treat this class as one of those. [/datum/client_login_processor/proc/get_query] and
+  * [/datum/client_login_processor/proc/process_result] MUST be overriden.
   */
 /datum/client_login_processor
 	/// The login priority. A lower priority will fire first

--- a/code/modules/maptext_alerts/text_blurbs.dm
+++ b/code/modules/maptext_alerts/text_blurbs.dm
@@ -1,18 +1,27 @@
 /**
 	Shows a ticker reading out the given text on a client's screen.
 
-	targets = mob or list of mobs to show it to.
-	duration = how long it lingers after it finishes ticking.
-	message = the message to display. Due to using maptext it isn't very flexible format-wise. 11px font, up to 480 pixels per line. Use \n for line breaks. Single-character HTML tags (<b>, <i>, <u> etc.) are handled correctly but others display strangely. Note that maptext can display text macros in strange ways, ex. \improper showing as "ÿ". Lines containing only spaces, including ones only containing "\improper ", don't display.
-	scroll_down = by default each line pushes the previous line upwards - this tells it to start high and scroll down. Ticks on \n - does not autodetect line breaks in long strings.
-	screen_position = screen loc for the bottom-left corner of the blurb.
-	text_alignment = "right", "left", or "center"
-	text_color = colour of the text.
-	blurb_key = a key used for specific blurb types so they are not shown repeatedly.
-	ignore_key = used to skip key checks.
-	text_limit = limit in characters of the message.
-**/
+	Arguments:
 
+	* targets - mob or list of mobs to show it to.
+	* duration - how long it lingers after it finishes ticking.
+	* message - the message to display. Due to using maptext it isn't very
+	  flexible format-wise. 11px font, up to 480 pixels per line. Use `\n` for
+	  line breaks. Single-character HTML tags (`<b>`, `<i>`, `<u>` etc.) are handled
+	  correctly but others display strangely. Note that maptext can display text
+	  macros in strange ways, ex. \improper showing as "&yuml;". Lines containing
+	  only spaces, including ones only containing "\improper ", don't display.
+	* scroll_down - by default each line pushes the previous line upwards - this
+	  tells it to start high and scroll down. Ticks on `\n` - does not autodetect
+	  line breaks in long strings.
+	* screen_position - screen loc for the bottom-left corner of the blurb.
+	* text_alignment - "right", "left", or "center"
+	* text_color - colour of the text.
+	* blurb_key - a key used for specific blurb types so they are not shown
+	  repeatedly.
+	* ignore_key - used to skip key checks.
+	* text_limit - limit in characters of the message.
+**/
 /proc/show_blurb(list/mob/targets, duration = 3 SECONDS, message, scroll_down, screen_position = "LEFT+0:16,BOTTOM+1:16", text_alignment = "left", text_color = "#FFFFFF", blurb_key, ignore_key = FALSE, speed = 1)
 	set waitfor = 0
 	if(!islist(targets))

--- a/code/modules/mob/living/init_signals.dm
+++ b/code/modules/mob/living/init_signals.dm
@@ -1,4 +1,4 @@
-/// Called on [/mob/living/Initialize(mapload)], for the mob to register to relevant signals.
+/// Called on [/mob/living/proc/Initialize], for the mob to register to relevant signals.
 /mob/living/proc/register_init_signals()
 	RegisterSignal(src, SIGNAL_ADDTRAIT(TRAIT_KNOCKEDOUT), PROC_REF(on_knockedout_trait_gain))
 	RegisterSignal(src, SIGNAL_REMOVETRAIT(TRAIT_KNOCKEDOUT), PROC_REF(on_knockedout_trait_loss))

--- a/code/modules/power/lights.dm
+++ b/code/modules/power/lights.dm
@@ -17,7 +17,7 @@
   *
   * Incomplete light tube fixture
   *
-  * Becomes a [Light fixture] when completed
+  * Becomes a [/obj/machinery/light/built] when completed.
   */
 /obj/machinery/light_construct
 	name = "light fixture frame"
@@ -133,7 +133,7 @@
   *
   * Incomplete light bulb fixture
   *
-  * Becomes a [Small light fixture] when completed
+  * Becomes a [/obj/machinery/light/small/built] when completed
   */
 /obj/machinery/light_construct/small
 	name = "small light fixture frame"

--- a/code/modules/tgui/tgui_panel/to_chat.dm
+++ b/code/modules/tgui/tgui_panel/to_chat.dm
@@ -43,12 +43,15 @@
  * to_chat(client, "You have found <strong>[object]</strong>", MESSAGE_TYPE_INFO,
  * ```
  * Always remember to close spans!
- * TARGET: Refers to the target of the to_chat message. Valid targets include clients, mobs, and the static world controller
- * HTML: The Message to be sent to the TARGET. Converted to a string if not already one in this function
- * TYPE: The chat tab that this message will be sent to, a list of all valid types can be found in chat.dm
- * TEXT: Unused
- * AVOID_HIGHLIGHTING: Unused
- * trailing_newline, confidential, and handle_whitespace currently have no effect, please fix this in the future or remove the arguments to lower cache!
+ *
+ * Arguments:
+ * - target: Refers to the target of the to_chat message. Valid targets include clients, mobs, and the static world controller
+ * - html: The Message to be sent to the TARGET. Converted to a string if not already one in this function
+ * - type: The chat tab that this message will be sent to, a list of all valid types can be found in chat.dm
+ * - text: Unused
+ * - avoid_highlighting: Unused
+ *
+ * `trailing_newline`, `confidential`, and `handle_whitespace` currently have no effect, please fix this in the future or remove the arguments to lower cache!
  */
 /proc/to_chat(target, html, type, text, avoid_highlighting, handle_whitespace = TRUE, trailing_newline = TRUE, confidential = FALSE, ticket_id = -1)
 	if(Master.current_runlevel == RUNLEVEL_INIT || !SSchat?.initialized)

--- a/code/modules/world_topic/_topic_base.dm
+++ b/code/modules/world_topic/_topic_base.dm
@@ -11,7 +11,7 @@
   * This includes sanity checking for if the key is required, as well as other sanity checks
   * DO NOT OVERRIDE
   * Arguments:
-  * * input - The list of topic data, sent from [world/Topic]
+  * * input - The list of topic data, sent from [/world/proc/Topic]
   */
 /datum/world_topic_handler/proc/invoke(list/input)
 	SHOULD_NOT_OVERRIDE(TRUE)
@@ -28,7 +28,7 @@
   * Override this to do your work in subtypes of this topic
   *
   * Arguments:
-  * * input - The list of topic data, sent from [world/Topic]
+  * * input - The list of topic data, sent from [/world/proc/Topic]
   * * key_valid - Has the user entered the correct auth key
   */
 /datum/world_topic_handler/proc/execute(list/input, key_valid = FALSE)


### PR DESCRIPTION
## What Does This PR Do
This PR fixes some formatting issues and a bunch of crosslinks in dmdocs. This results in a reduction of dmdoc warnings from 168 to 124. A bunch of these warnings require more things to be documented; some things can't create proper crosslinks (such as subclassing native procs like /world/proc/Topic); some types are documented but can't properly be linked to because none of their members are documented.
## Why It's Good For The Game
dmdoc is kind of neglected and needs some cleanups. Fixing all the existing warnings seems likes a good place to start.
## Images of changes
One of the bad formatting issues fixed, where HTML tags caused the rest of the dmdoc page to be broken:

### Before
![2024_10_30__12_11_43__code_datums_elements_strippable dm - Paradise (Workspace) - Visual Studio Code](https://github.com/user-attachments/assets/5c9c7823-8e6a-494b-865f-f0a927bc36be)

### After
![2024_10_30__12_19_58__(global) - Space Station 13](https://github.com/user-attachments/assets/476665d4-ccfb-43eb-ba44-5269d4ec028e)

## Testing
Generated dmdoc, inspected warnings.

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog
NPFC