### PR TITLE
docs: update attack chain docs to use correct python

### DIFF
--- a/docs/references/attack_chain.md
+++ b/docs/references/attack_chain.md
@@ -604,10 +604,20 @@ the _migration plan checker_ and the _attack chain CI checks_.
 
 If you are making a code change and need to update the attack chain on an
 object, the migration plan checker will tell you what other types will need to
-be migrated in the same PR. For example, if I wanted to migrate `/turf/simulated/wall/cult`, I could rune the migration plan checker at the command line:
+be migrated in the same PR. For example, if I wanted to migrate
+`/turf/simulated/wall/cult`, I could run the migration plan checker at the
+command line:
+
+> ![NOTE]
+>
+> When running the migration plan checker, be sure to run it from the root
+> directory of your repository (`\Paradise`) and to use the version of Python
+> provided by the bootstrap module (`tools\bootstrap\python`). If you know
+> specifically that you are running in PowerShell, use the appropriate command
+> (`tools\bootstrap\python_.ps1`).
 
 ```
-$ python .\tools\migrate_attack_chain.py /turf/simulated/wall/cult
+$ tools\bootstrap\python .\tools\migrate_attack_chain.py /turf/simulated/wall/cult
 Migration Plan for Path /turf/simulated/wall/cult
 Required Additional Migrations:
         /turf
@@ -653,7 +663,7 @@ be migrating 28 types. This is a lot! A migration of this size is not recommende
 for new contributors. On the other hand, let us examine migrating wirecutters:
 
 ```
-$ python .\tools\migrate_attack_chain.py /obj/item/wirecutters
+$ tools\bootstrap\python .\tools\migrate_attack_chain.py /obj/item/wirecutters
 Migration Plan for Path /obj/item/wirecutters
 Required Additional Migrations:
         /obj/item/wirecutters


### PR DESCRIPTION
## What Does This PR Do
This PR updates the attack chain migration docs to tell people which Python to use.
## Why It's Good For The Game
Bad docs bad.
## Testing
On a brand new machine with no pre-existing Python environment, ran commands from cmd.exe and powershell.

![2024-12-04 08_58_26-Comparing ParadiseSS13_master warriorstar-orion_docs_attack-chain-commands · P](https://github.com/user-attachments/assets/6de22658-0e4a-463c-9ce9-610c150a2d45)
![2024-12-04 08_57_52-Comparing ParadiseSS13_master warriorstar-orion_docs_attack-chain-commands · P](https://github.com/user-attachments/assets/0d20da64-779d-441c-978a-6bf38125c32e)


<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there
 are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog
NPFC