### PR TITLE
Adjust depot loot a little and remove some irrelevant items.

### DIFF
--- a/code/game/objects/effects/spawners/depot_spawners.dm
+++ b/code/game/objects/effects/spawners/depot_spawners.dm
@@ -143,7 +143,6 @@
 	// Primarily utility items with occasional low damage weaponry.
 	loot = list(
 		/obj/item/borg/upgrade/syndicate,
-		/obj/item/card/id/syndicate,
 		/obj/item/clothing/glasses/hud/security/chameleon,
 		/obj/item/clothing/glasses/thermal,
 		/obj/item/clothing/shoes/magboots/elite,
@@ -172,7 +171,6 @@
 		/obj/item/autosurgeon/organ/syndicate/oneuse/sensory_enhancer,
 		/obj/item/bio_chip_implanter/proto_adrenalin,
 		/obj/item/chameleon,
-		/obj/item/clothing/gloves/fingerless/rapid,
 		/obj/item/cqc_manual,
 		/obj/item/gun/medbeam,
 		/obj/item/gun/projectile/automatic/sniper_rifle/toy,

--- a/code/game/objects/effects/spawners/depot_spawners.dm
+++ b/code/game/objects/effects/spawners/depot_spawners.dm
@@ -167,8 +167,6 @@
 	spawn_inside = /obj/structure/closet/secure_closet/depot/armory
 	// Combat orientated items that could give the player an advantage if an antag messes with them.
 	loot = list(
-		/obj/item/autosurgeon/organ/syndicate/oneuse/razorwire,
-		/obj/item/autosurgeon/organ/syndicate/oneuse/sensory_enhancer,
 		/obj/item/bio_chip_implanter/proto_adrenalin,
 		/obj/item/chameleon,
 		/obj/item/cqc_manual,
@@ -176,6 +174,8 @@
 		/obj/item/gun/projectile/automatic/sniper_rifle/toy,
 		/obj/item/melee/energy/sword/saber,
 		/obj/item/mod/control/pre_equipped/traitor_elite,
+		/obj/item/organ/internal/cyberimp/arm/razorwire,
+		/obj/item/organ/internal/cyberimp/brain/sensory_enhancer,
 		/obj/item/reagent_containers/hypospray/autoinjector/stimulants,
 		/obj/item/shield/energy,
 		/obj/item/storage/box/syndie_kit/teleporter,

--- a/code/game/objects/effects/spawners/depot_spawners.dm
+++ b/code/game/objects/effects/spawners/depot_spawners.dm
@@ -76,11 +76,15 @@
 	loot = list(
 		/obj/item/clothing/mask/gas/syndicate,
 		/obj/item/clothing/shoes/magboots/syndie,
-		/obj/item/clothing/under/syndicate,
+		/obj/item/clothing/suit/jacket/bomber/syndicate,
+		/obj/item/clothing/suit/storage/iaa/blackjacket/armored,
+		/obj/item/clothing/under/syndicate/combat,
+		/obj/item/clothing/under/syndicate/sniper,
 		/obj/item/coin/antagtoken/syndicate,
 		/obj/item/deck/cards/syndicate,
+		/obj/item/lighter/zippo/gonzofist,
 		/obj/item/soap/syndie,
-		/obj/item/storage/box/syndie_kit/space,
+		/obj/item/stamp/chameleon,
 		/obj/item/storage/fancy/cigarettes/cigpack_syndicate,
 		/obj/item/storage/secure/briefcase/syndie,
 		/obj/item/storage/toolbox/syndicate,
@@ -109,29 +113,28 @@
 		/obj/item/ammo_box/magazine/m10mm,
 		/obj/item/clothing/gloves/color/black/thief,
 		/obj/item/clothing/shoes/chameleon/noslip,
-		/obj/item/clothing/suit/jacket/bomber/syndicate,
-		/obj/item/clothing/suit/storage/iaa/blackjacket/armored,
-		/obj/item/clothing/under/chameleon,
 		/obj/item/clothing/under/syndicate/silicon_cham,
+		/obj/item/clothing/mask/chameleon/voice_change,
 		/obj/item/flash/cameraflash,
 		/obj/item/gun/projectile/automatic/toy/pistol/riot,
-		/obj/item/lighter/zippo/gonzofist,
 		/obj/item/mod/control/pre_equipped/traitor,
 		/obj/item/mod/module/chameleon,
 		/obj/item/mod/module/holster/hidden,
 		/obj/item/mod/module/noslip,
 		/obj/item/mod/module/visor/night,
+		/obj/item/mod/module/plate_compression,
+		/obj/item/reagent_containers/hypospray/autoinjector/hyper_medipen,
 		/obj/item/reagent_containers/hypospray/autoinjector/nanocalcium,
 		/obj/item/stack/sheet/mineral/gold{amount = 20},
 		/obj/item/stack/sheet/mineral/plasma{amount = 20},
 		/obj/item/stack/sheet/mineral/silver{amount = 20},
 		/obj/item/stack/sheet/mineral/uranium{amount = 20},
-		/obj/item/stamp/chameleon,
 		/obj/item/storage/backpack/duffel/syndie/med/surgery,
 		/obj/item/storage/backpack/satchel_flat,
 		/obj/item/storage/belt/military,
 		/obj/item/storage/box/syndie_kit/camera_bug,
-		/obj/item/storage/firstaid/tactical,
+		/obj/item/storage/box/syndie_kit/chameleon,
+		/obj/item/storage/box/syndie_kit/space,
 	)
 
 /obj/effect/spawner/random/syndicate/loot/officer
@@ -139,13 +142,14 @@
 	spawn_loot_chance = 40
 	// Primarily utility items with occasional low damage weaponry.
 	loot = list(
-		/obj/item/borg/upgrade/selfrepair,
 		/obj/item/borg/upgrade/syndicate,
+		/obj/item/card/id/syndicate,
 		/obj/item/clothing/glasses/hud/security/chameleon,
 		/obj/item/clothing/glasses/thermal,
 		/obj/item/clothing/shoes/magboots/elite,
 		/obj/item/door_remote/omni/access_tuner,
 		/obj/item/encryptionkey/binary,
+		/obj/item/gun/projectile/automatic/c20r/toy/riot,
 		/obj/item/jammer,
 		/obj/item/mod/module/power_kick,
 		/obj/item/mod/module/stealth,
@@ -153,9 +157,10 @@
 		/obj/item/pen/edagger,
 		/obj/item/pinpointer/advpinpointer,
 		/obj/item/stack/sheet/mineral/diamond{amount = 10},
-		/obj/item/stack/sheet/mineral/uranium{amount = 10},
+		/obj/item/storage/belt/sheath/snakesfang,
 		/obj/item/storage/box/syndidonkpockets,
 		/obj/item/storage/box/syndie_kit/stechkin,
+		/obj/item/storage/firstaid/tactical,
 	)
 
 /obj/effect/spawner/random/syndicate/loot/armory
@@ -164,16 +169,19 @@
 	// Combat orientated items that could give the player an advantage if an antag messes with them.
 	loot = list(
 		/obj/item/autosurgeon/organ/syndicate/oneuse/razorwire,
+		/obj/item/autosurgeon/organ/syndicate/oneuse/sensory_enhancer,
+		/obj/item/bio_chip_implanter/proto_adrenalin,
 		/obj/item/chameleon,
 		/obj/item/clothing/gloves/fingerless/rapid,
 		/obj/item/cqc_manual,
 		/obj/item/gun/medbeam,
+		/obj/item/gun/projectile/automatic/sniper_rifle/toy,
 		/obj/item/melee/energy/sword/saber,
+		/obj/item/mod/control/pre_equipped/traitor_elite,
 		/obj/item/reagent_containers/hypospray/autoinjector/stimulants,
 		/obj/item/shield/energy,
 		/obj/item/storage/box/syndie_kit/teleporter,
 		/obj/item/weaponcrafting/gunkit/universal_gun_kit,
-		/obj/item/mod/control/pre_equipped/traitor_elite
 	)
 
 // Layout-affecting spawns


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Replaces autosurgeons with standalone implants.

Removes, adds, replaces items from next pools:
- Armory:
  - Qani-Laaca (40TC) replaces gloves of North Star (40TC).
  - Added proto-adrenal biochip (10TC), toy SR (priceless).
 - Officer:
   - Added toy c20r (25TC), snakesfang (25TC), tactical first aid kit.
   - Removed **self-repair** module for borgs (I **didn't** mention it to get the pre-approval), 10 uranium (we have 20 uranium in rare loot).
 - Rare:
   - Chameleon kit (10TC) replaces chameleon jumpsuit.
   - Added chameleon voice change mask (5TC), plate compression module (10TC), hyper medipen (10TC), syndie eva.
   - Removed chameleon stamp, zippo, tactical first aid kit, syndie and black jacket.
 - Common:
   - Added combat and sniper uniforms (from bundles, same as tactical turtlenecks), zippo, chameleon stamp, syndie and black jacket.
   - Removed syndie eva, tactical turtleneck.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

Up to dating loot with "new" uplink items. Giving few more options for explorers to shine.
I consider Qani-Laaca implant is a good replace for gloves of North Star. You are being able to get benifit from it as an explorer - like completing some ruins or runaway from sentry bot, avoiding his deadly GL shots, meantime gloves give you nothing against simple mobs, they are only useful against other players on station. Qani is good against players as well, but you have a side effect of heart damage and toxins, not just nothing as with gloves.
Proto-adrenal is nowhere as good as other armory loot, but it's something that could just save your life once in a round.
Removing self repair module is good since it requires no syndie techs to build for robo, why would it be in a depot? Also a very common module for a "officer" loot list.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Compiled, spawned different depot closets, ensured they have new items inside.

<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
![image](https://github.com/user-attachments/assets/b9dcadd9-a1eb-4c5e-9496-de389aee0b45)
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
tweak: Syndie Depot received a couple more items to supply their agents among the sector with.
tweak: Syndie Depot's autosurgeons became too expensive for the local regiment, so the implants now should be installed via surgical help. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
