### PR TITLE
fix catwalk cabling placement when clicking on space

### DIFF
--- a/code/game/turfs/space/space_turf.dm
+++ b/code/game/turfs/space/space_turf.dm
@@ -117,6 +117,8 @@
 			to_chat(user, "<span class='warning'>The plating is going to need some support! Place metal rods first.</span>")
 			return ITEM_INTERACT_COMPLETE
 
+	return ..()
+
 /turf/space/Entered(atom/movable/A as mob|obj, atom/OL, ignoreRest = 0)
 	..()
 	if((!(A) || !(src in A.locs)))

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -478,27 +478,27 @@
 	if(SSticker)
 		GLOB.cameranet.update_visibility(src)
 
-/turf/attack_by(obj/item/attacking, mob/user, params)
-	if(..())
-		return TRUE
+/turf/item_interaction(mob/living/user, obj/item/used, list/modifiers)
 	if(can_lay_cable())
-		if(istype(attacking, /obj/item/stack/cable_coil))
-			var/obj/item/stack/cable_coil/C = attacking
+		if(istype(used, /obj/item/stack/cable_coil))
+			var/obj/item/stack/cable_coil/C = used
 			for(var/obj/structure/cable/LC in src)
 				if(LC.d1 == 0 || LC.d2 == 0)
 					LC.attackby__legacy__attackchain(C, user)
-					return TRUE
+					return ITEM_INTERACT_COMPLETE
 			C.place_turf(src, user)
-			return TRUE
-		else if(istype(attacking, /obj/item/rcl))
-			var/obj/item/rcl/R = attacking
+			return ITEM_INTERACT_COMPLETE
+		else if(istype(used, /obj/item/rcl))
+			var/obj/item/rcl/R = used
 			if(R.loaded)
 				for(var/obj/structure/cable/LC in src)
 					if(LC.d1 == 0 || LC.d2 == 0)
 						LC.attackby__legacy__attackchain(R, user)
-						return TRUE
+						return ITEM_INTERACT_COMPLETE
 				R.loaded.place_turf(src, user)
 				R.is_empty(user)
+
+			return ITEM_INTERACT_COMPLETE
 
 /turf/proc/can_have_cabling()
 	return TRUE


### PR DESCRIPTION
## What Does This PR Do
This PR fixes being unable to lay cable on catwalks in space by clicking on the space itself. Fixes #28069.
## Why It's Good For The Game
Bugfix.
## Testing
Wired solars, using alt-click to specifically select the space, and not the catwalk on the space. Confirmed it worked as an engiborg.

<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: Cables can properly be placed on space catwalks by clicking on space.
/:cl: