### PR TITLE
Unfucks Bulldog Bundles

### DIFF
--- a/code/datums/uplink_items/uplink_nuclear.dm
+++ b/code/datums/uplink_items/uplink_nuclear.dm
@@ -90,6 +90,14 @@
 	uplinktypes = list(UPLINK_TYPE_NUCLEAR, UPLINK_TYPE_SST)
 	surplus = 0
 
+/datum/uplink_item/dangerous/bulldog
+	name = "Bulldog Shotgun"
+	desc = "Lean and mean: Optimized for people that want to get up close and personal. Extra Ammo sold separately."
+	reference = "BULD"
+	item = /obj/item/gun/projectile/automatic/shotgun/bulldog
+	cost = 15
+	uplinktypes = list(UPLINK_TYPE_NUCLEAR, UPLINK_TYPE_SST)
+
 ////////////////////////////////////////
 // MARK: SUPPORT AND MECHAS
 ////////////////////////////////////////
@@ -223,18 +231,19 @@
 
 /datum/uplink_item/ammo/bulldog_ammobag
 	name = "Bulldog - 12g Ammo Duffel Bag"
-	desc = "A duffel bag filled with enough 12g ammo to supply an entire team, at a discounted price."
+	desc = "A duffel bag filled with nine 8 round drum magazines. (6 Slug, 2 Buckshot, 1 Dragon's Breath)"
 	reference = "12ADB"
 	item = /obj/item/storage/backpack/duffel/syndie/shotgun
 	cost = 60 // normally 90
 	uplinktypes = list(UPLINK_TYPE_NUCLEAR, UPLINK_TYPE_SST)
 
 /datum/uplink_item/ammo/bulldog_XLmagsbag
-	name = "Bulldog - 12g XL Magazine Duffel Bag"
-	desc = "A duffel bag containing three 16 round drum magazines(Slug, Buckshot, Dragon's Breath)."
+	name = "Bulldog - 12g Extra-Large Magazine Duffel Bag"
+	desc = "A duffel bag containing five XL 16 round drum magazines. (3 Slug, 1 Buckshot, 1 Dragon's Breath)."
 	reference = "12XLDB"
 	item = /obj/item/storage/backpack/duffel/syndie/shotgunXLmags
-	cost = 60 // normally 90
+	// same price for more ammo, but you're likely to lose more ammo if you drop your bulldog. High risk, high reward.
+	cost = 60
 	uplinktypes = list(UPLINK_TYPE_NUCLEAR, UPLINK_TYPE_SST)
 
 /datum/uplink_item/ammo/smg
@@ -612,15 +621,6 @@
 ////////////////////////////////////////
 // MARK: BUNDLES
 ////////////////////////////////////////
-
-/datum/uplink_item/bundles_TC/bulldog
-	name = "Bulldog Bundle"
-	desc = "Lean and mean: Optimized for people that want to get up close and personal. Contains the popular \
-			Bulldog shotgun, two 12g buckshot drums, and a pair of Thermal imaging goggles."
-	reference = "BULB"
-	item = /obj/item/storage/backpack/duffel/syndie/bulldogbundle
-	cost = 45 // normally 60
-	uplinktypes = list(UPLINK_TYPE_NUCLEAR, UPLINK_TYPE_SST)
 
 /datum/uplink_item/bundles_TC/c20r
 	name = "C-20r Bundle"

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -526,6 +526,8 @@
 
 /obj/item/storage/backpack/duffel/syndie/shotgunXLmags/populate_contents()
 	new /obj/item/ammo_box/magazine/m12g/XtrLrg(src)
+	new /obj/item/ammo_box/magazine/m12g/XtrLrg(src)
+	new /obj/item/ammo_box/magazine/m12g/XtrLrg(src)
 	new /obj/item/ammo_box/magazine/m12g/XtrLrg/buckshot(src)
 	new /obj/item/ammo_box/magazine/m12g/XtrLrg/dragon(src)
 
@@ -563,15 +565,6 @@
 	new /obj/item/ammo_box/magazine/smgm45(src)
 	new /obj/item/gun/projectile/automatic/c20r(src)
 	new /obj/item/suppressor/specialoffer(src)
-
-/obj/item/storage/backpack/duffel/syndie/bulldogbundle
-	desc = "A large duffel bag containing a Bulldog, some drums, and a pair of thermal imaging glasses."
-
-/obj/item/storage/backpack/duffel/syndie/bulldogbundle/populate_contents()
-	new /obj/item/gun/projectile/automatic/shotgun/bulldog(src)
-	new /obj/item/ammo_box/magazine/m12g(src)
-	new /obj/item/ammo_box/magazine/m12g(src)
-	new /obj/item/clothing/glasses/chameleon/thermal(src)
 
 /obj/item/storage/backpack/duffel/syndie/med/medicalbundle
 	desc = "A large duffel bag containing a tactical medkit, a medical beam gun and a pair of syndicate magboots."


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Currently theres 3 bulldog "bundles":
- "Bulldog Bundle" (1 bulldog shotgun, 2 slug mags, 1 chame thermals)  = (45 TC) 
- "Bulldog Ammo Bag" (6 slug mags, 2 buckshot mags, 1 dragons breath mag)  = (60 TC) 
- "Bulldog XL Ammo Bag" (1 slug mag, 1 buckshot mag, 1 dragons breath mag)  = (60 TC) (magazines are twice the size)

The only good one is the Bulldog ammo bag. This PR changes them to be:
- "Bulldog Shotgun" (1 bulldog shotgun)  = (15 TC) 
- "Bulldog Ammo Bag" (No Changes)
- "Bulldog XL Ammo Bag" (3 slug mag, 1 buckshot mag, 1 dragons breath mag)  = (60 TC) (magazines are twice the size)

Basically replacing the bundle with just the shotgun for cheaper, and adding 2 more slug mags to the XL ammo bundle.

The descriptions of each were also altered to make it more clear what they are.

## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
The first and third bundles are quite honestly, *scams*. The first one is buffed by making it more obvious what it is, and making so you don't mistake it for the ammo bundles. The XL ammo, while good costs JUST as much while losing a good amount of ammo. By adding 2 more slug mags it becomes a sidegrade to the normal ammo bag. 

How are larger mags and more ammo than a normal bag a sidegrade? It adds just 8 more rounds of dragon's breath shots, which are some of the worst ammo (imo) you can use for the bulldog. Secondly, one of the strong-suits of the bulldog is that the gun itself is easily replaceable, allowing nukies to carry multiple of them. However, this upside disappears when using larger mags as the crew that stole your gun has 2x as much ammo as usual and you lost 2x as much as usual. This makes XL mags significantly worse at replacement.

## Testing

<!-- How did you test the PR, if at all? -->
Opened uplink, bought a bulldog and a XL ammo bag for 75 TC, fired all 5 drums.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

![image](https://github.com/user-attachments/assets/672198d4-265f-4312-8a91-945232d2ba91)

## Changelog

:cl:
del: Removes "Bulldog Bundle" from the nukie uplink (45 TC)
add: Adds "Bulldog Shotgun" to nukie uplink (15 TC)
tweak: Bulldog XL ammo duffel bag now contains 2 more slug drums.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
