### PR TITLE
Ups flavortext length before cutoff to 400

### DIFF
--- a/code/__DEFINES/text_defines.dm
+++ b/code/__DEFINES/text_defines.dm
@@ -6,6 +6,7 @@
 #define MAX_CHARACTERS_PER_BOOKPAGE 5000
 #define MAX_SUMMARY_LEN 1500
 #define MAX_NAME_LEN 50 	//diona names can get loooooooong
+#define MAX_FLAVORTEXT_PRINT 400 //Amount of flavor text characters to print before cutting off.
 
 /// Removes characters incompatible with file names.
 #define SANITIZE_FILENAME(text) (GLOB.filename_forbidden_chars.Replace(text, ""))

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -791,10 +791,10 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 /mob/proc/print_flavor_text(shrink = TRUE)
 	if(flavor_text && flavor_text != "")
 		var/msg = dna?.flavor_text ? replacetext(dna.flavor_text, "\n", " ") : replacetext(flavor_text, "\n", " ")
-		if(length(msg) <= 40 || !shrink)
+		if(length(msg) <= MAX_FLAVORTEXT_PRINT || !shrink)
 			return "<span class='notice'>[msg]</span>" // There is already encoded by tgui_input
 		else
-			return "<span class='notice'>[copytext_preserve_html(msg, 1, 37)]... <a href='byond://?src=[UID()];flavor_more=1'>More...</a></span>"
+			return "<span class='notice'>[copytext_preserve_html(msg, 1, MAX_FLAVORTEXT_PRINT - 3)]... <a href='byond://?src=[UID()];flavor_more=1'>More...</a></span>"
 
 /mob/proc/is_dead()
 	return stat == DEAD


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This ups the flavor text length before being cut off to 400, from 40

40 characters is really not enough to describe anything meaningful about a character.
400 characters sounds like a _lot_, but it's about this much:
![flavortext-1](https://github.com/user-attachments/assets/a7b76a8b-3a82-4aea-ba47-2bc55e19cb7d)


For reference, you're currently only allowed this much before cutoff:
![flavortext-3](https://github.com/user-attachments/assets/c1b35294-9793-442f-a26c-4b9fd1ca28ec)
That's not enough to write something even as simple as "An average-looking skrell with blue skin."
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
It'd be nice to be able to read a bit more of characters' flavor text without having to open up a clunky popup. 400 characters isn't a huge amount, but it's enough to write at least a decent amount about your character. It's not such a large amount that it'll crowd out your chat window and interfere with mechanical uses for examining people.

Being able to write/read flavor text more easily might add to the RP environment and enhance character interaction a bit.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Gave myself a huge flavor text, nuggeted myself to add as many lines as possible to the examine window to make sure it wasn't too big.
![flavortext](https://github.com/user-attachments/assets/1de2176d-f24d-4913-aa07-46434873f792)

<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
tweak: Increased the length of flavor text before cutoff when examining characters.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
