### PR TITLE
Add ability to check chatlog for test assertions.

### DIFF
--- a/code/controllers/subsystem/SSchat.dm
+++ b/code/controllers/subsystem/SSchat.dm
@@ -71,6 +71,11 @@ SUBSYSTEM_DEF(chat)
 /datum/controller/subsystem/chat/proc/send_immediate(send_target, list/message_data)
 	var/list/targets = islist(send_target) ? send_target : list(send_target)
 	for(var/target in targets)
+#ifdef GAME_TESTS
+		var/mob/M = target
+		if(istype(M) && M?:mind?:key == "interaction_test_[M.UID()]")
+			LAZYADD(GLOB.game_test_chats[M.mind.key], message_to_html(message_data))
+#endif
 		var/client/client = CLIENT_FROM_VAR(target)
 		if(isnull(client))
 			continue

--- a/code/tests/_game_test.dm
+++ b/code/tests/_game_test.dm
@@ -1,3 +1,5 @@
+GLOBAL_LIST_EMPTY(game_test_chats)
+
 /// For advanced cases, fail unconditionally but don't return (so a test can return multiple results)
 #define TEST_FAIL(reason) (Fail(reason || "No reason", __FILE__, __LINE__))
 

--- a/code/tests/_game_test_puppeteer.dm
+++ b/code/tests/_game_test_puppeteer.dm
@@ -66,3 +66,10 @@
 
 /datum/test_puppeteer/proc/rejuvenate()
 	puppet.rejuvenate()
+
+/datum/test_puppeteer/proc/last_chatlog_has_text(snippet)
+	if(!(puppet.mind.key in GLOB.game_test_chats))
+		return FALSE
+	var/list/puppet_chat_list = GLOB.game_test_chats[puppet.mind.key]
+	var/last_chat_html = puppet_chat_list[length(puppet_chat_list)]
+	return findtextEx(last_chat_html, snippet)

--- a/code/tests/attack_chain/test_attack_chain_vehicles.dm
+++ b/code/tests/attack_chain/test_attack_chain_vehicles.dm
@@ -6,10 +6,9 @@
 	player.click_on(janicart)
 	TEST_ASSERT_EQUAL(janicart.inserted_key, janicart_key, "did not find janicart key in vehicle")
 
-	var/move_delay = janicart.vehicle_move_delay
 	player.spawn_obj_in_hand(/obj/item/borg/upgrade/vtec)
 	player.click_on(janicart)
-	TEST_ASSERT(janicart.vehicle_move_delay < move_delay, "VTEC upgrade not applied properly")
+	TEST_ASSERT(player.last_chatlog_has_text("You upgrade the janicart"), "VTEC upgrade not applied properly")
 
 	TEST_ASSERT_NULL(janicart.mybag, "unexpected trash bag on janicart")
 	var/obj/item/storage/bag/trash/bag = player.spawn_obj_in_hand(/obj/item/storage/bag/trash)


### PR DESCRIPTION
## What Does This PR Do
This PR adds a small shim to SSchat to redirect chatlog messages sent in tests to a list in order to query that list for test assertions.
## Why It's Good For The Game
Improves fidelity for puppeteer testing by being able to actually check the contents of the chatlog to see the outcome of events, rather than inspecting the internal state of objects, since puppeteer tests are meant to be a player-imitating abstraction.
## Testing
See modification of existing test as an example usage.
<hr>
### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog
NPFC