### PR TITLE
Reagents go into kitchen appliances again

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
@@ -123,7 +123,7 @@
 			if(!(R.id in GLOB.cooking_reagents[recipe_type]))
 				to_chat(user, "<span class='alert'>Your [used.name] contains components unsuitable for cookery.</span>")
 				return ITEM_INTERACT_COMPLETE
-		return ITEM_INTERACT_COMPLETE
+		return ..()
 	else if(istype(used, /obj/item/storage))
 		var/obj/item/storage/S = used
 		if(!S.allow_quick_empty)


### PR DESCRIPTION
## What Does This PR Do
Re-bonk reagent containers on kitchen appliances

## Why It's Good For The Game
Without the bonk, the reagents don't go in.

The bonk happens when the reagent container's legacy attack chain fires, and that's what's handling the reagent transfer.

## Testing
Used a cream carton on a microwave. Bonk. Got reagents in microwave.
<hr>

### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

<hr>

## Changelog
:cl:
fix: Reagents go into kitchen appliances again. This does make reagent containers bonk on them again, for now.
/:cl:
