### PR TITLE
Clean up firedoors and add proper emag behavior

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -303,8 +303,14 @@
 		// At this point, the area is safe and the door is technically functional.
 
 		INVOKE_ASYNC(D, (opening ? TYPE_PROC_REF(/obj/machinery/door/firedoor, deactivate_alarm) : TYPE_PROC_REF(/obj/machinery/door/firedoor, activate_alarm)))
-		if(D.welded)
+		if(D.welded || D.emagged)
 			continue // Alarm is toggled, but door stuck
+		
+		// Firedoors do not close automatically by default, and setting it to false when the alarm is off prevents unnecessary timers from being created.
+		if(opening)
+			D.autoclose = FALSE
+		else
+			D.autoclose = TRUE
 		if(D.operating)
 			if((D.operating == DOOR_OPENING && opening) || (D.operating == DOOR_CLOSING && !opening))
 				continue

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -301,16 +301,21 @@
 			continue
 
 		// At this point, the area is safe and the door is technically functional.
+		// Firedoors do not close automatically by default, and setting it to false when the alarm is off prevents unnecessary timers from being created. Emagged doors are permanently disabled from automatically closing, or being operated by alarms altogether apart from the lights.
+		if(!D.emagged)
+			if(opening)
+				D.autoclose = FALSE
+			else
+				D.autoclose = TRUE
 
 		INVOKE_ASYNC(D, (opening ? TYPE_PROC_REF(/obj/machinery/door/firedoor, deactivate_alarm) : TYPE_PROC_REF(/obj/machinery/door/firedoor, activate_alarm)))
 		if(D.welded || D.emagged)
 			continue // Alarm is toggled, but door stuck
 		
-		// Firedoors do not close automatically by default, and setting it to false when the alarm is off prevents unnecessary timers from being created.
-		if(opening)
-			D.autoclose = FALSE
-		else
-			D.autoclose = TRUE
+
+
+
+			
 		if(D.operating)
 			if((D.operating == DOOR_OPENING && opening) || (D.operating == DOOR_CLOSING && !opening))
 				continue

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -311,11 +311,7 @@
 		INVOKE_ASYNC(D, (opening ? TYPE_PROC_REF(/obj/machinery/door/firedoor, deactivate_alarm) : TYPE_PROC_REF(/obj/machinery/door/firedoor, activate_alarm)))
 		if(D.welded || D.emagged)
 			continue // Alarm is toggled, but door stuck
-		
 
-
-
-			
 		if(D.operating)
 			if((D.operating == DOOR_OPENING && opening) || (D.operating == DOOR_CLOSING && !opening))
 				continue

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -190,7 +190,7 @@
 	if(!density)
 		return
 	autoclose = FALSE
-	. = ..()
+	return ..()
 
 /obj/machinery/door/firedoor/try_to_crowbar(obj/item/I, mob/user)
 	if(welded || operating)

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -122,7 +122,7 @@
 		user.visible_message(
 			"<span class='notice'>[user] opens [src].</span>",
 			"<span class='notice'>You open [src].</span>")
-		open(auto_close = FALSE)
+		open()
 
 /obj/machinery/door/firedoor/attackby__legacy__attackchain(obj/item/C, mob/user, params)
 	add_fingerprint(user)
@@ -186,6 +186,12 @@
 	welded = !welded
 	update_icon(UPDATE_OVERLAYS)
 
+/obj/machinery/door/firedoor/emag_act(mob/user)
+	if(!density)
+		return
+	autoclose = FALSE
+	. = ..()
+
 /obj/machinery/door/firedoor/try_to_crowbar(obj/item/I, mob/user)
 	if(welded || operating)
 		return
@@ -244,15 +250,13 @@
 	adjust_light()
 	update_icon()
 
-/obj/machinery/door/firedoor/open(auto_close = TRUE)
+/obj/machinery/door/firedoor/open()
 	if(welded)
 		return
 	. = ..()
-	latetoggle(auto_close)
+	latetoggle()
 	if(active_alarm)
 		layer = closingLayer // Active firedoors take precedence and remain visible over closed airlocks.
-	if(auto_close)
-		autoclose = TRUE
 
 /obj/machinery/door/firedoor/close()
 	. = ..()
@@ -262,20 +266,20 @@
 	if(active_alarm)
 		. = ..()
 
-/obj/machinery/door/firedoor/proc/latetoggle(auto_close = TRUE)
+/obj/machinery/door/firedoor/proc/latetoggle()
 	if(operating || !hasPower() || !nextstate)
 		return
 	if(nextstate == FD_OPEN)
-		INVOKE_ASYNC(src, PROC_REF(open), auto_close)
+		INVOKE_ASYNC(src, PROC_REF(open))
 	if(nextstate == FD_CLOSED)
 		INVOKE_ASYNC(src, PROC_REF(close))
 	nextstate = null
 
-/obj/machinery/door/firedoor/proc/forcetoggle(magic = FALSE, auto_close = TRUE)
+/obj/machinery/door/firedoor/proc/forcetoggle(magic = FALSE)
 	if(!magic && (operating || !hasPower()))
 		return
 	if(density)
-		open(auto_close)
+		open()
 	else
 		close()
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
While this was intended as a fix, I ended up cleaning up the code at the same time since the behavior was really weird if taken at face value.

So to sum up the behavior now:

- Firedoors do not close automatically unless an alarm is active
- The alarm/area itself will close the doors every 10 seconds, while opening it manually will close it in 5, whichever comes first baring obstructions.
- Emagging turns it into a manual-only door, on top of opening up right then.

The first two are technically the current behavior, minus the extra quirks.

## Why It's Good For The Game
Fixes #25952

A lot of the inconsistent behavior was probably borne out of the odd code.

## Images of changes
https://github.com/user-attachments/assets/30c9fd16-5c66-4556-add1-7151c42dd70f

## Testing
Messed with firealarms and firedoors, noting the new behaviors with cleaned up code.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
add: Emagged firedoors are manual operation only
fix: Firedoor behavior should be more consistent
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
