### PR TITLE
fix immovable rods looping continuously

### DIFF
--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -39,6 +39,7 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 
 /obj/effect/immovablerod/New(atom/_start, atom/_end, delay)
 	. = ..()
+	ADD_TRAIT(src, TRAIT_NO_EDGE_TRANSITIONS, ROUNDSTART_TRAIT)
 	start = _start
 	end = _end
 	loc = start


### PR DESCRIPTION
## What Does This PR Do
This PR prevents immovable rods from looping continuously because their destination turfs are within the space transition edge. Fixes #28107.
## Why It's Good For The Game
Very funny regression but regression nonetheless.
## Testing
Triggered rods in event manager a dozen times, ensured each one ended and did not loop around.

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: Immovable rods will now properly leave the station sector and not loop back around for multiple passes.
/:cl:
