### PR TITLE
Cauterize surgery checks for lit implements, tweak lighter/flamethrowers/cautery so they deal burn when appropriate

### DIFF
--- a/code/game/objects/items/weapons/flamethrower.dm
+++ b/code/game/objects/items/weapons/flamethrower.dm
@@ -231,11 +231,13 @@
 	to_chat(user, "<span class='notice'>You [lit ? "extinguish" : "ignite"] [src]!</span>")
 	lit = !lit
 	if(lit)
+		damtype = BURN
 		START_PROCESSING(SSobj, src)
 		if(!warned_admins)
 			message_admins("[ADMIN_LOOKUPFLW(user)] has lit a flamethrower.")
 			warned_admins = TRUE
 	else
+		damtype = initial(damtype)
 		STOP_PROCESSING(SSobj,src)
 	update_icon()
 

--- a/code/game/objects/items/weapons/lighters.dm
+++ b/code/game/objects/items/weapons/lighters.dm
@@ -78,7 +78,7 @@
 	hitsound = "swing_hit"
 	force = 0
 	attack_verb = null //human_defense.dm takes care of it
-
+	damtype = initial(damtype)
 	update_icon()
 	if(user)
 		show_off_message(user)

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -180,6 +180,12 @@
 	failure_sound = 'sound/items/welder.ogg'
 	time = 2.4 SECONDS
 
+/datum/surgery_step/generic/cauterize/tool_check(mob/user, obj/item/tool)
+	if(tool.damtype != BURN)
+		to_chat(user, "<span class='warning'>[tool] is too cold to cauterize!</span>")
+		return FALSE
+	return TRUE
+
 /datum/surgery_step/generic/cauterize/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message(

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -52,6 +52,7 @@
 	materials = list(MAT_METAL=2500, MAT_GLASS=750)
 	flags = CONDUCT
 	w_class = WEIGHT_CLASS_TINY
+	damtype = BURN
 	origin_tech = "materials=1;biotech=1"
 	attack_verb = list("burnt")
 	tool_behaviour = TOOL_CAUTERY


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds a burn check for the cauterize surgery step, and tweaks lighters, flamethrowers and cautery so they have logical damage types. Lighters would permanently set their damage to burn if lit once in their lifetime, flamethrowers were always brute which is weird, and same for cautery even though they use "burnt" as an attack verb.

I didn't want to rescope `lit` down to an item level var otherwise.

## Why It's Good For The Game
Fixes #25359. Opens up some other possibilities, either with lighters/flamethrowers, or for the cauterize step.

## Images of changes
![oops](https://github.com/user-attachments/assets/83bf8d18-cca4-4b5d-a5df-7e8af0aa3722)

## Testing
Did a little surgery with a zippo.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
tweak: Lit flamethrowers and cautery deal burn damage on physical hits
fix: Cauterize needs lit flamethrowers or lighters
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
