### PR TITLE
Fix standing corpse when unbuckling it from a meat spike

### DIFF
--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -171,7 +171,6 @@
 
 /obj/structure/kitchenspike/post_unbuckle_mob(mob/living/M)
 	M.pixel_y = M.get_standard_pixel_y_offset(0)
-	M.set_lying_angle(pick(90, 270))
 	M.update_transform()
 
 /obj/structure/kitchenspike/Destroy()

--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -171,7 +171,7 @@
 
 /obj/structure/kitchenspike/post_unbuckle_mob(mob/living/M)
 	M.pixel_y = M.get_standard_pixel_y_offset(0)
-	M.set_lying_angle(0)
+	M.set_lying_angle(pick(90, 270))
 	M.update_transform()
 
 /obj/structure/kitchenspike/Destroy()


### PR DESCRIPTION
## What Does This PR Do
Fixes lying_angle set on post_unbuckle_mob on kitchen spike, so unbuckled mob will be displayed horizontally. The value was 0, so the body was lying in the north (up) direction. The default value is pick(90, 270), so this does not need to be explicitly specified
Fixes #28018

## Why It's Good For The Game
Bugs are bad

## Testing
Spawned kitchen spike, killed human and buckled him to spike, unbuckled him, his corpse was displayed horizontally
Buckled alive human, unbuckled him, his body was displayed horizontally

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<hr>

## Changelog

:cl:
fix: Fixed standing corpse when unbuckling it from a meat spike
/:cl:
