### PR TITLE
Fixes some display issues with the next step on the surgical computer

### DIFF
--- a/code/__DEFINES/tools_defines.dm
+++ b/code/__DEFINES/tools_defines.dm
@@ -6,6 +6,15 @@
 #define TOOL_WRENCH 		"wrench"
 #define TOOL_WELDER 		"welder"
 
+GLOBAL_LIST_INIT(tool_tool_behaviors, list(
+	TOOL_CROWBAR,
+	TOOL_MULTITOOL,
+	TOOL_SCREWDRIVER,
+	TOOL_WIRECUTTER,
+	TOOL_WRENCH,
+	TOOL_WELDER
+))
+
 // Surgery tools
 #define TOOL_RETRACTOR "retractor"
 #define TOOL_HEMOSTAT "hemostat"

--- a/code/__DEFINES/tools_defines.dm
+++ b/code/__DEFINES/tools_defines.dm
@@ -6,7 +6,7 @@
 #define TOOL_WRENCH 		"wrench"
 #define TOOL_WELDER 		"welder"
 
-GLOBAL_LIST_INIT(tool_tool_behaviors, list(
+GLOBAL_LIST_INIT(construction_tool_behaviors, list(
 	TOOL_CROWBAR,
 	TOOL_MULTITOOL,
 	TOOL_SCREWDRIVER,

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -500,7 +500,7 @@
 	var/list/tools = list()
 	for(var/tool in allowed_tools)
 		// only list main surgery tools. you can figure out the improvised version by trying (or reading the wiki lul)
-		if((tool in GLOB.surgery_tool_behaviors) || ((tool in GLOB.tool_tool_behaviors) && allowed_tools[tool] == 100))
+		if((tool in GLOB.surgery_tool_behaviors) || ((tool in GLOB.construction_tool_behaviors) && allowed_tools[tool] == 100))
 			tools |= tool
 	if(!length(tools))
 		// if nothing else, just pick the first in the list.

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -500,15 +500,15 @@
 	var/list/tools = list()
 	for(var/tool in allowed_tools)
 		// only list main surgery tools. you can figure out the improvised version by trying (or reading the wiki lul)
-		if(tool in GLOB.surgery_tool_behaviors)
+		if((tool in GLOB.surgery_tool_behaviors) || ((tool in GLOB.tool_tool_behaviors) && allowed_tools[tool] == 100))
 			tools |= tool
 	if(!length(tools))
 		// if nothing else, just pick the first in the list.
 		var/atom/tool = allowed_tools[1]
-		tools |= tool.name
+		tools |= (ispath(tool)) ? tool::name : "[tool]"
 
 
-	return "[name] ([english_list(tools, and_text="or")])"
+	return "[name] ([english_list(tools, and_text=" or ")])"
 
 /**
  * Spread some nasty germs to an organ.


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
- Improves spacing when only two items are specified
- Fixes a runtime that would occur when non-surgical tools (such as screwdrivers) were the primary tool for a surgery
- Ensures regular tools (or anything else unconventional) will display properly on the computer.
- Regular tools will only appear on the surgical computer if they have a 100% success chance (or are the first item in the tool list)
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
The computer being broken for robotic surgeries isn't great. This ensures better parity.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


## Testing
Sliced open some robots and a vulp, ensured everything worked as intended.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: The surgical computer now properly displays the names of work tools for the next steps in surgeries.
fix: Spacing on the surgical computer's tool display has been improved.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
