### PR TITLE
Remove non-existant mapmerge doc link

### DIFF
--- a/docs/mapping/quickstart.md
+++ b/docs/mapping/quickstart.md
@@ -20,8 +20,9 @@ has the ability to look at the changes between two maps, merge them together
 correctly, and provide markers on the map where it requires a contributor to
 make a manual change.
 
-To install Mapmerge, run `\tools\hooks\Install.bat`. Further usage of Mapmerge
-is documented in the [Guide to Mapmerge]().
+To install Mapmerge, run `\tools\hooks\Install.bat`.
+
+Further documentation on Mapmerge is forthcoming.
 
 <div class="warning">
 


### PR DESCRIPTION
## What Does This PR Do
This PR removes a hyperlink to a non-existent doc in devdocs.
## Why It's Good For The Game
Links that go nowhere are bad.
## Testing
Visual inspection.
<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog


NPFC


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
