### PR TITLE
Don't orphan wind

### DIFF
--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -158,6 +158,10 @@
 				if(TURF_WET_PERMAFROST) // Permafrost
 					M.slip("the frosted floor", 10 SECONDS, tilesSlipped = 1, walkSafely = 0, slipAny = 1)
 
+/turf/simulated/BeforeChange()
+	QDEL_NULL(wind_effect)
+	return ..()
+
 /turf/simulated/ChangeTurf(path, defer_change = FALSE, keep_icon = TRUE, ignore_air = FALSE, copy_existing_baseturf = TRUE)
 	. = ..()
 	QUEUE_SMOOTH_NEIGHBORS(src)


### PR DESCRIPTION
## What Does This PR Do
Ensures that simulated turfs clean up their wind effect before going away.

Probably fixes #28048 

## Why It's Good For The Game
Bugs bad.

## Testing
I can't reproduce the original issue, but even if this doesn't fix it, it's harmless to do.
<hr>

### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<hr>

## Changelog
:cl:
fix: Added some extra cleanup to hopefully prevent wind effects from getting orphaned and remaining forever.
/:cl: