### PR TITLE
Remove an old proc

### DIFF
--- a/code/modules/shuttle/shuttle_manipulator.dm
+++ b/code/modules/shuttle/shuttle_manipulator.dm
@@ -194,7 +194,7 @@
 					intact for round sanity.")
 			else if(S)
 				// If successful, returns the mobile docking port
-				var/obj/docking_port/mobile/mdp = action_load_old(S)
+				var/obj/docking_port/mobile/mdp = action_load(S)
 				if(mdp)
 					usr.forceMove(get_turf(mdp))
 					message_admins("[key_name_admin(usr)] loaded [mdp] with the shuttle manipulator.")
@@ -203,27 +203,6 @@
 /obj/machinery/shuttle_manipulator/proc/action_load(datum/map_template/shuttle/loading_template)
 	if(isnull(loading_template))
 		CRASH("No template passed.")
-	if(istype(loading_template, /datum/map_template/shuttle/emergency) && SSshuttle.emergency_locked_in)
-		message_admins("The emergency shuttle has been locked in. You can not load another shuttle.")
-		return
-
-	if(preview_shuttle && (loading_template != preview_template))
-		preview_shuttle.jumpToNullSpace()
-		preview_shuttle = null
-		preview_template = null
-
-	if(!preview_shuttle)
-		preview_shuttle = SSshuttle.load_template(loading_template)
-		preview_template = loading_template
-
-	SSshuttle.replace_shuttle(preview_shuttle)
-
-	existing_shuttle = null
-	preview_shuttle = null
-	preview_template = null
-	selected = null
-
-/obj/machinery/shuttle_manipulator/proc/action_load_old(datum/map_template/shuttle/loading_template)
 	if(istype(loading_template, /datum/map_template/shuttle/emergency) && SSshuttle.emergency_locked_in)
 		message_admins("The emergency shuttle has been locked in. You can not load another shuttle.")
 		return


### PR DESCRIPTION
## What Does This PR Do
Removes `/obj/machinery/shuttle_manipulator/proc/action_load`, replaces it with `/obj/machinery/shuttle_manipulator/proc/action_load_old` which was, somewhat ironically, more recently updated.

## Why It's Good For The Game
Dead code is bad.

## Testing
Compiled, confirmed it wasn't used.
<hr>

### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

<hr>

## Changelog
NPFC