### PR TITLE
Respect return values of legacy attack in chain negotiation

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -130,7 +130,7 @@
 
 	. = __attack_core(target, user)
 
-	if(!target.new_attack_chain)
+	if(!target.new_attack_chain && .)
 		return target.attacked_by__legacy__attackchain(src, user, /* def_zone */ null)
 
 /obj/item/proc/__after_attack_core(mob/user, atom/target, params, proximity_flag = 1)

--- a/code/tests/attack_chain/test_attack_chain_cult_dagger.dm
+++ b/code/tests/attack_chain/test_attack_chain_cult_dagger.dm
@@ -15,3 +15,10 @@
 
 	cultist.click_on(target)
 	TEST_ASSERT_EQUAL(target.puppet.health, target.puppet.getMaxHealth(), "cultist attacking cultist with dagger caused damage")
+
+	// Test some new -> old attack chain shenanigans
+	target.puppet.mind.remove_antag_datum(/datum/antagonist/cultist)
+
+	ADD_TRAIT(cultist.puppet, TRAIT_PACIFISM, "test")
+	cultist.click_on(target)
+	TEST_ASSERT_EQUAL(target.puppet.health, target.puppet.getMaxHealth(), "non-cultist attacked by pacifist")


### PR DESCRIPTION
## What Does This PR Do
This PR fixes the attack chain so that legacy return values from attack are taken into account for legacy attacked_by calls.
## Why It's Good For The Game
Unblocks issues with https://github.com/ParadiseSS13/Paradise/pull/27563.

## Testing
Made accompanying change to unit test, ensured test failed, made implementation change, ensured test passed.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog
NPFC