### PR TITLE
Fixes managers runtiming on delete

### DIFF
--- a/code/modules/hallucinations/hallucination_manager.dm
+++ b/code/modules/hallucinations/hallucination_manager.dm
@@ -31,7 +31,6 @@
 /datum/hallucination_manager/Destroy(force, ...)
 	. = ..()
 	owner = null
-	deltimer(trigger_timer)
 	QDEL_NULL(hallucination_list)
 	QDEL_NULL(images)
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes a runtime when a `null` is trying to be deleted
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Runtimes bad
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
None. The timer has `TIMER_DELETE_ME` as a flag, which makes it automatically delete when the datum is deleted. This line is not needed
<!-- How did you test the PR, if at all? -->

<hr>

NPFC
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
