### PR TITLE
[FIX] Fixes descriptions of two armor pieces

### DIFF
--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -1,6 +1,6 @@
 /obj/item/clothing/head/helmet
 	name = "helmet"
-	desc = "A standard-issue protective helmet used by Nanotrasen corporate security. Provides light protection against most sources of damage."
+	desc = "A mass-produced protective helmet used by security personnel across the sector. Provides light protection against most sources of damage."
 	icon_state = "helmetmaterials"
 	w_class = WEIGHT_CLASS_NORMAL
 	flags = HEADBANGPROTECT

--- a/code/modules/clothing/suits/armor_suits.dm
+++ b/code/modules/clothing/suits/armor_suits.dm
@@ -16,8 +16,8 @@
 	w_class = WEIGHT_CLASS_NORMAL
 
 /obj/item/clothing/suit/armor/vest
-	name = "perfectly generic armor vest"
-	desc = "A perfectly generic armored vest. Every aspect of it is exceptionally boring. If you see this, make an issue report on GitHub."
+	name = "armor vest"
+	desc = "A mass-produced Level II soft armor vest that provides light protection against most sources of damage."
 	sprite_sheets = list(
 		"Grey" = 'icons/mob/clothing/species/grey/suit.dmi',
 		"Vox" = 'icons/mob/clothing/species/vox/suit.dmi'


### PR DESCRIPTION
## What Does This PR Do
Title. Corrects the descriptions of the generic armor vest and helmet.

## Why It's Good For The Game
Descriptions which lie to people are bad.

## Testing

spawned the items and observed them.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  
<hr>

## Changelog

:cl:
fix: Fixes two armor descriptions
/:cl:
