### PR TITLE
fix bad judo belt unequip state

### DIFF
--- a/code/modules/martial_arts/judo.dm
+++ b/code/modules/martial_arts/judo.dm
@@ -43,6 +43,7 @@
 	style = new()
 
 /obj/item/storage/belt/judobelt/equipped(mob/user, slot)
+	. = ..()
 	if(!ishuman(user))
 		return
 	if(slot == ITEM_SLOT_BELT)


### PR DESCRIPTION
## What Does This PR Do
This PR makes `/obj/item/storage/belt/judobelt/equipped()` call its parent, ensuring that all the related bookkeeping and effects proc.
## Why It's Good For The Game
Judo belt can get in an inconsistent state when unequipped into a hand slot because its `in_inventory` is never set properly. This fixes that.
## Testing
Equipped judo belt, and then pulled into empty hand slot. Ensured 'in_inventory' was set to 1, and that hovering over the belt in the hand slot properly outlined it.
<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: Judo belts make the proper sounds when unequipped and are properly highlighted when hovering over them in hands after being unequipped from the belt slot.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
