### PR TITLE
Makes the power biochip more normal to use, and makes it use TG cool downs.

### DIFF
--- a/code/_onclick/click_override.dm
+++ b/code/_onclick/click_override.dm
@@ -43,16 +43,16 @@
 	..()
 
 /datum/middle_click_override/shock_implant
+	COOLDOWN_DECLARE(last_shocked)
+	var/shock_delay = 3 SECONDS
 
 /datum/middle_click_override/shock_implant/onClick(atom/A, mob/living/carbon/human/user)
-	if(A == user || user.a_intent == INTENT_HELP || user.a_intent == INTENT_GRAB)
-		return FALSE
-	if(user.incapacitated())
+	if(user.incapacitated() || A == user)
 		return FALSE
 	var/obj/item/bio_chip/shock/P = locate() in user
 	if(!P)
 		return
-	if(world.time < P.last_shocked + P.shock_delay)
+	if(!COOLDOWN_FINISHED(src, last_shocked))
 		to_chat(user, "<span class='warning'>The powerchip is still recharging.</span>")
 		return FALSE
 	var/turf/T = get_turf(user)
@@ -76,7 +76,7 @@
 		if(isliving(target_atom))
 			var/mob/living/L = target_atom
 			var/powergrid = C.get_available_power() //We want available power, so the station being conservative doesn't mess with the power biochip / dark bundle users
-			if(user.a_intent == INTENT_DISARM)
+			if(user.a_intent == INTENT_DISARM || user.a_intent == INTENT_HELP)
 				add_attack_logs(user, L, "shocked with power bio-chip.")
 				L.apply_damage(60, STAMINA)
 				L.Jitter(10 SECONDS)
@@ -110,7 +110,7 @@
 		A = target_atom
 		next_shocked.Cut()
 
-	P.last_shocked = world.time
+	COOLDOWN_START(src, last_shocked, shock_delay)
 	return TRUE
 
 /**

--- a/code/datums/uplink_items/uplink_traitor.dm
+++ b/code/datums/uplink_items/uplink_traitor.dm
@@ -218,7 +218,7 @@
 	name = "Power Bio-Chip"
 	desc = "A Bio-Chip that can utilize the power of the station to deliver a short arc of electricity at a target. \
 			Must be standing on a powered cable to use. \
-			Activated by alt-clicking, or pressing the middle mouse button. Disarm intent will deal stamina damage and cause jittering, while harm intent will deal damage based on the power of the cable you're standing on. Can be toggled on / off via the action button."
+			Activated by alt-clicking, or pressing the middle mouse button. Help/disarm intent will deal stamina damage and cause jittering, while harm/grab intent will deal damage based on the power of the cable you're standing on. Can be toggled on / off via the action button."
 	reference = "PG"
 	item = /obj/item/bio_chip_implanter/shock
 	cost = 50

--- a/code/game/objects/items/weapons/bio_chips/bio_chip_shock.dm
+++ b/code/game/objects/items/weapons/bio_chips/bio_chip_shock.dm
@@ -6,11 +6,9 @@
 	origin_tech = "combat=5;magnets=3;biotech=4;syndicate=2"
 	implant_data = /datum/implant_fluff/shock
 	implant_state = "implant-syndicate"
-	var/enabled = TRUE
+	var/enabled = FALSE
 	var/old_mclick_override
 	var/datum/middle_click_override/shock_implant/mclick_override = new /datum/middle_click_override/shock_implant
-	var/last_shocked = 0
-	var/shock_delay = 3 SECONDS
 	var/unlimited_power = FALSE // Does this really need explanation?
 	var/shock_range = 7
 


### PR DESCRIPTION


<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes the power biochip treat help intent like disarm, and grab intent like harm intent. (this doesn't remove disarm/harm doing stuff)
As well as makes the cool downs use TG cool downs, as they're more better to use.
And fixes needing to turn the biochip off and on to work.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Theres *ZERO* feedback on the biochip if you're not on harm/disarm, making it frustrating to use in combat. This changes that, so its a little more sane.

Shifting stuff to TG cool downs is better as it's standard and better to work with.
There was also a bug that made it so you needed to turn the biochip off, then back on to work. So i made the biochip start off, so you only need to turn it on. 
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
shocked people on all the intents, counted to 3 while doing it
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
tweak: The power Bio-Chip will treat help and disarm intent the same, as with grab and harm. Rather than just not doing anything
fix: Fixed needing to turn off and on the power Bio-Chip to make it work. You now just need to turn it on.z
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
