### PR TITLE
Remaps Delta's Brig and Courtroom

### DIFF
--- a/_maps/map_files/stations/deltastation.dmm
+++ b/_maps/map_files/stations/deltastation.dmm
@@ -14099,7 +14099,6 @@
 	pixel_x = 32
 	},
 /obj/item/reagent_containers/drinks/bottle/whiskey,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard2)
 "aYJ" = (


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Remaps delta brig and courtroom. The courtroom has become much smaller, the magi's office much larger, and the IAAs got put in a broom closet (literally, theres a broom in their locker). Brig specifically was designed with how NT would design a good security brig in mind, but it still has quite a few flaws.
- Detective's office has new experimental shutters, allowing them to talk to the public.
- Execution has new experimental shutters, allowing perma prisoners to watch executions. Cameras have been carefully places so that the AI cannot see inside the execution room when the shutters are open.
- Perma has had items added to make it more fun to be in there, stuff like crayons and new kitchen machines. This perma may be easier to escape from than before, but security has a better observatory to watch you from.
- Evidence is still nearby maint, but is now only behind 2 doors of protection, but it can be seen from processing. I think its about the same difficulty as old delta evidence. The maint door has a metal sheet covering over it, so it requires welding or emagging.
- The Warden keeps their Crew Monitor Console in this remap, but the HOS does not.
- Processing is right next to all the cells, which makes it convenient when the prisoners are not fighting back. But if they shove you while you're taking someone to processing, they're very likely to run away.
- Cell 5 is mashed inbetween the HOS office and warden office, and is totally run down. All it contains is a space law book. Read up.

## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Delta brig really had "long empty hallway" syndrome. This remap removes the majority of that while keeping some unique features and adding others.

## Images of changes

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
Old brig: https://webmap.affectedarc07.co.uk/maps/paradise/deltastation/

New brig: 
![StrongDMM-2024-11-18 08 32 20](https://github.com/user-attachments/assets/1b71456e-896c-4a30-a39d-8a9a846cff39)
Walkthrough:

https://github.com/user-attachments/assets/2d89c82d-977e-464f-a160-e7a1df2f880c


## Testing

<!-- How did you test the PR, if at all? -->
Ran around a lot, tbh can use more testing!

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>
  
  
![image](https://github.com/user-attachments/assets/080e4385-0510-4d2f-bdb7-d5f7201f6cbd)


## Changelog

:cl:
tweak: NSS Kerberos' brig, courtroom, magistrate's office, and IAA office have been remapped.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
