### PR TITLE
[FIX] Slimes can now resist to stop feeding

### DIFF
--- a/code/modules/mob/living/simple_animal/slime/slime_mob.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime_mob.dm
@@ -226,8 +226,8 @@
 /mob/living/simple_animal/slime/Process_Spacemove(movement_dir = 0)
 	return 2
 
-/mob/living/simple_animal/slime/resist()
-	. = ..()
+/mob/living/simple_animal/slime/resist_buckle()
+	..()
 	Feedstop()
 
 /mob/living/simple_animal/slime/get_status_tab_items()

--- a/code/modules/mob/living/simple_animal/slime/slime_mob.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime_mob.dm
@@ -8,7 +8,6 @@
 	gender = NEUTER
 	var/is_adult = FALSE
 	var/docile = FALSE
-	// var/is_feeding = FALSE
 	faction = list("slime", "neutral")
 
 	harm_intent_damage = 5

--- a/code/modules/mob/living/simple_animal/slime/slime_mob.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime_mob.dm
@@ -8,6 +8,7 @@
 	gender = NEUTER
 	var/is_adult = FALSE
 	var/docile = FALSE
+	// var/is_feeding = FALSE
 	faction = list("slime", "neutral")
 
 	harm_intent_damage = 5
@@ -225,6 +226,10 @@
 
 /mob/living/simple_animal/slime/Process_Spacemove(movement_dir = 0)
 	return 2
+
+/mob/living/simple_animal/slime/resist()
+	. = ..()
+	Feedstop()
 
 /mob/living/simple_animal/slime/get_status_tab_items()
 	var/list/status_tab_data = ..()

--- a/code/modules/mob/living/simple_animal/slime/slime_powers.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime_powers.dm
@@ -104,6 +104,7 @@
 		layer = M.layer + 0.01 //appear above the target mob
 		M.visible_message("<span class='danger'>[name] has latched onto [M]!</span>", \
 						"<span class='userdanger'>[name] has latched onto [M]!</span>")
+		// is_feeding = TRUE
 	else
 		to_chat(src, "<span class='warning'><i>I have failed to latch onto the subject!</i></span>")
 
@@ -117,6 +118,7 @@
 		if(!silent)
 			visible_message("<span class='warning'>[src] has let go of [buckled]!</span>", \
 							"<span class='notice'><i>I stopped feeding.</i></span>")
+			// is_feeding = FALSE
 		layer = initial(layer)
 		unbuckle(force=TRUE)
 

--- a/code/modules/mob/living/simple_animal/slime/slime_powers.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime_powers.dm
@@ -104,7 +104,6 @@
 		layer = M.layer + 0.01 //appear above the target mob
 		M.visible_message("<span class='danger'>[name] has latched onto [M]!</span>", \
 						"<span class='userdanger'>[name] has latched onto [M]!</span>")
-		// is_feeding = TRUE
 	else
 		to_chat(src, "<span class='warning'><i>I have failed to latch onto the subject!</i></span>")
 
@@ -118,7 +117,6 @@
 		if(!silent)
 			visible_message("<span class='warning'>[src] has let go of [buckled]!</span>", \
 							"<span class='notice'><i>I stopped feeding.</i></span>")
-			// is_feeding = FALSE
 		layer = initial(layer)
 		unbuckle(force=TRUE)
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Stops the feeding process if slimes resist()

Either with the keybind or by clicking the "Buckled!" icon.

Fixes #27903 

## Why It's Good For The Game

Opening a tgui menu full of targets to then having to try and select your current one to stop feeding is bad.

## Testing

Tested on a local server, could use resist to stop feeding. ✔

Video of testing post changes;

https://github.com/user-attachments/assets/f4fa9a94-8676-4879-8d55-01c973e0d089

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: Slimes can resist to stop feeding.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
