### PR TITLE
Make wind not unpredictably break CI due to bad init.

### DIFF
--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -240,6 +240,9 @@
 	layer = MASSIVE_OBJ_LAYER
 	blend_mode = BLEND_OVERLAY
 
+	// Wind has nothing it needs to initialize, and it's not surprising if it gets both created and qdeleted during an init freeze. Prevent that from causing an init sanity error.
+	initialized = TRUE
+
 #undef INDEX_NORTH
 #undef INDEX_EAST
 #undef INDEX_SOUTH

--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -240,8 +240,13 @@
 	layer = MASSIVE_OBJ_LAYER
 	blend_mode = BLEND_OVERLAY
 
-	// Wind has nothing it needs to initialize, and it's not surprising if it gets both created and qdeleted during an init freeze. Prevent that from causing an init sanity error.
+	// See comment on attempt_init.
 	initialized = TRUE
+
+// Wind has nothing it needs to initialize, and it's not surprising if it gets both created and qdeleted during an init freeze. Prevent that from causing an init sanity error.
+/obj/effect/wind/attempt_init(...)
+	initialized = TRUE
+	return
 
 #undef INDEX_NORTH
 #undef INDEX_EAST


### PR DESCRIPTION
## What Does This PR Do
Marks wind as always-initialized so that it doesn't randomly break CI

## Why It's Good For The Game
CI failures bad.

## Testing
Server started fine, wind flowed fine.
<hr>

### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

<hr>

## Changelog
NPFC