### PR TITLE
Fixes Farragus Service Bathroom Area Being "Dormitory Toilets"

### DIFF
--- a/_maps/map_files/stations/cerestation.dmm
+++ b/_maps/map_files/stations/cerestation.dmm
@@ -2990,7 +2990,7 @@
 	name = "Cyborg Recharger"
 	},
 /turf/simulated/floor/plasteel/freezer,
-/area/station/public/toilet)
+/area/station/public/toilet/unisex)
 "azS" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -14512,7 +14512,7 @@
 /area/station/public/quantum/security)
 "bUc" = (
 /turf/simulated/floor/plasteel/freezer,
-/area/station/public/toilet)
+/area/station/public/toilet/unisex)
 "bUg" = (
 /obj/structure/table,
 /obj/item/storage/fancy/donut_box,
@@ -42120,7 +42120,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel/freezer,
-/area/station/public/toilet)
+/area/station/public/toilet/unisex)
 "hRF" = (
 /obj/machinery/door/airlock/atmos/glass{
 	autoclose = 0;
@@ -46942,7 +46942,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel/freezer,
-/area/station/public/toilet)
+/area/station/public/toilet/unisex)
 "jbn" = (
 /obj/structure/sign/atmosplaque{
 	pixel_y = 32
@@ -53695,7 +53695,7 @@
 	},
 /obj/machinery/recharge_station,
 /turf/simulated/floor/plasteel/freezer,
-/area/station/public/toilet)
+/area/station/public/toilet/unisex)
 "kHU" = (
 /obj/item/ashtray/glass,
 /obj/structure/table/wood,
@@ -57593,7 +57593,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel/freezer,
-/area/station/public/toilet)
+/area/station/public/toilet/unisex)
 "lFB" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -59588,7 +59588,7 @@
 	name = "Toilet"
 	},
 /turf/simulated/floor/plasteel/freezer,
-/area/station/public/toilet)
+/area/station/public/toilet/unisex)
 "mfu" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -67015,7 +67015,7 @@
 /obj/structure/curtain/open/shower,
 /obj/machinery/firealarm/directional/south,
 /turf/simulated/floor/plasteel/freezer,
-/area/station/public/toilet)
+/area/station/public/toilet/unisex)
 "oeQ" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
@@ -69394,7 +69394,7 @@
 	name = "Bathroom"
 	},
 /turf/simulated/floor/plasteel/freezer,
-/area/station/public/toilet)
+/area/station/public/toilet/unisex)
 "oLl" = (
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /obj/structure/cable/orange{
@@ -73770,7 +73770,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel/freezer,
-/area/station/public/toilet)
+/area/station/public/toilet/unisex)
 "pPN" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -74858,7 +74858,7 @@
 "qdP" = (
 /obj/structure/sign/restroom,
 /turf/simulated/wall,
-/area/station/public/toilet)
+/area/station/public/toilet/unisex)
 "qdQ" = (
 /obj/machinery/firealarm/directional/east,
 /turf/simulated/floor/plasteel{
@@ -76804,7 +76804,7 @@
 /obj/item/soap/nanotrasen,
 /obj/structure/curtain/open/shower,
 /turf/simulated/floor/plasteel/freezer,
-/area/station/public/toilet)
+/area/station/public/toilet/unisex)
 "qDd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -81246,7 +81246,7 @@
 /area/station/hallway/secondary/entry/north)
 "rNT" = (
 /turf/simulated/wall,
-/area/station/public/toilet)
+/area/station/public/toilet/unisex)
 "rNW" = (
 /obj/effect/spawner/random/barrier/obstruction,
 /turf/simulated/floor/plating/asteroid/ancient,
@@ -85177,7 +85177,7 @@
 /obj/structure/curtain/open/shower,
 /obj/machinery/alarm/directional/north,
 /turf/simulated/floor/plasteel/freezer,
-/area/station/public/toilet)
+/area/station/public/toilet/unisex)
 "sLQ" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
@@ -88312,7 +88312,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel/freezer,
-/area/station/public/toilet)
+/area/station/public/toilet/unisex)
 "tzy" = (
 /obj/structure/sink{
 	dir = 8;
@@ -91557,7 +91557,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/plasteel/freezer,
-/area/station/public/toilet)
+/area/station/public/toilet/unisex)
 "upd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -93621,7 +93621,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel/freezer,
-/area/station/public/toilet)
+/area/station/public/toilet/unisex)
 "uNw" = (
 /obj/structure/chair/sofa/corp{
 	dir = 1
@@ -96775,7 +96775,7 @@
 /area/station/turret_protected/ai_upload)
 "vCl" = (
 /turf/simulated/wall/r_wall,
-/area/station/public/toilet)
+/area/station/public/toilet/unisex)
 "vCs" = (
 /obj/structure/sink{
 	dir = 4;
@@ -98058,7 +98058,7 @@
 	pixel_x = 11
 	},
 /turf/simulated/floor/plasteel/freezer,
-/area/station/public/toilet)
+/area/station/public/toilet/unisex)
 "vSy" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Swaps the area of the Farragus Service Asteroid bathroom from Dormitory Toilets to Unisex Restroom
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
The toilets are not in dorms. The labelling will direct engineers and atmos techs to the incorrect part of the station if an alarm goes off there. This is bad and should be fixed.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Loaded in.
Saw it was unisex and not dorm.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Fixed Farragus' service toilets being incorrectly labelled as "Dormitory Toilets".
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
