### PR TITLE
Revert "Updates the technical names of BoxStation and DeltaStation"

### DIFF
--- a/code/modules/mapping/station_datums.dm
+++ b/code/modules/mapping/station_datums.dm
@@ -1,6 +1,6 @@
 /datum/map/boxstation
 	fluff_name = "NSS Cyberiad"
-	technical_name = "BoxStation"
+	technical_name = "Cyberiad"
 	map_path = "_maps/map_files/stations/boxstation.dmm"
 	webmap_url = "https://webmap.affectedarc07.co.uk/maps/paradise/cyberiad/"
 	welcome_sound = 'sound/AI/welcome_cyberiad.ogg'
@@ -14,7 +14,7 @@
 
 /datum/map/deltastation
 	fluff_name = "NSS Kerberos"
-	technical_name = "DeltaStation"
+	technical_name = "Delta"
 	map_path = "_maps/map_files/stations/deltastation.dmm"
 	webmap_url = "https://webmap.affectedarc07.co.uk/maps/paradise/deltastation/"
 	welcome_sound = 'sound/AI/welcome_kerberos.ogg'


### PR DESCRIPTION
Reverts ParadiseSS13/Paradise#27394

This name change is going to break blackbox data. There should have been a DB migration included in that PR. I was hasty and merged it while not realizing this.