### PR TITLE
Fix: legacy attackby respects can_be_hit again

### DIFF
--- a/code/_onclick/item_attack_legacy.dm
+++ b/code/_onclick/item_attack_legacy.dm
@@ -46,9 +46,9 @@
 	return FALSE
 
 /obj/attackby__legacy__attackchain(obj/item/I, mob/living/user, params)
-	return ..() || (can_be_hit && I.new_attack_chain \
+	return ..() || (can_be_hit && (I.new_attack_chain \
 		? I.attack_obj(src, user, params) \
-		: I.attack_obj__legacy__attackchain(src, user, params))
+		: I.attack_obj__legacy__attackchain(src, user, params)))
 
 /mob/living/attackby__legacy__attackchain(obj/item/I, mob/living/user, params)
 	user.changeNext_move(CLICK_CD_MELEE)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds missing parentheses to `/obj/attackby__legacy__attackchain`. You can no longer hit objects with `can_be_hit = FALSE`
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Beating a holoray and fire isnt immersive.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Spawned /obj/effect/holoray and a door.  Tried  beating the holoray and tried beating the door. The door was attacked, the holoray wasnt.
Cleaned blood with soap.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: Can't beat fire and holorays anymore
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
