### PR TITLE
Fix wallets not ingesting cards on click.

### DIFF
--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -286,6 +286,10 @@
 		attach_guest_pass(used, user)
 		return ITEM_INTERACT_SUCCESS
 
+	else if(istype(used, /obj/item/storage/wallet))
+		used.attackby__legacy__attackchain(src, user)
+		return ITEM_INTERACT_SUCCESS
+
 /obj/item/card/id/AltClick(mob/user)
 	if(user.stat || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED) || !Adjacent(user))
 		return


### PR DESCRIPTION
## What Does This PR Do
This PR fixes a regression where clicking on an ID card with a wallet would not put the card in the wallet.
## Why It's Good For The Game
Bugfix.
## Testing

https://github.com/user-attachments/assets/490f5eca-b32b-405e-8618-0747f063d742


<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Wallets now correctly insert ID cards by using the wallet on the card.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
