### PR TITLE
Tweaks cult harvester  attack sound

### DIFF
--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -305,9 +305,9 @@
 	health = 40
 	melee_damage_lower = 20
 	melee_damage_upper = 25
-	attacktext = "prods"
+	attacktext = "rends"
 	environment_smash = ENVIRONMENT_SMASH_RWALLS
-	attack_sound = 'sound/weapons/tap.ogg'
+	attack_sound = 'sound/weapons/bladeslice.ogg'
 	construct_type = "harvester"
 	construct_spells = list(/datum/spell/night_vision,
 							/datum/spell/aoe/conjure/build/wall,


### PR DESCRIPTION
## What Does This PR Do

Changes the Harvester hit sound from Prod to bladeslice (similar to the wraith).
Changes the harvester attack text to "Rends"

## Why It's Good For The Game

The sound seems so wimpy, considering they do more damage that a lot of other things on station, and nearly as much as a wraith. They frequently are very successful killers and with the current sound it feels like you're just poking someone. Having some proper feedback you're actually doing damage is good for gamefeel

## Testing

Rended a buncha skrells

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
tweak: Tweaked harvester hit sound and text
/:cl:

