### PR TITLE
Tweak for meatpackers ruin turrets

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/meatpackers.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/meatpackers.dmm
@@ -19,10 +19,7 @@
 /turf/simulated/floor/engine,
 /area/ruin/unpowered/BMPship/Delta)
 "af" = (
-/obj/machinery/porta_turret{
-	lethal = 1;
-	name = "ship defense turret"
-	},
+/obj/machinery/porta_turret/meatpacker_ship,
 /turf/simulated/floor/engine,
 /area/ruin/unpowered/BMPship/Delta)
 "ag" = (
@@ -1948,11 +1945,7 @@
 /turf/simulated/floor/plasteel,
 /area/ruin/unpowered/BMPship/Aft)
 "go" = (
-/obj/machinery/porta_turret{
-	check_synth = 1;
-	lethal = 1;
-	name = "ship defense turret"
-	},
+/obj/machinery/porta_turret/meatpacker_ship,
 /turf/simulated/floor/engine,
 /area/ruin/unpowered/BMPship/Fore)
 "gp" = (
@@ -2258,11 +2251,7 @@
 /turf/simulated/floor/engine,
 /area/ruin/unpowered/BMPship/Aft)
 "hp" = (
-/obj/machinery/porta_turret{
-	check_synth = 1;
-	lethal = 1;
-	name = "ship defense turret"
-	},
+/obj/machinery/porta_turret/meatpacker_ship,
 /turf/simulated/floor/engine,
 /area/ruin/unpowered/BMPship/Aft)
 "hq" = (

--- a/_maps/map_files/RandomRuins/SpaceRuins/meatpackers.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/meatpackers.dmm
@@ -20,7 +20,6 @@
 /area/ruin/unpowered/BMPship/Delta)
 "af" = (
 /obj/machinery/porta_turret{
-	installation = /obj/item/gun/energy/gun;
 	lethal = 1;
 	name = "ship defense turret"
 	},
@@ -1951,7 +1950,6 @@
 "go" = (
 /obj/machinery/porta_turret{
 	check_synth = 1;
-	installation = /obj/item/gun/energy/gun;
 	lethal = 1;
 	name = "ship defense turret"
 	},
@@ -2262,7 +2260,6 @@
 "hp" = (
 /obj/machinery/porta_turret{
 	check_synth = 1;
-	installation = /obj/item/gun/energy/gun;
 	lethal = 1;
 	name = "ship defense turret"
 	},

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -1225,3 +1225,9 @@ GLOBAL_LIST_EMPTY(turret_icons)
 
 /obj/machinery/porta_turret/inflatable_turret/CanPathfindPass(to_dir, datum/can_pass_info/pass_info)
 	return ((stat & BROKEN) || !pass_info.is_living)
+
+// Meatpackers' ruin turret
+/obj/machinery/porta_turret/meatpacker_ship
+	name = "ship defense turret"
+	lethal = TRUE
+	check_synth = TRUE


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes #27421.
Removes custom installation on ship turrets so they don't anymore give you `/gun/energy/gun` but `/gun/energy/gun/turret`

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

Fixes an issue. You shouldn't be able to get 1500 worth of credits (6 eguns) for destroying 6 dummy turrets

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Compiled, destroyed a turret, deconstructed it using a crowbar, ensured there is a turret-egun instead of a normal one.

<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Turrets on meatpackers ruin no more drop energy guns on deconstruction.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
