### PR TITLE
fix: remove stray cig vendor from USSP

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/ussp.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/ussp.dmm
@@ -7371,12 +7371,6 @@
 /obj/effect/spawner/random/fungus/frequent,
 /turf/simulated/wall/indestructible/titanium/soviet/nodiagonal,
 /area/ruin/space/derelict/arrival)
-"zc" = (
-/obj/machinery/economy/vending/cigarette/free{
-	slogan_list = list("Just remember! No capitalist.","Best enjoyed with Vodka!.","Smoke!","Nine out of ten USSP scientists agree, smoking reduces stress!","There's no cigarette like a Soviet cigarette!","Cigarettes! Now with 100% less capitalism.")
-	},
-/turf/template_noop,
-/area/template_noop)
 "Bx" = (
 /obj/machinery/door_control{
 	id = "ruslock";
@@ -13937,7 +13931,7 @@ ac
 ac
 ac
 ac
-zc
+ac
 ac
 ac
 ac


### PR DESCRIPTION
## What Does This PR Do
This PR removes a stray cig vendor from USSP space introduced by #27017. No idea how I did this, probably an accidental click.
## Why It's Good For The Game
Fixes mapping regression.
## Images of changes
Before:
![2024_11_24__15_54_15__paradise dme  ussp dmm  - StrongDMM](https://github.com/user-attachments/assets/cee18125-0e94-4868-9eb2-53fb8bd0dc83)
After:
![2024_11_24__15_54_18__paradise dme  ussp dmm  - StrongDMM](https://github.com/user-attachments/assets/63dfa810-3c56-485e-a8ec-f347a62b1ee6)


<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Visual inspection.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: A stray cigarette vendor outside the USSP ruin has been removed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
