### PR TITLE
fixes some ipc mindflayer shenanigan

### DIFF
--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -678,6 +678,10 @@
 	COOLDOWN_DECLARE(reviver_cooldown)
 	/// How long till we can try to defib again
 	COOLDOWN_DECLARE(defib_cooldown)
+	/// This check is an aditional minute delay applied to nuggeted IPCS, so they are not endlessly instantly reviving.
+	COOLDOWN_DECLARE(nugget_contingency)
+	/// The trigger when nuggeted is detected. Resets when revived. Prevents the cooldown from being applied again.
+	var/applied_nugget_cooldown = FALSE
 
 /obj/item/organ/internal/cyberimp/chest/reviver/hardened
 	name = "Hardened reviver implant"
@@ -699,12 +703,18 @@
 			COOLDOWN_START(src, reviver_cooldown, revive_cost)
 			reviving = FALSE
 			to_chat(owner, "<span class='notice'>Your reviver implant shuts down and starts recharging. It will be ready again in [DisplayTimeText(revive_cost)].</span>")
+			applied_nugget_cooldown = FALSE
 		else
 			addtimer(CALLBACK(src, PROC_REF(heal)), 3 SECONDS)
 		return
-	if(!COOLDOWN_FINISHED(src, reviver_cooldown) || owner.suiciding) // don't heal while you're in cooldown!
+	if(!COOLDOWN_FINISHED(src, reviver_cooldown) || owner.suiciding || !COOLDOWN_FINISHED(src, nugget_contingency)) // don't heal while you're in cooldown!
 		return
 	if(owner.health <= 0 || owner.stat == DEAD)
+		if(ismachineperson(owner))
+			if(!applied_nugget_cooldown && length(owner.bodyparts) <= 2)
+				COOLDOWN_START(src, nugget_contingency, 1 MINUTES)
+				applied_nugget_cooldown = TRUE
+				return
 		revive_cost = 0
 		reviving = TRUE
 		has_defibed = FALSE


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
nuggeted ipcs have their implant go on cooldown for a minute before healing begins so they can be dealt with by traitors or sec.
Especially if they are a ventcrawling ipc.
Normal ipcs / humans impacted.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
see above
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
confirmed ipcs healed fine normally.
Confirmed minute cooldown before healing for nuggeted ipcs.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
tweak: Nuggeted IPCS no longer instantly start reviving from reviver, which has been very problematic on mindflayers. There is now a minute cooldown before healing begins specifically for nuggeted ones. Normal ipcs are not impacted.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
