### PR TITLE
Fixes a Disposal Pipe in the Farragus Brig

### DIFF
--- a/_maps/map_files/stations/cerestation.dmm
+++ b/_maps/map_files/stations/cerestation.dmm
@@ -11868,7 +11868,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area)
+/area/station/security/brig)
 "bGM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{

--- a/_maps/map_files/stations/cerestation.dmm
+++ b/_maps/map_files/stations/cerestation.dmm
@@ -11864,13 +11864,11 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/structure/disposalpipe/junction/reversed{
-	dir = 1
-	},
+/obj/structure/disposalpipe/wrapsortjunction,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/station/security/brig)
+/area)
 "bGM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{

--- a/_maps/map_files/stations/cerestation.dmm
+++ b/_maps/map_files/stations/cerestation.dmm
@@ -11864,7 +11864,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/structure/disposalpipe/wrapsortjunction,
+/obj/structure/disposalpipe/junction,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},

--- a/code/modules/mod/mod_theme.dm
+++ b/code/modules/mod/mod_theme.dm
@@ -553,7 +553,7 @@
 	)
 
 /obj/item/mod/armor/mod_theme_rescue
-	armor = list(MELEE = 20, BULLET = 20, LASER = 5, ENERGY = 5, BOMB = 10, RAD = 50, FIRE = 150, ACID = 150) //Extra melee / bullet armor for if they get caught in a fight. Of course, no laser armor.
+	armor = list(MELEE = 20, BULLET = 20, LASER = 5, ENERGY = 5, BOMB = 10, RAD = 150, FIRE = 150, ACID = 150) //Extra melee / bullet armor for if they get caught in a fight. Of course, no laser armor.
 
 /datum/mod_theme/research
 	name = "'Minerva' research"

--- a/code/modules/mod/mod_theme.dm
+++ b/code/modules/mod/mod_theme.dm
@@ -553,7 +553,7 @@
 	)
 
 /obj/item/mod/armor/mod_theme_rescue
-	armor = list(MELEE = 20, BULLET = 20, LASER = 5, ENERGY = 5, BOMB = 10, RAD = 150, FIRE = 150, ACID = 150) //Extra melee / bullet armor for if they get caught in a fight. Of course, no laser armor.
+	armor = list(MELEE = 20, BULLET = 20, LASER = 5, ENERGY = 5, BOMB = 10, RAD = INFINITY, FIRE = 150, ACID = 150) //Extra melee / bullet armor for if they get caught in a fight. Of course, no laser armor.
 
 /datum/mod_theme/research
 	name = "'Minerva' research"

--- a/code/modules/mod/mod_theme.dm
+++ b/code/modules/mod/mod_theme.dm
@@ -553,7 +553,7 @@
 	)
 
 /obj/item/mod/armor/mod_theme_rescue
-	armor = list(MELEE = 20, BULLET = 20, LASER = 5, ENERGY = 5, BOMB = 10, RAD = INFINITY, FIRE = 150, ACID = 150) //Extra melee / bullet armor for if they get caught in a fight. Of course, no laser armor.
+	armor = list(MELEE = 20, BULLET = 20, LASER = 5, ENERGY = 5, BOMB = 10, RAD = 50, FIRE = 150, ACID = 150) //Extra melee / bullet armor for if they get caught in a fight. Of course, no laser armor.
 
 /datum/mod_theme/research
 	name = "'Minerva' research"


### PR DESCRIPTION
## What Does This PR Do
Fixes a spot in the brig where a disposal pipe would sometimes route disposals coming from the warden's office into processing.
## Why It's Good For The Game
Makes sure that things thrown down the disposal chute from the warden's officer are properly routed.
## Images of changes
![StrongDMM_gs0mHr9Spt](https://github.com/user-attachments/assets/2e710e6e-2b7a-4b13-8be9-cb655ee90282)
## Testing
Spawned a mob and used disposals in the warden's office.
Spawned a mob and used disposals in processing. 
Tracked routing of each mob.
<hr>

### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<hr>

## Changelog

:cl:
fix: Fixed a disposal junction leading from processing in the brig.
/:cl: