### PR TITLE
[FIX] SM monitoring console crash

### DIFF
--- a/code/game/machinery/computer/sm_monitor.dm
+++ b/code/game/machinery/computer/sm_monitor.dm
@@ -105,7 +105,7 @@
 		return
 	for(var/obj/machinery/atmospherics/supermatter_crystal/S in SSair.atmos_machinery)
 		// Delaminating, not within coverage, not on a tile.
-		if(!(is_station_level(S.z) || is_mining_level(S.z) || atoms_share_level(S, T) || issimulatedturf(S.loc)))
+		if(!is_station_level(S.z) && !is_mining_level(S.z) && !atoms_share_level(S, T) && !issimulatedturf(S.loc))
 			continue
 		supermatters.Add(S)
 

--- a/code/game/machinery/computer/sm_monitor.dm
+++ b/code/game/machinery/computer/sm_monitor.dm
@@ -105,7 +105,7 @@
 		return
 	for(var/obj/machinery/atmospherics/supermatter_crystal/S in SSair.atmos_machinery)
 		// Delaminating, not within coverage, not on a tile.
-		if(!is_station_level(S.z) && !is_mining_level(S.z) && !atoms_share_level(S, T) && !issimulatedturf(S.loc))
+		if(!atoms_share_level(S, T) || !issimulatedturf(S.loc))
 			continue
 		supermatters.Add(S)
 

--- a/code/game/machinery/computer/sm_monitor.dm
+++ b/code/game/machinery/computer/sm_monitor.dm
@@ -105,7 +105,7 @@
 		return
 	for(var/obj/machinery/atmospherics/supermatter_crystal/S in SSair.atmos_machinery)
 		// Delaminating, not within coverage, not on a tile.
-		if(!(is_station_level(S.z) || is_mining_level(S.z) || atoms_share_level(S, T) || !issimulatedturf(S.loc)))
+		if(!(is_station_level(S.z) || is_mining_level(S.z) || atoms_share_level(S, T) || issimulatedturf(S.loc)))
 			continue
 		supermatters.Add(S)
 

--- a/code/modules/power/engines/supermatter/supermatter.dm
+++ b/code/modules/power/engines/supermatter/supermatter.dm
@@ -143,7 +143,7 @@
 	/// Refered to as eer on the moniter. This value effects gas output, heat, damage, and radiation.
 	var/power = 0
 	/// A bonus to rad production equal to EER multiplied by the bonus given by each gas. The bonus gets higher the more gas there is in the chamber.
-	var/gas_coefficient
+	var/gas_coefficient = 0
 	///Determines the rate of positve change in gas comp values
 	var/gas_change_rate = 0.05
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Stops the SM monitoring console from pulling data from crystals that aren't on sim_floors.

It just doesn't add them to its list(array?)

Also adds a default value to the sm's gas coeff var. _(I believe trying to get and display a null was causing this in the first place)_

Fixes #27885 

## Why It's Good For The Game

TGUI crashes are bad, and annoying.

## Testing

<!-- How did you test the PR, if at all? -->

Tested and works, monitoring console behaved as normal, shards in crates no longer appear until they are opened.

Video below is proof of new behaviour and NO crashing.


https://github.com/user-attachments/assets/90b708fb-6d57-408e-8a6a-5d591979d2de

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
