### PR TITLE
Fix attacked_by being called after handled attacks

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -163,6 +163,8 @@
 	user.do_attack_animation(target)
 	add_fingerprint(user)
 
+	return TRUE
+
 /// The equivalent of the standard version of [/obj/item/proc/attack] but for non mob targets.
 /obj/item/proc/attack_obj(obj/attacked_obj, mob/living/user, params)
 	var/signal_return = SEND_SIGNAL(src, COMSIG_ATTACK_OBJ, attacked_obj, user) | SEND_SIGNAL(user, COMSIG_ATTACK_OBJ_LIVING, attacked_obj)

--- a/code/_onclick/item_attack_legacy.dm
+++ b/code/_onclick/item_attack_legacy.dm
@@ -25,10 +25,11 @@
 
 	SEND_SIGNAL(user, COMSIG_MOB_ITEM_ATTACK, M, user)
 
-	. = __attack_core(M, user)
+	if(!__attack_core(M, user))
+		return
 
 	if(!M.new_attack_chain)
-		M.attacked_by__legacy__attackchain(src, user, def_zone)
+		return M.attacked_by__legacy__attackchain(src, user, def_zone)
 
 /**
  * Called when `user` attacks us with item `W`.


### PR DESCRIPTION
## What Does This PR Do
This PR fixes an error in #26834 where attacked_by was being called when it shouldn't be, such as when an item couldn't bludgeon.
## Why It's Good For The Game
Bugfix.
## Testing
- [X] Spawned as borg, chose miner module, spawned goliath hide, used gripper to attach them to myself, confirmed that I only attached them to myself and didn't attack myself with them.
- [X] Performed cult dagger tests to ensure new attack chain behavior was still preserved.

<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Several unexpected attack side-effects, including borgs bludgeoning themselves with goliath hide plates, have been fixed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
