### PR TITLE
Make computer screens glow brighter and match screen color.

### DIFF
--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -12,8 +12,8 @@
 	var/obj/item/circuitboard/circuit = null //if circuit==null, computer can't disassembly
 	var/icon_keyboard = "generic_key"
 	var/icon_screen = "generic"
-	var/light_range_on = 1
-	var/light_power_on = 0.7
+	var/light_range_on = 2
+	var/light_power_on = 0.9
 	/// Are we in the middle of a flicker event?
 	var/flickering = FALSE
 	/// Are we forcing the icon to be represented in a no-power state?
@@ -85,6 +85,14 @@
 	if(icon_keyboard)
 		. += "[icon_keyboard]"
 		underlays += emissive_appearance(icon, "[icon_keyboard]_lightmask")
+
+	if(!(stat & BROKEN))
+		// Get the average color of the computer screen so it can be used as a tinted glow
+		// Shamelessly stolen from /tg/'s /datum/component/customizable_reagent_holder.
+		var/icon/emissive_avg_screen_color = new(icon, overlay_state)
+		emissive_avg_screen_color.Scale(1, 1)
+		var/screen_emissive_color = copytext(emissive_avg_screen_color.GetPixel(1, 1), 1, 8) // remove opacity
+		set_light(light_range_on, light_power_on, screen_emissive_color)
 
 /obj/machinery/computer/power_change()
 	. = ..() //we don't check parent return due to this also being contigent on the BROKEN stat flag


### PR DESCRIPTION
## What Does This PR Do
This PR bumps the brightness of computer's ambient light, and uses the computer's screen state to suss out an appropriate color for the light.
## Why It's Good For The Game
Better atmosphere. The start of an attempt to improve environmental ambience.
## Images of changes
With no lights:
![2024_11_29__13_43_45__Paradise Station 13](https://github.com/user-attachments/assets/1a46dca2-54fc-4899-b2bc-8f8be58a77b1)

![2024_11_29__13_44_21__Paradise Station 13](https://github.com/user-attachments/assets/d030013c-5fb7-4973-98fd-f616d0529b50)

![2024_11_29__13_44_32__Paradise Station 13](https://github.com/user-attachments/assets/52c059fa-d41e-478a-adf2-67e0199f0636)

![2024_11_29__13_44_59__Paradise Station 13](https://github.com/user-attachments/assets/e7c48af9-33d3-4253-a414-26b3c7676d78)


With emergency lights:

![2024_11_29__13_45_46__Paradise Station 13](https://github.com/user-attachments/assets/588a5f9d-aed1-4926-9439-f5131df45657)


Testing broken screens don't use it:

![2024_11_29__13_47_07__Paradise Station 13](https://github.com/user-attachments/assets/ecfacf68-ecd8-4c73-84df-d344b7a74921)


<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
See above
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
tweak: Computer screens now glow slightly brighter and in an appropriate color.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
