### PR TITLE
Fixes Cerebron's exosuit fabricators printing to the wrong direction

### DIFF
--- a/_maps/map_files/stations/metastation.dmm
+++ b/_maps/map_files/stations/metastation.dmm
@@ -56230,7 +56230,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/mecha_part_fabricator/station,
+/obj/machinery/mecha_part_fabricator/station/east,
 /turf/simulated/floor/plasteel,
 /area/station/science/robotics)
 "iAS" = (

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -568,7 +568,6 @@
 
 /obj/machinery/mecha_part_fabricator/station/east
 	dir = EAST
-	output_dir = EAST
 
 #undef EXOFAB_BASE_CAPACITY
 #undef EXOFAB_CAPACITY_PER_RATING

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -566,6 +566,10 @@
 /obj/machinery/mecha_part_fabricator/station
 	autolink_id = "station_rnd"
 
+/obj/machinery/mecha_part_fabricator/station/east
+	dir = EAST
+	output_dir = EAST
+
 #undef EXOFAB_BASE_CAPACITY
 #undef EXOFAB_CAPACITY_PER_RATING
 #undef EXOFAB_EFFICIENCY_PER_RATING


### PR DESCRIPTION
## What Does This PR Do

It makes it so exosuit fabs print towards east on MetaStation/Cerebron. Fixes #27406 

## Why It's Good For The Game

The machines follow the correct printing direction as indicated by the floor decals.

## Images of changes

https://github.com/user-attachments/assets/74d098a2-b4b6-414f-8756-1746e3e7189a

## Testing

1. Load metastation
2. Insert metal into the exosuit fab
3. Print something

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: The exosuit fabricators on NSS Cerebron now correctly print to the east.
/:cl:
