### PR TITLE
Remove unused 'broken light' light floor state

### DIFF
--- a/code/game/turfs/simulated/floor/light_floor.dm
+++ b/code/game/turfs/simulated/floor/light_floor.dm
@@ -5,8 +5,6 @@
 	floor_tile = /obj/item/stack/tile/light
 	/// Are we on
 	var/on = FALSE
-	/// Are we broken
-	var/light_broken = FALSE
 	/// Can we modify a colour
 	var/can_modify_colour = TRUE
 	/// Are we draining power
@@ -50,43 +48,29 @@
 		return
 	toggle_light(!on)
 
-/turf/simulated/floor/light/attackby__legacy__attackchain(obj/item/C, mob/user, params)
-	if(istype(C, /obj/item/light/bulb)) //only for light tiles
-		if(!light_broken)
-			qdel(C)
-			light_broken = FALSE
-			update_icon()
-			to_chat(user, "<span class='notice'>You replace the light bulb.</span>")
-		else
-			to_chat(user, "<span class='notice'>The light bulb seems fine, no need to replace it.</span>")
-	else
-		return ..()
-
 /turf/simulated/floor/light/multitool_act(mob/user, obj/item/I)
 	. = TRUE
 	if(!can_modify_colour)
 		return
 	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
 		return
-	if(!light_broken)
-		var/new_color = tgui_input_color(user, "Select a bulb color", "Select a bulb color", color)
-		if(isnull(new_color))
-			return
 
-		// Cancel if they walked away
-		if(!Adjacent(user, src))
-			return
+	var/new_color = tgui_input_color(user, "Select a bulb color", "Select a bulb color", color)
+	if(isnull(new_color))
+		return
 
-		// Now lets make sure it cant go fully black. Yes I know this is more dense than my skull.
-		var/list/hsl = rgb2hsl(hex2num(copytext(new_color, 2, 4)), hex2num(copytext(new_color, 4, 6)), hex2num(copytext(new_color, 6, 8)))
-		hsl[3] = max(hsl[3], 0.4)
-		var/list/rgb = hsl2rgb(arglist(hsl))
-		color = "#[num2hex(rgb[1], 2)][num2hex(rgb[2], 2)][num2hex(rgb[3], 2)]"
+	// Cancel if they walked away
+	if(!Adjacent(user, src))
+		return
 
-		to_chat(user, "<span class='notice'>You change [src]'s light bulb color.</span>")
-		update_icon()
-	else
-		to_chat(user, "<span class='warning'>[src]'s light bulb appears to have burned out.</span>")
+	// Now lets make sure it cant go fully black. Yes I know this is more dense than my skull.
+	var/list/hsl = rgb2hsl(hex2num(copytext(new_color, 2, 4)), hex2num(copytext(new_color, 4, 6)), hex2num(copytext(new_color, 6, 8)))
+	hsl[3] = max(hsl[3], 0.4)
+	var/list/rgb = hsl2rgb(arglist(hsl))
+	color = "#[num2hex(rgb[1], 2)][num2hex(rgb[2], 2)][num2hex(rgb[3], 2)]"
+
+	to_chat(user, "<span class='notice'>You change [src]'s light bulb color.</span>")
+	update_icon()
 
 /turf/simulated/floor/light/proc/toggle_light(light)
 	if(!on && !power_check())


### PR DESCRIPTION
## What Does This PR Do
This PR removes some behavior in the light floors related to bulb replacement. As can be seen, `light_broken` is never modified anywhere, and the logic here is in reverse, replacing a bulb if `!light_broken`, causing floor lights to accept infinite light bulbs.
## Why It's Good For The Game
Mostly dead code, unused behavior, no more bizarre in-game behavior.
## Testing
Spawned light floor in-game, ensured that bulbs could not be used on it.
<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Behavior where light bulbs could be inserted an infinite number of times into light floors has been fixed.
/:cl:
