### PR TITLE
BSH Improvement Fix: Cleaning and Event Prob

### DIFF
--- a/code/modules/station_goals/bluespace_tap.dm
+++ b/code/modules/station_goals/bluespace_tap.dm
@@ -507,11 +507,17 @@
 	flick_overlay_view(image(icon, src, "flash", FLY_LAYER))
 	log_game("Bluespace harvester product spawned at [turf]")
 
+// Highest possible probabilty of an event
+#define PROB_CAP 5
+// Higher number means approaching the limit slower
+#define PROB_CURVE 250
+
 /obj/machinery/power/bluespace_tap/proc/try_events()
 	if(!mining_power)
 		return
 	// Calculate prob of event based on mining power. Return if no event.
-	var/event_prob = min(5, (mining_power / 150 MW)) + (emagged * 5)
+	var/megawatts = mining_power / 1000000
+	var/event_prob = (PROB_CAP * megawatts / (megawatts + PROB_CURVE)) + (emagged * 5)
 	if(!prob(event_prob))
 		return
 	var/static/list/event_list = list(
@@ -531,6 +537,8 @@
 		return
 	event.start_event()
 
+#undef PROB_CAP
+#undef PROB_CURVE
 //UI stuff below
 
 /obj/machinery/power/bluespace_tap/ui_act(action, params)

--- a/code/modules/station_goals/bluespace_tap.dm
+++ b/code/modules/station_goals/bluespace_tap.dm
@@ -175,7 +175,7 @@
 	radio.follow_target = src
 	radio.config(list("Engineering" = 0))
 
-/obj/machinery/power/bluespace_tap/post_clean()
+/obj/machinery/power/bluespace_tap/cleaning_act(mob/user, atom/cleaner, cleanspeed, text_verb, text_description, text_targetname)
 	. = ..()
 	dirty = FALSE
 
@@ -510,7 +510,9 @@
 /obj/machinery/power/bluespace_tap/proc/try_events()
 	if(!mining_power)
 		return
-	if(!prob((mining_power / (10 MW)) + (emagged * 5))) // Calculate prob of event based on mining power. Return if no event.
+	// Calculate prob of event based on mining power. Return if no event.
+	var/event_prob = min(5, (mining_power / 150 MW)) + (emagged * 5)
+	if(!prob(event_prob))
 		return
 	var/static/list/event_list = list(
 		/datum/engi_event/bluespace_tap_event/dirty,


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes cleaning bug in recent BSH Changes. Reduces the chance of events.

## Why It's Good For The Game

Events have a way too high probability at high energy states. This adds a cap to the chance of an event and reduces the odds of an event overall.

Dirty is bugged. Bugs are bad. Cleans up a cleaning bug.

## Testing

Spawned BSH. Made it dirty. Cleaned the BSH.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Lowered probabilty of BSH events to more expected levels
fix: Cleaning a BSH actually cleans it
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
