### PR TITLE
Gives Paramedic MODsuit more Radiation Protection

### DIFF
--- a/code/modules/mod/mod_theme.dm
+++ b/code/modules/mod/mod_theme.dm
@@ -553,7 +553,7 @@
 	)
 
 /obj/item/mod/armor/mod_theme_rescue
-	armor = list(MELEE = 20, BULLET = 20, LASER = 5, ENERGY = 5, BOMB = 10, RAD = 50, FIRE = 150, ACID = 150) //Extra melee / bullet armor for if they get caught in a fight. Of course, no laser armor.
+	armor = list(MELEE = 20, BULLET = 20, LASER = 5, ENERGY = 5, BOMB = 10, RAD = 150, FIRE = 150, ACID = 150) //Extra melee / bullet armor for if they get caught in a fight. Of course, no laser armor.
 
 /datum/mod_theme/research
 	name = "'Minerva' research"


### PR DESCRIPTION
## What Does This PR Do
Increases the radiation protection on the paramedic MODsuit.
## Why It's Good For The Game
Allows paramedics to rescue engineers when they inevitably blow up the station without sustaining maximum brain damage for each body.
## Testing
TBC (for values)

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
![Discord_xNItwXGWGt](https://github.com/user-attachments/assets/1577e7d5-7aee-4368-891b-e7af69bb2ceb)
<hr>

## Changelog
:cl:
tweak: Increased radiation protection on paramedic MODsuits.
/:cl: