### PR TITLE
Attack Chain Migration: /obj/item/airlock_electronics/destroyed

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -2020,3 +2020,15 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 			return_list[path] = 0
 		return_list[path] += 1
 	return return_list
+
+/// Used for signal registrars who wish to completely ignore all behavior
+/// in the attack chain from parent types. Should be used sparingly, as
+/// subtypes are meant to build on behavior from the parent type.
+/proc/cancel_attack_by(datum/source, obj/item/attacking, mob/user, params)
+	return COMPONENT_SKIP_AFTERATTACK
+
+/// Used for signal registrars who wish to completely ignore all behavior
+/// in the attack chain from parent types. Should be used sparingly, as
+/// subtypes are meant to build on behavior from the parent type.
+/proc/cancel_activate_self(mob/user)
+	return COMPONENT_CANCEL_ATTACK_CHAIN

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -2020,15 +2020,3 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 			return_list[path] = 0
 		return_list[path] += 1
 	return return_list
-
-/// Used for signal registrars who wish to completely ignore all behavior
-/// in the attack chain from parent types. Should be used sparingly, as
-/// subtypes are meant to build on behavior from the parent type.
-/proc/cancel_attack_by(datum/source, obj/item/attacking, mob/user, params)
-	return COMPONENT_SKIP_AFTERATTACK
-
-/// Used for signal registrars who wish to completely ignore all behavior
-/// in the attack chain from parent types. Should be used sparingly, as
-/// subtypes are meant to build on behavior from the parent type.
-/proc/cancel_activate_self(mob/user)
-	return COMPONENT_CANCEL_ATTACK_CHAIN

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -274,3 +274,16 @@
 		"<span class='combat danger'>You hear someone being attacked with a weapon!</span>"
 	)
 	return TRUE
+
+/// Used for signal registrars who wish to completely ignore all behavior
+/// in the attack chain from parent types. Should be used sparingly, as
+/// subtypes are meant to build on behavior from the parent type.
+/datum/proc/signal_cancel_activate_self(mob/user)
+	return COMPONENT_CANCEL_ATTACK_CHAIN
+
+/// Used for signal registrars who wish to completely ignore all behavior
+/// in the attack chain from parent types calling `attack_by`. Should be
+/// used sparingly, as subtypes are meant to build on behavior from the parent
+/// type.
+/datum/proc/signal_cancel_attack_by(datum/source, obj/item/attacking, mob/user, params)
+	return COMPONENT_SKIP_AFTERATTACK

--- a/code/game/machinery/doors/airlock_electronics.dm
+++ b/code/game/machinery/doors/airlock_electronics.dm
@@ -112,7 +112,7 @@
 
 /obj/item/airlock_electronics/destroyed/Initialize(mapload)
 	. = ..()
-	RegisterSignal(src, COMSIG_ACTIVATE_SELF, GLOBAL_PROC_REF(cancel_activate_self))
+	RegisterSignal(src, COMSIG_ACTIVATE_SELF, TYPE_PROC_REF(/datum, signal_cancel_activate_self))
 
 /obj/item/airlock_electronics/destroyed/decompile_act(obj/item/matter_decompiler/C, mob/user)
 	C.stored_comms["metal"] += 1

--- a/code/game/machinery/doors/airlock_electronics.dm
+++ b/code/game/machinery/doors/airlock_electronics.dm
@@ -21,6 +21,8 @@
 	/// Is this electronic installed in a door?
 	var/is_installed = FALSE
 
+	new_attack_chain = TRUE
+
 /obj/item/airlock_electronics/Initialize(mapload)
 	. = ..()
 	if(!length(door_accesses_list))
@@ -108,8 +110,9 @@
 	name = "burned-out airlock electronics"
 	icon_state = "door_electronics_smoked"
 
-/obj/item/airlock_electronics/destroyed/attack_self__legacy__attackchain(mob/user)
-	return
+/obj/item/airlock_electronics/destroyed/Initialize(mapload)
+	. = ..()
+	RegisterSignal(src, COMSIG_ACTIVATE_SELF, GLOBAL_PROC_REF(cancel_activate_self))
 
 /obj/item/airlock_electronics/destroyed/decompile_act(obj/item/matter_decompiler/C, mob/user)
 	C.stored_comms["metal"] += 1

--- a/docs/references/attack_chain.md
+++ b/docs/references/attack_chain.md
@@ -607,14 +607,14 @@ problem.
 
 In order to implement behavior such as this, the child type should register to
 listen for the signal that applies to the attack chain proc, and respond by
-calling one of the global procs which return a signal preventing the rest of the
-attack chain from running.
+calling one of the procs which return a signal preventing the rest of the attack
+chain from running.
 
-For `attack_by` prevention, this proc is [/proc/cancel_attack_by][]. For
-`activate_self` prevention, this proc is [/proc/cancel_activate_self][].
+For `attack_by` prevention, this proc is [/datum/proc/signal_cancel_attack_by][]. For
+`activate_self` prevention, this proc is [/datum/proc/signal_cancel_activate_self][].
 
-[/proc/cancel_attack_by]: https://codedocs.paradisestation.org/global.html#proc/cancel_attack_by
-[/proc/cancel_activate_self]: https://codedocs.paradisestation.org/global.html#proc/cancel_activate_self
+[/datum/proc/signal/cancel_attack_by]: https://codedocs.paradisestation.org/datum.html#proc/signal_cancel_attack_by
+[/datum/proc/signal/cancel_activate_self]: https://codedocs.paradisestation.org/datum.html#proc/signal_cancel_activate_self
 
 For example, when we migrated the airlock electronics above, we neglected to
 handle the `/destroyed` subtype, which prevents any interaction via
@@ -623,7 +623,7 @@ handle the `/destroyed` subtype, which prevents any interaction via
 ```diff
 +/obj/item/airlock_electronics/destroyed/Initialize(mapload)
 +	. = ..()
-+	RegisterSignal(src, COMSIG_ACTIVATE_SELF, GLOBAL_PROC_REF(cancel_activate_self))
++	RegisterSignal(src, COMSIG_ACTIVATE_SELF, TYPE_PROC_REF(/datum, signal_cancel_activate_self))
 ```
 
 ## Migration Helpers

--- a/docs/references/attack_chain.md
+++ b/docs/references/attack_chain.md
@@ -595,6 +595,37 @@ sequence of events. Finally, because we constantly check the parent proc, all
 signals that are expected to be sent, are, so any other components or listeners
 can take appropriate action and cancel the attack chain themselves, if requested.
 
+### Cancelling All Behavior
+
+Frequently, a subtype will want to completely prevent any of its parent type
+behavior from running. Examples may be a holofloor, which should prevent any
+attempts to deconstruct it, or a destroyed variant of an object, which cancels
+out the existing functionality of the parent type.
+
+Attack chain methods must always call their parent procs, so this presents a
+problem.
+
+In order to implement behavior such as this, the child type should register to
+listen for the signal that applies to the attack chain proc, and respond by
+calling one of the global procs which return a signal preventing the rest of the
+attack chain from running.
+
+For `attack_by` prevention, this proc is [/proc/cancel_attack_by][]. For
+`activate_self` prevention, this proc is [/proc/cancel_activate_self][].
+
+[/proc/cancel_attack_by]: https://codedocs.paradisestation.org/global.html#proc/cancel_attack_by
+[/proc/cancel_activate_self]: https://codedocs.paradisestation.org/global.html#proc/cancel_activate_self
+
+For example, when we migrated the airlock electronics above, we neglected to
+handle the `/destroyed` subtype, which prevents any interaction via
+`activate_self`. To ensure this, we make the following change:
+
+```diff
++/obj/item/airlock_electronics/destroyed/Initialize(mapload)
++	. = ..()
++	RegisterSignal(src, COMSIG_ACTIVATE_SELF, GLOBAL_PROC_REF(cancel_activate_self))
+```
+
 ## Migration Helpers
 
 There are two important tools which can help make the migration process easier:


### PR DESCRIPTION
## What Does This PR Do
This PR fixes the attack chain migration for airlock electronics, properly handling their destroyed subtype. It also updates the documentation to explain how to do this in the future, using the incorrect migration as an example (the code doc links won't work until the day after this PR gets merged).
## Why It's Good For The Game
Bugfix, better docs.
## Testing
- [X] Spawned in an airlock electronics, ensured I could activate it with the keyboard shortcut, and by clicking on it in my hand.
- [X] Spawned in a destroyed airlock electronics, ensured that using the activate keyboard shortcut and clicking on it did nothing.
- [X] Spawned in an airlock, emagged it, ensured that the electronics was properly spawned to replace the original.

<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Destroyed airlock electronics should now properly prevent players from setting their access.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
