### PR TITLE
Reduces the chance of hijack to roll per traitor from 10% to 5%

### DIFF
--- a/code/__DEFINES/antag_defines.dm
+++ b/code/__DEFINES/antag_defines.dm
@@ -104,7 +104,7 @@ GLOBAL_LIST(contractors)
 #define ORG_PROB_HUNTER 10
 #define ORG_PROB_MILD 20
 #define ORG_PROB_AVERAGE 60
-#define ORG_PROB_HIJACK 10
+#define ORG_PROB_HIJACK 5
 
 // Chance that a traitor will receive a 'You are being targeted by another syndicate agent' notification regardless of being an actual target
 #define ORG_PROB_PARANOIA 5

--- a/code/__DEFINES/antag_defines.dm
+++ b/code/__DEFINES/antag_defines.dm
@@ -103,7 +103,7 @@ GLOBAL_LIST(contractors)
 
 #define ORG_PROB_HUNTER 10
 #define ORG_PROB_MILD 20
-#define ORG_PROB_AVERAGE 60
+#define ORG_PROB_AVERAGE 65
 #define ORG_PROB_HIJACK 5
 
 // Chance that a traitor will receive a 'You are being targeted by another syndicate agent' notification regardless of being an actual target

--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -404,11 +404,11 @@ GLOBAL_LIST_EMPTY(antagonists)
 
 /**
  * Create and assign a full set of randomized, basic human traitor objectives.
- * can_hijack - If you want the 10% chance for the antagonist to be able to roll hijack, only true for traitors
+ * can_hijack - If you want the 5% chance for the antagonist to be able to roll hijack, only true for traitors
  */
 /datum/antagonist/proc/forge_basic_objectives(can_hijack = FALSE)
 	// Hijack objective.
-	if(can_hijack && prob(10) && !(locate(/datum/objective/hijack) in owner.get_all_objectives()))
+	if(can_hijack && prob(5) && !(locate(/datum/objective/hijack) in owner.get_all_objectives()))
 		add_antag_objective(/datum/objective/hijack)
 		return // Hijack should be their only objective (normally), so return.
 


### PR DESCRIPTION
## What Does This PR Do
This reduces the chance that the hijack objective will roll on a traitor by half, moving from 10% to 5%.
This PR also changes the average organization role percentage from 60% to 65% to match the change in reduction of one organization by 5%.

## Why It's Good For The Game
Overall, hijack is an objective that ends rounds early, prevents ERT from being sent in most cases, and is brutal when it comes to lower population shifts. Normally the first two would be fine, but the amount of times it happens becomes too chaotic, when you account for things like midround rolls, higher amounts of antag, and current security on board. This PR aims to level those issues out, while we plan the move over to dynamic. In that essence it is temporary.

On a personal note. I believe that hijack should be rare. This gives it a more meaningful impact when it does roll in the round. 

## Testing
It compiled, and testing something like this would almost be impossible.


<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

![Discord_sB0hgEBPf6](https://github.com/user-attachments/assets/8dbeef27-e14f-4da6-81d2-f644ed225689)
![Discord_e2q32KFQZP](https://github.com/user-attachments/assets/9199733c-b592-4162-b93a-efd0b6ac4c45)


<hr>

## Changelog

:cl:
tweak: Lowers chance for traitors to roll hijack from 10% to 5%
tweak: Raises the change for average organizations from 60% to 65%
/:cl:
