### PR TITLE
Fixes flavor text not being viewable

### DIFF
--- a/code/modules/mob/living/default_language.dm
+++ b/code/modules/mob/living/default_language.dm
@@ -2,7 +2,7 @@
 	set name = "Set Default Language"
 	set category = "IC"
 
-	if(!(language in languages))
+	if(!(language in languages) && !isnull(language))
 		to_chat(src, "<span class='warning'>You don't seem to know how to speak [language].</span>")
 		return
 	if(language)
@@ -16,7 +16,7 @@
 	set name = "Set Default Language"
 	set category = "IC"
 
-	if(!(language in speech_synthesizer_langs))
+	if(!(language in speech_synthesizer_langs) && !isnull(language))
 		to_chat(src, "<span class='warning'>You don't seem to know how to speak [language].</span>")
 		return
 	if(language)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -792,6 +792,12 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 			src:cameraFollow = null
 
 /mob/Topic(href, href_list)
+	if(href_list["flavor_more"])
+		usr << browse(text("<html><meta charset='utf-8'><head><title>[]</title></head><body><tt>[]</tt></body></html>", name, replacetext(flavor_text, "\n", "<br>")), "window=[name];size=500x200")
+		onclose(usr, "[name]")
+	if(href_list["flavor_change"])
+		update_flavor_text()
+
 	if(usr != src)
 		return TRUE
 	if(..())
@@ -801,11 +807,6 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 		unset_machine()
 		src << browse(null, t1)
 
-	if(href_list["flavor_more"])
-		usr << browse(text("<html><meta charset='utf-8'><head><title>[]</title></head><body><tt>[]</tt></body></html>", name, replacetext(flavor_text, "\n", "<br>")), "window=[name];size=500x200")
-		onclose(usr, "[name]")
-	if(href_list["flavor_change"])
-		update_flavor_text()
 
 	if(href_list["scoreboard"])
 		usr << browse(GLOB.scoreboard, "window=roundstats;size=500x600")


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Fixes flavor text not being viewable. Also fixes not being able to reset the default language.

## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Oversights bad

## Testing

<!-- How did you test the PR, if at all? -->
Could view the flavorful text. Could reset my default language.
<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: You can view other mob's flavor text again
fix: You can clear your default language
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
