### PR TITLE
fixes blind rushers hallucination runtimes

### DIFF
--- a/code/controllers/subsystem/SStimer.dm
+++ b/code/controllers/subsystem/SStimer.dm
@@ -134,6 +134,8 @@ SUBSYSTEM_DEF(timer)
 		callBack.InvokeAsync()
 
 		if(ctime_timer.flags & TIMER_LOOP)
+			if(QDELETED(ctime_timer))
+				continue
 			ctime_timer.spent = 0
 			ctime_timer.timeToRun = REALTIMEOFDAY + ctime_timer.wait
 			BINARY_INSERT_TG(ctime_timer, clienttime_timers, /datum/timedevent, ctime_timer, timeToRun, COMPARE_KEY)
@@ -180,6 +182,8 @@ SUBSYSTEM_DEF(timer)
 				last_invoke_tick = world.time
 
 			if(timer.flags & TIMER_LOOP) // Prepare looping timers to re-enter the queue
+				if(QDELETED(timer))
+					continue
 				timer.spent = 0
 				timer.timeToRun = world.time + timer.wait
 				timer.bucketJoin()

--- a/code/modules/hallucinations/effects/blind_rush_hallucination.dm
+++ b/code/modules/hallucinations/effects/blind_rush_hallucination.dm
@@ -59,6 +59,8 @@
 	return ..()
 
 /obj/effect/hallucination/no_delete/blind_rusher/proc/rush()
+	if(QDELETED(src))
+		return
 	if(get_dist(src, target) > min_distance)
 		var/direction = get_dir(src, target) //making sure the hallucination is facing the player correctly.
 		forceMove(get_step(src, direction)) //forceMove to go through walls and other dense turfs.

--- a/code/modules/hallucinations/effects/blind_rush_hallucination.dm
+++ b/code/modules/hallucinations/effects/blind_rush_hallucination.dm
@@ -48,19 +48,13 @@
 	var/rush_timer = null
 
 /obj/effect/hallucination/no_delete/blind_rusher/Initialize(mapload, mob/living/carbon/target)
-	rush_timer = addtimer(CALLBACK(src, PROC_REF(rush)), rush_time, TIMER_LOOP | TIMER_STOPPABLE)
+	rush_timer = addtimer(CALLBACK(src, PROC_REF(rush)), rush_time, TIMER_LOOP | TIMER_DELETE_ME)
 	if(prob(50))
 		hallucination_icon = 'icons/mob/simple_human.dmi'
 		hallucination_icon_state = pick("clown", "skeleton_warden", "skeleton_warden_alt")
 	return ..()
 
-/obj/effect/hallucination/no_delete/blind_rusher/Destroy()
-	deltimer(rush_timer)
-	return ..()
-
 /obj/effect/hallucination/no_delete/blind_rusher/proc/rush()
-	if(QDELETED(src))
-		return
 	if(get_dist(src, target) > min_distance)
 		var/direction = get_dir(src, target) //making sure the hallucination is facing the player correctly.
 		forceMove(get_step(src, direction)) //forceMove to go through walls and other dense turfs.


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #28054
The Blind Rusher timer failed to delete itself and would run indefinitely. This PR adds 2 QDELETED checks (from https://github.com/tgstation/tgstation/pull/69879) in the timer fire proc. If the timer has been deleted inside it's callback, it wont reinsert itself.

Blind Rusher now has the TIMER_DELETE_ME flag instead of TIMER_STOPPABLE, as  that seemed to always fail to delete.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
runtime spam not good
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Invoked the hallucination on myself, didn't runtime, didn't run infinitely.  Tried another TIMER_LOOP hallucination, deadchat control on a mob, the timers seem to run and delete. Aside of that, I have very surface level clue of what this actually does. Issues seemed related, so I gave it a shot.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog
NPFC

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
