### PR TITLE
Fix a couple logging runtimes

### DIFF
--- a/code/__HELPERS/_logging.dm
+++ b/code/__HELPERS/_logging.dm
@@ -52,7 +52,7 @@ GLOBAL_PROTECT(log_end)
 		rustg_log_write(GLOB.world_game_log, "VOTE: [text][GLOB.log_end]")
 
 /proc/log_if_mismatch(mob/who, message)
-	if(!isnull(usr) && istype(who) && usr.last_known_ckey != who.last_known_ckey)
+	if(istype(usr, /mob) && istype(who) && usr.last_known_ckey != who.last_known_ckey)
 		rustg_log_write(GLOB.world_game_log, "LOG USER MISMATCH: [usr.simple_info_line()] was usr for [message][GLOB.log_end]")
 
 /proc/log_access_in(client/new_client)
@@ -105,7 +105,10 @@ GLOBAL_PROTECT(log_end)
 
 /proc/log_attack(mob/attacker, defender_str, attack_message)
 	if(GLOB.configuration.logging.attack_logging)
-		var/message = "ATTACK: [attacker.simple_info_line()] against [defender_str]: [attack_message]"
+		var/attacker_str = "INVALID"
+		if(istype(attacker))
+			attacker_str = attacker.simple_info_line()
+		var/message = "ATTACK: [attacker_str] against [defender_str]: [attack_message]"
 		rustg_log_write(GLOB.world_game_log, "[message][GLOB.log_end]")
 		log_if_mismatch(attacker, message)
 


### PR DESCRIPTION
## What Does This PR Do
Fix a couple logging runtimes

## Why It's Good For The Game
Runtimes bad.

## Testing
Tried shooting a watcher with a KA. No runtime.
Tried hallucinating. No runtime.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog
NPFC