### PR TITLE
Add customized welding helmets to the loadout

### DIFF
--- a/code/modules/client/preference/loadout/loadout_donor.dm
+++ b/code/modules/client/preference/loadout/loadout_donor.dm
@@ -76,13 +76,6 @@
 	display_name = "Fur Cap"
 	path = /obj/item/clothing/head/furcap
 
-/datum/gear/donor/welding_redflame
-	display_name = "Red flame decal welding helmet"
-	path = /obj/item/clothing/head/welding/flamedecal
-	allowed_roles = list("Chief Engineer", "Station Engineer", "Life Support Specialist", "Roboticist")
-	donator_tier = 2
-	cost = 2
-
 /datum/gear/donor/welding_blueflame
 	display_name = "Blue flame decal welding helmet"
 	path = /obj/item/clothing/head/welding/flamedecal/blue

--- a/code/modules/client/preference/loadout/loadout_donor.dm
+++ b/code/modules/client/preference/loadout/loadout_donor.dm
@@ -76,6 +76,27 @@
 	display_name = "Fur Cap"
 	path = /obj/item/clothing/head/furcap
 
+/datum/gear/donor/welding_redflame
+	display_name = "Red flame decal welding helmet"
+	path = /obj/item/clothing/head/welding/flamedecal
+	allowed_roles = list("Chief Engineer", "Station Engineer", "Life Support Specialist")
+	donator_tier = 2
+	cost = 2
+
+/datum/gear/donor/welding_blueflame
+	display_name = "Blue flame decal welding helmet"
+	path = /obj/item/clothing/head/welding/flamedecal/blue
+	allowed_roles = list("Chief Engineer", "Station Engineer", "Life Support Specialist")
+	donator_tier = 2
+	cost = 2
+
+/datum/gear/donor/welding_white
+	display_name = "White decal welding helmet"
+	path = /obj/item/clothing/head/welding/white
+	allowed_roles = list("Chief Engineer", "Station Engineer", "Life Support Specialist")
+	donator_tier = 2
+	cost = 2
+
 /datum/gear/donor/fawkes
 	display_name = "Guy Fawkes mask"
 	path = /obj/item/clothing/mask/fawkes

--- a/code/modules/client/preference/loadout/loadout_donor.dm
+++ b/code/modules/client/preference/loadout/loadout_donor.dm
@@ -79,21 +79,21 @@
 /datum/gear/donor/welding_redflame
 	display_name = "Red flame decal welding helmet"
 	path = /obj/item/clothing/head/welding/flamedecal
-	allowed_roles = list("Chief Engineer", "Station Engineer", "Life Support Specialist")
+	allowed_roles = list("Chief Engineer", "Station Engineer", "Life Support Specialist", "Roboticist")
 	donator_tier = 2
 	cost = 2
 
 /datum/gear/donor/welding_blueflame
 	display_name = "Blue flame decal welding helmet"
 	path = /obj/item/clothing/head/welding/flamedecal/blue
-	allowed_roles = list("Chief Engineer", "Station Engineer", "Life Support Specialist")
+	allowed_roles = list("Chief Engineer", "Station Engineer", "Life Support Specialist", "Roboticist")
 	donator_tier = 2
 	cost = 2
 
 /datum/gear/donor/welding_white
 	display_name = "White decal welding helmet"
 	path = /obj/item/clothing/head/welding/white
-	allowed_roles = list("Chief Engineer", "Station Engineer", "Life Support Specialist")
+	allowed_roles = list("Chief Engineer", "Station Engineer", "Life Support Specialist", "Roboticist")
 	donator_tier = 2
 	cost = 2
 


### PR DESCRIPTION
## What Does This PR Do
Adds customized welding helmets to the loadout.

## Why It's Good For The Game
I was surprised to notice these helmets. They don't seem to be found anywhere, so adding to the loadout seems appropriate.

## Images of changes
![image](https://github.com/user-attachments/assets/e6c8d28a-4fe8-4815-9b0b-c69227199217)

## Testing
Started with a nice helmet in a backpack.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl: Maxiemar
tweak: Customized welding helmets are available in the loadout now.
/:cl:
