### PR TITLE
Adds Business Suits to the Loadout Menu

### DIFF
--- a/code/modules/client/preference/loadout/loadout_uniform.dm
+++ b/code/modules/client/preference/loadout/loadout_uniform.dm
@@ -190,6 +190,18 @@
 	display_name = "Kilt"
 	path = /obj/item/clothing/under/costume/kilt
 
+/datum/gear/uniform/suit/executive
+	display_name = "Executive Suit"
+	path = /obj/item/clothing/under/suit/really_black
+
+/datum/gear/uniform/suit/navyblue
+	display_name = "Navy Suit"
+	path = /obj/item/clothing/under/suit/navy
+
+/datum/gear/uniform/suit/checkered
+	display_name = "Checkered Suit"
+	path = /obj/item/clothing/under/suit/checkered
+
 /datum/gear/uniform/skirt
 	main_typepath = /datum/gear/uniform/skirt
 


### PR DESCRIPTION
## What Does This PR Do
This adds the 3 business suits to the loadout menu that appear in the ClothesMate vending machine. 
## Why It's Good For The Game
It gives players more options to choose how they customize the look of their characters.
## Images of changes
![qSCB7Hky3k](https://github.com/user-attachments/assets/df6e9dbb-8c9c-45ae-a931-c21fd047bcdc)
## Testing
Started a test instance.
Opened Loadout to see if suits appeared in the Uniform tab.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<hr>

## Changelog

:cl:
add: Added business suits to the loadout menu
/:cl: