### PR TITLE
Move some per-tile tests to maplints.

### DIFF
--- a/code/modules/unit_tests/map_tests.dm
+++ b/code/modules/unit_tests/map_tests.dm
@@ -20,48 +20,6 @@
 	failure_count++
 
 /**
-  * Check atmos pipes are not routed under unary devices such as vents and
-  * scrubbers.
-  */
-/datum/map_per_tile_test/pipe_vent_checker
-	var/list/pipe_roots = list(
-		/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-		/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers
-	)
-	var/list/unary_roots = list(
-		/obj/machinery/atmospherics/unary
-	)
-
-/datum/map_per_tile_test/pipe_vent_checker/CheckTile(turf/T)
-	var/has_pipe = FALSE
-	var/has_unary = FALSE
-
-	for(var/pipe_root in pipe_roots)
-		if(locate(pipe_root) in T.contents)
-			has_pipe = TRUE
-
-	if(locate(/obj/machinery/atmospherics/unary) in T.contents)
-		has_unary = TRUE
-
-	if(has_pipe && has_unary)
-		Fail(T, "pipe on same tile as vent or scrubber")
-
-/**
-  * Check that only one cable node exists on a tile.
-  */
-/datum/map_per_tile_test/cable_node_checker
-
-/datum/map_per_tile_test/cable_node_checker/CheckTile(turf/T)
-	var/center_nodes = 0
-
-	for(var/obj/structure/cable/cable in T.contents)
-		if(cable.d1 == 0 || cable.d2 == 0)
-			center_nodes++
-
-	if(center_nodes > 1)
-		Fail(T, "tile has multiple center cable nodes")
-
-/**
   * Check to ensure that APCs have a cable node on their tile.
   */
 /datum/map_per_tile_test/apc_cable_node_checker
@@ -87,28 +45,6 @@
 	if(disposal)
 		if(!locate(/obj/structure/disposalpipe/trunk) in T.contents)
 			Fail(T, "tile has disposal unit/chute but no pipe trunk")
-
-/**
-  * Check for certain objects that should never be over space turfs.
-  */
-/datum/map_per_tile_test/invalid_objs_over_space_checker
-	var/list/invalid_types = list(
-		/obj/machinery/door/airlock
-	)
-
-/datum/map_per_tile_test/invalid_objs_over_space_checker/CheckTile(turf/T)
-	for(var/invalid_type in invalid_types)
-		if(isspaceturf(T) && locate(invalid_type) in T.contents)
-			Fail(T, "space turf contains at least one invalid object of type [invalid_type]")
-
-/**
-  * Check that structures in space are always in near-station space.
-  */
-/datum/map_per_tile_test/structures_in_farspace_checker
-
-/datum/map_per_tile_test/structures_in_farspace_checker/CheckTile(turf/T)
-	if((T.loc.type == /area/space || T.loc.type == /area/space/centcomm) && locate(/obj/structure) in T.contents)
-		Fail(T, "tile contains at least one structure found in non-near space area")
 
 /datum/map_per_tile_test/nearspace_checker
 	var/allowed_turfs = list(/turf/space,
@@ -144,16 +80,6 @@
 
 	Fail(origin_turf, "tile has an unconnected cable ([report_name] connection: [uppertext(dir2text(direction))]).")
 	return FALSE
-
-/datum/map_per_tile_test/duplicate_cable_check
-
-/datum/map_per_tile_test/duplicate_cable_check/CheckTile(turf/T)
-	var/obj/structure/cable/cable = locate() in T.contents
-	for(var/obj/structure/cable/other_cable in T.contents)
-		if(cable == other_cable)
-			continue // same object, continue
-		if(cable.d1 == other_cable.d1 && cable.d2 == other_cable.d2)
-			Fail(T, "tile has duplicated cables.")
 
 /datum/map_per_tile_test/missing_pipe_connection
 

--- a/code/modules/unit_tests/map_tests.dm
+++ b/code/modules/unit_tests/map_tests.dm
@@ -46,6 +46,21 @@
 		if(!locate(/obj/structure/disposalpipe/trunk) in T.contents)
 			Fail(T, "tile has disposal unit/chute but no pipe trunk")
 
+/**
+  * Check that only one cable node exists on a tile.
+  */
+/datum/map_per_tile_test/cable_node_checker
+
+/datum/map_per_tile_test/cable_node_checker/CheckTile(turf/T)
+	var/center_nodes = 0
+
+	for(var/obj/structure/cable/cable in T.contents)
+		if(cable.d1 == 0 || cable.d2 == 0)
+			center_nodes++
+
+	if(center_nodes > 1)
+		Fail(T, "tile has multiple center cable nodes")
+
 /datum/map_per_tile_test/nearspace_checker
 	var/allowed_turfs = list(/turf/space,
 		/turf/simulated/floor/plating/airless,

--- a/tools/maplint/lints/invalid_space_neighbors.yml
+++ b/tools/maplint/lints/invalid_space_neighbors.yml
@@ -1,0 +1,6 @@
+/area/space:
+  banned_neighbors:
+  - /obj/machinery/door/airlock
+=/area/space:
+  banned_neighbors:
+  - /obj/structure

--- a/tools/maplint/lints/invalid_space_neighbors.yml
+++ b/tools/maplint/lints/invalid_space_neighbors.yml
@@ -1,14 +1,6 @@
 /area/space:
   banned_neighbors:
   - /obj/machinery/door/airlock
-# TODO: See if the windows around holodeck scenes on z-1 are necessary
-# so we can apply this to all subtypes
 =/area/space:
-  banned_neighbors:
-  - /obj/structure
-=/area/space/nearstation:
-  banned_neighbors:
-  - /obj/structure
-=/area/space/no_teleport:
   banned_neighbors:
   - /obj/structure

--- a/tools/maplint/lints/invalid_space_neighbors.yml
+++ b/tools/maplint/lints/invalid_space_neighbors.yml
@@ -1,6 +1,14 @@
 /area/space:
   banned_neighbors:
   - /obj/machinery/door/airlock
+# TODO: See if the windows around holodeck scenes on z-1 are necessary
+# so we can apply this to all subtypes
 =/area/space:
+  banned_neighbors:
+  - /obj/structure
+=/area/space/nearstation:
+  banned_neighbors:
+  - /obj/structure
+=/area/space/no_teleport:
   banned_neighbors:
   - /obj/structure

--- a/tools/maplint/lints/unary_vents.yml
+++ b/tools/maplint/lints/unary_vents.yml
@@ -1,0 +1,5 @@
+/obj/machinery/atmospherics/unary:
+  banned_neighbors:
+  - /obj/machinery/atmospherics/pipe/manifold/hidden/supply
+  - /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers
+


### PR DESCRIPTION
## What Does This PR Do
This PR moves some per-tile tests into maplints. Per-tile tests are almost certainly slower on measure, and I prefer the way @Contrabang is using them, for verifying tile state after map load. Maplints should be used for map pre-load checks; anything that doesn't need atoms being initialized.

Some details:
- there were two checks involving checking for duplicate cables on tiles, one just for nodes and one that compared each cable's d1 and d2. These are both already handled by `stacked_matching_cables.yml`.
- that there was a check for structures on centcomm areas that never ran because centcomm was never passed as a z-level, and it fails because the windows surrounding the holodeck scenes are on space areas, and I'm not touching that part of the map.
## Why It's Good For The Game
Almost certainly faster, even if only in CI compilation. Less code.
## Testing
Ran em

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog
NPFC
