### PR TITLE
Makes triple citrus tick on life instead of ingest

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drinks_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks_reagents.dm
@@ -104,7 +104,7 @@
 
 /datum/reagent/consumable/drink/triple_citrus/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
-	if(prob(33))
+	if(prob(15))
 		update_flags |= M.adjustToxLoss(-rand(1, 2), FALSE)
 	return ..() | update_flags
 

--- a/code/modules/reagents/chemistry/reagents/drinks_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks_reagents.dm
@@ -102,9 +102,11 @@
 	drink_desc = "As colorful and healthy as it is delicious."
 	taste_description = "citrus juice"
 
-/datum/reagent/consumable/drink/triple_citrus/reaction_mob(mob/living/M, method=REAGENT_TOUCH, volume)
-	if(method == REAGENT_INGEST)
-		M.adjustToxLoss(-rand(1,2))
+/datum/reagent/consumable/drink/triple_citrus/on_mob_life(mob/living/M)
+	var/update_flags = STATUS_UPDATE_NONE
+	if(prob(33))
+		update_flags |= M.adjustToxLoss(-rand(1, 2), FALSE)
+	return ..() | update_flags
 
 /datum/reagent/consumable/drink/berryjuice
 	name = "Berry Juice"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Triple citrus now ticks with `on_mob_life` instead of only on ingest
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Helps set it straight with like 95% of other drinks.
The toxin healing is slightly lower than Doctor's Delight, which takes 1 more ingredient to make
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Drank some triple citrus without any runtimes
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
tweak: Triple citrus now heals with metabolism instead of only on ingestion
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
