### PR TITLE
Restores the Ability to Dye Bedsheets

### DIFF
--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -20,6 +20,7 @@ LINEN BINS
 	resistance_flags = FLAMMABLE
 	slot_flags = ITEM_SLOT_NECK
 	dog_fashion = /datum/dog_fashion/head/ghost
+	dyeable = TRUE
 	dyeing_key = DYE_REGISTRY_BEDSHEET
 
 	var/list/dream_messages = list("white")


### PR DESCRIPTION
## What Does This PR Do
Fixes not being able to dye bedsheets using the washing machine.

## Why It's Good For The Game
Oversight bad

## Images
![dreamseeker_GjFmEUNZCa](https://github.com/user-attachments/assets/fbc54b90-096f-4b18-a8ca-702d024ee053)

## Testing

Washed a bedsheet with a purple crayon in washing machine

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<hr>

## Changelog
:cl:
fix: Fixed the ability to dye bedsheets.
/:cl:
