### PR TITLE
Dragging storage bags now drops items around the mouse pointer

### DIFF
--- a/code/controllers/subsystem/non_firing/SSmapping.dm
+++ b/code/controllers/subsystem/non_firing/SSmapping.dm
@@ -230,8 +230,7 @@ SUBSYSTEM_DEF(mapping)
 		var/obj/structure/closet/C = pick_n_take(seeded_salvage_closets)
 		var/salvage_item_type = pick(small_salvage_items)
 		var/obj/salvage_item = new salvage_item_type(C)
-		salvage_item.pixel_x = rand(-5, 5)
-		salvage_item.pixel_y = rand(-5, 5)
+		salvage_item.scatter_atom()
 		max_salvage_attempts -= 1
 
 	max_salvage_attempts = rand(10, 15)
@@ -239,8 +238,7 @@ SUBSYSTEM_DEF(mapping)
 		var/obj/T = pick_n_take(seeded_salvage_surfaces)
 		var/salvage_item_type = pick(small_salvage_items)
 		var/obj/salvage_item = new salvage_item_type(T.loc)
-		salvage_item.pixel_x = rand(-5, 5)
-		salvage_item.pixel_y = rand(-5, 5)
+		salvage_item.scatter_atom()
 		max_salvage_attempts -= 1
 
 	log_startup_progress("Successfully seeded space salvage in [stop_watch(space_salvage_timer)]s.")

--- a/code/datums/elements/shatters_when_thrown.dm
+++ b/code/datums/elements/shatters_when_thrown.dm
@@ -46,8 +46,7 @@
 
 	for(var/iteration in 1 to number_of_shards)
 		var/obj/item/shard = new shard_type(scatter_turf)
-		shard.pixel_x = rand(-6, 6)
-		shard.pixel_y = rand(-6, 6)
+		shard.scatter_atom()
 	playsound(scatter_turf, shattering_sound, 60, TRUE)
 	if(isobj(source))
 		var/obj/obj_source = source

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -69,6 +69,9 @@
 	/// Used for icon smoothing. Won't smooth if it ain't anchored and can be unanchored. Only set to true on windows
 	var/can_be_unanchored = FALSE
 
+	/// How far (in pixels) should this atom scatter when created/dropped/etc. Does not apply to mapped-in items.
+	var/scatter_distance = 0
+
 /atom/movable/attempt_init(loc, ...)
 	var/turf/T = get_turf(src)
 	if(T && SSatoms.initialized != INITIALIZATION_INSSATOMS && GLOB.space_manager.is_zlevel_dirty(T.z))
@@ -1062,3 +1065,8 @@
 /// useful callback for things that want special behavior on crush
 /atom/movable/proc/on_crush_thing(atom/thing)
 	return
+
+/// Used to scatter atoms so that multiple copies aren't all at the exact same spot.
+/atom/movable/proc/scatter_atom(x_offset=0, y_offset=0)
+	pixel_x = x_offset + rand(-scatter_distance, scatter_distance)
+	pixel_y = y_offset + rand(-scatter_distance, scatter_distance)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -1067,6 +1067,6 @@
 	return
 
 /// Used to scatter atoms so that multiple copies aren't all at the exact same spot.
-/atom/movable/proc/scatter_atom(x_offset=0, y_offset=0)
+/atom/movable/proc/scatter_atom(x_offset = 0, y_offset = 0)
 	pixel_x = x_offset + rand(-scatter_distance, scatter_distance)
 	pixel_y = y_offset + rand(-scatter_distance, scatter_distance)

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -415,8 +415,7 @@
 			var/obj/item/new_item = new D.build_path(BuildTurf)
 			new_item.materials[MAT_METAL] /= coeff
 			new_item.materials[MAT_GLASS] /= coeff
-			new_item.pixel_y = rand(-5, 5)
-			new_item.pixel_x = rand(-5, 5)
+			new_item.scatter_atom()
 		if(is_station_level(z))
 			SSblackbox.record_feedback("tally", "station_autolathe_production", 1, "[D.type]")
 	SStgui.update_uis(src)

--- a/code/game/machinery/pipe/pipe_construction.dm
+++ b/code/game/machinery/pipe/pipe_construction.dm
@@ -157,8 +157,7 @@
 			connect_types = list(CONNECT_TYPE_NORMAL, CONNECT_TYPE_SUPPLY, CONNECT_TYPE_SCRUBBER)
 
 	update(make_from)
