### PR TITLE
Removes accidental smoke greande buff

### DIFF
--- a/code/game/objects/effects/effect_system/effects_smoke.dm
+++ b/code/game/objects/effects/effect_system/effects_smoke.dm
@@ -128,8 +128,6 @@
 /obj/effect/particle_effect/smoke/bad
 	lifetime = 16 SECONDS_TO_LIFE_CYCLES
 	causes_coughing = TRUE
-	direction = SOUTH
-	steps = 10
 
 /obj/effect/particle_effect/smoke/bad/CanPass(atom/movable/mover, border_dir)
 	if(istype(mover, /obj/item/projectile/beam))

--- a/code/game/objects/effects/effect_system/effects_smoke.dm
+++ b/code/game/objects/effects/effect_system/effects_smoke.dm
@@ -126,7 +126,7 @@
 /////////////////////////////////////////////
 
 /obj/effect/particle_effect/smoke/bad
-	lifetime = 60 SECONDS_TO_LIFE_CYCLES
+	lifetime = 16 SECONDS_TO_LIFE_CYCLES
 	causes_coughing = TRUE
 	direction = SOUTH
 	steps = 10


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Sets `/obj/effect/particle_effect/smoke/bad` to last for 16 cycles (32 seconds) instead of 60 (120 seconds).

Also makes the direction the smoke spreads random and the amount it will spread less.

These changes come from #26762 . Warrior said this change was done by accident and was only intended for testing purposes.

## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

It was an accidental change that needs to be reverted.

Smoke grenades are way too strong and last way too long right now.

## Testing

<!-- How did you test the PR, if at all? -->

Loaded into the admin testing area and spawned in `/obj/effect/particle_effect/smoke/bad` and timed it.

Tested smoke spread to ensure it spreads out in random directions.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Sets smoke from smoke grenades to last 32 seconds instead of 120. This change was done by accident.
fix: Smoke from smoke grenades spread around in random directions again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
