### PR TITLE
[PORT/REFACTOR] Implements clothing traits

### DIFF
--- a/code/__DEFINES/clothing_defines.dm
+++ b/code/__DEFINES/clothing_defines.dm
@@ -112,3 +112,7 @@
 #define MUZZLE_MUTE_MUFFLE 1 // Muffles everything you say "MHHPHHMMM!!!
 #define MUZZLE_MUTE_ALL 2 // Completely mutes you.
 
+/// Wrapper for adding clothing based traits
+#define ADD_CLOTHING_TRAIT(mob, trait) ADD_TRAIT(mob, trait, "[CLOTHING_TRAIT]_[UID(src)]")
+/// Wrapper for removing clothing based traits
+#define REMOVE_CLOTHING_TRAIT(mob, trait) REMOVE_TRAIT(mob, trait, "[CLOTHING_TRAIT]_[UID(src)]")

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -593,7 +593,9 @@ GLOBAL_DATUM_INIT(welding_sparks, /mutable_appearance, mutable_appearance('icons
 // The default action is attack_self().
 // Checks before we get to here are: mob is alive, mob is not restrained, paralyzed, asleep, resting, laying, item is on the mob.
 /obj/item/proc/ui_action_click(mob/user, actiontype)
-	attack_self__legacy__attackchain(user)
+	if(!new_attack_chain)
+		return attack_self__legacy__attackchain(user)
+	activate_self(user)
 
 /obj/item/proc/IsReflect(def_zone) // This proc determines if and at what% an object will reflect energy projectiles if it's in l_hand,r_hand or wear_suit
 	return FALSE

--- a/code/game/objects/items/weapons/cigs.dm
+++ b/code/game/objects/items/weapons/cigs.dm
@@ -452,6 +452,7 @@ LIGHTERS ARE IN LIGHTERS.DM
 	name = "Holo-Cigar"
 	desc = "A sleek electronic cigar imported straight from Sol. You feel badass merely glimpsing it..."
 	icon_state = "holocigaroff"
+	clothing_traits = list(TRAIT_BADASS) //CHAP-TODO: Convert holo_cigar to using clothing traits.
 	/// Is the holo-cigar lit?
 	var/enabled = FALSE
 	/// Tracks if this is the first cycle smoking the cigar.

--- a/code/game/objects/items/weapons/cigs.dm
+++ b/code/game/objects/items/weapons/cigs.dm
@@ -452,7 +452,7 @@ LIGHTERS ARE IN LIGHTERS.DM
 	name = "Holo-Cigar"
 	desc = "A sleek electronic cigar imported straight from Sol. You feel badass merely glimpsing it..."
 	icon_state = "holocigaroff"
-	clothing_traits = list(TRAIT_BADASS) //CHAP-TODO: Convert holo_cigar to using clothing traits.
+	clothing_traits = list(TRAIT_BADASS)
 	/// Is the holo-cigar lit?
 	var/enabled = FALSE
 	/// Tracks if this is the first cycle smoking the cigar.

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -72,7 +72,7 @@
 /datum/action/item_action/chameleon_change/New(Target)
 	. = ..()
 	holder = Target
-	
+
 
 /datum/action/item_action/chameleon_change/Grant(mob/M)
 	if(M && (owner != M))
@@ -587,7 +587,7 @@
 	icon_state = "black"
 	item_color = "black"
 	desc = "A pair of black shoes."
-	no_slip = TRUE
+	clothing_traits = list(TRAIT_NOSLIP)
 
 /obj/item/clothing/shoes/chameleon/noslip/broken/Initialize(mapload)
 	. = ..()

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -118,6 +118,40 @@
 
 	return TRUE
 
+/**
+ * Inserts a trait (or multiple traits) into the clothing traits list
+ *
+ * If worn, then we will also give the wearer the trait as if equipped
+ *
+ * This is so you can add clothing traits without worrying about needing to equip or unequip them to gain effects
+ */
+/obj/item/clothing/proc/attach_clothing_traits(trait_or_traits)
+	if(!islist(trait_or_traits))
+		trait_or_traits = list(trait_or_traits)
+
+	LAZYOR(clothing_traits, trait_or_traits)
+	var/mob/wearer = loc
+	if(istype(wearer) && (wearer.get_slot_by_item(src) & slot_flags))
+		for(var/new_trait in trait_or_traits)
+			ADD_CLOTHING_TRAIT(wearer, new_trait)
+
+/**
+ * Removes a trait (or multiple traits) from the clothing traits list
+ *
+ * If worn, then we will also remove the trait from the wearer as if unequipped
+ *
+ * This is so you can add clothing traits without worrying about needing to equip or unequip them to gain effects
+ */
+/obj/item/clothing/proc/detach_clothing_traits(trait_or_traits)
+	if(!islist(trait_or_traits))
+		trait_or_traits = list(trait_or_traits)
+
+	LAZYREMOVE(clothing_traits, trait_or_traits)
+	var/mob/wearer = loc
+	if(istype(wearer))
+		for(var/new_trait in trait_or_traits)
+			REMOVE_CLOTHING_TRAIT(wearer, new_trait)
+
 /obj/item/clothing/proc/refit_for_species(target_species)
 	//Set icon
 	if(sprite_sheets && (target_species in sprite_sheets))

--- a/code/modules/clothing/ears/earmuffs.dm
+++ b/code/modules/clothing/ears/earmuffs.dm
@@ -3,6 +3,7 @@
 	desc = "Protects your hearing from loud noises, and quiet ones as well."
 	icon_state = "earmuffs"
 	item_state = "earmuffs"
+	clothing_traits = list(TRAIT_DEAF)
 	flags = EARBANGPROTECT
 	strip_delay = 15
 	put_on_delay = 25
@@ -11,12 +12,3 @@
 /obj/item/clothing/ears/earmuffs/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/earhealing)
-
-/obj/item/clothing/ears/earmuffs/equipped(mob/user, slot)
-	. = ..()
-	if(ishuman(user) && (slot & ITEM_SLOT_BOTH_EARS))
-		ADD_TRAIT(user, TRAIT_DEAF, "[CLOTHING_TRAIT][UID()]")
-
-/obj/item/clothing/ears/earmuffs/dropped(mob/user)
-	. = ..()
-	REMOVE_TRAIT(user, TRAIT_DEAF, "[CLOTHING_TRAIT][UID()]")

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -88,6 +88,7 @@
 	desc = "Used for seeing walls, floors, and stuff through anything."
 	icon_state = "meson"
 	item_state = "meson"
+	clothing_traits = list(TRAIT_MESON_VISION)
 	origin_tech = "magnets=1;engineering=2"
 	prescription_upgradable = TRUE
 
@@ -100,16 +101,6 @@
 		)
 
 	var/active_on_equip = TRUE
-
-/obj/item/clothing/glasses/meson/equipped(mob/user, slot, initial)
-	. = ..()
-	if(active_on_equip && slot == ITEM_SLOT_EYES)
-		ADD_TRAIT(user, TRAIT_MESON_VISION, "meson_glasses[UID()]")
-
-/obj/item/clothing/glasses/meson/dropped(mob/user)
-	. = ..()
-	if(user)
-		REMOVE_TRAIT(user, TRAIT_MESON_VISION, "meson_glasses[UID()]")
 
 /obj/item/clothing/glasses/meson/night
 	name = "night vision optical meson scanner"

--- a/code/modules/clothing/glasses/tajblind.dm
+++ b/code/modules/clothing/glasses/tajblind.dm
@@ -59,20 +59,11 @@
 	name = "\improper Tajaran engineering meson veil"
 	icon_state = "tajblind_engi"
 	item_state = "tajblind_engi"
+	clothing_traits = list(TRAIT_MESON_VISION)
 
 /obj/item/clothing/glasses/hud/tajblind/meson/Initialize(mapload)
 	. = ..()
 	desc += "<br><span class='notice'>It has an optical meson scanner integrated into it.</span>"
-
-/obj/item/clothing/glasses/hud/tajblind/meson/equipped(mob/user, slot, initial)
-	. = ..()
-	if(slot == ITEM_SLOT_EYES)
-		ADD_TRAIT(user, TRAIT_MESON_VISION, "meson_glasses[UID()]")
-
-/obj/item/clothing/glasses/hud/tajblind/meson/dropped(mob/user)
-	. = ..()
-	if(user)
-		REMOVE_TRAIT(user, TRAIT_MESON_VISION, "meson_glasses[UID()]")
 
 /obj/item/clothing/glasses/hud/tajblind/meson/cargo
 	name = "\improper Tajaran mining meson veil"
@@ -129,21 +120,11 @@
 	name = "shaded Tajaran engineering meson veil"
 	icon_state = "tajblind_engi"
 	item_state = "tajblind_engi"
+	clothing_traits = list(TRAIT_MESON_VISION)
 
 /obj/item/clothing/glasses/hud/tajblind/shaded/meson/Initialize(mapload)
 	. = ..()
 	desc += "<br><span class='notice'>It has an optical meson scanner integrated into it.</span>"
-
-/obj/item/clothing/glasses/hud/tajblind/shaded/meson/equipped(mob/user, slot, initial)
-	. = ..()
-	if(slot == ITEM_SLOT_EYES)
-		ADD_TRAIT(user, TRAIT_MESON_VISION, "meson_glasses[UID()]")
-
-/obj/item/clothing/glasses/hud/tajblind/shaded/meson/dropped(mob/user)
-	. = ..()
-	if(user)
-		REMOVE_TRAIT(user, TRAIT_MESON_VISION, "meson_glasses[UID()]")
-
 
 /obj/item/clothing/glasses/hud/tajblind/shaded/meson/cargo
 	name = "shaded Tajaran mining meson veil"

--- a/code/modules/clothing/gloves/misc_gloves.dm
+++ b/code/modules/clothing/gloves/misc_gloves.dm
@@ -237,15 +237,9 @@
 		"Grey" = 'icons/mob/clothing/species/grey/gloves.dmi',
 		"Drask" = 'icons/mob/clothing/species/drask/gloves.dmi'
 	)
+	clothing_traits = list(TRAIT_SUPERMATTER_IMMUNE)
 
 /obj/item/clothing/gloves/color/white/supermatter_immune/Initialize(mapload)
 	. = ..()
 	ADD_TRAIT(src, TRAIT_SUPERMATTER_IMMUNE, ROUNDSTART_TRAIT)
 
-/obj/item/clothing/gloves/color/white/supermatter_immune/equipped(mob/user, slot, initial)
-	. = ..()
-	ADD_TRAIT(user, TRAIT_SUPERMATTER_IMMUNE, ENFORCER_GLOVES)
-
-/obj/item/clothing/gloves/color/white/supermatter_immune/dropped(mob/user, silent)
-	. = ..()
-	REMOVE_TRAIT(user, TRAIT_SUPERMATTER_IMMUNE, ENFORCER_GLOVES)

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -55,16 +55,7 @@
 	name = "meson visor helmet"
 	desc = "A helmet with a built-in meson scanning visor."
 	icon_state = "helmetmesons"
-
-/obj/item/clothing/head/helmet/meson/equipped(mob/user, slot, initial)
-	. = ..()
-	if(slot == ITEM_SLOT_HEAD)
-		ADD_TRAIT(user, TRAIT_MESON_VISION, "meson_helmet[UID()]")
-
-/obj/item/clothing/head/helmet/meson/dropped(mob/user)
-	. = ..()
-	if(user)
-		REMOVE_TRAIT(user, TRAIT_MESON_VISION, "meson_helmet[UID()]")
+	clothing_traits = list(TRAIT_MESON_VISION)
 
 /obj/item/clothing/head/helmet/material
 	name = "material visor helmet"

--- a/code/modules/clothing/shoes/colour.dm
+++ b/code/modules/clothing/shoes/colour.dm
@@ -73,18 +73,21 @@
 	QDEL_NULL(shackles)
 	return ..()
 
-/obj/item/clothing/shoes/orange/attack_self__legacy__attackchain(mob/user)
+/obj/item/clothing/shoes/orange/activate_self(mob/user)
+	if(..())
+		return
+
 	if(shackles)
 		user.put_in_hands(shackles)
 		shackles = null
 		slowdown = SHOES_SLOWDOWN
 		icon_state = "orange"
 
-/obj/item/clothing/shoes/orange/attackby__legacy__attackchain(obj/item/I, mob/user, params)
-	if(istype(I, /obj/item/restraints/handcuffs) && !shackles)
+/obj/item/clothing/shoes/orange/item_interaction(mob/living/user, obj/item/used, list/modifiers)
+	if(istype(used, /obj/item/restraints/handcuffs) && !shackles)
 		if(user.drop_item())
-			I.forceMove(src)
-			shackles = I
+			used.forceMove(src)
+			shackles = used
 			slowdown = 15
 			icon_state = "orange1"
 			return

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -8,7 +8,7 @@
 	strip_delay = 7 SECONDS
 	put_on_delay = 7 SECONDS
 	resistance_flags = FIRE_PROOF
-
+	new_attack_chain = TRUE
 	var/magboot_state = "magboots"
 	var/magpulse = FALSE
 	var/slowdown_active = 2
@@ -33,7 +33,11 @@
 	if(magpulse)
 		detach_clothing_traits(active_traits)
 
-/obj/item/clothing/shoes/magboots/attack_self(mob/user, forced = FALSE)
+/obj/item/clothing/shoes/magboots/ui_action_click(mob/user)
+	toggle_magpulse(user)
+
+/obj/item/clothing/shoes/magboots/activate_self(mob/user, forced = FALSE)
+	. = ..()
 	toggle_magpulse(user, forced)
 
 /obj/item/clothing/shoes/magboots/proc/toggle_magpulse(mob/user, forced)

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -36,11 +36,11 @@
 /obj/item/clothing/shoes/magboots/ui_action_click(mob/user)
 	toggle_magpulse(user)
 
-/obj/item/clothing/shoes/magboots/activate_self(mob/user, forced = FALSE)
+/obj/item/clothing/shoes/magboots/activate_self(mob/user)
 	. = ..()
 	toggle_magpulse(user, forced)
 
-/obj/item/clothing/shoes/magboots/proc/toggle_magpulse(mob/user, forced)
+/obj/item/clothing/shoes/magboots/proc/toggle_magpulse(mob/user, no_message)
 	magpulse = !magpulse
 	if(magpulse) //magpulse and no_slip will always be the same value unless VV happens
 		attach_clothing_traits(active_traits)
@@ -50,7 +50,7 @@
 		slowdown = slowdown_passive
 	if(multiple_icons)
 		icon_state = "[magboot_state][magpulse]"
-	if(!forced)
+	if(!no_message)
 		to_chat(user, "You [magpulse ? "enable" : "disable"] the [magpulse_name].")
 	user.update_inv_shoes()	//so our mob-overlays update
 	user.update_gravity(user.mob_has_gravity())

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -263,31 +263,30 @@
 	cell = null
 	update_icon()
 
-/obj/item/clothing/shoes/magboots/gravity/attackby__legacy__attackchain(obj/item/I, mob/user, params)
-	if(istype(I, /obj/item/stock_parts/cell))
+/obj/item/clothing/shoes/magboots/gravity/item_interaction(mob/living/user, obj/item/used, list/modifiers)
+	if(istype(used, /obj/item/stock_parts/cell))
 		if(cell)
 			to_chat(user, "<span class='warning'>[src] already has a cell!</span>")
 			return
-		if(!user.unEquip(I))
+		if(!user.unEquip(used))
 			return
-		I.forceMove(src)
-		cell = I
-		to_chat(user, "<span class='notice'>You install [I] into [src].</span>")
+		used.forceMove(src)
+		cell = used
+		to_chat(user, "<span class='notice'>You install [used] into [src].</span>")
 		update_icon()
-		return
+		return ITEM_INTERACT_SUCCESS
 
-	if(istype(I, /obj/item/assembly/signaler/anomaly/grav))
+	if(istype(used, /obj/item/assembly/signaler/anomaly/grav))
 		if(core)
-			to_chat(user, "<span class='notice'>[src] already has a [I]!</span>")
+			to_chat(user, "<span class='notice'>[src] already has a [used]!</span>")
 			return
 		if(!user.drop_item())
-			to_chat(user, "<span class='warning'>[I] is stuck to your hand!</span>")
+			to_chat(user, "<span class='warning'>[used] is stuck to your hand!</span>")
 			return
-		to_chat(user, "<span class='notice'>You insert [I] into [src], and [src] starts to warm up.</span>")
-		I.forceMove(src)
-		core = I
-	else
-		return ..()
+		used.forceMove(src)
+		core = used
+		to_chat(user, "<span class='notice'>You insert [used] into [src], and [src] starts to warm up.</span>")
+		return ITEM_INTERACT_SUCCESS
 
 /obj/item/clothing/shoes/magboots/gravity/equipped(mob/user, slot)
 	..()

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -40,7 +40,7 @@
 	. = ..()
 	toggle_magpulse(user)
 
-/obj/item/clothing/shoes/magboots/proc/toggle_magpulse(mob/user, no_message = FALSE)
+/obj/item/clothing/shoes/magboots/proc/toggle_magpulse(mob/user, no_message)
 	magpulse = !magpulse
 	if(magpulse) //magpulse and no_slip will always be the same value unless VV happens
 		attach_clothing_traits(active_traits)

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -38,9 +38,9 @@
 
 /obj/item/clothing/shoes/magboots/activate_self(mob/user)
 	. = ..()
-	toggle_magpulse(user, forced)
+	toggle_magpulse(user)
 
-/obj/item/clothing/shoes/magboots/proc/toggle_magpulse(mob/user, no_message)
+/obj/item/clothing/shoes/magboots/proc/toggle_magpulse(mob/user, no_message = FALSE)
 	magpulse = !magpulse
 	if(magpulse) //magpulse and no_slip will always be the same value unless VV happens
 		attach_clothing_traits(active_traits)

--- a/code/modules/clothing/shoes/misc_shoes.dm
+++ b/code/modules/clothing/shoes/misc_shoes.dm
@@ -23,8 +23,8 @@
 	name = "\improper SWAT shoes"
 	desc = "High speed, no drag combat boots."
 	permeability_coefficient = 0.01
+	clothing_traits = list(TRAIT_NOSLIP)
 	armor = list(MELEE = 35, BULLET = 20, LASER = 15, ENERGY = 15, BOMB = 50, RAD = 20, FIRE = 450, ACID = 50)
-	no_slip = TRUE
 
 /obj/item/clothing/shoes/sandal
 	name = "sandals"
@@ -53,7 +53,7 @@
 	desc = "A pair of yellow rubber boots, designed to prevent slipping on wet surfaces."
 	icon_state = "galoshes"
 	permeability_coefficient = 0.05
-	no_slip = TRUE
+	clothing_traits = list(TRAIT_NOSLIP)
 	slowdown = SHOES_SLOWDOWN+1
 	strip_delay = 50
 	put_on_delay = 50

--- a/code/modules/clothing/spacesuits/alien_suits.dm
+++ b/code/modules/clothing/spacesuits/alien_suits.dm
@@ -237,7 +237,6 @@
 	if(magpulse)
 		user.visible_message("[src] go limp as they are removed from [usr]'s feet.", "[src] go limp as they are removed from your feet.")
 		magpulse = FALSE
-		no_slip = FALSE
 		flags &= ~NODROP
 
 /obj/item/clothing/shoes/magboots/vox/examine(mob/user)

--- a/code/modules/clothing/spacesuits/alien_suits.dm
+++ b/code/modules/clothing/spacesuits/alien_suits.dm
@@ -214,7 +214,7 @@
 		"Vox" = 'icons/mob/clothing/species/vox/feet.dmi')
 	multiple_icons = FALSE
 
-/obj/item/clothing/shoes/magboots/vox/attack_self__legacy__attackchain(mob/user)
+/obj/item/clothing/shoes/magboots/vox/activate_self(mob/user)
 	if(magpulse)
 		flags &= ~NODROP
 		to_chat(user, "You relax your deathgrip on the flooring.")

--- a/code/modules/clothing/suits/armor_suits.dm
+++ b/code/modules/clothing/suits/armor_suits.dm
@@ -545,16 +545,7 @@
 /obj/item/clothing/suit/armor/reactive/cryo
 	name = "reactive gelidic armor" //is "gelidic" a word? probably not, but it sounds cool
 	desc = "This armor harnesses a cryogenic anomaly core to defend its user from the cold and attacks alike. Its unstable thermal regulation system occasionally vents gasses."
-
-/obj/item/clothing/suit/armor/reactive/cryo/equipped(mob/user, slot)
-	..()
-	if(slot != ITEM_SLOT_OUTER_SUIT)
-		return
-	ADD_TRAIT(user, TRAIT_RESISTCOLD, "[UID()]")
-
-/obj/item/clothing/suit/armor/reactive/cryo/dropped(mob/user, silent)
-	..()
-	REMOVE_TRAIT(user, TRAIT_RESISTCOLD, "[UID()]")
+	clothing_traits = list(TRAIT_RESISTCOLD)
 
 /obj/item/clothing/suit/armor/reactive/cryo/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	if(!active)

--- a/code/modules/clothing/suits/armor_suits.dm
+++ b/code/modules/clothing/suits/armor_suits.dm
@@ -527,16 +527,7 @@
 	desc = "This armor uses the power of a pyro anomaly core to shoot protective jets of fire, in addition to absorbing all damage from fire."
 	heat_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS | HEAD
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
-
-/obj/item/clothing/suit/armor/reactive/fire/equipped(mob/user, slot)
-	..()
-	if(slot != ITEM_SLOT_OUTER_SUIT)
-		return
-	ADD_TRAIT(user, TRAIT_RESISTHEAT, "[UID()]")
-
-/obj/item/clothing/suit/armor/reactive/fire/dropped(mob/user, silent)
-	..()
-	REMOVE_TRAIT(user, TRAIT_RESISTHEAT, "[UID()]")
+	clothing_traits = list(TRAIT_RESISTHEAT)
 
 /obj/item/clothing/suit/armor/reactive/fire/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	if(!active)

--- a/code/modules/clothing/suits/misc_suits.dm
+++ b/code/modules/clothing/suits/misc_suits.dm
@@ -693,15 +693,7 @@
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT|HIDETAIL
 	strip_delay = 60
 	breakouttime = 3000
-
-/obj/item/clothing/suit/straight_jacket/equipped(mob/living/carbon/human/user, slot)
-	. = ..()
-	if(slot == ITEM_SLOT_OUTER_SUIT)
-		ADD_TRAIT(user, TRAIT_RESTRAINED, "straight_jacket")
-
-/obj/item/clothing/suit/straight_jacket/dropped(mob/user, silent)
-	. = ..()
-	REMOVE_TRAIT(user, TRAIT_RESTRAINED, "straight_jacket")
+	clothing_traits = list(TRAIT_RESTRAINED)
 
 /obj/item/clothing/suit/ianshirt
 	name = "worn shirt"

--- a/code/modules/clothing/under/syndicate_jumpsuits.dm
+++ b/code/modules/clothing/under/syndicate_jumpsuits.dm
@@ -48,17 +48,16 @@
 	name = "tactical turtleneck"
 	desc = "A non-descript and slightly suspicious looking turtleneck with digital camouflage cargo pants. <b>This one has extra cybernetic modifications.</b>"
 	blockTracking = TRUE
