### PR TITLE
Multitool cable pulse message is now outputs in regular chat rather than the combat log

### DIFF
--- a/code/modules/power/cables/cable.dm
+++ b/code/modules/power/cables/cable.dm
@@ -120,7 +120,7 @@ By design, d1 is the smallest direction and d2 is the highest
 	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
 		return
 	if(powernet && (powernet.available_power > 0))		// is it powered?
-		to_chat(user, chat_box_examine("<span class='notice'>Total power: [DisplayPower(powernet.available_power)]\nLoad: [DisplayPower(powernet.power_demand)]\nExcess power: [DisplayPower(get_surplus())]</span>"))
+		to_chat(user, chat_box_examine("<span class='warning'>Total power: [DisplayPower(powernet.available_power)]\nLoad: [DisplayPower(powernet.power_demand)]\nExcess power: [DisplayPower(get_surplus())]</span>"))
 	else
 		to_chat(user, "<span class='warning'>The cable is not powered.</span>")
 	shock(user, 5, 0.2)

--- a/code/modules/power/cables/cable.dm
+++ b/code/modules/power/cables/cable.dm
@@ -120,7 +120,7 @@ By design, d1 is the smallest direction and d2 is the highest
 	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
 		return
 	if(powernet && (powernet.available_power > 0))		// is it powered?
-		to_chat(user, "<span class='notice'>Total power: [DisplayPower(powernet.available_power)]\nLoad: [DisplayPower(powernet.power_demand)]\nExcess power: [DisplayPower(get_surplus())]</span>")
+		to_chat(user, chat_box_examine("<span class='notice'>Total power: [DisplayPower(powernet.available_power)]\nLoad: [DisplayPower(powernet.power_demand)]\nExcess power: [DisplayPower(get_surplus())]</span>"))
 	else
 		to_chat(user, "<span class='notice'>The cable is not powered.</span>")
 	shock(user, 5, 0.2)

--- a/code/modules/power/cables/cable.dm
+++ b/code/modules/power/cables/cable.dm
@@ -122,7 +122,7 @@ By design, d1 is the smallest direction and d2 is the highest
 	if(powernet && (powernet.available_power > 0))		// is it powered?
 		to_chat(user, chat_box_examine("<span class='notice'>Total power: [DisplayPower(powernet.available_power)]\nLoad: [DisplayPower(powernet.power_demand)]\nExcess power: [DisplayPower(get_surplus())]</span>"))
 	else
-		to_chat(user, "<span class='notice'>The cable is not powered.</span>")
+		to_chat(user, "<span class='warning'>The cable is not powered.</span>")
 	shock(user, 5, 0.2)
 
 /obj/structure/cable/wirecutter_act(mob/user, obj/item/I)

--- a/code/modules/power/cables/cable.dm
+++ b/code/modules/power/cables/cable.dm
@@ -120,9 +120,9 @@ By design, d1 is the smallest direction and d2 is the highest
 	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
 		return
 	if(powernet && (powernet.available_power > 0))		// is it powered?
-		to_chat(user, "<span class='danger'>Total power: [DisplayPower(powernet.available_power)]\nLoad: [DisplayPower(powernet.power_demand)]\nExcess power: [DisplayPower(get_surplus())]</span>")
+		to_chat(user, "<span class='notice'>Total power: [DisplayPower(powernet.available_power)]\nLoad: [DisplayPower(powernet.power_demand)]\nExcess power: [DisplayPower(get_surplus())]</span>")
 	else
-		to_chat(user, "<span class='danger'>The cable is not powered.</span>")
+		to_chat(user, "<span class='notice'>The cable is not powered.</span>")
 	shock(user, 5, 0.2)
 
 /obj/structure/cable/wirecutter_act(mob/user, obj/item/I)

--- a/code/modules/power/cables/cable.dm
+++ b/code/modules/power/cables/cable.dm
@@ -120,7 +120,7 @@ By design, d1 is the smallest direction and d2 is the highest
 	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
 		return
 	if(powernet && (powernet.available_power > 0))		// is it powered?
-		to_chat(user, chat_box_examine("<span class='warning'>Total power: [DisplayPower(powernet.available_power)]\nLoad: [DisplayPower(powernet.power_demand)]\nExcess power: [DisplayPower(get_surplus())]</span>"))
+		to_chat(user, chat_box_examine("<span class='notice'>Total power: [DisplayPower(powernet.available_power)]\nLoad: [DisplayPower(powernet.power_demand)]\nExcess power: [DisplayPower(get_surplus())]</span>"))
 	else
 		to_chat(user, "<span class='warning'>The cable is not powered.</span>")
 	shock(user, 5, 0.2)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Changes the multitool cable pulse (the one that shows you grid power) from 'danger' to 'notice', thus stopping it from spitting out its results in the Combat Log.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Wondering why you aint seeing the grid power coz its spitting it out in the combat log is annoying.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![cables](https://github.com/user-attachments/assets/1ef291e9-835e-43d7-8950-15ba6a493571)




<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Compiled master, pulsed cable, went in combat log.
Changed message, compiled branch, pulsed cable, went in chat.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
tweak:Multitool cable pulses no longer outputs in the combat log.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
