### PR TITLE
Fix missing animation/cooldown for item attacks

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -173,6 +173,9 @@
 	if(flags & NOBLUDGEON)
 		return FALSE
 
+	user.changeNext_move(CLICK_CD_MELEE)
+	user.do_attack_animation(attacked_obj)
+
 	if(!attacked_obj.new_attack_chain)
 		attacked_obj.attacked_by__legacy__attackchain(src, user)
 


### PR DESCRIPTION
## What Does This PR Do
This PR fixes an issue where items migrated to the new attack chain do not properly handle cooldowns or animations. There's only one item affected by this in the game under specific conditions so I'm not too worried about this being exploited.
## Why It's Good For The Game
Bugfix.
## Testing
Tested the one item, ensured animation and cooldown procced.
<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog

:cl:
fix: Some items missing an attack animation have been fixed.
/:cl:
