### PR TITLE
Fixes brain gibberish from attempting to emote

### DIFF
--- a/code/modules/mob/living/brain/brain_say.dm
+++ b/code/modules/mob/living/brain/brain_say.dm
@@ -9,7 +9,7 @@
 		if(prob(10)) //10% chance to drop the message entirely
 			return
 		else
-			message = Gibberish(message, (emp_damage*6))//scrambles the message, gets worse when emp_damage is higher
+			message = brain_gibberish(message, (emp_damage*6))//scrambles the message, gets worse when emp_damage is higher
 
 	..(message)
 

--- a/code/modules/mob/mob_misc_procs.dm
+++ b/code/modules/mob/mob_misc_procs.dm
@@ -337,9 +337,6 @@
 /proc/Gibberish(t, p, replace_rate = 50)//t is the inputted message, and any value higher than 70 for p will cause letters to be replaced instead of added. replace_rate is the chance a letter is corrupted.
 	/* Turn text into complete gibberish! */
 	var/returntext = ""
-	var/first_letter = pick("@","&","%","$","/") // interjects a letter and allows the say message to go through without being stopped by * (emote character) and others.
-	
-	returntext += first_letter
 	for(var/i = 1, i <= length_char(t), i++)
 
 		var/letter = copytext_char(t, i, i + 1)
@@ -353,6 +350,18 @@
 		returntext += letter
 
 	return returntext
+
+
+/proc/brain_gibberish(message, emp_damage)
+	if(copytext(message, 1, 2) == "*") // if the brain tries to emote, return an emote
+		return message
+
+	var/repl_char = pick("@","&","%","$","/")
+	var/regex/bad_char = regex("\[*]|#")
+	message = Gibberish(message, emp_damage)
+	message = bad_char.Replace(message, repl_char, 1, 2) // prevents the gibbered message from emoting
+
+	return message
 
 /proc/Gibberish_all(list/message_pieces, p, replace_rate)
 	for(var/datum/multilingual_say_piece/S in message_pieces)

--- a/code/modules/mob/mob_misc_procs.dm
+++ b/code/modules/mob/mob_misc_procs.dm
@@ -337,6 +337,9 @@
 /proc/Gibberish(t, p, replace_rate = 50)//t is the inputted message, and any value higher than 70 for p will cause letters to be replaced instead of added. replace_rate is the chance a letter is corrupted.
 	/* Turn text into complete gibberish! */
 	var/returntext = ""
+	var/first_letter = pick("@","&","%","$","/") // interjects a letter and allows the say message to go through without being stopped by * (emote character) and others.
+	
+	returntext += first_letter
 	for(var/i = 1, i <= length_char(t), i++)
 
 		var/letter = copytext_char(t, i, i + 1)

--- a/code/modules/mob/mob_misc_procs.dm
+++ b/code/modules/mob/mob_misc_procs.dm
@@ -351,7 +351,6 @@
 
 	return returntext
 
-
 /proc/brain_gibberish(message, emp_damage)
 	if(copytext(message, 1, 2) == "*") // if the brain tries to emote, return an emote
 		return message


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #27344
Fixes EMP'd brain speaking by making a new proc, brain_gibberish. First, it checks if the first letter is * and returns the message to allow emoting. Else, it checks the first letter of a Gibberish message and if the first letter is * or #, replaces it with one of the replacement characters. 
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Trying to speak as an EMP'd robobrain would often result in an extremely annoying experience where your message fails to go through due to starting with * which attempts to emote.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![dreamseeker_UgYCb9l9Bf](https://github.com/user-attachments/assets/41192ba1-19ce-4c0e-8016-245dee58f2ed)


<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Made myself a robobrain and EMP'd myself. Spammed chat and watched if I tried to emote.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  <hr>

## Changelog

:cl:
fix: EMP'd brains will no longer try to emote
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
