### PR TITLE
Non-AI cameras can take pictures of unconcealed runes and cult portals

### DIFF
--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -187,6 +187,8 @@
 	var/icon_off = "camera_off"
 	var/size = 3
 	var/see_ghosts = FALSE //for the spoop of it
+	/// Cult portals and unconcealed runes have a minor form of invisibility
+	var/see_cult = TRUE
 	var/current_photo_num = 1
 	var/digital = FALSE
 	/// Should camera light up the scene
@@ -292,7 +294,7 @@ GLOBAL_LIST_INIT(SpookyGhosts, list("ghost","shade","shade2","ghost-narsie","hor
 				continue
 
 			// AI can't see unconcealed runes or cult portals
-			if(A.invisibility == INVISIBILITY_RUNES && !istype(src, /obj/item/camera/siliconcam/ai_camera))
+			if(A.invisibility == INVISIBILITY_RUNES && see_cult)
 				atoms.Add(A)
 				continue
 			if(A.invisibility)

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -291,6 +291,10 @@ GLOBAL_LIST_INIT(SpookyGhosts, list("ghost","shade","shade2","ghost-narsie","hor
 				atoms.Add(A)
 				continue
 
+			// Silicons can't see unconsealed runes or cult portals
+			if(A.invisibility == INVISIBILITY_RUNES && !istype(src, /obj/item/camera/siliconcam))
+				atoms.Add(A)
+				continue
 			if(A.invisibility)
 				if(see_ghosts && isobserver(A))
 					var/mob/dead/observer/O = A

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -291,7 +291,7 @@ GLOBAL_LIST_INIT(SpookyGhosts, list("ghost","shade","shade2","ghost-narsie","hor
 				atoms.Add(A)
 				continue
 
-			// AI can't see unconsealed runes or cult portals
+			// AI can't see unconcealed runes or cult portals
 			if(A.invisibility == INVISIBILITY_RUNES && !istype(src, /obj/item/camera/siliconcam/ai_camera))
 				atoms.Add(A)
 				continue

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -291,8 +291,8 @@ GLOBAL_LIST_INIT(SpookyGhosts, list("ghost","shade","shade2","ghost-narsie","hor
 				atoms.Add(A)
 				continue
 
-			// Silicons can't see unconsealed runes or cult portals
-			if(A.invisibility == INVISIBILITY_RUNES && !istype(src, /obj/item/camera/siliconcam))
+			// AI can't see unconsealed runes or cult portals
+			if(A.invisibility == INVISIBILITY_RUNES && !istype(src, /obj/item/camera/siliconcam/ai_camera))
 				atoms.Add(A)
 				continue
 			if(A.invisibility)

--- a/code/modules/paperwork/silicon_photography.dm
+++ b/code/modules/paperwork/silicon_photography.dm
@@ -15,6 +15,7 @@
 /// camera AI can take pictures with
 /obj/item/camera/siliconcam/ai_camera
 	name = "AI photo camera"
+	see_cult = FALSE
 
 /// camera cyborgs can take pictures with
 /obj/item/camera/siliconcam/robot_camera


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes it so cameras can take pictures of unconsealed runes and cult portals unless they're the AI subtype. The change to rune interaction with AI also affected cameras since they check for _any_ form of invisibility.

## Why It's Good For The Game
Fixes #25203

## Images of changes
![rune](https://github.com/user-attachments/assets/68c7d6f4-00db-4145-8806-d38de0c09df2)

## Testing
Placed runes, and took a picture with both a normal camera, and from the AI.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: Cameras can take photos of unconsealed runes and cult portals. AIs are unaffected.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
