### PR TITLE
Librarian bookshelf tweaks

### DIFF
--- a/_maps/map_files/stations/boxstation.dmm
+++ b/_maps/map_files/stations/boxstation.dmm
@@ -5354,8 +5354,7 @@
 /area/station/legal/lawoffice)
 "asO" = (
 /obj/machinery/computer/prisoner{
-	dir = 4;
-	req_access = list(2)
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cult"
@@ -5722,8 +5721,7 @@
 /area/station/maintenance/fore)
 "atN" = (
 /obj/machinery/computer/prisoner{
-	dir = 4;
-	req_access = list(2)
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -8414,9 +8412,7 @@
 	pixel_y = 32
 	},
 /obj/machinery/alarm/directional/west,
-/obj/machinery/computer/prisoner{
-	req_access = list(2)
-	},
+/obj/machinery/computer/prisoner,
 /turf/simulated/floor/plasteel{
 	icon_state = "cult"
 	},
@@ -19457,9 +19453,7 @@
 	},
 /area/station/service/bar)
 "bjc" = (
-/obj/structure/closet/secure_closet/bar{
-	req_access = list(25)
-	},
+/obj/structure/closet/secure_closet/bar,
 /turf/simulated/floor/wood,
 /area/station/service/bar)
 "bjd" = (
@@ -22509,7 +22503,7 @@
 /area/station/public/locker)
 "brw" = (
 /obj/structure/bookcase{
-	name = "bookcase (Adult)"
+	name = "bookcase (Romance)"
 	},
 /turf/simulated/floor/wood,
 /area/station/service/library)
@@ -52364,7 +52358,7 @@
 	inlet_injector_autolink_id = "o2_in";
 	name = "Oxygen Supply Control";
 	outlet_vent_autolink_id = "o2_out";
-	autolink_sensors = list("o2_sensor" = "Tank")
+	autolink_sensors = list("o2_sensor"="Tank")
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "blue"
@@ -54195,7 +54189,7 @@
 	inlet_injector_autolink_id = "n2_in";
 	name = "Nitrogen Supply Control";
 	outlet_vent_autolink_id = "n2_out";
-	autolink_sensors = list("n2_sensor" = "Tank")
+	autolink_sensors = list("n2_sensor"="Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /turf/simulated/floor/plasteel{
@@ -55483,7 +55477,7 @@
 /obj/machinery/computer/general_air_control{
 	dir = 4;
 	name = "Tank Monitor";
-	autolink_sensors = list("n2_sensor" = "Nitrogen", "o2_sensor" = "Oxygen", "co2_sensor" = "Carbon Dioxide", "tox_sensor" = "Toxins", "n2o_sensor" = "Nitrous Oxide", "waste_sensor" = "Gas Mix Tank")
+	autolink_sensors = list("n2_sensor"="Nitrogen","o2_sensor"="Oxygen","co2_sensor"="Carbon Dioxide","tox_sensor"="Toxins","n2o_sensor"="Nitrous Oxide","waste_sensor"="Gas Mix Tank")
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos/control)
@@ -65998,7 +65992,7 @@
 	inlet_injector_autolink_id = "co2_in";
 	name = "Carbon Dioxide Supply Control";
 	outlet_vent_autolink_id = "co2_out";
-	autolink_sensors = list("co2_sensor" = "Tank")
+	autolink_sensors = list("co2_sensor"="Tank")
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -66221,9 +66215,7 @@
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
 "kNx" = (
-/obj/machinery/computer/prisoner{
-	req_access = list(2)
-	},
+/obj/machinery/computer/prisoner,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "red"
@@ -68901,7 +68893,7 @@
 	dir = 1;
 	level = 3;
 	name = "Distribution and Waste Monitor";
-	autolink_sensors = list("mair_in_meter" = "Mixed Air In", "air_sensor" = "Mixed Air Supply Tank", "mair_out_meter" = "Mixed Air Out", "dloop_atm_meter" = "Distribution Loop", "wloop_atm_meter" = "Waste Loop")
+	autolink_sensors = list("mair_in_meter"="Mixed Air In","air_sensor"="Mixed Air Supply Tank","mair_out_meter"="Mixed Air Out","dloop_atm_meter"="Distribution Loop","wloop_atm_meter"="Waste Loop")
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/controlroom)
@@ -74513,7 +74505,7 @@
 	inlet_injector_autolink_id = "tox_in";
 	name = "Toxin Supply Control";
 	outlet_vent_autolink_id = "tox_out";
-	autolink_sensors = list("tox_sensor" = "Tank")
+	autolink_sensors = list("tox_sensor"="Tank")
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -74870,7 +74862,7 @@
 	dir = 8;
 	level = 3;
 	name = "Distribution and Waste Monitor";
-	autolink_sensors = list("mair_in_meter" = "Mixed Air In", "air_sensor" = "Mixed Air Supply Tank", "mair_out_meter" = "Mixed Air Out", "dloop_atm_meter" = "Distribution Loop", "wloop_atm_meter" = "Waste Loop")
+	autolink_sensors = list("mair_in_meter"="Mixed Air In","air_sensor"="Mixed Air Supply Tank","mair_out_meter"="Mixed Air Out","dloop_atm_meter"="Distribution Loop","wloop_atm_meter"="Waste Loop")
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos/control)
@@ -77575,7 +77567,7 @@
 	},
 /obj/machinery/computer/general_air_control{
 	name = "Bomb Mix Monitor";
-	autolink_sensors = list("burn_sensor" = "Burn Mix")
+	autolink_sensors = list("burn_sensor"="Burn Mix")
 	},
 /obj/machinery/door_control{
 	id = "ToxinsVenting";
@@ -79340,7 +79332,7 @@
 	},
 /obj/machinery/computer/general_air_control{
 	name = "Tank Monitor";
-	autolink_sensors = list("n2_sensor" = "Nitrogen", "o2_sensor" = "Oxygen", "co2_sensor" = "Carbon Dioxide", "tox_sensor" = "Toxins", "n2o_sensor" = "Nitrous Oxide", "waste_sensor" = "Gas Mix Tank")
+	autolink_sensors = list("n2_sensor"="Nitrogen","o2_sensor"="Oxygen","co2_sensor"="Carbon Dioxide","tox_sensor"="Toxins","n2o_sensor"="Nitrous Oxide","waste_sensor"="Gas Mix Tank")
 	},
 /obj/machinery/light{
 	dir = 4
@@ -80512,7 +80504,7 @@
 	name = "Mixed Air Supply Control";
 	outlet_vent_autolink_id = "air_out";
 	outlet_setting = 2000;
-	autolink_sensors = list("air_sensor" = "Tank")
+	autolink_sensors = list("air_sensor"="Tank")
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "arrival"
@@ -86345,7 +86337,7 @@
 	inlet_injector_autolink_id = "waste_in";
 	name = "Gas Mix Tank Control";
 	outlet_vent_autolink_id = "waste_out";
-	autolink_sensors = list("waste_sensor" = "Tank")
+	autolink_sensors = list("waste_sensor"="Tank")
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -91959,7 +91951,7 @@
 	inlet_injector_autolink_id = "n2o_in";
 	name = "Nitrous Oxide Supply Control";
 	outlet_vent_autolink_id = "n2o_out";
-	autolink_sensors = list("n2o_sensor" = "Tank")
+	autolink_sensors = list("n2o_sensor"="Tank")
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;

--- a/_maps/map_files/stations/cerestation.dmm
+++ b/_maps/map_files/stations/cerestation.dmm
@@ -14989,7 +14989,7 @@
 /obj/machinery/computer/general_air_control{
 	dir = 4;
 	name = "Tank Monitor";
-	autolink_sensors = list("n2_sensor" = "Nitrogen", "o2_sensor" = "Oxygen", "co2_sensor" = "Carbon Dioxide", "tox_sensor" = "Toxins", "n2o_sensor" = "Nitrous Oxide", "waste_sensor" = "Gas Mix Tank")
+	autolink_sensors = list("n2_sensor"="Nitrogen","o2_sensor"="Oxygen","co2_sensor"="Carbon Dioxide","tox_sensor"="Toxins","n2o_sensor"="Nitrous Oxide","waste_sensor"="Gas Mix Tank")
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos/control)
@@ -17582,7 +17582,7 @@
 	inlet_injector_autolink_id = "co2_in";
 	name = "Carbon Dioxide Supply Control";
 	outlet_vent_autolink_id = "co2_out";
-	autolink_sensors = list("co2_sensor" = "Tank");
+	autolink_sensors = list("co2_sensor"="Tank");
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green{
@@ -17767,7 +17767,7 @@
 	inlet_injector_autolink_id = "waste_in";
 	name = "Gas Mix Tank Control";
 	outlet_vent_autolink_id = "waste_out";
-	autolink_sensors = list("waste_sensor" = "Tank")
+	autolink_sensors = list("waste_sensor"="Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
@@ -27119,7 +27119,7 @@
 	inlet_injector_autolink_id = "n2_in";
 	name = "Nitrogen Supply Control";
 	outlet_vent_autolink_id = "n2_out";
-	autolink_sensors = list("n2_sensor" = "Tank")
+	autolink_sensors = list("n2_sensor"="Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/structure/window/reinforced{
@@ -27192,7 +27192,7 @@
 	inlet_injector_autolink_id = "o2_in";
 	name = "Oxygen Supply Control";
 	outlet_vent_autolink_id = "o2_out";
-	autolink_sensors = list("o2_sensor" = "Tank")
+	autolink_sensors = list("o2_sensor"="Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/structure/window/reinforced{
@@ -27344,7 +27344,7 @@
 	name = "Mixed Air Supply Control";
 	outlet_vent_autolink_id = "air_out";
 	outlet_setting = 2000;
-	autolink_sensors = list("air_sensor" = "Tank")
+	autolink_sensors = list("air_sensor"="Tank")
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -27392,7 +27392,7 @@
 	inlet_injector_autolink_id = "tox_in";
 	name = "Toxin Supply Control";
 	outlet_vent_autolink_id = "tox_out";
-	autolink_sensors = list("tox_sensor" = "Tank")
+	autolink_sensors = list("tox_sensor"="Tank")
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plasteel,
@@ -27427,7 +27427,7 @@
 	inlet_injector_autolink_id = "n2o_in";
 	name = "Nitrous Oxide Supply Control";
 	outlet_vent_autolink_id = "n2o_out";
-	autolink_sensors = list("n2o_sensor" = "Tank")
+	autolink_sensors = list("n2o_sensor"="Tank")
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plasteel,
@@ -29259,7 +29259,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
 "dsc" = (
-/obj/structure/bookcase/random,
+/obj/structure/bookcase{
+	name = "bookcase (Reference)"
+	},
 /turf/simulated/floor/wood,
 /area/station/service/library)
 "dsd" = (
@@ -36540,7 +36542,7 @@
 /obj/machinery/camera{
 	c_tag = "Supply Dock External";
 	dir = 5;
-	network = list("SS13", "QM")
+	network = list("SS13","QM")
 	},
 /turf/space,
 /area/space)
@@ -50168,7 +50170,7 @@
 /obj/machinery/camera{
 	c_tag = "Cargo Delivery Office";
 	dir = 4;
-	network = list("SS13", "QM")
+	network = list("SS13","QM")
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -57211,7 +57213,7 @@
 /obj/machinery/camera{
 	c_tag = "Cargo Bay Storage";
 	dir = 8;
-	network = list("SS13", "QM")
+	network = list("SS13","QM")
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -60575,6 +60577,12 @@
 	icon_state = "cafeteria"
 	},
 /area/station/service/kitchen)
+"lVz" = (
+/obj/structure/bookcase{
+	name = "bookcase (Religious)"
+	},
+/turf/simulated/floor/wood,
+/area/station/service/library)
 "lVB" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -62895,6 +62903,7 @@
 	name = "south bump";
 	pixel_y = -28
 	},
+/obj/structure/bookcase/random,
 /turf/simulated/floor/wood,
 /area/station/service/library)
 "mEc" = (
@@ -63296,6 +63305,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/station/service/library)
+"mKF" = (
+/obj/structure/bookcase{
+	name = "bookcase (Romance)"
 	},
 /turf/simulated/floor/wood,
 /area/station/service/library)
@@ -71999,7 +72014,7 @@
 /obj/machinery/computer/general_air_control{
 	dir = 8;
 	name = "Distribution and Waste Monitor";
-	autolink_sensors = list("mair_in_meter" = "Mixed Air In", "air_sensor" = "Mixed Air Supply Tank", "mair_out_meter" = "Mixed Air Out", "dloop_atm_meter" = "Distribution Loop", "wloop_atm_meter" = "Waste Loop")
+	autolink_sensors = list("mair_in_meter"="Mixed Air In","air_sensor"="Mixed Air Supply Tank","mair_out_meter"="Mixed Air Out","dloop_atm_meter"="Distribution Loop","wloop_atm_meter"="Waste Loop")
 	},
 /obj/item/radio/intercom{
 	pixel_x = 28;
@@ -72310,7 +72325,7 @@
 /obj/structure/filingcabinet,
 /obj/machinery/camera{
 	c_tag = "Quartermaster's Office";
-	network = list("SS13", "QM")
+	network = list("SS13","QM")
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -76958,6 +76973,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal/northwest)
+"qEx" = (
+/obj/structure/bookcase{
+	name = "bookcase (Fiction)"
+	},
+/turf/simulated/floor/wood,
+/area/station/service/library)
 "qEA" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -79463,6 +79484,12 @@
 	icon_state = "darkyellowcorners"
 	},
 /area/station/engineering/smes)
+"rum" = (
+/obj/structure/bookcase{
+	name = "bookcase (Non-Fiction)"
+	},
+/turf/simulated/floor/wood,
+/area/station/service/library)
 "rux" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -80523,7 +80550,7 @@
 /obj/machinery/camera{
 	c_tag = "Mining Dock";
 	dir = 10;
-	network = list("SS13", "QM")
+	network = list("SS13","QM")
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/miningdock)
@@ -90836,7 +90863,7 @@
 /obj/machinery/camera{
 	c_tag = "Expedition Access";
 	dir = 8;
-	network = list("SS13", "QM")
+	network = list("SS13","QM")
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -117552,11 +117579,11 @@ vjL
 xaR
 lhM
 aEe
-dsc
+mKF
 kiv
-dsc
+rum
 kiv
-dsc
+qEx
 kiv
 dsc
 bHZ
@@ -117809,11 +117836,11 @@ wzC
 eCI
 aXn
 xOy
-dsc
+lVz
 ybP
-dsc
+rum
 ybP
-dsc
+qEx
 ybP
 dsc
 bHZ

--- a/_maps/map_files/stations/deltastation.dmm
+++ b/_maps/map_files/stations/deltastation.dmm
@@ -26064,7 +26064,7 @@
 	dir = 8;
 	level = 3;
 	name = "Distribution and Waste Monitor";
-	autolink_sensors = list("mair_in_meter" = "Mixed Air In", "air_sensor" = "Mixed Air Supply Tank", "mair_out_meter" = "Mixed Air Out", "dloop_atm_meter" = "Distribution Loop", "wloop_atm_meter" = "Waste Loop")
+	autolink_sensors = list("mair_in_meter"="Mixed Air In","air_sensor"="Mixed Air Supply Tank","mair_out_meter"="Mixed Air Out","dloop_atm_meter"="Distribution Loop","wloop_atm_meter"="Waste Loop")
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -36398,9 +36398,7 @@
 /turf/simulated/floor/wood,
 /area/station/legal/lawoffice)
 "caM" = (
-/obj/machinery/computer/prisoner{
-	req_access = list(2)
-	},
+/obj/machinery/computer/prisoner,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -40307,7 +40305,9 @@
 /turf/simulated/floor/plasteel/grimy,
 /area/station/service/library)
 "clC" = (
-/obj/structure/bookcase,
+/obj/structure/bookcase{
+	name = "bookcase (Romance)"
+	},
 /turf/simulated/floor/wood,
 /area/station/service/library)
 "clD" = (
@@ -41388,9 +41388,11 @@
 /turf/simulated/floor/plating,
 /area/station/engineering/equipmentstorage)
 "cow" = (
-/obj/structure/bookcase,
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/structure/bookcase{
+	name = "bookcase (Fiction)"
 	},
 /turf/simulated/floor/wood,
 /area/station/service/library)
@@ -64455,7 +64457,7 @@
 /area/station/medical/virology)
 "ebU" = (
 /obj/machinery/computer/general_air_control{
-	autolink_sensors = list("burn_sensor" = "Burn Mix");
+	autolink_sensors = list("burn_sensor"="Burn Mix");
 	dir = 1;
 	name = "Bomb Mix Monitor"
 	},
@@ -65839,6 +65841,12 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/surgery/observation)
+"eNh" = (
+/obj/structure/bookcase{
+	name = "bookcase (Fiction)"
+	},
+/turf/simulated/floor/wood,
+/area/station/service/library)
 "eNk" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -67605,7 +67613,7 @@
 	dir = 8
 	},
 /obj/machinery/computer/general_air_control/large_tank_control{
-	autolink_sensors = list("n2o_sensor" = "Tank");
+	autolink_sensors = list("n2o_sensor"="Tank");
 	dir = 4;
 	inlet_injector_autolink_id = "n2o_in";
 	name = "Nitrous Oxide Supply Control";
@@ -70174,6 +70182,12 @@
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/science/xenobiology)
+"hnG" = (
+/obj/structure/bookcase{
+	name = "bookcase (Reference)"
+	},
+/turf/simulated/floor/wood,
+/area/station/service/library)
 "hnH" = (
 /obj/structure/sign/nosmoking_1{
 	pixel_x = -30
@@ -70586,7 +70600,7 @@
 	dir = 4
 	},
 /obj/machinery/computer/general_air_control/large_tank_control{
-	autolink_sensors = list("air_sensor" = "Tank");
+	autolink_sensors = list("air_sensor"="Tank");
 	dir = 8;
 	inlet_injector_autolink_id = "air_in";
 	name = "Mixed Air Supply Control";
@@ -74044,7 +74058,7 @@
 	dir = 4
 	},
 /obj/machinery/computer/general_air_control/large_tank_control{
-	autolink_sensors = list("n2_sensor" = "Tank");
+	autolink_sensors = list("n2_sensor"="Tank");
 	dir = 8;
 	inlet_injector_autolink_id = "n2_in";
 	name = "Nitrogen Supply Control";
@@ -75224,6 +75238,12 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/maintenance/starboard)
+"koD" = (
+/obj/structure/bookcase{
+	name = "bookcase (Non-Fiction)"
+	},
+/turf/simulated/floor/wood,
+/area/station/service/library)
 "koT" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -79498,6 +79518,12 @@
 	icon_state = "redcorner"
 	},
 /area/station/hallway/primary/starboard/north)
