### PR TITLE
Fixes duplicate vanilla cake by renaming it to its real type

### DIFF
--- a/code/modules/food_and_drinks/food/foods/baked_goods.dm
+++ b/code/modules/food_and_drinks/food/foods/baked_goods.dm
@@ -76,7 +76,7 @@
 	goal_difficulty = FOOD_GOAL_EASY
 
 /obj/item/food/sliceable/plaincake
-	name = "vanilla cake"
+	name = "plain cake"
 	desc = "A plain cake, not a lie."
 	icon = 'icons/obj/food/bakedgoods.dmi'
 	icon_state = "plaincake"

--- a/code/modules/food_and_drinks/food/foods/baked_goods.dm
+++ b/code/modules/food_and_drinks/food/foods/baked_goods.dm
@@ -89,7 +89,7 @@
 	goal_difficulty = FOOD_GOAL_DUPLICATE
 
 /obj/item/food/plaincakeslice
-	name = "vanilla cake slice"
+	name = "plain cake slice"
 	desc = "Just a slice of cake, it is enough for everyone."
 	icon = 'icons/obj/food/bakedgoods.dmi'
 	icon_state = "plaincake_slice"


### PR DESCRIPTION
## What Does This PR Do

`/obj/item/food/sliceable/plaincake` is currently called `vanilla cake`
`/obj/item/food/sliceable/vanilla_cake` is also called `vanilla cake`

This PR renames `/obj/item/food/sliceable/plaincake` to `plain cake`

I'm handling the wiki edit as well

## Why It's Good For The Game

People don't get confused about the recipe, pound cake needs plain cakes, not vanilla cakes

## Images of changes

none, it is a name change

## Testing

1. Spawned in, spawned a `/obj/item/food/sliceable/plaincake`
2. Spawned a knife
3. Sliced it

![image](https://github.com/user-attachments/assets/154425cb-5727-47c1-b668-337362459501)

![image](https://github.com/user-attachments/assets/902971b7-b1c4-4c75-bc1e-9116e60b09eb)

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Plain cakes are now called plain cakes instead of vanilla cakes (as we also have vanilla cakes, this removes a duplication).
/:cl:
