### PR TITLE
fixes vendor's descriptions.

### DIFF
--- a/code/game/machinery/vendors/wardrobe_vendors.dm
+++ b/code/game/machinery/vendors/wardrobe_vendors.dm
@@ -232,7 +232,7 @@
 
 /obj/machinery/economy/vending/virodrobe
 	name = "\improper ViroDrobe"
-	desc = "An unsterilized machine for dispending virology related clothing."
+	desc = "An unsterilized machine for dispensing virology related clothing."
 	icon_state = "base_drobe"
 	icon_lightmask = "base_drobe"
 	icon_panel = "drobe"
@@ -862,7 +862,7 @@
 
 /obj/machinery/economy/vending/lawdrobe
 	name = "\improper LawDrobe"
-	desc = "Objection! This wardrobe dispenses the rule of law... and lawyer clothing."
+	desc = "Objection! This wardrobe dispenses the rule of law... Does not make you a lawyer."
 	icon_state = "lawdrobe"
 	icon_lightmask = "base_drobe"
 	icon_panel = "drobe"


### PR DESCRIPTION
## What Does This PR Do

This changes a typo in the virodrobe's description
It also purges the last of the "IAAs are lawyers" legend by changing the IAA's vendor description.

## Why It's Good For The Game

Typos bad, IAAs are not lawyers.

## Testing

Loaded the game, stared at the vendor. Correct descriptions

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

<hr>

## Changelog

:cl:
fix: IAAs are no longer referred to as lawyers by the Lawdrobe
spellcheck: Fixed a typo in the virodrobe's description.
/:cl:
