### PR TITLE
Update Script for PR #27257 -  Language Changes & Lore Pt. 1

### DIFF
--- a/tools/pr_sql/27257/update_script.sql
+++ b/tools/pr_sql/27257/update_script.sql
@@ -1,0 +1,3 @@
+UPDATE character
+SET language = 'Zvezhan'
+WHERE language = 'Neo-Russkiya';

--- a/tools/pr_sql/27257/update_script.sql
+++ b/tools/pr_sql/27257/update_script.sql
@@ -1,3 +1,3 @@
-UPDATE character
+UPDATE characters
 SET language = 'Zvezhan'
 WHERE language = 'Neo-Russkiya';


### PR DESCRIPTION
## What Does This PR Do
This retroactively adds an update script for PR #27257

## Why It's Good For The Game
This assures that characters that had the secondary language `Neo-Russkiya` will have it changed to `Zvezhan` per the original PR.

## Testing
To be handled by DBA if needed.


<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

  <hr>

## Changelog
NPFC