### PR TITLE
Begone combat paper stun!

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -158,7 +158,7 @@
 	if(user.zone_selected == "eyes")
 		user.visible_message("<span class='notice'>[user] holds up a paper and shows it to [H].</span>",
 			"<span class='notice'>You show the paper to [H].</span>")
-		to_chat(H, "<A href='byond://?src=[UID()];show_content=1'>Read \the [src]</A>")
+		to_chat(H, "<a href='byond://?src=[UID()];show_content=1'>Read \the [src]</a>")
 
 	else if(user.zone_selected == "mouth")
 		if(H == user)

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -156,15 +156,9 @@
 		return ..()
 	var/mob/living/carbon/human/H = M
 	if(user.zone_selected == "eyes")
-		user.visible_message("<span class='notice'>[user] begins to raise up \the [src] up to [H]'s face.</span>",
-				"<span class='notice'>You start to raise \the [src] up to [H]'s face.</span>")
-		if(do_after(user, 1 SECONDS, TRUE, src, allow_moving = FALSE, allow_moving_target = FALSE))
-			user.visible_message("<span class='notice'>[user] holds up a paper and shows it to [H].</span>",
-				"<span class='notice'>You show the paper to [H].</span>")
-			//show_content(H, forceshow = FALSE, view = FALSE)
-			to_chat(H, "<A href='byond://?src=[UID()];show_content=1'>Read \the [src]</A>")
-		else
-			to_chat(user, "<span class='notice'>I'm too far away from [H] to show them \the [src]!</span>")
+		user.visible_message("<span class='notice'>[user] holds up a paper and shows it to [H].</span>",
+			"<span class='notice'>You show the paper to [H].</span>")
+		to_chat(H, "<A href='byond://?src=[UID()];show_content=1'>Read \the [src]</A>")
 
 	else if(user.zone_selected == "mouth")
 		if(H == user)

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -156,9 +156,15 @@
 		return ..()
 	var/mob/living/carbon/human/H = M
 	if(user.zone_selected == "eyes")
-		user.visible_message("<span class='notice'>[user] holds up a paper and shows it to [H].</span>",
-			"<span class='notice'>You show the paper to [H].</span>")
-		H.examinate(src)
+		user.visible_message("<span class='notice'>[user] begins to raise up \the [src] up to [H]'s face.</span>",
+				"<span class='notice'>You start to raise \the [src] up to [H]'s face.</span>")
+		if(do_after(user, 1 SECONDS, TRUE, src, allow_moving = FALSE, allow_moving_target = FALSE))
+			user.visible_message("<span class='notice'>[user] holds up a paper and shows it to [H].</span>",
+				"<span class='notice'>You show the paper to [H].</span>")
+			//show_content(H, forceshow = FALSE, view = FALSE)
+			to_chat(H, "<A href='byond://?src=[UID()];show_content=1'>Read \the [src]</A>")
+		else
+			to_chat(user, "<span class='notice'>I'm too far away from [H] to show them \the [src]!</span>")
 
 	else if(user.zone_selected == "mouth")
 		if(H == user)
@@ -392,6 +398,12 @@
 		var/id = href_list["write"]
 		var/input_element = input("Enter what you want to write:", "Write") as message
 		topic_href_write(id, input_element)
+	if(href_list["show_content"])
+		var/dist = get_dist(src, usr)
+		if(dist < 2)
+			show_content(usr)
+		else
+			to_chat(usr, "<span class='notice'>I'm too far away from \the [src] to read it.</span>")
 
 /obj/item/paper/attackby__legacy__attackchain(obj/item/P, mob/living/user, params)
 	..()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Gives shoving paper in someone's face a prompt for the target in their chat to click to view the paper.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

Being able to force a pop up in combat, or in general, without a cooldown... was deemed bad gameplay design.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

<!-- How did you test the PR, if at all? -->

![image](https://github.com/user-attachments/assets/9d99877a-14b3-4836-b1c6-3b8df955f4e8)

https://github.com/user-attachments/assets/d6156308-68f1-4669-8205-ca818a6d99c8


<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: Aiming eyes with a piece of paper will no longer instantly open up a pop up browser that would cause the game to become unfocused. Gives the target a link in which they can click to read the paper.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
