### PR TITLE
Fix a vending migration bug

### DIFF
--- a/code/game/machinery/vendors/vending.dm
+++ b/code/game/machinery/vendors/vending.dm
@@ -356,7 +356,7 @@
 			to_chat(user, "<span class='notice'>[src] does not respond.</span>")
 			return ITEM_INTERACT_COMPLETE
 
-		var/obj/item/vending_refill/canister = ITEM_INTERACT_COMPLETE
+		var/obj/item/vending_refill/canister = used
 		var/transferred = restock(canister)
 		if(!transferred && !canister.get_part_rating()) // It transferred no products and has no products left, thus it is empty
 			to_chat(user, "<span class='warning'>[canister] is empty!</span>")


### PR DESCRIPTION
## What Does This PR Do
Fix a vending migration bug. ITEM_INTERACT_COMPLETE is definitely not a canister.

## Why It's Good For The Game
Bugs bad.

## Testing
If it passes CI, it can't be any more broken than what's currently there.
<hr>

### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

<hr>

## Changelog
:cl:
fix: Refill canisters should work on vending machines again.
/:cl: