### PR TITLE
Move time defines to the defines folder

### DIFF
--- a/code/__DEFINES/time_defines.dm
+++ b/code/__DEFINES/time_defines.dm
@@ -1,0 +1,18 @@
+#define MILLISECONDS *0.01
+
+#define DECISECONDS *1 //the base unit all of these defines are scaled by, because byond uses that as a unit of measurement for some fucking reason
+
+// So you can be all 10 SECONDS
+#define SECONDS *10
+
+#define MINUTES *600
+
+#define HOURS *36000
+
+#define TICKS *world.tick_lag
+
+#define SECONDS_TO_LIFE_CYCLES /2
+
+#define DS2TICKS(DS) ((DS)/world.tick_lag)
+
+#define TICKS2DS(T) ((T) TICKS)

--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -1,22 +1,3 @@
-#define MILLISECONDS *0.01
-
-#define DECISECONDS *1 //the base unit all of these defines are scaled by, because byond uses that as a unit of measurement for some fucking reason
-
-// So you can be all 10 SECONDS
-#define SECONDS *10
-
-#define MINUTES *600
-
-#define HOURS *36000
-
-#define TICKS *world.tick_lag
-
-#define SECONDS_TO_LIFE_CYCLES /2
-
-#define DS2TICKS(DS) ((DS)/world.tick_lag)
-
-#define TICKS2DS(T) ((T) TICKS)
-
 /* This proc should only be used for world/Topic.
  * If you want to display the time for which dream daemon has been running ("round time") use worldtime2text.
  * If you want to display the canonical station "time" (aka the in-character time of the station) use station_time_timestamp

--- a/paradise.dme
+++ b/paradise.dme
@@ -135,6 +135,7 @@
 #include "code\__DEFINES\tgs.dm"
 #include "code\__DEFINES\tgui_defines.dm"
 #include "code\__DEFINES\tickets_defines.dm"
+#include "code\__DEFINES\time_defines.dm"
 #include "code\__DEFINES\tools_defines.dm"
 #include "code\__DEFINES\turfs.dm"
 #include "code\__DEFINES\typeids.dm"


### PR DESCRIPTION
## What Does This PR Do
Moves time defines to the defines folder

## Why It's Good For The Game
Time defines are loaded earlier than __HELPERS, so they can be used in it

## Testing
It's just moving the code

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<hr>

## Changelog
NPFC
