### PR TITLE
Fix some cases of silicons teleporting items on put_in_hands

### DIFF
--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -137,7 +137,8 @@
 			if("cellremove")
 				if(open && cell && !usr.get_active_hand())
 					cell.update_icon()
-					usr.put_in_hands(cell)
+					if(Adjacent(usr) && !issilicon(usr))
+						usr.put_in_hands(cell)
 					cell.add_fingerprint(usr)
 					cell = null
 					usr.visible_message("<span class='notice'>[usr] removes the power cell from [src].</span>", "<span class='notice'>You remove the power cell from [src].</span>")

--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -137,6 +137,7 @@
 			if("cellremove")
 				if(open && cell && !usr.get_active_hand())
 					cell.update_icon()
+					cell.forceMove(loc)
 					if(Adjacent(usr) && !issilicon(usr))
 						usr.put_in_hands(cell)
 					cell.add_fingerprint(usr)

--- a/code/modules/hydroponics/gene_modder.dm
+++ b/code/modules/hydroponics/gene_modder.dm
@@ -338,7 +338,8 @@
 		if("eject_seed")
 			if(seed)
 				seed.forceMove(loc)
-				user.put_in_hands(seed)
+				if(Adjacent(usr) && !issilicon(usr))
+					user.put_in_hands(seed)
 				seed = null
 				update_genes()
 				update_icon(UPDATE_OVERLAYS)
@@ -351,7 +352,8 @@
 			var/obj/item/disk/plantgene/D = contents[text2num(params["index"])]
 			if(D)
 				D.forceMove(loc)
-				user.put_in_hands(D)
+				if(Adjacent(usr) && !issilicon(usr))
+					user.put_in_hands(D)
 				disk = null
 				update_genes()
 			else
@@ -420,7 +422,8 @@
 			for(var/obj/item/disk/plantgene/D in contents)
 				if(!D.gene && !D.is_bulk_core)
 					D.forceMove(loc)
-					user.put_in_hands(D)
+					if(Adjacent(usr) && !issilicon(usr))
+						user.put_in_hands(D)
 					update_genes()
 					return
 			to_chat(user, "<span class='warning'>No Empty Disks to Eject!</span>")

--- a/code/modules/hydroponics/gene_modder.dm
+++ b/code/modules/hydroponics/gene_modder.dm
@@ -338,7 +338,7 @@
 		if("eject_seed")
 			if(seed)
 				seed.forceMove(loc)
-				if(Adjacent(usr) && !issilicon(usr))
+				if(Adjacent(user) && !issilicon(user))
 					user.put_in_hands(seed)
 				seed = null
 				update_genes()
@@ -352,7 +352,7 @@
 			var/obj/item/disk/plantgene/D = contents[text2num(params["index"])]
 			if(D)
 				D.forceMove(loc)
-				if(Adjacent(usr) && !issilicon(usr))
+				if(Adjacent(user) && !issilicon(user))
 					user.put_in_hands(D)
 				disk = null
 				update_genes()
@@ -422,7 +422,7 @@
 			for(var/obj/item/disk/plantgene/D in contents)
 				if(!D.gene && !D.is_bulk_core)
 					D.forceMove(loc)
-					if(Adjacent(usr) && !issilicon(usr))
+					if(Adjacent(user) && !issilicon(user))
 						user.put_in_hands(D)
 					update_genes()
 					return


### PR DESCRIPTION
## What Does This PR Do
Adds some missing checks on put_in_hands to ensure that AI and silicons don’t teleport items to themselves
Fixes #27335

## Why It's Good For The Game
Bugs are bad

## Testing
Loaded plant DNA manipulator with disks, tried to eject disk as AI; disk spawned on DNA manipulator
Uncrewed space heater, tried to remove power cell as AI, cell spawned on space heater
<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<hr>

## Changelog

:cl:
fix: AI don’t teleport disks and seeds from plant DNA manipulator to the core on eject
/:cl: