### PR TITLE
Ports stop sounds verb from TG

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -80,7 +80,8 @@ GLOBAL_LIST_INIT(admin_verbs_sounds, list(
 	/client/proc/play_sound,
 	/client/proc/play_server_sound,
 	/client/proc/play_intercomm_sound,
-	/client/proc/stop_global_admin_sounds
+	/client/proc/stop_global_admin_sounds,
+	/client/proc/stop_sounds
 	))
 GLOBAL_LIST_INIT(admin_verbs_event, list(
 	/client/proc/object_talk,

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -81,7 +81,7 @@ GLOBAL_LIST_INIT(admin_verbs_sounds, list(
 	/client/proc/play_server_sound,
 	/client/proc/play_intercomm_sound,
 	/client/proc/stop_global_admin_sounds,
-	/client/proc/stop_sounds
+	/client/proc/stop_global_all_sounds
 	))
 GLOBAL_LIST_INIT(admin_verbs_event, list(
 	/client/proc/object_talk,

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -81,7 +81,7 @@ GLOBAL_LIST_INIT(admin_verbs_sounds, list(
 	/client/proc/play_server_sound,
 	/client/proc/play_intercomm_sound,
 	/client/proc/stop_global_admin_sounds,
-	/client/proc/stop_global_all_sounds
+	/client/proc/stop_sounds_global
 	))
 GLOBAL_LIST_INIT(admin_verbs_event, list(
 	/client/proc/object_talk,

--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -114,9 +114,10 @@ GLOBAL_LIST_EMPTY(sounds_cache)
 			continue
 		playsound(I, melody, cvol)
 
-/client/proc/stop_global_all_sounds()
+/client/proc/stop_sounds_global()
 	set category = "Debug"
-	set name = "Stop Global All Sounds"
+	set name = "Stop Sounds Global"
+	set desc = "Stop all playing sounds globally."
 	if(!check_rights(R_SOUNDS))
 		return
 

--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -114,9 +114,9 @@ GLOBAL_LIST_EMPTY(sounds_cache)
 			continue
 		playsound(I, melody, cvol)
 
-/client/proc/stop_sounds()
+/client/proc/stop_global_all_sounds()
 	set category = "Debug"
-	set name = "Stop All Playing Sounds"
+	set name = "Stop Global All Sounds"
 	if(!check_rights(R_SOUNDS))
 		return
 

--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -113,3 +113,16 @@ GLOBAL_LIST_EMPTY(sounds_cache)
 		if(!I.on && !ignore_power)
 			continue
 		playsound(I, melody, cvol)
+
+/client/proc/stop_sounds()
+	set category = "Debug"
+	set name = "Stop All Playing Sounds"
+	if(!check_rights(R_SOUNDS))
+		return
+
+	log_admin("[key_name(src)] stopped all currently playing sounds.")
+	message_admins("[key_name_admin(src)] stopped all currently playing sounds.")
+	for(var/mob/M in GLOB.player_list)
+		SEND_SOUND(M, sound(null))
+		var/client/C = M.client
+		C?.tgui_panel?.stop_music()

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -1317,6 +1317,14 @@
 
 	editor.ui_interact(mob)
 
+/client/verb/stop_client_sounds()
+	set name = "Stop Sounds"
+	set category = "Special Verbs"
+	set desc = "Stop Current Sounds"
+	SEND_SOUND(usr, sound(null))
+	to_chat(src, "All sounds stopped")
+	tgui_panel?.stop_music()
+
 #undef LIMITER_SIZE
 #undef CURRENT_SECOND
 #undef SECOND_COUNT

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -1322,7 +1322,7 @@
 	set category = "Special Verbs"
 	set desc = "Stop Current Sounds"
 	SEND_SOUND(usr, sound(null))
-	to_chat(src, "All sounds stopped")
+	to_chat(src, "All sounds stopped.")
 	tgui_panel?.stop_music()
 
 #undef LIMITER_SIZE

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -1318,9 +1318,9 @@
 	editor.ui_interact(mob)
 
 /client/verb/stop_client_sounds()
-	set name = "Stop Sounds"
 	set category = "Special Verbs"
-	set desc = "Stop Current Sounds"
+	set name = "Stop Sounds"
+	set desc = "Stop Current Sounds."
 	SEND_SOUND(usr, sound(null))
 	to_chat(src, "All sounds stopped.")
 	tgui_panel?.stop_music()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Ports two verbs from TG:

`Stop Sounds` Special verbs verb that anyone can use. Stops all sounds when used.

`Stop Sounds Global` Debug verb for those holding sound flags(GA+). Stops sounds for every player when used.

Original PRs/commits from TG:
https://github.com/tgstation/tgstation/pull/1310 (original global verb)
https://github.com/tgstation/tgstation/commit/df189498ce42127575c30a3175406e742e2bd2db (client verb)
https://github.com/tgstation/tgstation/pull/29611 (updated version)

I think I got most of the PRs but dear god this verb was subject to several non-atomic refactors. The code is all from TG with a few edits that I made for paracode/removal of blackbox logging which isn't necessary.

## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Having the ability to stop sounds is useful for when someone does something annoying and you want the sounds to stop (like spam a dozen windup toolboxes beside you)

Admins having the ability to stop all global sound is also useful (like globally stopping sounds in the pre-game lobby so that an OGG can be played and it not interfere with the default lobby music)
## Testing

<!-- How did you test the PR, if at all? -->

Stop Sounds:

- Loaded in-game

- Tested the Stop Sounds while playing a sounds

Stop Sounds Global:

- Started a VM client and server

- Connected the VM to the server 

- Played a sound next to the VM client and ran the global command

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
add: Added Stop Sounds to the special verbs tab. This verb will stop all playing sound when used.
add: Added Stop Sounds Global to the debug tab. This admin only command will stop all sounds for every player.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
