### PR TITLE
IPCs get gibbed when rolling a 5 on the Die of Fate

### DIFF
--- a/code/game/objects/items/weapons/dice.dm
+++ b/code/game/objects/items/weapons/dice.dm
@@ -197,6 +197,13 @@
 				qdel(I)
 		if(5)
 			//Monkeying
+			if(ismachineperson(user))
+				playsound(get_turf(user), 'sound/machines/ding.ogg', 100, 1)
+				var/obj/fresh_toast = new /obj/item/food/toast(get_turf(user))
+				fresh_toast.desc += " It came out of [user]!"
+				to_chat(user, "<span class='userdanger'>Your internal structure is getting really toasty!</span>")
+				user.gib()
+				return
 			T.visible_message("<span class='userdanger'>[user] transforms into a monkey!</span>")
 			user.monkeyize()
 		if(6)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Species without a lesser form just get gibbed when rolling a 5 on the die of fate, so it makes sense for it to happen for IPCs too.

Oh, and they toast bread when that happens.

## Why It's Good For The Game
Fixes #25542

## Images of changes
https://github.com/user-attachments/assets/f21f17cc-2cbb-4b81-8241-228c012cd1ea

![Toast](https://github.com/user-attachments/assets/bf5ff606-43c4-44e1-970e-c2e6b7463a12)

## Testing
Threw a rigged die of fate and made breakfast.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: Machine people get gibbed when rolling a 5 on the Die of Fate
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
