### PR TITLE
SM sanity at low pressure

### DIFF
--- a/code/modules/power/engines/supermatter/supermatter.dm
+++ b/code/modules/power/engines/supermatter/supermatter.dm
@@ -574,17 +574,17 @@
 		//Power * 0.55 * a value between 1 and 0.8
 		var/device_energy = power * REACTION_POWER_MODIFIER
 
-		// Calculate temperature change in terms of thermal energy, scaled by the average specific heat of the gas.
-		if(removed.total_moles())
-			var/produced_joules = max(0, ((device_energy * dynamic_heat_modifier) / THERMAL_RELEASE_MODIFIER) * heat_multiplier)
-			produced_joules *= (removed.heat_capacity() / removed.total_moles())
-			removed.set_temperature((removed.thermal_energy() + produced_joules) / removed.heat_capacity())
-
 		//Calculate how much gas to release
 		//Varies based on power and gas content
 		removed.set_toxins(removed.toxins() + max(((device_energy * dynamic_heat_modifier) / PLASMA_RELEASE_MODIFIER) * gas_multiplier, 0))
 		//Varies based on power, gas content, and heat
 		removed.set_oxygen(removed.oxygen() + max((((device_energy + removed.temperature() * dynamic_heat_modifier) - T0C) / OXYGEN_RELEASE_MODIFIER) * gas_multiplier, 0))
+
+		// Calculate temperature change in terms of thermal energy, scaled by the average specific heat of the gas.
+		if(removed.total_moles() >= 1)
+			var/produced_joules = max(0, ((device_energy * dynamic_heat_modifier) / THERMAL_RELEASE_MODIFIER) * heat_multiplier)
+			produced_joules *= (removed.heat_capacity() / removed.total_moles())
+			removed.set_temperature((removed.thermal_energy() + produced_joules) / removed.heat_capacity())
 
 		if(produces_gas)
 			env.merge(removed)


### PR DESCRIPTION
## What Does This PR Do
Adjust the SM gas production method to avoid producing a ridiculous output when active and at very low pressure.

## Why It's Good For The Game
SM should not go supernova because it was low pressure.

## Testing
Procedure:
1. Disable engine bypass.
2. Enable and maximize the engine input/output pipes.
3. Configure the air alarm normally. This will create a vacuum in the chamber.
4. Fire one emitter shot at the SM.
5. Set the output speed on one N2 tank's pump to 9 kPa.
6. Turn on that pump.

Results without this change:
![image](https://github.com/user-attachments/assets/754f74d8-218b-44b8-b35f-de3835c88288)
and worsening. It will quickly reach a state that's effectively unsalvageable.

Results with this change:
![image](https://github.com/user-attachments/assets/d2204d09-f2f0-4850-8192-dc4896fb719b)
and stable.
<hr>

### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

<hr>

## Changelog
:cl:
fix: Fixed a bug that would cause the SM to go haywire if it was ever active and exposed to an extremely low (but nonzero) amount of gas.
/:cl: