### PR TITLE
Fix carbon/Destory runtime

### DIFF
--- a/code/modules/mob/living/carbon/carbon_procs.dm
+++ b/code/modules/mob/living/carbon/carbon_procs.dm
@@ -12,8 +12,8 @@
 		drop_item_to_ground(item, silent = TRUE)
 		qdel(item)
 	QDEL_LIST_CONTENTS(internal_organs)
-	QDEL_LIST_CONTENTS(stomach_contents)
-	QDEL_LIST_CONTENTS(processing_patches)
+	QDEL_LAZYLIST(stomach_contents)
+	QDEL_LAZYLIST(processing_patches)
 	GLOB.carbon_list -= src
 	if(in_throw_mode)
 		toggle_throw_mode()


### PR DESCRIPTION
## What Does This PR Do
Fixes a runtime in carbon/Destory

These two lists are both lazy, so they should be using QDEL_LAZYLIST. Normally, this isn't a big deal, because QDEL_LIST_CONTENTS checks if(the_list). In the case of processing_patches, however, this has caused a runtime because we LAZYREMOVE a patch when it's deleted, and qdel will immediately trigger that.

## Why It's Good For The Game
Runtimes bad.

## Testing
Nope. It's replacing one define with a slightly more paranoid one. If it compiles, it's fine.
<hr>

### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

<hr>

## Changelog
NPFC