### PR TITLE
fix return value of check_datum_loop CI check

### DIFF
--- a/tools/ci/check_grep2.py
+++ b/tools/ci/check_grep2.py
@@ -139,12 +139,12 @@ FOR_ALL_DATUMS = re.compile(r"for\s*\(\s*var\/((\w+)(?:(?:\/\w+){2,})?)\)")
 FOR_ALL_NOT_DATUMS = re.compile(r"for\s*\(\s*var\/((?:atom|area|turf|obj|mob)(?:\/\w+))\)")
 def check_datum_loops(idx, line):
     if FOR_ALL_DATUMS.search(line) or FOR_ALL_NOT_DATUMS.search(line):
-        return Failure(
+        return [(
             idx + 1,
             # yes this will concatenate the strings, don't look too hard
             "Found a for loop without explicit contents. If you're trying to loop over everything in the world, first double check that you truly need to, and if so specify \'in world\'.\n"
             "If you're trying to check bare datums, please ensure that your value is only cast to /datum, and please make sure you use \'as anything\', or use a global list instead."
-        )
+        )]
 
 HREF_OLD_STYLE = re.compile(r"href[\s='\"\\]*\?")
 def check_href_styles(idx, line):


### PR DESCRIPTION
## What Does This PR Do
This PR fixes a CI check which was returning the wrong kind of return value, so its error messages weren't getting collected properly.
## Why It's Good For The Game
Fixes CI failure failure.
## Testing
Ran against https://github.com/ParadiseSS13/Paradise/pull/27788/commits/dd04dcfabafe5f9003afc06213cced946175f87b:

![2025_01_01__20_50_26__Comparing ParadiseSS13_master warriorstar-orion_ci_datums-return · ParadiseSS1](https://github.com/user-attachments/assets/95ac3472-36cd-4765-b84c-e25beaf4eebb)

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog
NPFC
