### PR TITLE
[FIX] Fix Code Loop in rod of asclepius try_attach_to_owner()

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -376,33 +376,42 @@
 	addtimer(CALLBACK(src, PROC_REF(try_attach_to_owner)), 0) // Do this once the drop call stack is done. The holding limb might be getting removed
 
 /obj/item/rod_of_asclepius/proc/try_attach_to_owner()
-	if(ishuman(owner) && !QDELETED(owner))
-		if(ishuman(loc))
-			var/mob/living/carbon/human/thief = loc
-			thief.drop_item_to_ground(src, force = TRUE, silent = TRUE) // You're not my owner!
-		if(owner.stat == DEAD)
-			qdel(src) // Oh no! Oh well a new rod will be made from the STATUS_EFFECT_HIPPOCRATIC_OATH
-			return
-		flags |= NODROP // Readd the nodrop
-		var/mob/living/carbon/human/H = owner
-		var/limb_regrown = FALSE
-		if(usedHand == LEFT_HAND)
-			limb_regrown = H.regrow_external_limb_if_missing("l_arm")
-			limb_regrown = H.regrow_external_limb_if_missing("l_hand") || limb_regrown
-			H.drop_l_hand(TRUE)
-			H.put_in_l_hand(src, TRUE)
-		else
-			limb_regrown = H.regrow_external_limb_if_missing("r_arm")
-			limb_regrown = H.regrow_external_limb_if_missing("r_hand") || limb_regrown
-			H.drop_r_hand(TRUE)
-			H.put_in_r_hand(src, TRUE)
-		if(!limb_regrown)
-			to_chat(H, "<span class='notice'>The Rod of Asclepius suddenly grows back out of your arm!</span>")
-		else
-			H.update_body() // Update the limb sprites
-			to_chat(H, "<span class='notice'>Your arm suddenly grows back with the Rod of Asclepius still attached!</span>")
-	else
+	if(!ishuman(owner) || QDELETED(owner))
 		deactivate()
+		return
+
+	var/mob/living/carbon/human/thief = loc
+
+	if(thief == owner) // stealing from yourself, huh?
+		return
+
+	if(ishuman(thief))
+		thief.drop_item_to_ground(src, force = TRUE, silent = TRUE) // You're not my owner!
+
+	if(owner.stat == DEAD)
+		qdel(src) // Oh no! Oh well a new rod will be made from the STATUS_EFFECT_HIPPOCRATIC_OATH
+		return
+
+	flags |= NODROP // Readd the nodrop
+	var/mob/living/carbon/human/H = owner
+	var/limb_regrown = FALSE
+
+	if(usedHand == LEFT_HAND)
+		limb_regrown = H.regrow_external_limb_if_missing("l_arm")
+		limb_regrown = H.regrow_external_limb_if_missing("l_hand") || limb_regrown
+		H.drop_l_hand(TRUE)
+		H.put_in_l_hand(src, TRUE)
+	else
+		limb_regrown = H.regrow_external_limb_if_missing("r_arm")
+		limb_regrown = H.regrow_external_limb_if_missing("r_hand") || limb_regrown
+		H.drop_r_hand(TRUE)
+		H.put_in_r_hand(src, TRUE)
+
+	if(!limb_regrown)
+		to_chat(H, "<span class='notice'>The Rod of Asclepius suddenly grows back out of your arm!</span>")
+	else
+		H.update_body() // Update the limb sprites
+		to_chat(H, "<span class='notice'>Your arm suddenly grows back with the Rod of Asclepius still attached!</span>")
 
 /obj/item/rod_of_asclepius/proc/activated(mob/living/carbon/new_owner)
 	owner = new_owner


### PR DESCRIPTION
## What Does This PR Do
Fixes a code loop in the try_attach_to_owner() function of the Rod of Asclepius by adding a check to see if the owner is equal to the thief. Previously, it was called on dropped(), which forced the thief to drop the rod and then it returns to the owner's hand, causing an infinite loop.
Additionally, refactors try_attach_to_owner() to utilize guard clauses.
Fixes #28035

## Why It's Good For The Game
Code loops are bad

## Testing
Used the rod of asclepius, gave myself advanced kingston disease, changed the disease's stage probability to 50, transformed into Unathi, spawned a human, and set his brute damage to 50. The code did not loop, and the rod still healed the human.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<hr>

## Changelog

:cl:
fix: Fixed code loop when you change your species with rod of asclepius in hand
/:cl: