### PR TITLE
Borg Plushies Have Selectable Modules, Adds Missing Species Plushies to Plush Spawner

### DIFF
--- a/code/game/objects/effects/spawners/random/plushie_spawners.dm
+++ b/code/game/objects/effects/spawners/random/plushie_spawners.dm
@@ -53,13 +53,19 @@
 			/obj/item/toy/plushie/tuxedo_cat
 		),
 
-		list(// species plushie minus nian
-			/obj/item/toy/plushie/voxplushie,
-			/obj/item/toy/plushie/ipcplushie,
+		list(// Species plushies minus Nian.
+			/obj/item/toy/plushie/dionaplushie,
+			/obj/item/toy/plushie/draskplushie,
 			/obj/item/toy/plushie/greyplushie,
-			/obj/item/toy/plushie/nianplushie,
+			/obj/item/toy/plushie/humanplushie,
+			/obj/item/toy/plushie/kidanplushie,
+			/obj/item/toy/plushie/ipcplushie,
+			/obj/item/toy/plushie/plasmamanplushie,
+			/obj/item/toy/plushie/skrellplushie,
+			/obj/item/toy/plushie/voxplushie,
 			/obj/item/toy/plushie/abductor,
-			/obj/item/toy/plushie/abductor/agent
+			/obj/item/toy/plushie/abductor/agent,
+			/obj/item/toy/plushie/borgplushie/random
 		),
 
 		list (

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -1106,7 +1106,7 @@
 		return
 
 	borg_plushie_overlay = plushie_module_overlays[user_selection]
-	to_chat(user, "<span class = 'notice'>The fabric on [src] changes color, turning it into a [borg_plushie_overlay] plush!</span>")
+	to_chat(user, "<span class = 'notice'>The fabric on [src] changes color, transforming it into \a [lowertext(user_selection)] plush!</span>")
 	update_icon()
 	plushie_module_selected = TRUE
 

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -1115,12 +1115,12 @@
 		return 	. = ..()
 	
 	if(!plushie_module_selected)
-		to_chat(user,"<span class = 'warning'>[src] is already in standard mode!</span>")
+		to_chat(user, "<span class = 'warning'>[src] is already in standard mode!</span>")
 		return ITEM_INTERACT_COMPLETE
 	
 	borg_plushie_overlay = "plushie_borgassist"
 	update_icon()
-	to_chat(user,"<span class = 'notice'>The fabirc on [src] changes color, reverting it back to standard mode.</span>")
+	to_chat(user, "<span class = 'notice'>The fabirc on [src] changes color, reverting it back to standard mode.</span>")
 	plushie_module_selected = FALSE
 	qdel(used)
 	return ITEM_INTERACT_COMPLETE
@@ -1167,7 +1167,7 @@
 
 /obj/item/toy/plushie/borgplushie/random/Initialize(mapload)
 	. = ..()
-	borg_plushie_overlay = (pick("plushie_borgjan", "plushie_borgsec", "plushie_borgmed", "plushie_borgmine", "plushie_borgserv", "plushie_borgassist", "plushie_borgengi"))
+	borg_plushie_overlay = pick("plushie_borgjan", "plushie_borgsec", "plushie_borgmed", "plushie_borgmine", "plushie_borgserv", "plushie_borgassist", "plushie_borgengi")
 	if(borg_plushie_overlay != "plushie_borgassist")
 		plushie_module_selected = TRUE
 	update_icon()

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -1056,15 +1056,74 @@
 
 /obj/item/toy/plushie/borgplushie
 	name = "borg plushie"
-	desc = "The synthetic backbone of the station, rendered in plush form. Inbuilt flashlight included!"
+	desc = "The synthetic backbone of the station, rendered in plush form. Features a built-in flashlight and polychromic fabric."
 	icon_state = "plushie_borg"
-	var/borg_plushie_overlay
+	var/borg_plushie_overlay = "plushie_borgassist"
+	var/plushie_module_selected = FALSE
 	var/on = FALSE
 
 /obj/item/toy/plushie/borgplushie/Initialize(mapload)
 	. = ..()
-	borg_plushie_overlay = (pick("plushie_borgjan", "plushie_borgsec", "plushie_borgmed", "plushie_borgmine", "plushie_borgserv", "plushie_borgassist", "plushie_borgengi"))
 	update_icon()
+
+/obj/item/toy/plushie/borgplushie/examine(mob/user)
+	. = ..()
+	if(!plushie_module_selected)
+		. += "<span class = 'notice'>Alt-Click [src] to change its color.</span>"
+	else
+		. += "<span class = 'notice'>You can use a cyborg module reset board to change [src] back into standard mode.</span>"
+
+/obj/item/toy/plushie/borgplushie/AltClick(mob/user)
+	if(!istype(user) || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED) || !Adjacent(user))
+		return
+
+	pick_borg_plush_module()
+
+/obj/item/toy/plushie/borgplushie/proc/pick_borg_plush_module(mob/user)
+	if(plushie_module_selected)
+		return
+
+	var/static/list/menu_options = list(
+		"Security"		= image('icons/mob/robots.dmi', "security-radial"),
+		"Engineering"	= image('icons/mob/robots.dmi', "engi-radial"),
+		"Mining"		= image('icons/mob/robots.dmi', "mining-radial"),
+		"Service"		= image('icons/mob/robots.dmi', "serv-radial"),
+		"Medical"		= image('icons/mob/robots.dmi', "med-radial"),
+		"Janitor"		= image('icons/mob/robots.dmi', "jan-radial")
+		)
+	var/static/list/plushie_module_overlays = list(
+		"Security"		= "plushie_borgsec",
+		"Engineering"	= "plushie_borgengi",
+		"Mining"		= "plushie_borgmine",
+		"Service"		= "plushie_borgserv",
+		"Medical"		= "plushie_borgmed",
+		"Janitor"		= "plushie_borgjan"
+	)
+	playsound(src, 'sound/effects/pop.ogg', 50, TRUE)
+	var/user_selection = show_radial_menu(user, src, menu_options, require_near = TRUE, radius = 42)
+
+	if(!user_selection)
+		return
+
+	borg_plushie_overlay = plushie_module_overlays[user_selection]
+	to_chat(user, "<span class = 'notice'>The fabric on [src] changes color, turning it into a [borg_plushie_overlay] plush!</span>")
+	update_icon()
+	plushie_module_selected = TRUE
+
+/obj/item/toy/plushie/borgplushie/item_interaction(mob/living/user, obj/item/used, list/modifiers)
+	if(!istype(used, /obj/item/borg/upgrade/reset))
+		return 	. = ..()
+	
+	if(!plushie_module_selected)
+		to_chat(user,"<span class = 'warning'>[src] is already in standard mode!</span>")
+		return ITEM_INTERACT_COMPLETE
+	
+	borg_plushie_overlay = "plushie_borgassist"
+	update_icon()
+	to_chat(user,"<span class = 'notice'>The fabirc on [src] changes color, reverting it back to standard mode.</span>")
+	plushie_module_selected = FALSE
+	qdel(used)
+	return ITEM_INTERACT_COMPLETE
 
 /obj/item/toy/plushie/borgplushie/activate_self(mob/user)
 	if(..())
@@ -1103,6 +1162,15 @@
 			explosive_betrayal(grenade)
 		if(!QDELETED(src))
 			qdel(src)
+
+/obj/item/toy/plushie/borgplushie/random
+
+/obj/item/toy/plushie/borgplushie/random/Initialize(mapload)
+	. = ..()
+	borg_plushie_overlay = (pick("plushie_borgjan", "plushie_borgsec", "plushie_borgmed", "plushie_borgmine", "plushie_borgserv", "plushie_borgassist", "plushie_borgengi"))
+	if(borg_plushie_overlay != "plushie_borgassist")
+		plushie_module_selected = TRUE
+	update_icon()
 
 /obj/item/toy/plushie/dionaplushie
 	name = "diona plushie"

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -1120,7 +1120,7 @@
 	
 	borg_plushie_overlay = "plushie_borgassist"
 	update_icon()
-	to_chat(user, "<span class = 'notice'>The fabirc on [src] changes color, reverting it back to standard mode.</span>")
+	to_chat(user, "<span class = 'notice'>The fabric on [src] changes color, reverting it back to standard mode.</span>")
 	plushie_module_selected = FALSE
 	qdel(used)
 	return ITEM_INTERACT_COMPLETE

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -1069,7 +1069,7 @@
 /obj/item/toy/plushie/borgplushie/examine(mob/user)
 	. = ..()
 	if(!plushie_module_selected)
-		. += "<span class='notice'><b>Alt-Click</b> [src] to change its color.</span>"
+		. += "<span class='notice'><b>Alt-Click</b> [src] to select a module.</span>"
 	else
 		. += "<span class='notice'>You can use a cyborg module reset board to change [src] back into standard mode.</span>"
 

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -1069,7 +1069,7 @@
 /obj/item/toy/plushie/borgplushie/examine(mob/user)
 	. = ..()
 	if(!plushie_module_selected)
-		. += "<span class = 'notice'>Alt-Click [src] to change its color.</span>"
+		. += "<span class = 'notice'><b>Alt-Click</b> [src] to change its color.</span>"
 	else
 		. += "<span class = 'notice'>You can use a cyborg module reset board to change [src] back into standard mode.</span>"
 
@@ -1077,7 +1077,7 @@
 	if(!istype(user) || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED) || !Adjacent(user))
 		return
 
-	pick_borg_plush_module()
+	pick_borg_plush_module(user)
 
 /obj/item/toy/plushie/borgplushie/proc/pick_borg_plush_module(mob/user)
 	if(plushie_module_selected)

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -1069,9 +1069,9 @@
 /obj/item/toy/plushie/borgplushie/examine(mob/user)
 	. = ..()
 	if(!plushie_module_selected)
-		. += "<span class = 'notice'><b>Alt-Click</b> [src] to change its color.</span>"
+		. += "<span class='notice'><b>Alt-Click</b> [src] to change its color.</span>"
 	else
-		. += "<span class = 'notice'>You can use a cyborg module reset board to change [src] back into standard mode.</span>"
+		. += "<span class='notice'>You can use a cyborg module reset board to change [src] back into standard mode.</span>"
 
 /obj/item/toy/plushie/borgplushie/AltClick(mob/user)
 	if(!istype(user) || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED) || !Adjacent(user))
@@ -1090,7 +1090,7 @@
 		"Service"		= image('icons/mob/robots.dmi', "serv-radial"),
 		"Medical"		= image('icons/mob/robots.dmi', "med-radial"),
 		"Janitor"		= image('icons/mob/robots.dmi', "jan-radial")
-		)
+	)
 	var/static/list/plushie_module_overlays = list(
 		"Security"		= "plushie_borgsec",
 		"Engineering"	= "plushie_borgengi",
@@ -1106,21 +1106,21 @@
 		return
 
 	borg_plushie_overlay = plushie_module_overlays[user_selection]
-	to_chat(user, "<span class = 'notice'>The fabric on [src] changes color, transforming it into \a [lowertext(user_selection)] plush!</span>")
+	to_chat(user, "<span class='notice'>The fabric on [src] changes color, transforming it into \a [lowertext(user_selection)] plush!</span>")
 	update_icon()
 	plushie_module_selected = TRUE
 
 /obj/item/toy/plushie/borgplushie/item_interaction(mob/living/user, obj/item/used, list/modifiers)
 	if(!istype(used, /obj/item/borg/upgrade/reset))
-		return 	. = ..()
+		return ..()
 	
 	if(!plushie_module_selected)
-		to_chat(user, "<span class = 'warning'>[src] is already in standard mode!</span>")
+		to_chat(user, "<span class='warning'>[src] is already in standard mode!</span>")
 		return ITEM_INTERACT_COMPLETE
 	
 	borg_plushie_overlay = "plushie_borgassist"
 	update_icon()
-	to_chat(user, "<span class = 'notice'>The fabric on [src] changes color, reverting it back to standard mode.</span>")
+	to_chat(user, "<span class='notice'>The fabric on [src] changes color, reverting it back to standard mode.</span>")
 	plushie_module_selected = FALSE
 	qdel(used)
 	return ITEM_INTERACT_COMPLETE


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds Diona, Drask, Human, Kidan, Plasmaman, Skrell, and Borg plushies to the plushie spawner.

Removes Nian plushie from the list that says it doesn't contain Nan plushies so Nians aren't twice as likely to appear as any other species.

Borg plushie modules can be selected if no module has been selected using **Alt-Click**. If a module has already been selected, a cyborg module reset board can be used to turn it back into a basic borg plushie.

Borg plushies obtained from the loadout menu always start as standard module plushies. Borg plushies generated by the plushie spawner are randomized.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Prize balls and mapped-in plush spawners can now pick all the species plushies instead of arbitrarily lacking some and including others.

Borg plushies now include an extra gimmick based on stuff actual cyborgs do, for extra realism and immersion.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Spawned 100 prize balls.
Kept opening them until all the new species plushies spawned.
Alt-clicked a grey borg plush, I was able to pick any module I wanted.
Alt-clicked a non-grey borg plush, I was unable to pick a module.
Used a cyborg reset board on a non-grey plush. It turned grey.
Used a cyborg reset board on a grey plush, it told me that this was not necessary.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
tweak: Diona, Drask, Human, Kidan, Plasmaman, Skrell, and Borg plushies can now spawn in prize balls and map plush spawners.
add: Borg plushies can have their module selected by Alt-Click if they are grey, if they are not grey, they can be reset with a cyborg reset module.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
