### PR TITLE
Adds papersacks to the Plasteel Chef vendor

### DIFF
--- a/code/game/machinery/vendors/departmental_vendors.dm
+++ b/code/game/machinery/vendors/departmental_vendors.dm
@@ -108,6 +108,7 @@
 					/obj/item/reagent_containers/condiment/saltshaker =5,
 					/obj/item/reagent_containers/condiment/peppermill =5,
 					/obj/item/whetstone = 2,
+					/obj/item/storage/box/papersack = 20,
 					/obj/item/mixing_bowl = 10,
 					/obj/item/kitchen/mould/bear = 1,
 					/obj/item/kitchen/mould/worm = 1,


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Adds 20 papersacks to the Plasteel Chef's Dinnerware Vendor.
## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Papersacks are a great gimmick for chef's to package food and encourages some wholesome interactions, having some to start up your packaged food business is handy and might inspire newer chef players to also try the same. *(additionally, they would also discover the crafting feature when they need to make more and i feel like the crafting feature isn't so obvious right now to newcomers)*

There's 20, so there's plenty to begin with but when business begins to boom one might have to steal and empty a bin of papers.

## Images of changes

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->
![image](https://github.com/user-attachments/assets/46441812-c084-4c9a-8820-280ec07f694d)
![image](https://github.com/user-attachments/assets/112a39ce-20c2-4ec9-92a1-5ee8626ddb05)

## Testing

<!-- How did you test the PR, if at all? -->
>join
>check vendor
>paper sack
> :D
<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
add: The Chef's Dinnerware vendor now has some papersacks to jumpstart your packaged food business.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