+	clothing_traits = list(TRAIT_AI_UNTRACKABLE)
 
 /obj/item/clothing/under/syndicate/silicon_cham/equipped(mob/user, slot, initial)
 	. = ..()
 	if(slot == ITEM_SLOT_JUMPSUIT)
-		ADD_TRAIT(user, TRAIT_AI_UNTRACKABLE, "silicon_cham[UID()]")
 		user.set_invisible(SEE_INVISIBLE_LIVING)
 		to_chat(user, "<span class='notice'>You feel a slight shiver as the cybernetic obfuscators activate.</span>")
 
 /obj/item/clothing/under/syndicate/silicon_cham/dropped(mob/user)
 	. = ..()
 	if(user)
-		REMOVE_TRAIT(user, TRAIT_AI_UNTRACKABLE, "silicon_cham[UID()]")
 		user.set_invisible(INVISIBILITY_MINIMUM)
 		to_chat(user, "<span class='notice'>You feel a slight shiver as the cybernetic obfuscators deactivate.</span>")

--- a/code/modules/martial_arts/bearserk.dm
+++ b/code/modules/martial_arts/bearserk.dm
@@ -43,6 +43,7 @@
 	armor = list(MELEE = 30, BULLET = 20, LASER = 20, ENERGY = 20, BOMB = 20, RAD = 0, FIRE = INFINITY, ACID = 75)
 	resistance_flags = FIRE_PROOF
 	body_parts_covered = UPPER_TORSO|HEAD|ARMS
+	clothing_traits = list(TRAIT_RESISTHEAT)
 	var/datum/martial_art/bearserk/style
 
 /obj/item/clothing/head/bearpelt/bearserk/Initialize(mapload)
@@ -58,7 +59,6 @@
 		style.teach(H, TRUE)
 		H.faction |= "soviet"
 		H.physiology.stun_mod *= 0.80
-		ADD_TRAIT(H, TRAIT_RESISTHEAT, "bearserk")
 
 /obj/item/clothing/head/bearpelt/bearserk/dropped(mob/user, datum/reagent/R)
 	..()
@@ -69,7 +69,6 @@
 		style.remove(H)
 		H.faction -= "soviet"
 		H.physiology.stun_mod /= 0.80
-		REMOVE_TRAIT (H, TRAIT_RESISTHEAT, "bearserk")
 
 /obj/item/clothing/head/bearpelt/bearserk/examine(mob/user)
 	. = ..()

--- a/code/modules/ninja/suit/ninja_shoes.dm
+++ b/code/modules/ninja/suit/ninja_shoes.dm
@@ -4,7 +4,7 @@
 	desc = "A pair of running shoes. Excellent for running and even better for smashing skulls."
 	icon_state = "s-ninja"
 	permeability_coefficient = 0.01
-	no_slip = TRUE
+	clothing_traits = list(TRAIT_NOSLIP)
 	armor = list(MELEE = 75, BULLET = 50, LASER = 20, ENERGY = 10, BOMB = 20, RAD = 15, FIRE = INFINITY, ACID = INFINITY)
 	cold_protection = FEET
 	min_cold_protection_temperature = SHOES_MIN_TEMP_PROTECT


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Implements clothing traits from TG, allowing you to easily add traits that should be applied to a mob when equipped.
Removes the no_slip variable to depend on clothing_traits instead.
Moves some traits into clothing_traits (Deafness for earmuffs, fireproofing for reactive armour, etc.)
Also makes it so that the base ui_action_click() (Called when you use the toggle button for something, eg. toggling magboots) checks for legacy attack attack chain, and calls activate_self if the new attack is in use.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Cleaner solution to adding traits to mobs when equipping clothes, rather than implementing identical code in several places.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Noslips make you unable to slip. Taking off the noslips but keeping them in your hand does not give you slipping immunity.
Magboots only give noslip when toggled on, and slowdown is applied properly.
Meson goggles give meson vision when equipped, and meson vision is removed when the goggles are removed.
Being on fire while wearing reactive incendiary armour does no damage.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

NPFC

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
