### PR TITLE
fix flaky vetus test failures in the dumbest way possible

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -467,6 +467,8 @@
 /mob/living/simple_animal/hostile/proc/EscapeConfinement()
 	if(buckled)
 		buckled.attack_animal(src)
+	if(!targets_from)
+		return
 	if(!isturf(targets_from.loc) && targets_from.loc != null)//Did someone put us in something?
 		var/atom/A = targets_from.loc
 		A.attack_animal(src)//Bang on it till we get out


### PR DESCRIPTION
## What Does This PR Do
This PR does a null check before this runtime failure in tests:
```
[2025-01-25T19:06:28] Runtime in code/modules/mob/living/simple_animal/hostile/hostile.dm:470: Cannot read null.loc
  proc name: EscapeConfinement (/mob/living/simple_animal/hostile/proc/EscapeConfinement)
  src: the leg (/mob/living/simple_animal/hostile/ancient_robot_leg)
  src.loc: null
  call stack:
  the leg (/mob/living/simple_animal/hostile/ancient_robot_leg): EscapeConfinement
  the leg (/mob/living/simple_animal/hostile/ancient_robot_leg): DestroySurroundings
  the leg (/mob/living/simple_animal/hostile/ancient_robot_leg): leg_movement
  the Vetus Speculator (/mob/living/simple_animal/hostile/megafauna/ancient_robot): leg_control_system
  the Vetus Speculator (/mob/living/simple_animal/hostile/megafauna/ancient_robot): fix_specific_leg
  /datum/callback (/datum/callback): InvokeAsync
  Timer (/datum/controller/subsystem/timer): fire
  Timer (/datum/controller/subsystem/timer): ignite
  Master (/datum/controller/master): RunQueue
  Master (/datum/controller/master): Loop
  Master (/datum/controller/master): StartProcessing
Error: Cannot read null.loc
``` 

## Why It's Good For The Game
Flaky tests bad, trying to find the real root cause worse.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing

<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog
NPFC