-	pixel_x = rand(-5, 5)
-	pixel_y = rand(-5, 5)
+	scatter_atom()
 
 //update the name and icon of the pipe item depending on the type
 

--- a/code/game/machinery/vendors/vending.dm
+++ b/code/game/machinery/vendors/vending.dm
@@ -825,8 +825,7 @@
 		if(put_on_turf)
 			var/turf/T = get_turf(src)
 			vended.forceMove(T)
-			vended.pixel_x = rand(-5, 5)
-			vended.pixel_y = rand(-5, 5)
+			vended.scatter_atom()
 		return TRUE
 	return FALSE
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -184,6 +184,8 @@ GLOBAL_DATUM_INIT(welding_sparks, /mutable_appearance, mutable_appearance('icons
 	/// In tiles, how far this weapon can reach; 1 for adjacent, which is default
 	var/reach = 1
 
+	scatter_distance = 5
+
 /obj/item/New()
 	..()
 

--- a/code/game/objects/items/random_items.dm
+++ b/code/game/objects/items/random_items.dm
@@ -39,19 +39,18 @@
 	reagents.add_reagent(R, volume)
 	name = "unlabelled bottle"
 	icon_state = pick("alco-white","alco-green","alco-blue","alco-clear","alco-red")
-	pixel_x = rand(-5, 5)
-	pixel_y = rand(-5, 5)
+	scatter_atom()
 
 /obj/item/storage/pill_bottle/random_meds
 	name = "unlabelled pillbottle"
 	desc = "The sheer recklessness of this bottle's existence astounds you."
 	allow_wrap = FALSE
 	var/labelled = FALSE
+	scatter_distance = 10
 
 /obj/item/storage/pill_bottle/random_meds/Initialize(mapload)
 	. = ..()
-	pixel_x = rand(-10, 10)
-	pixel_y = rand(-10, 10)
+	scatter_atom()
 
 /obj/item/storage/pill_bottle/random_meds/populate_contents()
 	var/list/possible_meds_standard = GLOB.standard_medicines.Copy()

--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -149,7 +149,7 @@ GLOBAL_LIST_INIT(snow_recipes, list(
 	throw_speed = 3
 
 /obj/item/stack/sheet/mineral/Initialize(mapload, new_amount, merge)
-	..()
+	. = ..()
 	scatter_atom()
 
 /obj/item/stack/sheet/mineral/scatter_atom(offset_x, offset_y)

--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -149,9 +149,12 @@ GLOBAL_LIST_INIT(snow_recipes, list(
 	throw_speed = 3
 
 /obj/item/stack/sheet/mineral/Initialize(mapload, new_amount, merge)
-	. = ..()
-	pixel_x = rand(0,4)-4
-	pixel_y = rand(0,4)-4
+	..()
+	scatter_atom()
+
+/obj/item/stack/sheet/mineral/scatter_atom(offset_x, offset_y)
+	pixel_x = rand(-4,0) + offset_x
+	pixel_y = rand(-4,0) + offset_y
 
 /obj/item/stack/sheet/mineral/sandstone
 	name = "sandstone brick"

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -18,7 +18,7 @@
 	scatter_distance = 3
 
 /obj/item/stack/tile/Initialize(mapload, new_amount, merge)
-	..()
+	. = ..()
 	scatter_atom()
 
 /obj/item/stack/tile/welder_act(mob/user, obj/item/I)

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -15,11 +15,11 @@
 	origin_tech = "materials=1"
 	var/turf_type = null
 	var/mineralType = null
+	scatter_distance = 3
 
 /obj/item/stack/tile/Initialize(mapload, new_amount, merge)
-	. = ..()
-	pixel_x = rand(-3, 3)
-	pixel_y = rand(-3, 3) //randomize a little
+	..()
+	scatter_atom()
 
 /obj/item/stack/tile/welder_act(mob/user, obj/item/I)
 	if(get_amount() < 4)

--- a/code/game/objects/items/trash.dm
+++ b/code/game/objects/items/trash.dm
@@ -142,11 +142,11 @@
 	name = "arbitrary spent casing item"
 	desc = "If you can see this and didn't spawn it, make an issue report on GitHub."
 	icon_state = "gshell"
+	scatter_distance = 10
 
 /obj/item/trash/spentcasing/Initialize(mapload)
 	. = ..()
-	pixel_x = rand(-10, 10)
-	pixel_y = rand(-10, 10)
+	scatter_atom()
 	transform = turn(transform, rand(0, 360))
 
 /obj/item/trash/spentcasing/shotgun

--- a/code/game/objects/items/weapons/cigs.dm
+++ b/code/game/objects/items/weapons/cigs.dm
@@ -333,9 +333,7 @@ LIGHTERS ARE IN LIGHTERS.DM
 
 /obj/item/clothing/mask/cigarette/rollie/Initialize(mapload)
 	. = ..()
-	pixel_x = rand(-5, 5)
-	pixel_y = rand(-5, 5)
-
+	scatter_atom()
 /obj/item/clothing/mask/cigarette/rollie/custom
 	list_reagents = list()
 
@@ -346,11 +344,11 @@ LIGHTERS ARE IN LIGHTERS.DM
 	icon_state = "cigbutt"
 	w_class = WEIGHT_CLASS_TINY
 	throwforce = 1
+	scatter_distance = 10
 
 /obj/item/cigbutt/Initialize(mapload)
 	. = ..()
-	pixel_x = rand(-10, 10)
-	pixel_y = rand(-10, 10)
+	scatter_atom()
 	transform = turn(transform, rand(0, 360))
 
 /obj/item/cigbutt/decompile_act(obj/item/matter_decompiler/C, mob/user)
@@ -364,11 +362,11 @@ LIGHTERS ARE IN LIGHTERS.DM
 	name = "roach"
 	desc = "A manky old roach, or for non-stoners, a used rollup."
 	icon_state = "roach"
+	scatter_distance = 5
 
 /obj/item/cigbutt/roach/Initialize(mapload)
 	. = ..()
-	pixel_x = rand(-5, 5)
-	pixel_y = rand(-5, 5)
+	scatter_atom()
 
 //////////////////////////////
 // MARK: ROLLING

--- a/code/game/objects/items/weapons/gift_wrappaper.dm
+++ b/code/game/objects/items/weapons/gift_wrappaper.dm
@@ -14,11 +14,11 @@
 	icon_state = "gift1"
 	item_state = "gift1"
 	resistance_flags = FLAMMABLE
+	scatter_distance = 10
 
 /obj/item/a_gift/New()
 	..()
-	pixel_x = rand(-10,10)
-	pixel_y = rand(-10,10)
+	scatter_atom()
 	if(w_class > 0 && w_class < 4)
 		icon_state = "gift[w_class]"
 	else

--- a/code/game/objects/items/weapons/grenades/frag.dm
+++ b/code/game/objects/items/weapons/grenades/frag.dm
@@ -66,11 +66,11 @@
 	w_class = WEIGHT_CLASS_SMALL
 	sharp = TRUE
 	hitsound = 'sound/weapons/pierce.ogg'
+	scatter_distance = 8
 
 /obj/item/shrapnel/Initialize(mapload)
 	. = ..()
 	icon_state = pick("shrapnel1", "shrapnel2", "shrapnel3")
-	pixel_x = rand(-8, 8)
-	pixel_y = rand(-8, 8)
+	scatter_atom()
 
 #undef DEFAULT_SHRAPNEL_RANGE

--- a/code/game/objects/items/weapons/storage/storage_base.dm
+++ b/code/game/objects/items/weapons/storage/storage_base.dm
@@ -103,7 +103,7 @@
 /obj/item/storage/proc/removal_allowed_check(mob/user)
 	return TRUE
 
-/obj/item/storage/MouseDrop(obj/over_object)
+/obj/item/storage/MouseDrop(obj/over_object, src_location, over_location, src_control, over_control, params)
 	if(!ismob(usr)) //so monkeys can take off their backpacks -- Urist
 		return
 	var/mob/M = usr
@@ -134,8 +134,12 @@
 		M.face_atom(over_object)
 		M.visible_message("<span class='notice'>[M] empties [src] onto [over_object].</span>",
 			"<span class='notice'>You empty [src] onto [over_object].</span>")
+		var/list/params_list = params2list(params)
+		var/x_offset = text2num(params_list["icon-x"]) - 16
+		var/y_offset = text2num(params_list["icon-y"]) - 16
 		for(var/obj/item/I in contents)
 			remove_from_storage(I, T)
+			I.scatter_atom(x_offset, y_offset)
 		update_icon() // For content-sensitive icons
 		return
 
@@ -608,6 +612,7 @@
 	hide_from(user)
 	for(var/obj/item/I in contents)
 		remove_from_storage(I, T)
+		I.scatter_atom()
 		CHECK_TICK
 
 /**

--- a/code/modules/fish/fish_items.dm
+++ b/code/modules/fish/fish_items.dm
@@ -159,8 +159,7 @@
 
 /obj/item/shard/shark_teeth/set_initial_icon_state()
 	icon_state = "teeth"
-	pixel_x = rand(-5,5)
-	pixel_y = rand(-5,5)
+	scatter_atom()
 
 /obj/item/fish/catfish
 	name = "catfish"

--- a/code/modules/food_and_drinks/food_base.dm
+++ b/code/modules/food_and_drinks/food_base.dm
@@ -336,8 +336,7 @@
 	for(var/i in 1 to (slices_num - slices_lost))
 		var/obj/slice = new slice_path (loc)
 		reagents.trans_to(slice,reagents_per_slice)
-		slice.pixel_x = rand(-7, 7)
-		slice.pixel_y = rand(-7, 7)
+		slice.scatter_atom()
 	qdel(src)
 	return ..()
 

--- a/code/modules/hydroponics/beekeeping/honeycomb.dm
+++ b/code/modules/hydroponics/beekeeping/honeycomb.dm
@@ -7,11 +7,11 @@
 	volume = 10
 	list_reagents = list("honey" = 5)
 	var/honey_color = ""
+	scatter_distance = 8
 
 /obj/item/food/honeycomb/Initialize(mapload)
 	. = ..()
-	pixel_x = rand(8,-8)
-	pixel_y = rand(8,-8)
+	scatter_atom()
 	update_icon(UPDATE_OVERLAYS)
 
 /obj/item/food/honeycomb/update_overlays()

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -36,8 +36,7 @@
 	else if(seed)
 		seed = new seed
 
-	pixel_x = rand(-5, 5)
-	pixel_y = rand(-5, 5)
+	scatter_atom()
 
 	if(dried_type == -1)
 		dried_type = type
@@ -92,8 +91,7 @@
 			for(var/i = 1 to (slices_num - slices_lost))
 				var/obj/slice = new slice_path (loc)
 				reagents.trans_to(slice, reagents_per_slice)
-				slice.pixel_x = rand(-7, 7)
-				slice.pixel_y = rand(-7, 7)
+				slice.scatter_atom()
 			qdel(src)
 			return ..()
 

--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -174,8 +174,7 @@
 	if(!has_buckled_mobs() && do_after(user, 50, target = src))
 		for(var/I in 1 to 5)
 			var/obj/item/grown/log/L = new /obj/item/grown/log(loc)
-			L.pixel_x += rand(1,4)
-			L.pixel_y += rand(1,4)
+			L.scatter_atom()
 		qdel(src)
 		return
 	..()

--- a/code/modules/hydroponics/growninedible.dm
+++ b/code/modules/hydroponics/growninedible.dm
@@ -26,9 +26,7 @@
 	else if(seed)
 		seed = new seed
 
-	pixel_x = rand(-5, 5)
-	pixel_y = rand(-5, 5)
-
+	scatter_atom()
 	if(seed)
 		for(var/datum/plant_gene/trait/T in seed.genes)
 			T.on_new(src)

--- a/code/modules/hydroponics/hydroitemdefines.dm
+++ b/code/modules/hydroponics/hydroitemdefines.dm
@@ -342,8 +342,7 @@
 
 /obj/item/reagent_containers/glass/bottle/nutrient/killer/Initialize(mapload)
 	. = ..()
-	pixel_x = rand(-5, 5)
-	pixel_y = rand(-5, 5)
+	scatter_atom()
 
 /obj/item/reagent_containers/glass/bottle/nutrient/killer/weedkiller
 	name = "jug of weed killer"

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -619,8 +619,7 @@
 /obj/item/unsorted_seeds/New(obj/item/seeds/template, mutation_level, list/mutation_focus, seed_data_in = null)
 	..()
 	template = template.Copy()
-	pixel_x = rand(-6, 6)
-	pixel_y = rand(-6, 6)
+	scatter_atom()
 	if(seed_data_in)
 		seed_data = seed_data_in
 	else

--- a/code/modules/mining/lavaland/ash_flora.dm
+++ b/code/modules/mining/lavaland/ash_flora.dm
@@ -203,8 +203,7 @@
 
 /obj/item/food/grown/ash_flora/Initialize(mapload)
 	. = ..()
-	pixel_x = rand(-4, 4)
-	pixel_y = rand(-4, 4)
+	scatter_atom()
 
 /// for actual crafting
 /obj/item/food/grown/ash_flora/shavings

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -18,7 +18,7 @@
 	var/refined_type = null //What this ore defaults to being refined into
 
 /obj/item/stack/ore/Initialize(mapload, new_amount, merge = TRUE)
-	..()
+	. = ..()
 	scatter_atom()
 
 /obj/item/stack/ore/scatter_atom(x_offset, y_offset)

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -18,9 +18,12 @@
 	var/refined_type = null //What this ore defaults to being refined into
 
 /obj/item/stack/ore/Initialize(mapload, new_amount, merge = TRUE)
-	. = ..()
-	pixel_x = rand(0, 16) - 8
-	pixel_y = rand(0, 8) - 8
+	..()
+	scatter_atom()
+
+/obj/item/stack/ore/scatter_atom(x_offset, y_offset)
+	pixel_x = rand(-8, 8) + x_offset
+	pixel_y = rand(-8, 0) + y_offset
 
 /obj/item/stack/ore/welder_act(mob/user, obj/item/I)
 	. = TRUE

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -223,9 +223,11 @@
 
 /mob/living/simple_animal/chick/Initialize(mapload)
 	. = ..()
+	scatter_atom()
 
-	pixel_x = rand(-6, 6)
-	pixel_y = rand(0, 10)
+/mob/living/simple_animal/chick/scatter_atom(x_offset, y_offset)
+	pixel_x = rand(-6, 6) + x_offset
+	pixel_y = rand(0, 10) + y_offset
 
 /mob/living/simple_animal/chick/Life(seconds, times_fired)
 	. =..()
@@ -302,10 +304,13 @@ GLOBAL_VAR_INIT(chicken_count, 0)
 	icon_state = "[icon_prefix]_[body_color]"
 	icon_living = "[icon_prefix]_[body_color]"
 	icon_dead = "[icon_prefix]_[body_color]_dead"
-	pixel_x = rand(-6, 6)
-	pixel_y = rand(0, 10)
+	scatter_atom()
 	update_appearance(UPDATE_ICON_STATE)
 	GLOB.chicken_count += 1
+
+/mob/living/simple_animal/chick/scatter_atom(x_offset, y_offset)
+	pixel_x = rand(-6, 6) + x_offset
+	pixel_y = rand(0, 10) + y_offset
 
 /mob/living/simple_animal/chicken/death(gibbed)
 	// Only execute the below if we successfully died
@@ -339,8 +344,7 @@ GLOBAL_VAR_INIT(chicken_count, 0)
 		visible_message("[src] [pick(layMessage)]")
 		eggsleft--
 		var/obj/item/E = new egg_type(get_turf(src))
-		E.pixel_x = rand(-6,6)
-		E.pixel_y = rand(-6,6)
+		E.scatter_atom()
 		if(eggsFertile)
 			if(GLOB.chicken_count < MAX_CHICKENS && prob(25))
 				START_PROCESSING(SSobj, E)

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -50,6 +50,8 @@
 	var/const/crayonfont = "Comic Sans MS"
 	var/regex/blacklist = new("(<iframe|<embed|<script|<canvas|<video|<audio|onload)", "g") // Blacklist of naughties
 
+	scatter_distance = 8
+
 //lipstick wiping is in code/game/objects/items/weapons/cosmetics.dm!
 
 /obj/item/paper/New()

--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -15,6 +15,7 @@
 	var/screen = 0
 	drop_sound = 'sound/items/handling/paper_drop.ogg'
 	pickup_sound =  'sound/items/handling/paper_pickup.ogg'
+	scatter_distance = 8
 
 /obj/item/paper_bundle/New(default_papers = TRUE)
 	. = ..()

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -96,8 +96,7 @@
 		P.loc = user.loc
 		user.put_in_hands(P)
 		P.add_fingerprint(user)
-		P.pixel_x = rand(-9, 9) // Random position
-		P.pixel_y = rand(-8, 8)
+		P.scatter_atom()
 		to_chat(user, "<span class='notice'>You take [P] out of [src].</span>")
 	else
 		to_chat(user, "<span class='notice'>[src] is empty!</span>")

--- a/code/modules/paperwork/paperplane.dm
+++ b/code/modules/paperwork/paperplane.dm
@@ -13,11 +13,11 @@
 	no_spin = TRUE
 
 	var/obj/item/paper/internal_paper
+	scatter_distance = 8
 
 /obj/item/paperplane/New(loc, obj/item/paper/new_paper)
 	..()
-	pixel_y = rand(-8, 8)
-	pixel_x = rand(-9, 9)
+	scatter_atom()
 	if(new_paper)
 		internal_paper = new_paper
 		flags = new_paper.flags

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -128,8 +128,7 @@
 	p.tiny = photocopy.tiny
 	p.img = photocopy.img
 	p.desc = photocopy.desc
-	p.pixel_x = rand(-10, 10)
-	p.pixel_y = rand(-10, 10)
+	p.scatter_atom()
 	if(photocopy.scribble)
 		p.scribble = photocopy.scribble
 	return p
@@ -170,8 +169,7 @@
 	else if(folder)
 		p.forceMove(folder)
 	p.desc = "You see [copymob]'s ass on the photo."
-	p.pixel_x = rand(-10, 10)
-	p.pixel_y = rand(-10, 10)
+	p.scatter_atom()
 	p.img = temp_img
 	var/icon/small_img = icon(temp_img) //Icon() is needed or else temp_img will be rescaled too >.>
 	var/icon/ic = icon('icons/obj/items.dmi',"photo")
@@ -220,8 +218,7 @@
 
 	P.icon_state = "paper_words"
 	P.name = bundle.name
-	P.pixel_y = rand(-8, 8)
-	P.pixel_x = rand(-9, 9)
+	P.scatter_atom()
 	return P
 
 /obj/machinery/photocopier/proc/remove_document()

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -35,6 +35,7 @@
 	var/scribble	//Scribble on the back.
 	var/icon/tiny
 	var/photo_size = 3
+	scatter_distance = 8
 
 /obj/item/photo/attack_self__legacy__attackchain(mob/user as mob)
 	user.examinate(src)

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -28,12 +28,13 @@
 	/// How strong the flash is
 	var/muzzle_flash_strength = MUZZLE_FLASH_STRENGTH_WEAK
 
+	scatter_distance = 10
+
 /obj/item/ammo_casing/New()
 	..()
 	if(projectile_type)
 		BB = new projectile_type(src)
-	pixel_x = rand(-10.0, 10)
-	pixel_y = rand(-10.0, 10)
+	scatter_atom()
 	dir = pick(GLOB.alldirs)
 	update_appearance(UPDATE_DESC|UPDATE_ICON_STATE)
 

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -571,8 +571,7 @@
 		var/obj/item/reagent_containers/P = new item_type(location)
 		if(!isnull(medicine_name))
 			P.name = "[medicine_name][name_suffix]"
-		P.pixel_x = rand(-7, 7) // Random position
-		P.pixel_y = rand(-7, 7)
+		P.scatter_atom()
 		configure_item(data, reagents, P)
 		reagents.trans_to(P, amount_per_item)
 

--- a/code/modules/reagents/chemistry/machinery/pandemic.dm
+++ b/code/modules/reagents/chemistry/machinery/pandemic.dm
@@ -82,8 +82,7 @@
 /obj/machinery/computer/pandemic/proc/create_culture(name, bottle_type = "culture", cooldown = 50)
 	var/obj/item/reagent_containers/glass/bottle/B = new/obj/item/reagent_containers/glass/bottle(loc)
 	B.icon_state = "bottle"
-	B.pixel_x = rand(-3, 3)
-	B.pixel_y = rand(-3, 3)
+	B.scatter_atom()
 	replicator_cooldown(cooldown)
 	B.name = "[name] [bottle_type] bottle"
 	return B

--- a/code/modules/research/backup_console.dm
+++ b/code/modules/research/backup_console.dm
@@ -270,8 +270,7 @@
 
 /obj/item/disk/rnd_backup_disk/Initialize(mapload)
 	. = ..()
-	pixel_x = rand(-5, 5)
-	pixel_y = rand(-5, 5)
+	scatter_atom()
 	// Level it all out
 	for(var/tech_id in GLOB.rnd_tech_id_to_name)
 		stored_tech_assoc[tech_id] = 0

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -453,9 +453,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 				SSblackbox.record_feedback("tally", "station_protolathe_production", amount, "[being_built.type]")
 			for(var/i in 1 to amount)
 				var/obj/item/new_item = new being_built.build_path(src)
-				if(istype(new_item)) // Only want a random pixel offset if it IS actually an item, and not a structure like a bluespace closet
-					new_item.pixel_x = rand(-5, 5)
-					new_item.pixel_y = rand(-5, 5)
+				new_item.scatter_atom()
 				if(istype(new_item, /obj/item/storage/backpack/holding))
 					new_item.investigate_log("built by [key]","singulo")
 				if(!istype(new_item, /obj/item/stack/sheet)) // To avoid materials dupe glitches

--- a/code/modules/ruins/lavalandruin_code/dead_ratvar.dm
+++ b/code/modules/ruins/lavalandruin_code/dead_ratvar.dm
@@ -144,15 +144,14 @@
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	var/randomsinglesprite = FALSE
 	var/randomspritemax = 2
-	var/sprite_shift = 9
+	scatter_distance = 9
 
 /obj/item/clockwork/alloy_shards/Initialize(mapload)
 	. = ..()
 	if(randomsinglesprite)
 		replace_name_desc()
 		icon_state = "[base_icon_state][rand(1, randomspritemax)]"
-		pixel_x = rand(-sprite_shift, sprite_shift)
-		pixel_y = rand(-sprite_shift, sprite_shift)
+		scatter_atom()
 
 /obj/item/clockwork/alloy_shards/proc/replace_name_desc()
 	name = "replicant alloy shard"
@@ -162,27 +161,27 @@
 	name = "clockwork golem scrap"
 	desc = "A pile of scrap metal. It seems damaged beyond repair."
 	icon_state = "clockgolem_dead"
-	sprite_shift = 0
+	scatter_distance = 0
 
 /obj/item/clockwork/alloy_shards/large
 	w_class = WEIGHT_CLASS_TINY
 	randomsinglesprite = TRUE
 	icon_state = "shard_large"
 	base_icon_state = "shard_large"
-	sprite_shift = 9
+	scatter_distance = 9
 
 /obj/item/clockwork/alloy_shards/medium
 	w_class = WEIGHT_CLASS_TINY
 	randomsinglesprite = TRUE
 	icon_state = "shard_medium"
 	base_icon_state = "shard_medium"
-	sprite_shift = 10
+	scatter_distance = 10
 
 /obj/item/clockwork/alloy_shards/medium/gear_bit
 	randomspritemax = 4
 	icon_state = "gear_bit1"
 	base_icon_state = "gear_bit"
-	sprite_shift = 12
+	scatter_distance = 12
 
 /obj/item/clockwork/alloy_shards/medium/gear_bit/replace_name_desc()
 	name = "gear bit"
@@ -201,7 +200,7 @@
 	randomspritemax = 3
 	icon_state = "shard_small"
 	base_icon_state = "shard_small"
-	sprite_shift = 12
+	scatter_distance = 12
 
 /obj/item/clockwork/alloy_shards/pinion_lock
 	name = "pinion lock"

--- a/code/modules/telesci/bscrystal.dm
+++ b/code/modules/telesci/bscrystal.dm
@@ -31,8 +31,7 @@
 
 /obj/item/stack/ore/bluespace_crystal/Initialize(mapload, new_amount, merge)
 	. = ..()
-	pixel_x = rand(-5, 5)
-	pixel_y = rand(-5, 5)
+	scatter_atom()
 
 /obj/item/stack/ore/bluespace_crystal/attack_self__legacy__attackchain(mob/user)
 	if(use(1))


### PR DESCRIPTION
## What Does This PR Do
Storage bags scatter contents on empty, and scatter them around the cursor when drag-and-dropped onto a table/floor.
Atom scatter is now consistently done through `scatter_atom`

## Why It's Good For The Game
Gives chefs more control over where they drop their dishes on the counter, and similar.

## Images of changes

https://github.com/user-attachments/assets/55d629bf-6fdf-4662-b337-664f9fb3bb05

(Ignore the debug output; that's since been removed.)

## Testing

<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <hr>

## Changelog
:cl:
tweak: Storage bags (including the chef's trays) now scatter their contents near the cursor when you drag-and-drop them onto a table or tile.
/:cl: