### PR TITLE
Upgraded VV and proc call arguments

### DIFF
--- a/code/__DEFINES/vv.dm
+++ b/code/__DEFINES/vv.dm
@@ -21,3 +21,6 @@
 #define VV_MARKED_DATUM "Marked Datum"
 #define VV_BITFIELD "Bitfield"
 #define VV_REGEX "Regex"
+#define VV_VISIBLE_ATOM "Visible Atom"
+#define VV_INSIDE_VISIBLE_ATOM "Inside a Visible Atom"
+#define VV_VISIBLE_TURF "Visible Turf"

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -208,57 +208,12 @@ GLOBAL_PROTECT(AdminProcCallSpamPrevention)
 	//this will protect us from a fair few errors ~Carn
 
 	while(argnum--)
-		var/class = null
-		// Make a list with each index containing one variable, to be given to the proc
-		if(src.holder && src.holder.marked_datum)
-			class = input("What kind of variable?","Variable Type") in list("text","num","type","reference","reference in range","reference in view", "mob reference","icon","file","client","mob's area","Marked datum ([holder.marked_datum.type])","CANCEL")
-			if(holder.marked_datum && class == "Marked datum ([holder.marked_datum.type])")
-				class = "Marked datum"
-		else
-			class = input("What kind of variable?","Variable Type") in list("text","num","type","reference","mob reference","reference in range","reference in view","icon","file","client","mob's area","CANCEL")
-		switch(class)
-			if("CANCEL")
-				return null
+		var/list/value = vv_get_value(restricted_classes = list(VV_RESTORE_DEFAULT))
+		var/class = value["class"]
+		if(!class)
+			return null
 
-			if("text")
-				lst += clean_input("Enter new text:","Text",null)
-
-			if("num")
-				lst += input("Enter new number:","Num",0) as num
-
-			if("type")
-				lst += input("Enter type:","Type") in typesof(/obj,/mob,/area,/turf)
-
-			if("reference")
-				lst += input("Select reference:","Reference",src) as mob|obj|turf|area in world
-
-			if("reference in range")
-				lst += input("Select reference in range:", "Reference in range", src) as mob|obj|turf|area in range(view)
-
-			if("reference in view")
-				lst += input("Select reference in view:", "Reference in view", src) as mob|obj|turf|area in view(view)
-
-			if("mob reference")
-				lst += input("Select reference:","Reference",usr) as mob in world
-
-			if("file")
-				lst += input("Pick file:","File") as file
-
-			if("icon")
-				lst += input("Pick icon:","Icon") as icon
-
-			if("client")
-				var/list/keys = list()
-				for(var/mob/M in world)
-					keys += M.client
-				lst += input("Please, select a player!", "Selection", null, null) as null|anything in keys
-
-			if("mob's area")
-				var/mob/temp = input("Select mob", "Selection", usr) as mob in world
-				lst += temp.loc
-
-			if("Marked datum")
-				lst += holder.marked_datum
+		lst += value["value"]
 	return lst
 
 /client/proc/Cell()


### PR DESCRIPTION
## What Does This PR Do
VV and proc calls now use the same value-picking method (vv_get_value), which has been upgraded to allow you to pick an atom by clicking on it, pick something inside that atom, or pick an atom's turf.

## Why It's Good For The Game
Less clunky admin interfaces. Proc calls in particular had some options (e.g. typepath) that were completely unusable, because they'd freeze your client.

## Images of changes
https://github.com/user-attachments/assets/0cf2665d-5aa2-46ce-8880-ee8c839c8765

## Testing
Made stuff in view float.
Made stuff nested in inventory glow.
Made myself jump to a turf.
Set a var to a visible object.
Entered buildmode while picking an atom. Got buildmode clicks.
Reconnected while picking an atom. Got normal clicks.
<hr>

### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog
:cl:
tweak: Admin UIs for editing variables and calling procs now share the same value picker, which can now pick stuff by clicking on it.
/:cl: