### PR TITLE
minor test fixture improvements

### DIFF
--- a/code/tests/_game_test.dm
+++ b/code/tests/_game_test.dm
@@ -17,6 +17,8 @@ GLOBAL_LIST_EMPTY(game_test_chats)
 
 #define TEST_ASSERT_LAST_CHATLOG(puppet, text) if(!puppet.last_chatlog_has_text(text)) { return Fail("Expected `[text]` in last chatlog but got `[puppet.get_last_chatlog()]`", __FILE__, __LINE__) }
 
+#define TEST_ASSERT_ANY_CHATLOG(puppet, text) if(!puppet.any_chatlog_has_text(text))  { return Fail("Expected `[text]` in any chatlog but got [jointext(puppet.get_chatlogs(), "\n")]", __FILE__, __LINE__) }
+
 /// Asserts that the two parameters passed are equal, fails otherwise
 /// Optionally allows an additional message in the case of a failure
 #define TEST_ASSERT_EQUAL(a, b, message) do { \

--- a/code/tests/_game_test_puppeteer.dm
+++ b/code/tests/_game_test_puppeteer.dm
@@ -52,9 +52,9 @@
 	var/datum/test_puppeteer/puppet_target = target
 	if(istype(puppet_target))
 		puppet.ClickOn(puppet_target.puppet, params)
-		return
+	else
+		puppet.ClickOn(target, params)
 
-	puppet.ClickOn(target, params)
 	puppet.next_click = world.time
 	puppet.next_move = world.time
 
@@ -94,13 +94,23 @@
 	puppet.rejuvenate()
 
 /datum/test_puppeteer/proc/get_last_chatlog()
-	if(!(puppet.mind.key in GLOB.game_test_chats))
-		return FALSE
-	var/list/puppet_chat_list = GLOB.game_test_chats[puppet.mind.key]
+	var/list/puppet_chat_list = get_chatlogs()
 	return puppet_chat_list[length(puppet_chat_list)]
 
 /datum/test_puppeteer/proc/last_chatlog_has_text(snippet)
 	return findtextEx(get_last_chatlog(), snippet)
+
+/datum/test_puppeteer/proc/any_chatlog_has_text(snippet)
+	for(var/chat_line in get_chatlogs())
+		if(findtextEx(chat_line, snippet))
+			return TRUE
+
+	return FALSE
+
+/datum/test_puppeteer/proc/get_chatlogs()
+	if(!(puppet.mind.key in GLOB.game_test_chats))
+		return FALSE
+	return GLOB.game_test_chats[puppet.mind.key]
 
 /datum/test_puppeteer/proc/find_nearby(atom_type)
 	for(var/turf/T in RANGE_TURFS(1, puppet))


### PR DESCRIPTION
## What Does This PR Do
This PR makes some small improvements to testing: allowing testers to check all chatlogs for a given string, and fixing a bug with click cooldown resetting for puppets.
## Why It's Good For The Game
Unblocks testers.
## Images
Example of the new assertion failing and printing out the whole chat log
![2025_01_31__15_27_56__data_test_run-2025-01-31T15_27_44 log - Paradise (Workspace) - Visual Studio Cod](https://github.com/user-attachments/assets/1a612610-638e-4ab6-b946-cccbdc3d6d9e)

## Testing
Ran test suite.

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

<hr>

## Changelog
NPFC