### PR TITLE
Fix RCD interactions with invalid types

### DIFF
--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -211,6 +211,11 @@
 	delay = 5 SECONDS
 	start_effect_type = /obj/effect/temp_visual/rcd_effect/reverse
 
+/datum/rcd_act/remove_user/can_act(atom/A, obj/item/rcd/rcd)
+	if(!..())
+		return FALSE
+	return A == rcd.loc
+
 /obj/item/rcd
 	name = "rapid-construction-device (RCD)"
 	desc = "A device used to rapidly build and deconstruct walls, floors and airlocks."
@@ -343,11 +348,10 @@
 /obj/item/rcd/suicide_act(mob/living/user)
 	user.Immobilize(10 SECONDS) // You cannot move.
 	flags |= NODROP				// You cannot drop. You commit to die.
-	var/turf/suicide_tile = get_turf(src)
 	if(mode == MODE_DECON)
 		user.visible_message("<span class='suicide'>[user] points [src] at [user.p_their()] chest and pulls the trigger. It looks like [user.p_theyre()] trying to commit suicide!</span>")
 		var/datum/rcd_act/remove_user/act = new()
-		if(!act.try_act(suicide_tile, src, user))
+		if(!act.try_act(user, src, user))
 			flags &= ~NODROP
 			return SHAME
 		user.visible_message("<span class='suicide'>[user] deconstructs [user.p_themselves()] with [src]!</span>")
@@ -358,7 +362,7 @@
 		return OBLITERATION
 
 	user.visible_message("<span class='suicide'>[user] puts the barrel of [src] into [user.p_their()] mouth and pulls the trigger. It looks like [user.p_theyre()] trying to commit suicide!</span>")
-	if(!interact_with_atom(suicide_tile, user, TRUE))
+	if(!interact_with_atom(get_turf(src), user, TRUE))
 		flags &= ~NODROP
 		return SHAME
 	user.visible_message("<span class='suicide'>[user] explodes as [src] builds a structure inside [user.p_them()]!</span>")


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Due to how RCDs try to interact with atoms by looping through their actions, they'd wind up showing the suicide message if trying to deconstruct something invalid.

This adds a proper check, and also tweaks what gets passed in certain proc calls to retain functionality.

## Why It's Good For The Game
Fixes #25891

## Images of changes
https://github.com/user-attachments/assets/faf374fa-9cb1-49a6-a92b-57e4003c0d74

## Testing
Used the RCD on an indestructible wall, built and deconstructed things. Let the thing meet my maker.

<hr>

### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: Fixed bogus message/interact when trying to do an invalid deconstruct with the RCD
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
