### PR TITLE
fix: remove access-less helpers and add a maplint

### DIFF
--- a/_maps/map_files/shuttles/emergency_lance.dmm
+++ b/_maps/map_files/shuttles/emergency_lance.dmm
@@ -472,9 +472,6 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/windoor/access/all/command{
-	dir = 4
-	},
 /obj/machinery/door/window/reinforced/normal{
 	name = "Last Resort";
 	dir = 4
@@ -487,6 +484,9 @@
 	pixel_y = -6
 	},
 /obj/item/gun/energy/gun/mini,
+/obj/effect/mapping_helpers/airlock/windoor/access/all/command/general{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/shuttle/escape)
 "vk" = (

--- a/_maps/map_files/stations/emeraldstation.dmm
+++ b/_maps/map_files/stations/emeraldstation.dmm
@@ -22599,8 +22599,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/any/command,
 /obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/any/command/general,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -55171,7 +55171,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/mapping_helpers/airlock/windoor/access/all/command,
+/obj/effect/mapping_helpers/airlock/windoor/access/all/command/general,
 /turf/simulated/floor/plasteel,
 /area/station/command/bridge)
 "klt" = (

--- a/tools/maplint/lints/generic_access_helpers.yml
+++ b/tools/maplint/lints/generic_access_helpers.yml
@@ -1,0 +1,71 @@
+help: 'These access helpers are only organizational and do not provide any access. Use one of the appropriate subtypes.'
+=/obj/effect/mapping_helpers/airlock/windoor/access/all:
+  banned: true
+=/obj/effect/mapping_helpers/airlock/windoor/access/all/command:
+  banned: true
+=/obj/effect/mapping_helpers/airlock/windoor/access/all/engineering:
+  banned: true
+=/obj/effect/mapping_helpers/airlock/windoor/access/all/medical:
+  banned: true
+=/obj/effect/mapping_helpers/airlock/windoor/access/all/science:
+  banned: true
+=/obj/effect/mapping_helpers/airlock/windoor/access/all/security:
+  banned: true
+=/obj/effect/mapping_helpers/airlock/windoor/access/all/service:
+  banned: true
+=/obj/effect/mapping_helpers/airlock/windoor/access/all/supply:
+  banned: true
+=/obj/effect/mapping_helpers/airlock/windoor/access/any:
+  banned: true
+=/obj/effect/mapping_helpers/airlock/windoor/access/any/command:
+  banned: true
+=/obj/effect/mapping_helpers/airlock/windoor/access/any/engineering:
+  banned: true
+=/obj/effect/mapping_helpers/airlock/windoor/access/any/medical:
+  banned: true
+=/obj/effect/mapping_helpers/airlock/windoor/access/any/science:
+  banned: true
+=/obj/effect/mapping_helpers/airlock/windoor/access/any/security:
+  banned: true
+=/obj/effect/mapping_helpers/airlock/windoor/access/any/service:
+  banned: true
+=/obj/effect/mapping_helpers/airlock/windoor/access/any/supply:
+  banned: true
+=/obj/effect/mapping_helpers/airlock/access/all:
+  banned: true
+=/obj/effect/mapping_helpers/airlock/access/all/centcomm:
+  banned: true
+=/obj/effect/mapping_helpers/airlock/access/all/command:
+  banned: true
+=/obj/effect/mapping_helpers/airlock/access/all/engineering:
+  banned: true
+=/obj/effect/mapping_helpers/airlock/access/all/medical:
+  banned: true
+=/obj/effect/mapping_helpers/airlock/access/all/ruins:
+  banned: true
+=/obj/effect/mapping_helpers/airlock/access/all/science:
+  banned: true
+=/obj/effect/mapping_helpers/airlock/access/all/security:
+  banned: true
+=/obj/effect/mapping_helpers/airlock/access/all/service:
+  banned: true
+=/obj/effect/mapping_helpers/airlock/access/all/shuttles:
+  banned: true
+=/obj/effect/mapping_helpers/airlock/access/all/supply:
+  banned: true
+=/obj/effect/mapping_helpers/airlock/access/any:
+  banned: true
+=/obj/effect/mapping_helpers/airlock/access/any/command:
+  banned: true
+=/obj/effect/mapping_helpers/airlock/access/any/engineering:
+  banned: true
+=/obj/effect/mapping_helpers/airlock/access/any/medical:
+  banned: true
+=/obj/effect/mapping_helpers/airlock/access/any/science:
+  banned: true
+=/obj/effect/mapping_helpers/airlock/access/any/security:
+  banned: true
+=/obj/effect/mapping_helpers/airlock/access/any/service:
+  banned: true
+=/obj/effect/mapping_helpers/airlock/access/any/supply:
+  banned: true


### PR DESCRIPTION
## What Does This PR Do
This PR fixes the use of some access helpers that didn't actually provide any access, and creates a maplint prohibiting their use in the future.
## Why It's Good For The Game
I'm not sure how/if these ever worked but if they worked before, my switch to req_access lists probably broke them. Either way, none of these should be used in maps.
## Testing
Spawned in, bumped into doors and ensure I could walk into them with the correct access, and couldn't with the wrong access.
<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Diagoras: A door in the bridge and on AI sat hallway have had their command access fixed.
fix: Lance: A door in the command cockpit has had its command access fixed.
/:cl:
