### PR TITLE
Emerald Station solars are now built by default [NOT WIRED] and properly labled 

### DIFF
--- a/_maps/map_files/stations/emeraldstation.dmm
+++ b/_maps/map_files/stations/emeraldstation.dmm
@@ -7298,7 +7298,7 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/item/solar_assembly,
+/obj/machinery/power/tracker,
 /turf/space,
 /area/station/engineering/solar/fore_port)
 "bwP" = (
@@ -19137,6 +19137,7 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
+/obj/item/solar_assembly,
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "solarpanel"
 	},
@@ -19822,40 +19823,6 @@
 	},
 /area/station/medical/break_room)
 "dXx" = (
-/obj/structure/closet/crate,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/tracker_electronics,
-/obj/item/stack/cable_coil{
-	pixel_x = 3;
-	pixel_y = -4
-	},
-/obj/item/stack/sheet/glass{
-	amount = 50;
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/stack/sheet/glass{
-	amount = 50
-	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/fore_port)
 "dXC" = (
@@ -43905,32 +43872,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/starboard)
-"iHX" = (
-/obj/structure/closet/crate,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/circuitboard/solar_control,
-/turf/simulated/floor/plating,
-/area/station/maintenance/solar_maintenance/fore_port)
 "iHY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/structure/table,
@@ -53187,42 +53128,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/aft_port)
-"kyY" = (
-/obj/structure/closet/crate,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/stack/sheet/glass{
-	amount = 50
-	},
-/obj/item/stack/sheet/glass{
-	amount = 50;
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/stack/cable_coil{
-	pixel_x = 3;
-	pixel_y = -4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/solar_maintenance/fore_port)
 "kzl" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
@@ -61595,6 +61500,7 @@
 /area/station/maintenance/aft2)
 "mlB" = (
 /obj/structure/cable,
+/obj/item/solar_assembly,
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "solarpanel"
 	},
@@ -72262,6 +72168,7 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
+/obj/item/solar_assembly,
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "solarpanel"
 	},
@@ -76196,6 +76103,7 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/item/solar_assembly,
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "solarpanel"
 	},
@@ -103285,16 +103193,6 @@
 	},
 /area/station/service/theatre)
 "usw" = (
-/obj/structure/table,
-/obj/item/stack/cable_coil{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil{
-	pixel_x = 3;
-	pixel_y = -4
-	},
 /obj/effect/spawner/random/cobweb/right/rare,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/fore_port)
@@ -147427,7 +147325,7 @@ dGi
 uTg
 uVV
 fXb
-kyY
+dXx
 oJh
 vWJ
 muu
@@ -147684,7 +147582,7 @@ dGi
 usw
 pOM
 pTR
-iHX
+dXx
 dGi
 lfn
 mQF

--- a/_maps/map_files/stations/emeraldstation.dmm
+++ b/_maps/map_files/stations/emeraldstation.dmm
@@ -53126,13 +53126,13 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
 "kyS" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Aft Starboard Solar Access"
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/machinery/door/airlock/engineering{
+	name = "Aft Port Solar Access"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/aft_port)
 "kzl" = (

--- a/_maps/map_files/stations/emeraldstation.dmm
+++ b/_maps/map_files/stations/emeraldstation.dmm
@@ -80425,14 +80425,6 @@
 	icon_state = "white"
 	},
 /area/station/maintenance/starboard)
-"pTv" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plasteel/airless{
-	icon_state = "solarpanel"
-	},
-/area/station/engineering/solar/fore_port)
 "pTE" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -145264,7 +145256,7 @@ jnP
 jnP
 wXf
 jnP
-pTv
+pay
 jSB
 jSB
 bsP

--- a/_maps/map_files/stations/emeraldstation.dmm
+++ b/_maps/map_files/stations/emeraldstation.dmm
@@ -13542,6 +13542,20 @@
 "cHG" = (
 /turf/simulated/wall,
 /area/station/medical/patients_rooms_secondary)
+"cHH" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/solar{
+	name = "Fore-Port Solar Array"
+	},
+/obj/machinery/power/solar{
+	name = "Fore-Port Solar Array"
+	},
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "solarpanel"
+	},
+/area/station/engineering/solar/fore_port)
 "cHI" = (
 /obj/effect/spawner/random/maintenance,
 /obj/effect/decal/cleanable/dirt,
@@ -19137,7 +19151,9 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/item/solar_assembly,
+/obj/machinery/power/solar{
+	name = "Fore-Port Solar Array"
+	},
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "solarpanel"
 	},
@@ -31354,11 +31370,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/security/fore)
 "gjA" = (
-/obj/machinery/power/solar{
-	name = "Starboard Solar Array"
-	},
 /obj/structure/cable{
 	icon_state = "0-8"
+	},
+/obj/machinery/power/solar{
+	name = "Aft-Starboard Solar Array"
 	},
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "solarpanel"
@@ -31385,7 +31401,7 @@
 /area/station/service/hydroponics)
 "gkj" = (
 /obj/machinery/power/solar{
-	name = "Starboard Solar Array"
+	name = "Fore-Starboard Solar Array"
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -35249,15 +35265,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry)
-"gYN" = (
-/obj/item/solar_assembly,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plasteel/airless{
-	icon_state = "solarpanel"
-	},
-/area/station/engineering/solar/fore_port)
 "gYO" = (
 /obj/structure/chair{
 	dir = 4
@@ -39394,10 +39401,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint2)
 "hMY" = (
-/obj/machinery/power/solar{
-	name = "Starboard Solar Array"
-	},
 /obj/structure/cable,
+/obj/machinery/power/solar{
+	name = "Aft-Starboard Solar Array"
+	},
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "solarpanel"
 	},
@@ -43092,11 +43099,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft2)
 "iAv" = (
-/obj/machinery/power/solar{
-	name = "Starboard Solar Array"
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
+	},
+/obj/machinery/power/solar{
+	name = "Aft-Starboard Solar Array"
 	},
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "solarpanel"
@@ -61500,7 +61507,9 @@
 /area/station/maintenance/aft2)
 "mlB" = (
 /obj/structure/cable,
-/obj/item/solar_assembly,
+/obj/machinery/power/solar{
+	name = "Fore-Port Solar Array"
+	},
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "solarpanel"
 	},
@@ -62685,11 +62694,11 @@
 	},
 /area/station/hallway/primary/starboard/south)
 "mxT" = (
-/obj/machinery/power/solar{
-	name = "Starboard Solar Array"
-	},
 /obj/structure/cable{
 	icon_state = "0-8"
+	},
+/obj/machinery/power/solar{
+	name = "Aft-Port Solar Array"
 	},
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "solarpanel"
@@ -69134,11 +69143,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint2)
 "nLU" = (
-/obj/machinery/power/solar{
-	name = "Starboard Solar Array"
-	},
 /obj/structure/cable{
 	icon_state = "0-4"
+	},
+/obj/machinery/power/solar{
+	name = "Aft-Starboard Solar Array"
 	},
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "solarpanel"
@@ -72168,7 +72177,9 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/item/solar_assembly,
+/obj/machinery/power/solar{
+	name = "Fore-Port Solar Array"
+	},
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "solarpanel"
 	},
@@ -76103,7 +76114,9 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/item/solar_assembly,
+/obj/machinery/power/solar{
+	name = "Fore-Port Solar Array"
+	},
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "solarpanel"
 	},
@@ -80412,6 +80425,14 @@
 	icon_state = "white"
 	},
 /area/station/maintenance/starboard)
+"pTv" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "solarpanel"
+	},
+/area/station/engineering/solar/fore_port)
 "pTE" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -86468,11 +86489,11 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/security/aft_starboard)
 "rfz" = (
-/obj/machinery/power/solar{
-	name = "Starboard Solar Array"
-	},
 /obj/structure/cable{
 	icon_state = "0-4"
+	},
+/obj/machinery/power/solar{
+	name = "Aft-Port Solar Array"
 	},
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "solarpanel"
@@ -106752,7 +106773,7 @@
 /area/station/engineering/atmos)
 "vcm" = (
 /obj/machinery/power/solar{
-	name = "Starboard Solar Array"
+	name = "Fore-Starboard Solar Array"
 	},
 /obj/structure/cable,
 /turf/simulated/floor/plasteel/airless{
@@ -115920,15 +115941,6 @@
 	icon_state = "white"
 	},
 /area/station/science/research)
-"wUg" = (
-/obj/item/solar_assembly,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plasteel/airless{
-	icon_state = "solarpanel"
-	},
-/area/station/engineering/solar/fore_port)
 "wUh" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -120286,15 +120298,6 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/processing)
-"xOh" = (
-/obj/item/solar_assembly,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plasteel/airless{
-	icon_state = "solarpanel"
-	},
-/area/station/engineering/solar/fore_port)
 "xOk" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -142186,7 +142189,7 @@ jnP
 aZS
 jnP
 aZS
-gYN
+dOB
 aZS
 jnP
 wXf
@@ -144233,7 +144236,7 @@ jnP
 jnP
 wXf
 jnP
-wUg
+pay
 jSB
 jSB
 raE
@@ -144500,7 +144503,7 @@ oCR
 onQ
 onQ
 onQ
-xOh
+onQ
 onQ
 aZS
 aZS
@@ -145261,7 +145264,7 @@ jnP
 jnP
 wXf
 jnP
-pay
+pTv
 jSB
 jSB
 bsP
@@ -145520,12 +145523,12 @@ wXf
 aZS
 aZS
 onQ
-xOh
+onQ
 onQ
 onQ
 onQ
 knb
-onQ
+cHH
 onQ
 onQ
 onQ


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes Emerald Stations solars be built by default, to where you would only need to wire them.

Labels all solar array's correctly

Fixed mislabled door in Aft-Port Solars
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
This stations solars almost never get set-up due to the time it takes to do it, and makes it next to impossible to quickly setup in an emergency. Solars should be easy power and them taking upwards of an hour to setup is not needed

## Images of changes
![Screenshot 2024-12-16 164655](https://github.com/user-attachments/assets/dad4839c-bbcb-40c6-b857-9304f1072fe8)
![Screenshot 2024-12-16 164644](https://github.com/user-attachments/assets/cf1797ff-a642-4d17-add1-2032ec860e67)
![Screenshot 2024-12-16 164614](https://github.com/user-attachments/assets/82d9c639-b570-4831-9e14-324000285dc2)
![Screenshot 2024-12-16 164555](https://github.com/user-attachments/assets/b58dec7e-beed-4298-b635-53b2f4801854)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing

<!-- How did you test the PR, if at all? -->
loaded server and wired solars, worked as expected and all solars are properly labled
<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>
![Screenshot 2024-12-16 151743](https://github.com/user-attachments/assets/5d6bdf88-888b-45d7-be42-331d3d7b6578)

## Changelog

:cl:
add: Emerald Station solars are now built by default, only needing to be wired
del: Removed solar crates from Emerald Station
fix: Fixed a mislabeled door on Emerald Station
fix: All solar arrays are now properly labeled on Emerald Station 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
