### PR TITLE
Stop portable machines updating their icon every atmos tick

### DIFF
--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -46,14 +46,10 @@
 
 GLOBAL_DATUM_INIT(canister_icon_container, /datum/canister_icons, new())
 
-#define HOLDING_TANK 		(1<<0)
-#define CONNECTED_PORT 		(1<<1)
-#define LOW_PRESSURE 		(1<<2)
-#define NORMAL_PRESSURE 	(1<<3)
-#define HIGH_PRESSURE 		(1<<4)
-#define EXTREME_PRESSURE 	(1<<5)
-#define NEW_COLOR 			(1<<6)
-#define RESET 				(LOW_PRESSURE | NEW_COLOR)
+#define LOW_PRESSURE 		0
+#define NORMAL_PRESSURE		1
+#define HIGH_PRESSURE		2
+#define EXTREME_PRESSURE	3
 
 /obj/machinery/atmospherics/portable/canister
 	name = "canister"
@@ -71,9 +67,6 @@ GLOBAL_DATUM_INIT(canister_icon_container, /datum/canister_icons, new())
 	var/list/canister_color //variable that stores colours
 	var/list/color_index // list which stores tgui color indexes for the recoloring options, to enable previously-set colors to show up right
 
-	//lists for check_change()
-	var/list/old_color
-
 	//passed to the ui to render the color lists
 	var/list/colorcontainer
 
@@ -85,7 +78,7 @@ GLOBAL_DATUM_INIT(canister_icon_container, /datum/canister_icons, new())
 	power_state = NO_POWER_USE
 	interact_offline = TRUE
 	var/release_log = ""
-	var/update_flag = NONE
+	var/current_pressure_appearance
 
 /obj/machinery/atmospherics/portable/canister/Initialize(mapload)
 	. = ..()
@@ -96,8 +89,6 @@ GLOBAL_DATUM_INIT(canister_icon_container, /datum/canister_icons, new())
 		"ter" = "none",
 		"quart" = "none"
 	)
-
-	old_color = list()
 
 	colorcontainer = list(
 		"prim" = list(
@@ -130,46 +121,24 @@ GLOBAL_DATUM_INIT(canister_icon_container, /datum/canister_icons, new())
 	if(isAntag(user))
 		. += "<span class='notice'>Canisters can be damaged, spilling their contents into the air, or you can just leave the release valve open.</span>"
 
-/obj/machinery/atmospherics/portable/canister/proc/check_change()
-	var/old_flag = update_flag
-	update_flag = NONE
-	if(holding_tank)
-		update_flag |= HOLDING_TANK
-	if(connected_port)
-		update_flag |= CONNECTED_PORT
-
-	var/tank_pressure = air_contents.return_pressure()
+/obj/machinery/atmospherics/portable/canister/proc/pressure_to_appearance(tank_pressure)
 	if(tank_pressure < 10)
-		update_flag |= LOW_PRESSURE
+		return LOW_PRESSURE
 	else if(tank_pressure < ONE_ATMOSPHERE)
-		update_flag |= NORMAL_PRESSURE
-	else if(tank_pressure < 15*ONE_ATMOSPHERE)
-		update_flag |= HIGH_PRESSURE
+		return NORMAL_PRESSURE
+	else if(tank_pressure < 15 * ONE_ATMOSPHERE)
+		return HIGH_PRESSURE
 	else
-		update_flag |= EXTREME_PRESSURE
-
-	if(list2params(old_color) != list2params(canister_color))
-		update_flag |= NEW_COLOR
-		old_color = canister_color.Copy()
-
-	if(update_flag == old_flag)
-		return FALSE
-	return TRUE
+		return EXTREME_PRESSURE
 
 /obj/machinery/atmospherics/portable/canister/update_icon_state()
-/*
-(note: colors has to be applied every icon update)
-*/
-
+	// Colors has to be applied every icon update
 	if(stat & BROKEN)
 		icon_state = "[canister_color["prim"]]-1"//yes, I KNOW the colours don't reflect when the can's borked, whatever.
 		return
 
 	if(icon_state != canister_color["prim"])
 		icon_state = canister_color["prim"]
-
-	if(!check_change()) //Returns FALSE if no change needed to icons.
-		return
 
 /obj/machinery/atmospherics/portable/canister/update_overlays()
 	. = ..()
@@ -183,21 +152,19 @@ GLOBAL_DATUM_INIT(canister_icon_container, /datum/canister_icons, new())
 			continue
 		. += canister_color[C]
 
-	if(update_flag & HOLDING_TANK)
+	if(holding_tank)
 		. += "can-open"
-	if(update_flag & CONNECTED_PORT)
+	if(connected_port)
 		. += "can-connector"
-	if(update_flag & LOW_PRESSURE)
-		. += "can-o0"
-	if(update_flag & NORMAL_PRESSURE)
-		. += "can-o1"
-	else if(update_flag & HIGH_PRESSURE)
-		. += "can-o2"
-	else if(update_flag & EXTREME_PRESSURE)
-		. += "can-o3"
 
-	update_flag &= ~RESET //the flag NEW_COLOR represents change, not states. As such, we have to reset them to be able to detect a change on the next go.
-	return
+	if(current_pressure_appearance == LOW_PRESSURE)
+		. += "can-o0"
+	else if(current_pressure_appearance == NORMAL_PRESSURE)
+		. += "can-o1"
+	else if(current_pressure_appearance == HIGH_PRESSURE)
+		. += "can-o2"
+	else if(current_pressure_appearance == EXTREME_PRESSURE)
+		. += "can-o3"
 
 /obj/machinery/atmospherics/portable/canister/temperature_expose(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	..()
@@ -234,8 +201,15 @@ GLOBAL_DATUM_INIT(canister_icon_container, /datum/canister_icons, new())
 
 	T.blind_release_air(expelled_gas)
 
+/obj/machinery/atmospherics/portable/canister/proc/sync_pressure_appearance()
+	var/new_pressure_appearance = pressure_to_appearance(air_contents.return_pressure())
+	if(current_pressure_appearance != new_pressure_appearance)
+		current_pressure_appearance = new_pressure_appearance
+		update_icon()
+
 /obj/machinery/atmospherics/portable/canister/process_atmos()
 	..()
+	sync_pressure_appearance()
 	var/datum/milla_safe/canister_process/milla = new()
 	milla.invoke_async(src)
 
@@ -265,8 +239,7 @@ GLOBAL_DATUM_INIT(canister_icon_container, /datum/canister_icons, new())
 			var/datum/gas_mixture/removed = canister.air_contents.remove(transfer_moles)
 
 			environment.merge(removed)
-			canister.update_icon()
-
+			canister.sync_pressure_appearance()
 
 	if(canister.air_contents.return_pressure() < 1)
 		canister.can_label = TRUE
@@ -357,6 +330,7 @@ GLOBAL_DATUM_INIT(canister_icon_container, /datum/canister_icons, new())
 						name = T
 					else
 						name = "canister"
+					update_appearance(UPDATE_NAME)
 				else
 					to_chat(ui.user, "<span class='warning'>As you attempted to rename it the pressure rose!</span>")
 					. = FALSE
@@ -424,9 +398,9 @@ GLOBAL_DATUM_INIT(canister_icon_container, /datum/canister_icons, new())
 				color_index[ctype] = newcolor
 				newcolor++ // javascript starts arrays at 0, byond (for some reason) starts them at 1, this converts JS values to byond values
 				canister_color[ctype] = colorcontainer[ctype]["options"][newcolor]["icon"]
+				update_icon()
 
 	add_fingerprint(ui.user)
-	update_icon()
 
 /obj/machinery/atmospherics/portable/canister/atmos_init()
 	. = ..()
@@ -532,11 +506,7 @@ GLOBAL_DATUM_INIT(canister_icon_container, /datum/canister_icons, new())
 		new /obj/item/stack/sheet/metal(drop_location(), 3)
 		qdel(src)
 
-#undef HOLDING_TANK
-#undef CONNECTED_PORT
 #undef LOW_PRESSURE
 #undef NORMAL_PRESSURE
 #undef HIGH_PRESSURE
 #undef EXTREME_PRESSURE
-#undef NEW_COLOR
-#undef RESET

--- a/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
+++ b/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
@@ -41,8 +41,6 @@
 		air_contents.react()
 		return
 
-	update_icon()
-
 /obj/machinery/atmospherics/portable/Destroy()
 	SSair.atmos_machinery -= src
 	disconnect()
@@ -70,6 +68,8 @@
 
 	anchored = TRUE //Prevent movement
 
+	update_icon()
+
 	return TRUE
 
 /obj/machinery/atmospherics/portable/disconnect()
@@ -80,6 +80,8 @@
 
 	connected_port.connected_device = null
 	connected_port = null
+
+	update_icon()
 
 	return TRUE
 


### PR DESCRIPTION
## What Does This PR Do
This PR makes it so that portable atmos machines, notably canisters, spend less time in SSair updating their icons and checking to see whether they should update their icons. Despite all the bookkeeping and flag updating here, update_icon was still getting called and executing countless times, to the tune of 3.5 million times a round:
![2025_01_11__11_17_57__Paradise Profile Viewer](https://github.com/user-attachments/assets/cf2adf6c-9e9c-4440-b4ae-1803b6f0f255)

This removes all that and just calls update_icon when it needs to be called, when we know the appearance needs changing:

- When the portable is connected to a port
- When a tank has been inserted
- When the total pressure in the portable has changed
- When the can is repainted

## Why It's Good For The Game
Performance.

## Images of changes

### Before

![2025_01_11__11_53_30__2025_01_11__11_52_57__dreamdaemon exe @ 2025-01-11 11_45_23 - Tracy Profiler 0 8](https://github.com/user-attachments/assets/611c59bc-bda4-4905-aacc-437a74fe5f9a)

### After

![2025_01_11__11_52_57__dreamdaemon exe @ 2025-01-11 11_45_23 - Tracy Profiler 0 8 2](https://github.com/user-attachments/assets/2d20307e-7d34-4b42-8cd6-21e5c167c2a4)

## Testing
Attached canisters to ports, unattached, added tank to canister, removed tank, opened valve, watched light as pressure changed, modified canister paint job.

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog
NPFC