### PR TITLE
Tentacle fix 2, no runtime on adjacent hit, cling beartrap activates now

### DIFF
--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -220,9 +220,9 @@
 	shooting_right_now = TRUE
 	. = ..()
 	shooting_right_now = FALSE
-	check_delete_on_shoot()
+	check_should_delete()
 
-/obj/item/gun/magic/tentacle/proc/check_delete_on_shoot()
+/obj/item/gun/magic/tentacle/proc/check_should_delete()
 	if(!shooting_right_now && hit_something)
 		qdel(src)
 
@@ -307,7 +307,7 @@
 /obj/item/projectile/tentacle/on_hit(atom/target, blocked = 0)
 	var/mob/living/carbon/human/H = firer
 	source.gun.hit_something = TRUE
-	source.gun.check_delete_on_shoot()
+	source.gun.check_should_delete()
 	if(blocked >= 100)
 		return FALSE
 	if(isitem(target))

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -223,7 +223,6 @@
 	check_delete_on_shoot()
 
 /obj/item/gun/magic/tentacle/proc/check_delete_on_shoot()
-	hit_something = TRUE
 	if(!shooting_right_now)
 		qdel(src)
 
@@ -307,7 +306,7 @@
 
 /obj/item/projectile/tentacle/on_hit(atom/target, blocked = 0)
 	var/mob/living/carbon/human/H = firer
-	source.gun.check_delete_on_shoot()
+	source.gun.hit_something = TRUE
 	if(blocked >= 100)
 		return FALSE
 	if(isitem(target))

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -220,8 +220,7 @@
 	shooting_right_now = TRUE
 	. = ..()
 	shooting_right_now = FALSE
-	if(hit_something)
-		qdel(src)
+	check_delete_on_shoot()
 
 /obj/item/gun/magic/tentacle/proc/check_delete_on_shoot()
 	hit_something = TRUE

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -213,6 +213,20 @@
 	throw_range = 0
 	throw_speed = 0
 	var/datum/action/changeling/weapon/parent_action
+	var/hit_something = FALSE //Used for deleting gun after hitting something
+	var/shooting_right_now = FALSE //Used to track shooting to prevent deleting mid shot
+
+/obj/item/gun/magic/tentacle/process_fire(atom/target, mob/living/user, message, params, zone_override, bonus_spread)
+	shooting_right_now = TRUE
+	. = ..()
+	shooting_right_now = FALSE
+	if(hit_something)
+		qdel(src)
+
+/obj/item/gun/magic/tentacle/proc/check_delete_on_shoot()
+	hit_something = TRUE
+	if(!shooting_right_now)
+		qdel(src)
 
 /obj/item/gun/magic/tentacle/customised_abstract_text(mob/living/carbon/owner)
 	return "<span class='warning'>[owner.p_their(TRUE)] [owner.l_hand == src ? "left arm" : "right arm"] has been turned into a grotesque tentacle.</span>"
@@ -294,7 +308,7 @@
 
 /obj/item/projectile/tentacle/on_hit(atom/target, blocked = 0)
 	var/mob/living/carbon/human/H = firer
-	qdel(source.gun)
+	source.gun.check_delete_on_shoot()
 	if(blocked >= 100)
 		return FALSE
 	if(isitem(target))
@@ -353,8 +367,8 @@
 			add_attack_logs(H, C, "imobilised with a changeling tentacle")
 			if(!iscarbon(H))
 				return TRUE
-			var/obj/item/restraints/legcuffs/beartrap/changeling/B = new(H.loc)
-			B.Crossed(C)
+			var/obj/item/restraints/legcuffs/beartrap/changeling/B = new(get_turf(L))
+			B.on_atom_entered(C, L)
 			return TRUE
 
 		if(INTENT_HARM)

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -213,8 +213,10 @@
 	throw_range = 0
 	throw_speed = 0
 	var/datum/action/changeling/weapon/parent_action
-	var/hit_something = FALSE //Used for deleting gun after hitting something
-	var/shooting_right_now = FALSE //Used to track shooting to prevent deleting mid shot
+	/// Used for deleting gun after hitting something
+	var/hit_something = FALSE
+	/// True if we're shooting our shot -- used to track shooting to prevent deleting mid shot
+	var/shooting_right_now = FALSE 
 
 /obj/item/gun/magic/tentacle/process_fire(atom/target, mob/living/user, message, params, zone_override, bonus_spread)
 	shooting_right_now = TRUE

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -223,7 +223,7 @@
 	check_delete_on_shoot()
 
 /obj/item/gun/magic/tentacle/proc/check_delete_on_shoot()
-	if(!shooting_right_now)
+	if(!shooting_right_now && hit_something)
 		qdel(src)
 
 /obj/item/gun/magic/tentacle/customised_abstract_text(mob/living/carbon/owner)
@@ -307,6 +307,7 @@
 /obj/item/projectile/tentacle/on_hit(atom/target, blocked = 0)
 	var/mob/living/carbon/human/H = firer
 	source.gun.hit_something = TRUE
+	source.gun.check_delete_on_shoot()
 	if(blocked >= 100)
 		return FALSE
 	if(isitem(target))


### PR DESCRIPTION
…lee shots

<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Remember https://github.com/ParadiseSS13/Paradise/pull/26245 ?
Apparently it didnt fix all the issues and we have runtime right now if you hit someone point blank
Well, not after that PR. It adds couple variables to track when the tentacle can be deleted instead of qdeling it in the middle of the shot causing runtime
I also switched `Crossed` to `on_atom_entered` on the beartrap so it works now

## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Bugs bad, runtimes bad

## Testing

<!-- How did you test the PR, if at all? -->
Compiled, shot tentacle point blank and from far away, shot it down the hallway(not hitting anything), made sure all works as intended

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: Changeling tentacle activates beartrap if shot point blank at the target.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
