### PR TITLE
Make mice not chew cables through catwalks

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -46,19 +46,22 @@
 #ifdef GAME_TESTS // DO NOT EAT MY CABLES DURING UNIT TESTS
 	return
 #endif
-	if(prob(chew_probability) && isturf(loc))
-		var/turf/simulated/floor/F = get_turf(src)
-		if(istype(F) && !F.intact)
-			var/obj/structure/cable/C = locate() in F
-			if(C && prob(15))
-				if(C.get_available_power() && !HAS_TRAIT(src, TRAIT_SHOCKIMMUNE))
-					visible_message("<span class='warning'>[src] chews through [C]. It's toast!</span>")
-					playsound(src, 'sound/effects/sparks2.ogg', 100, 1)
-					toast() // mmmm toasty.
-				else
-					visible_message("<span class='warning'>[src] chews through [C].</span>")
-				investigate_log("was chewed through by a mouse in [get_area(F)]([F.x], [F.y], [F.z] - [ADMIN_JMP(F)])","wires")
-				C.deconstruct()
+	if(!prob(chew_probability) || !isfloorturf(loc))
+		return
+	var/turf/simulated/floor/F = get_turf(src)
+	if(F.intact || F.transparent_floor)
+		return
+	var/obj/structure/cable/C = locate() in F
+	if(!C || !prob(15))
+		return
+	if(C.get_available_power() && !HAS_TRAIT(src, TRAIT_SHOCKIMMUNE))
+		visible_message("<span class='warning'>[src] chews through [C]. It's toast!</span>")
+		playsound(src, 'sound/effects/sparks2.ogg', 100, 1)
+		toast() // mmmm toasty.
+	else
+		visible_message("<span class='warning'>[src] chews through [C].</span>")
+	investigate_log("was chewed through by a mouse in [get_area(F)]([F.x], [F.y], [F.z] - [ADMIN_JMP(F)])","wires")
+	C.deconstruct()
 
 /mob/living/simple_animal/mouse/handle_automated_speech()
 	..()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Due to a quirk of catwalks, they are technically valid for mice eating cables. This adds another check to prevent that, and at the same time rework the proc into early returns.

IC justification? They're chunky mice.

## Why It's Good For The Game
Fixes #27943

## Images of changes
![tasty](https://github.com/user-attachments/assets/b123159b-9a91-43a4-a788-8c5d69f0d883)


## Testing
Boxed in a mouse over catwalks and cables, then removed a catwalk. No animals were harmed.
<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: Mice won't eat cables through catwalks anymore
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
