### PR TITLE
Adds Burza to Headcoders in CONTRIBUTING.md

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -199,8 +199,8 @@ Each role inherits the lower role's responsibilities
 `Headcoders` are the overarching "administrators" of the repository. People
 included in this role are:
 
+- [Burzah](https://github.com/Burzah)
 - [farie82](https://github.com/farie82)
-- [S34N](https://github.com/S34NW)
 - [SteelSlayer](https://github.com/SteelSlayer)
 
 ---
@@ -209,25 +209,24 @@ included in this role are:
 PRs. People included in this role are:
 
 - [AffectedArc07](https://github.com/AffectedArc07)
-- [Burzah](https://github.com/Burzah)
 - [Charliminator](https://github.com/hal9000PR)
 - [Contrabang](https://github.com/Contrabang)
 - [DGamerL](https://github.com/DGamerL)
 - [lewcc](https://github.com/lewcc)
+- [S34N](https://github.com/S34NW)
 
 ---
 
 `Review Team` members are people who are denoted as having reviews which can
 affect mergeability status. People included in this role are:
 
-- [Burzah](https://github.com/Burzah)
 - [Charliminator](https://github.com/hal9000PR)
 - [Chuga](https://github.com/chuga-git)
 - [Contrabang](https://github.com/Contrabang)
 - [DGamerL](https://github.com/DGamerL)
 - [FunnyMan3595](https://github.com/FunnyMan3595)
-- [Henri215](https://github.com/Henri215)
 - [lewcc](https://github.com/lewcc)
+- [S34N](https://github.com/S34NW)
 - [Sirryan2002](https://github.com/Sirryan2002)
 - [Warriorstar](https://github.com/warriorstar-orion)
 - [Wilkson](https://github.com/BiancaWilkson)


### PR DESCRIPTION
## What Does This PR Do
Adds Burza to the list of headcoders.
## Why It's Good For The Game
It's not.
## Testing
What's that?

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<hr>

## Changelog
Probably some player facing changes.