### PR TITLE
Fix stacking ability buttons when removing hijacked xeno organs

### DIFF
--- a/code/modules/surgery/organs/subtypes/xenos.dm
+++ b/code/modules/surgery/organs/subtypes/xenos.dm
@@ -25,8 +25,8 @@
 		for(var/powers_to_remove in alien_powers)
 			M.RemoveSpell(new powers_to_remove)
 	else
-		for(var/powers_to_add in human_powers)
-			M.AddSpell(new powers_to_add)
+		for(var/powers_to_remove in human_powers)
+			M.RemoveSpell(new powers_to_remove)
 	. = ..()
 
 /obj/item/organ/internal/alien/examine(mob/user)


### PR DESCRIPTION
## What Does This PR Do
Fixes stacking ability buttons when removing hijacked xeno organs
Fixes #27337 

## Why It's Good For The Game
Bugs are bad

## Testing
Implanted and removed xeno plasma vessels multiple times; at each step, there was the correct number of ability buttons: 0 or 1.
<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<hr>

## Changelog

:cl:
fix: Fixed stacking ability buttons when removing hijacked xeno organs
/:cl:
