### PR TITLE
Fixes an oversight with med scanner hallucinations

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -257,7 +257,7 @@ SLIME SCANNER
 	msgs += "Damage Specifics: <span class='healthscan_oxy'>[OX]</span> - <font color='green'>[TX]</font> - <font color='#FFA500'>[BU]</font> - <font color='red'>[BR]</font>"
 
 	if(H.timeofdeath && (H.stat == DEAD || (HAS_TRAIT(H, TRAIT_FAKEDEATH)) || probably_dead))
-		var/tod = probably_dead || (HAS_TRAIT(user, TRAIT_MED_MACHINE_HALLUCINATING) && prob(10)) ? world.time - rand(10, 5000) : H.timeofdeath  // Sure let's blow it out
+		var/tod = probably_dead && (HAS_TRAIT(user, TRAIT_MED_MACHINE_HALLUCINATING) && prob(10)) ? world.time - rand(10, 5000) : H.timeofdeath  // Sure let's blow it out
 		msgs += "<span class='notice'>Time of Death: [station_time_timestamp("hh:mm:ss", tod)]</span>"
 		var/tdelta = round(world.time - tod)
 		if(H.is_revivable() && !DNR)


### PR DESCRIPTION
## What Does This PR Do
Fixes a small oversight where a conditional check returned true no matter if the user of a scanner was hallucinating or not.
## Why It's Good For The Game
Stops wacky death times on the scanner even if the user is not hallucinating
## Images of changes
![image](https://github.com/user-attachments/assets/e75a8535-5dba-4477-88a4-61269a56cd6c)
## Testing
Used a health scanner on a dead mob without hallucination to check for normal behavior.
Used a health scanner with the hallucination trait to check for proper hallucination behavior.
Checked that the hallucination was working properly by using a ghost to scan the same mob with ghost health scanner.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<hr>

## Changelog

:cl:
fix: Fixed an oversight with health scanners always showing random death times.
/:cl: