### PR TITLE
fix: typo making unintentional type

### DIFF
--- a/code/modules/station_goals/bluespace_tap.dm
+++ b/code/modules/station_goals/bluespace_tap.dm
@@ -545,4 +545,3 @@
 
 #undef POINTS_PER_W
 #undef BASE_POINTS
-ER_W


### PR DESCRIPTION
## What Does This PR Do
This PR removes a typo from the bluespace tap file which was causing the creation of a distinct type. This was almost certainly some truncated text from the defines above it.
## Why It's Good For The Game
Fixing typos good.
## Images of changes

### Before

![2024_11_03__16_47_55__code_modules_station_goals_bluespace_tap dm - Paradise (Workspace) - Visual Stud](https://github.com/user-attachments/assets/31fbb24e-e604-4020-af48-6046f83c58d7)

### After

![2024_11_03__16_49_42__Comparing ParadiseSS13_master warriorstar-orion_fix_er_w · ParadiseSS13_Paradi](https://github.com/user-attachments/assets/a08316cf-2bd2-432b-a5e7-ad2cc980fe3b)

## Testing
See above.

<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog
NPFC
