### PR TITLE
Make adding custom objectives work right

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -788,6 +788,7 @@
 					return
 				new_objective = new /datum/objective
 				new_objective.explanation_text = expl
+				new_objective.needs_target = FALSE
 
 		if(!new_objective)
 			return


### PR DESCRIPTION
## What Does This PR Do
Adding a new custom objective (rather than editing an existing objective) from the traitor panel would make its explanation text "Free objective", no matter what you tried to say the objective was.
It now keeps the text you gave it.

## Why It's Good For The Game
Please do not frustrate the admins.

## Testing
Gave myself a new custom objective. Text was correct.

<hr>
### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <hr>

## Changelog
:cl:
fix: Admin-added custom objectives will no longer accidentally end up as "Free objective" sometimes.
/:cl: