### PR TITLE
Fix legion beam damage output.

### DIFF
--- a/code/datums/beam.dm
+++ b/code/datums/beam.dm
@@ -100,18 +100,18 @@
 			Pixel_y = round(cos(Angle)+32*cos(Angle)*(N+16)/32)
 
 		//Position the effect so the beam is one continous line
-		var/a
+		var/final_x = X.x
+		var/final_y = X.y
 		if(abs(Pixel_x)>32)
-			a = Pixel_x > 0 ? round(Pixel_x/32) : CEILING(Pixel_x/32, 1)
-			X.x += a
+			final_x += Pixel_x > 0 ? round(Pixel_x/32) : CEILING(Pixel_x/32, 1)
 			Pixel_x %= 32
 		if(abs(Pixel_y)>32)
-			a = Pixel_y > 0 ? round(Pixel_y/32) : CEILING(Pixel_y/32, 1)
-			X.y += a
+			final_y += Pixel_y > 0 ? round(Pixel_y/32) : CEILING(Pixel_y/32, 1)
 			Pixel_y %= 32
 
-		X.pixel_x = Pixel_x
-		X.pixel_y = Pixel_y
+		X.forceMove(locate(final_x, final_y, X.z))
+		X.pixel_x = origin.pixel_x + Pixel_x
+		X.pixel_y = origin.pixel_y + Pixel_y
 
 /obj/effect/ebeam
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT

--- a/code/datums/beam.dm
+++ b/code/datums/beam.dm
@@ -103,7 +103,7 @@
 		var/final_x = X.x
 		var/final_y = X.y
 		if(abs(Pixel_x)>32)
-			final_x += Pixel_x > 0 ? round(Pixel_x/32) : CEILING(Pixel_x/32, 1)
+			final_x += Pixel_x > 0 ? round(Pixel_x / 32) : CEILING(Pixel_x / 32, 1)
 			Pixel_x %= 32
 		if(abs(Pixel_y)>32)
 			final_y += Pixel_y > 0 ? round(Pixel_y/32) : CEILING(Pixel_y/32, 1)

--- a/code/datums/beam.dm
+++ b/code/datums/beam.dm
@@ -97,7 +97,7 @@
 		if(DY == 0)
 			Pixel_y = 0
 		else
-			Pixel_y = round(cos(Angle)+32*cos(Angle)*(N+16)/32)
+			Pixel_y = round(cos(Angle) + 32 * cos(Angle) * (N + 16) / 32)
 
 		//Position the effect so the beam is one continous line
 		var/final_x = X.x

--- a/code/datums/beam.dm
+++ b/code/datums/beam.dm
@@ -106,7 +106,7 @@
 			final_x += Pixel_x > 0 ? round(Pixel_x / 32) : CEILING(Pixel_x / 32, 1)
 			Pixel_x %= 32
 		if(abs(Pixel_y)>32)
-			final_y += Pixel_y > 0 ? round(Pixel_y/32) : CEILING(Pixel_y/32, 1)
+			final_y += Pixel_y > 0 ? round(Pixel_y / 32) : CEILING(Pixel_y / 32, 1)
 			Pixel_y %= 32
 
 		X.forceMove(locate(final_x, final_y, X.z))


### PR DESCRIPTION
## What Does This PR Do
This PR moves beam segments to their visual location in order to ensure that connect_loc signals attached to each beam segment fire when passed through at their perceived location. Fixes #27872.
## Why It's Good For The Game
Fixes legion beams causing 50x damage when walking under the legion.
## Testing
Commented out godmode-ignoring targeting in hostile.dm, set legion boss attack probabilities to always fire a beam.
Spawned in player and made godmode, spawned in legion, and attacked. Walked through and crawled under beam to ensure that only one disintegration beam proc was fired.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Legion disintegration beams should no longer cause 50x their expected damage.
/:cl:
