### PR TITLE
fix: update random plant menu icon

### DIFF
--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -271,6 +271,7 @@
 		icon_state = "plant-eye"
 	if(icon_state == "random_plant")
 		icon_state = "plant-[rand(1, 34)]"
+	update_appearance(UPDATE_ICON_STATE)
 	AddComponent(/datum/component/two_handed, require_twohands = TRUE)
 
 /obj/item/kirbyplants/Destroy()


### PR DESCRIPTION
## What Does This PR Do
This PR fixes the menu icon for randomly spawned plants.
## Why It's Good For The Game
Right-click menu icons should be as accurate as possible when BYOND will let us get away with it.
## Images of changes
### Spawners
![2024_10_31__19_43_55__paradise dme  centcomm dmm  - StrongDMM](https://github.com/user-attachments/assets/c5e853af-2301-4844-b964-8660c88a64ce)

### Before
![2024_10_31__19_46_14__Paradise Station 13](https://github.com/user-attachments/assets/ba4f3366-a106-4288-97b5-5b832eeeaf1e)

### After
![2024_10_31__19_44_05__Paradise Station 13](https://github.com/user-attachments/assets/bbd8685c-94d6-44e1-ab6c-b56c328f4083)

## Testing
Checked plants on centcomm as above.

<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Potted plants should now show their proper icon in the right-click menu.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
