### PR TITLE
[FIX] Disguise self now updates security HUD

### DIFF
--- a/code/datums/status_effects/magic_disguise.dm
+++ b/code/datums/status_effects/magic_disguise.dm
@@ -74,6 +74,7 @@
 	H.overlays = disguise.overlays
 	H.update_inv_r_hand()
 	H.update_inv_l_hand()
+	H.sec_hud_set_ID()
 	SEND_SIGNAL(H, COMSIG_CARBON_REGENERATE_ICONS)
 	to_chat(H, "<span class='notice'>You disguise yourself as [disguise.name].</span>")
 
@@ -84,4 +85,5 @@
 	var/mob/living/carbon/human/H = owner
 	H.name_override = null
 	H.overlays.Cut()
+	H.sec_hud_set_ID()
 	qdel(src)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Using disguise self/flesh facsimile now updates your security HUD so you no longer appear wanted when disguised as someone else.

Fixes: #27504
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Disguising yourself should also disguise your security status, otherwise this ability is kind of moot.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Set myself to wanted.
Use disguise self.
I am no longer wanted.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Disguise self now hides your security HUD.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
