### PR TITLE
Fix toggling suit sensors while inside other objects

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -302,7 +302,7 @@
 	return TRUE
 
 /obj/item/clothing/under/proc/set_sensors(mob/user)
-	if(!user.Adjacent(src))
+	if(!Adjacent(user))
 		to_chat(user, "<span class='warning'>You are too far away!</span>")
 		return
 
@@ -321,7 +321,7 @@
 	var/list/modes = list("Off", "Binary sensors", "Vitals tracker", "Tracking beacon")
 	var/switchMode = tgui_input_list(user, "Select a sensor mode:", "Suit Sensor Mode", modes, modes[sensor_mode + 1])
 	// If they walk away after the menu is already open.
-	if(!user.Adjacent(src))
+	if(!Adjacent(user))
 		to_chat(user, "<span class='warning'>You have moved too far away!</span>")
 		return
 		// If your hands get lopped off or cuffed after the menu is open.


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Switches the adjacent check for toggling sensors. Mobs and objects have different `Adjacent` procs, and it is objects that will recurse to check if they're in storage or on the mob.

## Why It's Good For The Game
Fixes #26520

## Images of changes
![Sensors](https://github.com/user-attachments/assets/7ab7b4fe-65c3-4a72-8028-705f2fcd6c1f)

## Testing
Toggled sensors in and out of disposals or closets, also stuffed jumpsuits in storage to try too.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: Suit sensors can be toggled while in disposal or other large containers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
