### PR TITLE
Fixes event C-3

### DIFF
--- a/code/modules/power/engines/supermatter/supermatter_event.dm
+++ b/code/modules/power/engines/supermatter/supermatter_event.dm
@@ -109,7 +109,7 @@
 	duration = 5 MINUTES
 
 /datum/engi_event/supermatter_event/charlie_tier/heat_penalty_threshold/on_start()
-	supermatter.heat_penalty_threshold -= -173
+	supermatter.heat_penalty_threshold -= 173
 
 //Class B events
 /datum/engi_event/supermatter_event/bravo_tier


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Your honor, I plea oopsie daisy. Removes a double negative from event C-3.

## Why It's Good For The Game

Makes the event do what it says on the tin!

## Images of changes

![image](https://github.com/user-attachments/assets/5c1c312d-09e9-4ea3-90f8-54f149c3b60f)

## Testing

Code complied. 

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: Fixed SM event C-3
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
