### PR TITLE
Removes NAD Steal as a traitor objective

### DIFF
--- a/code/game/gamemodes/steal_items.dm
+++ b/code/game/gamemodes/steal_items.dm
@@ -100,17 +100,6 @@
 	protected_jobs = list("Captain")
 	location_override = "the Captain's Office"
 
-/datum/theft_objective/nukedisc
-	name = "the nuclear authentication disk"
-	typepath = /obj/item/disk/nuclear
-	protected_jobs = list("Captain")
-	location_override = "the Captain's Office"
-
-/datum/theft_objective/nukedisc/check_special_completion(obj/item/I)
-	if(istype(I, /obj/item/disk/nuclear/training)) //Haha no
-		return FALSE
-	return TRUE
-
 /datum/theft_objective/reactive
 	name = "any type of reactive armor"
 	typepath = /obj/item/clothing/suit/armor/reactive

--- a/code/modules/antagonists/antag_org/antag_org_syndicate.dm
+++ b/code/modules/antagonists/antag_org/antag_org_syndicate.dm
@@ -36,7 +36,6 @@
 	targeted_departments = list(DEPARTMENT_COMMAND, DEPARTMENT_SECURITY)
 	theft_targets = list(
 		/datum/theft_objective/antique_laser_gun,
-		/datum/theft_objective/nukedisc,
 		/datum/theft_objective/hoslaser,
 		/datum/theft_objective/captains_saber,
 		/datum/theft_objective/capmedal


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Removes the NAD as a steal target for traitors.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
NAD steal always tends to be a murderbone objective, because at the least you have to kill the Blueshield and Captain, both who are normally armed, and more often then not results in you having to fight a good portion of the security team. This requires someone going for NAD steal to be hyper lethal and more often then not results in an ERT being called and causing issues for other traitors in the round. This objective is not fun for the Captain or the Blueshield, nor is it fun for the traitor who gets it once they get the NAD as they now can't leave the station and are hunted for it, possibly by an ERT. 

This still leaves the captain with the most  stuff to steal with 4 high value items that can be rolled as a steal objective.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Loaded up the game and confirmed that the NAD was no longer able to be picked as a steal target
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
![Screenshot 2025-01-08 165507](https://github.com/user-attachments/assets/196d342f-1477-42ae-aa83-697185b23a69)
![Screenshot 2025-01-08 165553](https://github.com/user-attachments/assets/07634a5a-20a3-4b56-9ffb-da8e0a28c5bc)
![Screenshot 2025-01-08 165612](https://github.com/user-attachments/assets/5290af95-5471-4280-a24e-ddb01a7cb5cb)
<hr>

## Changelog

:cl:
del: The NAD is no longer a steal objective for traitors.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
