### PR TITLE
.NET 9 SDK setup action for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,11 @@ jobs:
           python -m tools.ci.check_legacy_attack_chain
           python -m tools.maplint.source --github
 
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4.2.0
+        with:
+          dotnet-version: 9.x
+
       - name: Run DreamChecker
         shell: bash
         run: ~/dreamchecker 2>&1 | bash tools/ci/annotate_dm.sh


### PR DESCRIPTION
## What Does This PR Do
From pull request: 
https://github.com/tgstation/tgstation/pull/88988

`OpenDream was recently bumped to .NET 9, which is not on our runner image. I added an action which installs the required .NET version for DMCompiler to function.`
## Why It's Good For The Game
`Adding this action is not only good as a quick hack fix, but also for posterity.
I also considered the impact this has on our runner execution time, but my hope is that it should not matter if we have .NET installed already.`
<hr>

### Declaration

-  [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

<hr>

## Changelog
NPFC