### PR TITLE
Fix borg gripper held item self-activation.

### DIFF
--- a/code/game/objects/items/robot/cyborg_gripper.dm
+++ b/code/game/objects/items/robot/cyborg_gripper.dm
@@ -62,7 +62,10 @@
 	if(!gripped_item)
 		to_chat(user, "<span class='warning'>[src] is empty.</span>")
 		return
-	gripped_item.attack_self__legacy__attackchain(user)
+	if(gripped_item.new_attack_chain)
+		gripped_item.activate_self(user)
+	else
+		gripped_item.attack_self__legacy__attackchain(user)
 
 // This is required to ensure that the forceMove checks on some objects don't rip the gripper out of the borg's inventory and toss it on the floor. That would hurt, a lot!
 /obj/item/gripper/forceMove(atom/destination)


### PR DESCRIPTION
## What Does This PR Do
This PR adds a shim to the borg gripper for attack-self/self-activating held items.
## Why It's Good For The Game
Ensures new attack chain-migrated items work with borg gripper.
## Testing
Spawned in as borg, selected engineering module, spawned in airlock electronics, grabbed electronics with gripper, clicked on gripper and used keyboard shortcut to ensure I could modify airlock electronics.
<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog

:cl:
fix: An issue where borgs could not modify airlock electronics via their gripper has been fixed.
/:cl:
