### PR TITLE
fix two vermin infestation issues

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1562,12 +1562,6 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 		if(areas)
 			. |= T.loc
 
-/proc/turf_clear(turf/T)
-	for(var/atom/A in T)
-		if(A.simulated)
-			return FALSE
-	return TRUE
-
 /proc/screen_loc2turf(scr_loc, turf/origin)
 	var/tX = splittext(scr_loc, ",")
 	var/tY = splittext(tX[2], ":")

--- a/code/modules/events/infestation.dm
+++ b/code/modules/events/infestation.dm
@@ -27,17 +27,28 @@
 
 /datum/event/infestation/start()
 	var/list/turf/simulated/floor/turfs = list()
-	spawn_area_type = pick(spawn_areas)
-	for(var/areapath in typesof(spawn_area_type))
-		var/area/A = locate(areapath)
-		if(!A)
-			log_debug("Failed to locate area for infestation event!")
-			kill()
-			return
-		for(var/turf/simulated/floor/F in A.contents)
-			if(turf_clear(F))
-				turfs += F
+	// shuffle in place so we don't have do that dance where we make a copy of
+	// the list, then pick and take, then do some conditional logic to make sure
+	// there's still areas to choose from, etc etc, it's a small list, it's cheap
+	shuffle_inplace(spawn_areas)
+	for(var/spawn_area in spawn_areas)
+		for(var/area_type in typesof(spawn_area))
+			var/area/destination = locate(area_type)
+			if(!destination)
+				continue
+			for(var/turf/simulated/floor/F in destination.contents)
+				if(!is_blocked_turf(F))
+					turfs += F
+			if(length(turfs))
+				spawn_area_type = area_type
+				spawn_on_turfs(turfs)
+				return
 
+	log_debug("Failed to locate area for infestation event!")
+	kill()
+	return
+
+/datum/event/infestation/proc/spawn_on_turfs(list/turfs)
 	var/list/spawn_types = list()
 	var/max_number
 	vermin = rand(0, 2)

--- a/code/modules/events/infestation.dm
+++ b/code/modules/events/infestation.dm
@@ -46,7 +46,6 @@
 
 	log_debug("Failed to locate area for infestation event!")
 	kill()
-	return
 
 /datum/event/infestation/proc/spawn_on_turfs(list/turfs)
 	var/list/spawn_types = list()


### PR DESCRIPTION
## What Does This PR Do
This PR fixes two issues with the vermin infestation event. The first is that locating an area always returns a result, even if that area has no turfs, meaning a station without the chosen area (like Meta using Turbine instead of Incinerator) will silently fail. The second is that the `turf_clear` method it was using for checking for available spawn points was awful, essentially excluding any floor with any contents whatsoever: lights, underfloor cables, etc. This meant that for example, Metastation tech storage was seen as having no eligible turfs for spawning:

![2025_01_29__23_21_44__paradise dme  metastation dmm  - StrongDMM](https://github.com/user-attachments/assets/f6379df0-f4ec-493f-ac47-df035b4cf265)

Despite having tons of floor space.
## Why It's Good For The Game
More reliable event.
## Testing

Used event manager to run Vermin Infestation event, ensured results were still random and all expected locations worked.

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: Vermin infestation events will now more reliably trigger.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
