### PR TITLE
Prohibit multitool act for television

### DIFF
--- a/code/game/machinery/computer/camera_console.dm
+++ b/code/game/machinery/computer/camera_console.dm
@@ -273,6 +273,9 @@
 	if(default_unfasten_wrench(user, I, time = 4 SECONDS))
 		return TRUE
 
+/obj/machinery/computer/security/telescreen/entertainment/television/multitool_act(mob/user, obj/item/I)
+	return
+
 /obj/machinery/computer/security/telescreen/entertainment/television/on_deconstruction()
 	return
 


### PR DESCRIPTION
## What Does This PR Do
Prohibits `multitool_act` for `/obj/machinery/computer/security/telescreen/entertainment/television` that causes invalid sprite offset like it's wall-mounted but it's actually not.

## Why It's Good For The Game
No more invisible wall tricks.

## Testing
No act allowed.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl: Maxiemar
fix: The direction of wooden entertainment tv can no longer be changed.
/:cl:
