### PR TITLE
Recounts `rise_number` and related variables every once in a while

### DIFF
--- a/code/modules/antagonists/cult/team_cult.dm
+++ b/code/modules/antagonists/cult/team_cult.dm
@@ -39,8 +39,8 @@ RESTRICT_TYPE(/datum/team/cult)
 	recount_timer = addtimer(CALLBACK(src, PROC_REF(cult_threshold_check)), 5 MINUTES, TIMER_STOPPABLE|TIMER_DELETE_ME|TIMER_LOOP)
 
 /datum/team/cult/Destroy(force, ...)
-	. = ..()
-	QDEL_NULL(recount_timer)
+	deltimer(recount_timer)
+	return ..()
 
 /datum/team/cult/create_team(list/starting_members)
 	cult_threshold_check() // Set this ALWAYS before any check_cult_size check, or

--- a/code/modules/antagonists/cult/team_cult.dm
+++ b/code/modules/antagonists/cult/team_cult.dm
@@ -31,6 +31,17 @@ RESTRICT_TYPE(/datum/team/cult)
 	/// Boolean that prevents all_members_timer from being called multiple times
 	var/is_in_transition = FALSE
 
+	/// Timer until we do a recount of cultist members
+	var/recount_timer
+
+/datum/team/cult/New(list/starting_members)
+	. = ..()
+	recount_timer = addtimer(CALLBACK(src, PROC_REF(cult_threshold_check)), 5 MINUTES, TIMER_STOPPABLE|TIMER_DELETE_ME|TIMER_LOOP)
+
+/datum/team/cult/Destroy(force, ...)
+	. = ..()
+	QDEL_NULL(recount_timer)
+
 /datum/team/cult/create_team(list/starting_members)
 	cult_threshold_check() // Set this ALWAYS before any check_cult_size check, or
 	. = ..()

--- a/code/modules/antagonists/cult/team_cult.dm
+++ b/code/modules/antagonists/cult/team_cult.dm
@@ -48,8 +48,6 @@ RESTRICT_TYPE(/datum/team/cult)
 
 	objective_holder.add_objective(/datum/objective/servecult)
 
-	addtimer(CALLBACK(src, PROC_REF(cult_threshold_check)), 2 MINUTES) // Check again in 2 minutes for latejoiners
-
 	cult_status = NARSIE_DEMANDS_SACRIFICE
 
 	create_next_sacrifice()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Every 5 minutes, the rise and ascend thresholds are recalculated, to account for people leaving the round / joining late
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
This helps a lot when a lot of people leave the game, or a lot of people latejoin
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://github.com/user-attachments/assets/58f1cf7c-c86c-4036-967c-e3c1aeddcd64)

**This image should say `-1` but I accidentally closed my instance before taking a screenshot**
![image](https://github.com/user-attachments/assets/95df33a5-5190-4abd-aed3-57c66049fe11)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
See above
<!-- How did you test the PR, if at all? -->

<hr>

## Changelog

:cl:
fix: Cult will now be a little more consistent when a lot of people latejoin / leave the round early
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
