### PR TITLE
Touches up deltas science a little

### DIFF
--- a/_maps/map_files/stations/deltastation.dmm
+++ b/_maps/map_files/stations/deltastation.dmm
@@ -60366,6 +60366,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/science/test_chamber)
+"geq" = (
+/obj/machinery/firealarm/directional/east,
+/turf/simulated/floor/plasteel{
+	icon_state = "whitepurplecorner"
+	},
+/area/station/science/research)
 "get" = (
 /obj/effect/turf_decal/stripes/white/line,
 /turf/simulated/floor/plasteel,
@@ -72240,6 +72246,13 @@
 	icon_state = "vault"
 	},
 /area/station/command/bridge)
+"mXh" = (
+/obj/machinery/firealarm/directional/west,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "whitepurplecorner"
+	},
+/area/station/science/research)
 "mXA" = (
 /turf/simulated/wall,
 /area/station/medical/sleeper)
@@ -82625,6 +82638,13 @@
 	icon_state = "whitegreen"
 	},
 /area/station/medical/virology)
+"svR" = (
+/obj/machinery/firealarm/directional/north,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitepurplecorner"
+	},
+/area/station/science/research)
 "svX" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
@@ -85188,6 +85208,10 @@
 	icon_state = "neutralfull"
 	},
 /area/station/engineering/atmos)
+"tOx" = (
+/obj/machinery/firealarm/directional/west,
+/turf/simulated/floor/plasteel/white,
+/area/station/science/research)
 "tOF" = (
 /obj/structure/grille,
 /obj/structure/lattice,
@@ -125104,7 +125128,7 @@ hdu
 hnH
 ojf
 lSc
-cPn
+mXh
 cRd
 cZt
 hHk
@@ -127150,7 +127174,7 @@ fBk
 fBk
 fBk
 fBk
-dau
+svR
 yid
 cPn
 dFm
@@ -129460,7 +129484,7 @@ tQM
 cSm
 cZt
 cTU
-cMm
+tOx
 cXb
 cZt
 dZb
@@ -130246,7 +130270,7 @@ cSt
 cSt
 dIi
 dsu
-cSt
+geq
 cSt
 cSt
 dvj

--- a/_maps/map_files/stations/deltastation.dmm
+++ b/_maps/map_files/stations/deltastation.dmm
@@ -45066,10 +45066,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel,
 /area/station/science/xenobiology)
-"cVr" = (
-/obj/structure/sign/nosmoking_2,
-/turf/simulated/wall,
-/area/station/science/rnd)
 "cVs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -64514,6 +64510,7 @@
 	name = "Toxins Launcher Bay Door";
 	protected = 0
 	},
+/obj/structure/fans/tiny,
 /turf/simulated/floor/plating,
 /area/station/science/toxins/launch)
 "ixF" = (
@@ -82504,9 +82501,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central/nw)
-"ssx" = (
-/turf/simulated/floor/plasteel/dark,
-/area/station/science/break_room)
 "ssy" = (
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
@@ -82809,10 +82803,10 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/science/robotics,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/access/all/science/research,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/robotics/chargebay)
 "sAB" = (
@@ -86044,12 +86038,12 @@
 /area/station/security/permabrig)
 "ugy" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/science/robotics,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/mapping_helpers/airlock/access/all/science/research,
+/obj/machinery/door/airlock/research/glass,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/robotics/chargebay)
 "ugz" = (
@@ -87224,6 +87218,15 @@
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
+"uND" = (
+/obj/structure/sign/nosmoking_2{
+	pixel_y = 32
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitepurplecorner"
+	},
+/area/station/science/research)
 "uNJ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -89042,9 +89045,7 @@
 /area/station/medical/surgery/observation)
 "vPd" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/science/robotics,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -89054,6 +89055,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/research/glass,
+/obj/effect/mapping_helpers/airlock/access/all/science/research,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/robotics/chargebay)
 "vPo" = (
@@ -128946,7 +128949,7 @@ aNa
 qJw
 vDT
 fBk
-dau
+uND
 yid
 cPn
 hkY
@@ -128970,7 +128973,7 @@ dBe
 wJr
 oKa
 kxJ
-ssx
+ykJ
 ykJ
 hOr
 iqc
@@ -130741,7 +130744,7 @@ pGk
 xAc
 cSp
 cTQ
-cVr
+cTR
 cTR
 cTR
 cTR


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Gives science access to the mecha bay, as robotics had access to sci via it, so why should science not get that privilege?
Moves a sign, that was covering up the guest pass machine
Adds a tiny fan to the toxins launch room
And fixes a tile that was the wrong colour in break room.
Also adds some fire alarms scattered about the main hall for sci, as it lacked them before hand. 
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
As stated above, robotics can just run into rnd via the mecha bay, and the door is just kinda.. in rnd, it's a strange design choice, but RND not having access to the door that leads into/out of their room was something thats bugged me for a  while.
The sign is self explanatory, it was covering the guestpass machine
The fan makes toxins 100% less annoying todo
And there was a stray floor tile that i think i did ages ago, thats just never been fixed
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![dreamseeker_tRQonmC3dZ](https://github.com/user-attachments/assets/657f287a-51b6-41f4-8fa8-488e18b03100)
![StrongDMM_GaLIOIKIzI](https://github.com/user-attachments/assets/e6aca156-270c-4fe8-8d4d-9559ac1d8e31)
![dreamseeker_ms4cZQZh0n](https://github.com/user-attachments/assets/dd3d4a21-7118-4f41-a309-d576ec27a06f)
![dreamseeker_1FoVcGP2bR](https://github.com/user-attachments/assets/7c2c56df-559f-4b4c-8dcb-aa2f2704a449)
![dreamseeker_1tfXuWakNB](https://github.com/user-attachments/assets/3a6151ca-d0e0-41bf-8c52-b25f9addf223)
![dreamseeker_5rmgKpEXz4](https://github.com/user-attachments/assets/a51292b8-09a5-4cc2-84a3-fa909278c912)
![dreamseeker_9xkJNVRLAU](https://github.com/user-attachments/assets/8d447ed9-340e-4837-897d-4c0b60f712c8)
![StrongDMM_eWXe1HJ6eG](https://github.com/user-attachments/assets/4afe6790-f74b-434b-9b8b-21cb36dd46fd)
![StrongDMM_tk9tQPiXUX](https://github.com/user-attachments/assets/d7b7747e-fdbc-4edd-af10-d91c5d29a1f5)
![StrongDMM_gMIdRsBXL0](https://github.com/user-attachments/assets/61699108-a85d-4cf5-8fb8-dfb6c4b70ecf)
![StrongDMM_oJ8JfCkZXx](https://github.com/user-attachments/assets/0ae8445b-2b84-448b-b369-46dde0583e44)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
see above

<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
add: Added some fire alarms to science on delta
tweak: Sci now has access to the Mech bay on delta
tweak: Added a tiny fan to the toxins launch room of delta, as it was very finicky todo without it
tweak: Moved a sign that was covering the guest pass machine in RND on delta.
fix: Fixed a stray tile in deltas break room that was the wrong colour
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
