### PR TITLE
fix fusion gauntlets failing to deploy

### DIFF
--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -864,7 +864,7 @@
 	if(on_cooldown)
 		to_chat(user, "<span class='notice'>[src] is on cooldown!</span>")
 		return
-	if(!user.drop_l_hand() || !user.drop_r_hand())
+	if((user.l_hand && !user.drop_l_hand()) || (user.r_hand && !user.drop_r_hand()))
 		to_chat(user, "<span class='notice'>[src] are unable to deploy the blades with the items in your hands!</span>")
 		return
 	var/obj/item/W = new /obj/item/pyro_claws


### PR DESCRIPTION
## What Does This PR Do
This PR fixes fusion gauntlets failing to deploy with empty hands. Fixes #27945.
## Why It's Good For The Game
Bugfix.
## Testing
Spawned fusion gauntlets and pyro core, inserted core into gauntlets, wore gauntlets and confirmed I could activate them with the UI button. Waited for cooldown, put a toolbox in my hand, flagged it NODROP, ensured I could not activate gauntlets.
<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: Fusion gauntlets will now properly activate.
/:cl:
