### PR TITLE
Fixes abstract items showing on mob examine

### DIFF
--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -147,6 +147,7 @@
 				continue
 			if(istype(item, /obj/item/grab))
 				grab_items |= item
+
 			if(item.flags & ABSTRACT)
 				abstract_items |= item
 			else

--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -143,12 +143,12 @@
 			accessories = parts[5]
 
 		if(item)
+			if(HAS_TRAIT(item, TRAIT_SKIP_EXAMINE))
+				continue
 			if(istype(item, /obj/item/grab))
 				grab_items |= item
 			if(item.flags & ABSTRACT)
 				abstract_items |= item
-			if(HAS_TRAIT(item, TRAIT_SKIP_EXAMINE))
-				continue
 			else
 				var/item_words = item.name
 				if(item.blood_DNA)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes abstract items showing on mob examine by moving the trait_skip_examine up so the else doesnt falsely trigger
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Abstract items should not show on examine
skip examine items should still not show on examine
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

<!-- How did you test the PR, if at all? -->

Equipped abstract nullrod.
Did not show on examine, did show the fleshy arm message
Made a non abstract item have TRAIT_SKIP_EXAMINE
Did not show on examine still

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: Fixes abstract items showing on mob examine
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
