### PR TITLE
Diona eye adjustment

### DIFF
--- a/code/modules/client/preference/preferences.dm
+++ b/code/modules/client/preference/preferences.dm
@@ -299,7 +299,7 @@ GLOBAL_LIST_INIT(special_role_times, list(
 				active_character.f_style = "Shaved"
 
 
-			if(!(S.bodyflags & ALL_RPARTS))
+			if(!(S.bodyflags & ALL_RPARTS) && (S.eyes != "blank_eyes") && !(S.bodyflags & NO_EYES))
 				dat += "<b>Eyes:</b> "
 				dat += "<a href='byond://?_src_=prefs;preference=eyes;task=input'>Color</a> [color_square(active_character.e_colour)]<br>"
 

--- a/code/modules/mob/living/carbon/human/species/diona_species.dm
+++ b/code/modules/mob/living/carbon/human/species/diona_species.dm
@@ -17,6 +17,7 @@
 	As a gestalt entity, each nymph possesses an individual personality, yet they communicate collectively. \
 	Consequently, Diona often speak in a unique blend of first and third person, using 'We' and 'I' to reflect their unified yet multifaceted nature."
 
+	eyes = "blank_eyes"
 	species_traits = list(NO_HAIR)
 	inherent_traits = list(TRAIT_NOGERMS, TRAIT_NODECAY)
 	inherent_biotypes = MOB_ORGANIC | MOB_HUMANOID | MOB_PLANT


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

This removes the weird human eyes that are layered on top of diona characters' heads. A diona's actual eyes are the small lime green spots on their face and body, and most of the time to make your character look right you'd have to deliberately change the color of the human eye overlay to the diona skintone to make it harder to see.

![eyediona](https://github.com/user-attachments/assets/46558ddc-71df-4fa2-85ed-bd8a43c3e403)

This also removes the menu item in preferences to customize the color of eyes for diona, because it doesn't work on the diona's actual eyes, only the human eye overlay. 

It also removes the menu item to customize the color of slimepeople eyes, because (as far as I could tell in my testing) the NO_EYES flag on slimepeople prevents their eyes from being a custom color, and the customization menu has no effect.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
I think having the human eyes overlay on dionea might be an oversight, because the base diona body has a proper eye on the face already. It's good to not have to change the eyes to skintone color to hide them.
It's also good not to have options that don't do anything.

This shouldn't make it harder to add colored eyes to dionea if somebody chooses to.

If anybody still wants human-style eyes on their diona, there's a hairstyle you can pick that includes them:
![humandionaeyes](https://github.com/user-attachments/assets/79958109-3d31-4399-bff2-447a3afface8)

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![dionaeyes](https://github.com/user-attachments/assets/038640c0-cadc-462a-87b7-fa935a0d3db3)
![eyesdrask](https://github.com/user-attachments/assets/42fca8a2-ff90-4427-b5a0-2c235029f3d2)
![eyesslime](https://github.com/user-attachments/assets/0db49dba-bc63-4efb-8884-630f79d28453)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Loaded up customization, looked at different species and their options, made sure species with eyes could still change eye color.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
imagedel: Dionea no longer have human eyes on top of their Diona eyes.
tweak: Removed non-functional eye color menu for slimepeople
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
