### PR TITLE
Radiation collectors use plasma

### DIFF
--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -705,7 +705,7 @@ GLOBAL_PROTECT(AdminProcCallSpamPrevention)
 			if(!Rad.loaded_tank)
 				var/obj/item/tank/internals/plasma/Plasma = new/obj/item/tank/internals/plasma(Rad)
 				Plasma.air_contents.set_toxins(70)
-				Rad.drainratio = 0
+				Rad.drain_ratio = 0
 				Rad.loaded_tank = Plasma
 				Plasma.loc = Rad
 

--- a/code/modules/power/engines/singularity/collector.dm
+++ b/code/modules/power/engines/singularity/collector.dm
@@ -24,7 +24,7 @@
 	var/drain_ratio = 1
 
 	/// Amount of plasma to consume per joule generated.
-	var/drain_per_joule = 0.0000006
+	var/drain_per_joule = 0.00000007
 
 	/// Plasma consumption above this threshild in wats is doubled.
 	var/efficiency_threshold = 50000
@@ -120,7 +120,7 @@
 		// Therefore, its units are joules per SSmachines.wait * 0.1 seconds.
 		// So joules = stored_energy * SSmachines.wait * 0.1
 		var/joules = stored_energy * SSmachines.wait * 0.1
-		. += "<span class='notice'>[src]'s display states that it has stored <b>[DisplayJoules(joules)]</b>, and is processing <b>[DisplayPower(RAD_COLLECTOR_OUTPUT)]</b>.</span>"
+		. += "<span class='notice'>[src]'s display states that it has stored <b>[DisplayJoules(joules)]</b>, and is processing <b>[DisplayPower(RAD_COLLECTOR_OUTPUT)]</b>. Remaining plasma: [round(loaded_tank.air_contents.toxins(), 0.001)] mol</span>"
 	else
 		. += "<span class='notice'><b>[src]'s display displays the words:</b> \"Power production mode. Please insert <b>Plasma</b>.\"</span>"
 


### PR DESCRIPTION
## What Does This PR Do
Makes radiation collectors use (significant amounts of) plasma.

As configured, a basic N2 SM will run out of collector fuel around 1h40m after starting, by which point there should be plenty in the SMESes to coast for the rest of the round. An SM pushed up to around 5,000 EER, however, will need its plasma tanks loaded to capacity from a canister, and even then, will need to be refueled every 45 minutes or so.

Adds a line to the description of radiation collectors showing their remaining plasma.

(Yes, I'm aware it's possible to get past 45m without needing a refuel, but let's let people figure out how on their own for a bit.)

## Why It's Good For The Game
Although this is technically a bug fix (the var names implied that it should be multiplied by power generation--it just wasn't), the real reason for it is to make advanced SM setups less fire-and-forget. A basic setup will benefit slightly from filling the plasma tanks at the start of the round, but an advanced one generating lots of power will require regular refueling.

## Testing
Ran a N2 SM, waited for power production to stabilize, calculated plasma drain rate.
Ran a CO2 SM, waited for power production to stabilize, calculated plasma drain rate.
<hr>

### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

<hr>

## Changelog
:cl:
tweak: Radiation collectors will now consume their plasma at a noticeable rate, rather than a default tank being enough to last over 4 hours. A basic N2 SM will run out after around 1h40m, and it should be able to coast on SMES power for the remainder of an ordinary shift. A CO2 SM riding the boundary of 5,000 EER, however, will need to be refueled every 45 mins or so, even with plasma tanks filled from a canister.
/:cl: