### PR TITLE
Dynamic Mice: Let's populate maintenance randomly

### DIFF
--- a/_maps/map_files/stations/boxstation.dmm
+++ b/_maps/map_files/stations/boxstation.dmm
@@ -35,7 +35,6 @@
 "aag" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/mouse,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/incinerator)
 "aah" = (
@@ -5887,7 +5886,6 @@
 "avE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/cable_coil/random,
-/mob/living/simple_animal/mouse/white,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
 "avF" = (
@@ -10098,7 +10096,6 @@
 /turf/simulated/floor/plating,
 /area/shuttle/pod_2)
 "aJW" = (
-/mob/living/simple_animal/mouse,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/floor/wood,
@@ -10107,11 +10104,6 @@
 /obj/structure/chair/stool{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fpmaint2)
-"aJY" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/mouse,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
 "aJZ" = (
@@ -11121,10 +11113,6 @@
 /obj/machinery/atmospherics/portable/canister/air{
 	filled = 0.1
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
-"aNi" = (
-/mob/living/simple_animal/mouse,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "aNj" = (
@@ -12254,10 +12242,6 @@
 	icon_state = "arrival"
 	},
 /area/station/hallway/secondary/entry/north)
-"aRg" = (
-/mob/living/simple_animal/mouse,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fpmaint2)
 "aRh" = (
 /obj/machinery/sleeper{
 	dir = 4
@@ -21821,11 +21805,6 @@
 /obj/item/storage/toolbox/emergency,
 /turf/simulated/floor/plating,
 /area/station/public/storage/emergency/port)
-"buj" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/mouse/gray,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/port)
 "buk" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
@@ -25807,10 +25786,6 @@
 	name = "KEEP CLEAR: DOCKING AREA"
 	},
 /turf/simulated/wall/r_wall,
-/area/station/maintenance/port)
-"bKH" = (
-/mob/living/simple_animal/mouse/gray,
-/turf/simulated/floor/plating,
 /area/station/maintenance/port)
 "bKI" = (
 /obj/structure/cable{
@@ -32451,7 +32426,6 @@
 /turf/simulated/floor/plating/airless,
 /area/station/science/toxins/test)
 "clF" = (
-/mob/living/simple_animal/mouse,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
@@ -33633,7 +33607,6 @@
 /area/station/command/office/ntrep)
 "cqK" = (
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/mouse,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
@@ -34885,12 +34858,6 @@
 /obj/item/stack/rods,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint)
-"cvl" = (
-/mob/living/simple_animal/mouse/gray,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/port)
 "cvm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/suit_storage_unit/expedition,
@@ -44097,7 +44064,6 @@
 /area/station/maintenance/turbine)
 "dev" = (
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/mouse,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/turbine)
 "dew" = (
@@ -45625,10 +45591,6 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
-"dkv" = (
-/mob/living/simple_animal/mouse,
-/turf/simulated/floor/plating,
-/area/station/maintenance/asmaint)
 "dky" = (
 /obj/machinery/camera{
 	c_tag = "Central Hallway North-East"
@@ -49233,10 +49195,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port/east)
-"egi" = (
-/mob/living/simple_animal/mouse,
-/turf/simulated/floor/plating,
-/area/station/maintenance/apmaint)
 "egq" = (
 /obj/structure/closet/secure_closet/brig,
 /obj/machinery/power/apc/directional/east,
@@ -53660,7 +53618,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/mob/living/simple_animal/mouse,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
 "gsl" = (
@@ -71961,22 +71918,6 @@
 	icon_state = "caution"
 	},
 /area/station/engineering/break_room)
-"pUR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/mob/living/simple_animal/mouse,
-/turf/simulated/floor/plating,
-/area/station/maintenance/asmaint2)
 "pUU" = (
 /obj/structure/filingcabinet,
 /turf/simulated/floor/carpet,
@@ -80364,7 +80305,6 @@
 	},
 /area/station/maintenance/asmaint)
 "uql" = (
-/mob/living/simple_animal/mouse,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -101858,7 +101798,7 @@ nxX
 aGn
 aPW
 aQb
-aRg
+aHS
 aHl
 aGn
 rPS
@@ -103391,7 +103331,7 @@ bat
 aDA
 aEH
 aEJ
-aJY
+aHl
 aIK
 aGn
 aHS
@@ -103423,7 +103363,7 @@ blM
 bvq
 cho
 bwZ
-cvl
+pcH
 bCr
 pwm
 cwA
@@ -106994,7 +106934,7 @@ aaa
 aaa
 loS
 dEG
-aRg
+aHS
 vbm
 aJX
 jQt
@@ -108053,7 +107993,7 @@ bnK
 bnK
 cJV
 blQ
-bKH
+bnK
 bxb
 bIX
 bQf
@@ -111127,7 +111067,7 @@ bkg
 blX
 blQ
 bsR
-buj
+svp
 bvw
 bDJ
 blQ
@@ -111674,7 +111614,7 @@ bBf
 wrU
 nIY
 cqs
-egi
+coL
 xxQ
 omB
 coL
@@ -131409,7 +131349,7 @@ aGX
 aQI
 aGY
 aGX
-aNi
+aGY
 aGY
 aGX
 aGX
@@ -132253,7 +132193,7 @@ bGG
 qZN
 oyY
 oyY
-pUR
+upd
 bGG
 qZN
 dQM
@@ -137415,7 +137355,7 @@ cNq
 cga
 ePu
 ePu
-dkv
+csL
 isD
 csL
 jPw

--- a/_maps/map_files/stations/cerestation.dmm
+++ b/_maps/map_files/stations/cerestation.dmm
@@ -23636,13 +23636,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos/distribution)
-"deS" = (
-/mob/living/simple_animal/mouse/brown,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating{
-	icon_state = "asteroidplating"
-	},
-/area/station/maintenance/port2)
 "deW" = (
 /obj/item/radio/intercom{
 	pixel_y = 28;
@@ -36622,7 +36615,6 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/mob/living/simple_animal/mouse/brown,
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/station/maintenance/port2)
 "gtH" = (
@@ -37921,12 +37913,6 @@
 	},
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/station/maintenance/starboard)
-"gLX" = (
-/mob/living/simple_animal/mouse/brown,
-/turf/simulated/floor/plating{
-	icon_state = "asteroidplating"
-	},
-/area/station/maintenance/fsmaint)
 "gLY" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 8;
@@ -38245,15 +38231,6 @@
 /obj/machinery/space_heater,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal/south)
-"gRw" = (
-/mob/living/simple_animal/mouse/white,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating{
-	icon_state = "asteroidplating"
-	},
-/area/station/maintenance/starboard)
 "gRz" = (
 /obj/effect/decal/cleanable/blood/tracks/mapped,
 /obj/effect/mapping_helpers/turfs/burn,
@@ -38604,10 +38581,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/simulated/floor/plating/asteroid/ancient,
 /area/station/maintenance/maintcentral)
-"gWv" = (
-/mob/living/simple_animal/mouse,
-/turf/simulated/floor/plating,
-/area/station/maintenance/port)
 "gWO" = (
 /obj/structure/closet/wardrobe/white,
 /obj/item/clothing/shoes/jackboots,
@@ -41488,7 +41461,6 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/mob/living/simple_animal/mouse/brown,
 /turf/simulated/floor/plating{
 	icon_state = "asteroidplating"
 	},
@@ -46695,13 +46667,6 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal/southwest)
-"iXy" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/mob/living/simple_animal/mouse/gray,
-/turf/simulated/floor/plating/asteroid/ancient,
-/area/station/maintenance/starboard)
 "iXK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
@@ -53284,14 +53249,6 @@
 	icon_state = "green"
 	},
 /area/station/public/quantum/service)
-"kAu" = (
-/mob/living/simple_animal/mouse/gray,
-/obj/effect/spawner/random/dirt/often,
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "yellow"
-	},
-/area/station/maintenance/fore)
 "kAv" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -55199,10 +55156,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/wall,
 /area/station/hallway/primary/port/south)
-"laM" = (
-/mob/living/simple_animal/mouse/brown,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore2)
 "lbf" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -62945,10 +62898,6 @@
 	icon_state = "escape"
 	},
 /area/station/maintenance/port2)
-"mXW" = (
-/mob/living/simple_animal/mouse/white,
-/turf/simulated/floor/plating/asteroid/ancient,
-/area/station/maintenance/asmaint)
 "mYa" = (
 /obj/machinery/flasher{
 	id = "Cell 2";
@@ -63472,7 +63421,6 @@
 /area/station/maintenance/fore)
 "neD" = (
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/mouse/white,
 /obj/effect/turf_decal/delivery/partial{
 	dir = 4
 	},
@@ -66193,11 +66141,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore/west)
-"nQU" = (
-/mob/living/simple_animal/mouse/brown,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore2)
 "nQW" = (
 /obj/machinery/door/airlock/public/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -68334,7 +68277,6 @@
 /area/station/science/test_chamber)
 "ove" = (
 /obj/effect/spawner/random/dirt/frequent,
-/mob/living/simple_animal/mouse/gray,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
@@ -70262,15 +70204,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/fore/east)
-"oUR" = (
-/mob/living/simple_animal/mouse/gray,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/plating{
-	icon_state = "asteroidplating"
-	},
-/area/station/maintenance/apmaint)
 "oVb" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
@@ -72741,12 +72674,6 @@
 	icon_state = "bluered"
 	},
 /area/station/hallway/secondary/entry/west)
-"pAV" = (
-/mob/living/simple_animal/mouse/gray,
-/turf/simulated/floor/plating{
-	icon_state = "asteroidplating"
-	},
-/area/station/maintenance/port)
 "pBh" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -76374,13 +76301,6 @@
 /obj/structure/flora/ausbushes/sunnybush,
 /turf/simulated/floor/grass,
 /area/station/hallway/spacebridge/scidock)
-"qvA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/mob/living/simple_animal/mouse/white,
-/turf/simulated/floor/plating{
-	icon_state = "asteroidplating"
-	},
-/area/station/maintenance/fore)
 "qvJ" = (
 /obj/structure/lattice/catwalk,
 /turf/space,
@@ -81989,10 +81909,6 @@
 	icon_state = "asteroidplating"
 	},
 /area/station/maintenance/starboard)
-"rVL" = (
-/mob/living/simple_animal/mouse/gray,
-/turf/simulated/floor/plating/asteroid/ancient,
-/area/station/maintenance/apmaint)
 "rVZ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door_control{
@@ -86268,11 +86184,6 @@
 	icon_state = "cafeteria"
 	},
 /area/station/medical/break_room)
-"sXA" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/mouse/white,
-/turf/simulated/floor/plating,
-/area/station/maintenance/port2)
 "sXG" = (
 /obj/machinery/light{
 	dir = 8
@@ -106601,7 +106512,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
 "xUz" = (
-/mob/living/simple_animal/mouse/gray,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment/corner,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -106867,12 +106777,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/service/janitor)
-"xXN" = (
-/mob/living/simple_animal/mouse/brown,
-/turf/simulated/floor/plating{
-	icon_state = "asteroidplating"
-	},
-/area/station/maintenance/starboard)
 "xXS" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
@@ -119133,7 +119037,7 @@ aXn
 lVV
 qcE
 tiE
-gWv
+jee
 kZy
 lVV
 aXn
@@ -121184,7 +121088,7 @@ aXn
 aXn
 hvI
 eTI
-pAV
+eCI
 pXy
 dHZ
 wzC
@@ -121508,7 +121412,7 @@ wms
 adg
 fZa
 fdG
-oUR
+qlW
 sKh
 sKh
 wIq
@@ -128427,7 +128331,7 @@ ueB
 rXS
 lSc
 reB
-deS
+reB
 kZd
 iaF
 aXn
@@ -130608,7 +130512,7 @@ wDs
 wDs
 wDs
 bDo
-nQU
+vXM
 vrQ
 wDs
 afd
@@ -132267,7 +132171,7 @@ rNK
 lzH
 rNK
 cKa
-sXA
+dQZ
 dQZ
 qpx
 shL
@@ -132446,7 +132350,7 @@ wDs
 wDs
 uEX
 tbe
-laM
+vrQ
 bJW
 tbe
 wDs
@@ -132584,7 +132488,7 @@ koR
 koR
 dHN
 xPU
-rVL
+wsR
 wsR
 cWF
 wIq
@@ -138339,7 +138243,7 @@ vPt
 vPt
 vPt
 vPt
-laM
+vrQ
 aGg
 bbc
 bbc
@@ -143460,7 +143364,7 @@ fFd
 gKc
 cdz
 rTz
-qvA
+bjF
 bjF
 bjF
 bjF
@@ -144500,7 +144404,7 @@ bkp
 bkp
 mEg
 scz
-kAu
+scz
 vnu
 qIa
 qaI
@@ -147455,7 +147359,7 @@ plQ
 plQ
 plQ
 rlz
-mXW
+imG
 ggK
 xON
 mJk
@@ -159508,7 +159412,7 @@ xyF
 sVv
 yfZ
 gFg
-gRw
+xAV
 tvJ
 aZN
 aZM
@@ -161292,7 +161196,7 @@ bCq
 bkH
 qhP
 fqw
-iXy
+bLj
 gSQ
 bLj
 bLj
@@ -165357,7 +165261,7 @@ hqL
 cpC
 cpC
 cpC
-gLX
+cpC
 rNW
 gGH
 pMv
@@ -165402,7 +165306,7 @@ vHH
 wyL
 gSQ
 gSQ
-xXN
+gFg
 gFg
 gSQ
 gSQ

--- a/_maps/map_files/stations/deltastation.dmm
+++ b/_maps/map_files/stations/deltastation.dmm
@@ -83129,13 +83129,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/aft_starboard)
-"sQr" = (
-/mob/living/simple_animal/mouse,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/port)
 "sQw" = (
 /obj/structure/weightmachine/stacklifter,
 /turf/simulated/floor/plasteel{
@@ -89257,10 +89250,6 @@
 	icon_state = "whitepurple"
 	},
 /area/station/science/toxins/mixing)
-"wce" = (
-/mob/living/simple_animal/mouse/white,
-/turf/simulated/floor/plating,
-/area/station/security/permabrig)
 "wcu" = (
 /obj/machinery/atmospherics/unary/cryo_cell,
 /turf/simulated/floor/plasteel{
@@ -113454,7 +113443,7 @@ cWl
 unt
 lxh
 cHA
-sQr
+ddg
 sZp
 nCh
 cHA
@@ -147818,7 +147807,7 @@ aaa
 aaa
 ygH
 coI
-wce
+aQx
 aQx
 mtL
 aKU

--- a/_maps/map_files/stations/emeraldstation.dmm
+++ b/_maps/map_files/stations/emeraldstation.dmm
@@ -14361,11 +14361,6 @@
 "cRi" = (
 /turf/simulated/wall,
 /area/station/security/main)
-"cRk" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/mouse,
-/turf/simulated/floor/plating,
-/area/station/maintenance/apmaint2)
 "cRu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -15571,7 +15566,6 @@
 /turf/simulated/floor/plasteel,
 /area/station/engineering/hardsuitstorage)
 "dfs" = (
-/mob/living/simple_animal/mouse,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood,
 /area/station/maintenance/abandoned_office)
@@ -22315,7 +22309,6 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/mob/living/simple_animal/mouse,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
@@ -37928,7 +37921,6 @@
 "hzk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
-/mob/living/simple_animal/mouse,
 /turf/simulated/floor/plating,
 /area/station/maintenance/security/aft_starboard)
 "hzA" = (
@@ -40360,11 +40352,6 @@
 /obj/machinery/atmospherics/meter,
 /turf/simulated/floor/engine,
 /area/station/engineering/engine)
-"iam" = (
-/obj/effect/spawner/random/oil/maybe,
-/mob/living/simple_animal/mouse,
-/turf/simulated/floor/plating,
-/area/station/maintenance/security/fore)
 "iaw" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -53362,11 +53349,6 @@
 	icon_state = "dark"
 	},
 /area/station/aisat/atmos)
-"kCz" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/mouse,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/apmaint2)
 "kCA" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -55233,11 +55215,6 @@
 /obj/machinery/economy/vending/boozeomat,
 /turf/simulated/floor/wood,
 /area/station/maintenance/abandonedbar)
-"kXa" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/mouse,
-/turf/simulated/floor/plating,
-/area/station/maintenance/dorms/port)
 "kXf" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -57395,15 +57372,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/dorms/starboard)
-"lut" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/mouse,
-/turf/simulated/floor/plating,
-/area/station/maintenance/security/fore)
 "luC" = (
 /obj/effect/decal/cleanable/confetti,
 /obj/effect/decal/cleanable/dirt,
@@ -60007,7 +59975,6 @@
 /area/station/supply/lobby)
 "lWJ" = (
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/mouse,
 /obj/item/trash/spentcasing/shotgun,
 /turf/simulated/floor/wood,
 /area/station/maintenance/dorms/starboard)
@@ -64944,12 +64911,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
-"mXx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/oil/maybe,
-/mob/living/simple_animal/mouse,
-/turf/simulated/floor/plating,
-/area/station/maintenance/apmaint)
 "mXy" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/machinery/firealarm/directional/north,
@@ -67699,14 +67660,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
-"nzU" = (
-/mob/living/simple_animal/mouse,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/apmaint2)
 "nAc" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -68380,12 +68333,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/secure_storage)
-"nGt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/mob/living/simple_animal/mouse,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/starboard)
 "nGw" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -69395,11 +69342,6 @@
 	icon_state = "white"
 	},
 /area/station/science/toxins/mixing)
-"nPx" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/mouse,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/starboard)
 "nPG" = (
 /obj/item/kirbyplants,
 /turf/simulated/floor/plasteel,
@@ -69687,11 +69629,6 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/station/medical/virology)
-"nSa" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/mouse,
-/turf/simulated/floor/plating,
-/area/station/maintenance/dorms/fore)
 "nSe" = (
 /turf/simulated/floor/plating/airless,
 /area/station/aisat/hall)
@@ -74317,7 +74254,6 @@
 /turf/simulated/wall,
 /area/station/engineering/tech_storage)
 "oMl" = (
-/mob/living/simple_animal/mouse/white,
 /obj/effect/landmark/spawner/nukedisc_respawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/security/fore)
@@ -76832,7 +76768,6 @@
 /area/station/engineering/break_room/secondary)
 "piI" = (
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/mouse/white,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -77523,11 +77458,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/dorms/port)
-"pqt" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/mouse,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/fpmaint)
 "pqI" = (
 /obj/structure/chair{
 	dir = 1
@@ -79178,10 +79108,6 @@
 	icon_state = "dark"
 	},
 /area/station/medical/morgue)
-"pHV" = (
-/mob/living/simple_animal/mouse,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/asmaint)
 "pHX" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
@@ -81942,11 +81868,6 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/aisat/hall)
-"qmI" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/mouse,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fpmaint)
 "qmJ" = (
 /obj/machinery/power/apc/directional/south,
 /obj/structure/cable,
@@ -95408,11 +95329,6 @@
 "sTG" = (
 /turf/simulated/wall,
 /area/station/science/genetics)
-"sTI" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/mouse,
-/turf/simulated/floor/plating,
-/area/station/maintenance/starboard)
 "sTJ" = (
 /obj/effect/spawner/random/barrier/grille_maybe,
 /obj/effect/decal/cleanable/dirt,
@@ -106010,12 +105926,6 @@
 	icon_state = "cult"
 	},
 /area/station/legal/magistrate)
-"uWS" = (
-/obj/effect/decal/cleanable/generic,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/mouse,
-/turf/simulated/floor/plating,
-/area/station/maintenance/dorms/starboard)
 "uWU" = (
 /obj/item/kirbyplants,
 /turf/simulated/floor/plasteel{
@@ -106394,7 +106304,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 10
 	},
-/mob/living/simple_animal/mouse,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "whiteblue"
@@ -109585,10 +109494,6 @@
 	icon_state = "dark"
 	},
 /area/station/security/brig)
