### PR TITLE
fix: mining charges work again for non-ore rock

### DIFF
--- a/code/modules/mining/equipment/mining_charges.dm
+++ b/code/modules/mining/equipment/mining_charges.dm
@@ -81,10 +81,11 @@
 	S.start()
 	for(var/turf/simulated/mineral/rock in circlerangeturfs(location, boom_sizes[3]))
 		var/distance = get_dist_euclidian(location, rock)
-		if(distance <= boom_sizes[3] && rock.ore)
-			rock.ore.drop_max += 3 // if rock is going to get drilled, add bonus mineral amount
-			rock.ore.drop_min += 3
-			rock.gets_drilled()
+		if(distance <= boom_sizes[3])
+			if(rock.ore)
+				rock.ore.drop_max += 3 // if rock is going to get drilled, add bonus mineral amount
+				rock.ore.drop_min += 3
+			rock.gets_drilled(triggered_by_explosion = TRUE)
 	for(var/mob/living/carbon/C in circlerange(location, boom_sizes[3]))
 		var/distance = get_dist_euclidian(location, C)
 		C.flash_eyes()


### PR DESCRIPTION
## What Does This PR Do
This PR fixes mining charges not working on non-ore rock, a regression caused by https://github.com/ParadiseSS13/Paradise/pull/27043.
## Why It's Good For The Game
Bugfix.
## Images of changes

https://github.com/user-attachments/assets/0fea2725-e32f-4816-a0ce-462f71c2c0b5


## Testing

See above.

<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Mining charges properly detonate all rock.
/:cl:
