### PR TITLE
Adds announcement of job objectives upon spawning in

### DIFF
--- a/code/controllers/subsystem/SSjobs.dm
+++ b/code/controllers/subsystem/SSjobs.dm
@@ -491,6 +491,16 @@ SUBSYSTEM_DEF(jobs)
 
 	to_chat(H, chat_box_green(L.Join("<br>")))
 
+	// If the job has objectives, announce those too
+	if(length(H.mind.job_objectives))
+		var/list/objectives_message = list()
+		var/counter = 1
+		for(var/datum/job_objective/objective as anything in H.mind.job_objectives)
+			objectives_message.Add("<b>Objective #[counter]: [objective.objective_name]</b>")
+			objectives_message.Add("[objective.description]<br>")
+			counter++
+		to_chat(H, chat_box_notice(objectives_message.Join("<br>")))
+
 	return H
 
 /datum/controller/subsystem/jobs/proc/EquipRank(mob/living/carbon/human/H, rank, joined_late = 0) // Equip and put them in an area

--- a/code/game/jobs/job_objectives/science.dm
+++ b/code/game/jobs/job_objectives/science.dm
@@ -25,7 +25,7 @@
 //Cyborgs
 /datum/job_objective/make_cyborg
 	objective_name = "Construct Additional Cyborgs"
-	description = "Construct at least one cyborg for the station to increase workplace productivity"
+	description = "Construct at least one cyborg for the station to increase workplace productivity."
 	gives_payout = TRUE
 	completion_payment = 100
 


### PR DESCRIPTION
## What Does This PR Do

When you spawn in, you get notified about your job objectives (currently: RD, scientist, roboticist, virologist). These are the same objectives you can already find in IC > Notes.

## Why It's Good For The Game

Job objectives, that are meant for new players to get started in their department, will be actually displayed for said new players, not just get tucked away in an obscure IC verb.

I intend to add more job objectives, figured I'd split this into two separate PRs.

## Images of changes

Roboticist:

![image](https://github.com/user-attachments/assets/72b6d690-17a6-465e-b633-5f0a7257ccbe)

Scientist:

![image](https://github.com/user-attachments/assets/77a66ab8-8d9e-41e5-8e3f-65ca92e2f163)

Research Director:

![image](https://github.com/user-attachments/assets/64c33224-d7d1-42dc-a1a2-43c9def3ab31)

Virologist:

![image](https://github.com/user-attachments/assets/ff12a364-c12e-4f49-8835-822cff2b7ea1)


## Testing

1. Spawn in as a Scientist, Roboticist, Research Director, or Virologist
2. Take screenshots as above

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
add: Job objectives are now displayed when you spawn in (currently, this is for the Research Director, Roboticists, Scientists, and the Virologist).
/:cl:
