### PR TITLE
Update SIT spawn prompt

### DIFF
--- a/code/modules/admin/verbs/infiltratorteam_syndicate.dm
+++ b/code/modules/admin/verbs/infiltratorteam_syndicate.dm
@@ -32,7 +32,7 @@ GLOBAL_VAR_INIT(sent_syndicate_infiltration_team, 0)
 		if(!input)
 			alert("No mission specified. Aborting.")
 			return
-	var/tctext = input(src, "How much TC do you want to give each team member? Suggested: 20-30. They cannot trade TC.") as num
+	var/tctext = input(src, "How much TC do you want to give each team member? Suggested: 100-150.") as num
 	var/tcamount = text2num(tctext)
 	tcamount = clamp(tcamount, 0, 1000)
 	if(GLOB.sent_syndicate_infiltration_team == 1)


### PR DESCRIPTION
## What Does This PR Do
The SIT spawn prompt was 9 years old. It didn't account for the TC inflation, and falsely claimed that they wouldn't be able to trade TC.

## Why It's Good For The Game
Honest messaging.

## Testing
I changed a string. If this somehow breaks something, I'm going to need to step away from the computer for a while.
<hr>

### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<hr>

## Changelog
:cl:
fix: The prompt admins get when spawning an SIT has been updated to account for the TC inflation in 2023. We should be less likely to give far too little TC now. Oops.
/:cl: