### PR TITLE
fix brped distance check

### DIFF
--- a/code/game/objects/items/weapons/stock_parts.dm
+++ b/code/game/objects/items/weapons/stock_parts.dm
@@ -50,7 +50,7 @@
 	if(!proximity_flag)
 		if(!works_from_distance)
 			return
-		if(get_dist(src, M) <= (user.client.maxview() + 2))
+		if(get_dist(src, M) > (user.client.maxview() + 2))
 			return
 
 	if(M.component_parts)


### PR DESCRIPTION
## What Does This PR Do
This PR fixes the logic check for distance for BRPEDs which I mistakenly inverted in #27784. Fixes #28127.
## Why It's Good For The Game
Bugfix.
## Testing
Spawned with debug outfit, went into kitchen, used tier 4 BRPED to click on machines from a distance, ensured upgrades occurred.
<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

<hr>

## Changelog

:cl:
fix: Bluespace RPEDs will properly upgrade machines from a distance again.
/:cl:
