### PR TITLE
Adds surgical tray crafting recipe, renames and increases cost for the wheeled one

### DIFF
--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -461,8 +461,8 @@ GLOBAL_LIST_INIT(titanium_recipes, list(
 	new /datum/stack_recipe("titanium airlock assembly", /obj/structure/door_assembly/door_assembly_titanium, 4, time = 50, one_per_turf = TRUE, on_floor = TRUE),
 	null,
 	new /datum/stack_recipe("titanium tile", /obj/item/stack/tile/mineral/titanium, 1, 4, 20),
-	new /datum/stack_recipe("surgical tray", /obj/item/storage/surgical_tray, 5),
-	new /datum/stack_recipe("surgical instrument table", /obj/structure/table/tray, 10, one_per_turf = TRUE, on_floor = TRUE),
+	new /datum/stack_recipe("surgical tray", /obj/item/storage/surgical_tray, 1),
+	new /datum/stack_recipe("surgical instrument table", /obj/structure/table/tray, 3, one_per_turf = TRUE, on_floor = TRUE),
 	))
 
 /obj/item/stack/sheet/mineral/titanium/Initialize(mapload, new_amount, merge)

--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -461,7 +461,8 @@ GLOBAL_LIST_INIT(titanium_recipes, list(
 	new /datum/stack_recipe("titanium airlock assembly", /obj/structure/door_assembly/door_assembly_titanium, 4, time = 50, one_per_turf = TRUE, on_floor = TRUE),
 	null,
 	new /datum/stack_recipe("titanium tile", /obj/item/stack/tile/mineral/titanium, 1, 4, 20),
-	new /datum/stack_recipe("surgical tray", /obj/structure/table/tray, 2, one_per_turf = TRUE, on_floor = TRUE),
+	new /datum/stack_recipe("surgical tray", /obj/item/storage/surgical_tray, 5),
+	new /datum/stack_recipe("surgical instrument table", /obj/structure/table/tray, 10, one_per_turf = TRUE, on_floor = TRUE),
 	))
 
 /obj/item/stack/sheet/mineral/titanium/Initialize(mapload, new_amount, merge)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -818,7 +818,7 @@
 		animate(src, color = previouscolor, time = 8)
 
 /obj/structure/table/tray
-	name = "surgical tray"
+	name = "surgical instrument table"
 	desc = "A small metal tray with wheels."
 	anchored = FALSE
 	smoothing_flags = NONE


### PR DESCRIPTION
## What Does This PR Do

1. Adds `surgical tray` (the one that holds surgical tools) to titanium recipes, costing 1 sheet
2. Renames `surgical tray` (the wheeled one) to `surgical instrument table`
3. Increases the cost of `surgical instrument table` to 3 sheets

## Why It's Good For The Game

1. Cargo can print / order surgical tools, but we have no way to store them properly should the originally spawned 2 trays get destroyed
2. We had two identically named items
3. It made no sense for an entire structure to only cost that few sheets

## Images of changes

https://github.com/user-attachments/assets/c62a564c-0d1c-4c56-9ea3-62626384d80c

## Testing

See above, the video has the old costs

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
add: Added surgical trays (the green box holding surgical tools) to the titanium recipes, they cost 1 titanium sheet to be crafted.
tweak: Surgical trays (the draggable, green tables) are now called 'surgical instrument table'.
tweak: The crafting cost of surgical instrument tables was raised from 2 titanium sheets to 3.
/:cl:
