### PR TITLE
Nerfs Mantis Blades

### DIFF
--- a/code/datums/uplink_items/uplink_general.dm
+++ b/code/datums/uplink_items/uplink_general.dm
@@ -957,7 +957,10 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	Can be used to parry incoming melee attacks."
 	reference = "MBK"
 	item = /obj/item/storage/box/syndie_kit/syndie_mantis
-	cost = 60
+	cost = 75
+	surplus = 0
+	can_discount = FALSE
+	excludefrom = list(UPLINK_TYPE_NUCLEAR)
 
 ////////////////////////////////////////
 // MARK: POINTLESS BADASSERY

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -892,7 +892,7 @@
 	name = "'Naginata' mantis blade"
 	icon_state = "syndie_mantis"
 	item_state = "syndie_mantis"
-	force = 20
+	force = 15
 	armour_penetration_percentage = 30
 
 /obj/item/melee/mantis_blade/syndicate/Initialize(mapload)
@@ -903,7 +903,7 @@
 	name = "'Scylla' mantis blade"
 	icon_state = "mantis"
 	item_state = "mantis"
-	force = 18
+	force = 12
 
 /obj/item/melee/mantis_blade/nt/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
## What Does This PR Do
Provides much needed nerfs to the Mantis Blades.

Raises the prices on Mantis Blades 60 -> 75
Reduces the force on Mantis blades from 20 -> 15 (Syndicate) and 18 -> 12 (Nanotrasen)
Removes Mantis blades from the Nuclear Uplink
Removes Mantis blades from Surplus
Removes Mantis blades from discount item list

## Why It's Good For The Game
Mantis blades were a bit over tuned when introduced to the game. This levels them out after being tested in different conditions with multiple Balance Team members. This puts them more in line with higher damaged weapons while considering other items they can be paired with.

## Testing
Spawned in Uplink and checked Force on Mantis Blades (Syndicate) and checked their price.
Spawned in Mantis Blades (Nanotrasen) and checked the force.
Spawned in a Nuclear Uplink and checked to see if Mantis Blades were excluded.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
![Discord_a5wX7abexF](https://github.com/user-attachments/assets/1a574d20-49e6-43ab-a72f-823f57018f07)
<hr>


## Changelog

:cl:
tweak: Raised price of Mantis Blades in the Traitor Uplink
tweak: Reduced force on Syndicate and NT Mantis blades
tweak: Removed Mantis blades from the Nuclear Uplink
tweak: Prevented Mantis blades from being included in Surplus crates
tweak: Prevented Mantis blades from being discount eligible
/:cl: