### PR TITLE
Fixes an admonition in Attack Chain Documentation

### DIFF
--- a/docs/references/attack_chain.md
+++ b/docs/references/attack_chain.md
@@ -608,7 +608,7 @@ be migrated in the same PR. For example, if I wanted to migrate
 `/turf/simulated/wall/cult`, I could run the migration plan checker at the
 command line:
 
-> ![NOTE]
+> [!NOTE]
 >
 > When running the migration plan checker, be sure to run it from the root
 > directory of your repository (`\Paradise`) and to use the version of Python


### PR DESCRIPTION
## What Does This PR Do
Fixes an admonition in the new attack chain documentation.

## Why It's Good For The Game
Style of the devdoc site is important to us, especially when it comes to information on attack chain migration.

## Images of changes
![Code_VOF1TOYIFf](https://github.com/user-attachments/assets/9a93560a-52b2-4611-a961-d251bd77b888)


## Testing

Checked the markdown viewer in VS code for proper format.
(See image above)

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

<hr>

## Changelog

NPFC
