### PR TITLE
Fixes uninstalled windoor electronics.

### DIFF
--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -386,6 +386,7 @@
 					ae = electronics
 					electronics = null
 					ae.forceMove(loc)
+				ae.is_installed = FALSE
 
 				qdel(src)
 	else


### PR DESCRIPTION
## What Does This PR Do
Fixes #27565

## Why It's Good For The Game
Bugs bad.

## Testing
Removed and reinstalled windoor electronics.
<hr>

### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

<hr>

## Changelog
:cl:
fix: Airlock electronics no longer brick when removed from a windoor.
/:cl: