### PR TITLE
Refactor Fire Alarm `item_interaction()`

### DIFF
--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -137,7 +137,7 @@ FIRE ALARM
 			return ITEM_INTERACT_COMPLETE
 
 		buildstage = FIRE_ALARM_READY
-		playsound(get_turf(src), used.usesound, 50, 1)
+		playsound(get_turf(src), used.usesound, 50, TRUE)
 		to_chat(user, "<span class='notice'>You wire [src]!</span>")
 		update_icon()
 		return ITEM_INTERACT_COMPLETE

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -149,6 +149,8 @@ FIRE ALARM
 		update_icon()
 		return ITEM_INTERACT_COMPLETE
 
+	return ..()
+
 /obj/machinery/firealarm/crowbar_act(mob/user, obj/item/I)
 	if(buildstage != FIRE_ALARM_UNWIRED)
 		return
@@ -200,6 +202,7 @@ FIRE ALARM
 		return
 	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
 		return
+	update_icon()
 	WIRECUTTER_SNIP_MESSAGE
 	var/obj/item/stack/cable_coil/new_coil = new /obj/item/stack/cable_coil(drop_location())
 	new_coil.amount = 5

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -127,25 +127,27 @@ FIRE ALARM
 
 /obj/machinery/firealarm/item_interaction(mob/living/user, obj/item/used, list/modifiers)
 	add_fingerprint(user)
-	if(wiresexposed)
-		if(buildstage == FIRE_ALARM_UNWIRED && istype(used, /obj/item/stack/cable_coil))
-			var/obj/item/stack/cable_coil/coil = used
-			if(!coil.use(5))
-				to_chat(user, "<span class='warning'>You need a total of five cables to wire [src]!</span>")
-				return ITEM_INTERACT_COMPLETE
+	if(!wiresexposed)
+		return ..()
 
-			buildstage = FIRE_ALARM_READY
-			playsound(get_turf(src), used.usesound, 50, 1)
-			to_chat(user, "<span class='notice'>You wire [src]!</span>")
-			update_icon()
-		else if(buildstage == FIRE_ALARM_FRAME && istype(used, /obj/item/firealarm_electronics))
-			to_chat(user, "<span class='notice'>You insert the circuit!</span>")
-			qdel(used)
-			buildstage = FIRE_ALARM_UNWIRED
-			update_icon()
+	if(buildstage == FIRE_ALARM_UNWIRED && istype(used, /obj/item/stack/cable_coil))
+		var/obj/item/stack/cable_coil/coil = used
+		if(!coil.use(5))
+			to_chat(user, "<span class='warning'>You need a total of five cables to wire [src]!</span>")
+			return ITEM_INTERACT_COMPLETE
 
+		buildstage = FIRE_ALARM_READY
+		playsound(get_turf(src), used.usesound, 50, 1)
+		to_chat(user, "<span class='notice'>You wire [src]!</span>")
+		update_icon()
 		return ITEM_INTERACT_COMPLETE
-	return ..()
+
+	if(buildstage == FIRE_ALARM_FRAME && istype(used, /obj/item/firealarm_electronics))
+		to_chat(user, "<span class='notice'>You insert the circuit!</span>")
+		qdel(used)
+		buildstage = FIRE_ALARM_UNWIRED
+		update_icon()
+		return ITEM_INTERACT_COMPLETE
 
 /obj/machinery/firealarm/crowbar_act(mob/user, obj/item/I)
 	if(buildstage != FIRE_ALARM_UNWIRED)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Refactors `/obj/machinery/firealarm/item_interaction()` for readability.

Also fixes the following bugs:
- The sprite doesn't change to its unwired state when wires are cut.
- Borg grippers cannot add circuitry to the alarm.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Better more readable code. Enabling more better code down the line.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Assembled a fire alarm from 0 to completion.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: Fire alarm now changes to unwired sprite when wires are removed.
fix: Borg grippers can add fire alarm electronics to fire alarms.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
