### PR TITLE
Buff mining mod from vendor

### DIFF
--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -40,7 +40,7 @@
 	prize_list["Modsuits and Exosuits"] = list(
 		EQUIPMENT("Standard MODsuit", /obj/item/mod/control/pre_equipped/standard/explorer, 1000),
 		EQUIPMENT("Advanced Jetpack Module", /obj/item/mod/module/jetpack/advanced, 2000),
-		EQUIPMENT("Mining MODsuit", /obj/item/mod/control/pre_equipped/mining/vendor, 3500),
+		EQUIPMENT("Mining MODsuit", /obj/item/mod/control/pre_equipped/mining, 3500),
 		EQUIPMENT("Asteroid MODsuit Skin", /obj/item/mod/skin_applier/asteroid, 1000),
 		EQUIPMENT("Exosuit Grenade Launcher", /obj/item/mecha_parts/mecha_equipment/weapon/energy/mining_grenade, 2500),
 	)
@@ -407,7 +407,7 @@
 		EQUIPMENT("Standard MODsuit", /obj/item/mod/control/pre_equipped/standard/explorer, 1000),
 		EQUIPMENT("Advanced Jetpack Module", /obj/item/mod/module/jetpack/advanced, 2000),
 		EQUIPMENT("Exosuit Jetpack Module", /obj/item/mecha_parts/mecha_equipment/thrusters, 1500), // they stack up, so put 3-4 for FTL speed.
-		EQUIPMENT("Mining MODsuit", /obj/item/mod/control/pre_equipped/mining/vendor, 3500),
+		EQUIPMENT("Mining MODsuit", /obj/item/mod/control/pre_equipped/mining, 3500),
 		EQUIPMENT("Asteroid MODsuit Skin", /obj/item/mod/skin_applier/asteroid, 1000),
 		EQUIPMENT("Exosuit Grenade Launcher", /obj/item/mecha_parts/mecha_equipment/weapon/energy/mining_grenade, 2500)
 	)

--- a/code/modules/mod/mod_types.dm
+++ b/code/modules/mod/mod_types.dm
@@ -118,7 +118,7 @@
 	theme = /datum/mod_theme/mining
 	applied_core = /obj/item/mod/core/plasma
 	applied_modules = list(
-		/obj/item/mod/module/storage,
+		/obj/item/mod/module/storage/large_capacity,
 		/obj/item/mod/module/gps,
 		/obj/item/mod/module/orebag,
 		/obj/item/mod/module/clamp,
@@ -129,18 +129,6 @@
 		/obj/item/mod/module/drill,
 		/obj/item/mod/module/sphere_transform,
 	)
-
-/// visit robotics.
-/obj/item/mod/control/pre_equipped/mining/vendor
-	theme = /datum/mod_theme/mining
-	applied_core = /obj/item/mod/core/plasma
-	applied_modules = list(
-		/obj/item/mod/module/storage,
-	)
-	default_pins = list(
-		/obj/item/mod/module/sphere_transform,
-	)
-
 
 /// The asteroid skin, as that one looks more space worthy / older. Good for space ruins.
 /obj/item/mod/control/pre_equipped/mining/asteroid


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Buffs mining mod for miners by making it full packaged when buying from vendor + all mining mods (e.g. from ruins) now carry an expanded capacity storage.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

Mod for 3500 mining points gives you.. default storage and thats all. However a standard (explorer) mod for 1000 pts gives you a large capacity storage, welding shield module, jetpack. Kinda unfair to miners + explorers have the mod by roundstart.

There was a comment "visit robotics to get the modules" in the code, but you still would like to visit robotics to get the medical hud, thermal regulation, holster, welding shield or a syndie storage. 

A default version only has all needed for a miner to.. "mine", the rest are up to those who would like to get the max of their modsuit. After all, you are wasting 3500 pts on that.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Bought one on local, ensured the modules are in.

<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>
  

## Changelog

:cl:
tweak: Mining mod from vendor now goes full packaged, as well as all mining mods now have a large capacity storage by default.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
