### PR TITLE
Chasms fix pixel Y when spitting things out, and spit out indestructable things again

### DIFF
--- a/code/game/turfs/simulated/floor/chasm.dm
+++ b/code/game/turfs/simulated/floor/chasm.dm
@@ -205,6 +205,7 @@
 	var/oldtransform = AM.transform
 	var/oldcolor = AM.color
 	var/oldalpha = AM.alpha
+	var/oldoffset = AM.pixel_y
 	animate(AM, transform = matrix() - matrix(), alpha = 0, color = rgb(0, 0, 0), time = 10)
 	for(var/i in 1 to 5)
 		//Make sure the item is still there after our sleep
@@ -222,6 +223,7 @@
 		AM.alpha = oldalpha
 		AM.color = oldcolor
 		AM.transform = oldtransform
+		AM.pixel_y = oldoffset
 		var/mob/living/fallen_mob = AM
 		fallen_mob.notransform = FALSE
 		if(fallen_mob.stat != DEAD)
@@ -237,6 +239,14 @@
 		M.forceMove(src)
 
 	qdel(AM)
+
+	if(AM && !QDELETED(AM))	//It's indestructible, mobs have already returned above!
+		visible_message("<span class='boldwarning'>[src] spits out [AM]!</span>")
+		AM.alpha = oldalpha
+		AM.color = oldcolor
+		AM.transform = oldtransform
+		AM.pixel_y = oldoffset
+		AM.throw_at(get_edge_target_turf(src,pick(GLOB.alldirs)),rand(1, 10),rand(1, 10))
 
 /**
  * An abstract object which is basically just a bag that the chasm puts people inside


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Pixel_y is reset to initial values when a mob is spit out of a chasm.
Reintroduces the line where non qdeleted (things with QDEL_HINT_LETMELIVE, ie /obj/item/immortality_talisman), are spit out of chasms when they finish the fall animation.
This fixes the above talismans falling into chasms endlessly, while also making the talisman have their icon return to being visable, rather than being invisible while falling into the chasm.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

Endlessly falling items are bad.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

threw a bunch of lockers into chasms to ensure chasms still worked with normal items.
Threw talismans into chasms.
Boxed a room in, filled half of it with chasms, ensured that after falling into multiple chasms in a row pixel Y was reset.

<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Immortality Talisman's no longer fall into chasms endlessly and being invisible, and now properly get spit out of chasms.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
