### PR TITLE
Add ruin jump description messages back.

### DIFF
--- a/code/modules/mob/dead/observer/observer_base.dm
+++ b/code/modules/mob/dead/observer/observer_base.dm
@@ -484,6 +484,12 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		forceMove(get_turf(landmark))
 		update_parallax_contents()
 
+		var/list/messages = list(
+			"<span class='notice'>Jumped to <b>[landmark.ruin_template.name]</b>:</span>",
+			"<span class='notice'>[landmark.ruin_template.description]</span>"
+		)
+		to_chat(usr, chat_box_examine(messages.Join("<br />")))
+
 /mob/dead/observer/proc/teleport(area/A)
 	if(!A || !isobserver(usr))
 		return


### PR DESCRIPTION
## What Does This PR Do
This PR adds back the chat messages displayed when ghosts jump to a ruin. I originally removed these in #22953 because the descriptions were pretty bad, but they've been improved since then, and the ones that still need improvement will at least show up in-game and possibly motivate people to clean them up.
## Why It's Good For The Game
More interesting in-game info.
## Images of changes
Jumping to some space ruins:
![2024_12_01__10_52_54__](https://github.com/user-attachments/assets/027a1c16-715f-4c67-99ed-5424b33ccf32)

Jumping to some lava ruins:
![2024_12_01__10_57_43__](https://github.com/user-attachments/assets/a73f013f-c3b6-4f97-b8f5-d352bef33558)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
See above.

<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
add: Jumping to ruins as a ghost will now display the ruin's name and some flavor text.
/:cl:
