### PR TITLE
Let chefs dump entire bags into kitchen appliances

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
@@ -119,8 +119,30 @@
 
 		for(var/datum/reagent/R in O.reagents.reagent_list)
 			if(!(R.id in GLOB.cooking_reagents[recipe_type]))
-				to_chat(user, "<span class='alert'>Your [O] contains components unsuitable for cookery.</span>")
+				to_chat(user, "<span class='alert'>Your [O.name] contains components unsuitable for cookery.</span>")
 				return TRUE
+	else if(istype(O, /obj/item/storage))
+		var/obj/item/storage/S = O
+		if(!S.allow_quick_empty)
+			to_chat(user, "<span class='alert'>[O] is too awkward a shape to dump into [src].</span>")
+			return TRUE
+		if(length(S.contents) + length(contents) >= max_n_of_items)
+			to_chat(user, "<span class='alert'>You can't fit everything from [O] into [src].</span>")
+			return TRUE
+		if(length(S.contents) == 0)
+			to_chat(user, "<span class='alert'>[O] is empty!</span>")
+			return TRUE
+		for(var/obj/item/ingredient in O.contents)
+			if(!is_type_in_list(ingredient, GLOB.cooking_ingredients[recipe_type]) && !istype(ingredient, /obj/item/mixing_bowl))
+				to_chat(user, "<span class='alert'>Your [O.name] contains contents unsuitable for cookery.</span>")
+				return TRUE
+		S.hide_from(user)
+		user.visible_message("<span class='notice'>[user] dumps [O] into [src].</span>", "<span class='notice'>You dump [O] into [src].</span>")
+		for(var/obj/item/ingredient in O.contents)
+			S.remove_from_storage(ingredient, src)
+			CHECK_TICK
+		SStgui.update_uis(src)
+
 
 	else if(istype(O, /obj/item/grab))
 		var/obj/item/grab/G = O


### PR DESCRIPTION
## What Does This PR Do
Lets chefs dump entire bags/trays into kitchen appliances. Only works with things that can be quick-emptied onto the floor.
Fixes a minor grammar error when trying to put incorrect reagents into kitchen appliances

## Why It's Good For The Game
Moving things one-by-one is annoying. Now you can drop all the ingredients you need out of the fridge, and move them together.

## Testing
Tried dumping a backpack into a microwave.
Tried putting a kitchen knife into a microwave.
Tried emptying an empty serving tray into a microwave.
Tried emptying a serving tray containing a cream carton into a microwave.
Put one olive into a microwave with a serving tray.
Put one olive into a microwave by hand.
Put several olives into a microwave with a serving tray.
Tried to add enough olives with a serving tray that the microwave would be overfilled.
Tried to add olives and a cream carton to a microwave with a serving tray.
Tried to add dozens of olives to a microwave with a plant bag.
Forcemoved a mixing bowl into a serving tray and emptied the tray into a microwave.
Watched the microwave's UI when adding an olive to it.
Tried to add universal enzyme to a microwave.

<hr>

### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <hr>

## Changelog
:cl:
add: Chefs can now dump entire bags/trays into kitchen appliances. Only works with bags that can be quick-emptied onto the floor, including serving trays and plant bags, but not backpacks.
spellcheck: Removed an errant "the" when trying to add unsuitable reagents to a microwave.
/:cl: