### PR TITLE
Fixes missing window grilles and singular missing cold rock at the Farragus vox box

### DIFF
--- a/_maps/map_files/stations/cerestation.dmm
+++ b/_maps/map_files/stations/cerestation.dmm
@@ -35253,7 +35253,7 @@
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/station/maintenance/fpmaint)
 "gbz" = (
-/obj/effect/spawner/window/reinforced,
+/obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/maintenance/abandonedbar)
 "gbC" = (
@@ -85789,9 +85789,6 @@
 	},
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/station/maintenance/storage)
-"tba" = (
-/turf/simulated/mineral/ancient/outer,
-/area/station/maintenance/abandonedbar)
 "tbe" = (
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
@@ -115525,12 +115522,12 @@ hUU
 hUU
 aXn
 stw
-tba
+qUT
 gbz
 gbz
 gbz
 gbz
-tba
+qUT
 stw
 sMZ
 qIF
@@ -115778,7 +115775,7 @@ rNK
 rNK
 bhO
 hUU
-aXn
+hUU
 aXn
 aXn
 stw


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Replaces the reinforced window spawners at the Farragus vox box with grilled reinforced window spawners, as space-facing windows are supposed to be grilled.

Replaces the rock on either side of the windows with metal walls so that the windows actually tile-blend with the window frame.

Replaces a single asteroid rock with cold asteroid rock.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Space-facing windows are supposed to be grilled.

The windows look bad when they don't tile-blend into the walls adjacent to them.

Asteroid rock diagonally adjacent to space is cold everywhere else on Farragus, this should be consistent.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://github.com/user-attachments/assets/69489f78-fa02-473e-9df9-3cbdb7aa73b3)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Went to the area, windows were grilled and flanked by metal walls. The one bit of asteroid rock was now cold.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Fixes missing window grilles at the farragus vox box.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
