### PR TITLE
Increase w_class of most hooded suits by 1

### DIFF
--- a/code/modules/clothing/suits/hood.dm
+++ b/code/modules/clothing/suits/hood.dm
@@ -6,6 +6,7 @@
 	var/hoodtype = /obj/item/clothing/head/hooded/winterhood //so the chaplain hoodie or other hoodies can override this
 	/// If this variable is true, the hood can not be removed if the hood is nodrop
 	var/respects_nodrop = FALSE
+	w_class = WEIGHT_CLASS_NORMAL
 
 /obj/item/clothing/suit/hooded/Initialize(mapload)
 	. = ..()

--- a/code/modules/clothing/suits/misc_suits.dm
+++ b/code/modules/clothing/suits/misc_suits.dm
@@ -452,7 +452,6 @@
 /obj/item/clothing/suit/hooded/wintercoat/captain
 	name = "captain's winter coat"
 	icon_state = "wintercoat_captain"
-	w_class = WEIGHT_CLASS_NORMAL
 	item_state = "coatcaptain"
 	armor = list(MELEE = 15, BULLET = 20, LASER = 20, ENERGY = 5, BOMB = 15, RAD = 0, FIRE = 0, ACID = 50)
 	allowed = list(/obj/item/gun/energy, /obj/item/reagent_containers/spray/pepper, /obj/item/gun/projectile, /obj/item/ammo_box,/obj/item/ammo_casing, /obj/item/melee/baton, /obj/item/restraints/handcuffs, /obj/item/flashlight/seclite, /obj/item/melee/classic_baton/telescopic)
@@ -472,7 +471,6 @@
 /obj/item/clothing/suit/hooded/wintercoat/security
 	name = "security winter coat"
 	icon_state = "wintercoat_sec"
-	w_class = WEIGHT_CLASS_NORMAL
 	item_state = "coatsecurity"
 	armor = list(MELEE = 10, BULLET = 5, LASER = 10, ENERGY = 5, BOMB = 10, RAD = 0, FIRE = 20, ACID = 20)
 	allowed = list(/obj/item/gun/energy, /obj/item/reagent_containers/spray/pepper, /obj/item/gun/projectile, /obj/item/ammo_box, /obj/item/ammo_casing, /obj/item/melee/baton, /obj/item/restraints/handcuffs, /obj/item/flashlight/seclite, /obj/item/melee/classic_baton/telescopic)
@@ -494,7 +492,6 @@
 /obj/item/clothing/suit/hooded/wintercoat/medical
 	name = "medical winter coat"
 	icon_state = "wintercoat_med"
-	w_class = WEIGHT_CLASS_NORMAL
 	item_state = "coatmedical"
 	allowed = list(/obj/item/analyzer, /obj/item/dnainjector, /obj/item/reagent_containers/dropper, /obj/item/reagent_containers/syringe, /obj/item/reagent_containers/hypospray, /obj/item/reagent_containers/applicator,/obj/item/healthanalyzer,/obj/item/flashlight/pen, /obj/item/reagent_containers/glass/bottle, /obj/item/reagent_containers/glass/beaker, /obj/item/storage/pill_bottle, /obj/item/paper, /obj/item/melee/classic_baton/telescopic)
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, RAD = 0, FIRE = 0, ACID = 40)
@@ -514,7 +511,6 @@
 /obj/item/clothing/suit/hooded/wintercoat/science
 	name = "science winter coat"
 	icon_state = "wintercoat_sci"
-	w_class = WEIGHT_CLASS_NORMAL
 	item_state = "coatscience"
 	allowed = list(/obj/item/analyzer, /obj/item/stack/medical, /obj/item/dnainjector, /obj/item/reagent_containers/dropper, /obj/item/reagent_containers/syringe, /obj/item/reagent_containers/hypospray, /obj/item/reagent_containers/applicator,/obj/item/healthanalyzer,/obj/item/flashlight/pen, /obj/item/reagent_containers/glass/bottle, /obj/item/reagent_containers/glass/beaker, /obj/item/storage/pill_bottle, /obj/item/paper, /obj/item/melee/classic_baton/telescopic)
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 5, RAD = 0, FIRE = 0, ACID = 0)
@@ -534,7 +530,6 @@
 /obj/item/clothing/suit/hooded/wintercoat/engineering
 	name = "engineering winter coat"
 	icon_state = "wintercoat_engi"
-	w_class = WEIGHT_CLASS_NORMAL
 	item_state = "coatengineer"
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, RAD = 10, FIRE = 20, ACID = 40)
 	allowed = list(/obj/item/flashlight, /obj/item/tank/internals/emergency_oxygen, /obj/item/t_scanner, /obj/item/rcd, /obj/item/rpd)
@@ -607,7 +602,6 @@
 /obj/item/clothing/suit/hooded/wintercoat/miner
 	name = "mining winter coat"
 	icon_state = "wintercoat_miner"
-	w_class = WEIGHT_CLASS_NORMAL
 	item_state = "coatminer"
 	allowed = list(/obj/item/pickaxe, /obj/item/flashlight, /obj/item/tank/internals/emergency_oxygen, /obj/item/toy, /obj/item/storage/fancy/cigarettes, /obj/item/lighter, /obj/item/t_scanner/adv_mining_scanner, /obj/item/storage/bag/ore, /obj/item/gun/energy/kinetic_accelerator)
 	armor = list(MELEE = 5, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, RAD = 0, FIRE = 0, ACID = 0)
@@ -640,7 +634,6 @@
 	desc = "A cutting-edge ablative armor system developed by Nanotrasen. Miniaturized shielding systems deflect incoming energy projectiles, while prototype heatsinks and dissipation materials blunt any energy weapon that makes impact. \
 		Unfortunately, if offers little to no protection against solid impacts."
 	icon_state = "ablativecoat"
-	w_class = WEIGHT_CLASS_NORMAL
 	item_state = "ablativecoat"
 	body_parts_covered = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
 	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
@@ -677,6 +670,7 @@
 	desc = "It's a hoodie. It has a hood. Most hoodies do."
 	icon_state = "black_hoodie"
 	item_state = "blueshieldcoat"
+	w_class = WEIGHT_CLASS_SMALL
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS
 	allowed = list(/obj/item/flashlight, /obj/item/tank/internals/emergency_oxygen)
 	hoodtype = /obj/item/clothing/head/hooded/hood
@@ -1292,7 +1286,6 @@
 
 //Syndicate Chaplain Robe (WOLOLO!)
 /obj/item/clothing/suit/hooded/chaplain_hoodie/missionary_robe
-	w_class = WEIGHT_CLASS_NORMAL
 	armor = list(MELEE = 5, BULLET = 5, LASER = 5, ENERGY = 5, BOMB = 0, RAD = 10, FIRE = 20, ACID = 20)
 	var/obj/item/nullrod/missionary_staff/linked_staff = null
 

--- a/code/modules/customitems/item_defines.dm
+++ b/code/modules/customitems/item_defines.dm
@@ -16,6 +16,12 @@
 /obj/item/fluff
 	var/used = FALSE
 
+/obj/item/clothing/suit/hooded/hoodie/fluff
+	w_class = WEIGHT_CLASS_SMALL
+
+/obj/item/clothing/suit/hooded/fluff
+	w_class = WEIGHT_CLASS_SMALL
+
 /// Generic tattoo gun, make subtypes for different folks
 /obj/item/fluff/tattoo_gun
 	name = "disposable tattoo pen"
@@ -152,7 +158,6 @@
 	flags = CONDUCT
 	slot_flags = ITEM_SLOT_BELT
 	throwforce = 5
-	w_class = WEIGHT_CLASS_NORMAL
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 
@@ -944,16 +949,19 @@
 	icon_state = "greenhood"
 
 /// Hylocereus: Sam Aria
-/obj/item/clothing/suit/hooded/hoodie/hylo
+/obj/item/clothing/suit/hooded/hoodie/fluff/hylo
 	name = "worn assymetrical hoodie"
 	desc = "A soft, cozy longline hoodie. It looks old and worn, but well cared for. There's no label, but a series of dates and names is penned on a scrap of fabric sewn on the inside of the left side of the chest - 'Sam Aria' is scrawled atop them all, next to the words 'Please Remember'."
 	icon = 'icons/obj/custom_items.dmi'
 	icon_state = "sam_hoodie"
-	hoodtype = /obj/item/clothing/head/hooded/hood/hylo
+	hoodtype = /obj/item/clothing/head/hooded/hood/fluff/hylo
 
-/obj/item/clothing/head/hooded/hood/hylo
+/obj/item/clothing/head/hooded/hood/fluff/hylo
 	icon = 'icons/obj/custom_items.dmi'
 	icon_state = "sam_hood"
+
+/obj/item/clothing/suit/hooded/fluff
+	w_class = WEIGHT_CLASS_SMALL
 
 /// Doru7: Jack Bone
 /obj/item/clothing/suit/hooded/fluff/bone
@@ -1074,8 +1082,6 @@
 
 	if(target.change_hair("Sasook Hair", 1))
 		to_chat(target, "<span class='notice'>You dump some of [src] on your head and style it around.</span>")
