### PR TITLE
config: allow disabling default SSweather events

### DIFF
--- a/code/controllers/configuration/sections/general_configuration.dm
+++ b/code/controllers/configuration/sections/general_configuration.dm
@@ -84,6 +84,9 @@
 	var/revival_brain_life = 10 MINUTES
 	/// Enable random AI lawsets from the default=TRUE pool
 	var/random_ai_lawset = TRUE
+	/// Enable weather events initialized by SSweather. New weather events can still
+	/// be added during the round if this is disabled.
+	var/enable_default_weather_events = TRUE
 
 /datum/configuration_section/general_configuration/load_data(list/data)
 	// Use the load wrappers here. That way the default isnt made 'null' if you comment out the config line
@@ -117,6 +120,7 @@
 	CONFIG_LOAD_BOOL(enable_night_shifts, data["enable_night_shifts"])
 	CONFIG_LOAD_BOOL(reactionary_explosions, data["reactionary_explosions"])
 	CONFIG_LOAD_BOOL(random_ai_lawset, data["random_ai_lawset"])
+	CONFIG_LOAD_BOOL(enable_default_weather_events, data["enable_default_weather_events"])
 
 	// Numbers
 	CONFIG_LOAD_NUM(lobby_time, data["lobby_time"])

--- a/code/controllers/subsystem/SSweather.dm
+++ b/code/controllers/subsystem/SSweather.dm
@@ -40,6 +40,9 @@ SUBSYSTEM_DEF(weather)
 		next_hit_by_zlevel["[z]"] = world.time + randTime + initial(W.telegraph_duration)
 
 /datum/controller/subsystem/weather/Initialize()
+	if(!GLOB.configuration.general.enable_default_weather_events)
+		return
+
 	for(var/V in subtypesof(/datum/weather))
 		var/datum/weather/W = V
 		var/probability = initial(W.probability)

--- a/config/example/config.toml
+++ b/config/example/config.toml
@@ -380,7 +380,8 @@ bomb_cap = 20
 revival_brain_life = 6000 # 10 minutes
 # Enable random silicon lawset (If said lawset has default = TRUE in the code). Disable for always crewsimov
 random_ai_lawset = true
-
+# Enable weather events initialized by SSweather. New weather events can still be added during the round if this is disabled.
+enable_default_weather_events = true
 
 ################################################################
 


### PR DESCRIPTION
## What Does This PR Do
This PR exposes a setting in `config.toml` for disabling SSweather's collecting of `/datum/weather` subtypes on Initialize, thus preventing any weather events from occurring.

It'd be nice if I could disable subsystems wholesale via config but the load order don't work that way, plus this allows admins to add weather even if it's disabled in the config.
## Why It's Good For The Game
Developers often have to debug things on Lavaland and ash storms get in the way. This makes it easy to disable them without having to make a source code change in their branch.
## Images of changes

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Enabled config, ensured eligible zlevels showed up:

![2024_11_04__21_04_14__Paradise Station 13](https://github.com/user-attachments/assets/d3bfcfa0-917d-40e1-977b-ae3282be62e9)


Disabled config, ensured eligible zlevels were empty, started round, ensured no ash storm occurred.

![2024_11_04__21_00_27__Paradise Station 13](https://github.com/user-attachments/assets/2c3dbfca-0c3d-464a-9a2f-e7de1d5254c8)


<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog
NPFC
