### PR TITLE
Fix more chef bonks

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
@@ -123,6 +123,7 @@
 			if(!(R.id in GLOB.cooking_reagents[recipe_type]))
 				to_chat(user, "<span class='alert'>Your [used.name] contains components unsuitable for cookery.</span>")
 				return ITEM_INTERACT_COMPLETE
+		return ITEM_INTERACT_COMPLETE
 	else if(istype(used, /obj/item/storage))
 		var/obj/item/storage/S = used
 		if(!S.allow_quick_empty)
@@ -144,6 +145,7 @@
 			S.remove_from_storage(ingredient, src)
 			CHECK_TICK
 		SStgui.update_uis(src)
+		return ITEM_INTERACT_COMPLETE
 
 	else if(istype(used, /obj/item/grab))
 		var/obj/item/grab/G = used

--- a/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
@@ -154,11 +154,9 @@
 			return ITEM_INTERACT_COMPLETE
 		special_attack_grab(G, user)
 		return ITEM_INTERACT_COMPLETE
-	else
-		to_chat(user, "<span class='alert'>You have no idea what you can cook with [used].</span>")
-		return ITEM_INTERACT_COMPLETE
 
-	return ..()
+	to_chat(user, "<span class='alert'>You have no idea what you can cook with [used].</span>")
+	return ITEM_INTERACT_COMPLETE
 
 /obj/machinery/kitchen_machine/wrench_act(mob/living/user, obj/item/I)
 	if(operating)


### PR DESCRIPTION
## What Does This PR Do
Reagent containers and storages no longer bonk when used on kitchen machinery.

## Why It's Good For The Game
I don't want to break my oven, thanks.

## Testing
Dumped a tray into the candy maker.
Poured cream into a microwave.
<hr>

### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

<hr>

## Changelog
:cl:
fix: Storage items and reagent containers no longer bonk on kitchen machinery.
/:cl: