### PR TITLE
reset glide size for thrown objects once throw ends

### DIFF
--- a/code/controllers/subsystem/SSthrowing.dm
+++ b/code/controllers/subsystem/SSthrowing.dm
@@ -254,6 +254,9 @@ SUBSYSTEM_DEF(throwing)
 	else
 		thrownthing.newtonian_move(init_dir)
 
+	// Attempt to reset glide size once throw ends
+	thrownthing.set_glide_size(initial(thrownthing.glide_size))
+
 	if(target)
 		thrownthing.throw_impact(target, src)
 		if(QDELETED(thrownthing)) //throw_impact can delete things, such as glasses smashing


### PR DESCRIPTION
## What Does This PR Do
This PR resets the glide size of thrown objects once the throw ends.
## Why It's Good For The Game
Throwing things increases their glide size and without a reset, their movement becomes keyed to the new glide size and is jumpy and weird.
## Testing
Threw a monkey, VV'd to ensure glide size reset.
### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

<hr>

## Changelog

:cl:
fix: Thrown simple mobs should no longer have jumpy/glitchy movement after being thrown.
/:cl:
