### PR TITLE
Fixes revinfo

### DIFF
--- a/code/datums/revision.dm
+++ b/code/datums/revision.dm
@@ -108,7 +108,9 @@ GLOBAL_PROTECT(revision_info) // Dont mess with this
 	msg += "<b>RUST-G Build</b>: [rustg_get_version()]"
 
 	if(world.TgsAvailable())
-		msg += "<b>TGS Version</b>: [world.TgsVersion()] (API: [world.TgsApiVersion()])"
+		var/datum/tgs_version/tgs_ver = world.TgsVersion()
+		var/datum/tgs_version/api_ver = world.TgsApiVersion()
+		msg += "<b>TGS Version</b>: [tgs_ver.deprefixed_parameter] (API: [api_ver.deprefixed_parameter])"
 
 	if(world.TgsAvailable() && length(GLOB.revision_info.testmerges))
 		msg += "<b>Active Testmerges:</b>"


### PR DESCRIPTION
## What Does This PR Do
Fixes this
![image](https://github.com/user-attachments/assets/030d3e26-16bb-4614-a699-f1bed9a01775)

## Why It's Good For The Game
The above looks wank

## Images of changes
See main desc

## Testing
None, I aint spinning up TGS for a 3 line change

<hr>

### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

<hr>

## Changelog

:cl: AffectedArc07
fix: Fixed the TGS version not showing right in Get Revision Info
/:cl: