### PR TITLE
People activating a powersink now pokes ghosts with a follow prompt

### DIFF
--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -99,6 +99,7 @@
 				"<span class='italics'>You hear a click.</span>")
 			message_admins("Power sink activated by [ADMIN_LOOKUPFLW(user)] at [ADMIN_VERBOSEJMP(src)]")
 			log_game("Power sink activated by [key_name(user)] at [AREACOORD(src)]")
+			notify_ghosts("[user] has activated a [src]!", title = "Something's Interesting!", source = src, flashwindow = FALSE, action = NOTIFY_FOLLOW)
 			set_mode(OPERATING)
 
 		if(OPERATING)

--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -99,7 +99,7 @@
 				"<span class='italics'>You hear a click.</span>")
 			message_admins("Power sink activated by [ADMIN_LOOKUPFLW(user)] at [ADMIN_VERBOSEJMP(src)]")
 			log_game("Power sink activated by [key_name(user)] at [AREACOORD(src)]")
-			notify_ghosts("[user] has activated a [src]!", title = "Something's Interesting!", source = src, flashwindow = FALSE, action = NOTIFY_FOLLOW)
+			notify_ghosts("[user] has activated a [name]!", title = "Something's Interesting!", source = src, flashwindow = FALSE, action = NOTIFY_FOLLOW)
 			set_mode(OPERATING)
 
 		if(OPERATING)

--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -99,7 +99,7 @@
 				"<span class='italics'>You hear a click.</span>")
 			message_admins("Power sink activated by [ADMIN_LOOKUPFLW(user)] at [ADMIN_VERBOSEJMP(src)]")
 			log_game("Power sink activated by [key_name(user)] at [AREACOORD(src)]")
-			notify_ghosts("[user] has activated a [name]!", title = "Something's Interesting!", source = src, flashwindow = FALSE, action = NOTIFY_FOLLOW)
+			notify_ghosts("[user] has activated a [name]!", title = "Someone's plan is going into effect! (Click to follow)", source = src, flashwindow = FALSE, action = NOTIFY_FOLLOW)
 			set_mode(OPERATING)
 
 		if(OPERATING)

--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -99,7 +99,7 @@
 				"<span class='italics'>You hear a click.</span>")
 			message_admins("Power sink activated by [ADMIN_LOOKUPFLW(user)] at [ADMIN_VERBOSEJMP(src)]")
 			log_game("Power sink activated by [key_name(user)] at [AREACOORD(src)]")
-			notify_ghosts("[user] has activated a [name]!", title = "Someone's plan is going into effect! (Click to follow)", source = src, flashwindow = FALSE, action = NOTIFY_FOLLOW)
+			notify_ghosts("[user] has activated a [name]!", title = "An electrifying occurence! (Click to follow)", source = src, flashwindow = FALSE, action = NOTIFY_FOLLOW)
 			set_mode(OPERATING)
 
 		if(OPERATING)
@@ -142,6 +142,7 @@
 		if(!admins_warned)
 			admins_warned = TRUE
 			message_admins("Power sink at ([x],[y],[z] - <A href='byond://?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>) is 95% full. Explosion imminent.")
+			notify_ghosts("A [name] is almost at max capacity, and is about to explode!", title = "An electrifying occurence! (Click to follow)", source = src, flashwindow = FALSE, action = NOTIFY_FOLLOW)
 		playsound(src, 'sound/effects/screech.ogg', 100, TRUE, 1)
 
 	if(power_drained >= max_power)

--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -99,7 +99,7 @@
 				"<span class='italics'>You hear a click.</span>")
 			message_admins("Power sink activated by [ADMIN_LOOKUPFLW(user)] at [ADMIN_VERBOSEJMP(src)]")
 			log_game("Power sink activated by [key_name(user)] at [AREACOORD(src)]")
-			notify_ghosts("[user] has activated a [name]!", title = "An electrifying occurence! (Click to follow)", source = src, flashwindow = FALSE, action = NOTIFY_FOLLOW)
+			notify_ghosts("[user] has activated a [name]!", title = "An electrifying occurrence! (Click to follow)", source = src, flashwindow = FALSE, action = NOTIFY_FOLLOW)
 			set_mode(OPERATING)
 
 		if(OPERATING)
@@ -142,7 +142,7 @@
 		if(!admins_warned)
 			admins_warned = TRUE
 			message_admins("Power sink at ([x],[y],[z] - <A href='byond://?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>) is 95% full. Explosion imminent.")
-			notify_ghosts("A [name] is almost at max capacity, and is about to explode!", title = "An electrifying occurence! (Click to follow)", source = src, flashwindow = FALSE, action = NOTIFY_FOLLOW)
+			notify_ghosts("A [name] is almost at max capacity, and is about to explode!", title = "An electrifying occurrence! (Click to follow)", source = src, flashwindow = FALSE, action = NOTIFY_FOLLOW)
 		playsound(src, 'sound/effects/screech.ogg', 100, TRUE, 1)
 
 	if(power_drained >= max_power)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds an 'object of interest' notification when powersinks are turned on. 
and when its at 95% capacity
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Letting ghosts know whats happening in a round is nice, a powersink is a VERY impactful event for the round, so letting ghosts quickly be able to watch people walk past it is nice.
same with it exploding
Im sure some people will be quick to point out 'wouldn't this lead to dead crewmember metagaming?' and well, yeah. probably. but ghosts can already find the powersink much easier than crew can, and from there its not too hard for that information to make its way to a dead crewmember that could use the information to disable it.
So i dont think it'll be that big of a problem
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![dreamseeker_1fWs6W8n3q](https://github.com/user-attachments/assets/8886041b-9b8b-4c6a-b940-9750b690ae37)
(`a the powersink` has since been fixed, forgot to take a new screenshot :p)
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
see above, did some multi instance ~~drifting~~ testing, screwdrivered down a powersink, then turned it on, tabbed to the other client, watched as it pinged ghosts who and what
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
![Discord_qR1CvDKXQ4](https://github.com/user-attachments/assets/d6e6733e-6f9f-49fd-8261-a1f430c74590)

  <hr>

## Changelog

:cl:
add: Turning on a powersink will now ping ghosts with a prompt to follow the powersink. As with when its about to explode
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
