### PR TITLE
Fixes the Deltastation Brig Lockers to Be Linked to the Door Timers

### DIFF
--- a/_maps/map_files/stations/deltastation.dmm
+++ b/_maps/map_files/stations/deltastation.dmm
@@ -22142,7 +22142,7 @@
 /turf/simulated/floor/greengrid,
 /area/station/command/vault)
 "bzj" = (
-/obj/structure/closet/secure_closet/brig/temp/cell_5,
+/obj/structure/closet/secure_closet/brig/temp/cell_3,
 /turf/simulated/floor/plasteel{
 	icon_state = "redcorner"
 	},
@@ -76960,11 +76960,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
 "pBA" = (
-/obj/structure/closet/secure_closet/brig/temp/cell_5,
 /obj/machinery/camera{
 	c_tag = "Brig Cell 2";
 	dir = 8
 	},
+/obj/structure/closet/secure_closet/brig/temp/cell_2,
 /turf/simulated/floor/plasteel{
 	icon_state = "redcorner"
 	},
@@ -80725,6 +80725,12 @@
 /obj/effect/spawner/random/fungus/maybe,
 /turf/simulated/wall,
 /area/station/maintenance/fsmaint)
+"rBj" = (
+/obj/structure/closet/secure_closet/brig/temp/cell_4,
+/turf/simulated/floor/plasteel{
+	icon_state = "redcorner"
+	},
+/area/station/security/prison/cell_block/a)
 "rBP" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
@@ -82479,11 +82485,11 @@
 /turf/simulated/floor/plasteel,
 /area/station/engineering/transmission_laser)
 "ssh" = (
-/obj/structure/closet/secure_closet/brig/temp/cell_5,
 /obj/machinery/flasher{
 	id = "Cell 2";
 	pixel_y = -26
 	},
+/obj/structure/closet/secure_closet/brig/temp/cell_1,
 /turf/simulated/floor/plasteel{
 	icon_state = "redcorner"
 	},
@@ -147151,7 +147157,7 @@ aPx
 kbZ
 vOc
 viy
-bzj
+rBj
 mAS
 spL
 hWP


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Places Brig Locker 1, 2, 3, etc. in the corresponding cell. Previously, all the cells had Cell 5's locker in it.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

Currently, the door timers don't close/lock the lockers when you start a sentence or open when the sentence is over. This fixes it so officers don't need to lock or unlock the lockers manually.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

![image](https://github.com/user-attachments/assets/9af42216-3de1-4d42-9330-9118ac7af3b6)
The lockers look the exact same.

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Booted up test server and brigged Urist McAntag, McVampire, McChangeling, McTide, and McNNO. All the lockers locked and unlocked properly. 
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Fixes Deltastation's brig lockers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
