### PR TITLE
Moves Pulse Demon from a Moderate Event to a Major Event

### DIFF
--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -188,7 +188,6 @@ GLOBAL_LIST_EMPTY(event_last_fired)
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Gravitational Anomaly",	/datum/event/anomaly/anomaly_grav,		200),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Revenant", 				/datum/event/revenant, 					150),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Morph Spawn", 				/datum/event/spawn_morph, 				40,		list(ASSIGNMENT_SECURITY = 10), is_one_shot = TRUE),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Pulse Demon Infiltration",	/datum/event/spawn_pulsedemon,			150,	list(ASSIGNMENT_ENGINEER = 10), is_one_shot = TRUE),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Disease Outbreak",			/datum/event/disease_outbreak, 			50,		list(ASSIGNMENT_MEDICAL = 30), TRUE),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Door Runtime",				/datum/event/door_runtime,				50,		list(ASSIGNMENT_ENGINEER = 25, ASSIGNMENT_AI = 150), TRUE),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Tourist Arrivals",			/datum/event/tourist_arrivals,			100,	list(ASSIGNMENT_SECURITY = 15), TRUE)

--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -208,7 +208,8 @@ GLOBAL_LIST_EMPTY(event_last_fired)
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Traders",				/datum/event/traders,			85, 	is_one_shot = TRUE),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Terror Spiders",		/datum/event/spider_terror, 	15,		list(ASSIGNMENT_SECURITY = 3), TRUE),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Slaughter Demon",		/datum/event/spawn_slaughter,	20,  	is_one_shot = TRUE),
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Shadow Demon", /datum/event/spawn_slaughter/shadow,	20, 	is_one_shot = TRUE)
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Shadow Demon", /datum/event/spawn_slaughter/shadow,	20, 	is_one_shot = TRUE),
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Pulse Demon Infiltration",	/datum/event/spawn_pulsedemon,	20,	is_one_shot = TRUE),
 		//new /datum/event_meta(EVENT_LEVEL_MAJOR, "Floor Cluwne",	/datum/event/spawn_floor_cluwne,	15, is_one_shot = TRUE)
 	)
 


### PR DESCRIPTION
## What Does This PR Do
This PR moves the Pulse Demon in the event container from Moderate to Major. It now has the same chance to roll as a Shadow or Slaughter Demon.

## Why It's Good For The Game
Pulse in its current stage is very strong. Mixed with major event rolls and possibly other moderate rolls it can become too much for the crew to handle with the amount of chaos it can potentially cause.

## Testing

Compiled.
Checked that the Pulse Demon was now a Major in the Event Manager.
Checked that Pulse Demon would be triggered by Major event rolls.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
![Discord_3E5xTVkx4G](https://github.com/user-attachments/assets/2fec2059-a81b-4ab3-a819-ca29a1eb8a5d)
![Discord_QjqaJSCJ5y](https://github.com/user-attachments/assets/ab60dcb0-435e-46d4-9e29-cfe95cf2cfaf)
![Discord_E3KQCHdfDB](https://github.com/user-attachments/assets/a8564a66-01e6-4cad-8a40-05a05c8bec60)
![Discord_skZW6DKyOn](https://github.com/user-attachments/assets/fad129ed-de60-436e-801e-64a5e6f1ea6d)
![Discord_JVA9KmV8Pr](https://github.com/user-attachments/assets/ecaa6282-2dd4-4f3d-8d84-eeab09b2fc85)


<hr>

## Changelog

:cl:
tweak: Pulse Demon is now a Major Event instead of a Moderate Event
/:cl:
