### PR TITLE
Reduces slowdown on Security Biosuits

### DIFF
--- a/code/modules/clothing/suits/bio.dm
+++ b/code/modules/clothing/suits/bio.dm
@@ -76,6 +76,7 @@
 /obj/item/clothing/suit/bio_suit/security
 	armor = list(MELEE = 15, BULLET = 10, LASER = 15, ENERGY = 5, BOMB = 15, RAD = 200, FIRE = 20, ACID = INFINITY)
 	icon_state = "bio_security"
+	slowdown = 0.45 //Same as Sec MODsuit
 
 
 //Janitor's biosuit, grey with purple


### PR DESCRIPTION
## What Does This PR Do

Reduces slowdown for Security Biosuits from 1 to 0.45, same as Security MODsuits.

Other biosuits are not affected by this PR.

## Why It's Good For The Game

Everyone is familiar with the dreaded Botany gaming with their fluorosulphuric acid + deathmix tomatos, which melts away most protection that you would have - While you can get breathing tubes to counter breathing in the toxic fumes, most injectproof clothing are not acidproof and will still melt from the acid.

Biosuits on the other hand are currently extremely underused due to their crippling slowdown, and the Security biosuit is usually left forgotten in the Armoury even when a Botany war criminal is out and about - While I'm hesistant in making all the biosuits move faster, I feel like the Security variant could use a little boost, especially since it is one of a kind and not purchasable from Cargo. (Which I do want to change, but that is for another PR)

## Images of changes

![image](https://github.com/user-attachments/assets/aaa86495-513b-4058-9b9a-5c2effafb7cf)

## Testing

Loaded up the game, it compiles, checked variables and confirmed that only Sec biosuit has reduced slowdown, wore the biosuits and confirmed that I move normally in Sec biosuits but not in Janitor biosuit.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>
![image](https://github.com/user-attachments/assets/ad0dd290-aad7-412b-aa4a-1e3d9480ba51)

## Changelog

:cl:
tweak: Security Biosuits now have a less severe slowdown
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
