### PR TITLE
[FIX] Cyborgs cannot be emag spammed

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_mob.dm
+++ b/code/modules/mob/living/silicon/robot/robot_mob.dm
@@ -1174,8 +1174,8 @@ GLOBAL_LIST_INIT(robot_verbs_default, list(
 			to_chat(user, "You must close the panel first")
 			return
 		else
-			sleep(6)
 			SetEmagged(TRUE)
+			sleep(6)
 			SetLockdown(1) //Borgs were getting into trouble because they would attack the emagger before the new laws were shown
 			if(hud_used)
 				hud_used.update_robot_modules_display()	//Shows/hides the emag item if the inventory screen is already open.


### PR DESCRIPTION
## What Does This PR Do
Moves the setting of the emagged state on borgs before sleep, so borgs can't be emagged multiple times within a 0.6 seconds interval.
Fixes #28007
## Why It's Good For The Game
Poor borgs

## Testing
Emagged a cyborg and clicked quickly, but it was only emagged once.
<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<hr>

## Changelog

:cl:
fix: Borgs cannot be emag spammed
/:cl:
