### PR TITLE
Improved plant bag harvesting

### DIFF
--- a/code/modules/hydroponics/grown/misc_seeds.dm
+++ b/code/modules/hydroponics/grown/misc_seeds.dm
@@ -15,13 +15,15 @@
 	growing_icon = 'icons/obj/hydroponics/growing_flowers.dmi'
 	genes = list(/datum/plant_gene/trait/plant_type/weed_hardy)
 
-/obj/item/seeds/starthistle/harvest(mob/user)
+/obj/item/seeds/starthistle/harvest(mob/user, obj/item/storage/bag/plants/bag)
 	var/obj/machinery/hydroponics/parent = loc
 	var/output_loc = parent.Adjacent(user) ? user.loc : parent.loc
 	var/seed_count = getYield()
 	for(var/i in 1 to seed_count)
 		var/obj/item/seeds/starthistle/harvestseeds = Copy()
 		harvestseeds.forceMove(output_loc)
+		if(bag && bag.can_be_inserted(harvestseeds))
+			bag.handle_item_insertion(harvestseeds, user, TRUE)
 
 	parent.update_tray(user, seed_count)
 

--- a/code/modules/hydroponics/grown/replicapod.dm
+++ b/code/modules/hydroponics/grown/replicapod.dm
@@ -54,7 +54,7 @@
 	return text
 
 
-/obj/item/seeds/replicapod/harvest(mob/user = usr) //now that one is fun -- Urist
+/obj/item/seeds/replicapod/harvest(mob/user, obj/item/storage/bag/plants/bag)
 	var/obj/machinery/hydroponics/parent = loc
 	var/make_podman = 0
 	var/ckey_holder = null
@@ -102,5 +102,7 @@
 		for(var/i=0,i<seed_count,i++)
 			var/obj/item/seeds/replicapod/harvestseeds = src.Copy()
 			harvestseeds.forceMove(output_loc)
+			if(bag && bag.can_be_inserted(harvestseeds))
+				bag.handle_item_insertion(harvestseeds, user, TRUE)
 
 	parent.update_tray(user, 1)

--- a/code/modules/hydroponics/hydroponics_tray.dm
+++ b/code/modules/hydroponics/hydroponics_tray.dm
@@ -857,12 +857,11 @@
 			to_chat(user, "<span class='warning'>This plot is completely devoid of weeds! It doesn't need uprooting.</span>")
 
 	else if(istype(O, /obj/item/storage/bag/plants))
-		attack_hand(user)
-		var/obj/item/storage/bag/plants/S = O
-		for(var/obj/item/food/grown/G in locate(user.x,user.y,user.z))
-			if(!S.can_be_inserted(G))
-				return
-			S.handle_item_insertion(G, user, TRUE)
+		if(!harvest)
+			attack_hand(user)
+			return
+
+		myseed.harvest(user, O)
 
 	else if(istype(O, /obj/item/shovel/spade))
 		if(!myseed && !weedlevel)

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -210,7 +210,7 @@
 
 	return new /obj/item/unsorted_seeds(src, mutation_level, tray.get_mutation_focus())
 
-/obj/item/seeds/proc/harvest(mob/user = usr)
+/obj/item/seeds/proc/harvest(mob/user, obj/item/storage/bag/plants/bag)
 	var/obj/machinery/hydroponics/tray = loc
 	var/output_loc = tray.Adjacent(user) ? user.loc : tray.loc // Needed for TK
 
@@ -222,6 +222,8 @@
 		var/obj/item/produce = new product(output_loc, mutated_seed)
 		if(!produce)
 			return
+		if(bag && bag.can_be_inserted(produce))
+			bag.handle_item_insertion(produce, user, TRUE)
 
 		product_name = produce.name
 


### PR DESCRIPTION
## What Does This PR Do
Makes plant bag harvesting more logical:
* Non-food produce (e.g. logs) now goes into the plant bag.
* Stuff on the ground no longer goes into the plant bag.

## Why It's Good For The Game
It's good when things behave the way you'd expect them to.

## Testing
Harvested berries, tower caps, replica pods, and starthistle, all both without the bag and with the bag while standing on other produce.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog

:cl:
fix: When harvesting a hydroponics tray with a plant bag, non-food produce (e.g. logs) now goes into the plant bag.
fix: When harvesting a hydroponics tray with a plant bag, you no longer pick up other produce off the floor.
/:cl: