### PR TITLE
SSair correctness improvments

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -641,11 +641,11 @@
 	RETURN_TYPE(/datum/gas_mixture)
 	// This is one of two intended places to call this otherwise-unsafe proc.
 	var/datum/gas_mixture/bound_to_turf/air = private_unsafe_get_air()
-	if(air.lastread < SSair.times_fired)
+	if(air.lastread < SSair.milla_tick)
 		var/list/milla_tile = new/list(MILLA_TILE_SIZE)
 		get_tile_atmos(src, milla_tile)
 		air.copy_from_milla(milla_tile)
-		air.lastread = SSair.times_fired
+		air.lastread = SSair.milla_tick
 		air.readonly = null
 		air.dirty = FALSE
 		air.synchronized = FALSE
@@ -678,7 +678,7 @@
 			return FALSE
 
 		// If it's old, delete it.
-		if(active_hotspot.death_timer < SSair.times_fired)
+		if(active_hotspot.death_timer < SSair.milla_tick)
 			QDEL_NULL(active_hotspot)
 			return FALSE
 		else
@@ -687,7 +687,7 @@
 	if(isnull(active_hotspot))
 		active_hotspot = new(src)
 
-	active_hotspot.death_timer = SSair.times_fired + 4
+	active_hotspot.death_timer = SSair.milla_tick + 4
 	if(air.hotspot_volume() > 0)
 		active_hotspot.temperature = air.hotspot_temperature()
 		active_hotspot.volume = air.hotspot_volume() * CELL_VOLUME
@@ -699,7 +699,7 @@
 	return TRUE
 
 /turf/simulated/proc/update_wind()
-	if(wind_tick != SSair.times_fired)
+	if(wind_tick != SSair.milla_tick)
 		QDEL_NULL(wind_effect)
 		wind_tick = null
 		return FALSE

--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -129,9 +129,9 @@
 	if(direction == 0)
 		return
 
-	if(last_high_pressure_movement_time >= SSair.times_fired - 3)
+	if(last_high_pressure_movement_time >= SSair.milla_tick - 3)
 		return
-	last_high_pressure_movement_time = SSair.times_fired
+	last_high_pressure_movement_time = SSair.milla_tick
 
 	air_push(direction, (force - force_needed) / force_needed)
 
@@ -171,7 +171,7 @@
 #define INDEX_SOUTH	3
 #define INDEX_WEST	4
 
-/turf/proc/Initialize_Atmos(times_fired)
+/turf/proc/Initialize_Atmos(milla_tick)
 	// This is one of two places expected to call this otherwise-unsafe method.
 	var/list/connectivity = private_unsafe_recalculate_atmos_connectivity()
 	var/list/air = list(oxygen, carbon_dioxide, nitrogen, toxins, sleeping_agent, agent_b, temperature)

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -762,6 +762,7 @@ What are the archived variables for?
 #undef QUANTIZE
 
 /datum/gas_mixture/bound_to_turf
+	synchronized = FALSE
 	var/dirty = FALSE
 	var/lastread = 0
 	var/turf/bound_turf = null

--- a/code/modules/atmospherics/machinery/components/unary_devices/heat_exchanger.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/heat_exchanger.dm
@@ -32,11 +32,11 @@
 	if(!partner)
 		return 0
 
-	if(!SSair || SSair.times_fired <= update_cycle)
+	if(!SSair || SSair.milla_tick <= update_cycle)
 		return 0
 
-	update_cycle = SSair.times_fired
-	partner.update_cycle = SSair.times_fired
+	update_cycle = SSair.milla_tick
+	partner.update_cycle = SSair.milla_tick
 
 	var/air_heat_capacity = air_contents.heat_capacity()
 	var/other_air_heat_capacity = partner.air_contents.heat_capacity()


### PR DESCRIPTION
## What Does This PR Do
Makes SSair maintain its own pause and tick count, because the way it runs makes the MC's not accurate enough.
Fixes #28048 for realsies.
Build mode atmos should work reliably now.

## Why It's Good For The Game
Bugs bad.

## Testing
Found a way to reproduce wind and fire getting stuck: Make increasingly large overlapping plasmafires in admin testing, by using buildmode atmos to add 1000 kPa, 3000 K, 50/50 O2/plasma air, from 1x1 to 7x7 or so areas. Some sections of the fire would start to look out of place and not changing, at which point setting the air back to standard left fire and wind effects stuck in place.
After these changes, that no longer worked. Additionally, I discovered that buildmode atmos was becoming unresponsive while doing the above test, needing to attempt fills multiple times. That also went away with these changes.
<hr>

### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

<hr>

## Changelog
:cl:
fix: Stuck fire and wind should be gone for real now.
fix: Buildmode atmos will no longer fail to set air sometimes.
fix: Other air changes were also likely to have been not working sometimes, and are fixed now.
/:cl: