### PR TITLE
Allow speedbikers to pull mobs and use their hands.

### DIFF
--- a/code/modules/vehicle/speedbike.dm
+++ b/code/modules/vehicle/speedbike.dm
@@ -22,7 +22,7 @@
 /datum/component/riding/vehicle/speedbike
 	vehicle_move_delay = 1
 	override_allow_spacemove = TRUE
-	ride_check_flags = RIDER_NEEDS_LEGS | RIDER_NEEDS_ARMS | UNBUCKLE_DISABLED_RIDER
+	ride_check_flags = RIDER_NEEDS_LEGS | UNBUCKLE_DISABLED_RIDER
 
 /datum/component/riding/vehicle/speedbike/handle_specials()
 	. = ..()
@@ -36,3 +36,6 @@
 	set_vehicle_dir_offsets(SOUTH, -16, -16)
 	set_vehicle_dir_offsets(EAST, -18, 0)
 	set_vehicle_dir_offsets(WEST, -18, 0)
+
+/datum/component/riding/vehicle/speedbike/on_rider_try_pull(mob/living/rider_pulling, atom/movable/target, force)
+	return


### PR DESCRIPTION
## What Does This PR Do
This PR allows speedbike riders to pull mobs, and removes the arm requirement for riding, allowing them to have things in their hands.
## Why It's Good For The Game
Regression caused by #27698. Fixes #28091.
## Testing

https://github.com/user-attachments/assets/9b1edc26-3591-41b4-9cea-3c1f970a105f

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Changelog

:cl:
fix: Speedbike riders can properly pull things while riding.
fix: Speedbike riders can properly use items in their hands while buckled to the bike.
/:cl:
