### PR TITLE
Fixes locker breakout message showing the wrong time

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -435,6 +435,7 @@
 
 /obj/structure/closet/container_resist(mob/living/L)
 	var/breakout_time = 2 MINUTES
+	var/breakout_time_msg = (breakout_time / 10) / 60
 	if(opened)
 		if(L.loc == src)
 			L.forceMove(get_turf(src)) // Let's just be safe here
@@ -446,7 +447,7 @@
 	//		breakout_time++ //Harder to get out of welded lockers than locked lockers
 
 	//okay, so the closet is either welded or locked... resist!!!
-	to_chat(L, "<span class='warning'>You lean on the back of \the [src] and start pushing the door open. (this will take about [breakout_time] minutes)</span>")
+	to_chat(L, "<span class='warning'>You lean on the back of \the [src] and start pushing the door open. (this will take about [breakout_time_msg] minutes)</span>")
 	for(var/mob/O in viewers(usr.loc))
 		O.show_message("<span class='danger'>[src] begins to shake violently!</span>", 1)
 

--- a/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
@@ -77,6 +77,7 @@
 
 /obj/structure/closet/secure_closet/container_resist(mob/living/L)
 	var/breakout_time = 2 MINUTES
+	var/breakout_time_msg = (breakout_time / 10) / 60
 	if(opened)
 		if(L.loc == src)
 			L.forceMove(get_turf(src)) // Let's just be safe here
@@ -85,7 +86,7 @@
 		return //It's a secure closet, but isn't locked. Easily escapable from, no need to 'resist'
 
 	//okay, so the closet is either welded or locked... resist!!!
-	to_chat(L, "<span class='warning'>You lean on the back of \the [src] and start pushing the door open. (this will take about [breakout_time] minutes)</span>")
+	to_chat(L, "<span class='warning'>You lean on the back of \the [src] and start pushing the door open. (this will take about [breakout_time_msg] minutes)</span>")
 	for(var/mob/O in viewers(src))
 		O.show_message("<span class='danger'>[src] begins to shake violently!</span>", 1)
 


### PR DESCRIPTION
## What Does This PR Do
Displays the correct time when breaking out of a locker that is welded or secure.
## Why It's Good For The Game
Gives the player the correct information.
## Testing
Took control of a mob in a welded locker. 
Broke out and observed the correct message and time.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

<hr>

## Changelog

:cl:
fix: Fixed breakout messages for locker displaying the incorrect time.
/:cl:
