### PR TITLE
Fixes particle beam and singularity inconsistent interactions

### DIFF
--- a/code/modules/power/engines/singularity/particle_accelerator/particle.dm
+++ b/code/modules/power/engines/singularity/particle_accelerator/particle.dm
@@ -40,11 +40,16 @@
 		B.take_damage(energy * 0.6)
 		movement_range = 0
 
+/// The particles bump the singularity
 /obj/effect/accelerated_particle/Bump(obj/singularity/S)
 	if(!istype(S))
 		return ..()
 	S.energy += energy
+	energy = 0
 
+/// The singularity bumps the particles
+/obj/effect/accelerated_particle/singularity_act()
+	return
 
 /obj/effect/accelerated_particle/ex_act(severity)
 	qdel(src)


### PR DESCRIPTION


<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes inconsistent behaviour between accelerated particles from the PA and the singularity. 
Sometimes the particles would be bumped by the singularity and be destroyed(they called obj/effect/singularity_act()) and other time the particles would bump the singularity twice which would impart the energy twice. 

This PR overrides singularity_act() on the accelerated particle effect so it just returns 0, and reduces the energy to 0 once the particles give the singularity energy.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Inconsistent behaviour is bad.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
- Made a singularity, fired particle beams at it, and made sure each beam gave exactly as much energy to the singularity as it should have
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Accelerated particles now always give the singularity energy and only do so once.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
