### PR TITLE
Removes Carbon from Towercaps and replaces them with Plantmatter

### DIFF
--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -19,7 +19,7 @@
 	icon_dead = "towercap-dead"
 	genes = list(/datum/plant_gene/trait/plant_type/fungal_metabolism)
 	mutatelist = list(/obj/item/seeds/tower/steel)
-	reagents_add = list("carbon" = 0.2)
+	reagents_add = list("plantmatter" = 0.225)
 
 /obj/item/seeds/tower/steel
 	name = "pack of steel-cap mycelium"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Removes the Carbon chemical from Towercaps and replaces it with Plant-matter.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
This stops botany being able to easily produce synthflesh tomatos/plants within >15m of the round, this does not prevent them from making it all as carbon is still present in gatfruit, however encourages them to cooperate with xenobiology in order to achieve this if they really want to. As suggested by Stoniest, it is now replaced with 45% Plantmatter giving it a niche of being the plant with the most plantmatter (great for the biogen!)

Furthermore we wont be seeing people frequently give 100 potency synthflesh tomatos out to regular crew which nullifies the need to ever visit medbay besides for surgeries since with a few tomatos crushed in your hand you'll be good as new. This will also stop security needing to escalate to stronger weapons for the 1 antag healing everything instantly and then as a result also stomping everybody elses round indirectly when they happen to come across them.

![tomato](https://github.com/user-attachments/assets/aea81ed3-67a9-4628-8842-a8ac1ff678df)

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

![image](https://github.com/user-attachments/assets/3b6bb773-c9f9-4fbc-bc99-5d65ed4b3707)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
>Towercap in DNA manipulator
>45% Plantmatter
>Ground up a towercap log in the all-in-one grinder
>Plantmatter as a result

<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
![image](https://github.com/user-attachments/assets/021cb57f-cded-4623-b80a-61caec5b45f8)
![image](https://github.com/user-attachments/assets/b68f2571-81ff-4038-b8d3-d40ddb30a5e3)
![image](https://github.com/user-attachments/assets/75915fdf-437c-40bd-885f-d18d36295cb5)
 <hr>

## Changelog

:cl:
tweak: Replaces Carbon in Towercaps with Plant-matter
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
