### PR TITLE
Tries to stop the linter fails

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -467,6 +467,10 @@
 /mob/living/simple_animal/hostile/proc/EscapeConfinement()
 	if(buckled)
 		buckled.attack_animal(src)
+	if(!targets_from)
+		stack_trace("[src] had a null `targets_from`. GC status: [QDELING(src)]")
+		return
+
 	if(!isturf(targets_from.loc) && targets_from.loc != null)//Did someone put us in something?
 		var/atom/A = targets_from.loc
 		A.attack_animal(src)//Bang on it till we get out

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/ancient_robot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/ancient_robot.dm
@@ -129,7 +129,6 @@ Difficulty: Hard
 	fix_specific_leg(BOTTOM_RIGHT)
 	fix_specific_leg(BOTTOM_LEFT)
 
-
 /mob/living/simple_animal/hostile/megafauna/ancient_robot/Destroy()
 	QDEL_NULL(TR)
 	QDEL_NULL(TL)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/ancient_robot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/ancient_robot.dm
@@ -664,15 +664,15 @@ Difficulty: Hard
 /mob/living/simple_animal/hostile/ancient_robot_leg/Initialize(mapload, mob/living/ancient, who)
 	. = ..()
 	if(!ancient)
-		qdel(src) //no
+		return INITIALIZE_HINT_QDEL // No
 	core = ancient
 	who_am_i = who
 	ranged_cooldown_time = rand(30, 60) // keeps them not running on the same time
 	addtimer(CALLBACK(src, PROC_REF(beam_setup)), 1 SECONDS)
 
-
 /mob/living/simple_animal/hostile/ancient_robot_leg/Destroy()
 	QDEL_NULL(leg_part)
+	core = null
 	return ..()
 
 /mob/living/simple_animal/hostile/ancient_robot_leg/Life(seconds, times_fired)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/ancient_robot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/ancient_robot.dm
@@ -97,11 +97,11 @@ Difficulty: Hard
 
 /mob/living/simple_animal/hostile/megafauna/ancient_robot/Initialize(mapload, mob/living/ancient) //We spawn and move them to clear out area for the legs, rather than risk the legs getting put in a wall
 	. = ..()
-	TR = new /mob/living/simple_animal/hostile/ancient_robot_leg(loc, src, TOP_RIGHT)
-	TL = new /mob/living/simple_animal/hostile/ancient_robot_leg(loc, src, TOP_LEFT)
-	BR = new /mob/living/simple_animal/hostile/ancient_robot_leg(loc, src, BOTTOM_RIGHT)
-	BL = new /mob/living/simple_animal/hostile/ancient_robot_leg(loc, src, BOTTOM_LEFT)
-	beam = new /obj/effect/abstract(loc)
+	TR = new /mob/living/simple_animal/hostile/ancient_robot_leg(get_turf(src), src, TOP_RIGHT)
+	TL = new /mob/living/simple_animal/hostile/ancient_robot_leg(get_turf(src), src, TOP_LEFT)
+	BR = new /mob/living/simple_animal/hostile/ancient_robot_leg(get_turf(src), src, BOTTOM_RIGHT)
+	BL = new /mob/living/simple_animal/hostile/ancient_robot_leg(get_turf(src), src, BOTTOM_LEFT)
+	beam = new /obj/effect/abstract(get_turf(src))
 	mode = pick(BLUESPACE, GRAV, PYRO, FLUX, VORTEX, CRYO) //picks one of the 6 cores
 	switch(mode)
 		if(BLUESPACE)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes the legs explicitly spawn on the turf instead of loc. This probably won't fix it but I have absolutely no idea
Also makes the leg properly return that they need to be deleted properly

Also also adds a stacktrace in case a mob has `targets_from` being `null` which is what is causing the linter fail inthe first place
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Linters shouldn't fail
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
That's what I'm doing by opening this PR
<!-- How did you test the PR, if at all? -->

## Changelog

NPFC

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
