### PR TITLE
Fix belt disappearing on mouse drop

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -62,6 +62,9 @@
 /obj/item/storage/belt/proc/can_use()
 	return is_equipped()
 
+/obj/item/storage/belt/MouseDrop(obj/over_object, src_location, over_location)
+	..()
+	playsound(loc, "rustle", 50, TRUE, -5)
 
 /obj/item/storage/belt/deserialize(list/data)
 	..()

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -62,27 +62,6 @@
 /obj/item/storage/belt/proc/can_use()
 	return is_equipped()
 
-/obj/item/storage/belt/MouseDrop(obj/over_object, src_location, over_location)
-	var/mob/M = usr
-	if(!is_screen_atom(over_object))
-		return ..()
-	playsound(loc, "rustle", 50, TRUE, -5)
-	if(!M.restrained() && !M.stat && can_use())
-		switch(over_object.name)
-			if("r_hand")
-				if(M.unequip(src))
-					if(M.r_hand)
-						M.drop_item_to_ground(src)
-					else
-						M.put_in_r_hand(src)
-			if("l_hand")
-				if(M.unequip(src))
-					if(M.l_hand)
-						M.drop_item_to_ground(src)
-					else
-						M.put_in_l_hand(src)
-		add_fingerprint(usr)
-		return
 
 /obj/item/storage/belt/deserialize(list/data)
 	..()


### PR DESCRIPTION
## What Does This PR Do
Stops belts from disappearing on mouse drop when the wearer is being grabbed  be their neck.
I believe `/obj/item/storage/MouseDrop()` completely overlaps `/obj/item/storage/belt/MouseDrop()` functionality, so the latter can be removed.

## Why It's Good For The Game
Fixes a bug.

## Testing
- [x] Belt is ok being mouse dragged to a hand and back to its slot.
- [x] Can't mouse drag the belt while being grabbed by the neck.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl: Maxiemar
fix: Belts no longer disappear when being mouse dragged to a hand while the wearer is being grabbed by their neck.
/:cl:
