### PR TITLE
Negative pressure sucks

### DIFF
--- a/code/modules/power/engines/supermatter/supermatter.dm
+++ b/code/modules/power/engines/supermatter/supermatter.dm
@@ -471,7 +471,7 @@
 		// Pass all the gas related code an empty gas container
 		removed = new()
 	damage_archived = damage
-	if(!removed || !removed.total_moles() || isspaceturf(T)) //we're in space or there is no gas to process
+	if(!removed || removed.total_moles() <= 0 || isspaceturf(T)) //we're in space or there is no gas to process
 		if(takes_damage)
 			damage += max((power / 1000) * DAMAGE_INCREASE_MULTIPLIER, 0.1) // always does at least some damage
 	else


### PR DESCRIPTION
## What Does This PR Do
Prevents the SM from runtiming if the total air in the chamber becomes negative.

How can this happen when MILLA zeroes out negatives every tick? Well, what happens with turf air is:
1. MILLA runs a tick.
2. Something wants to look at the air in a turf, so it loads that from MILLA.
3. Any further accesses use the already-loaded air.
4. MILLA-safe code can edit the loaded air.
5. Later code will use the edited air.
6. The final value gets written back to MILLA just before the next MILLA tick.

The SM is also set to run last, so any other code that edits the turf's air will run first, and could potentially make the total air negative. It'll get fixed by MILLA next tick, but the SM will run before that, and runtime.

## Why It's Good For The Game
Runtimes bad.

## Testing
If CI passes, it's fine.
<hr>

### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

<hr>

## Changelog
NPFC