### PR TITLE
Los heads pueden cambiar a alerta azul

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -152,7 +152,7 @@
 			var/obj/item/card/id/I = H.get_idcard(TRUE)
 			if(istype(I))
 				// You must have captain access and it must be red alert or lower (no getting off delta/epsilon)
-				if((ACCESS_CAPTAIN in I.access) && SSsecurity_level.get_current_level_as_number() <= SEC_LEVEL_RED)
+				if((ACCESS_HEADS in I.access) && SSsecurity_level.get_current_level_as_number() <= SEC_LEVEL_RED)
 					change_security_level(text2num(params["level"]))
 				else
 					to_chat(ui.user, "<span class='warning'>You are not authorized to do this.</span>")


### PR DESCRIPTION
Trae este PR que en su momento escribio evan

https://github.com/Helixis/Paradise/pull/53

`Razones para este cambio: el sistema de codigos de la estacion presenta un inconveniente y es que si no esta un capitan para cambiar el codigo y a azul y los oficiales de seguridad necesitan los permisos que les ofrece el codigo azul, deben esperar y permitir que un head entre a la oficina del capitan a tomar la spare (osea, permitir un acceso ilegal) o dos, actuar como si ya estuvieran en codigo azul, que vendria siendo violar la ley de todos modos. De esta forma nueva forma, los cambios de codigo seran mas frecuentes segun la situacion lo amerite, no se necesitara saltarse la ley para proceder como se deberia y cambiar la alerta a azul en una emergencia llevara a la tripulacion a estar alerta antes de que un crimen grave suceda (antes del codigo rojo)`

Los motivos son los mismos