### PR TITLE
Removes Slowdown from ERT Hardsuits

### DIFF
--- a/code/modules/clothing/spacesuits/ert_hardsuits.dm
+++ b/code/modules/clothing/spacesuits/ert_hardsuits.dm
@@ -56,6 +56,7 @@
 	desc = "A powered combat hardsuit produced by Citadel Armories. Decently armored, environmentally sealed, and fire-resistant."
 	icon_state = "ert_commander"
 	item_state = "suit-command"
+	slowdown = 0
 	w_class = WEIGHT_CLASS_NORMAL
 	armor = list(MELEE = 40, BULLET = 15, LASER = 20, ENERGY = 5, BOMB = 15, RAD = 50, FIRE = 200, ACID = 200)
 	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/t_scanner, /obj/item/rcd, /obj/item/crowbar, \


### PR DESCRIPTION
## What Does This PR Do
This removes the slowdown from ERT hardsuits, bringing them in line with the other ERT levels which do not experience any slowdown. 

## Why It's Good For The Game
ERT is often called to a station in times of need, having the slowdown compared to the other groups is counterproductive of that. 
Currently even the security modsuits have more bullet and bomb protection and less slowdown than the ERT hardsuits.

## Testing
Spawned in an RT Red suit and tested the speed.


<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
![Discord_voQ3aUnkxa](https://github.com/user-attachments/assets/c13a3a46-e539-4c5c-8fc6-5849a37be035)

<hr>

## Changelog
:cl:
tweak: Removed slowdown for ERT hardsuit
/:cl: