### PR TITLE
Fix chef hat inhands sprite

### DIFF
--- a/code/modules/clothing/head/job_hats.dm
+++ b/code/modules/clothing/head/job_hats.dm
@@ -4,7 +4,7 @@
 	name = "chef's hat"
 	desc = "The commander in chef's head wear."
 	icon_state = "chef"
-	item_state = "chef"
+	item_state = "chefhat"
 	strip_delay = 10
 	put_on_delay = 10
 	dog_fashion = /datum/dog_fashion/head/chef


### PR DESCRIPTION
## What Does This PR Do
Fixes item_state name for chef hat

## Why It's Good For The Game
You won't hold chef outfit while hold chef hat
Fixes #27322 

## Images of changes
![image](https://github.com/user-attachments/assets/8c64b14a-b73f-47d5-a8c3-3459f02d12dc)

## Testing
I see chef hat in hands on screenshot above

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

<hr>

## Changelog

:cl:
fix: You will no longer see the chef outfit in your hands when you hold the chef hat
/:cl:
