### PR TITLE
fix cabling placement on plating

### DIFF
--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -113,6 +113,8 @@
 
 		return ITEM_INTERACT_COMPLETE
 
+	return ..()
+
 /turf/simulated/floor/plating/screwdriver_act(mob/user, obj/item/I)
 	if(!I.tool_use_check(user, 0))
 		return


### PR DESCRIPTION
## What Does This PR Do
Fixes cable placement on plating.
## Why It's Good For The Game
Bugfix.
## Testing
![2025_01_26__00_05_30__Paradise Station 13](https://github.com/user-attachments/assets/b3a3b284-c40e-4abc-8974-4730fe8090db)

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

<hr>

## Changelog

:cl:
fix: Cable placement works on plating properly.
/:cl:
