### PR TITLE
fix cloning pods not accepting beaker transfers

### DIFF
--- a/code/game/machinery/clonepod.dm
+++ b/code/game/machinery/clonepod.dm
@@ -562,7 +562,7 @@
 
 /obj/machinery/clonepod/item_interaction(mob/living/user, obj/item/used, list/modifiers)
 	if(used.is_open_container())
-		return ITEM_INTERACT_COMPLETE
+		return ITEM_INTERACT_SKIP_TO_AFTER_ATTACK
 
 	if(istype(used, /obj/item/card/id) || istype(used, /obj/item/pda))
 		if(!allowed(user))


### PR DESCRIPTION
## What Does This PR Do
This PR fixes cloning pods not accepting reagent transfers from open containers.
## Why It's Good For The Game
Bugfix.
## Testing
First attempted with closed container, then open container.
https://github.com/user-attachments/assets/94213dfb-41fb-4893-8f58-6a9373cf98ff

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<hr>

## Changelog

:cl:
fix: Cloning pods properly accept reagents from containers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