+"mSB" = (
+/obj/structure/bookcase{
+	name = "bookcase (Religious)"
+	},
+/turf/simulated/floor/wood,
+/area/station/service/library)
 "mSF" = (
 /obj/effect/turf_decal{
 	dir = 1
@@ -79866,7 +79892,7 @@
 	dir = 8
 	},
 /obj/machinery/computer/general_air_control/large_tank_control{
-	autolink_sensors = list("tox_sensor" = "Tank");
+	autolink_sensors = list("tox_sensor"="Tank");
 	dir = 4;
 	inlet_injector_autolink_id = "tox_in";
 	name = "Toxin Supply Control";
@@ -81983,7 +82009,7 @@
 /area/station/supply/miningdock)
 "olZ" = (
 /obj/machinery/computer/general_air_control/large_tank_control{
-	autolink_sensors = list("waste_sensor" = "Tank");
+	autolink_sensors = list("waste_sensor"="Tank");
 	dir = 4;
 	inlet_injector_autolink_id = "waste_in";
 	name = "Gas Mix Tank Control";
@@ -85294,7 +85320,7 @@
 	dir = 4
 	},
 /obj/machinery/computer/general_air_control/large_tank_control{
-	autolink_sensors = list("o2_sensor" = "Tank");
+	autolink_sensors = list("o2_sensor"="Tank");
 	dir = 8;
 	inlet_injector_autolink_id = "o2_in";
 	name = "Oxygen Supply Control";
@@ -88699,7 +88725,7 @@
 	dir = 8
 	},
 /obj/machinery/computer/general_air_control/large_tank_control{
-	autolink_sensors = list("co2_sensor" = "Tank");
+	autolink_sensors = list("co2_sensor"="Tank");
 	dir = 4;
 	inlet_injector_autolink_id = "co2_in";
 	name = "Carbon Dioxide Supply Control";
@@ -130887,11 +130913,11 @@ cfq
 cgW
 cgX
 cni
-clC
+eNh
 cnh
 cow
 cpH
-clC
+eNh
 bYj
 bZO
 cvh
@@ -131144,11 +131170,11 @@ cfr
 cgX
 ciu
 cni
-clC
+eNh
 cni
-clC
+eNh
 bvL
-clC
+eNh
 bYk
 ctH
 crn
@@ -131915,9 +131941,9 @@ cfs
 crn
 ciz
 ckj
-clC
+hnG
 ckj
-clC
+mSB
 ckj
 clC
 bYk
@@ -132172,9 +132198,9 @@ cft
 crn
 ciy
 ckj
-clC
+hnG
 ckj
-clC
+mSB
 ckj
 clC
 bYj
@@ -132686,11 +132712,11 @@ cfv
 crn
 ciz
 ckj
-clC
+koD
 ckj
-clC
+koD
 ckj
-clC
+koD
 bYj
 ctL
 cvn
@@ -132943,11 +132969,11 @@ ckj
 crn
 ciz
 ckj
-clC
+koD
 ckj
-clC
+koD
 ckj
-clC
+koD
 bYj
 bYj
 bYj

--- a/_maps/map_files/stations/emeraldstation.dmm
+++ b/_maps/map_files/stations/emeraldstation.dmm
@@ -24688,9 +24688,7 @@
 	},
 /area/station/engineering/break_room/secondary)
 "eHF" = (
-/obj/machinery/computer/prisoner{
-	req_access = list(2)
-	},
+/obj/machinery/computer/prisoner,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "red"
@@ -31285,8 +31283,7 @@
 /area/station/public/shops)
 "fPs" = (
 /obj/machinery/computer/prisoner{
-	dir = 8;
-	req_access = list(2)
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -54193,8 +54190,7 @@
 /area/station/hallway/primary/fore/north)
 "kcA" = (
 /obj/machinery/computer/prisoner{
-	dir = 4;
-	req_access = list(2)
+	dir = 4
 	},
 /obj/machinery/button/windowtint{
 	dir = 4;
@@ -68522,8 +68518,7 @@
 /area/station/command/meeting_room)
 "mSw" = (
 /obj/machinery/computer/prisoner{
-	dir = 1;
-	req_access = list(2)
+	dir = 1
 	},
 /obj/item/radio/intercom{
 	name = "south bump";
@@ -74858,8 +74853,7 @@
 /area/station/maintenance/asmaint)
 "nYy" = (
 /obj/machinery/computer/prisoner{
-	dir = 4;
-	req_access = list(2)
+	dir = 4
 	},
 /obj/machinery/light{
 	dir = 8
@@ -81214,7 +81208,7 @@
 /area/station/hallway/secondary/exit)
 "pdF" = (
 /obj/structure/bookcase{
-	name = "bookcase (Adult)"
+	name = "bookcase (Romance)"
 	},
 /turf/simulated/floor/wood,
 /area/station/service/library)
@@ -121862,9 +121856,7 @@
 	},
 /area/station/hallway/primary/starboard/south)
 "wFX" = (
-/obj/structure/closet/secure_closet/bar{
-	req_access = list(25)
-	},
+/obj/structure/closet/secure_closet/bar,
 /obj/item/ammo_box/shotgun/beanbag,
 /turf/simulated/floor/wood,
 /area/station/service/bar)
@@ -164486,7 +164478,7 @@ frO
 vKF
 pdF
 pdF
-nEg
+gEN
 arj
 mWA
 vHx
@@ -164741,9 +164733,9 @@ xdJ
 gBS
 fNn
 vKF
-gEN
-gEN
 nEg
+nEg
+gEN
 sux
 mEj
 qTh

--- a/_maps/map_files/stations/metastation.dmm
+++ b/_maps/map_files/stations/metastation.dmm
@@ -211,8 +211,7 @@
 	},
 /obj/machinery/alarm/directional/west,
 /obj/machinery/computer/prisoner{
-	dir = 4;
-	req_access = list(2)
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cult"
@@ -19868,9 +19867,7 @@
 	},
 /area/station/service/barber)
 "buI" = (
-/obj/structure/closet/secure_closet/bar{
-	req_access = list(25)
-	},
+/obj/structure/closet/secure_closet/bar,
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -26641,7 +26638,7 @@
 /area/station/service/library)
 "bRK" = (
 /obj/structure/bookcase{
-	name = "bookcase (Adult)"
+	name = "bookcase (Romance)"
 	},
 /turf/simulated/floor/wood,
 /area/station/service/library)
@@ -39386,9 +39383,7 @@
 /area/station/science/toxins/launch)
 "cOA" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/secure_closet/bar{
-	req_access = list(25)
-	},
+/obj/structure/closet/secure_closet/bar,
 /obj/machinery/light_switch{
 	name = "north bump";
 	pixel_y = 24
@@ -48502,7 +48497,7 @@
 	inlet_injector_autolink_id = "n2o_in";
 	name = "Nitrous Oxide Supply Control";
 	outlet_vent_autolink_id = "n2o_out";
-	autolink_sensors = list("n2o_sensor" = "Tank")
+	autolink_sensors = list("n2o_sensor"="Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/structure/window/reinforced{
@@ -54551,7 +54546,7 @@
 	inlet_injector_autolink_id = "o2_in";
 	name = "Oxygen Supply Control";
 	outlet_vent_autolink_id = "o2_out";
-	autolink_sensors = list("o2_sensor" = "Tank")
+	autolink_sensors = list("o2_sensor"="Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
@@ -58490,7 +58485,7 @@
 /obj/machinery/computer/general_air_control{
 	dir = 1;
 	name = "Bomb Mix Monitor";
-	autolink_sensors = list("burn_sensor" = "Burn Mix")
+	autolink_sensors = list("burn_sensor"="Burn Mix")
 	},
 /obj/machinery/door_control{
 	id = "ToxinsVenting";
@@ -66001,7 +65996,7 @@
 	inlet_injector_autolink_id = "n2_in";
 	name = "Nitrogen Supply Control";
 	outlet_vent_autolink_id = "n2_out";
-	autolink_sensors = list("n2_sensor" = "Tank")
+	autolink_sensors = list("n2_sensor"="Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
@@ -70129,9 +70124,6 @@
 /turf/space,
 /area/station/engineering/solar/fore_port)
 "ovR" = (
-/obj/structure/bookcase{
-	name = "bookcase (Adult)"
-	},
 /turf/simulated/floor/wood,
 /area/station/maintenance/starboard)
 "owq" = (
@@ -71830,7 +71822,7 @@
 	inlet_injector_autolink_id = "tox_in";
 	name = "Toxin Supply Control";
 	outlet_vent_autolink_id = "tox_out";
-	autolink_sensors = list("tox_sensor" = "Tank")
+	autolink_sensors = list("tox_sensor"="Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/structure/window/reinforced{
@@ -78498,7 +78490,7 @@
 	name = "Mixed Air Supply Control";
 	outlet_vent_autolink_id = "air_out";
 	outlet_setting = 2000;
-	autolink_sensors = list("air_sensor" = "Tank")
+	autolink_sensors = list("air_sensor"="Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
@@ -82316,8 +82308,7 @@
 /area/station/security/permabrig)
 "tAF" = (
 /obj/machinery/computer/prisoner{
-	dir = 1;
-	req_access = list(2)
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cult"
@@ -83215,7 +83206,7 @@
 	inlet_injector_autolink_id = "waste_in";
 	name = "Gas Mix Tank Control";
 	outlet_vent_autolink_id = "waste_out";
-	autolink_sensors = list("waste_sensor" = "Tank")
+	autolink_sensors = list("waste_sensor"="Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /turf/simulated/floor/plasteel{
@@ -86224,7 +86215,7 @@
 	inlet_injector_autolink_id = "co2_in";
 	name = "Carbon Dioxide Supply Control";
 	outlet_vent_autolink_id = "co2_out";
-	autolink_sensors = list("co2_sensor" = "Tank")
+	autolink_sensors = list("co2_sensor"="Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/structure/window/reinforced{
@@ -88772,8 +88763,7 @@
 /area/station/maintenance/fsmaint)
 "wAJ" = (
 /obj/machinery/computer/prisoner{
-	dir = 8;
-	req_access = list(2)
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -90120,7 +90110,7 @@
 	dir = 8;
 	level = 3;
 	name = "Distribution and Waste Monitor";
-	autolink_sensors = list("mair_in_meter" = "Mixed Air In", "air_sensor" = "Mixed Air Supply Tank", "mair_out_meter" = "Mixed Air Out", "dloop_atm_meter" = "Distribution Loop", "wloop_atm_meter" = "Waste Loop")
+	autolink_sensors = list("mair_in_meter"="Mixed Air In","air_sensor"="Mixed Air Supply Tank","mair_out_meter"="Mixed Air Out","dloop_atm_meter"="Distribution Loop","wloop_atm_meter"="Waste Loop")
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -91762,7 +91752,7 @@
 /obj/machinery/computer/general_air_control{
 	dir = 4;
 	name = "Tank Monitor";
-	autolink_sensors = list("n2_sensor" = "Nitrogen", "o2_sensor" = "Oxygen", "co2_sensor" = "Carbon Dioxide", "tox_sensor" = "Toxins", "n2o_sensor" = "Nitrous Oxide", "waste_sensor" = "Gas Mix Tank")
+	autolink_sensors = list("n2_sensor"="Nitrogen","o2_sensor"="Oxygen","co2_sensor"="Carbon Dioxide","tox_sensor"="Toxins","n2o_sensor"="Nitrous Oxide","waste_sensor"="Gas Mix Tank")
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Replaces all shelves labeled "adult" to "romance"
Replaces the random shelves on cerestation with the standard empty labeled ones.
Also slightly shifts the organization of bookshelves.

## Why It's Good For The Game

We do not tolerate adult content, so having a library shelf for it seems incorrect.
Also consistency is good.

## Testing
Complied. 
<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
tweak: Changed "Adult" shelves in the library to "romance"
tweak: Replaced random bookshelves in cerestation library to standard empty labeled ones for consistancy.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
