### PR TITLE
[FIX] Scope runtime if user loses the tracker

### DIFF
--- a/code/datums/components/scope.dm
+++ b/code/datums/components/scope.dm
@@ -58,6 +58,8 @@
 	))
 
 /datum/component/scope/process()
+	if(!tracker)
+		return
 	var/mob/user_mob = tracker.owner
 	var/client/user_client = user_mob.client
 	if(!user_client)

--- a/code/datums/components/scope.dm
+++ b/code/datums/components/scope.dm
@@ -59,6 +59,7 @@
 
 /datum/component/scope/process()
 	if(!tracker)
+		STOP_PROCESSING(SSprojectiles, src)
 		return
 	var/mob/user_mob = tracker.owner
 	var/client/user_client = user_mob.client


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Stops the runtime in process() by checking if the tracker is valid before trying to get the owner.

Fixes #28165 

## Why It's Good For The Game

Runtimes are bad, validity checks are good.

## Testing

Tested on a local server, shoot myself which applied the knockdown. Did NOT runtime.

https://github.com/user-attachments/assets/7fb4149f-a3fb-4b10-aae1-132a167a2f50

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
