### PR TITLE
Fixes <hr> tag spacing on the Pull Request Template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,7 +28,7 @@
 - [ ] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
   <!-- Replace the box with [x] to mark as complete. -->
   <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
-  <hr>
+<hr>
 
 ## Changelog
 


### PR DESCRIPTION
## What Does This PR Do
Removes spaces in front of an `<hr>` tag on the pull request template. 
## Why It's Good For The Game
It will stop driving me insane every time I make a PR.
## Testing
Made the changes based on fixing it before submitting other Pull Requests.
<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<hr>

## Changelog
NPFC