-"vJc" = (
-/mob/living/simple_animal/mouse,
-/turf/simulated/floor/plating,
-/area/station/maintenance/aft2)
 "vJm" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -112013,7 +111918,6 @@
 "whf" = (
 /obj/effect/mapping_helpers/turfs/damage,
 /obj/effect/decal/cleanable/generic,
-/mob/living/simple_animal/mouse,
 /turf/simulated/floor/plating,
 /area/station/maintenance/security/aft_starboard)
 "whh" = (
@@ -132920,7 +132824,7 @@ ipM
 hcH
 uPm
 bqU
-nzU
+xQq
 bGM
 xKc
 rPz
@@ -134462,7 +134366,7 @@ mIg
 eyo
 opq
 yiE
-cRk
+opq
 xQq
 fMB
 aco
@@ -138550,7 +138454,7 @@ qXp
 xrG
 feI
 idv
-mXx
+eBv
 sqZ
 mQe
 lQZ
@@ -140127,7 +140031,7 @@ oeh
 pdx
 vSD
 cBD
-kCz
+fMB
 lUy
 eJa
 sqB
@@ -146478,7 +146382,7 @@ ndJ
 qZs
 qci
 lfn
-qmI
+vWJ
 gmL
 nwf
 nwf
@@ -148244,7 +148148,7 @@ aSK
 wIh
 qci
 vWJ
-pqt
+eMT
 vWJ
 vWJ
 eMT
@@ -151137,7 +151041,7 @@ dsL
 twa
 vIV
 ril
-kXa
+ewj
 xmm
 rxd
 iSc
@@ -158586,7 +158490,7 @@ egS
 gsU
 fRA
 oPi
-uWS
+pIl
 xmi
 cPy
 kcb
@@ -159062,7 +158966,7 @@ soN
 dlV
 iNN
 syn
-nSa
+sul
 ydG
 rNs
 rtR
@@ -159890,7 +159794,7 @@ lRd
 snP
 aIj
 rWj
-vJc
+xaN
 bVp
 dtF
 bTR
@@ -162101,7 +162005,7 @@ iBy
 gbl
 oei
 iXk
-lut
+plQ
 oIH
 cwI
 cwI
@@ -168790,7 +168694,7 @@ cwI
 cwI
 qTH
 xEt
-iam
+cuO
 fsJ
 lVs
 vKT
@@ -169139,7 +169043,7 @@ mXw
 tVw
 dGc
 qFP
-nGt
+iPH
 bpH
 bpH
 bpp
@@ -172770,7 +172674,7 @@ qDC
 bNH
 jnC
 jnC
-pHV
+uMS
 ugn
 nuJ
 kTf
@@ -172966,7 +172870,7 @@ fIk
 stp
 stp
 oAs
-sTI
+mXw
 bnw
 tlf
 eDe
@@ -174532,7 +174436,7 @@ oTL
 mXw
 mIH
 nWG
-nPx
+jcy
 aQl
 caq
 pga

--- a/_maps/map_files/stations/metastation.dmm
+++ b/_maps/map_files/stations/metastation.dmm
@@ -834,11 +834,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/fore_port)
-"ajD" = (
-/mob/living/simple_animal/mouse,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/catwalk,
-/area/station/maintenance/fore)
 "ajE" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -12476,7 +12471,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/mob/living/simple_animal/mouse,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -15608,10 +15602,6 @@
 	dir = 1
 	},
 /obj/effect/spawner/random/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fpmaint)
-"bmA" = (
-/mob/living/simple_animal/mouse,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
 "bmE" = (
@@ -27082,16 +27072,6 @@
 	icon_state = "C11"
 	},
 /area/station/hallway/primary/central/south)
-"cbb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/mob/living/simple_animal/mouse,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/fsmaint)
 "cbc" = (
 /obj/effect/spawner/random/fungus/maybe,
 /turf/simulated/wall/r_wall,
@@ -29744,11 +29724,6 @@
 /obj/structure/lattice,
 /turf/space,
 /area/space/nearstation)
-"clJ" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/mouse,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/turbine)
 "clK" = (
 /obj/structure/closet,
 /obj/item/extinguisher,
@@ -36644,10 +36619,6 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/science/toxins/test)
-"cOU" = (
-/mob/living/simple_animal/mouse,
-/turf/simulated/floor/plating,
-/area/station/maintenance/port)
 "cOV" = (
 /obj/machinery/button/windowtint{
 	dir = 1;
@@ -36991,7 +36962,6 @@
 "cQt" = (
 /obj/effect/mapping_helpers/turfs/burn,
 /obj/machinery/light/small,
-/mob/living/simple_animal/mouse,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medmaint)
 "cQu" = (
@@ -39260,10 +39230,6 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/exam_room)
-"dbH" = (
-/mob/living/simple_animal/mouse,
-/turf/simulated/floor/plating,
-/area/station/maintenance/aft)
 "dbI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/structure/cable{
@@ -47165,10 +47131,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
-"gof" = (
-/mob/living/simple_animal/mouse,
-/turf/simulated/floor/plating,
-/area/station/maintenance/apmaint)
 "goq" = (
 /obj/structure/closet/secure_closet/hos,
 /obj/item/cartridge/detective,
@@ -47930,7 +47892,6 @@
 	dir = 5
 	},
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/mouse,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/starboard2)
 "gHh" = (
@@ -48673,11 +48634,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/aft2)
-"gWz" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/mouse,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/fsmaint)
 "gWE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -51906,10 +51862,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
-"isf" = (
-/mob/living/simple_animal/mouse,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
 "isB" = (
 /obj/machinery/door/airlock/engineering/glass{
 	autoclose = 0;
@@ -57255,10 +57207,6 @@
 	icon_state = "red"
 	},
 /area/station/security/checkpoint/secondary)
-"kQF" = (
-/mob/living/simple_animal/mouse,
-/turf/simulated/floor/wood,
-/area/station/maintenance/starboard)
 "kRc" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -66837,11 +66785,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/virology)
-"peg" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/mouse,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/starboard2)
 "pej" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -69570,10 +69513,6 @@
 	icon_state = "white"
 	},
 /area/station/maintenance/aft)
-"qoK" = (
-/mob/living/simple_animal/mouse,
-/turf/simulated/floor/plating,
-/area/station/maintenance/starboard2)
 "qoQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -70750,7 +70689,6 @@
 	},
 /area/station/security/interrogation)
 "qRm" = (
-/mob/living/simple_animal/mouse,
 /obj/effect/spawner/random/oil/maybe,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fore)
@@ -76370,10 +76308,6 @@
 	icon_state = "whitepurplecorner"
 	},
 /area/station/science/research)
-"tnW" = (
-/mob/living/simple_animal/mouse,
-/turf/simulated/floor/plating,
-/area/station/maintenance/starboard)
 "toc" = (
 /obj/structure/sign/electricshock,
 /turf/simulated/wall/r_wall,
@@ -79937,7 +79871,6 @@
 	dir = 6
 	},
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/mouse,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -80297,7 +80230,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/mob/living/simple_animal/mouse,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
@@ -83366,10 +83298,6 @@
 /obj/structure/sign/biohazard,
 /turf/simulated/wall/r_wall,
 /area/station/science/research)
-"wLB" = (
-/mob/living/simple_animal/mouse,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
 "wMb" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -86652,7 +86580,6 @@
 /area/station/engineering/atmos/distribution)
 "yih" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/mob/living/simple_animal/mouse,
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -86661,10 +86588,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard2)
-"yiP" = (
-/mob/living/simple_animal/mouse,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/fore)
 "yiU" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -99415,7 +99338,7 @@ qCK
 aOB
 aOB
 adY
-bmA
+adY
 aOB
 aLF
 aML
@@ -103078,7 +103001,7 @@ cpD
 crG
 bZP
 clK
-gof
+crG
 crG
 bZP
 aaa
@@ -104853,7 +104776,7 @@ cdT
 cdT
 cdT
 cdT
-cOU
+bTY
 xOy
 aSM
 aSM
@@ -105576,7 +105499,7 @@ awh
 hka
 imw
 adY
-bmA
+adY
 aOB
 bmK
 bgA
@@ -106185,7 +106108,7 @@ chy
 tPO
 eJG
 czw
-dbH
+chy
 bZU
 abq
 aaa
@@ -118662,7 +118585,7 @@ nEV
 nEV
 awp
 aDY
-wLB
+alW
 cnV
 nVQ
 whf
@@ -119967,7 +119890,7 @@ nSs
 acL
 aWv
 aFj
-yiP
+fpy
 bne
 ajg
 iGR
@@ -121831,7 +121754,7 @@ dtC
 cte
 gnS
 cFB
-peg
+gSO
 ipj
 cmB
 qub
@@ -124098,7 +124021,7 @@ aLl
 ayv
 aLl
 apL
-isf
+avA
 eiI
 aLl
 bdt
@@ -124833,7 +124756,7 @@ aaa
 aaa
 aaa
 ahH
-ajD
+oTt
 azu
 awp
 air
@@ -124858,7 +124781,7 @@ gip
 nET
 blB
 wYm
-cbb
+blB
 beF
 juq
 apV
@@ -124914,7 +124837,7 @@ bPj
 wdY
 cte
 cqE
-qoK
+cwG
 dhw
 dhw
 bUz
@@ -125363,7 +125286,7 @@ air
 aBZ
 iAS
 oyN
-gWz
+cxr
 hgU
 aLl
 fpk
@@ -125399,7 +125322,7 @@ aoG
 aoG
 aoG
 dSv
-tnW
+asJ
 nWJ
 oXK
 aoG
@@ -126451,7 +126374,7 @@ cfL
 ciu
 ciH
 aRQ
-clJ
+aRQ
 biB
 bul
 clB
@@ -126696,7 +126619,7 @@ kbr
 vud
 axh
 cyv
-kQF
+ovR
 bZH
 fTV
 nXk

--- a/code/controllers/subsystem/non_firing/SSlate_mapping.dm
+++ b/code/controllers/subsystem/non_firing/SSlate_mapping.dm
@@ -27,4 +27,30 @@ SUBSYSTEM_DEF(late_mapping)
 		var/duration = stop_watch(watch)
 		log_startup_progress("Generated [mgcount] mazes in [duration]s")
 
+	maintenance_mice()
+
 	GLOB.spawn_pool_manager.process_pools()
+
+/**
+ * Randomly spawns mice in maintenance instead of being purely fixed spawn points
+ */
+/datum/controller/subsystem/late_mapping/proc/maintenance_mice()
+	var/watch = start_watch()
+	log_startup_progress("Populating maintenance with mice...")
+
+	// Looking up for maintenance floors specifically as possible spawn points
+	var/list/maintenance_turfs = list()
+	for(var/area/station/maintenance/A in SSmapping.existing_station_areas)
+		for(var/turf/simulated/floor/F in A)
+			if(locate(/obj/structure/window) in F)
+				continue
+			maintenance_turfs.Add(F)
+	
+	// The ratio is based on turfs per mice. Using Boxstation as an example, it would average between 20 to 30 mice.
+	var/ratio = rand(125, 200)
+	var/mice_number = floor(length(maintenance_turfs) / ratio)
+
+	for(var/i in 1 to mice_number)
+		new /mob/living/simple_animal/mouse(pick_n_take(maintenance_turfs))
+
+	log_startup_progress("Spawned [mice_number] mice over in [stop_watch(watch)]s")

--- a/code/controllers/subsystem/non_firing/SSlate_mapping.dm
+++ b/code/controllers/subsystem/non_firing/SSlate_mapping.dm
@@ -46,11 +46,15 @@ SUBSYSTEM_DEF(late_mapping)
 				continue
 			maintenance_turfs.Add(F)
 	
+	if(!length(maintenance_turfs))
+		log_debug("No valid turfs has been found for mice.")
+		return
+
 	// The ratio is based on turfs per mice. Using Boxstation as an example, it would average between 20 to 30 mice.
-	var/ratio = rand(125, 200)
-	var/mice_number = floor(length(maintenance_turfs) / ratio)
+	var/floor_tiles_per_one_mice = rand(125, 200)
+	var/mice_number = ceil(length(maintenance_turfs) / floor_tiles_per_one_mice)
 
 	for(var/i in 1 to mice_number)
 		new /mob/living/simple_animal/mouse(pick_n_take(maintenance_turfs))
 
-	log_startup_progress("Spawned [mice_number] mice over in [stop_watch(watch)]s")
+	log_debug("Spawned [mice_number] mice over in [stop_watch(watch)]s")


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This creates a step in the late mapping process where mice are spawned in maintenance randomly, with a random ratio range. Instead of just placing them manually, let the game do it for you unless you have _really_ specific spots in mind.

Current ratios are 125 to 200 valid maintenance turfs per mice, making it range from 20 to 30 on Boxstation.

Maps are edited to remove all mice except for Tom, as the current fixed spawns would be excessive on top of the random ones (Except for Delta, which has a notable lack of mice). Let me know if there's some that should remain, or if the ratio should be tweaked.

## Why It's Good For The Game
Mice being hard placed essentially means they'll have the same outcome most of the time (i.e. chew on the same cable every round). This changes things up, and is not reliant on dropping random spawners.

## Images of changes
![Rats](https://github.com/user-attachments/assets/3268878a-7109-48bc-8e2d-b237ddd63b05)
![Rats2](https://github.com/user-attachments/assets/f1175a1d-e8d1-4884-a70e-e5b6ae1fcc8a)

## Testing
Launched an instance, and looked around for mice.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
add: Added dynamic spawning of mice in maintenance on new rounds.
del: Removed fixed spawn points for mice (Except Tom) in all stations.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
