### PR TITLE
Fix sword sheaths disappearing when clicked with telekinesis

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -803,8 +803,6 @@
 	name = "saber sheath"
 	desc = "Can hold sabers."
 	base_icon_state = "sheath"
-	icon_state = "sheath"
-	item_state = "sheath"
 	can_hold = list(/obj/item/melee/saber)
 
 /obj/item/storage/belt/sheath/saber/populate_contents()
@@ -815,8 +813,6 @@
 	name = "snakesfang scabbard"
 	desc = "Can hold scimitars."
 	base_icon_state = "snakesfangsheath"
-	icon_state = "snakesfangsheath"
-	item_state = "snakesfangsheath"
 	can_hold = list(/obj/item/melee/snakesfang)
 
 /obj/item/storage/belt/sheath/snakesfang/populate_contents()
@@ -827,8 +823,6 @@
 	name = "breach cleaver scabbard"
 	desc = "Can hold massive cleavers."
 	base_icon_state = "breachcleaversheath"
-	icon_state = "breachcleaversheath"
-	item_state = "breachcleaversheath"
 	can_hold = list(/obj/item/melee/breach_cleaver)
 
 /obj/item/storage/belt/sheath/breach_cleaver/populate_contents()

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -785,15 +785,16 @@
 /obj/item/storage/belt/sheath/remove_from_storage(obj/item/W, atom/new_location)
 	if(!..())
 		return
-	playsound(src, 'sound/weapons/blade_unsheath.ogg', 20)
+	if(!length(contents)) // telekinesis grab spawns inside of the sheath and leaves it immediately...
+		playsound(src, 'sound/weapons/blade_unsheath.ogg', 20)
 
 /obj/item/storage/belt/sheath/update_icon_state()
 	if(length(contents))
-		icon_state = "[icon_state]-sword"
-		item_state = "[item_state]-sword"
+		icon_state = "[base_icon_state]-sword"
+		item_state = "[base_icon_state]-sword"
 	else
-		icon_state = initial(icon_state)
-		item_state = initial(item_state)
+		icon_state = base_icon_state
+		item_state = base_icon_state
 	if(isliving(loc))
 		var/mob/living/L = loc
 		L.update_inv_belt()
@@ -801,6 +802,7 @@
 /obj/item/storage/belt/sheath/saber
 	name = "saber sheath"
 	desc = "Can hold sabers."
+	base_icon_state = "sheath"
 	icon_state = "sheath"
 	item_state = "sheath"
 	can_hold = list(/obj/item/melee/saber)

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -814,6 +814,7 @@
 /obj/item/storage/belt/sheath/snakesfang
 	name = "snakesfang scabbard"
 	desc = "Can hold scimitars."
+	base_icon_state = "snakesfangsheath"
 	icon_state = "snakesfangsheath"
 	item_state = "snakesfangsheath"
 	can_hold = list(/obj/item/melee/snakesfang)
@@ -825,6 +826,7 @@
 /obj/item/storage/belt/sheath/breach_cleaver
 	name = "breach cleaver scabbard"
 	desc = "Can hold massive cleavers."
+	base_icon_state = "breachcleaversheath"
 	icon_state = "breachcleaversheath"
 	item_state = "breachcleaversheath"
 	can_hold = list(/obj/item/melee/breach_cleaver)


### PR DESCRIPTION
## What Does This PR Do
Fixes the wrong icon state on the sword sheaths when clicked with telekinesis.
Fixes the unsheath sound playing when clicked with telekinesis.
Fixes #27782 

## Why It's Good For The Game
An invisible items is bad

## Testing
Gave myself telekinesis, clicked on the sabre sheath, it didn't become invisible and didn't play the unsheath sound

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: Fixed the sword sheaths disappearing when clicked with telekinesis
/:cl:
