### PR TITLE
refactor: /New -> /Initialize §1: simple animals

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/butterfly.dm
+++ b/code/modules/mob/living/simple_animal/friendly/butterfly.dm
@@ -24,8 +24,8 @@
 	gold_core_spawnable = FRIENDLY_SPAWN
 	initial_traits = list(TRAIT_FLYING, TRAIT_EDIBLE_BUG)
 
-/mob/living/simple_animal/butterfly/New()
-	..()
+/mob/living/simple_animal/butterfly/Initialize(mapload)
+	. = ..()
 	color = rgb(rand(0, 255), rand(0, 255), rand(0, 255))
 
 /mob/living/simple_animal/butterfly/npc_safe(mob/user)

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -42,9 +42,9 @@
 	var/list/family = list()
 	var/list/children = list() //Actual mob instances of children
 
-/mob/living/simple_animal/pet/cat/Runtime/New()
+/mob/living/simple_animal/pet/cat/Runtime/Initialize(mapload)
+	. = ..()
 	SSpersistent_data.register(src)
-	..()
 
 /mob/living/simple_animal/pet/cat/Runtime/Destroy()
 	SSpersistent_data.registered_atoms -= src

--- a/code/modules/mob/living/simple_animal/friendly/diona_nymph.dm
+++ b/code/modules/mob/living/simple_animal/friendly/diona_nymph.dm
@@ -81,8 +81,9 @@
 	var/mob/living/simple_animal/diona/user = owner
 	user.steal_blood()
 
-/mob/living/simple_animal/diona/New()
-	..()
+/mob/living/simple_animal/diona/Initialize(mapload)
+	. = ..()
+
 	if(name == initial(name)) //To stop Pun-Pun becoming generic.
 		name = "[name] ([rand(1, 1000)])"
 		real_name = name

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -221,8 +221,9 @@
 	gold_core_spawnable = FRIENDLY_SPAWN
 	footstep_type = FOOTSTEP_MOB_CLAW
 
-/mob/living/simple_animal/chick/New()
-	..()
+/mob/living/simple_animal/chick/Initialize(mapload)
+	. = ..()
+
 	pixel_x = rand(-6, 6)
 	pixel_y = rand(0, 10)
 
@@ -294,8 +295,8 @@ GLOBAL_VAR_INIT(chicken_count, 0)
 	gold_core_spawnable = FRIENDLY_SPAWN
 	footstep_type = FOOTSTEP_MOB_CLAW
 
-/mob/living/simple_animal/chicken/New()
-	..()
+/mob/living/simple_animal/chicken/Initialize(mapload)
+	. = ..()
 	if(!body_color)
 		body_color = pick(validColors)
 	icon_state = "[icon_prefix]_[body_color]"
@@ -303,6 +304,7 @@ GLOBAL_VAR_INIT(chicken_count, 0)
 	icon_dead = "[icon_prefix]_[body_color]_dead"
 	pixel_x = rand(-6, 6)
 	pixel_y = rand(0, 10)
+	update_appearance(UPDATE_ICON_STATE)
 	GLOB.chicken_count += 1
 
 /mob/living/simple_animal/chicken/death(gibbed)

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -75,15 +75,16 @@
 	else if(prob(0.5))
 		lay_down()
 
-/mob/living/simple_animal/mouse/New()
-	..()
+/mob/living/simple_animal/mouse/Initialize(mapload)
+	. = ..()
+
 	if(!mouse_color)
-		mouse_color = pick( list("brown","gray","white") )
+		mouse_color = pick("brown", "gray", "white")
 	icon_state = "mouse_[mouse_color]"
 	icon_living = "mouse_[mouse_color]"
 	icon_dead = "mouse_[mouse_color]_dead"
 	icon_resting = "mouse_[mouse_color]_sleep"
-	update_appearance(UPDATE_DESC)
+	update_appearance(UPDATE_ICON_STATE|UPDATE_DESC)
 
 /mob/living/simple_animal/mouse/update_desc()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -67,8 +67,8 @@
 	var/parrot_speed = 5 //"Delay in world ticks between movement." according to byond. Yeah, that's BS but it does directly affect movement. Higher number = slower.
 	var/parrot_been_shot = 0 //Parrots get a speed bonus after being shot. This will deincrement every process_ai() and at 0 the parrot will return to regular speed.
 
-	var/list/speech_buffer
-	var/list/available_channels
+	var/list/speech_buffer = list()
+	var/list/available_channels = list()
 
 	//Headset for Poly to yell at engineers :)
 	var/obj/item/radio/headset/ears = null
@@ -80,35 +80,43 @@
 	//Parrots will generally sit on their pertch unless something catches their eye.
 	//These vars store their preffered perch and if they dont have one, what they can use as a perch
 	var/obj/parrot_perch = null
-	var/obj/desired_perches = null
+	var/list/desired_perches
 
 	//Parrots are kleptomaniacs. This variable ... stores the item a parrot is holding.
 	var/obj/item/held_item = null
 	initial_traits = list(TRAIT_FLYING)
 	gold_core_spawnable = FRIENDLY_SPAWN
 
-/mob/living/simple_animal/parrot/New()
-	..()
-	speech_buffer = list()
-	available_channels = list()
+/mob/living/simple_animal/parrot/Initialize(mapload)
+	. = ..()
+
 	GLOB.hear_radio_list += src
 	update_speak()
 
 	parrot_sleep_dur = parrot_sleep_max //In case someone decides to change the max without changing the duration var
 
-	verbs.Add(/mob/living/simple_animal/parrot/proc/steal_from_ground, \
-			/mob/living/simple_animal/parrot/proc/steal_from_mob, \
-			/mob/living/simple_animal/parrot/verb/drop_held_item_player, \
-			/mob/living/simple_animal/parrot/proc/perch_player)
+	verbs.Add(list(
+		/mob/living/simple_animal/parrot/proc/steal_from_ground,
+		/mob/living/simple_animal/parrot/proc/steal_from_mob,
+		/mob/living/simple_animal/parrot/verb/drop_held_item_player,
+		/mob/living/simple_animal/parrot/proc/perch_player
+	))
 
-	desired_perches = typecacheof(list(/obj/structure/computerframe, 	/obj/structure/displaycase, \
-									/obj/structure/filingcabinet,	/obj/machinery/teleport, \
-									/obj/machinery/suit_storage_unit,/obj/machinery/clonepod, \
-									/obj/machinery/dna_scannernew,	/obj/machinery/tcomms, \
-									/obj/machinery/nuclearbomb,		/obj/machinery/particle_accelerator, \
-									/obj/machinery/recharge_station,	/obj/machinery/smartfridge, \
-									/obj/machinery/computer))
-
+	desired_perches = typecacheof(list(
+		/obj/machinery/clonepod,
+		/obj/machinery/computer,
+		/obj/machinery/dna_scannernew,
+		/obj/machinery/nuclearbomb,
+		/obj/machinery/particle_accelerator,
+		/obj/machinery/recharge_station,
+		/obj/machinery/smartfridge,
+		/obj/machinery/suit_storage_unit,
+		/obj/machinery/tcomms,
+		/obj/machinery/teleport,
+		/obj/structure/computerframe,
+		/obj/structure/displaycase,
+		/obj/structure/filingcabinet
+	))
 
 /mob/living/simple_animal/parrot/add_strippable_element()
 	AddElement(/datum/element/strippable, GLOB.strippable_parrot_items)
@@ -669,12 +677,13 @@
 		)
 	unique_pet = TRUE
 	gold_core_spawnable = NO_SPAWN
-
-/mob/living/simple_animal/parrot/Poly/New()
-	ears = new /obj/item/radio/headset/headset_eng(src)
 	available_channels = list(":e")
+
+/mob/living/simple_animal/parrot/Poly/Initialize(mapload)
+	. = ..()
+
+	ears = new /obj/item/radio/headset/headset_eng(src)
 	clean_speak += "Danger! Crystal hyperstructure integrity faltering! Integrity: [rand(75, 99)]%" // Has to be here cause of the `rand()`.
-	..()
 
 /mob/living/simple_animal/parrot/Poly/npc_safe(mob/user) // Hello yes, I have universal speak and I follow people around and shout out antags
 	return FALSE

--- a/code/modules/mob/living/simple_animal/posessed_object.dm
+++ b/code/modules/mob/living/simple_animal/posessed_object.dm
@@ -91,8 +91,8 @@
 	to_chat(src, "<span class='notice'><b>Your spirit has entered [src] and possessed it.</b><br>You are able to do most things a humanoid would be able to do with a [src] in their hands.<br>If you want to end your ghostly possession, use the '<b>ghost</b>' verb, it won't penalize your ability to respawn.</span>")
 
 
-/mob/living/simple_animal/possessed_object/New(atom/loc as obj)
-	..()
+/mob/living/simple_animal/possessed_object/Initialize(mapload)
+	. = ..()
 
 	if(!isitem(loc)) // Some silly motherfucker spawned us directly via the game panel.
 		message_admins("<span class='adminnotice'>Possessed object improperly spawned, deleting.</span>") // So silly admins with debug off will see the message too and not spam these things.


### PR DESCRIPTION
## What Does This PR Do
This PR migrates all overrides of /New for simple animals to /Initialize.
## Why It's Good For The Game
See #27261.
## Testing
- [X] Ensured butterflies spawn in different colors.
- [X] Ensured chicks spawn with random pixel offsets.
- [X] Ensured mice spawn with different colors.
- [X] Ensured Runtime persistent data was registered at roundstart.
- [X] Ensured diona nymph names were randomized and rootspeak language added.
- [X] Ensured parrot player verbs were added and Poly had eng channel access. Perching continues to not work because it hasn't worked since #18984 two years ago when the first JPS implementation was added because everything in the desired perches list is dense which means they count as an obstacle for pathfinding and I'm not fixing it because basic mobs will fix it, and also their flying trait doesn't get removed when perching so it looks like they're floating while sitting. 
- [X] Ensured dragging admin ghost onto object properly creates possessed objects and spawning one manually properly stacktraces.
- [X] Ensured chickens were added to GLOB.chicken_count and their pixel offsets were randomized.

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog
NPFC
