### PR TITLE
Death alarms have a SLIGHT cooldown on when they send another message

### DIFF
--- a/code/game/objects/items/weapons/bio_chips/bio_chip_death_alarm.dm
+++ b/code/game/objects/items/weapons/bio_chips/bio_chip_death_alarm.dm
@@ -8,6 +8,8 @@
 
 	var/mobname = "Unknown"
 	var/static/list/stealth_areas = typecacheof(list(/area/syndicate_mothership, /area/shuttle/syndicate_elite))
+	/// Tracking to prevent multiple EMPs in the same tick from flooding radio.
+	var/emp_spam_lock = FALSE
 
 /obj/item/bio_chip/death_alarm/implant(mob/target)
 	. = ..()
@@ -26,8 +28,12 @@
 			a.autosay("[mobname] has died-zzzzt in-in-in...", "[mobname]'s Death Alarm")
 			qdel(src)
 		if("emp")
+			if(emp_spam_lock)
+				return
 			var/name = prob(50) ? t.name : pick(SSmapping.teleportlocs)
 			a.autosay("[mobname] has died in [name]!", "[mobname]'s Death Alarm")
+			emp_spam_lock = TRUE
+			addtimer(VARSET_CALLBACK(src, emp_spam_lock, FALSE), 0.1 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE) // shamelessly stolen from pulse demon code
 		else
 			if(is_type_in_typecache(t, stealth_areas))
 				//give the syndies a bit of stealth

--- a/code/game/objects/items/weapons/bio_chips/bio_chip_death_alarm.dm
+++ b/code/game/objects/items/weapons/bio_chips/bio_chip_death_alarm.dm
@@ -9,7 +9,7 @@
 	var/mobname = "Unknown"
 	var/static/list/stealth_areas = typecacheof(list(/area/syndicate_mothership, /area/shuttle/syndicate_elite))
 	/// Tracking to prevent multiple EMPs in the same tick from flooding radio.
-	var/emp_spam_lock = FALSE
+	COOLDOWN_DECLARE(emp_spam_lock)
 
 /obj/item/bio_chip/death_alarm/implant(mob/target)
 	. = ..()
@@ -28,12 +28,11 @@
 			a.autosay("[mobname] has died-zzzzt in-in-in...", "[mobname]'s Death Alarm")
 			qdel(src)
 		if("emp")
-			if(emp_spam_lock)
+			if(!COOLDOWN_FINISHED(src, emp_spam_lock))
 				return
 			var/name = prob(50) ? t.name : pick(SSmapping.teleportlocs)
 			a.autosay("[mobname] has died in [name]!", "[mobname]'s Death Alarm")
-			emp_spam_lock = TRUE
-			addtimer(VARSET_CALLBACK(src, emp_spam_lock, FALSE), 0.1 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE) // shamelessly stolen from pulse demon code
+			COOLDOWN_START(src, emp_spam_lock, 0.1 SECONDS)
 		else
 			if(is_type_in_typecache(t, stealth_areas))
 				//give the syndies a bit of stealth


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds small cooldown(0.1 seconds) to the death alarm emp message to prevent spamming when ion scatter shot is used.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Having common flooded with 7 death alarm messages is really not ideal.
![image](https://github.com/user-attachments/assets/749cdf78-5e18-4f21-9942-070454eb41cb)

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
## Testing

<!-- How did you test the PR, if at all? -->
Compiled, shot a target with a death alarm with a regular ion rifle, no dropped messages noticed.
shot a target with ion scatter, only one message was sent per shot
<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
is very tweaky fix, lemme know if i should've gotten approval first.
  <hr>

## Changelog

:cl:
fix: ion scatter no longer floods common radio with death alarm messages if the target has one

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
