### PR TITLE
Fix appearance changes from the mirror resetting on any UpdateAppearance() call

### DIFF
--- a/code/game/dna/dna2.dm
+++ b/code/game/dna/dna2.dm
@@ -101,7 +101,7 @@ GLOBAL_LIST_EMPTY(bad_blocks)
 	ResetUI(1)
 	// Hair
 	// FIXME:  Species-specific defaults pls
-	var/obj/item/organ/external/head/H = character.get_organ("head")
+	var/obj/item/organ/external/head/head = character.get_organ("head")
 	var/obj/item/organ/internal/eyes/eyes_organ = character.get_int_organ(/obj/item/organ/internal/eyes)
 
 	/*// Body Accessory
@@ -117,7 +117,7 @@ GLOBAL_LIST_EMPTY(bad_blocks)
 	var/body_marks	= GLOB.marking_styles_list.Find(character.m_styles["body"])
 	var/tail_marks	= GLOB.marking_styles_list.Find(character.m_styles["tail"])
 
-	head_traits_to_dna(character, H)
+	head_traits_to_dna(character, head)
 	eye_color_to_dna(eyes_organ)
 
 	SetUIValueRange(DNA_UI_SKIN_R,		color2R(character.skin_colour),			255,	1)
@@ -163,6 +163,10 @@ GLOBAL_LIST_EMPTY(bad_blocks)
 		if(PLURAL)
 			SetUITriState(DNA_UI_GENDER, DNA_GENDER_PLURAL, 1)
 
+	if(head)
+		head.dna.UI = character.dna.UI
+	if(eyes_organ)
+		eyes_organ.dna.UI = character.dna.UI
 
 	UpdateUI()
 

--- a/code/game/dna/dna2_helpers.dm
+++ b/code/game/dna/dna2_helpers.dm
@@ -217,6 +217,7 @@
 	if((hair > 0) && (hair <= length(GLOB.hair_styles_full_list)))
 		head_organ.h_style = GLOB.hair_styles_full_list[hair]
 
+	// dna is taken from the head, not from the mob
 	head_organ.hair_colour = rgb(head_organ.dna.GetUIValueRange(DNA_UI_HAIR_R, 255), head_organ.dna.GetUIValueRange(DNA_UI_HAIR_G, 255), head_organ.dna.GetUIValueRange(DNA_UI_HAIR_B, 255))
 	head_organ.sec_hair_colour = rgb(head_organ.dna.GetUIValueRange(DNA_UI_HAIR2_R, 255), head_organ.dna.GetUIValueRange(DNA_UI_HAIR2_G, 255), head_organ.dna.GetUIValueRange(DNA_UI_HAIR2_B, 255))
 

--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -39,7 +39,7 @@
 		if(!AC)
 			AC = new(src, user)
 			AC.name = "SalonPro Nano-Mirror"
-			AC.flags = APPEARANCE_ALL_BODY | APPEARANCE_UPDATE_DNA
+			AC.flags = APPEARANCE_ALL_BODY
 			ui_users[user] = AC
 		AC.ui_interact(user)
 

--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -39,7 +39,7 @@
 		if(!AC)
 			AC = new(src, user)
 			AC.name = "SalonPro Nano-Mirror"
-			AC.flags = APPEARANCE_ALL_BODY
+			AC.flags = APPEARANCE_ALL_BODY | APPEARANCE_UPDATE_DNA
 			ui_users[user] = AC
 		AC.ui_interact(user)
 

--- a/code/modules/tgui/modules/appearance_changer.dm
+++ b/code/modules/tgui/modules/appearance_changer.dm
@@ -314,7 +314,7 @@
 	return data
 
 /datum/ui_module/appearance_changer/proc/update_dna()
-	if(owner && (flags & APPEARANCE_UPDATE_DNA))
+	if(owner)
 		owner.update_dna()
 
 /datum/ui_module/appearance_changer/proc/can_change(flag)


### PR DESCRIPTION
## What Does This PR Do
Adds eyes and head DNA synchronization with mob DNA in the `ResetUIFrom` proc. Removes the `APPEARANCE_UPDATE_DNA` flag check on the appearance changer mirror `update_dna` proc, so changes from any mirror is saved. If you just add `APPEARANCE_UPDATE_DNA` to the mirror, then it will be possible to change race.

It turns out that `head_traits_to_dna` is writing UI changes to the mob DNA, but `write_head_attributes` (bad name, it applies attributes, in fact) is taking DNA from the head DNA.

These changes will ensure that character DNA is consistent, preventing hair and other changes from resetting on any `UpdateAppearance` call.

Fixes #25892 
Fixes #27923 

## Why It's Good For The Game
Getting your appearance changed in moments when you don't expect it is bad

## Testing
Spawned the mirror, changed my hairstyle, and called `UpdateAppearance()` on myself

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<hr>

## Changelog

:cl:
fix: Fixed hairstyle changes from the mirror resetting when crushed by the vendor and on toxin compensation tick
/:cl: