### PR TITLE
Updates the technical names of BoxStation and DeltaStation

### DIFF
--- a/code/modules/mapping/station_datums.dm
+++ b/code/modules/mapping/station_datums.dm
@@ -1,6 +1,6 @@
 /datum/map/boxstation
 	fluff_name = "NSS Cyberiad"
-	technical_name = "Cyberiad"
+	technical_name = "BoxStation"
 	map_path = "_maps/map_files/stations/boxstation.dmm"
 	webmap_url = "https://webmap.affectedarc07.co.uk/maps/paradise/cyberiad/"
 	welcome_sound = 'sound/AI/welcome_cyberiad.ogg'
@@ -14,7 +14,7 @@
 
 /datum/map/deltastation
 	fluff_name = "NSS Kerberos"
-	technical_name = "Delta"
+	technical_name = "DeltaStation"
 	map_path = "_maps/map_files/stations/deltastation.dmm"
 	webmap_url = "https://webmap.affectedarc07.co.uk/maps/paradise/deltastation/"
 	welcome_sound = 'sound/AI/welcome_kerberos.ogg'


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Updates the technical names of BoxStation and DeltaStation to match their DMM file names (like the other maps).

This should only change how they are labelled in map votes.

The person who updated our map names from cyberiad.dmm to > boxstation.dmm and delta.dmm to > deltastation.dmm forgot to change this.

## Why It's Good For The Game

Consistency plus oversight fix.

BoxStation will no longer be labelled as the Cyberiad twice.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

![image](https://github.com/user-attachments/assets/df0536a0-8243-48f6-9d06-8ee56c83279c)

## Testing

<!-- How did you test the PR, if at all? -->

Ran a map vote to see if the change worked and then loaded into both maps.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Map votes now correctly display the technical names of BoxStation and DeltaStation.
/:cl:

