### PR TITLE
Places a limit on gas_coefficient to limit rad issues

### DIFF
--- a/code/modules/power/engines/supermatter/supermatter.dm
+++ b/code/modules/power/engines/supermatter/supermatter.dm
@@ -567,7 +567,7 @@
 
 		var/crush_ratio = combined_gas / MOLE_CRUNCH_THRESHOLD
 
-		gas_coefficient = min(1 + (crush_ratio ** 2 * (crush_ratio <= 1) + (crush_ratio > 1) * crush_ratio ** 0.5) * (plasmacomp * PLASMA_CRUNCH + o2comp * O2_CRUNCH + co2comp * CO2_CRUNCH + n2comp * N2_CRUNCH + n2ocomp * N2O_CRUNCH), 10)
+		gas_coefficient = 1 + (crush_ratio ** 2 * (crush_ratio <= 1) + (crush_ratio > 1) * 2 * crush_ratio / (crush_ratio + 1)) * (plasmacomp * PLASMA_CRUNCH + o2comp * O2_CRUNCH + co2comp * CO2_CRUNCH + n2comp * N2_CRUNCH + n2ocomp * N2O_CRUNCH)
 		if(prob(50))
 			radiation_pulse(src, power * (gas_coefficient + max(0, ((power_transmission_bonus / 10)))))
 

--- a/code/modules/power/engines/supermatter/supermatter.dm
+++ b/code/modules/power/engines/supermatter/supermatter.dm
@@ -567,7 +567,7 @@
 
 		var/crush_ratio = combined_gas / MOLE_CRUNCH_THRESHOLD
 
-		gas_coefficient = 1 + (crush_ratio ** 2 * (crush_ratio <= 1) + (crush_ratio > 1) * crush_ratio ** 0.5) * (plasmacomp * PLASMA_CRUNCH + o2comp * O2_CRUNCH + co2comp * CO2_CRUNCH + n2comp * N2_CRUNCH + n2ocomp * N2O_CRUNCH)
+		gas_coefficient = min(1 + (crush_ratio ** 2 * (crush_ratio <= 1) + (crush_ratio > 1) * crush_ratio ** 0.5) * (plasmacomp * PLASMA_CRUNCH + o2comp * O2_CRUNCH + co2comp * CO2_CRUNCH + n2comp * N2_CRUNCH + n2ocomp * N2O_CRUNCH), 10)
 		if(prob(50))
 			radiation_pulse(src, power * (gas_coefficient + max(0, ((power_transmission_bonus / 10)))))
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Limits gas_coefficent to 10.
For context, with the _entire_ stations plasma tank in  the chamber, none in the cooling loop or secondary loop, you hit almost 11.

The reasoning for this PR is we have been having radiation from supermatters being significantly higher than it should be when undergoing a delamination for the past month or so
See examples like 
![image](https://github.com/user-attachments/assets/21fe6c8c-7218-4f24-b5d7-e2253780870d)
![image](https://github.com/user-attachments/assets/9935490e-2f07-422c-a787-377538acacdd)

I suspect this is part of the gas_coefficent getting spiked by an anomaly, or when situations like
![image](https://github.com/user-attachments/assets/6ae9acf8-683d-4f54-9d96-59c6379f1d49)
happen.

This leads to an insane gas coefficent, leading to the above insane rad values.

By capping it to 10, which **should not be reached under almost any supermatter setup**, we should hopefully have this happen less.

This will need an eye on.


<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

See above


## Testing

<!-- How did you test the PR, if at all? -->

dropped the supermatter in the plasma tank, hit exactly 10

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

![image](https://github.com/user-attachments/assets/055df2be-342a-4f2d-906f-3d38076cea2b)

Yes I did 10 instead of 11, but 11 shouldn't be reached, 10 is a nice sane number, and you probably don't need that many rads anyway. This multiplies EER by 10. It's stupid.

## Changelog

:cl:
tweak: Places a limit on gas_coefficient to limit rad issues
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
