### PR TITLE
Lazarus Reagent no longer forces you Alive

### DIFF
--- a/code/modules/mob/living/carbon/carbon_procs.dm
+++ b/code/modules/mob/living/carbon/carbon_procs.dm
@@ -1373,11 +1373,11 @@ so that different stomachs can handle things in different ways VB*/
 /mob/living/carbon/proc/can_breathe_tube()
 	return get_organ_slot("breathing_tube")
 
-/mob/living/carbon/proc/lazrevivial(mob/living/carbon/M)
+/mob/living/carbon/proc/lazrevival(mob/living/carbon/M, mob/dead/observer/G)
 
-	var/mob/dead/observer/ghost = M.get_ghost()
+	G = M.get_ghost() // Get the ghost again to see if it has returned to the body.
 
-	if(ghost) // If the ghost is still outside the body, the revival fails.
+	if(G) // ghosted after the timer expires.
 		M.visible_message("<span class='warning'>[M]'s body stops twitching as the Lazarus Reagent loses potency.</span>")
 		return
 

--- a/code/modules/mob/living/carbon/carbon_procs.dm
+++ b/code/modules/mob/living/carbon/carbon_procs.dm
@@ -1372,3 +1372,35 @@ so that different stomachs can handle things in different ways VB*/
 /// Returns TRUE if a breathing tube is equipped.
 /mob/living/carbon/proc/can_breathe_tube()
 	return get_organ_slot("breathing_tube")
+
+/mob/living/carbon/proc/lazrevivial(mob/living/carbon/M)
+
+	var/mob/dead/observer/ghost = M.get_ghost()
+
+	if(ghost) // If the ghost is still outside the body, the revival fails.
+		M.visible_message("<span class='warning'>[M]'s body stops twitching as the Lazarus Reagent loses potency.</span>")
+		return
+
+	// If the ghost has re-entered the body, perform the revival!
+	M.visible_message("<span class='success'>[M] gasps as they return to life!</span>")
+	M.adjustCloneLoss(50)
+	M.setOxyLoss(0)
+	M.adjustBruteLoss(rand(0, 15))
+	M.adjustToxLoss(rand(0, 15))
+	M.adjustFireLoss(rand(0, 15))
+
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		var/necrosis_prob = 15 * H.decaylevel
+		H.decaylevel = 0
+		for(var/obj/item/organ/O in (H.bodyparts | H.internal_organs))
+			if(prob(necrosis_prob) && !O.is_robotic() && !O.vital)
+				O.necrotize(FALSE)
+				if(O.status & ORGAN_DEAD)
+					O.germ_level = INFECTION_LEVEL_THREE
+		H.update_body()
+
+	M.grab_ghost()
+	M.update_revive()
+	add_attack_logs(M, M, "Revived with Lazarus Reagent")
+	SSblackbox.record_feedback("tally", "players_revived", 1, "lazarus_reagent")

--- a/code/modules/mob/living/carbon/carbon_procs.dm
+++ b/code/modules/mob/living/carbon/carbon_procs.dm
@@ -1388,6 +1388,7 @@ so that different stomachs can handle things in different ways VB*/
 	M.adjustBruteLoss(rand(0, 15))
 	M.adjustToxLoss(rand(0, 15))
 	M.adjustFireLoss(rand(0, 15))
+	M.do_jitter_animation(200)
 
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M

--- a/code/modules/mob/living/carbon/carbon_procs.dm
+++ b/code/modules/mob/living/carbon/carbon_procs.dm
@@ -1373,11 +1373,8 @@ so that different stomachs can handle things in different ways VB*/
 /mob/living/carbon/proc/can_breathe_tube()
 	return get_organ_slot("breathing_tube")
 
-/mob/living/carbon/proc/lazrevival(mob/living/carbon/M, mob/dead/observer/G)
-
-	G = M.get_ghost() // Get the ghost again to see if it has returned to the body.
-
-	if(G) // ghosted after the timer expires.
+/mob/living/carbon/proc/lazrevival(mob/living/carbon/M)
+	if(M.get_ghost()) // ghosted after the timer expires.
 		M.visible_message("<span class='warning'>[M]'s body stops twitching as the Lazarus Reagent loses potency.</span>")
 		return
 

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -969,16 +969,15 @@
 	if(iscarbon(M))
 		if(method == REAGENT_INGEST || (method == REAGENT_TOUCH && prob(25)))
 			if(M.stat == DEAD)
-				var/mob/dead/observer/ghost = M.get_ghost()
 				M.visible_message("<span class='notice'>[M]'s body begins to twitch as the Lazarus Reagent takes effect!</span>")
 				M.do_jitter_animation(200) // Visual feedback of lazarus working.
-
+				var/mob/dead/observer/ghost = M.get_ghost()
 				if(ghost)
 					to_chat(ghost, "<span class='ghostalert'>Lazarus Reagent is attempting to revive your body. Re-enter your body to be revived!</span> (Verbs -> Ghost -> Re-enter corpse)")
 					window_flash(ghost.client)
 					SEND_SOUND(ghost, sound('sound/effects/genetics.ogg'))
 
-				addtimer(CALLBACK(src, /datum/reagent/medicine/lazarus_reagent/proc/check_revival, M), 5 SECONDS) // 5 seconds to re-enter body
+				addtimer(CALLBACK(src, PROC_REF(check_revival), M), 5 SECONDS) // same time as the defib to keep things consistant.
 
 	..()
 
@@ -1001,7 +1000,7 @@
 		M.delayed_gib(TRUE)
 		return
 
-	// If the ghost has re-entered the body, perform the revival
+	// If the ghost has re-entered the body, perform the revival!
 	M.visible_message("<span class='success'>[M] gasps as they return to life!</span>")
 	M.adjustCloneLoss(50)
 	M.setOxyLoss(0)

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -972,11 +972,11 @@
 				if(M.suiciding) // Feedback if the player suicided.
 					M.visible_message("<span class='warning'>[M] twitches slightly, but appears to have no will to live!</span>")
 					return
-				if(HAS_TRAIT(M, TRAIT_HUSK || HAS_TRAIT(M, TRAIT_BADDNA))) // Feedback if the body is husked or has bad DNA.
+				if(HAS_TRAIT(M, TRAIT_HUSK) || HAS_TRAIT(M, TRAIT_BADDNA)) // Feedback if the body is husked or has bad DNA.
 					M.visible_message("<span class='warning'>[M] twitches slightly, but is otherwise unresponsive!</span>")
 					return
 				if(M.getBruteLoss() + M.getFireLoss() + M.getCloneLoss() >= 150)
-					if(IS_CHANGELING(M) || HAS_TRAIT(M, TRAIT_I_WANT_BRAINS || !M.ghost_can_reenter()))
+					if(IS_CHANGELING(M) || HAS_TRAIT(M, TRAIT_I_WANT_BRAINS) || !M.ghost_can_reenter())
 						M.visible_message("<span class='warning'>[M] twitches slightly, but nothing happens.</span>")
 						return
 					M.delayed_gib(TRUE)
@@ -988,7 +988,7 @@
 					to_chat(G, "<span class='ghostalert'>Lazarus Reagent is attempting to revive your body. Re-enter your body to be revived!</span> (Verbs -> Ghost -> Re-enter corpse)")
 					window_flash(G.client)
 					SEND_SOUND(G, sound('sound/effects/genetics.ogg'))
-				addtimer(CALLBACK(M, TYPE_PROC_REF(/mob/living/carbon, lazrevival), M, G), 5 SECONDS) // same time as the defib to keep things consistant.
+				addtimer(CALLBACK(M, TYPE_PROC_REF(/mob/living/carbon, lazrevival), M), 5 SECONDS) // same time as the defib to keep things consistant.
 
 	..()
 

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -982,13 +982,12 @@
 					return
 				M.visible_message("<span class='notice'>[M]'s body begins to twitch as the Lazarus Reagent takes effect!</span>")
 				M.do_jitter_animation(200) // Visual feedback of lazarus working.
-				var/mob/dead/observer/ghost = M.get_ghost()
-				if(ghost)
-					to_chat(ghost, "<span class='ghostalert'>Lazarus Reagent is attempting to revive your body. Re-enter your body to be revived!</span> (Verbs -> Ghost -> Re-enter corpse)")
-					window_flash(ghost.client)
-					SEND_SOUND(ghost, sound('sound/effects/genetics.ogg'))
-
-				addtimer(CALLBACK(M, TYPE_PROC_REF(/mob/living/carbon, lazrevivial), M), 5 SECONDS) // same time as the defib to keep things consistant.
+				var/mob/dead/observer/G = M.get_ghost()
+				if(G)
+					to_chat(G, "<span class='ghostalert'>Lazarus Reagent is attempting to revive your body. Re-enter your body to be revived!</span> (Verbs -> Ghost -> Re-enter corpse)")
+					window_flash(G.client)
+					SEND_SOUND(G, sound('sound/effects/genetics.ogg'))
+				addtimer(CALLBACK(M, TYPE_PROC_REF(/mob/living/carbon, lazrevival), M, G), 5 SECONDS) // same time as the defib to keep things consistant.
 
 	..()
 

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -969,42 +969,61 @@
 	if(iscarbon(M))
 		if(method == REAGENT_INGEST || (method == REAGENT_TOUCH && prob(25)))
 			if(M.stat == DEAD)
-				if(M.getBruteLoss() + M.getFireLoss() + M.getCloneLoss() >= 150)
-					if(IS_CHANGELING(M) || HAS_TRAIT(M, TRAIT_I_WANT_BRAINS))
-						return
-					M.delayed_gib(TRUE)
-					return
-				if(!M.ghost_can_reenter())
-					M.visible_message("<span class='warning'>[M] twitches slightly, but is otherwise unresponsive!</span>")
-					return
+				var/mob/dead/observer/ghost = M.get_ghost()
+				M.visible_message("<span class='notice'>[M]'s body begins to twitch as the Lazarus Reagent takes effect!</span>")
+				M.do_jitter_animation(200) // Visual feedback of lazarus working.
 
-				if(!M.suiciding && !HAS_TRAIT(M, TRAIT_HUSK) && !HAS_TRAIT(M, TRAIT_BADDNA))
-					M.visible_message("<span class='warning'>[M] seems to rise from the dead!</span>")
-					M.adjustCloneLoss(50)
-					M.setOxyLoss(0)
-					M.adjustBruteLoss(rand(0, 15))
-					M.adjustToxLoss(rand(0, 15))
-					M.adjustFireLoss(rand(0, 15))
-					if(ishuman(M))
-						var/mob/living/carbon/human/H = M
-						var/necrosis_prob = 15 * H.decaylevel
-						H.decaylevel = 0
-						for(var/obj/item/organ/O in (H.bodyparts | H.internal_organs))
-							// Per non-vital body part:
-							// 15% * H.decaylevel (1 to 4)
-							// Min of 0%, Max of 60%
-							if(prob(necrosis_prob) && !O.is_robotic() && !O.vital)
-								// side effects may include: Organ failure
-								O.necrotize(FALSE)
-								if(O.status & ORGAN_DEAD)
-									O.germ_level = INFECTION_LEVEL_THREE
-						H.update_body()
+				if(ghost)
+					to_chat(ghost, "<span class='ghostalert'>Lazarus Reagent is attempting to revive your body. Re-enter your body to be revived!</span> (Verbs -> Ghost -> Re-enter corpse)")
+					window_flash(ghost.client)
+					SEND_SOUND(ghost, sound('sound/effects/genetics.ogg'))
 
-					M.grab_ghost()
-					M.update_revive()
-					add_attack_logs(M, M, "Revived with lazarus reagent") //Yes, the logs say you revived yourself.
-					SSblackbox.record_feedback("tally", "players_revived", 1, "lazarus_reagent")
+				addtimer(CALLBACK(src, /datum/reagent/medicine/lazarus_reagent/proc/check_revival, M), 5 SECONDS) // 5 seconds to re-enter body
+
 	..()
+
+/datum/reagent/medicine/lazarus_reagent/proc/check_revival(mob/living/carbon/M)
+
+	var/mob/dead/observer/ghost = M.get_ghost()
+
+	if(ghost) // If the ghost is still outside the body, the revival fails.
+		M.visible_message("<span class='warning'>[M]'s body stops twitching as the Lazarus Reagent loses potency.</span>")
+		return
+	if(M.suiciding) // Feedback if the player suicided.
+		M.visible_message("<span class='warning'>[M] twitches slightly, but appears to have no will to live!</span>")
+		return
+	if(HAS_TRAIT(M, TRAIT_HUSK || HAS_TRAIT(M, TRAIT_BADDNA))) // Feedback if the body is husked or has bad DNA.
+		M.visible_message("<span class='warning'>[M] twitches slightly, but nothing happens.</span>")
+		return
+	if(M.getBruteLoss() + M.getFireLoss() + M.getCloneLoss() >= 150)
+		if(IS_CHANGELING(M) || HAS_TRAIT(M, TRAIT_I_WANT_BRAINS))
+			return
+		M.delayed_gib(TRUE)
+		return
+
+	// If the ghost has re-entered the body, perform the revival
+	M.visible_message("<span class='success'>[M] gasps as they return to life!</span>")
+	M.adjustCloneLoss(50)
+	M.setOxyLoss(0)
+	M.adjustBruteLoss(rand(0, 15))
+	M.adjustToxLoss(rand(0, 15))
+	M.adjustFireLoss(rand(0, 15))
+
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		var/necrosis_prob = 15 * H.decaylevel
+		H.decaylevel = 0
+		for(var/obj/item/organ/O in (H.bodyparts | H.internal_organs))
+			if(prob(necrosis_prob) && !O.is_robotic() && !O.vital)
+				O.necrotize(FALSE)
+				if(O.status & ORGAN_DEAD)
+					O.germ_level = INFECTION_LEVEL_THREE
+		H.update_body()
+
+	M.grab_ghost()
+	M.update_revive()
+	add_attack_logs(M, M, "Revived with Lazarus Reagent")
+	SSblackbox.record_feedback("tally", "players_revived", 1, "lazarus_reagent")
 
 /datum/reagent/medicine/sanguine_reagent
 	name = "Sanguine Reagent"

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -973,15 +973,16 @@
 					M.visible_message("<span class='warning'>[M] twitches slightly, but appears to have no will to live!</span>")
 					return
 				if(HAS_TRAIT(M, TRAIT_HUSK || HAS_TRAIT(M, TRAIT_BADDNA))) // Feedback if the body is husked or has bad DNA.
-					M.visible_message("<span class='warning'>[M] twitches slightly, but nothing happens.</span>")
+					M.visible_message("<span class='warning'>[M] twitches slightly, but is otherwise unresponsive!</span>")
 					return
 				if(M.getBruteLoss() + M.getFireLoss() + M.getCloneLoss() >= 150)
-					if(IS_CHANGELING(M) || HAS_TRAIT(M, TRAIT_I_WANT_BRAINS))
+					if(IS_CHANGELING(M) || HAS_TRAIT(M, TRAIT_I_WANT_BRAINS || !M.ghost_can_reenter()))
+						M.visible_message("<span class='warning'>[M] twitches slightly, but nothing happens.</span>")
 						return
 					M.delayed_gib(TRUE)
 					return
 				M.visible_message("<span class='notice'>[M]'s body begins to twitch as the Lazarus Reagent takes effect!</span>")
-				M.do_jitter_animation(200) // Visual feedback of lazarus working.
+				M.do_jitter_animation(300) // Visual feedback of lazarus working.
 				var/mob/dead/observer/G = M.get_ghost()
 				if(G)
 					to_chat(G, "<span class='ghostalert'>Lazarus Reagent is attempting to revive your body. Re-enter your body to be revived!</span> (Verbs -> Ghost -> Re-enter corpse)")


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

This changes Lazarus Reagent to behave more like a chemical version of defibrillators; it will give the ghost a notification that their body has Lazarus reagent in it, and if they return to their body, they will be revived. It also gives feedback in cases where this would fail or can't succeed.

It was once implemented this way here #18910 and was reverted here #19089 due to bugs.

I would like to prefix everything here with the fact that these are my most extensive changes to date, and with a history of how changes like this have not worked well on live before, a TM will likely be needed.

This would also resolve #27822 which is what first sent me down the rabbit hole.

## Why It's Good For The Game

Not being "SUDDENLY ALIVE" is good, and _should_ stop rare edge cases where LR revives someone and they are catatonic.

## Testing

I have tested these changes locally and they _appear_ to work just fine, I shall do more extensive testing and add relevant evidence below.

- [x] Works in Pill AND liquid form
- [x] Doesn't out changelings
- [x] Doesn't work on suicidees
- [x] Repeat attempts still work

Below is a quick video of LR in action.

https://github.com/user-attachments/assets/9cf1a2b3-899a-480f-b219-534c3886b1a2

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

![image](https://github.com/user-attachments/assets/b007c467-3cbd-4f28-8dc6-cb85ebdbec63)

## Changelog

:cl:
tweak: LR revival is now voluntary.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
