### PR TITLE
fix baps when adding ingredients to kitchen machines

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
@@ -113,6 +113,8 @@
 				add_item(S, user)
 		else
 			add_item(used, user)
+
+		return ITEM_INTERACT_COMPLETE
 	else if(is_type_in_list(used, list(/obj/item/reagent_containers/glass, /obj/item/reagent_containers/drinks, /obj/item/reagent_containers/condiment)))
 		if(!used.reagents)
 			return ITEM_INTERACT_COMPLETE


### PR DESCRIPTION
## What Does This PR Do
This PR stops players from bapping kitchen machines when inserting ingredients into them.
## Why It's Good For The Game
Bugfix.
## Testing
Spawned into kitchen, inserted eggs into grill, ensured no bap.
<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

<hr>

## Changelog

:cl:
fix: Players will no longer attempt to hit kitchen machines when inserting ingredients.
/:cl: