### PR TITLE
Dynamic Traitor Cost Adjustment

### DIFF
--- a/code/game/gamemodes/dynamic/antag_rulesets.dm
+++ b/code/game/gamemodes/dynamic/antag_rulesets.dm
@@ -161,7 +161,7 @@
 /datum/ruleset/traitor
 	name = "Traitor"
 	ruleset_weight = 11
-	antag_cost = 5
+	antag_cost = 7
 	antag_weight = 2
 	antagonist_type = /datum/antagonist/traitor
 


### PR DESCRIPTION
## What Does This PR Do
Increases the cost of traitors when selecting from the budget from 5 -> 7.
This will decrease the amount of traitors in a round during traitor rounds.
## Why It's Good For The Game
This needs to be adjusted to keep rounds fair within the antag/sec loop.
## Testing
Can't be tested properly without being ran on live.
<hr>

### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
![Discord_7ONOHOGZcE](https://github.com/user-attachments/assets/a7b493a7-7931-41e2-9a0f-87792ed5d3c1)
<hr>

## Changelog
:cl:
tweak: Increased the cost of traitors when drawing from the budget.
/:cl: