### PR TITLE
Fixes door remotes

### DIFF
--- a/code/game/objects/items/control_wand.dm
+++ b/code/game/objects/items/control_wand.dm
@@ -57,16 +57,18 @@
 /obj/item/door_remote/interact_with_atom(atom/target, mob/living/user, list/modifiers)
 	if(istype(target, /obj/machinery/door/airlock))
 		access_airlock(target, user)
+		return ITEM_INTERACT_COMPLETE
 	if(istype(target, /obj/machinery/door/window))
 		access_windoor(target, user)
-	return ITEM_INTERACT_COMPLETE
+		return ITEM_INTERACT_COMPLETE
 
 /obj/item/door_remote/ranged_interact_with_atom(atom/target, mob/living/user, list/modifiers)
 	if(istype(target, /obj/machinery/door/airlock))
 		access_airlock(target, user)
+		return ITEM_INTERACT_COMPLETE
 	if(istype(target, /obj/machinery/door/window))
 		access_windoor(target, user)
-	return ITEM_INTERACT_COMPLETE
+		return ITEM_INTERACT_COMPLETE
 
 /obj/item/door_remote/proc/access_airlock(obj/machinery/door/airlock/D, mob/user)
 	if(HAS_TRAIT(D, TRAIT_CMAGGED))
@@ -194,14 +196,12 @@
 	var/range
 
 /obj/item/door_remote/omni/access_tuner/interact_with_atom(atom/target, mob/living/user, list/modifiers)
-	if(!hack(target, user))	// if the hack is successful, calls the parent proc and does the door stuff
-		return ITEM_INTERACT_COMPLETE
-	return ..()
+	if(hack(target, user))	// if the hack is successful, calls the parent proc and does the door stuff
+		return ..()
 
 /obj/item/door_remote/omni/access_tuner/ranged_interact_with_atom(atom/target, mob/living/user, list/modifiers)
-	if(!hack(target, user))
-		return ITEM_INTERACT_COMPLETE
-	return ..()
+	if(hack(target, user))
+		return ..()
 
 /obj/item/door_remote/omni/access_tuner/proc/hack(atom/target, mob/user)
 	if(!istype(target, /obj/machinery/door/airlock) && !istype(target, /obj/machinery/door/window))
@@ -262,12 +262,11 @@
 	cooldown = world.time + JANGLE_COOLDOWN
 
 /obj/item/door_remote/janikeyring/interact_with_atom(obj/machinery/door/target, mob/living/user, list/modifiers)
-	if(!unlock(target, user))
-		return ITEM_INTERACT_COMPLETE
-	return ..()
+	if(unlock(target, user))
+		return ..()
 
 /obj/item/door_remote/janikeyring/ranged_interact_with_atom(atom/target, mob/living/user, list/modifiers) // THOSE AINT MAGICAL REMOTE KEYS
-	return ITEM_INTERACT_COMPLETE
+	return NONE
 
 
 /obj/item/door_remote/janikeyring/proc/unlock(obj/machinery/door/target, mob/living/user)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes #28137
Door remotes can go in backpack again when clicked
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
covering up my fuck ups
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Put all remotes in the backpack by clicking on it. Also opened the doors and bolted and checked what they do when activated again
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: door remotes can go in backpack again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
