### PR TITLE
Make character previews not stack trace

### DIFF
--- a/code/modules/client/preference/character.dm
+++ b/code/modules/client/preference/character.dm
@@ -831,7 +831,7 @@
 	var/coloured_tail
 	if(current_species)
 		if(current_species.bodyflags & HAS_ICON_SKIN_TONE) //Handling species-specific icon-based skin tones by flagged race.
-			var/mob/living/carbon/human/H = new
+			var/mob/living/carbon/human/fake/H = new
 			H.dna.species = current_species
 			H.s_tone = s_tone
 			H.dna.species.updatespeciescolor(H, 0) //The mob's species wasn't set, so it's almost certainly different than the character's species at the moment. Thus, we need to be owner-insensitive.

--- a/code/modules/mob/living/carbon/carbon_life.dm
+++ b/code/modules/mob/living/carbon/carbon_life.dm
@@ -1,6 +1,9 @@
 /mob/living/carbon/Life(seconds, times_fired)
 	set invisibility = 0
 
+	if(flags & ABSTRACT)
+		return
+
 	if(notransform)
 		return
 

--- a/code/modules/mob/living/carbon/carbon_procs.dm
+++ b/code/modules/mob/living/carbon/carbon_procs.dm
@@ -1,7 +1,7 @@
 /mob/living/carbon/Initialize(mapload)
 	. = ..()
 	GLOB.carbon_list += src
-	if(!loc)
+	if(!loc && !(flags & ABSTRACT))
 		stack_trace("Carbon mob being instantiated in nullspace")
 
 /mob/living/carbon/Destroy()

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -107,3 +107,6 @@
 
 	/// Lazylist of sources to track what our alpha should be, alpha is set to the minimum. Use the `set_alpha_tracking` and `get_alpha` helpers.
 	var/list/alpha_sources
+
+/mob/living/carbon/human/fake
+	flags = ABSTRACT


### PR DESCRIPTION
## What Does This PR Do
Make character previews not stack trace

## Why It's Good For The Game
Stack traces should happen for unusual things, not every player editing their character.

## Testing
Could see and edit my character without stack traces.
Ghost image was correct and didn't generate a stack trace.
Spawning in worked normally.
Was able to process chems after spawning in.
<hr>

### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

  <hr>

## Changelog
NPFC