### PR TITLE
Amber/Red ERT Now Get Crew Pinpointer, Gamma Gets NAD Pinpointer

### DIFF
--- a/code/modules/response_team/ert_outfits.dm
+++ b/code/modules/response_team/ert_outfits.dm
@@ -39,7 +39,7 @@
 	back = /obj/item/storage/backpack/ert/commander
 	l_ear = /obj/item/radio/headset/ert/alt/commander
 	id = /obj/item/card/id/ert/commander
-	l_pocket = /obj/item/pinpointer
+	l_pocket = /obj/item/pinpointer/crew
 	r_pocket = /obj/item/melee/classic_baton/telescopic
 
 /datum/outfit/job/response_team/commander/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
@@ -96,6 +96,7 @@
 	glasses = /obj/item/clothing/glasses/night
 	mask = /obj/item/clothing/mask/gas/sechailer/swat
 	belt = /obj/item/gun/projectile/automatic/pistol/enforcer/lethal
+	l_pocket = /obj/item/pinpointer
 
 	backpack_contents = list(
 		/obj/item/restraints/handcuffs = 1,


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Removes NAD Pinpointer from Amber/Red ERT, gives it to Gamma. Amber/Red now get a Crew Pinpointer.

## Why It's Good For The Game

NADJack is kinda a thing. Making so that you have to prep for all of Security, the Captain, the Blueshield, AND any future ERT is kinda rough. Unless we want to change NADJack to be something where you do have hijack-esque perms, this should make it so you dont have to go so big to have a chance at winning.

## Testing

Loaded in and checked the loadouts.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

![image](https://github.com/user-attachments/assets/8e4ae7ed-5b70-4a73-8490-f7d6afad9299)

  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
tweak: Amber/Red ERT gets Crew Pinpointer, Gamma gets NAD Pinpointer
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
