### PR TITLE
Fixes modsuit overlay issue

### DIFF
--- a/code/modules/mod/modules/_modules.dm
+++ b/code/modules/mod/modules/_modules.dm
@@ -305,9 +305,9 @@
 		return
 	var/image/final_overlay
 	if(sprite_sheets && sprite_sheets[user.dna.species.sprite_sheet_name])
-		final_overlay = image(icon = sprite_sheets[user.dna.species.sprite_sheet_name], icon_state = used_overlay, layer = EFFECTS_LAYER)
+		final_overlay = image(icon = sprite_sheets[user.dna.species.sprite_sheet_name], icon_state = used_overlay, layer = -HEAD_LAYER + 0.1)
 	else
-		final_overlay = image(icon = overlay_icon_file, icon_state = used_overlay, layer = EFFECTS_LAYER)
+		final_overlay = image(icon = overlay_icon_file, icon_state = used_overlay, layer = -HEAD_LAYER + 0.1)
 	if(mod_color_overide)
 		final_overlay.color = mod_color_overide
 	. += final_overlay


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Fixes #27250

Pegs modsuit modules to + 0.1 of the `HEAD_LAYER`. The `HEAD_LAYER` should be the highest layer any modsuit part uses which is why I chose it instead of the suit layer. This also means that modules will layer above cloaks which is a good thing.



## Why It's Good For The Game

Fixes a bug. In-hands now layer above modsuit modules.

This also means modules will no longer layer above HUDs (yes they were doing this before that is how stupidly high the effects layer is)

Modsuit module overlays should never have been on the `EFFECTS_LAYER`. Even the DM reference warns that `EFFECTS_LAYER` is mostly no longer needed.

## Testing

<!-- How did you test the PR, if at all? -->


Spawned in.

Checked modsuit module layering on suits (with the mirage module) and helmets (with the welding protection module)

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Modsuit modules now layer below in-hands.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
