### PR TITLE
Adds Tend Wounds/Tend Burns surgeries

### DIFF
--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -126,7 +126,7 @@
 	return SURGERY_STEP_RETRY
 
 /datum/surgery_step/treat_burns
-	name = "mend burns"
+	name = "treat severe burns"
 	allowed_tools = list(
 		/obj/item/stack/medical/ointment/advanced = 100,
 		/obj/item/stack/medical/ointment = 90

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -49,6 +49,14 @@
 	/// How likely it should be for the surgery to cause infection: 0-1
 	var/germ_prevention_quality = 0
 
+/**
+ * Create a new surgery.
+ *
+ * Arguments:
+ * * surgery_target - The atom the target is being performed on.
+ * * surgery_location - The body zone that the surgery is being performed on.
+ * * surgery_bodypart - The body part that the surgery is being performed on.
+ */
 /datum/surgery/New(atom/surgery_target, surgery_location, surgery_bodypart)
 	..()
 	if(!surgery_target)

--- a/code/modules/surgery/tending.dm
+++ b/code/modules/surgery/tending.dm
@@ -2,7 +2,6 @@
  * Surgeries for tending brute and burn damage without needing to expend items.
  */
 
-#define HEALING_STEP "healing_step"
 
 // Since these both share surgery steps, we can only realistically expose one
 /datum/surgery_step/proxy/open_organ/extra

--- a/code/modules/surgery/tending.dm
+++ b/code/modules/surgery/tending.dm
@@ -24,7 +24,6 @@
 
 /datum/surgery/heal
 	abstract = TRUE  // don't need this popping up
-	ignore_clothes = FALSE  // needs to be some kind of drawback
 	requires_organic_bodypart = TRUE
 	/// A subtype of /datum/surgery_step/heal that this will invoke.
 	var/healing_step_type
@@ -62,6 +61,8 @@
 
 	// no sounds, since it would quickly get annoying
 
+	var/shown_starting_message_already = FALSE
+
 	COOLDOWN_DECLARE(success_message_spam_cooldown)
 
 	var/damage_name_pretty = "wounds"
@@ -97,11 +98,13 @@
 
 /datum/surgery_step/heal/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message(
-		"[user] starts to patch some of the [damage_name_pretty] on [target]'s [affected.name] with [tool].",
-		"You start to patch some of the [damage_name_pretty] on [target]'s [affected.name] with [tool].",
-		chat_message_type = MESSAGE_TYPE_COMBAT
-	)
+	if(!shown_starting_message_already)
+		shown_starting_message_already = TRUE
+		user.visible_message(
+			"[user] starts to patch some of the [damage_name_pretty] on [target]'s [affected.name] with [tool].",
+			"You start to patch some of the [damage_name_pretty] on [target]'s [affected.name] with [tool].",
+			chat_message_type = MESSAGE_TYPE_COMBAT
+		)
 	affected.custom_pain("Something in your [affected.name] is causing you a lot of pain!")
 
 	return ..()
@@ -186,7 +189,7 @@
 	brute_damage_healmod = 0.07
 
 /datum/surgery_step/heal/brute/get_progress(mob/user, mob/living/carbon/target, brute_healed, burn_healed)
-x	if(!brute_healed)
+	if(!brute_healed)
 		return
 
 	var/estimated_remaining_steps = target.getBruteLoss() / brute_healed

--- a/code/modules/surgery/tending.dm
+++ b/code/modules/surgery/tending.dm
@@ -1,0 +1,230 @@
+/**
+ * Surgeries for tending brute and burn damage without needing to expend items.
+ */
+
+#define HEALING_STEP "healing_step"
+
+/datum/surgery/heal
+	abstract = TRUE  // don't need this popping up
+	ignore_clothes = FALSE  // needs to be some kind of drawback
+	requires_organic_bodypart = TRUE
+	/// A subtype of /datum/surgery_step/heal that this will invoke.
+	var/healing_step_type
+	possible_locs = list(BODY_ZONE_CHEST)
+	steps = list(
+		/datum/surgery_step/generic/cut_open,
+		/datum/surgery_step/generic/clamp_bleeders,
+		/datum/surgery_step/generic/retract_skin,
+		/datum/surgery_step/heal,
+		/datum/surgery_step/generic/cauterize
+	)
+
+/datum/surgery/heal/New(atom/surgery_target, surgery_location, surgery_bodypart)
+	..()
+	if(ispath(healing_step_type, /datum/surgery_step/heal))
+		steps = list(
+			/datum/surgery_step/generic/cut_open,
+			/datum/surgery_step/generic/clamp_bleeders,
+			/datum/surgery_step/generic/retract_skin,
+			healing_step_type,
+			/datum/surgery_step/generic/cauterize
+		)
+
+/datum/surgery_step/heal
+	name = "tend something"
+
+	allowed_tools = list(
+		TOOL_HEMOSTAT = 100,
+		TOOL_SCREWDRIVER = 65,
+		TOOL_WIRECUTTER = 60,
+		/obj/item/pen = 55
+	)
+
+	time = 2.5 SECONDS
+	repeatable = TRUE
+
+	// no sounds, since it would quickly get annoying
+
+	COOLDOWN_DECLARE(success_message_spam_cooldown)
+
+	var/damage_name_pretty = "wounds"
+	/// Amount of brute damage to treat per op.
+	var/brute_damage_healed
+	/// Amount of burn damage to treat per op.
+	var/burn_damage_healed
+
+	/// Multiplier based on the amount of brute damage that the patient has, increasing the efficiency at higher levels of damage.
+	var/brute_damage_healmod
+	/// Multiplier based on the amount of burn damage that the patient has.
+	var/burn_damage_healmod
+
+/// Get a message indicating how the surgery is going.
+/datum/surgery_step/heal/proc/get_progress(mob/user, mob/living/carbon/target, brute_healed, burn_healed)
+	return
+
+/datum/surgery_step/heal/proc/get_damage_amount(obj/item/organ/external/O)
+	return O.brute_dam
+
+/datum/surgery_step/heal/proc/can_be_healed(mob/living/user, mob/living/carbon/target, target_zone)
+	var/obj/item/organ/external/affected = target.get_organ(target_zone)
+	if(affected.is_broken())
+		return FALSE
+	return get_damage_amount(affected) > 0
+
+/datum/surgery_step/heal/can_repeat(mob/living/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	if(!can_be_healed(user, target, target_zone))
+		to_chat(user, "<span class='notice'>It doesn't look like [target] has any more [damage_name_pretty].</span>")
+		return FALSE
+	return TRUE
+
+/datum/surgery_step/heal/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	var/obj/item/organ/external/affected = target.get_organ(target_zone)
+	user.visible_message(
+		"[user] starts to patch some of the [damage_name_pretty] on [target]'s [affected.name] with [tool].",
+		"You start to patch some of the [damage_name_pretty] on [target]'s [affected.name] with [tool].",
+		chat_message_type = MESSAGE_TYPE_COMBAT
+	)
+	affected.custom_pain("Something in your [affected.name] is causing you a lot of pain!")
+
+	return ..()
+
+/datum/surgery_step/heal/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery)
+
+	if(!can_be_healed(user, target, target_zone))
+		to_chat(user, "<span class='notice'>It doesn't look like [target] has any more [damage_name_pretty].</span>")
+		return SURGERY_BEGINSTEP_SKIP
+
+	var/brute_healed = brute_damage_healed
+	var/burn_healed = burn_damage_healed
+
+	var/outer_msg = "[user] succeeds in fixing some of [target]'s [damage_name_pretty]"
+	var/self_msg = "You successfully manage to patch up some of [target]'s [damage_name_pretty]"
+
+	if(target.stat == DEAD) //dead patients get way less additional heal from the damage they have.
+		brute_healed += round((target.getBruteLoss() * (brute_damage_healmod * 0.2)), 0.1)
+		burn_healed += round((target.getFireLoss() * (burn_damage_healmod * 0.2)), 0.1)
+	else
+		brute_healed += round((target.getBruteLoss() * brute_damage_healmod), 0.1)
+		burn_healed += round((target.getFireLoss() * burn_damage_healmod), 0.1)
+
+	if(!get_location_accessible(target, target_zone))
+		brute_healed *= 0.55
+		burn_healed *= 0.55
+		self_msg += " as best as you can while [target.p_they()] [target.p_have()] clothing on"
+		outer_msg += " as best as [user.p_they()] can while [target.p_they()] [target.p_have()] clothing on"
+
+	target.heal_overall_damage(brute_healed, burn_healed)
+
+	self_msg += get_progress(user, target, brute_healed, burn_healed)
+
+	if(COOLDOWN_FINISHED(src, success_message_spam_cooldown))
+		user.visible_message(
+			"<span class='notice'>[outer_msg].</span>",
+			"<span class='notice'>[self_msg].</span>",
+			chat_message_type = MESSAGE_TYPE_COMBAT
+		)
+
+		COOLDOWN_START(src, success_message_spam_cooldown, 10 SECONDS)
+
+	// retry ad nauseum; can_repeat should handle anything else.
+	return SURGERY_STEP_RETRY
+
+/datum/surgery_step/heal/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	user.visible_message(
+		"<span class='warning'>[user] screws up, making things worse!</span>",
+		"<span class='warning'>You screw up, making things worse!</span>",
+		chat_message_type = MESSAGE_TYPE_COMBAT
+	)
+	var/burn_dealt = burn_damage_healed * 0.8
+	var/brute_dealt = brute_damage_healed * 0.8
+
+	brute_dealt += round((target.getBruteLoss() * (brute_damage_healmod * 0.5)), 0.1)
+	burn_dealt += round((target.getFireLoss() * (burn_damage_healmod * 0.5)), 0.1)
+
+	target.take_overall_damage(brute_dealt, burn_dealt)
+
+	return SURGERY_STEP_RETRY
+
+/datum/surgery/heal/wounds
+	name = "Tend Wounds"
+	desc = "Tend a patient's wounds, gradually treating their brute damage."
+	abstract = FALSE
+	healing_step_type = /datum/surgery_step/heal/brute
+
+/datum/surgery/heal/burns
+	name = "Treat Burns"
+	desc = "Tend a patient's burns, gradually treating their burn damage."
+	abstract = FALSE
+	healing_step_type = /datum/surgery_step/heal/burn
+
+
+/********************BRUTE STEPS********************/
+
+
+/datum/surgery_step/heal/brute
+	name = "tend wounds"
+	damage_name_pretty = "wounds"
+	brute_damage_healed = 5
+	brute_damage_healmod = 0.07
+
+/datum/surgery_step/heal/brute/get_progress(mob/user, mob/living/carbon/target, brute_healed, burn_healed)
+	if(!brute_healed)
+		return
+
+	var/estimated_remaining_steps = target.getBruteLoss() / brute_healed
+	var/progress_text
+
+	if(locate(/obj/item/healthanalyzer) in list(user.l_hand, user.r_hand))
+		progress_text = ". Remaining brute: <font color='#ff3333'>[target.getBruteLoss()]</font>"
+	else
+		switch(estimated_remaining_steps)
+			if(-INFINITY to 1)
+				return
+			if(1 to 3)
+				progress_text = ", stitching up the last few scrapes"
+			if(3 to 6)
+				progress_text = ", counting down the last few bruises left to treat"
+			if(6 to 9)
+				progress_text = ", continuing to plug away at [target.p_their()] extensive rupturing"
+			if(9 to 12)
+				progress_text = ", steadying yourself for the long surgery ahead"
+			if(12 to 15)
+				progress_text = ", though [target.p_they()] still look[target.p_s()] more like ground beef than a person"
+			if(15 to INFINITY)
+				progress_text = ", though you feel like you're barely making a dent in treating [target.p_their()] pulped body"
+
+	return progress_text
+
+/datum/surgery_step/heal/burn
+	name = "treat burns"
+	damage_name_pretty = "burns"
+	brute_damage_healed = 5
+	brute_damage_healmod = 0.07
+
+/********************BURN STEPS********************/
+/datum/surgery_step/heal/burn/get_progress(mob/living/user, mob/living/carbon/target, brute_healed, burn_healed)
+	if(!burn_healed)
+		return
+	var/estimated_remaining_steps = target.getFireLoss() / burn_healed
+	var/progress_text
+
+	if(locate(/obj/item/healthanalyzer) in list(user.l_hand, user.r_hand))
+		progress_text = ". Remaining burn: <font color='#ff9933'>[target.getFireLoss()]</font>"
+	else
+		switch(estimated_remaining_steps)
+			if(-INFINITY to 1)
+				return
+			if(1 to 3)
+				progress_text = ", finishing up the last few singe marks"
+			if(3 to 6)
+				progress_text = ", counting down the last few blisters left to treat"
+			if(6 to 9)
+				progress_text = ", continuing to plug away at [target.p_their()] thorough roasting"
+			if(9 to 12)
+				progress_text = ", steadying yourself for the long surgery ahead"
+			if(12 to 15)
+				progress_text = ", though [target.p_they()] still look[target.p_s()] more like burnt steak than a [target.dna?.species.name || "person" ]"
+			if(15 to INFINITY)
+				progress_text = ", though you feel like you're barely making a dent in treating [target.p_their()] charred body"
+
+	return progress_text

--- a/paradise.dme
+++ b/paradise.dme
@@ -2914,6 +2914,7 @@
 #include "code\modules\surgery\robotics.dm"
 #include "code\modules\surgery\surgery.dm"
 #include "code\modules\surgery\surgery_helpers.dm"
+#include "code\modules\surgery\tending.dm"
 #include "code\modules\surgery\tools.dm"
 #include "code\modules\surgery\organs\augments_arms.dm"
 #include "code\modules\surgery\organs\augments_eyes.dm"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Ports tend wounds/tend burns surgeries from /tg/. The first part in what's hopefully a substantial difference in healing on Paradise.

The two surgeries are fundamentally the same, they just differ in name. 

scalpel -> hemo -> retractor -> heal (or treat bones/IB) -> cautery,

where healing makes use of a hemostat (or a pen/pair of wirecutters in a pinch), and will repeat automatically until the patient is healed.

While performing the healing, you'll get a little indicator in chat that'll tell you how the healing is going, and if you have a health analyzer in your off-hand, it'll tell you the exact number of brute/burn remaining.

It'll heal a *teensy* bit faster when a patient has more brute damage, and will be less effective if the patient is wearing a jumpsuit/shirt. There has to be some kind of drawback, after all.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
This surgery provides a busy, resource-strapped OR a method to treat patients without chemicals, even if it's a little slow. Improved tools will make it a little faster, though.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://github.com/user-attachments/assets/56f5f8a2-9d39-4ed0-baf5-123ae01b90bb)
![image](https://github.com/user-attachments/assets/8055ff05-38ee-4321-b294-a2a97056195f)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing

<!-- How did you test the PR, if at all? -->
Loaded up the admin testing area, beat up a vulp and tended their wounds.
<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
add: New Tend Wounds surgery.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
