### PR TITLE
[s] Stealth box fix

### DIFF
--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -246,6 +246,11 @@
 	icon_state = "disky"
 	layer = BLIND_LAYER
 
+/atom/movable/screen/fullscreen/center/agent_box
+	icon = 'icons/obj/cardboard_boxes.dmi'
+	icon_state = "agentbox"
+	alpha = 128
+
 #undef FULLSCREEN_LAYER
 #undef BLIND_LAYER
 #undef CRIT_LAYER

--- a/code/game/objects/items/weapons/bio_chips/bio_chip_stealth.dm
+++ b/code/game/objects/items/weapons/bio_chips/bio_chip_stealth.dm
@@ -52,17 +52,17 @@
 
 	// Spawn the actual box
 	var/obj/structure/closet/cardboard/agent/box = new(get_turf(owner), owner)
-	box.implant_user_UID = owner.UID()
 	// Slightly shorter time since we needed 0.3s to to do the spawn animation.
 	INVOKE_ASYNC(box, TYPE_PROC_REF(/obj/structure/closet/cardboard/agent, go_invisible), 1.7 SECONDS)
-	box.create_fake_box()
 	owner.forceMove(box)
+	owner.overlay_fullscreen("agent_box", /atom/movable/screen/fullscreen/center/agent_box)
 	RegisterSignal(box, COMSIG_PARENT_QDELETING, PROC_REF(start_cooldown))
 
 /datum/action/item_action/agent_box/proc/start_cooldown(datum/source)
 	SIGNAL_HANDLER
 	on_cooldown = TRUE
 	addtimer(CALLBACK(src, PROC_REF(end_cooldown)), 10 SECONDS)
+	owner.clear_fullscreen("agent_box")
 	UpdateButtons()
 
 /datum/action/item_action/agent_box/proc/end_cooldown()
@@ -109,20 +109,6 @@
 	max_integrity = 1
 	move_speed_multiplier = 0.5 // You can move at run speed while in this box.
 	material_drop = null
-	/// UID of the person who summoned this box with an implant.
-	var/implant_user_UID
-	// This has to be a separate object and not just an image because the image will inherit the box's 0 alpha while it is stealthed.
-	/// A holder effect which follows the src box so we can display an image to the person inside the box.
-	var/obj/effect/fake_box
-	/// The box image attached to the `fake_box` object.
-	var/image/box_img
-
-/obj/structure/closet/cardboard/agent/Destroy()
-	var/mob/living/implant_user = locateUID(implant_user_UID)
-	implant_user?.client?.images -= box_img
-	QDEL_NULL(fake_box)
-	QDEL_NULL(box_img)
-	return ..()
 
 /obj/structure/closet/cardboard/agent/open()
 	. = ..()
@@ -133,27 +119,6 @@
 // When the box is opened, it's deleted, so we never need to update this.
 /obj/structure/closet/cardboard/agent/update_icon_state()
 	return
-
-/obj/structure/closet/cardboard/agent/proc/create_fake_box()
-	if(fake_box)
-		return
-	fake_box = new(get_turf(src))
-	fake_box.mouse_opacity = MOUSE_OPACITY_TRANSPARENT // This object should be completely invisible.
-	box_img = image(icon, fake_box, icon_state, ABOVE_MOB_LAYER)
-	box_img.alpha = 128
-	RegisterSignal(src, COMSIG_MOVABLE_MOVED, PROC_REF(move_fake_box))
-	var/mob/living/implant_user = locateUID(implant_user_UID)
-	implant_user.client?.images += box_img
-
-/obj/structure/closet/cardboard/agent/proc/move_fake_box(datum/source, oldloc, move_dir)
-	SIGNAL_HANDLER
-
-	// For non-standard movement such as teleports.
-	if(!move_dir)
-		fake_box.loc = get_turf(src)
-		return
-	// For basic 8-directional movement.
-	fake_box.loc = get_step(fake_box, move_dir)
 
 /obj/structure/closet/cardboard/agent/proc/go_invisible(invis_time = 2 SECONDS)
 	animate(src, alpha = 0, time = invis_time)

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -537,8 +537,11 @@
 	if(istype(user.loc, /obj/machinery/atmospherics)) //Come now, no emaging all the doors on station from a pipe
 		to_chat(user, "<span class='warning'>Your implant is unable to get a lock on anything in the pipes!</span>")
 		return
-
-	var/beam = user.Beam(target, icon_state = "sm_arc_supercharged", time = 3 SECONDS)
+	var/beam
+	if(!istype(user.loc, /turf)) //Using it inside a locker or stealth box is fine! Let us make sure the beam can be seen though.
+		beam = user.loc.Beam(target, icon_state = "sm_arc_supercharged", time = 3 SECONDS)
+	else
+		beam = user.Beam(target, icon_state = "sm_arc_supercharged", time = 3 SECONDS)
 
 	user.visible_message("<span class='warning'>[user] makes an unusual buzzing sound as the air between them and [target] crackles.</span>", \
 			"<span class='warning'>The air between you and [target] begins to crackle audibly as the Binyat gets to work and heats up in your head!</span>")
@@ -757,7 +760,7 @@
 
 /// Blocks teleports and stuns the would-be-teleportee.
 /obj/item/organ/internal/cyberimp/chest/bluespace_anchor/proc/on_teleport(mob/living/teleportee, atom/destination, channel)
-	SIGNAL_HANDLER  // COMSIG_MOVABLE_TELEPORTED 
+	SIGNAL_HANDLER  // COMSIG_MOVABLE_TELEPORTED
 
 	to_chat(teleportee, "<span class='userdanger'>You feel yourself teleporting, but are suddenly flung back to where you just were!</span>")
 
@@ -769,7 +772,7 @@
 
 /// Prevents a user from entering a jaunt.
 /obj/item/organ/internal/cyberimp/chest/bluespace_anchor/proc/on_jaunt(mob/living/jaunter)
-	SIGNAL_HANDLER  // COMSIG_MOB_PRE_JAUNT 
+	SIGNAL_HANDLER  // COMSIG_MOB_PRE_JAUNT
 
 	to_chat(jaunter, "<span class='userdanger'>As you attempt to jaunt, you slam directly into the barrier between realities and are sent crashing back into corporeality!</span>")
 

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -538,7 +538,7 @@
 		to_chat(user, "<span class='warning'>Your implant is unable to get a lock on anything in the pipes!</span>")
 		return
 	var/beam
-	if(!istype(user.loc, /turf)) //Using it inside a locker or stealth box is fine! Let us make sure the beam can be seen though.
+	if(!isturf(user.loc)) //Using it inside a locker or stealth box is fine! Let us make sure the beam can be seen though.
 		beam = user.loc.Beam(target, icon_state = "sm_arc_supercharged", time = 3 SECONDS)
 	else
 		beam = user.Beam(target, icon_state = "sm_arc_supercharged", time = 3 SECONDS)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Stealth box is now a fullscreen, should no longer disjoint from the stealth box.
Bynat now will show  the beam if you are in a locker or mech or stealth box
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Disjointing bad
Invisible emaging bad
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

<!-- How did you test the PR, if at all? -->
Emaged in locker
emaged in stealthbox
Tried as hard as possible to disjoint the stealth box image from mob, could not

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Stealth box image should no longer disjoint from the stealth box.
fix: Bynat will make a beam from the locker or mech or stealth box you are in if you emag something while in one
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
