### PR TITLE
Adds the CMO's action figure to the medical clothing vendor

### DIFF
--- a/code/game/machinery/vendors/wardrobe_vendors.dm
+++ b/code/game/machinery/vendors/wardrobe_vendors.dm
@@ -196,7 +196,8 @@
 					/obj/item/clothing/head/helmet/space/plasmaman/medical = 3,
 					/obj/item/clothing/under/plasmaman/medical = 3)
 
-	contraband = list(/obj/item/toy/figure/crew/md = 1)
+	contraband = list(/obj/item/toy/figure/crew/md = 1,
+					/obj/item/toy/figure/crew/cmo = 1)
 
 	prices = list(/obj/item/clothing/under/rank/medical/doctor = 50,
 				/obj/item/clothing/under/rank/medical/doctor/skirt = 50,


### PR DESCRIPTION
## What Does This PR Do

What the titles says. Adds the CMO's action figure to the contraband list of the medical clothing vendor

## Why It's Good For The Game

makes the CMO's figurine finally consistent with all other head's figurine and how to obtain them (except Cap/HoP)

## Testing

Loaded in, hacked medical clothe vendor, bought CMO figurine, threw it in the SM.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

 <hr>

## Changelog

:cl:
tweak: added CMO's figurine to the medical clothing vendor if it is hacked.
/:cl:
