### PR TITLE
Makes night shift actually save power like it should

### DIFF
--- a/code/modules/power/lights.dm
+++ b/code/modules/power/lights.dm
@@ -552,7 +552,11 @@
 			burnout()
 			return
 
-	change_power_mode(ACTIVE_POWER_USE)
+	if(nightshift_enabled)
+		change_power_mode(IDLE_POWER_USE)
+	else
+		change_power_mode(ACTIVE_POWER_USE)
+
 	update_icon()
 	set_light(BR, PO, CO)
 	if(play_sound)

--- a/code/modules/power/lights.dm
+++ b/code/modules/power/lights.dm
@@ -552,10 +552,7 @@
 			burnout()
 			return
 
-	if(nightshift_enabled)
-		change_power_mode(IDLE_POWER_USE)
-	else
-		change_power_mode(ACTIVE_POWER_USE)
+	change_power_mode(nightshift_enabled ? IDLE_POWER_USE : ACTIVE_POWER_USE)
 
 	update_icon()
 	set_light(BR, PO, CO)

--- a/code/modules/power/lights.dm
+++ b/code/modules/power/lights.dm
@@ -235,7 +235,7 @@
 	layer = FLY_LAYER
 	max_integrity = 100
 	power_state = ACTIVE_POWER_USE
-	idle_power_consumption = 2  //when in low power mode
+	idle_power_consumption = 10  //when in low power mode
 	active_power_consumption = 20 //when in full power mode
 	power_channel = PW_CHANNEL_LIGHTING //Lights are calc'd via area so they dont need to be in the machine list
 	var/base_state = "tube" // Base description and icon_state


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
So, remember this line from the nightshift message?
![image](https://github.com/user-attachments/assets/5c538ce2-2ae2-4066-9226-b67dd33e8ed8)

Yeah, turns out that never worked. But what if it did?
![image](https://github.com/user-attachments/assets/ae736630-840c-4833-8a98-49ad3162c7f9)

[Closed my instance by accident but the nightshift power usage was 40 W]
Finally, the text isn't lying and the bug has been fixed
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Dim lights = power saving
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
See above
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
See above
<!-- How did you test the PR, if at all? -->

<hr>

## Changelog

:cl:
fix: night shift lighting actually saves power now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
