### PR TITLE
Removes a Stack Trace that causes intermittent failing during Unit Testing

### DIFF
--- a/code/datums/components/proximity_monitor.dm
+++ b/code/datums/components/proximity_monitor.dm
@@ -339,7 +339,6 @@
 	for(var/direction in GLOB.alldirs)
 		var/turf/next_turf = get_step(current_table, direction)
 		if(!istype(next_turf))
-			stack_trace("Failed to proceed in direction [dir2text(direction)] when building card proximity monitors.")
 			continue
 		if(get_dist_euclidian(get_turf(parent), next_turf) > max_total_distance)
 			continue


### PR DESCRIPTION
## What Does This PR Do
This removes a Stack Trace introduced in  #26585 that causes map unit testing to fail during CI and Merge operations.

## Why It's Good For The Game
Fixes the issue with CI failing on unit testing only. As of now this has not appeared to affect live in any way.

## Testing
To be conducted

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

  <hr>

## Changelog

NPFC
