### PR TITLE
Change behavior when using 2 UI dependent modsuit modules.

### DIFF
--- a/code/modules/mod/modules/modules_medical.dm
+++ b/code/modules/mod/modules/modules_medical.dm
@@ -115,19 +115,22 @@
 	toolspeed = 2
 	defib_cooldown = 2.5 SECONDS
 
-///Crew Monitor - Deploys or retracts a built-in handheld crew monitor
 /obj/item/mod/module/monitor
 	name = "MOD crew monitor module"
 	desc = "A module installed into the wrist of the suit, this presents a display of crew sensor data."
 	icon_state = "scanner"
-	module_type = MODULE_ACTIVE
+	module_type = MODULE_USABLE
 	complexity = 1
-	active_power_cost = DEFAULT_CHARGE_DRAIN * 0.3
-	device = /obj/item/sensor_device/mod
+	use_power_cost = DEFAULT_CHARGE_DRAIN * 0.3
 	incompatible_modules = list(/obj/item/mod/module/monitor)
 	cooldown_time = 0.5 SECONDS
+	allow_flags = MODULE_ALLOW_INACTIVE
+	var/datum/ui_module/crew_monitor/mod/crew_monitor
 
-/obj/item/sensor_device/mod
-	name = "MOD crew monitor"
-	desc = "A miniature machine built into a modsuit that tracks suit sensors across the station."
-	flags = NODROP
+
+/obj/item/mod/module/monitor/Initialize(mapload)
+	. = ..()
+	crew_monitor = new(src)
+
+/obj/item/mod/module/monitor/on_use()
+	crew_monitor.ui_interact(mod.wearer)

--- a/code/modules/mod/modules/modules_supply.dm
+++ b/code/modules/mod/modules/modules_supply.dm
@@ -7,12 +7,20 @@
 		down to the exact coordinates. This information is fed to a central database viewable from the device itself, \
 		though using it to help people is up to you."
 	icon_state = "gps"
-	module_type = MODULE_ACTIVE
+	module_type = MODULE_USABLE
 	complexity = 1
 	use_power_cost = DEFAULT_CHARGE_DRAIN * 0.2
 	incompatible_modules = list(/obj/item/mod/module/gps)
 	cooldown_time = 0.5 SECONDS
-	device = /obj/item/gps/mod
+	allow_flags = MODULE_ALLOW_INACTIVE
+	var/obj/item/gps/mod/gps
+
+/obj/item/mod/module/gps/Initialize(mapload)
+	. = ..()
+	gps = new(src)
+
+/obj/item/mod/module/gps/on_use()
+	gps.attack_self__legacy__attackchain(mod.wearer)
 
 ///Hydraulic Clamp - Lets you pick up and drop crates.
 /obj/item/mod/module/clamp

--- a/code/modules/telesci/gps.dm
+++ b/code/modules/telesci/gps.dm
@@ -62,8 +62,8 @@ GLOBAL_LIST_EMPTY(GPS_list)
 	update_icon(UPDATE_OVERLAYS)
 	addtimer(CALLBACK(src, PROC_REF(reboot)), EMP_DISABLE_TIME)
 
-/obj/item/gps/AltClick(mob/user)
-	if(ui_status(user, GLOB.inventory_state) != UI_INTERACTIVE)
+/obj/item/gps/AltClick(mob/user, state)
+	if(ui_status(user, state) != UI_INTERACTIVE)
 		return //user not valid to use gps
 	if(emped)
 		to_chat(user, "<span class='warning'>It's busted!</span>")
@@ -130,7 +130,7 @@ GLOBAL_LIST_EMPTY(GPS_list)
 		ui = new(user, src, "GPS", "GPS")
 		ui.open()
 
-/obj/item/gps/ui_act(action, list/params)
+/obj/item/gps/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
 	if(..())
 		return
 
@@ -144,7 +144,7 @@ GLOBAL_LIST_EMPTY(GPS_list)
 			gpstag = newtag
 			name = "global positioning system ([gpstag])"
 		if("toggle")
-			AltClick(usr)
+			AltClick(usr, state)
 			return FALSE
 		if("same_z")
 			same_z = !same_z
@@ -181,7 +181,10 @@ GLOBAL_LIST_EMPTY(GPS_list)
 	icon_state = "gps-m"
 	gpstag = "MOD0"
 	desc = "A positioning system helpful for rescuing trapped or injured miners, after you have become lost from rolling around at the speed of sound."
-	flags = NODROP
+	tracking = FALSE
+
+/obj/item/gps/mod/ui_state()
+	return GLOB.deep_inventory_state
 
 /obj/item/gps/cyborg
 	icon_state = "gps-b"

--- a/code/modules/tgui/modules/crew_monitor.dm
+++ b/code/modules/tgui/modules/crew_monitor.dm
@@ -124,6 +124,12 @@
 
 	return data
 
+/datum/ui_module/crew_monitor/mod
+	name = "Crew monitor (Modsuit)"
+
+/datum/ui_module/crew_monitor/mod/ui_state(mob/user)
+	return GLOB.deep_inventory_state
+
 /datum/ui_module/crew_monitor/ghost
 	name = "Crew monitor (Observer)"
 	is_advanced = TRUE


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Makes UI based modsuit modules act like on TG.
Allows to use crew monitor module, gps module with modsuit state off.
Doesn't anymore spawns a crew monitor/gps in your hand with nodrop flag, instead just opens a UI on module use.
Turns off mod's GPS by default, so you are not going to see "Syndiecake" or "DK Excavator" on your GPS roundstart because of the mods that are spawned in the ruins.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

There was no point of using them. Most of the time you use GPS or a crew monitor - you have them in pockets, belt or chest slot, so their UI stands open and you can track the data to get the most recent info. Having them in your hands was ridiculous.

With this PR they become useful - you trade 1 pocket or similar slot for 1 modsuit complexity. 

Blueshield doesn't have to turn on his modsuit in order to track the heads' vital sensors. Same for miners/explorers.

IMO you shouldn't be able to spot space ruins by mods' GPS that are being spawned inside a ruin, better to just use a GPS mark for a ruin.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Ensured they are working (after many hours of testing).
Checked that removing a module from modsuit closes the UI.
Checked that throwing a modsuit away closes the UI.

However I could add something useless or break something so it's better to review the code and point me out if I really did.

<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
tweak: GPS and Crew monitor modules don't anymore spawn a proper item in your hand, instead, they open a UI on use.
tweak: GPS and Crew monitor modules don't anymore require modsuit to be active in order to be used.
tweak: GPS inside a modsuit's GPS module is turned off by default, so you have to manually turn it on.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
