### PR TITLE
[FIX] Json serialization/deserialization for characters

### DIFF
--- a/code/modules/mob/living/carbon/human/human_mob.dm
+++ b/code/modules/mob/living/carbon/human/human_mob.dm
@@ -1782,7 +1782,7 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 
 	// Equipment
 	equip_list.len = ITEM_SLOT_AMOUNT
-	for(var/i in 1 to (ITEM_SLOT_AMOUNT))
+	for(var/i in 1 to ITEM_SLOT_AMOUNT)
 		var/obj/item/thing = get_item_by_slot(1<<(i - 1)) // -1 because ITEM_SLOT_FLAGS start at 0 (and BYOND lists do not)
 		if(!isnull(thing))
 			equip_list[i] = thing.serialize()

--- a/code/modules/mob/living/carbon/human/human_mob.dm
+++ b/code/modules/mob/living/carbon/human/human_mob.dm
@@ -1782,10 +1782,10 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 
 	// Equipment
 	equip_list.len = ITEM_SLOT_AMOUNT
-	for(var/i = 1, i < ITEM_SLOT_AMOUNT, i++)
-		var/obj/item/thing = get_item_by_slot(i)
+	for(var/i = 0, i < ITEM_SLOT_AMOUNT, i++)
+		var/obj/item/thing = get_item_by_slot(1<<i)
 		if(thing != null)
-			equip_list[i] = thing.serialize()
+			equip_list[i+1] = thing.serialize() // +1 because Byond lists aren't zero-indexed
 
 	for(var/obj/item/bio_chip/implant in src)
 		implant_list[implant] = implant.serialize()
@@ -1841,20 +1841,20 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 	// #1: Jumpsuit
 	// #2: Outer suit
 	// #3+: Everything else
-	if(islist(equip_list[ITEM_SLOT_JUMPSUIT]))
-		var/obj/item/clothing/C = list_to_object(equip_list[ITEM_SLOT_JUMPSUIT], T)
+	if(islist(equip_list[ITEM_SLOT_2_INDEX(ITEM_SLOT_JUMPSUIT)]))
+		var/obj/item/clothing/C = list_to_object(equip_list[ITEM_SLOT_2_INDEX(ITEM_SLOT_JUMPSUIT)], T)
 		equip_to_slot_if_possible(C, ITEM_SLOT_JUMPSUIT)
 
-	if(islist(equip_list[ITEM_SLOT_OUTER_SUIT]))
-		var/obj/item/clothing/C = list_to_object(equip_list[ITEM_SLOT_OUTER_SUIT], T)
+	if(islist(equip_list[ITEM_SLOT_2_INDEX(ITEM_SLOT_OUTER_SUIT)]))
+		var/obj/item/clothing/C = list_to_object(equip_list[ITEM_SLOT_2_INDEX(ITEM_SLOT_OUTER_SUIT)], T)
 		equip_to_slot_if_possible(C, ITEM_SLOT_OUTER_SUIT)
 
 	for(var/i = 1, i < ITEM_SLOT_AMOUNT, i++)
-		if(i == ITEM_SLOT_JUMPSUIT || i == ITEM_SLOT_OUTER_SUIT)
+		if(i == ITEM_SLOT_2_INDEX(ITEM_SLOT_JUMPSUIT) || i == ITEM_SLOT_2_INDEX(ITEM_SLOT_OUTER_SUIT))
 			continue
 		if(islist(equip_list[i]))
 			var/obj/item/clothing/C = list_to_object(equip_list[i], T)
-			equip_to_slot_if_possible(C, i)
+			equip_to_slot_if_possible(C, 1<<(i-1)) // +1 because ITEM_SLOT_FLAGS start at 0 (and BYOND lists do not)
 	update_icons()
 
 	..()

--- a/code/modules/mob/living/carbon/human/human_mob.dm
+++ b/code/modules/mob/living/carbon/human/human_mob.dm
@@ -1783,9 +1783,9 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 	// Equipment
 	equip_list.len = ITEM_SLOT_AMOUNT
 	for(var/i in 1 to (ITEM_SLOT_AMOUNT))
-		var/obj/item/thing = get_item_by_slot(1<<(i - 1))
+		var/obj/item/thing = get_item_by_slot(1<<(i - 1)) // -1 because ITEM_SLOT_FLAGS start at 0 (and BYOND lists do not)
 		if(!isnull(thing))
-			equip_list[i] = thing.serialize() // +1 because Byond lists aren't zero-indexed
+			equip_list[i] = thing.serialize()
 
 	for(var/obj/item/bio_chip/implant in src)
 		implant_list[implant] = implant.serialize()
@@ -1854,7 +1854,7 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 			continue
 		if(islist(equip_list[i]))
 			var/obj/item/clothing/C = list_to_object(equip_list[i], T)
-			equip_to_slot_if_possible(C, 1<<(i - 1)) // +1 because ITEM_SLOT_FLAGS start at 0 (and BYOND lists do not)
+			equip_to_slot_if_possible(C, 1<<(i - 1)) // -1 because ITEM_SLOT_FLAGS start at 0 (and BYOND lists do not)
 	update_icons()
 
 	..()

--- a/code/modules/mob/living/carbon/human/human_mob.dm
+++ b/code/modules/mob/living/carbon/human/human_mob.dm
@@ -1782,10 +1782,10 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 
 	// Equipment
 	equip_list.len = ITEM_SLOT_AMOUNT
-	for(var/i = 0, i < ITEM_SLOT_AMOUNT, i++)
-		var/obj/item/thing = get_item_by_slot(1<<i)
-		if(thing != null)
-			equip_list[i+1] = thing.serialize() // +1 because Byond lists aren't zero-indexed
+	for(var/i in 1 to (ITEM_SLOT_AMOUNT))
+		var/obj/item/thing = get_item_by_slot(1<<(i - 1))
+		if(!isnull(thing))
+			equip_list[i] = thing.serialize() // +1 because Byond lists aren't zero-indexed
 
 	for(var/obj/item/bio_chip/implant in src)
 		implant_list[implant] = implant.serialize()
@@ -1849,12 +1849,12 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 		var/obj/item/clothing/C = list_to_object(equip_list[ITEM_SLOT_2_INDEX(ITEM_SLOT_OUTER_SUIT)], T)
 		equip_to_slot_if_possible(C, ITEM_SLOT_OUTER_SUIT)
 
-	for(var/i = 1, i < ITEM_SLOT_AMOUNT, i++)
+	for(var/i in 1 to (ITEM_SLOT_AMOUNT))
 		if(i == ITEM_SLOT_2_INDEX(ITEM_SLOT_JUMPSUIT) || i == ITEM_SLOT_2_INDEX(ITEM_SLOT_OUTER_SUIT))
 			continue
 		if(islist(equip_list[i]))
 			var/obj/item/clothing/C = list_to_object(equip_list[i], T)
-			equip_to_slot_if_possible(C, 1<<(i-1)) // -1 because ITEM_SLOT_FLAGS start at 0 (and BYOND lists do not)
+			equip_to_slot_if_possible(C, 1<<(i - 1)) // +1 because ITEM_SLOT_FLAGS start at 0 (and BYOND lists do not)
 	update_icons()
 
 	..()

--- a/code/modules/mob/living/carbon/human/human_mob.dm
+++ b/code/modules/mob/living/carbon/human/human_mob.dm
@@ -1854,7 +1854,7 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 			continue
 		if(islist(equip_list[i]))
 			var/obj/item/clothing/C = list_to_object(equip_list[i], T)
-			equip_to_slot_if_possible(C, 1<<(i-1)) // +1 because ITEM_SLOT_FLAGS start at 0 (and BYOND lists do not)
+			equip_to_slot_if_possible(C, 1<<(i-1)) // -1 because ITEM_SLOT_FLAGS start at 0 (and BYOND lists do not)
 	update_icons()
 
 	..()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes an issue introduced by the switch to ITEM_SLOT_FLAGs where character serialization/deserialization would be broken. Old JSONs probably won't work entirely as expected anymore but should still get partially equipped, with the rest of their items spawning on the ground.

Fixes: #27432
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Admins should be able to serialize and deserialize characters where needed.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Serialize a character with all slots filled
Deserialize that same character, all items equip as expected with no runtimes.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

NPFC

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
