### PR TITLE
Fixes nullspace breathing runtime.

### DIFF
--- a/code/modules/mob/living/carbon/carbon_life.dm
+++ b/code/modules/mob/living/carbon/carbon_life.dm
@@ -55,7 +55,11 @@
 
 /datum/milla_safe/carbon_breathe/on_run(mob/living/carbon/carbon)
 	var/turf/T = get_turf(carbon)
-	carbon.breathe(get_turf_air(T))
+	if(istype(T))
+		carbon.breathe(get_turf_air(T))
+	else
+		var/datum/gas_mixture/vacuum = new()
+		carbon.breathe(vacuum)
 
 //Second link in a breath chain, calls check_breath()
 /mob/living/carbon/proc/breathe(datum/gas_mixture/environment)

--- a/code/modules/mob/living/carbon/carbon_procs.dm
+++ b/code/modules/mob/living/carbon/carbon_procs.dm
@@ -1,6 +1,8 @@
 /mob/living/carbon/Initialize(mapload)
 	. = ..()
 	GLOB.carbon_list += src
+	if(!loc)
+		stack_trace("Carbon mob being instantiated in nullspace")
 
 /mob/living/carbon/Destroy()
 	// This clause is here due to items falling off from limb deletion


### PR DESCRIPTION
## What Does This PR Do
Carbon mobs breathing in nullspace was causing runtimes.

It doesn't anymore.

Fixes #27746 

## Why It's Good For The Game
Not breaking CI is good.

## Testing

Put a skrell inside a machine's circuit board without the PR. Runtimes.
Put a skrell inside a machine's circuit board with the PR. No runtimes.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog
NPFC