### PR TITLE
fix magic touch spells false deleting, fix spelling, allow escape

### DIFF
--- a/code/datums/spells/alien_spells/build_resin_structure.dm
+++ b/code/datums/spells/alien_spells/build_resin_structure.dm
@@ -85,6 +85,7 @@
 		to_chat(C, "<span class='alertalien'>You viciously rip apart and consume [target]!</span>")
 		C.add_plasma(-10)
 		qdel(target)
+	handle_delete(user)
 
 #undef RESIN_WALL
 #undef RESIN_NEST

--- a/code/datums/spells/alien_spells/corrosive_acid_spit.dm
+++ b/code/datums/spells/alien_spells/corrosive_acid_spit.dm
@@ -31,6 +31,7 @@
 		C.add_plasma(-200)
 	else
 		to_chat(C, "<span class='noticealien'>You cannot dissolve this object.</span>")
+	handle_delete(user)
 
 /datum/spell/touch/alien_spell/burning_touch
 	name = "Blazing touch"
@@ -72,3 +73,4 @@
 			C.visible_message("<span class='alertalien'>[C] touches [target] and burns right through it!</span>")
 			C.add_plasma(-100)
 			qdel(target)
+	handle_delete(user)

--- a/code/datums/spells/banana_touch.dm
+++ b/code/datums/spells/banana_touch.dm
@@ -18,20 +18,19 @@
 	on_use_sound = 'sound/items/AirHorn.ogg'
 	icon_state = "banana_touch"
 	item_state = "banana_touch"
+	var/is_apprentice_spell = FALSE
 
 /datum/spell/touch/banana/apprentice
 	hand_path = /obj/item/melee/touch_attack/banana/apprentice
 
 /obj/item/melee/touch_attack/banana/apprentice
-
-/obj/item/melee/touch_attack/banana/apprentice/after_attack(atom/target, mob/user, proximity_flag, click_parameters)
-	. = ..()
-	if(iswizard(target) && target != user)
-		to_chat(user, "<span class='danger'>Seriously?! Honk THEM, not me!</span>")
-		return
+	is_apprentice_spell = TRUE
 
 /obj/item/melee/touch_attack/banana/after_attack(atom/target, mob/user, proximity_flag, click_parameters)
 	. = ..()
+	if(is_apprentice_spell && iswizard(target) && target != user)
+		to_chat(user, "<span class='danger'>Seriously?! Honk THEM, not me!</span>")
+		return
 	if(!proximity_flag || target == user || !ishuman(target) || !iscarbon(user) || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
 		return
 
@@ -42,6 +41,7 @@
 	to_chat(user, "<font color='red' size='6'>HONK</font>")
 	var/mob/living/carbon/human/H = target
 	H.bananatouched()
+	handle_delete(user)
 
 /mob/living/carbon/human/proc/bananatouched()
 	to_chat(src, "<font color='red' size='6'>HONK</font>")

--- a/code/datums/spells/mime_malaise.dm
+++ b/code/datums/spells/mime_malaise.dm
@@ -30,6 +30,7 @@
 
 	var/mob/living/carbon/human/H = target
 	H.mimetouched()
+	handle_delete(user)
 
 /mob/living/carbon/human/proc/mimetouched()
 	Weaken(14 SECONDS)

--- a/code/datums/spells/sentient_sword_lunge.dm
+++ b/code/datums/spells/sentient_sword_lunge.dm
@@ -24,6 +24,6 @@
 			to_chat(user, "<span class='warning'>You fail to break out of [user_sword.loc]!</span>")
 			return
 		var/turf/our_turf = get_turf(user_sword.loc)
-		our_turf.visible_message("<span class='danger'>[user_sword] magically teleports out of [user_sword.loc]!</span>")
+		our_turf.visible_message("<span class='danger'>[user_sword] leaps out of [user_sword.loc]!</span>")
 		user_sword.forceMove(our_turf)
 	user_sword.throw_at(targets[1], 10, 3, user)

--- a/code/datums/spells/sentient_sword_lunge.dm
+++ b/code/datums/spells/sentient_sword_lunge.dm
@@ -16,7 +16,14 @@
 		to_chat(user, "<span class='warning'>You cannot use this ability if you're outside a blade!</span>")
 		return
 	var/obj/item/nullrod/scythe/talking/user_sword = user.loc
-	var/mob/living/carbon/holder = user_sword.loc
-	if(istype(holder))
+	if(ishuman(user_sword.loc))
+		var/mob/living/carbon/holder = user_sword.loc
 		holder.unEquip(user_sword)
+	else if(isstorage(user_sword.loc))
+		if(prob(50))
+			to_chat(user, "<span class='warning'>You fail to break out of [user_sword.loc]!</span>")
+			return
+		var/turf/our_turf = get_turf(user_sword.loc)
+		our_turf.visible_message("<span class='danger'>[user_sword] magically teleports out of [user_sword.loc]!</span>")
+		user_sword.forceMove(our_turf)
 	user_sword.throw_at(targets[1], 10, 3, user)

--- a/code/game/gamemodes/wizard/godhand.dm
+++ b/code/game/gamemodes/wizard/godhand.dm
@@ -37,8 +37,7 @@
 		to_chat(user, "<span class='warning'>You can't reach out!</span>")
 		return FINISH_ATTACK
 
-/obj/item/melee/touch_attack/after_attack(atom/target, mob/user, proximity_flag, click_parameters)
-	. = ..()
+/obj/item/melee/touch_attack/proc/handle_delete(mob/user)
 	if(catchphrase)
 		user.say(catchphrase)
 	playsound(get_turf(user), on_use_sound, 50, 1)
@@ -61,6 +60,7 @@
 	var/mob/M = target
 	do_sparks(4, 0, M.loc) //no idea what the 0 is
 	M.gib()
+	handle_delete(user)
 
 /obj/item/melee/touch_attack/fleshtostone
 	name = "petrifying touch"
@@ -77,6 +77,7 @@
 	var/mob/living/L = target
 	L.Stun(4 SECONDS)
 	new /obj/structure/closet/statue(L.loc, L)
+	handle_delete(user)
 
 /obj/item/melee/touch_attack/plushify
 	name = "fabric touch"
@@ -93,6 +94,7 @@
 		return
 	var/mob/living/L = target
 	L.plushify()
+	handle_delete(user)
 
 /obj/item/melee/touch_attack/fake_disintegrate
 	name = "toy plastic hand"
@@ -109,6 +111,7 @@
 		return
 	do_sparks(4, 0, target.loc)
 	playsound(target.loc, 'sound/goonstation/effects/gib.ogg', 50, 1)
+	handle_delete(user)
 
 /obj/item/melee/touch_attack/cluwne
 	name = "cluwne touch"
@@ -137,3 +140,4 @@
 			H.makeCluwne()
 		else
 			H.makeAntiCluwne()
+	handle_delete(user)

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -1181,7 +1181,7 @@
 
 /obj/item/toy/plushie/plasmamanplushie
 	name = "plasmaman plushie"
-	desc = "A freindly plasma-being in plush form. WARNING: KEEP AWAY FROM OPEN FLAME!"
+	desc = "A friendly plasma-being in plush form. WARNING: KEEP AWAY FROM OPEN FLAME!"
 	icon_state = "plushie_plasma"
 	rare_hug_sound = 'sound/voice/plas_rattle.ogg'
 	rare_hug_word = "Rattle!"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Magic touch spells no longer trigger and kill themselfs on floors or walls or lockers or holopads, etc.
Fixes spelling in plasmaman plush.
Allows sword / bread / plush spirits to break out of storage objects with a 50% chance. Makes it less harsh for crew.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Losing your spell charge because you missclicked is bad.
Spelling right good.
Allowing plushes to break out of bags 50% of the time their throw spell is good to make it less shitty for the victim.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

<!-- How did you test the PR, if at all? -->
clicked on everything with touch spells
Confirmed only activated on valid targets (basically everything for xeno acid, mobs for other things)
Confirmed could break out of backpacks and also fail to break out.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

![image](https://github.com/user-attachments/assets/f927ca09-eaba-4ef8-8ddc-36644ce5d52b)


## Changelog

:cl:
fix: Touch spells no longer false triggers on floors or lockers or other things.
fix: Fix plasmaman plush spelling.
tweak: Sword / bread / plush spirits can break out of storage objects 50% of the time.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
