### PR TITLE
Stop SSair ignoring sleepers

### DIFF
--- a/code/controllers/subsystem/SSair.dm
+++ b/code/controllers/subsystem/SSair.dm
@@ -190,7 +190,7 @@ SUBSYSTEM_DEF(air)
 	// All atmos stuff assumes MILLA is synchronous. Ensure it actually is.
 	var/now = world.timeofday + (world.tick_lag * world.tick_usage) / 100
 	var/elapsed = now - last_complete_tick
-	if(!milla_idle || (elapsed >= 0 && elapsed < self_wait))
+	if(!milla_idle || length(sleepers) || (elapsed >= 0 && elapsed < self_wait))
 		return
 
 	if(last_tick_start <= last_complete_tick)


### PR DESCRIPTION
## What Does This PR Do
Restores a missing conditional from SSair's "am I good to start running?" check.

## Why It's Good For The Game
Code correctness, fixes CI failures.

## Testing
The condition was there before, and got dropped by accident. It compiles. If it passes CI, it's fine.
<hr>

### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

<hr>

## Changelog
NPFC