-
-
 
 /// MrSynnester : Shesi Skaklas
 /obj/item/clothing/suit/hooded/wintercoat/fluff/shesi
@@ -1358,14 +1364,12 @@
 	flags = BLOCKHAIR
 	flags_inv = HIDEFACE
 
-
 /obj/item/clothing/shoes/fluff/arachno_boots
 	name = "Arachno-Man boots"
 	desc = "These boots were made for crawlin'."
 	icon = 'icons/obj/custom_items.dmi'
 	icon_state = "superior_boots"
 	item_state = "superior_boots"
-
 
 /// chronx100: Hughe O'Splash
 /obj/item/nullrod/fluff/chronx
@@ -1547,7 +1551,6 @@
 	if(target.change_hair("Zekes Tentacles", 1))
 		to_chat(target, "<span class='notice'>You take time to admire yourself in [src], brushing your tendrils down and revealing their true length.</span>")
 
-
 /// Fethas: Sefra'neem
 /obj/item/clothing/accessory/locket/fluff/fethasnecklace
 	name = "Orange gemmed locket"
@@ -1569,7 +1572,6 @@
 	item_state = "sheetcosmos"
 	item_color = "sheetcosmos"
 
-
 /// Lightfire: Hyperion
 /obj/item/clothing/head/fluff/lfbowler
 	name = "classy bowler hat"
@@ -1588,7 +1590,6 @@
 	item_state = "victorianvest"
 	item_color = "victorianlightfire"
 	displays_id = FALSE
-
 
 /// LightFire53: Ikelos
 /obj/item/fluff/lighty_plasman_modkit
@@ -1765,8 +1766,6 @@
 	item_color = "kiamask"
 	species_restricted = list("Vox")
 
-
-
 /obj/item/clothing/gloves/ring/fluff
 	name = "fluff ring"
 	desc = "Someone forgot to set this fluff item's description, notify a coder!"
@@ -1780,14 +1779,11 @@
 /obj/item/clothing/gloves/ring/fluff/attackby__legacy__attackchain(obj/item/I as obj, mob/user as mob, params)
 	return
 
-
-
 /// Benjaminfallout: Pretzel Brassheart
 /obj/item/clothing/gloves/ring/fluff/benjaminfallout
 	name = "Pretzel's Ring"
 	desc = "A small platinum ring with a large light blue diamond. Engraved inside the band are the words: 'To my lovely Pristine Princess. Forever yours, Savinien.'"
 	icon_state = "benjaminfallout_ring"
-
 
 /// Gangelwaefre: Kikeri
 /obj/item/clothing/under/fluff/kikeridress

--- a/code/modules/customitems/item_defines.dm
+++ b/code/modules/customitems/item_defines.dm
@@ -960,9 +960,6 @@
 	icon = 'icons/obj/custom_items.dmi'
 	icon_state = "sam_hood"
 
-/obj/item/clothing/suit/hooded/fluff
-	w_class = WEIGHT_CLASS_SMALL
-
 /// Doru7: Jack Bone
 /obj/item/clothing/suit/hooded/fluff/bone
 	name = "skeleton suit"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Increases `w_class` of `/obj/item/clothing/suit/hooded` from `2` to `3`.
Keeps `w_class` of `2` for hoodies and fluff hooded suits, but not for fluff wintercoats (there is only 1 fluff wintercoat atm)

<details>
  <summary>Notable changes with w_class increased from 2 to 3</summary>
  Explorer, goliath, drake and berserker armors<br>
  Flagellant and cult robes<br>
  Missonary robe (chaplain uplink)<br>
  Carp costume (doubtful) (including space dragon's)<br>
  Fluff winter coats<br>
</details>

<details>
  <summary>Suits that are left untouched</summary>
  Fluff hooded suits<br>
  All hoodies (/obj/item/clothing/suit/hooded/hoodie), since they are really small and none of them has any armor stats
</details>

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

You shouldn't be able to fold a bone armor into your pocket, or any other, especially when they are full of armor stats, which gives you full body protection.
Also winter coats look bulky af, so i have no idea how people are being able to stack 7 of them inside a single box.

It also might be worth making drake and berserker suits bulky-sized due to how huge they are compared to the rest of suits, putting them in line with empowered cult robe.

Things that might be controversial: salmon and carp costumes, they look pretty foldable. But space dragon's carp poncho should keep a w_class of 3 imo cos of it's armor.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Started a round on local, checked all of the suits to have a proper w_class.

<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
![image](https://github.com/user-attachments/assets/8daa7385-78cd-494f-8f3f-e93b8dc8b639)

  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
tweak: Most of the hooded suits are now normal-sized, instead of being small-sized. Hoodies and fluff hooded suits are untouched.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
