### PR TITLE
Resting offset fix 2

### DIFF
--- a/code/modules/mob/living/carbon/carbon_update_icons.dm
+++ b/code/modules/mob/living/carbon/carbon_update_icons.dm
@@ -12,7 +12,7 @@
 			final_pixel_y = pixel_y
 		else //if(lying != 0)
 			if(lying_prev == 0) //Standing to lying
-				final_pixel_y = PIXEL_Y_OFFSET_LYING
+				final_pixel_y = pixel_y + PIXEL_Y_OFFSET_LYING
 				if(dir & (EAST|WEST)) //Facing east or west
 					final_dir = pick(NORTH, SOUTH) //So you fall on your side rather than your face or ass
 	if(resize != RESIZE_DEFAULT_SIZE)

--- a/code/modules/mob/living/living_status_procs.dm
+++ b/code/modules/mob/living/living_status_procs.dm
@@ -118,7 +118,6 @@ STATUS EFFECTS
 			layer = BLASTDOOR_LAYER
 		else
 			layer = LYING_MOB_LAYER //so mob lying always appear behind standing mobs
-	pixel_y = PIXEL_Y_OFFSET_LYING
 	ADD_TRAIT(src, TRAIT_UI_BLOCKED, LYING_DOWN_TRAIT)
 	ADD_TRAIT(src, TRAIT_CANNOT_PULL, LYING_DOWN_TRAIT)
 	RegisterSignal(src, COMSIG_ATOM_DIR_CHANGE, PROC_REF(orient_crawling))


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Fixes resting off-set for non-carbon living mobs.

Reverts part of #19903 

I was wrong in my original PR about what was causing this issue to happen. It has nothing to do with the `pixel_y` being duplicated in `update_transform`.

While `pixel_y = pixel_y` was a completely useless part of the `update_transform` proc it red herringed me into thinking that was the cause of the issue.

Simply put, the actual issue was that on a `/mob/living/` level another `PIXEL_Y_OFFSET_LYING` was being applied to `pixel_y`. This breaks resting for non-carbons and once upon a time broke resting for carbons by applying `PIXEL_Y_OFFSET_LYING` twice to `pixel_y`.

The old fix was to completely ignore `pixel_y` and hard set the resting offset to `PIXEL_Y_OFFSET_LYING`. While this worked, it isn't ideal if you ever wanted to change the standing `pixel_y` because the resting offset wouldn't change with it.

`/mob/living/proc/on_lying_down(new_lying_angle)` should never have had `pixel_y = PIXEL_Y_OFFSET_LYING` applied to it and removing it fixes the issue for carbons and non-carbons alike.

Looking at both current and older versions of /tg/ code from around when we ported crawling I can see why this issue came to be in Paracode, but that's not really too important and this is already getting rather long. Ping me on Discord if you really want to know.

## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Non-carbons no longer rest below the tile they are on.

Dead non-carbons no longer appear below the tile they died on (as mobs rest when dead)

Resting offset is no longer hard coded and takes the `pixel_y` into account.

## Images of changes

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

![pr1](https://github.com/user-attachments/assets/cbdfe5be-92ac-4709-b9f2-8b926c57c1c2)

![pr2](https://github.com/user-attachments/assets/755ac6db-3d6a-476c-a572-92ccdd6bc6a7)


## Testing

<!-- How did you test the PR, if at all? -->

I testing resting for carbons and non-carbons alike (even tested xenos!!)

Carbon resting is unchanged and non-carbon resting is fixed.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Simple mobs no longer rest below the tile they are on.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
