### PR TITLE
Removes tourettes

### DIFF
--- a/code/_globalvars/genetics.dm
+++ b/code/_globalvars/genetics.dm
@@ -10,7 +10,6 @@ GLOBAL_VAR_INIT(fakeblock, 0)
 GLOBAL_VAR_INIT(coughblock, 0)
 GLOBAL_VAR_INIT(glassesblock, 0)
 GLOBAL_VAR_INIT(epilepsyblock, 0)
-GLOBAL_VAR_INIT(twitchblock, 0)
 GLOBAL_VAR_INIT(nervousblock, 0)
 GLOBAL_VAR_INIT(wingdingsblock, 0)
 GLOBAL_VAR_INIT(monkeyblock, DNA_SE_LENGTH) // Monkey block will always be the DNA_SE_LENGTH

--- a/code/datums/components/zombie_regen.dm
+++ b/code/datums/components/zombie_regen.dm
@@ -67,7 +67,6 @@
 	zomboid.cure_nearsighted()
 	zomboid.CureMute()
 	zomboid.CureDeaf()
-	zomboid.CureTourettes()
 	zomboid.CureEpilepsy()
 	zomboid.CureCoughing()
 	zomboid.CureNervous()

--- a/code/game/dna/mutations/disabilities.dm
+++ b/code/game/dna/mutations/disabilities.dm
@@ -68,29 +68,6 @@
 	..()
 	block = GLOB.clumsyblock
 
-/datum/mutation/disability/tourettes
-	name = "Tourettes"
-	activation_messages = list("You twitch.")
-	deactivation_messages = list("Your mouth tastes like soap.")
-
-/datum/mutation/disability/tourettes/New()
-	..()
-	block = GLOB.twitchblock
-
-/datum/mutation/disability/tourettes/on_life(mob/living/carbon/human/H)
-	if(prob(10))
-		switch(rand(1, 3))
-			if(1)
-				H.emote("twitch")
-			if(2 to 3)
-				H.say("[prob(50) ? ";" : ""][pick("SHIT", "PISS", "FUCK", "CUNT", "COCKSUCKER", "MOTHERFUCKER", "TITS")]")
-		var/x_offset_old = H.pixel_x
-		var/y_offset_old = H.pixel_y
-		var/x_offset = H.pixel_x + rand(-2, 2)
-		var/y_offset = H.pixel_y + rand(-1, 1)
-		animate(H, pixel_x = x_offset, pixel_y = y_offset, time = 1)
-		animate(H, pixel_x = x_offset_old, pixel_y = y_offset_old, time = 1)
-
 /datum/mutation/disability/nervousness
 	name = "Nervousness"
 	activation_messages = list("You feel nervous.")

--- a/code/game/gamemodes/setupgame.dm
+++ b/code/game/gamemodes/setupgame.dm
@@ -39,7 +39,6 @@
 	GLOB.coughblock         = getAssignedBlock("COUGH",         numsToAssign)
 	GLOB.glassesblock       = getAssignedBlock("GLASSES",       numsToAssign)
 	GLOB.epilepsyblock      = getAssignedBlock("EPILEPSY",      numsToAssign)
-	GLOB.twitchblock        = getAssignedBlock("TWITCH",        numsToAssign)
 	GLOB.nervousblock       = getAssignedBlock("NERVOUS",       numsToAssign)
 	GLOB.wingdingsblock     = getAssignedBlock("WINGDINGS",     numsToAssign)
 	GLOB.mesonblock			= getAssignedBlock("MESONS",        numsToAssign, good=1)

--- a/code/game/objects/items/weapons/dna_injector.dm
+++ b/code/game/objects/items/weapons/dna_injector.dm
@@ -464,26 +464,6 @@
 /obj/item/dnainjector/anticlumsy/GetInitBlock()
 	return GLOB.clumsyblock
 
-/obj/item/dnainjector/antitour
-	name = "DNA-Injector (Anti-Tour.)"
-	desc = "Will cure tourettes."
-	datatype = DNA2_BUF_SE
-	value = 0x001
-	forcedmutation = TRUE
-
-/obj/item/dnainjector/antitour/GetInitBlock()
-	return GLOB.twitchblock
-
-/obj/item/dnainjector/tourmut
-	name = "DNA-Injector (Tour.)"
-	desc = "Gives you a nasty case off tourettes."
-	datatype = DNA2_BUF_SE
-	value = 0xFFF
-	forcedmutation = TRUE
-
-/obj/item/dnainjector/tourmut/GetInitBlock()
-	return GLOB.twitchblock
-
 /obj/item/dnainjector/stuttmut
 	name = "DNA-Injector (Stutt.)"
 	desc = "Makes you s-s-stuttterrr."

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -530,7 +530,6 @@
 	cure_nearsighted()
 	CureMute()
 	CureDeaf()
-	CureTourettes()
 	CureEpilepsy()
 	CureCoughing()
 	CureNervous()

--- a/code/modules/mob/living/living_status_procs.dm
+++ b/code/modules/mob/living/living_status_procs.dm
@@ -837,10 +837,6 @@ STATUS EFFECTS
 /mob/living/proc/CureNervous()
 	CureIfHasDisability(GLOB.nervousblock)
 
-// Tourettes
-/mob/living/proc/CureTourettes()
-	CureIfHasDisability(GLOB.twitchblock)
-
 /mob/living/proc/CureIfHasDisability(block)
 	if(dna && dna.GetSEState(block))
 		dna.SetSEState(block, 0, 1) //Fix the gene

--- a/code/modules/reagents/chemistry/reagents/admin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/admin_reagents.dm
@@ -31,7 +31,6 @@
 	M.CureMute()
 	M.CureDeaf()
 	M.CureEpilepsy()
-	M.CureTourettes()
 	M.CureCoughing()
 	M.CureNervous()
 	M.SetEyeBlurry(0)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Removes tourettes
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
- It's in poor taste
- It's a caricature of what it actually is
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Opened player panel, saw no tourettes
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
tweak: Removed Tourettes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
