### PR TITLE
Increases the time to Strip and Put on clothing via the Strip Menu

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -968,6 +968,8 @@
 	drop_sound = 'sound/items/handling/cloth_drop.ogg'
 	pickup_sound =  'sound/items/handling/cloth_pickup.ogg'
 	dyeing_key = DYE_REGISTRY_UNDER
+	strip_delay = 6 SECONDS
+	put_on_delay = 6 SECONDS
 
 	sprite_sheets = list(
 		"Vox" = 'icons/mob/clothing/species/vox/under/misc.dmi',


### PR DESCRIPTION
## What Does This PR Do
Adds a custom `strip_delay` and `put_on_delay` to underclothes, a.k.a. jumpsuits and uniforms.
## Why It's Good For The Game
It should probably take more time to strip a jumpsuit off of someone than it should take to take off their shoes.
## Testing
Took off and put on a jumpsuit on a mob.
<hr>

### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
![Discord_b0perrpKHN](https://github.com/user-attachments/assets/f8340fdc-2537-4fdb-912e-3d01770449b3)

<hr>

## Changelog
:cl:
tweak: Increased strip and put on delays for the strip menu
/:cl: