### PR TITLE
Re-buff immovable rods

### DIFF
--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -32,6 +32,10 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	var/move_delay = 1
 	var/atom/start
 	var/atom/end
+	/// The minimum amount of damage dealt to walls, relative to their max HP.
+	var/wall_damage_min_fraction = 0.9
+	/// The maximum amount of damage dealt to walls, relative to their max HP. Values over 1 are useful for adjusting the probability of destroying the wall.
+	var/wall_damage_max_fraction = 1.4
 
 /obj/effect/immovablerod/New(atom/_start, atom/_end, delay)
 	. = ..()
@@ -84,6 +88,9 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 		audible_message("CLANG")
 
 	clong_turf(newloc)
+	if(isnull(newloc))
+		// The turf is dead, long live the turf!
+		newloc = loc
 	for(var/atom/victim as anything in newloc)
 		clong_thing(victim)
 
@@ -93,7 +100,7 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 
 	if(iswallturf(victim))
 		var/turf/simulated/wall/W = victim
-		W.take_damage(rand(W.damage_cap / 3, W.damage_cap * 4 / 3))
+		W.take_damage(rand(W.damage_cap * wall_damage_min_fraction, W.damage_cap * wall_damage_max_fraction))
 	else
 		victim.ex_act(EXPLODE_LIGHT)
 
@@ -111,9 +118,13 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 			victim.ex_act(EXPLODE_HEAVY)
 
 /obj/effect/immovablerod/event
+	wall_damage_min_fraction = 0.33
+	wall_damage_max_fraction = 1.33
 	// The base chance to "damage" the floor when passing. This is not guaranteed to cause a full on hull breach.
-	// Chance to expose the tile to space is like 15% of this value.
+	// Chance to expose the tile to space is like 60% of this value.
 	var/floor_rip_chance = 40
+	// Chance to damage the floor if we didn't rip it.
+	var/floor_graze_chance = 50
 
 /obj/effect/immovablerod/event/Move()
 	. = ..()
@@ -124,13 +135,10 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	if(!isfloorturf(victim))
 		return ..()
 
-	if(!prob(floor_rip_chance))
-		return
-
 	var/turf/simulated/floor/T = victim
-	if(prob(25))
+	if(prob(floor_rip_chance))
 		T.ex_act(EXPLODE_HEAVY)
-	else
+	else if(prob(floor_graze_chance))
 		T.ex_act(EXPLODE_LIGHT)
 
 /obj/effect/immovablerod/deadchat_plays(mode = DEADCHAT_DEMOCRACY_MODE, cooldown = 6 SECONDS)

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -91,8 +91,17 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	if(isnull(newloc))
 		// The turf is dead, long live the turf!
 		newloc = loc
-	for(var/atom/victim as anything in newloc)
-		clong_thing(victim)
+
+	while(TRUE)
+		var/hit_something_dense = FALSE
+		for(var/atom/victim as anything in newloc)
+			clong_thing(victim)
+			if(victim.density)
+				hit_something_dense = TRUE
+
+		// Keep hitting stuff until there's nothing dense or we randomly go through it.
+		if(!hit_something_dense || prob(25))
+			break
 
 /obj/effect/immovablerod/proc/clong_turf(turf/victim)
 	if(!victim.density)


### PR DESCRIPTION
## What Does This PR Do
Immovable rods cause more holes in the floor, back to their original ~24% chance.
Immovable rods now cause light damage to more floors that they don't break.
Immovable rods are more likely to break objects and deal more damage to mobs.
Wizard rods deal more wall damage.

## Why It's Good For The Game
With #27894, engineering ERTs can more effectively deal with large-scale breaches, So even if a rod breaks a lot of floors, it's still feasible to recover the station. They've also moved up to a major event since the initial nerf, so it's fair to make them more deadly.

Wizard rods shouldn't have gotten nerfed, but I forgot to fix that before MILLA 2 went in.

## Testing
Threw an event rod at the station. Many floors and objects were broken.
CLONGed my way through the station as a wizard. Many walls were broken.
CLONGed my way through a line of indestructible walls as a wizard. None broken, got through them.
<hr>

### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

![image](https://github.com/user-attachments/assets/741c1107-400d-4f24-9c9c-9a238ddf9b79)

<hr>

## Changelog
:cl:
tweak: Immovable rods got more dangerous again, both event and wizard ones.
/:cl: