### PR TITLE
Fixes #28022: mecha/AI/hologram bugs from #25078

### DIFF
--- a/code/_onclick/ai_onclick.dm
+++ b/code/_onclick/ai_onclick.dm
@@ -15,8 +15,10 @@
 		// But we return here since we don't want to do regular dblclick handling
 		return
 
-	if(control_disabled || stat) return
-	if(ismecha(loc)) return
+	if(control_disabled || stat) 
+		return
+	if(ismecha(loc)) 
+		return
 
 	if(ismob(A))
 		ai_actual_track(A, TRUE)

--- a/code/_onclick/ai_onclick.dm
+++ b/code/_onclick/ai_onclick.dm
@@ -16,6 +16,7 @@
 		return
 
 	if(control_disabled || stat) return
+	if(ismecha(loc)) return
 
 	if(ismob(A))
 		ai_actual_track(A, TRUE)

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -316,6 +316,8 @@ GLOBAL_LIST_EMPTY(holopads)
 		return
 	if(istype(robot))
 		interact(robot)
+	if(ismecha(ai.loc)) // AIs must exit mechs before activating holopads.
+		return
 	/*There are pretty much only three ways to interact here.
 	I don't need to check for client since they're clicking on an object.
 	This may change in the future but for now will suffice.*/

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1031,6 +1031,10 @@
 
 //Hack and From Card interactions share some code, so leave that here for both to use.
 /obj/mecha/proc/ai_enter_mech(mob/living/silicon/ai/AI, interaction)
+	var/mob/camera/eye/hologram/hologram_eye = AI.remote_control
+	if(istype(hologram_eye))
+		hologram_eye.release_control()
+		qdel(hologram_eye)
 	AI.aiRestorePowerRoutine = 0
 	AI.forceMove(src)
 	occupant = AI
@@ -1315,6 +1319,7 @@
 			RemoveActions(occupant, 1)
 			mob_container = AI
 			newloc = get_turf(AI.linked_core)
+			AI.eyeobj?.set_loc(newloc)
 			qdel(AI.linked_core)
 	else
 		return

--- a/code/modules/mob/camera/eye/hologram_eye.dm
+++ b/code/modules/mob/camera/eye/hologram_eye.dm
@@ -2,7 +2,6 @@
 	name = "Inactive Hologram Eye"
 	ai_detector_visible = FALSE
 	acceleration = FALSE
-	relay_speech = TRUE
 	var/obj/machinery/hologram/holopad/holopad
 
 /mob/camera/eye/hologram/Initialize(mapload, owner_name, camera_origin, mob/living/user)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

PR fixes https://github.com/ParadiseSS13/Paradise/issues/28022
PR fixes https://github.com/ParadiseSS13/Paradise/issues/28056

PR #25078 introduced a few bugs related to AI eyes, mechs, and holograms, which are referenced in #28022. This change fixes those bugs.
* Entering a mech with an active hologram eye will now release that eye before granting control of the mech.
* Double clicking on a turf as an AI while in a mech will no longer unstick the camera from the mech.
* When exiting a mech, the AI will now properly refocus on its core instead of on the spot that it first entered the mech.
* AI will no longer receive duplicate original audio from holopads, and now will receive only relayed speech.
* AIs will no longer be able to activate a holopad while occupying a mech.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

Bugs are bad. Fixing them is good.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

I booted up a test server and logged in as an AI. I `spawn`ed a phazon mech, and used VV to add an AI tracker to its `trackers`.

I took control of the mech, and then tried to use a holopad, to no effect. I also tried to double click on a turf, to no effect.

I navigated to another area as the mech.

I then used the eject button to eject from the mech. My camera was refocused on my core, and when I moved away from it, its movement was natural and did not jump to the location that the mech was first entered.

I activated a holopad. I then took control of the mech. The hologram disappeared. I ejected from the mech, and my camera was refocused on the core, and when I moved away from it, its movement was natural, as above.

I logged into the test server with another client as a guest. I joined as a botanist, and jumped to the central primary hallway above the bridge. On the client that I was logged in as an AI, I activated the holopad there. I spoke using departmental radio (`:h`) as the AI. The botanist client heard the hologram. (S.O.P.H.I.E. states, "Hello world.") I spoke normally as the botanist. The AI client heard the relayed speech only. (_Relayed Speech: Lando Riker says, "Hello world."_)
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl: Ascio
fix: Entering a mech with an active hologram eye will now release that eye before granting control of the mech.
fix: Double clicking on a turf as an AI while in a mech will no longer unstick the camera from the mech.
fix: When exiting a mech, the AI will now properly refocus on its core instead of on the spot that it first entered the mech.
fix: AI will no longer receive duplicate original audio from holopads, and now will receive only relayed speech.
fix: AIs will no longer be able to activate a holopad while occupying a mech.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
