### PR TITLE
Do not break pulls on zlevel transitions during forceMoves.

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -457,7 +457,7 @@
 	SET_ACTIVE_MOVEMENT(oldloc, NONE, TRUE, null)
 
 	if(destination)
-		if(pulledby)
+		if(pulledby && !HAS_TRAIT(src, TRAIT_CURRENTLY_Z_MOVING))
 			pulledby.stop_pulling()
 
 		var/same_loc = oldloc == destination


### PR DESCRIPTION
## What Does This PR Do
This PR checks the `TRAIT_CURRENTLY_Z_MOVING` for pulled objects being forcemoved, ensuring that pulls aren't broken in those cases. Fixes #27700.

## Why It's Good For The Game
Bugfix.
## Testing
Drifted across zlevel while pulling locker, used jetpack to pull locker across zlevel.
<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Mobs should no longer let go of objects while attempting to pull them across space levels.
/:cl: