### PR TITLE
make pencil shuttle cmag only

### DIFF
--- a/code/modules/supply/supply_packs/pack_shuttle.dm
+++ b/code/modules/supply/supply_packs/pack_shuttle.dm
@@ -81,12 +81,6 @@
 	cost = 2500
 	template = /datum/map_template/shuttle/emergency/old
 
-// this one isn't great but it isn't horrible either
-
-/datum/supply_packs/abstract/shuttle/cramped
-	cost = 3750
-	template = /datum/map_template/shuttle/emergency/cramped
-
 /datum/supply_packs/abstract/shuttle/military
 	cost = 3500
 	template = /datum/map_template/shuttle/emergency/military
@@ -134,12 +128,6 @@
 
 // these, otoh, have some pretty silly features, and are hidden behind emag
 
-/datum/supply_packs/abstract/shuttle/clown
-	speed_factor = 0.75  // this one's a little slower, enjoy your ride!
-	cmag_hidden = TRUE
-	cost = 500  // let the clown have it
-	template = /datum/map_template/shuttle/emergency/clown
-
 /datum/supply_packs/abstract/shuttle/narnar
 	cost = 3000
 	hidden = TRUE
@@ -149,3 +137,16 @@
 	hidden = TRUE
 	cost = 4000
 	template = /datum/map_template/shuttle/emergency/jungle
+
+// these are hidden behind cmag
+
+/datum/supply_packs/abstract/shuttle/clown
+	speed_factor = 0.75  // this one's a little slower, enjoy your ride!
+	cmag_hidden = TRUE
+	cost = 500  // let the clown have it
+	template = /datum/map_template/shuttle/emergency/clown
+
+/datum/supply_packs/abstract/shuttle/cramped
+	cost = 3750
+	cmag_hidden = TRUE
+	template = /datum/map_template/shuttle/emergency/cramped


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Makes the pencil shuttle only able to be bought when the supply console has been cmagged.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

Ultimately this is an exercise for the reader.

Every pencil shuttle is chaotic LRP hell. Regardless of whether you think it's funny or not, the shuttle ruins the potential for RP, kills the natural resolution of antag/sec rivalries, and now with MILLA it takes one person leaving the door open on exit to kill everyone inside that wasn't prepared.

There is no good reason for buying the shuttle besides "trolololol".
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Checked supply console shuttle options, no pencil, cmagged the console, bought it, waited 10 minutes because it was green alert and I didn't know how to set the shuttle time, got on the shuttle, rode it to CC, hated my life every second of the ride
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
tweak: Secure Transport Vessel 5 (STV5) only purchasable when supply console is cmagged
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
