### PR TITLE
Buffing the Hacker bundle by nerfing it

### DIFF
--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -124,12 +124,12 @@
 		/obj/item/bio_chip_implanter/storage, // 40TC
 		/obj/item/encryptionkey/syndicate) // 10TC
 
-/// 220TC
+/// 200TC
 /obj/item/storage/box/syndie_kit/bundle/hacker
 	name = "Hacker Bundle"
 	desc = "A kit with everything you need to hack into and disrupt the Station, AI, its cyborgs and the Security team. HACK THE PLANET!"
 	items = list(
-		/obj/item/melee/energy/sword/saber/blue, // 40TC
+		/obj/item/autosurgeon/organ/syndicate/oneuse/razorwire, // 20TC
 		/obj/item/autosurgeon/organ/syndicate/oneuse/hackerman_deck, // 30TC
 		/obj/item/door_remote/omni/access_tuner, // 30TC, HACK EVERYTHING
 		/obj/item/encryptionkey/syndicate, // 10TC


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Replaces the 40 TC Energy Sword in the Hacker bundle with the 20 TC Razorwire Spool Arm Implant Autoimplanter.

## Why It's Good For The Game

Literally this is miles cooler than budget lightsabers

![giphy-3_2-2722538377](https://github.com/user-attachments/assets/8b14fae7-e057-4a7d-8352-841461beceed)

But seriously - Energy swords always felt a bit out of place in a bundle for a Hacker, and the mono/razorwire is a really cool weapon for the Cyberpunk universe, which really fits the whole Combat Hacker theme along with the Binyat.

![giphy-1934145855](https://github.com/user-attachments/assets/e316669f-6b97-4a12-9bdb-4010b5164c11)

The razorwire's negative armour penetration also solidifies the Hacker bundle's role as a covert operator - You are a hacker who finesses your way through wiliness and guile, not brute force. If heavily armoured foes come your way you aren't supposed to take them head on.

## Images of changes

![Screenshot 2024-11-14 232452](https://github.com/user-attachments/assets/d34772bd-e7fc-4569-b194-dca7c9b3a6d3)

## Testing

It compiles fine.

Bought bundles with TC until I got Hacker

Verified that there are no Energy Swords, and that the Razorwire Spool Autoimplanter is in.

Verified that all other items of the bundle are included.

Implanted myself with the razorwire and whipped a few monkeys

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

![Screenshot 2024-11-15 002047](https://github.com/user-attachments/assets/274639bf-3f6c-454a-a082-fe9e9a09232f)
![Screenshot 2024-11-15 002147](https://github.com/user-attachments/assets/630d38b0-abdf-47a2-a378-5a3c43b20674)
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
add: Added the Razorwire Spool Arm Implant Autoimplanter into the Hacker Bundle
del: Removed the Energy Sword from the Hacker Bundle
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
