### PR TITLE
Adds hallucination managers

### DIFF
--- a/code/modules/hallucinations/hallucination_manager.dm
+++ b/code/modules/hallucinations/hallucination_manager.dm
@@ -7,9 +7,9 @@
 /datum/hallucination_manager
 	/// Person on who this hallucination is
 	var/mob/living/owner
-	/// Reference to the timer that will do the first callback
+	/// Reference to the timer that will do the first trigger
 	var/callback_timer
-	/// How fast do we need to start our first callback
+	/// How fast do we need to start our first trigger
 	var/callback_time = 10 SECONDS
 	/// A list with all of our hallucinations
 	var/list/hallucination_list = list()
@@ -25,27 +25,21 @@
 	if(QDELETED(owner))
 		qdel(src)
 		return
-	RegisterSignal(owner, COMSIG_PARENT_QDELETING, PROC_REF(clean_up))
+	RegisterSignal(owner, COMSIG_PARENT_QDELETING, PROC_REF(signal_qdel))
 	spawn_hallucination()
 
 /datum/hallucination_manager/Destroy(force, ...)
 	. = ..()
-	clean_up(TRUE)
-
-/datum/hallucination_manager/proc/clean_up(called_by_destroy = FALSE) // If anyone has a better suggestion to not go into a delete loop I'm all ears
 	owner = null
 	QDEL_NULL(hallucination_list)
 	QDEL_NULL(images)
 
-	if(!called_by_destroy)
-		qdel(src)
-
 /datum/hallucination_manager/proc/spawn_hallucination()
 	var/turf/spawn_location = get_spawn_location()
-	initial_hallucination = new (spawn_location, owner)
+	initial_hallucination = new(spawn_location, owner)
 	hallucination_list |= initial_hallucination
 	on_spawn()
-	callback_timer = addtimer(CALLBACK(src, PROC_REF(first_callback)), callback_time, TIMER_DELETE_ME)
+	callback_timer = addtimer(CALLBACK(src, PROC_REF(on_trigger)), callback_time, TIMER_DELETE_ME)
 
 /// Returns a turf on where to spawn a hallucination
 /datum/hallucination_manager/proc/get_spawn_location()
@@ -56,7 +50,7 @@
 /datum/hallucination_manager/proc/on_spawn()
 	return
 
-/// The first callback. By default will delete the manager
-/datum/hallucination_manager/proc/first_callback()
-	// If you want to have more behaviour after this callback, define a new proc on your own manager, for example `second_callback`
+/// Trigger. By default will delete the manager
+/datum/hallucination_manager/proc/on_trigger()
+	// If you want to have more behaviour after this callback, define a new proc on your own manager
 	qdel(src)

--- a/code/modules/hallucinations/hallucination_manager.dm
+++ b/code/modules/hallucinations/hallucination_manager.dm
@@ -1,7 +1,7 @@
 /*
  * Hallucination manager
- * Automatically spawns a hallucination effect according to `get_spawn_location`
- *
+ * Automatically spawns a hallucination effect according to `get_spawn_location` and `initial_hallucination`
+ * By default invokes a 10 second trigger. By default that trigger will delete the manager and thus the hallucination
  */
 
 /datum/hallucination_manager

