### PR TITLE
[s] Fixes an issue with dynamic late spawning

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -3,7 +3,6 @@ GLOBAL_LIST_EMPTY(dynamic_forced_rulesets)
 /datum/game_mode/dynamic
 	name = "Dynamic"
 	config_tag = "dynamic"
-	secondary_restricted_jobs = list("AI")
 	required_players = 10
 	/// Non-implied rulesets in play
 	var/list/datum/ruleset/rulesets = list()
@@ -126,7 +125,7 @@ GLOBAL_LIST_EMPTY(dynamic_forced_rulesets)
 
 	for(var/datum/ruleset/ruleset in (rulesets + implied_rulesets)) // rulesets first, then implied rulesets
 		// log_dynamic("Applying [ruleset.antag_amount] [ruleset.name]\s.")
-		budget_overflow += ruleset.pre_setup()
+		budget_overflow += ruleset.roundstart_pre_setup()
 
 	// log_dynamic("Budget overflow: [budget_overflow].")
 	// for the future, maybe try readding antagonists with apply_antag_budget(budget_overflow)
@@ -137,12 +136,10 @@ GLOBAL_LIST_EMPTY(dynamic_forced_rulesets)
 	for(var/datum/ruleset/ruleset in (rulesets + implied_rulesets))
 		// if(length(ruleset.pre_antags))
 		// 	log_dynamic("Making antag datums for [ruleset.name] ruleset.")
-		ruleset.post_setup(src)
+		ruleset.roundstart_post_setup(src)
+		if(ruleset.latespawn_time)
+			addtimer(CALLBACK(ruleset, TYPE_PROC_REF(/datum/ruleset, latespawn), src), ruleset.latespawn_time)
 	..()
-
-/datum/game_mode/dynamic/traitors_to_add()
-	. = floor(budget_overflow / /datum/ruleset/traitor::antag_cost)
-	budget_overflow -= (. * /datum/ruleset/traitor::antag_cost)
 
 /datum/game_mode/dynamic/latespawn(mob)
 	. = ..()

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -323,7 +323,7 @@
  * DEPRECATED!
  * Gets all alive players for a specific role. Disables offstation roles by default
  */
-/datum/game_mode/proc/get_alive_players_for_role(role, override_jobbans = FALSE, allow_offstation_roles = FALSE, banned_jobs)
+/datum/game_mode/proc/get_alive_players_for_role(role, override_jobbans = FALSE, allow_offstation_roles = FALSE)
 	var/list/players = list()
 	var/list/candidates = list()
 
@@ -352,9 +352,9 @@
 		players -= player
 
 	// Remove candidates who want to be antagonist but have a job that precludes it
-	if(banned_jobs)
+	if(restricted_jobs)
 		for(var/datum/mind/player in candidates)
-			if(player.assigned_role in banned_jobs)
+			if(player.assigned_role in restricted_jobs)
 				candidates -= player
 	return candidates
 
@@ -662,7 +662,7 @@
 	if(traitors_to_add <= 0)
 		return
 
-	var/list/potential_recruits = get_alive_players_for_role(ROLE_TRAITOR, /datum/ruleset/traitor::banned_jobs + /datum/ruleset/traitor::protected_jobs)
+	var/list/potential_recruits = get_alive_players_for_role(ROLE_TRAITOR)
 	for(var/datum/mind/candidate as anything in potential_recruits)
 		if(candidate.special_role) // no traitor vampires or changelings or traitors or wizards or ... yeah you get the deal
 			potential_recruits.Remove(candidate)

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -319,8 +319,11 @@
 							//			Less if there are not enough valid players in the game entirely to make recommended_enemies.
 
 // Just the above proc but for alive players
-/// Gets all alive players for a specific role. Disables offstation roles by default
-/datum/game_mode/proc/get_alive_players_for_role(role, override_jobbans = FALSE, allow_offstation_roles = FALSE)
+/**
+ * DEPRECATED!
+ * Gets all alive players for a specific role. Disables offstation roles by default
+ */
+/datum/game_mode/proc/get_alive_players_for_role(role, override_jobbans = FALSE, allow_offstation_roles = FALSE, banned_jobs)
 	var/list/players = list()
 	var/list/candidates = list()
 
@@ -349,9 +352,9 @@
 		players -= player
 
 	// Remove candidates who want to be antagonist but have a job that precludes it
-	if(restricted_jobs)
+	if(banned_jobs)
 		for(var/datum/mind/player in candidates)
-			if(player.assigned_role in restricted_jobs)
+			if(player.assigned_role in banned_jobs)
 				candidates -= player
 	return candidates
 
@@ -645,6 +648,9 @@
 /datum/game_mode/proc/traitors_to_add()
 	return 0
 
+/**
+ * DEPRECATED!
+ */
 /datum/game_mode/proc/fill_antag_slots()
 	var/traitors_to_add = 0
 
@@ -656,7 +662,7 @@
 	if(traitors_to_add <= 0)
 		return
 
-	var/list/potential_recruits = get_alive_players_for_role(ROLE_TRAITOR)
+	var/list/potential_recruits = get_alive_players_for_role(ROLE_TRAITOR, /datum/ruleset/traitor::banned_jobs + /datum/ruleset/traitor::protected_jobs)
 	for(var/datum/mind/candidate as anything in potential_recruits)
 		if(candidate.special_role) // no traitor vampires or changelings or traitors or wizards or ... yeah you get the deal
 			potential_recruits.Remove(candidate)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Fixes an issue with dynamic late spawning

## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Bug bad

## Testing

<!-- How did you test the PR, if at all? -->
Security cant roll antag :)

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog
NPFC 

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
