### PR TITLE
Nerfs the pulse demon

### DIFF
--- a/code/game/gamemodes/miniantags/pulsedemon/pulsedemon.dm
+++ b/code/game/gamemodes/miniantags/pulsedemon/pulsedemon.dm
@@ -766,6 +766,13 @@
 	if(istype(mover, /obj/item/projectile/ion))
 		return FALSE
 
+/mob/living/simple_animal/demon/pulse_demon/bullet_act(obj/item/projectile/proj)
+	if(proj.damage_type == BURN)
+		regen_lock = max(regen_lock, 1)
+		return ..()
+	else
+		visible_message("<span class='warning'>[proj] goes right through [src]!</span>")
+
 /mob/living/simple_animal/demon/pulse_demon/electrocute_act(shock_damage, source, siemens_coeff, flags)
 	return
 
@@ -808,12 +815,17 @@
 	return TRUE
 
 /mob/living/simple_animal/demon/pulse_demon/adjustHealth(amount, updating_health)
+	if(amount > 0) // This damages the pulse demon
+		return ..()
+
+	message_admins("Amount before [amount]")
 	if(!isapc(loc) && !istype(loc, /obj/machinery/power/smes))
 		if(health >= (maxHealth / 2))
 			amount = 0
 		else
-			amount = clamp(amount, 0, ((maxHealth / 2) - health))
-	message_admins(amount)
+			amount = clamp(amount, -((maxHealth / 2) - health), 0)
+	amount = round(amount, 1)
+	message_admins("Amount after [amount]")
 	return ..()
 
 /obj/item/organ/internal/heart/demon/pulse

--- a/code/game/gamemodes/miniantags/pulsedemon/pulsedemon.dm
+++ b/code/game/gamemodes/miniantags/pulsedemon/pulsedemon.dm
@@ -14,7 +14,7 @@
 	gender = NEUTER
 	speak_chance = 20
 
-	damage_coeff = list(BRUTE = 0, BURN = 0, TOX = 0, CLONE = 0, STAMINA = 0, OXY = 0) // Pulse demons take damage from nothing
+	damage_coeff = list(BRUTE = 0, BURN = 0.5, TOX = 0, CLONE = 0, STAMINA = 0, OXY = 0) // Pulse demons take damage from nothing except some from lasers
 
 	emote_hear = list("vibrates", "sizzles")
 	speak_emote = list("modulates")
@@ -766,11 +766,6 @@
 	if(istype(mover, /obj/item/projectile/ion))
 		return FALSE
 
-/mob/living/simple_animal/demon/pulse_demon/bullet_act(obj/item/projectile/proj)
-	if(istype(proj, /obj/item/projectile/ion))
-		return ..()
-	visible_message("<span class='warning'>[proj] goes right through [src]!</span>")
-
 /mob/living/simple_animal/demon/pulse_demon/electrocute_act(shock_damage, source, siemens_coeff, flags)
 	return
 
@@ -811,6 +806,15 @@
 	if(ourapc.hacked_by_ruin_AI || ourapc.malfai || ourapc.malfhack)
 		return FALSE
 	return TRUE
+
+/mob/living/simple_animal/demon/pulse_demon/adjustHealth(amount, updating_health)
+	if(!isapc(loc) && !istype(loc, /obj/machinery/power/smes))
+		if(health >= (maxHealth / 2))
+			amount = 0
+		else
+			amount = clamp(amount, 0, ((maxHealth / 2) - health))
+	message_admins(amount)
+	return ..()
 
 /obj/item/organ/internal/heart/demon/pulse
 	name = "perpetual pacemaker"

--- a/code/game/gamemodes/miniantags/pulsedemon/pulsedemon.dm
+++ b/code/game/gamemodes/miniantags/pulsedemon/pulsedemon.dm
@@ -818,14 +818,12 @@
 	if(amount > 0) // This damages the pulse demon
 		return ..()
 
-	message_admins("Amount before [amount]")
-	if(!isapc(loc) && !istype(loc, /obj/machinery/power/smes))
+	if(!ismachinery(loc))
 		if(health >= (maxHealth / 2))
 			amount = 0
 		else
 			amount = clamp(amount, -((maxHealth / 2) - health), 0)
 	amount = round(amount, 1)
-	message_admins("Amount after [amount]")
 	return ..()
 
 /obj/item/organ/internal/heart/demon/pulse


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
- Lasers deal 50% their damage to pulse demons. They also stop healing for 1 cycle
- Pulse demons now can only heal to 50% of their hp when outside of machinery.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Pulse has been a long time PITA to deal with, due to it only being vulnerable to ion shots and having exceptional healing while on the fly. This forces them to retreat and heal up after a fight instead of being able to fully heal when still moving about. It also gives security an extra weapon to fight them with, albeit overall worse than an ion rifle
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Did a bunch of testing, for example this is when a pulse has 24 out of 50 hp, it only healed 1 hp
![image](https://github.com/user-attachments/assets/418ee93a-fc26-4187-b054-e20eb2eb80be)

<!-- How did you test the PR, if at all? -->

<hr>

### Declaration
![image](https://github.com/user-attachments/assets/540c1539-0377-47bd-9ca9-8b7bf0018fdb)

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
tweak: Pulse demons now take half damage from lasers
tweak: Pulse demons now can only heal to half hp while outside of machinery
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
