### PR TITLE
Makes One-Click-Antag report who was made antag

### DIFF
--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -132,7 +132,7 @@
 			H = pick(candidates)
 			H?.mind?.add_antag_datum(/datum/antagonist/rev/head)
 			candidates.Remove(H)
-			message_admins("[key_name_admin(owner)] made [H] a Revolutionary with One-Click-Antag")
+			message_admins("[key_name(owner)] made [key_name_admin(H)] a Revolutionary with One-Click-Antag")
 		return TRUE
 	return FALSE
 

--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -69,9 +69,10 @@
 			H = pick(candidates)
 			H.mind.make_Traitor()
 			candidates.Remove(H)
+			message_admins("[key_name(owner)] made [key_name_admin(H)] a Traitor with One-Click-Antag")
 
-		return 1
-	return 0
+		return TRUE
+	return FALSE
 
 
 /datum/admins/proc/makeChangelings()
@@ -100,9 +101,10 @@
 			H = pick(candidates)
 			H.mind.add_antag_datum(/datum/antagonist/changeling)
 			candidates.Remove(H)
+			message_admins("[key_name(owner)] made [key_name_admin(H)] a Changeling with One-Click-Antag")
 
-		return 1
-	return 0
+		return TRUE
+	return FALSE
 
 /datum/admins/proc/makeRevs()
 
@@ -130,14 +132,15 @@
 			H = pick(candidates)
 			H?.mind?.add_antag_datum(/datum/antagonist/rev/head)
 			candidates.Remove(H)
-		return 1
-	return 0
+			message_admins("[key_name_admin(owner)] made [H] a Revolutionary with One-Click-Antag")
+		return TRUE
+	return FALSE
 
 /datum/admins/proc/makeWizard()
 
 	var/confirm = alert("Are you sure?", "Confirm creation", "Yes", "No")
 	if(confirm != "Yes")
-		return 0
+		return FALSE
 	var/image/I = new('icons/mob/simple_human.dmi', "wizard")
 	var/list/candidates = SSghost_spawns.poll_candidates("Do you wish to be considered for the position of a Wizard Federation 'diplomat'?", "wizard", source = I)
 
@@ -151,6 +154,7 @@
 		var/mob/living/carbon/human/new_character = makeBody(selected)
 		new_character.mind.add_antag_datum(/datum/antagonist/wizard)
 		new_character.forceMove(pick(GLOB.wizardstart))
+		message_admins("[key_name(owner)] made [key_name_admin(new_character)] a Wizard with One-Click-Antag")
 		dust_if_respawnable(selected)
 		return TRUE
 	return FALSE
@@ -184,6 +188,7 @@
 
 		var/datum/antagonist/cultist/cultist = H.mind.add_antag_datum(/datum/antagonist/cultist)
 		cultist.equip_roundstart_cultist(H)
+		message_admins("[key_name(owner)] made [key_name_admin(H)] a Cultist with One-Click-Antag")
 	return TRUE
 
 //Abductors
@@ -191,13 +196,13 @@
 
 	var/confirm = alert("Are you sure?", "Confirm creation", "Yes", "No")
 	if(confirm != "Yes")
-		return 0
+		return FALSE
 	new /datum/event/abductor
 
 	log_admin("[key_name(owner)] tried making Abductors with One-Click-Antag")
 	message_admins("[key_name_admin(owner)] tried making Abductors with One-Click-Antag")
 
-	return 1
+	return TRUE
 
 /datum/admins/proc/makeAliens()
 	var/antnum = input(owner, "How many aliens you want to create? Enter 0 to cancel.","Amount:", 0) as num
@@ -284,10 +289,11 @@
 		for(var/i = 0, i<numVampires, i++)
 			H = pick(candidates)
 			H.mind.make_vampire()
+			message_admins("[key_name(owner)] made [key_name_admin(H)] a Vampire with One-Click-Antag")
 			candidates.Remove(H)
 
-		return 1
-	return 0
+		return TRUE
+	return FALSE
 
 /datum/admins/proc/makeMindflayers()
 	var/datum/game_mode/vampire/temp = new()
@@ -309,6 +315,7 @@
 	for(var/i in 1 to num_mindflayers)
 		var/datum/mind/flayer = pick_n_take(possible_mindflayers)
 		flayer.make_mind_flayer()
+		message_admins("[key_name(owner)] made [key_name_admin(flayer)] a Mindflayer with One-Click-Antag")
 	qdel(temp)
 	return TRUE
 
@@ -366,6 +373,7 @@
 				O.needs_target = FALSE
 				H.mind.add_mind_objective(O)
 			H.mind.add_antag_datum(/datum/antagonist/eventmisc)
+			message_admins("[key_name(owner)] made [key_name_admin(H)] an Event Character with One-Click-Antag")
 			candidates.Remove(H)
 		return TRUE
 	return FALSE


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Lets admins know who just rolled antag with one-click-antag, and removes the guessing game.

## Why It's Good For The Game

Hopefully helps with handling situations where people in space are made vampires.

Feedback is also good, no more having to guess who was just made antag.

## Testing

Tested on a local server, sends feedback. Seems to work just fine. 👍

All true and false changes seem to work just fine too.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
