### PR TITLE
Fix alien egg not being able to can

### DIFF
--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -28,6 +28,7 @@
 	return S
 
 /obj/item/organ/internal/body_egg/alien_embryo/on_life()
+	..()
 	switch(stage)
 		if(2)
 			if(prob(2))

--- a/code/modules/surgery/organs/body_egg.dm
+++ b/code/modules/surgery/organs/body_egg.dm
@@ -27,6 +27,7 @@
 
 /obj/item/organ/internal/body_egg/on_life()
 	SHOULD_CALL_PARENT(TRUE)
+	..()
 	if(!(src in owner.internal_organs)) // I can only presume this is here for a reason, so not touching it.
 		remove(owner)
 		return
@@ -34,6 +35,7 @@
 
 /obj/item/organ/internal/body_egg/dead_process()
 	SHOULD_CALL_PARENT(TRUE)
+	..()
 	if(!(src in owner.internal_organs)) // I can only presume this is here for a reason, so not touching it.
 		remove(owner)
 		return

--- a/code/modules/surgery/organs/body_egg.dm
+++ b/code/modules/surgery/organs/body_egg.dm
@@ -33,6 +33,7 @@
 	egg_process()
 
 /obj/item/organ/internal/body_egg/dead_process()
+	SHOULD_CALL_PARENT(TRUE)
 	if(!(src in owner.internal_organs)) // I can only presume this is here for a reason, so not touching it.
 		remove(owner)
 		return

--- a/code/modules/surgery/organs/body_egg.dm
+++ b/code/modules/surgery/organs/body_egg.dm
@@ -26,6 +26,7 @@
 	. = ..()
 
 /obj/item/organ/internal/body_egg/on_life()
+	SHOULD_CALL_PARENT(TRUE)
 	if(!(src in owner.internal_organs)) // I can only presume this is here for a reason, so not touching it.
 		remove(owner)
 		return

--- a/code/modules/surgery/organs/parasites.dm
+++ b/code/modules/surgery/organs/parasites.dm
@@ -10,6 +10,7 @@
 	var/stage = 1
 
 /obj/item/organ/internal/body_egg/spider_eggs/on_life()
+	..()
 	if(stage < 5 && prob(3))
 		stage++
 
@@ -55,6 +56,7 @@
 	// Safety first.
 	if(!owner)
 		return
+	..()
 
 	// Parasite growth
 	cycle_num += 1


### PR DESCRIPTION
## What Does This PR Do
Forces body eggs to call parent `on_life()` and `dead_process()` cause `egg_process()` is called there.

## Why It's Good For The Game
This one fixes an alien egg not evolving inside a body. Can lead to some other bug fixes I am not aware of.

## Testing
Became an alien's young mom after wearing facehugger for a while.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl: Maxiemar
fix: Alien eggs evolve correctly now.
/:cl:
