### PR TITLE
Converts spawn_atom to use TGUI

### DIFF
--- a/code/modules/admin/misc_admin_procs.dm
+++ b/code/modules/admin/misc_admin_procs.dm
@@ -744,7 +744,7 @@ GLOBAL_VAR_INIT(disable_explosions, FALSE)
 	if(length(matches)==1)
 		chosen = matches[1]
 	else
-		chosen = input("Select an atom type", "Spawn Atom", matches[1]) as null|anything in matches
+		chosen = tgui_input_list(usr, "Select An Atom Type", "Spawn Atom", matches)
 		if(!chosen)
 			return
 


### PR DESCRIPTION
## What Does This PR Do
Converts the `Spawn` command to use TGUI.
## Why It's Good For The Game
Searches faster. Window can be resized. Items can be further filtered through search.
Useful for development and administration.
## Images of changes
![XQVKUjh0OJ](https://github.com/user-attachments/assets/82d4af07-68d1-4643-8139-b9fbb97ea635)
![i9bDKVpZvZ](https://github.com/user-attachments/assets/fdf71e37-f4d8-40d2-be18-afcae988df6b)

## Testing
Used the spawn verb to spawn in a few items and mobs.
Checked that input functioned properly and maintained previous safeguards.
<hr>

### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<hr>

## Changelog
NPFC
