### PR TITLE
Migrates door remotes to the new attack chain + fixes janikeyring

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -103,7 +103,6 @@ GLOBAL_LIST_EMPTY(airlock_emissive_underlays)
 	var/doorDeni = 'sound/machines/deniedbeep.ogg' // i'm thinkin' Deni's
 	var/boltUp = 'sound/machines/boltsup.ogg'
 	var/boltDown = 'sound/machines/boltsdown.ogg'
-	var/is_special = FALSE
 	/// Our ID tag for map-based linking shenanigans
 	var/id_tag
 	/// List of people who have shocked this door for logging purposes

--- a/code/game/objects/items/control_wand.dm
+++ b/code/game/objects/items/control_wand.dm
@@ -245,6 +245,10 @@
 	var/last_airlock_uid
 	additional_access = list(ACCESS_MEDICAL, ACCESS_RESEARCH, ACCESS_CONSTRUCTION, ACCESS_MAILSORTING, ACCESS_CARGO, ACCESS_MINING, ACCESS_KITCHEN, ACCESS_BAR, ACCESS_JANITOR, ACCESS_CHAPEL_OFFICE)
 
+/obj/item/door_remote/janikeyring/New()
+	..()
+	RegisterSignal(src, COMSIG_ACTIVATE_SELF, TYPE_PROC_REF(/datum, signal_cancel_activate_self))
+
 /obj/item/door_remote/janikeyring/examine(mob/user)
 	. = ..()
 	. += "<span class='notice'>This keyring has access to Medbay, Science, Engineering, Cargo, the Bar and the Kitchen!</span>"

--- a/code/game/objects/items/control_wand.dm
+++ b/code/game/objects/items/control_wand.dm
@@ -215,13 +215,12 @@
 	icon_state = "hacktool-g"
 	busy = TRUE
 	to_chat(user, "<span class='notice'>[src] is attempting to interface with [target]...</span>")
-	if(!do_after(user, hack_speed, target = target))
+	if(do_after(user, hack_speed, target = target))
 		busy = FALSE
 		icon_state = "hacktool"
-		return
+		return TRUE
 	busy = FALSE
 	icon_state = "hacktool"
-	return TRUE
 
 /obj/item/door_remote/omni/access_tuner/flayer
 	name = "integrated access tuner"
@@ -265,7 +264,7 @@
 	return ..()
 
 /obj/item/door_remote/janikeyring/ranged_interact_with_atom(atom/target, mob/living/user, list/modifiers) // THOSE AINT MAGICAL REMOTE KEYS
-	return
+	return ITEM_INTERACT_COMPLETE
 
 
 /obj/item/door_remote/janikeyring/proc/unlock(obj/machinery/door/target, mob/living/user)
@@ -286,7 +285,7 @@
 		else
 			hack_speed = rand(5, 20) SECONDS
 	playsound(src, 'sound/items/keyring_unlock.ogg', 50)
-	if(do_after(user, hack_speed, target = target, progress = 1))
+	if(do_after(user, hack_speed, target = target, progress = 0))
 		if(target.check_access(ID))
 			last_airlock_uid = target.UID()
 		busy =  FALSE

--- a/code/game/objects/items/control_wand.dm
+++ b/code/game/objects/items/control_wand.dm
@@ -16,6 +16,8 @@
 	var/additional_access = list()
 	var/obj/item/card/id/ID
 
+	new_attack_chain = TRUE
+
 /obj/item/door_remote/New()
 	..()
 	ID = new /obj/item/card/id
@@ -28,7 +30,10 @@
 	QDEL_NULL(ID)
 	return ..()
 
-/obj/item/door_remote/attack_self__legacy__attackchain(mob/user)
+/obj/item/door_remote/activate_self(mob/user)
+	if(..())
+		return
+
 	var/list/options = list(WAND_OPEN = image(icon = 'icons/mob/radial.dmi', icon_state = "radial_open"),
 									WAND_BOLT = image(icon = 'icons/mob/radial.dmi', icon_state = "radial_bolt"),
 									WAND_EMERGENCY = image(icon = 'icons/mob/radial.dmi', icon_state = "radial_ea"),
@@ -49,19 +54,23 @@
 	. = ..()
 	. += "<span class='notice'>It's current mode is: [mode]</span>"
 
-/obj/item/door_remote/afterattack__legacy__attackchain(obj/target, mob/user)
+/obj/item/door_remote/interact_with_atom(atom/target, mob/living/user, list/modifiers)
 	if(istype(target, /obj/machinery/door/airlock))
 		access_airlock(target, user)
 	if(istype(target, /obj/machinery/door/window))
 		access_windoor(target, user)
+	return ITEM_INTERACT_COMPLETE
+
+/obj/item/door_remote/ranged_interact_with_atom(atom/target, mob/living/user, list/modifiers)
+	if(istype(target, /obj/machinery/door/airlock))
+		access_airlock(target, user)
+	if(istype(target, /obj/machinery/door/window))
+		access_windoor(target, user)
+	return ITEM_INTERACT_COMPLETE
 
 /obj/item/door_remote/proc/access_airlock(obj/machinery/door/airlock/D, mob/user)
 	if(HAS_TRAIT(D, TRAIT_CMAGGED))
 		to_chat(user, "<span class='danger'>The door doesn't respond to [src]!</span>")
-		return
-
-	if(D.is_special)
-		to_chat(user, "<span class='danger'>[src] cannot access this kind of door!</span>")
 		return
 
 	if(!(D.arePowerSystemsOn()))
@@ -184,10 +193,20 @@
 	/// How far can we use this. Leave `null` for infinite range
 	var/range
 
-/obj/item/door_remote/omni/access_tuner/afterattack__legacy__attackchain(obj/machinery/door/D, mob/user)
-	if(!istype(D, /obj/machinery/door/airlock) && !istype(D, /obj/machinery/door/window))
+/obj/item/door_remote/omni/access_tuner/interact_with_atom(atom/target, mob/living/user, list/modifiers)
+	if(!hack(target, user))	// if the hack is successful, calls the parent proc and does the door stuff
+		return ITEM_INTERACT_COMPLETE
+	return ..()
+
+/obj/item/door_remote/omni/access_tuner/ranged_interact_with_atom(atom/target, mob/living/user, list/modifiers)
+	if(!hack(target, user))
+		return ITEM_INTERACT_COMPLETE
+	return ..()
+
+/obj/item/door_remote/omni/access_tuner/proc/hack(atom/target, mob/user)
+	if(!istype(target, /obj/machinery/door/airlock) && !istype(target, /obj/machinery/door/window))
 		return
-	if(!isnull(range) && get_dist(src, D) > range)
+	if(!isnull(range) && get_dist(src, target) > range)
 		return
 
 	if(busy)
@@ -195,11 +214,14 @@
 		return
 	icon_state = "hacktool-g"
 	busy = TRUE
-	to_chat(user, "<span class='notice'>[src] is attempting to interface with [D]...</span>")
-	if(do_after(user, hack_speed, target = D))
-		. = ..()
+	to_chat(user, "<span class='notice'>[src] is attempting to interface with [target]...</span>")
+	if(!do_after(user, hack_speed, target = target))
+		busy = FALSE
+		icon_state = "hacktool"
+		return
 	busy = FALSE
 	icon_state = "hacktool"
+	return TRUE
 
 /obj/item/door_remote/omni/access_tuner/flayer
 	name = "integrated access tuner"
@@ -228,46 +250,52 @@
 	. = ..()
 	. += "<span class='notice'>This keyring has access to Medbay, Science, Engineering, Cargo, the Bar and the Kitchen!</span>"
 
-/obj/item/door_remote/janikeyring/attack_self__legacy__attackchain(mob/user)
-	if(cooldown > world.time)
+/obj/item/door_remote/janikeyring/activate_self(mob/user)
+	RegisterSignal(src, COMSIG_ACTIVATE_SELF, TYPE_PROC_REF(/datum, signal_cancel_activate_self), override = TRUE)
+	if(..() || cooldown > world.time)
 		return
+
 	to_chat(user, "<span class='warning'>You shake [src]!</span>")
 	playsound(src, 'sound/items/keyring_shake.ogg', 50)
 	cooldown = world.time + JANGLE_COOLDOWN
 
-/obj/item/door_remote/janikeyring/afterattack__legacy__attackchain(obj/machinery/door/D, mob/user, proximity)
-	if(!proximity)
-		return
-	if(!istype(D, /obj/machinery/door/airlock) && !istype(D, /obj/machinery/door/window))
+/obj/item/door_remote/janikeyring/interact_with_atom(obj/machinery/door/target, mob/living/user, list/modifiers)
+	if(!unlock(target, user))
+		return ITEM_INTERACT_COMPLETE
+	return ..()
+
+/obj/item/door_remote/janikeyring/ranged_interact_with_atom(atom/target, mob/living/user, list/modifiers) // THOSE AINT MAGICAL REMOTE KEYS
+	return
+
+
+/obj/item/door_remote/janikeyring/proc/unlock(obj/machinery/door/target, mob/living/user)
+	if(!istype(target, /obj/machinery/door/airlock) && !istype(target, /obj/machinery/door/window))
 		return
 	if(busy)
-		to_chat(user, "<span class='warning'>You are already using [src] on the [D]'s access panel!</span>")
+		to_chat(user, "<span class='warning'>You are already using [src] on the [target]'s access panel!</span>")
 		return
 	busy = TRUE
 	var/mob/living/carbon/human/H = user
-	if(H.mind.assigned_role == "Janitor" && last_airlock_uid == D.UID())
-		to_chat(user, "<span class='notice'>You recognize [D] and look for the key you used...</span>")
+	if(H.mind.assigned_role == "Janitor" && last_airlock_uid == target.UID())
+		to_chat(user, "<span class='notice'>You recognize [target] and look for the key you used...</span>")
 		hack_speed = 5 SECONDS
 	else
-		to_chat(user, "<span class='notice'>You fiddle with [src], trying different keys to open [D]...</span>")
+		to_chat(user, "<span class='notice'>You fiddle with [src], trying different keys to open [target]...</span>")
 		if(H.mind.assigned_role != "Janitor")
 			hack_speed = rand(30, 60) SECONDS
 		else
 			hack_speed = rand(5, 20) SECONDS
 	playsound(src, 'sound/items/keyring_unlock.ogg', 50)
-	if(do_after(user, hack_speed, target = D, progress = 0))
-		if(D.check_access(ID))
-			last_airlock_uid = D.UID()
-		. = ..()
+	if(do_after(user, hack_speed, target = target, progress = 1))
+		if(target.check_access(ID))
+			last_airlock_uid = target.UID()
+		busy =  FALSE
+		return TRUE
 	busy = FALSE
 
 /obj/item/door_remote/janikeyring/access_airlock(obj/machinery/door/airlock/D, mob/user)
 	if(HAS_TRAIT(D, TRAIT_CMAGGED))
 		to_chat(user, "<span class='danger'>[src] won't fit in the [D] airlock's access panel, there's slime everywhere!</span>")
-		return
-
-	if(D.is_special)
-		to_chat(user, "<span class='danger'>[src] cannot fit in the [D] airlock's access panel!</span>")
 		return
 
 	if(!D.arePowerSystemsOn())

--- a/code/game/objects/items/control_wand.dm
+++ b/code/game/objects/items/control_wand.dm
@@ -18,8 +18,8 @@
 
 	new_attack_chain = TRUE
 
-/obj/item/door_remote/New()
-	..()
+/obj/item/door_remote/Initialize(mapload)
+	. = ..()
 	ID = new /obj/item/card/id
 	for(var/region in region_access)
 		ID.access += get_region_accesses(region)
@@ -245,8 +245,8 @@
 	var/last_airlock_uid
 	additional_access = list(ACCESS_MEDICAL, ACCESS_RESEARCH, ACCESS_CONSTRUCTION, ACCESS_MAILSORTING, ACCESS_CARGO, ACCESS_MINING, ACCESS_KITCHEN, ACCESS_BAR, ACCESS_JANITOR, ACCESS_CHAPEL_OFFICE)
 
-/obj/item/door_remote/janikeyring/New()
-	..()
+/obj/item/door_remote/janikeyring/Initialize(mapload)
+	. = ..()
 	RegisterSignal(src, COMSIG_ACTIVATE_SELF, TYPE_PROC_REF(/datum, signal_cancel_activate_self))
 
 /obj/item/door_remote/janikeyring/examine(mob/user)
@@ -254,7 +254,6 @@
 	. += "<span class='notice'>This keyring has access to Medbay, Science, Engineering, Cargo, the Bar and the Kitchen!</span>"
 
 /obj/item/door_remote/janikeyring/activate_self(mob/user)
-	RegisterSignal(src, COMSIG_ACTIVATE_SELF, TYPE_PROC_REF(/datum, signal_cancel_activate_self), override = TRUE)
 	if(..() || cooldown > world.time)
 		return
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #27816
Migrates door remotes to the new attack chain
Removes an unused var from airlocks and unused procs from door remotes

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
new attack chain + bug bad
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
None of the remotes tapped objects pre-migration and none of them tap objects after.

Janitor Keyring
- [x] Activate self jiggles
- [x] Interrupting do_after stops it
- [x] Doesn't work from range
- [x] Opens doors with matching access
- [x] Doesn't open doors with wrong access

Door Remote
- [x] Activate self changes modes
- [x] Works from distance
- [x] Works up close
- [x] Doesn't open doors with wrong access
- [x] Opens/Bolts/EA's/Speeds doors

Access Tuner
- [x] Activate self changes modes
- [x] Works from  distance
- [x] Works up close
- [x] Interrupting do_after stops it
- [x] Opens/Bolts/EA's/Speeds doors

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

NPFC

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
