### PR TITLE
refactor: /New -> /Initialize §2: stacks

### DIFF
--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -60,10 +60,9 @@ GLOBAL_LIST_INIT(rod_recipes, list (
 /obj/item/stack/rods/fifty
 	amount = 50
 
-/obj/item/stack/rods/New(loc, amount=null)
-	..()
+/obj/item/stack/rods/Initialize(mapload, new_amount, merge)
+	. = ..()
 	recipes = GLOB.rod_recipes
-	update_icon(UPDATE_ICON_STATE)
 
 /obj/item/stack/rods/update_icon_state()
 	var/amount = get_amount()

--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -61,9 +61,9 @@ GLOBAL_LIST_INIT(glass_recipes, list (
 /obj/item/stack/sheet/glass/cyborg/drone
 	energy_type = /datum/robot_storage/energy/glass
 
-/obj/item/stack/sheet/glass/New(loc, amount)
+/obj/item/stack/sheet/glass/Initialize(mapload, new_amount, merge)
+	. = ..()
 	recipes = GLOB.glass_recipes
-	..()
 
 /obj/item/stack/sheet/glass/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/stack/cable_coil))
@@ -128,9 +128,9 @@ GLOBAL_LIST_INIT(reinforced_glass_recipes, list (
 /obj/item/stack/sheet/rglass/fifty
 	amount = 50
 
-/obj/item/stack/sheet/rglass/New(loc, amount)
+/obj/item/stack/sheet/rglass/Initialize(mapload, new_amount, merge)
+	. = ..()
 	recipes = GLOB.reinforced_glass_recipes
-	..()
 
 GLOBAL_LIST_INIT(pglass_recipes, list (
 	new /datum/stack_recipe("plasma shard", /obj/item/shard/plasma, time = 0 SECONDS),
@@ -183,9 +183,9 @@ GLOBAL_LIST_INIT(pglass_recipes, list (
 /obj/item/stack/sheet/plasmaglass/fifty
 	amount = 50
 
-/obj/item/stack/sheet/plasmaglass/New(loc, amount)
+/obj/item/stack/sheet/plasmaglass/Initialize(mapload, new_amount, merge)
+	. = ..()
 	recipes = GLOB.pglass_recipes
-	..()
 
 /obj/item/stack/sheet/plasmaglass/attackby(obj/item/W, mob/user, params)
 	..()
@@ -241,9 +241,9 @@ GLOBAL_LIST_INIT(prglass_recipes, list (
 /obj/item/stack/sheet/plasmarglass/fifty
 	amount = 50
 
-/obj/item/stack/sheet/plasmarglass/New(loc, amount)
+/obj/item/stack/sheet/plasmarglass/Initialize(mapload, new_amount, merge)
+	. = ..()
 	recipes = GLOB.prglass_recipes
-	..()
 
 GLOBAL_LIST_INIT(titaniumglass_recipes, list(
 	new /datum/stack_recipe/window("shuttle window", /obj/structure/window/full/shuttle, 2, time = 0 SECONDS, on_floor = TRUE, window_checks = TRUE)
@@ -274,9 +274,9 @@ GLOBAL_LIST_INIT(titaniumglass_recipes, list(
 /obj/item/stack/sheet/titaniumglass/fifty
 	amount = 50
 
-/obj/item/stack/sheet/titaniumglass/New(loc, amount)
+/obj/item/stack/sheet/titaniumglass/Initialize(mapload, new_amount, merge)
+	. = ..()
 	recipes = GLOB.titaniumglass_recipes
-	..()
 
 GLOBAL_LIST_INIT(plastitaniumglass_recipes, list(
 	new /datum/stack_recipe/window("plastitanium window", /obj/structure/window/full/plastitanium, 2, time = 0 SECONDS, on_floor = TRUE, window_checks = TRUE)
@@ -308,7 +308,7 @@ GLOBAL_LIST_INIT(plastitaniumglass_recipes, list(
 /obj/item/stack/sheet/plastitaniumglass/fifty
 	amount = 50
 
-/obj/item/stack/sheet/plastitaniumglass/New(loc, amount)
+/obj/item/stack/sheet/plastitaniumglass/Initialize(mapload, new_amount, merge)
+	. = ..()
 	recipes = GLOB.plastitaniumglass_recipes
-	..()
 

--- a/code/game/objects/items/stacks/sheets/leather.dm
+++ b/code/game/objects/items/stacks/sheets/leather.dm
@@ -17,9 +17,9 @@ GLOBAL_LIST_INIT(human_recipes, list(
 	new /datum/stack_recipe("bloated human costume head", /obj/item/clothing/head/human_head, 5, on_floor = TRUE),
 	))
 
-/obj/item/stack/sheet/animalhide/human/New(loc, amount=null)
+/obj/item/stack/sheet/animalhide/human/Initialize(mapload, new_amount, merge)
+	. = ..()
 	recipes = GLOB.human_recipes
-	return ..()
 
 /obj/item/stack/sheet/animalhide/generic
 	name = "generic skin"
@@ -154,9 +154,9 @@ GLOBAL_LIST_INIT(leather_recipes, list (
 	new /datum/stack_recipe("leather overcoat", /obj/item/clothing/suit/jacket/leather/overcoat, 10),
 	new /datum/stack_recipe("hide mantle", /obj/item/clothing/suit/unathi/mantle, 4)))
 
-/obj/item/stack/sheet/leather/New(loc, new_amount, merge = TRUE)
+/obj/item/stack/sheet/leather/Initialize(mapload, new_amount, merge)
+	. = ..()
 	recipes = GLOB.leather_recipes
-	return ..()
 
 /obj/item/stack/sheet/sinew
 	name = "watcher sinew"
@@ -172,9 +172,9 @@ GLOBAL_LIST_INIT(sinew_recipes, list (
 	new /datum/stack_recipe("sinew restraints", /obj/item/restraints/handcuffs/sinew, 1, on_floor = 1),
 	))
 
-/obj/item/stack/sheet/sinew/New(loc, amount=null)
+/obj/item/stack/sheet/sinew/Initialize(mapload, new_amount, merge)
+	. = ..()
 	recipes = GLOB.sinew_recipes
-	return ..()
 
 /obj/item/stack/sheet/animalhide/goliath_hide
 	name = "goliath hide plates"

--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -148,8 +148,8 @@ GLOBAL_LIST_INIT(snow_recipes, list(
 	throwforce = 5
 	throw_speed = 3
 
-/obj/item/stack/sheet/mineral/New()
-	..()
+/obj/item/stack/sheet/mineral/Initialize(mapload, new_amount, merge)
+	. = ..()
 	pixel_x = rand(0,4)-4
 	pixel_y = rand(0,4)-4
 
@@ -167,8 +167,8 @@ GLOBAL_LIST_INIT(snow_recipes, list(
 /obj/item/stack/sheet/mineral/sandstone/fifty
 	amount = 50
 
-/obj/item/stack/sheet/mineral/sandstone/New()
-	..()
+/obj/item/stack/sheet/mineral/sandstone/Initialize(mapload, new_amount, merge)
+	. = ..()
 	recipes = GLOB.sandstone_recipes
 
 /*
@@ -188,9 +188,9 @@ GLOBAL_LIST_INIT(sandbag_recipes, list (
 	new /datum/stack_recipe("sandbags", /obj/structure/barricade/sandbags, 1, time = 25, one_per_turf = TRUE, on_floor = TRUE),
 	))
 
-/obj/item/stack/sheet/mineral/sandbags/New()
+/obj/item/stack/sheet/mineral/sandbags/Initialize(mapload, new_amount, merge)
+	. = ..()
 	recipes = GLOB.sandbag_recipes
-	..()
 
 /obj/item/emptysandbag
 	name = "empty sandbag"
@@ -230,8 +230,8 @@ GLOBAL_LIST_INIT(sandbag_recipes, list (
 	. += ""
 	. += "Diamond is highly sought after for both aesthetic uses and as a component of many advanced technologies."
 
-/obj/item/stack/sheet/mineral/diamond/New()
-	..()
+/obj/item/stack/sheet/mineral/diamond/Initialize(mapload, new_amount, merge)
+	. = ..()
 	recipes = GLOB.diamond_recipes
 
 /obj/item/stack/sheet/mineral/diamond/fifty
@@ -258,8 +258,8 @@ GLOBAL_LIST_INIT(sandbag_recipes, list (
 /obj/item/stack/sheet/mineral/uranium/fifty
 	amount = 50
 
-/obj/item/stack/sheet/mineral/uranium/New()
-	..()
+/obj/item/stack/sheet/mineral/uranium/Initialize(mapload, new_amount, merge)
+	. = ..()
 	recipes = GLOB.uranium_recipes
 
 /obj/item/stack/sheet/mineral/plasma
@@ -288,8 +288,8 @@ GLOBAL_LIST_INIT(sandbag_recipes, list (
 	. += "Despite its flammability, plasma-enhanced materials such as plasteel or plasma glass generally possess extreme fire resistance, ultra-low thermal conductivity, and a high emissivity. \
 	This allows, for example, a relatively thin pane of plasma glass to be cool to the touch even when a massive inferno is burning on the other side."
 
-/obj/item/stack/sheet/mineral/plasma/New()
-	..()
+/obj/item/stack/sheet/mineral/plasma/Initialize(mapload, new_amount, merge)
+	. = ..()
 	recipes = GLOB.plasma_recipes
 
 /obj/item/stack/sheet/mineral/plasma/fifty
@@ -341,8 +341,8 @@ GLOBAL_LIST_INIT(sandbag_recipes, list (
 /obj/item/stack/sheet/mineral/gold/fifty
 	amount = 50
 
-/obj/item/stack/sheet/mineral/gold/New()
-	..()
+/obj/item/stack/sheet/mineral/gold/Initialize(mapload, new_amount, merge)
+	. = ..()
 	recipes = GLOB.gold_recipes
 
 /obj/item/stack/sheet/mineral/silver
@@ -367,8 +367,8 @@ GLOBAL_LIST_INIT(sandbag_recipes, list (
 /obj/item/stack/sheet/mineral/silver/fifty
 	amount = 50
 
-/obj/item/stack/sheet/mineral/silver/New()
-	..()
+/obj/item/stack/sheet/mineral/silver/Initialize(mapload, new_amount, merge)
+	. = ..()
 	recipes = GLOB.silver_recipes
 
 /obj/item/stack/sheet/mineral/bananium
@@ -396,8 +396,8 @@ GLOBAL_LIST_INIT(sandbag_recipes, list (
 /obj/item/stack/sheet/mineral/bananium/fifty
 	amount = 50
 
-/obj/item/stack/sheet/mineral/bananium/New(loc, amount=null)
-	..()
+/obj/item/stack/sheet/mineral/bananium/Initialize(mapload, new_amount, merge)
+	. = ..()
 	recipes = GLOB.bananium_recipes
 
 /obj/item/stack/sheet/mineral/tranquillite
@@ -427,8 +427,8 @@ GLOBAL_LIST_INIT(sandbag_recipes, list (
 /obj/item/stack/sheet/mineral/tranquillite/fifty
 	amount = 50
 
-/obj/item/stack/sheet/mineral/tranquillite/New(loc, amount=null)
-	..()
+/obj/item/stack/sheet/mineral/tranquillite/Initialize(mapload, new_amount, merge)
+	. = ..()
 	recipes = GLOB.tranquillite_recipes
 
 /*
@@ -464,9 +464,9 @@ GLOBAL_LIST_INIT(titanium_recipes, list(
 	new /datum/stack_recipe("surgical tray", /obj/structure/table/tray, 2, one_per_turf = TRUE, on_floor = TRUE),
 	))
 
-/obj/item/stack/sheet/mineral/titanium/New(loc, amount=null)
+/obj/item/stack/sheet/mineral/titanium/Initialize(mapload, new_amount, merge)
+	. = ..()
 	recipes = GLOB.titanium_recipes
-	..()
 
 /obj/item/stack/sheet/mineral/titanium/fifty
 	amount = 50
@@ -507,9 +507,9 @@ GLOBAL_LIST_INIT(plastitanium_recipes, list(
 	new /datum/stack_recipe("reinforced wheelchair", /obj/structure/chair/wheelchair/plastitanium, 15, time = 7 SECONDS, one_per_turf = TRUE, on_floor = TRUE),
 	))
 
-/obj/item/stack/sheet/mineral/plastitanium/New(loc, amount=null)
+/obj/item/stack/sheet/mineral/plastitanium/Initialize(mapload, new_amount, merge)
+	. = ..()
 	recipes = GLOB.plastitanium_recipes
-	..()
 
 
 //Alien Alloy
@@ -537,9 +537,9 @@ GLOBAL_LIST_INIT(plastitanium_recipes, list(
 /obj/item/stack/sheet/mineral/abductor/fifty
 	amount = 50
 
-/obj/item/stack/sheet/mineral/abductor/New(loc, amount=null)
+/obj/item/stack/sheet/mineral/abductor/Initialize(mapload, new_amount, merge)
+	. = ..()
 	recipes = GLOB.abductor_recipes
-	..()
 
 /obj/item/stack/sheet/mineral/adamantine
 	name = "adamantine"
@@ -551,9 +551,9 @@ GLOBAL_LIST_INIT(plastitanium_recipes, list(
 	merge_type = /obj/item/stack/sheet/mineral/adamantine
 	wall_allowed = FALSE
 
-/obj/item/stack/sheet/mineral/adamantine/New(loc, amount = null)
+/obj/item/stack/sheet/mineral/adamantine/Initialize(mapload, new_amount, merge)
+	. = ..()
 	recipes = GLOB.adamantine_recipes
-	..()
 
 
 /obj/item/stack/sheet/mineral/adamantine/fifty
@@ -571,6 +571,6 @@ GLOBAL_LIST_INIT(plastitanium_recipes, list(
 	throwforce = 2
 	merge_type = /obj/item/stack/sheet/mineral/snow
 
-/obj/item/stack/sheet/mineral/snow/New(loc, amount = null)
+/obj/item/stack/sheet/mineral/snow/Initialize(mapload, new_amount, merge)
+	. = ..()
 	recipes = GLOB.snow_recipes
-	..()

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -172,9 +172,9 @@ GLOBAL_LIST_INIT(metal_recipes, list(
 	new /obj/item/stack/sheet/runed_metal(loc, amount)
 	qdel(src)
 
-/obj/item/stack/sheet/metal/New(loc, amount=null)
+/obj/item/stack/sheet/metal/Initialize(mapload, new_amount, merge)
+	. = ..()
 	recipes = GLOB.metal_recipes
-	return ..()
 
 //////////////////////////////
 // MARK: PLASTEEL
@@ -226,9 +226,9 @@ GLOBAL_LIST_INIT(plasteel_recipes, list(
 /obj/item/stack/sheet/plasteel/fifty
 	amount = 50
 
-/obj/item/stack/sheet/plasteel/New(loc, amount=null)
+/obj/item/stack/sheet/plasteel/Initialize(mapload, new_amount, merge)
+	. = ..()
 	recipes = GLOB.plasteel_recipes
-	return ..()
 
 /obj/item/stack/sheet/wood/cyborg
 	energy_type = /datum/robot_storage/energy/wood
@@ -291,9 +291,9 @@ GLOBAL_LIST_INIT(wood_recipes, list(
 	sheettype = "wood"
 	table_type = /obj/structure/table/wood
 
-/obj/item/stack/sheet/wood/New(loc, amount=null)
+/obj/item/stack/sheet/wood/Initialize(mapload, new_amount, merge)
+	. = ..()
 	recipes = GLOB.wood_recipes
-	return ..()
 
 //////////////////////////////
 // MARK: BAMBOO
@@ -330,9 +330,9 @@ GLOBAL_LIST_INIT(bamboo_recipes, list(
 	sheettype = "bamboo"
 	merge_type = /obj/item/stack/sheet/bamboo
 
-/obj/item/stack/sheet/bamboo/New(loc, amount=null)
+/obj/item/stack/sheet/bamboo/Initialize(mapload, new_amount, merge)
+	. = ..()
 	recipes = GLOB.bamboo_recipes
-	return ..()
 
 /obj/item/stack/sheet/bamboo/fifty
 	amount = 50
@@ -395,9 +395,9 @@ GLOBAL_LIST_INIT(cloth_recipes, list (
 	drop_sound = 'sound/items/handling/cloth_drop.ogg'
 	pickup_sound =  'sound/items/handling/cloth_pickup.ogg'
 
-/obj/item/stack/sheet/cloth/New(loc, amount=null)
+/obj/item/stack/sheet/cloth/Initialize(mapload, new_amount, merge)
+	. = ..()
 	recipes = GLOB.cloth_recipes
-	..()
 
 /obj/item/stack/sheet/cloth/ten
 	amount = 10
@@ -512,9 +512,9 @@ GLOBAL_LIST_INIT(cardboard_recipes, list (
 	resistance_flags = FLAMMABLE
 	merge_type = /obj/item/stack/sheet/cardboard
 
-/obj/item/stack/sheet/cardboard/New(loc, amt = null)
+/obj/item/stack/sheet/cardboard/Initialize(mapload, new_amount, merge)
+	. = ..()
 	recipes = GLOB.cardboard_recipes
-	return ..()
 
 //////////////////////////////
 // MARK: SOIL
@@ -567,6 +567,7 @@ GLOBAL_LIST_INIT(cult_recipes, list (
 	. += "Mundane matter turned extraordinary by the dark blessings of those things that lie in wait - such as this - is the canvas used to build the works that shall one day tear asunder the veil that shields our world."
 
 /obj/item/stack/sheet/runed_metal/New()
+// /obj/item/stack/sheet/runed_metal/Initialize(mapload, new_amount, merge)
 	. = ..()
 	icon_state = GET_CULT_DATA(runed_metal_icon_state, initial(icon_state))
 	item_state = GET_CULT_DATA(runed_metal_item_state, initial(item_state))
@@ -646,9 +647,9 @@ GLOBAL_LIST_INIT(brass_recipes, list (
 	new /obj/item/stack/sheet/runed_metal(loc, amount)
 	qdel(src)
 
-/obj/item/stack/tile/brass/New(loc, amount=null)
-	recipes = GLOB.brass_recipes
+/obj/item/stack/tile/brass/Initialize(mapload, new_amount, merge)
 	. = ..()
+	recipes = GLOB.brass_recipes
 	pixel_x = 0
 	pixel_y = 0
 
@@ -739,9 +740,9 @@ GLOBAL_LIST_INIT(plastic_recipes, list(
 	. += "Despite the extensive uses of plastics, they are not as ubiquitous as other materials (especially steel). This is due to a combination of environmental regulations, \
 	established market patterns, and the operational requirements for many space-based installations to employ easily recycled materials to conserve limited supplies."
 
-/obj/item/stack/sheet/plastic/New()
-	recipes = GLOB.plastic_recipes
+/obj/item/stack/sheet/plastic/Initialize(mapload, new_amount, merge)
 	. = ..()
+	recipes = GLOB.plastic_recipes
 
 /obj/item/stack/sheet/plastic/fifty
 	amount = 50

--- a/code/game/objects/items/stacks/tiles/tile_mineral.dm
+++ b/code/game/objects/items/stacks/tiles/tile_mineral.dm
@@ -40,8 +40,8 @@ GLOBAL_LIST_INIT(gold_tile_recipes, list ( \
 	mineralType = "gold"
 	materials = list(MAT_GOLD=500)
 
-/obj/item/stack/tile/mineral/gold/New(loc, amount=null)
-	..()
+/obj/item/stack/tile/mineral/gold/Initialize(mapload, new_amount, merge)
+	. = ..()
 	recipes = GLOB.gold_tile_recipes
 
 GLOBAL_LIST_INIT(goldfancy_tile_recipes, list ( \
@@ -52,8 +52,8 @@ GLOBAL_LIST_INIT(goldfancy_tile_recipes, list ( \
 	icon_state = "tile_goldfancy"
 	turf_type = /turf/simulated/floor/mineral/gold/fancy
 
-/obj/item/stack/tile/mineral/gold/fancy/New(loc, amount=null)
-	..()
+/obj/item/stack/tile/mineral/gold/fancy/Initialize(mapload, new_amount, merge)
+	. = ..()
 	recipes = GLOB.goldfancy_tile_recipes
 
 GLOBAL_LIST_INIT(silver_tile_recipes, list ( \
@@ -69,8 +69,8 @@ GLOBAL_LIST_INIT(silver_tile_recipes, list ( \
 	mineralType = "silver"
 	materials = list(MAT_SILVER=500)
 
-/obj/item/stack/tile/mineral/silver/New(loc, amount=null)
-	..()
+/obj/item/stack/tile/mineral/silver/Initialize(mapload, new_amount, merge)
+	. = ..()
 	recipes = GLOB.silver_tile_recipes
 
 GLOBAL_LIST_INIT(silverfancy_tile_recipes, list ( \
@@ -81,8 +81,8 @@ GLOBAL_LIST_INIT(silverfancy_tile_recipes, list ( \
 	icon_state = "tile_silverfancy"
 	turf_type = /turf/simulated/floor/mineral/silver/fancy
 
-/obj/item/stack/tile/mineral/silver/fancy/New(loc, amount=null)
-	..()
+/obj/item/stack/tile/mineral/silver/fancy/Initialize(mapload, new_amount, merge)
+	. = ..()
 	recipes = GLOB.silverfancy_tile_recipes
 
 /obj/item/stack/tile/mineral/diamond

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -16,8 +16,8 @@
 	var/turf_type = null
 	var/mineralType = null
 
-/obj/item/stack/tile/New(loc, amount)
-	..()
+/obj/item/stack/tile/Initialize(mapload, new_amount, merge)
+	. = ..()
 	pixel_x = rand(-3, 3)
 	pixel_y = rand(-3, 3) //randomize a little
 

--- a/code/game/objects/items/weapons/storage/toolbox.dm
+++ b/code/game/objects/items/weapons/storage/toolbox.dm
@@ -90,12 +90,12 @@
 	new /obj/item/wirecutters(src)
 	new /obj/item/t_scanner(src)
 	new /obj/item/crowbar(src)
-	new /obj/item/stack/cable_coil(src, 30, paramcolor = pickedcolor)
-	new /obj/item/stack/cable_coil(src, 30, paramcolor = pickedcolor)
+	new /obj/item/stack/cable_coil(src, 30, pickedcolor)
+	new /obj/item/stack/cable_coil(src, 30, pickedcolor)
 	if(prob(5))
 		new /obj/item/clothing/gloves/color/yellow(src)
 	else
-		new /obj/item/stack/cable_coil(src, 30, paramcolor = pickedcolor)
+		new /obj/item/stack/cable_coil(src, 30, pickedcolor)
 
 /obj/item/storage/toolbox/syndicate
 	name = "suspicious looking toolbox"
@@ -132,7 +132,7 @@
 	new /obj/item/wrench(src)
 	new /obj/item/weldingtool(src)
 	new /obj/item/crowbar(src)
-	new /obj/item/stack/cable_coil(src, 30, paramcolor = pickedcolor)
+	new /obj/item/stack/cable_coil(src, 30, pickedcolor)
 	new /obj/item/wirecutters(src)
 	new /obj/item/multitool(src)
 

--- a/code/modules/arcade/arcade_prize.dm
+++ b/code/modules/arcade/arcade_prize.dm
@@ -69,10 +69,6 @@
 	w_class = WEIGHT_CLASS_TINY
 	max_amount = 9999	//Dang that's a lot of tickets
 
-/obj/item/stack/tickets/New(loc, amount=null)
-	..()
-	update_icon(UPDATE_ICON_STATE)
-
 /obj/item/stack/tickets/attack_self(mob/user as mob)
 	return
 

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -17,8 +17,8 @@
 	var/points = 0 //How many points this ore gets you from the ore redemption machine
 	var/refined_type = null //What this ore defaults to being refined into
 
-/obj/item/stack/ore/New(loc, new_amount, merge = TRUE)
-	..()
+/obj/item/stack/ore/Initialize(mapload, new_amount, merge = TRUE)
+	. = ..()
 	pixel_x = rand(0, 16) - 8
 	pixel_y = rand(0, 8) - 8
 
@@ -377,14 +377,12 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 	var/cooldown = 0
 	var/credits = 10
 
-/obj/item/coin/New()
-	..()
+/obj/item/coin/Initialize(mapload)
+	. = ..()
 	icon_state = "coin_[cmineral]_[sideslist[1]]"
 	if(cmineral && name_by_cmineral)
 		name = "[cmineral] coin"
-
-/obj/item/coin/Initialize(mapload)
-	. = ..()
+	update_appearance(UPDATE_NAME|UPDATE_ICON_STATE)
 	AddComponent(/datum/component/surgery_initiator/robo)
 
 /obj/item/coin/gold

--- a/code/modules/power/cables/cable.dm
+++ b/code/modules/power/cables/cable.dm
@@ -157,9 +157,9 @@ By design, d1 is the smallest direction and d2 is the highest
 		investigate_log("was deconstructed by [key_name(usr, 1)] in [get_area(usr)]([T.x], [T.y], [T.z] - [ADMIN_JMP(T)])","wires")
 	if(!(flags & NODECONSTRUCT))
 		if(d1)	// 0-X cables are 1 unit, X-X cables are 2 units long
-			new/obj/item/stack/cable_coil(T, 2, paramcolor = color)
+			new/obj/item/stack/cable_coil(T, 2, color)
 		else
-			new/obj/item/stack/cable_coil(T, 1, paramcolor = color)
+			new/obj/item/stack/cable_coil(T, 1, color)
 	qdel(src)
 
 /* ===POWERNET PROCS=== */

--- a/code/modules/power/cables/cable_coil.dm
+++ b/code/modules/power/cables/cable_coil.dm
@@ -28,13 +28,11 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list (new/datum/stack_recipe/cable_restrain
 	usesound = 'sound/items/deconstruct.ogg'
 	toolspeed = 1
 
-/obj/item/stack/cable_coil/New(location, length, paramcolor)
+/obj/item/stack/cable_coil/Initialize(mapload, length, paramcolor)
 	. = ..()
 	if(paramcolor)
+		log_chat_debug("initialized with mapload=[mapload] length=[length] paramcolor=[paramcolor]")
 		color = paramcolor
-
-/obj/item/stack/cable_coil/Initialize(mapload)
-	. = ..()
 	update_icon()
 	recipes = GLOB.cable_coil_recipes
 	update_wclass()
@@ -210,7 +208,7 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list (new/datum/stack_recipe/cable_restrain
 
 	if(C.shock(user, 50))
 		if(prob(50)) //fail
-			new /obj/item/stack/cable_coil(get_turf(C), 1, paramcolor = C.color)
+			new /obj/item/stack/cable_coil(get_turf(C), 1, C.color)
 			C.deconstruct()
 
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_CABLE_UPDATED, T)
@@ -378,9 +376,9 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list (new/datum/stack_recipe/cable_restrain
 /obj/item/stack/cable_coil/white
 	color = COLOR_WHITE
 
-/obj/item/stack/cable_coil/random/New()
+/obj/item/stack/cable_coil/random/Initialize(mapload)
+	. = ..()
 	color = pick(COLOR_RED, COLOR_BLUE, COLOR_GREEN, COLOR_WHITE, COLOR_PINK, COLOR_YELLOW, COLOR_CYAN, COLOR_ORANGE)
-	..()
 
 /obj/item/stack/cable_coil/cut
 	item_state = "coil2"

--- a/code/modules/power/lights.dm
+++ b/code/modules/power/lights.dm
@@ -76,7 +76,7 @@
 
 	stage = LIGHT_CONSTRUCT_EMPTY_FRAME
 	update_icon(UPDATE_ICON_STATE)
-	new /obj/item/stack/cable_coil(get_turf(loc), 1, paramcolor = COLOR_RED)
+	new /obj/item/stack/cable_coil(get_turf(loc), 1, COLOR_RED)
 	WIRECUTTER_SNIP_MESSAGE
 
 /obj/machinery/light_construct/screwdriver_act(mob/living/user, obj/item/I)

--- a/code/modules/telesci/bscrystal.dm
+++ b/code/modules/telesci/bscrystal.dm
@@ -29,8 +29,8 @@
 	. += ""
 	. += "Nanotrasen and many of its rivals are scrambling to be the first to develop practical mass-producible bluespace technologies so they they can become the hegemon of a new market monopoly."
 
-/obj/item/stack/ore/bluespace_crystal/New(loc, new_amount, merge = TRUE)
-	..()
+/obj/item/stack/ore/bluespace_crystal/Initialize(mapload, new_amount, merge)
+	. = ..()
 	pixel_x = rand(-5, 5)
 	pixel_y = rand(-5, 5)
 


### PR DESCRIPTION
## What Does This PR Do
This PR migrates all overrides of /New for stacks (ore, metals, sheets, cables) to /Initialize.
## Why It's Good For The Game
See https://github.com/ParadiseSS13/Paradise/pull/27261.
## Testing
Spot checked spawning in various stack types. Ensured that cable colors/stack merging were respected when spawned. Will probably do a full checklist here.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog
NPFC