--- a/code/modules/hallucinations/hallucination_manager.dm
+++ b/code/modules/hallucinations/hallucination_manager.dm
@@ -1,0 +1,62 @@
+/*
+ * Hallucination manager
+ * Automatically spawns a hallucination effect according to `get_spawn_location`
+ *
+ */
+
+/datum/hallucination_manager
+	/// Person on who this hallucination is
+	var/mob/living/owner
+	/// Reference to the timer that will do the first callback
+	var/callback_timer
+	/// How fast do we need to start our first callback
+	var/callback_time = 10 SECONDS
+	/// A list with all of our hallucinations
+	var/list/hallucination_list = list()
+	/// A list with any images that we made separately from our hallucinations
+	var/list/images = list()
+	/// The first hallucination that we spawn. Also doubles as a reference to our hallucination
+	var/obj/effect/hallucination/no_delete/initial_hallucination
+
+// `ignore_this_argument` is here because there are still old hallucinations which require a location passed
+/datum/hallucination_manager/New(turf/ignore_this_argument, mob/living/hallucinator)
+	. = ..()
+	owner = hallucinator
+	if(QDELETED(owner))
+		qdel(src)
+		return
+	RegisterSignal(owner, COMSIG_PARENT_QDELETING, PROC_REF(clean_up))
+	spawn_hallucination()
+
+/datum/hallucination_manager/Destroy(force, ...)
+	. = ..()
+	clean_up(TRUE)
+
+/datum/hallucination_manager/proc/clean_up(called_by_destroy = FALSE) // If anyone has a better suggestion to not go into a delete loop I'm all ears
+	owner = null
+	QDEL_NULL(hallucination_list)
+	QDEL_NULL(images)
+
+	if(!called_by_destroy)
+		qdel(src)
+
+/datum/hallucination_manager/proc/spawn_hallucination()
+	var/turf/spawn_location = get_spawn_location()
+	initial_hallucination = new (spawn_location, owner)
+	hallucination_list |= initial_hallucination
+	on_spawn()
+	callback_timer = addtimer(CALLBACK(src, PROC_REF(first_callback)), callback_time, TIMER_DELETE_ME)
+
+/// Returns a turf on where to spawn a hallucination
+/datum/hallucination_manager/proc/get_spawn_location()
+	var/list/turfs = view(5, owner)
+	return pick(turfs)
+
+/// The proc that runs when our hallucination is first spawned
+/datum/hallucination_manager/proc/on_spawn()
+	return
+
+/// The first callback. By default will delete the manager
+/datum/hallucination_manager/proc/first_callback()
+	// If you want to have more behaviour after this callback, define a new proc on your own manager, for example `second_callback`
+	qdel(src)

--- a/code/modules/hallucinations/hallucination_manager.dm
+++ b/code/modules/hallucinations/hallucination_manager.dm
@@ -8,9 +8,9 @@
 	/// Person on who this hallucination is
 	var/mob/living/owner
 	/// Reference to the timer that will do the first trigger
-	var/callback_timer
+	var/trigger_timer
 	/// How fast do we need to start our first trigger
-	var/callback_time = 10 SECONDS
+	var/trigger_time = 10 SECONDS
 	/// A list with all of our hallucinations
 	var/list/hallucination_list = list()
 	/// A list with any images that we made separately from our hallucinations
@@ -31,6 +31,7 @@
 /datum/hallucination_manager/Destroy(force, ...)
 	. = ..()
 	owner = null
+	deltimer(trigger_timer)
 	QDEL_NULL(hallucination_list)
 	QDEL_NULL(images)
 
@@ -39,7 +40,7 @@
 	initial_hallucination = new(spawn_location, owner)
 	hallucination_list |= initial_hallucination
 	on_spawn()
-	callback_timer = addtimer(CALLBACK(src, PROC_REF(on_trigger)), callback_time, TIMER_DELETE_ME)
+	trigger_timer = addtimer(CALLBACK(src, PROC_REF(on_trigger)), trigger_time, TIMER_DELETE_ME)
 
 /// Returns a turf on where to spawn a hallucination
 /datum/hallucination_manager/proc/get_spawn_location()

--- a/code/modules/hallucinations/hallucinations.dm
+++ b/code/modules/hallucinations/hallucinations.dm
@@ -51,6 +51,8 @@ GLOBAL_LIST_INIT(hallucinations, list(
 	var/mob/living/carbon/target = null
 	/// Lazy list of images created as part of the hallucination. Cleared on destruction.
 	var/list/image/images = null
+	/// Should this hallucination delete itself
+	var/should_delete = TRUE
 
 /obj/effect/hallucination/Initialize(mapload, mob/living/carbon/hallucination_target)
 	. = ..()
@@ -66,7 +68,8 @@ GLOBAL_LIST_INIT(hallucinations, list(
 	// Lifetime
 	if(islist(duration))
 		duration = rand(duration[1], duration[2])
-	QDEL_IN(src, duration)
+	if(should_delete)
+		QDEL_IN(src, duration)
 
 /obj/effect/hallucination/Destroy()
 	clear_icons()
@@ -145,3 +148,8 @@ GLOBAL_LIST_INIT(hallucinations, list(
 		target?.playsound_local(source, snd, volume, vary, frequency)
 		return
 	addtimer(CALLBACK(target, TYPE_PROC_REF(/mob, playsound_local), source, snd, volume, vary, frequency), time)
+
+// Subtype that doesn't delete itself.
+// Mostly used for hallucination managers because they delete the hallucinations when required
+/obj/effect/hallucination/no_delete
+	should_delete = FALSE

--- a/code/modules/hallucinations/hallucinations.dm
+++ b/code/modules/hallucinations/hallucinations.dm
@@ -149,7 +149,7 @@ GLOBAL_LIST_INIT(hallucinations, list(
 		return
 	addtimer(CALLBACK(target, TYPE_PROC_REF(/mob, playsound_local), source, snd, volume, vary, frequency), time)
 
-// Subtype that doesn't delete itself.
-// Mostly used for hallucination managers because they delete the hallucinations when required
+/// Subtype that doesn't delete itself.
+/// Mostly used for hallucination managers because they delete the hallucinations when required
 /obj/effect/hallucination/no_delete
 	should_delete = FALSE

--- a/paradise.dme
+++ b/paradise.dme
@@ -1958,6 +1958,7 @@
 #include "code\modules\games\cards.dm"
 #include "code\modules\games\tarot.dm"
 #include "code\modules\games\unum.dm"
+#include "code\modules\hallucinations\hallucination_manager.dm"
 #include "code\modules\hallucinations\hallucinations.dm"
 #include "code\modules\hallucinations\effects\common.dm"
 #include "code\modules\hallucinations\effects\major.dm"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds a framework to use hallucinations with, `hallucination managers`!
These will automatically spawn hallucinations and do special behaviour at certain points, alongside allowing for special spawning placement.
They are made to work alongside normal hallucination effects, so these can easily be put in the global `hallucinations` list.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Our hallucinations are very old and bad, adding this framework will make it easier to add better hallucinations. I'm not sure if moving every (visual) hallucination as they currently are over to this is worth it, and it is probably better to improve what they do first.

## How do I use this?
The first and most important step is to decide what you want your hallucination to do.
After you've done that, you should start with making your `/obj/effect/hallucination/no_delete`. This is what will show up in-game.
The reason we use the `/no_delete` subtype is because the manager will handle deleting the hallucinations.
For example, this is a simple hallucination that will look like a NAD:
```js
/obj/effect/hallucination/no_delete/nad
	hallucination_icon = `icons/obj/module.dmi'
	hallucination_icon_state = "nucleardisk"
```
**If you want an effect to trigger when doing something with the hallucination, you have to define it on the hallucination.**

Now we have our hallucination! To make sure the manager spawns it, do:
`initial_hallucination = /obj/effect/hallucination/no_delete/nad`
This will automatically spawn in the nad hallucination, and change `initial_hallucination` into a reference.
To decide where to spawn the hallucination, the manager uses `get_spawn_location()`. By default this chooses a random turf in a 5 tile radius.

After your hallucination is spawned, you can give it any effects like sparks or sounds by overriding `on_spawn()`, like so for example:
```js
/datum/hallucination_manager/nad/on_spawn
	playsound(get_turf(initial_hallucination), "sparks", 50, TRUE)
	do_sparks(4, FALSE, initial_hallucination)
```

If you want extra effects to trigger some time after spawning, `first_callback` has your back! By default it will delete the hallucination after 10 seconds, but you can override the proc (and the time variable) to do other things.
If you want your hallucination to start an extra timer, you can define a second callback proc on your manager like this for example:
```js
/datum/hallucination_manager/nad/proc/second_callback
```
**Disclaimer: if you override `first_callback`, you must add a proc that will delete the manager**

And that is pretty much all that there is to it! If you have any questions or clarifications, please ask them and I'll update this description! Once others think it's good enough aswell, I'll add it to the devdocs!
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://github.com/user-attachments/assets/d7823832-df6a-4a14-9d7d-3905c5be809f)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Changelog

NPFC
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
