### PR TITLE
Remove redundant block that results in duplicate messages

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -180,11 +180,6 @@
 		return hear
 
 	for(var/atom/A in hear(R, T))
-		if(ismob(A))
-			var/mob/M = A
-			if(M.client || include_clientless)
-				hear += M
-
 		if(isobj(A) || ismob(A))
 			collect_nested_mobs(A, hear, 3, !include_clientless)
 


### PR DESCRIPTION
## What Does This PR Do
Removes a redundant block that results in duplicate messages

## Why It's Good For The Game
Bugs bad

## Testing
Probably should.
<hr>

### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

<hr>

## Changelog

:cl:
del: Doubled messages.
del: Doubled messages.
/:cl: