### PR TITLE
Advertises double-examine lore blurbs on a single examine

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -649,7 +649,7 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 	if(LAZYACCESS(client.recent_examines, ref_to_atom))
 		result = A.examine_more(src)
 		if(!length(result))
-			result += "<span class='notice'><i>You examine [A] closer, but find nothing of interest...</i></span>"
+			result = A.examine(src)
 	else
 		result = A.examine(src)
 		if(length(A.examine_more()))

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -652,6 +652,8 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 			result += "<span class='notice'><i>You examine [A] closer, but find nothing of interest...</i></span>"
 	else
 		result = A.examine(src)
+		if(length(A.examine_more()))
+			result += "<span class='notice'><i>You can take a closer look by examining [A] again...</i></span>"
 		client.recent_examines[ref_to_atom] = world.time + EXAMINE_MORE_WINDOW // set to when we should not examine something
 
 	to_chat(src, chat_box_examine(result.Join("\n")), MESSAGE_TYPE_INFO, confidential = TRUE)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -653,7 +653,7 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 	else
 		result = A.examine(src)
 		if(length(A.examine_more()))
-			result += "<span class='notice'><i>You can take a closer look by examining [A] again...</i></span>"
+			result += "<span class='notice'><i>You can examine [A.p_them()] again to take a closer look...</i></span>"
 		client.recent_examines[ref_to_atom] = world.time + EXAMINE_MORE_WINDOW // set to when we should not examine something
 
 	to_chat(src, chat_box_examine(result.Join("\n")), MESSAGE_TYPE_INFO, confidential = TRUE)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Examining atoms with double-examine lore blurbs now tells you you can examine again to find out more.

Edit: Double examining atoms with no lore blurb now gives you the normal examine message, rather than a message telling you there's no blurb.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
There are a bunch of lore blurbs in the game that most players will miss because there's no way to know which atoms have them.
This makes the lore blurbs more visible and stops the writers' work from going unread.

Edit: This also lets you examine atoms like pipe pressure meters as fast as you like without getting a "There's nothing more to see" message.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


## Testing
Examined a bunch of atoms with lore blurbs once and twice.
Examined a bunch of atoms without lore blurbs once and twice.
![examine-more](https://github.com/user-attachments/assets/740a1f69-47cd-4d61-912a-ac1f0f0016a2)
![examine-more-3](https://github.com/user-attachments/assets/c5703910-7b5a-47d6-8ea6-ecef07679027)


<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
tweak: Double-examine lore blurbs are more visible.
tweak: Double-examining objects with no flavortext now gives the standard examine message.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
