### PR TITLE
Meteor shielding improvements

### DIFF
--- a/code/__HELPERS/trait_helpers.dm
+++ b/code/__HELPERS/trait_helpers.dm
@@ -439,6 +439,10 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 // Causes the effect to go through a teleporter instead of being deleted by it.
 #define TRAIT_EFFECT_CAN_TELEPORT "trait_effect_can_teleport"
 
+//***** MOVABLE ATOM TRAITS *****//
+// Prevents the atom from being transitioned to another Z level when approaching the edge of the map.
+#define TRAIT_NO_EDGE_TRANSITIONS "trait_no_edge_transitions"
+
 //***** PROC WRAPPERS *****//
 /// Proc wrapper of add_trait. You should only use this for callback. Otherwise, use the macro.
 /proc/callback_add_trait(datum/target, trait, source)

--- a/code/_globalvars/traits.dm
+++ b/code/_globalvars/traits.dm
@@ -1,6 +1,6 @@
 /*
  FUN ZONE OF ADMIN LISTINGS
- Try to keep this in sync with __DEFINES/traits.dm
+ Try to keep this in sync with __HELPERS/trait_helpers.dm
  quirks have it's own panel so we don't need them here.
 */
 GLOBAL_LIST_INIT(traits_by_type, list(
@@ -151,6 +151,10 @@ GLOBAL_LIST_INIT(traits_by_type, list(
 
 	/obj/effect = list(
 		"TRAIT_EFFECT_CAN_TELEPORT" = TRAIT_EFFECT_CAN_TELEPORT
+	),
+
+	/atom/movable = list(
+		"TRAIT_NO_EDGE_TRANSITIONS" = TRAIT_NO_EDGE_TRANSITIONS
 	)
 ))
 

--- a/code/game/objects/effects/meteors.dm
+++ b/code/game/objects/effects/meteors.dm
@@ -29,8 +29,8 @@ GLOBAL_LIST_INIT(meteors_gore, list(/obj/effect/meteor/meaty = 5, /obj/effect/me
 	while(!isspaceturf(pickedstart))
 		var/startSide = pick(GLOB.cardinal)
 		var/startZ = level_name_to_num(MAIN_STATION)
-		pickedstart = spaceDebrisStartLoc(startSide, startZ)
-		pickedgoal = spaceDebrisFinishLoc(startSide, startZ)
+		pickedstart = pick_edge_loc(startSide, startZ)
+		pickedgoal = pick_edge_loc(REVERSE_DIR(startSide), startZ)
 		max_i--
 		if(max_i <= 0)
 			return
@@ -38,41 +38,23 @@ GLOBAL_LIST_INIT(meteors_gore, list(/obj/effect/meteor/meaty = 5, /obj/effect/me
 	var/obj/effect/meteor/M = new Me(pickedstart, pickedgoal)
 	M.dest = pickedgoal
 
-/proc/spaceDebrisStartLoc(startSide, Z)
+/proc/pick_edge_loc(startSide, Z)
 	var/starty
 	var/startx
 	switch(startSide)
 		if(NORTH)
-			starty = world.maxy-(TRANSITIONEDGE + MAP_EDGE_PAD)
-			startx = rand((TRANSITIONEDGE + MAP_EDGE_PAD), world.maxx-(TRANSITIONEDGE + MAP_EDGE_PAD))
+			starty = world.maxy
+			startx = rand(1, world.maxx)
 		if(EAST)
-			starty = rand((TRANSITIONEDGE + MAP_EDGE_PAD),world.maxy-(TRANSITIONEDGE + MAP_EDGE_PAD))
-			startx = world.maxx-(TRANSITIONEDGE + MAP_EDGE_PAD)
+			starty = rand(1, world.maxy)
+			startx = world.maxx
 		if(SOUTH)
-			starty = (TRANSITIONEDGE + MAP_EDGE_PAD)
-			startx = rand((TRANSITIONEDGE + MAP_EDGE_PAD), world.maxx-(TRANSITIONEDGE + MAP_EDGE_PAD))
+			starty = 1
+			startx = rand(1, world.maxx)
 		if(WEST)
-			starty = rand((TRANSITIONEDGE + MAP_EDGE_PAD), world.maxy-(TRANSITIONEDGE + MAP_EDGE_PAD))
-			startx = (TRANSITIONEDGE + MAP_EDGE_PAD)
-	. = locate(startx, starty, Z)
-
-/proc/spaceDebrisFinishLoc(startSide, Z)
-	var/endy
-	var/endx
-	switch(startSide)
-		if(NORTH)
-			endy = (TRANSITIONEDGE + MAP_EDGE_PAD)
-			endx = rand((TRANSITIONEDGE + MAP_EDGE_PAD), world.maxx-(TRANSITIONEDGE + MAP_EDGE_PAD))
-		if(EAST)
-			endy = rand((TRANSITIONEDGE + MAP_EDGE_PAD), world.maxy-(TRANSITIONEDGE + MAP_EDGE_PAD))
-			endx = (TRANSITIONEDGE + MAP_EDGE_PAD)
-		if(SOUTH)
-			endy = world.maxy-(TRANSITIONEDGE + MAP_EDGE_PAD)
-			endx = rand((TRANSITIONEDGE + MAP_EDGE_PAD), world.maxx-(TRANSITIONEDGE + MAP_EDGE_PAD))
-		if(WEST)
-			endy = rand((TRANSITIONEDGE + MAP_EDGE_PAD),world.maxy-(TRANSITIONEDGE + MAP_EDGE_PAD))
-			endx = world.maxx-(TRANSITIONEDGE + MAP_EDGE_PAD)
-	. = locate(endx, endy, Z)
+			starty = rand(1, world.maxy)
+			startx = 1
+	return locate(startx, starty, Z)
 
 ///////////////////////
 //The meteor effect
@@ -96,7 +78,8 @@ GLOBAL_LIST_INIT(meteors_gore, list(/obj/effect/meteor/meaty = 5, /obj/effect/me
 	var/list/meteordrop = list(/obj/item/stack/ore/iron)
 	var/dropamt = 2
 
-/obj/effect/meteor/Move()
+/obj/effect/meteor/Move(atom/newloc, direction, glide_size_override = 0, update_dir = TRUE)
+	// Delete if we reach our goal or somehow leave the Z level.
 	if(z != z_original || loc == dest)
 		qdel(src)
 		return FALSE
@@ -119,6 +102,7 @@ GLOBAL_LIST_INIT(meteors_gore, list(/obj/effect/meteor/meaty = 5, /obj/effect/me
 
 /obj/effect/meteor/Initialize(mapload, target)
 	. = ..()
+	ADD_TRAIT(src, TRAIT_NO_EDGE_TRANSITIONS, ROUNDSTART_TRAIT)
 	z_original = z
 	GLOB.meteor_list += src
 	SpinAnimation()

--- a/code/game/turfs/space/space_turf.dm
+++ b/code/game/turfs/space/space_turf.dm
@@ -122,7 +122,7 @@
 	if((!(A) || !(src in A.locs)))
 		return
 
-	if(destination_z && destination_x && destination_y && !A.pulledby && !HAS_TRAIT(A, TRAIT_CURRENTLY_Z_MOVING))
+	if(destination_z && destination_x && destination_y && !A.pulledby && !HAS_TRAIT(A, TRAIT_CURRENTLY_Z_MOVING) && !HAS_TRAIT(A, TRAIT_NO_EDGE_TRANSITIONS))
 		var/tx = destination_x
 		var/ty = destination_y
 		var/turf/DT = locate(tx, ty, destination_z)

--- a/code/modules/events/dust.dm
+++ b/code/modules/events/dust.dm
@@ -32,40 +32,16 @@
 	strength = 1
 	life = 40
 
-/obj/effect/space_dust/New()
+/obj/effect/space_dust/Initialize(mapload)
 	. = ..()
-	var/startx = 0
-	var/starty = 0
-	var/endy = 0
-	var/endx = 0
+	ADD_TRAIT(src, TRAIT_NO_EDGE_TRANSITIONS, ROUNDSTART_TRAIT)
+
 	var/startside = pick(GLOB.cardinal)
 	GLOB.meteor_list += src
 
-	switch(startside)
-		if(NORTH)
-			starty = world.maxy-(TRANSITIONEDGE+1)
-			startx = rand((TRANSITIONEDGE+1), world.maxx-(TRANSITIONEDGE+1))
-			endy = TRANSITIONEDGE
-			endx = rand(TRANSITIONEDGE, world.maxx-TRANSITIONEDGE)
-		if(EAST)
-			starty = rand((TRANSITIONEDGE+1),world.maxy-(TRANSITIONEDGE+1))
-			startx = world.maxx-(TRANSITIONEDGE+1)
-			endy = rand(TRANSITIONEDGE, world.maxy-TRANSITIONEDGE)
-			endx = TRANSITIONEDGE
-		if(SOUTH)
-			starty = (TRANSITIONEDGE+1)
-			startx = rand((TRANSITIONEDGE+1), world.maxx-(TRANSITIONEDGE+1))
-			endy = world.maxy-TRANSITIONEDGE
-			endx = rand(TRANSITIONEDGE, world.maxx-TRANSITIONEDGE)
-		if(WEST)
-			starty = rand((TRANSITIONEDGE+1), world.maxy-(TRANSITIONEDGE+1))
-			startx = (TRANSITIONEDGE+1)
-			endy = rand(TRANSITIONEDGE,world.maxy-TRANSITIONEDGE)
-			endx = world.maxx-TRANSITIONEDGE
-	goal = locate(endx, endy, 1)
-	src.x = startx
-	src.y = starty
-	src.z = level_name_to_num(MAIN_STATION)
+	var/turf/start = pick_edge_loc(startside, level_name_to_num(MAIN_STATION))
+	forceMove(start)
+	goal = pick_edge_loc(REVERSE_DIR(startside), level_name_to_num(MAIN_STATION))
 	walk_towards(src, goal, 1)
 
 /obj/effect/space_dust/Bump(atom/A)

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -15,8 +15,8 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 
 /datum/event/immovable_rod/start()
 	var/startside = pick(GLOB.cardinal)
-	var/turf/startT = spaceDebrisStartLoc(startside, level_name_to_num(MAIN_STATION))
-	var/turf/endT = spaceDebrisFinishLoc(startside, level_name_to_num(MAIN_STATION))
+	var/turf/startT = pick_edge_loc(startside, level_name_to_num(MAIN_STATION))
+	var/turf/endT = pick_edge_loc(REVERSE_DIR(startside), level_name_to_num(MAIN_STATION))
 	new /obj/effect/immovablerod/event(startT, endT)
 
 /obj/effect/immovablerod

--- a/code/modules/station_goals/shield.dm
+++ b/code/modules/station_goals/shield.dm
@@ -110,12 +110,13 @@
 
 	data["satellites"] = list()
 	for(var/obj/machinery/satellite/S in GLOB.machines)
+		var/turf/T = get_turf(S)
 		data["satellites"] += list(list(
 			"id" = S.id,
 			"active" = S.active,
 			"mode" = S.mode,
-			"x" = S.x,
-			"y" = S.y
+			"x" = T.x,
+			"y" = T.y
 		))
 	update_notice()
 	data["notice"] = notice
@@ -276,8 +277,9 @@
 			continue
 		if(get_dist(M, src) > kill_range)
 			continue
-		if(!emagged && space_los(M))
-			if(!istype(M, /obj/effect/meteor/fake))
+		var/is_fake = istype(M, /obj/effect/meteor/fake)
+		if((!emagged || is_fake) && space_los(M))
+			if(!is_fake)
 				Beam(get_turf(M), icon_state = "sat_beam", time = 5, maxdistance = kill_range)
 				if(istype(M, /obj/effect/space_dust/meaty))
 					new /obj/item/food/meatsteak(get_turf(M))


### PR DESCRIPTION
## What Does This PR Do
Meteors now appear at the edge of the map (beyond the buildable range), rather than so close they can bypass shield satellites.
Emagged shield satellites are now clever and shoot down simulated meteors.
Shield sats inside a crate now report the crate's position on the control map, rather than the corner of the map.

## Why It's Good For The Game
Makes the shields work better, emagged sats not tell on themselves, and fixes a bug.

## Testing
Spawned meteors. They flew normally, but from the map edge.
Threw meteors at emagged and non-emagged shield sats. Emagged ones didn't fire.
Simulated a meteor wave. Emagged sats reported shooting down meteors.
Looked at a crate on the shield sat map.
<hr>

### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

<hr>

## Changelog
:cl:
tweak: Meteors now appear at the edge of the map (beyond the buildable range), rather than so close they can bypass shield satellites.
tweak: Emagged shield satellites are now clever and shoot down simulated meteors.
fix: Shield sats inside a crate now report the crate's position on the control map, rather than the corner of the map.
/:cl: