### PR TITLE
Half printing price of alien alloy sheets

### DIFF
--- a/code/modules/research/designs/smelting_designs.dm
+++ b/code/modules/research/designs/smelting_designs.dm
@@ -49,7 +49,7 @@
 	id = "alienalloy"
 	req_tech = list("abductor" = 1, "materials" = 7, "plasmatech" = 2)
 	build_type = PROTOLATHE | SMELTER
-	materials = list(MAT_METAL = MINERAL_MATERIAL_AMOUNT * 2, MAT_PLASMA = MINERAL_MATERIAL_AMOUNT * 2)
+	materials = list(MAT_METAL = MINERAL_MATERIAL_AMOUNT, MAT_PLASMA = MINERAL_MATERIAL_AMOUNT)
 	build_path = /obj/item/stack/sheet/mineral/abductor
 	category = list("Stock Parts")
 	lathe_time_factor = 5


### PR DESCRIPTION
## What Does This PR Do

Half the price of "Alien Alloy" sheets from the protolathe and ORM so they only cost 1 metal and 1 plasma instead of 2 metal and 2 plasma per sheets.

## Why It's Good For The Game

Alien Alloy is a "decorative" items much like plastitanium glass and plasma glass, except unlike those it has no real benefits to regular walls and tables AND cost twice as much, leading to anyone wanting to make a fancy alien area to drain all of the plasma from the ORM.

Now instead we can cover twice as much of the station in abductor coating for the same price.

## Testing

Checked the material pricing on the protolathe.

Printed an alien alloy sheet from the protolathe. Checked it only used one metal and plasma and not two of each, it did.

Printed an alien alloy sheet from the ORM. Checked it only used one metal and plasma and not two of each, it did.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <hr>

## Changelog

:cl:
tweak: HOT NEW DEAL ON ALIEN ALLOYS: 50% OFF!
/:cl:
