### PR TITLE
Fix some autolathe signal issues.

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -50,7 +50,7 @@
 	component_parts += new /obj/item/stack/sheet/glass(null)
 	RefreshParts()
 
-	RegisterSignal(src, COMSIG_ATTACK_BY, PROC_REF(on_attack_by))
+	RegisterSignal(src, COMSIG_TOOL_ATTACK, PROC_REF(on_tool_attack))
 
 	wires = new(src)
 	files = new /datum/research/autolathe(src)
@@ -79,15 +79,15 @@
 	materials.retrieve_all()
 	return ..()
 
-/obj/machinery/autolathe/proc/on_attack_by(datum/source, obj/item/attacking, mob/user)
-	SIGNAL_HANDLER // COMSIG_ATTACK_BY
-
-	if(!istype(attacking))
+/obj/machinery/autolathe/proc/on_tool_attack(datum/source, atom/tool, mob/user)
+	SIGNAL_HANDLER // COMSIG_TOOL_ATTACK
+	var/obj/item/I = tool
+	if(!istype(I))
 		return
 
 	// Allows screwdrivers to be recycled on harm intent
-	if(attacking.tool_behaviour == TOOL_SCREWDRIVER && user.a_intent == INTENT_HARM)
-		return COMPONENT_SKIP_AFTERATTACK
+	if(I.tool_behaviour == TOOL_SCREWDRIVER && user.a_intent == INTENT_HARM)
+		return COMPONENT_CANCEL_TOOLACT
 
 /obj/machinery/autolathe/interact(mob/user)
 	if(shocked && !(stat & NOPOWER))


### PR DESCRIPTION
## What Does This PR Do
This PR fixes two issues with autolathe signals. `COMSIG_TOOL_ATTACK` is deprecated for new usage but is still required for autolathe/screwdriver interactions. It also prevents signal registration overrides with trapped autolathes. Fixes #27555.
## Why It's Good For The Game
Bugfix, less runtimes.
## Testing
- [X] Ensured a screwdriver opened a lathe panel on help intent, and recycled it on harm intent.
- [X] Ensured trapped lathe triggered with laser gun, and then ensured above screwdriver behavior continued to work.

<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Screwdrivers are properly recycled in autolathes on harm intent.
fix: A runtime related to the DVORAK ruin has been fixed.
/:cl:
