### PR TITLE
EmeraldStation misc fixes

### DIFF
--- a/_maps/map_files/stations/emeraldstation.dmm
+++ b/_maps/map_files/stations/emeraldstation.dmm
@@ -6015,7 +6015,7 @@
 /obj/effect/mapping_helpers/airlock/windoor/access/any/security/armory{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/security/armory{
+/obj/effect/mapping_helpers/airlock/windoor/access/any/security/doors{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
@@ -7049,11 +7049,9 @@
 	},
 /area/station/hallway/primary/fore/north)
 "buS" = (
-/obj/structure/closet/secure_closet/brig/temp{
-	opened = 1
-	},
-/obj/effect/spawner/random/maintenance,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/secure_closet/brig,
+/obj/effect/spawner/random/maintenance,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
 "buY" = (
@@ -31031,11 +31029,6 @@
 /turf/simulated/floor/wood,
 /area/station/service/library)
 "gfL" = (
-/obj/machinery/ai_status_display{
-	pixel_x = -32;
-	step_size = 0;
-	pixel_y = 32
-	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitepurplecorner"
@@ -32902,11 +32895,10 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/east)
 "gAl" = (
-/obj/structure/closet/secure_closet/brig/temp{
-	opened = 1
-	},
 /obj/item/card/id/prisoner,
 /obj/item/clothing/under/color/orange/prison,
+/obj/structure/closet/secure_closet/brig,
+/obj/effect/spawner/random/maintenance,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "redcorner"
@@ -50290,10 +50282,9 @@
 /area/station/maintenance/apmaint2)
 "jTd" = (
 /obj/item/airlock_electronics/destroyed,
-/obj/structure/closet/secure_closet/brig/temp{
-	opened = 1
-	},
 /obj/item/clothing/shoes/orange,
+/obj/structure/closet/secure_closet/brig,
+/obj/effect/spawner/random/maintenance,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
 "jTf" = (
@@ -99078,6 +99069,7 @@
 /obj/structure/sink{
 	pixel_y = 22
 	},
+/obj/machinery/firealarm/directional/west,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitepurplecorner"
@@ -116874,6 +116866,9 @@
 /obj/machinery/computer/camera_advanced/xenobio{
 	dir = 8
 	},
+/obj/machinery/ai_status_display{
+	pixel_y = -32
+	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "whitepurple"
@@ -120660,12 +120655,11 @@
 	},
 /area/station/science/server)
 "xQP" = (
-/obj/structure/closet/secure_closet/brig/temp{
-	opened = 1
-	},
 /obj/item/clothing/under/color/orange/prison,
 /obj/item/clothing/shoes/orange,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/secure_closet/brig,
+/obj/effect/spawner/random/maintenance,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
 "xQS" = (


### PR DESCRIPTION
## What Does This PR Do

Fixes #27664
Fixes #27814

An assortment of small fixes including: A weird access choice on the armory outward door, the broken lockers in the abandoned security area (cargo maint), and added a fire alarm to xenobiology

## Why It's Good For The Game

bugfix good

## Testing

booted up a test server and verified changes

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: Fixed emeraldstation abandoned sec lockers
fix: Fixed armory windoor access
fix: Gave xenobiology a proper fire alarm
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
