### PR TITLE
kills flick from jetpacks again

### DIFF
--- a/code/game/objects/effects/effect_system/effects_other.dm
+++ b/code/game/objects/effects/effect_system/effects_other.dm
@@ -4,8 +4,6 @@
 	var/allow_overlap = FALSE
 	var/auto_process = TRUE
 	var/qdel_in_time = 10
-	var/fadetype = "ion_fade"
-	var/fade = TRUE
 	var/nograv_required = FALSE
 
 /datum/effect_system/trail_follow/set_up(atom/atom)
@@ -42,9 +40,6 @@
 		if(!has_gravity(oldposition) || !nograv_required)
 			var/obj/effect/E = new effect_type(oldposition)
 			set_dir(E)
-			if(fade)
-				flick(fadetype, E)
-				E.icon_state = ""
 			if(qdel_in_time)
 				QDEL_IN(E, qdel_in_time)
 	oldposition = get_turf(holder)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Removes fadetype, fade, and the flick call in /datum/effect_system/trail_follow, as large ammount of flick calls seems to lead to effect removal corruption per  https://github.com/ParadiseSS13/Paradise/pull/25777, https://github.com/ParadiseSS13/Paradise/pull/25898, and this issue port showing up after flick was reintroduced: https://github.com/ParadiseSS13/Paradise/issues/28103

Fix: #28103

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

Random jetpack effects when cleaning decals is bad

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

<!-- How did you test the PR, if at all? -->
https://cdn.discordapp.com/attachments/984761070159818753/1332891795960631377/Paradise_Station_13_2025-01-25_20-55-47.mp4?ex=6796e7b8&is=67959638&hm=1129906d6701c3307271ee1dbe85c3adf83558aaeb07120f29c56a36ce5003e8&

https://cdn.discordapp.com/attachments/984761070159818753/1332892069307617290/Paradise_Station_13_2025-01-25_20-56-51.mp4?ex=6796e7f9&is=67959679&hm=bb1446ae13373c727e00edb770ef4d16f82120e0e6b053447e769823ddf56d59&

Visually the same as they still qdel themselfs and the icon state is already a fade animation
<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: We should no longer have cleaning decals producing random ion effects again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
