### PR TITLE
Tweaks abductor experimentor slightly and fixes a runtime

### DIFF
--- a/code/game/gamemodes/miniantags/abduction/machinery/experiment.dm
+++ b/code/game/gamemodes/miniantags/abduction/machinery/experiment.dm
@@ -234,7 +234,6 @@
 	if(!occupant)
 		return
 	to_chat(occupant, "<span class='warning'>Something is electrifying you!</span>")
-	sleep(1 SECONDS)
 	occupant.electrocute_act(10, src)
 	do_sparks(5, TRUE, src)
 
@@ -243,7 +242,7 @@
 		return
 	to_chat(occupant, "<span class='warning'>Something is stabbing you in the back!</span>")
 	occupant.apply_damage(5, BRUTE, BODY_ZONE_CHEST)
-	occupant.reagents.add_reagent("ether", 5)
+	occupant.reagents.add_reagent("pancuronium", 3)
 
 /obj/machinery/abductor/experiment/force_eject_occupant(mob/target)
 	eject_abductee()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Removes the delay in the abductor experimentor electrocution as this can cause runtimes, and changes the sedate chemical in said machine to pancuronium
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Runtimes bad, the runtime in question happened when the electrification response happened and the mob was removed from the experimentor less than 1 second after the electrification started. 
The ether took 80 seconds to sedate whereas pancuronium only takes 20 seconds to paralyse, which is conveniently the same as the escape attempt timer
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

I went into the experimentor and tried to escape, I was electrocuted instantly when electrocuted, and I was given pancuronium when injected

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
tweak: Replace ether with pancuronium in the sedate-response to escape attempts from the abductor experimentor
fix: Fixed a runtime caused by a 1 second sleep in the electrify-response to escape attempts from the abductor experimentor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
