### PR TITLE
Fixes cone spells accidentally going diagonal

### DIFF
--- a/code/datums/spell_targeting/cone.dm
+++ b/code/datums/spell_targeting/cone.dm
@@ -27,6 +27,18 @@
 		if(WEST)
 			left_dir = SOUTH
 			right_dir = NORTH
+		if(NORTHEAST)
+			left_dir = NORTH
+			right_dir = EAST
+		if(NORTHWEST)
+			left_dir = WEST
+			right_dir = NORTH
+		if(SOUTHEAST)
+			left_dir = SOUTH
+			right_dir = EAST
+		if(SOUTHWEST)
+			left_dir = WEST
+			right_dir = SOUTH
 
 	// Go though every level of the cone levels and generate the cone.
 	for(var/level in 1 to cone_levels)

--- a/code/datums/spell_targeting/cone.dm
+++ b/code/datums/spell_targeting/cone.dm
@@ -11,7 +11,7 @@
 	var/turf/turf_to_use = get_turf(user)
 	var/turf/left_turf
 	var/turf/right_turf
-	var/dir_to_use = get_dir(user, clicked_atom)
+	var/dir_to_use = user.dir
 	var/right_dir
 	var/left_dir
 	switch(dir_to_use)
@@ -27,18 +27,6 @@
 		if(WEST)
 			left_dir = SOUTH
 			right_dir = NORTH
-		if(NORTHEAST)
-			left_dir = NORTH
-			right_dir = EAST
-		if(NORTHWEST)
-			left_dir = WEST
-			right_dir = NORTH
-		if(SOUTHEAST)
-			left_dir = SOUTH
-			right_dir = EAST
-		if(SOUTHWEST)
-			left_dir = WEST
-			right_dir = SOUTH
 
 	// Go though every level of the cone levels and generate the cone.
 	for(var/level in 1 to cone_levels)

--- a/code/datums/spells/cones/cone_spell.dm
+++ b/code/datums/spells/cones/cone_spell.dm
@@ -1,6 +1,5 @@
 /datum/spell/cone
 
-
 /datum/spell/cone/create_new_targeting()
 	return new /datum/spell_targeting/cone
 
@@ -26,7 +25,7 @@
 				do_mob_cone_effect(movable_content, user, level)
 
 /datum/spell/cone/proc/do_turf_cone_effect(turf/target_turf, mob/caster, level)
-	return
+	target_turf.color = COLOR_GREEN
 
 /datum/spell/cone/proc/do_obj_cone_effect(obj/target_obj, mob/caster, level)
 	return

--- a/code/datums/spells/cones/cone_spell.dm
+++ b/code/datums/spells/cones/cone_spell.dm
@@ -25,7 +25,7 @@
 				do_mob_cone_effect(movable_content, user, level)
 
 /datum/spell/cone/proc/do_turf_cone_effect(turf/target_turf, mob/caster, level)
-	target_turf.color = COLOR_GREEN
+	return
 
 /datum/spell/cone/proc/do_obj_cone_effect(obj/target_obj, mob/caster, level)
 	return


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes cone spells sometimes trying to go diagonal
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Diagonals no worky
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Tried to cast diagonal, went into a cardinal direction instead
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

NPFC

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
