### PR TITLE
Prevents TGUI crash when slime tries to feed with 0 valid targets

### DIFF
--- a/code/modules/mob/living/simple_animal/slime/slime_powers.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime_powers.dm
@@ -30,7 +30,7 @@
 			choices += C
 
 	if(!length(choices))
-		to_chat(src, "<span class='warning'>No subjects nearby to feed on</span>")
+		to_chat(src, "<span class='warning'>No subjects nearby to feed on!</span>")
 		return
 
 	var/mob/living/M = tgui_input_list(src, "Who do you wish to feed on?", "Feeding Selection", choices)

--- a/code/modules/mob/living/simple_animal/slime/slime_powers.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime_powers.dm
@@ -29,6 +29,10 @@
 		if(C!=src && Adjacent(C))
 			choices += C
 
+	if(!length(choices))
+		to_chat(src, "<span class='warning'>No subjects nearby to feed on</span>")
+		return
+
 	var/mob/living/M = tgui_input_list(src, "Who do you wish to feed on?", "Feeding Selection", choices)
 	if(!M)
 		return FALSE


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Prevents TGUI crash when slime tries to feed with 0 valid targets, by not allowing to call a a TGUI input with 0 options.

## Why It's Good For The Game
Bugs are bad! I hate them!


## Testing
After
![image](https://github.com/user-attachments/assets/aff61b03-a7e7-4922-9edd-cf68fb3f379f)


<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

