### PR TITLE
Port - Optimized ISODD/ISEVEN

### DIFF
--- a/code/__DEFINES/_math.dm
+++ b/code/__DEFINES/_math.dm
@@ -63,9 +63,9 @@
 
 #define ISABOUTEQUAL(a, b, deviation) (deviation ? abs((a) - (b)) <= deviation : abs((a) - (b)) <= 0.1)
 
-#define ISEVEN(x) (x % 2 == 0)
+#define ISEVEN(x) (!((x) & 1))
 
-#define ISODD(x) (x % 2 != 0)
+#define ISODD(x) ((x) & 1)
 
 // Returns true if val is from min to max, inclusive.
 #define ISINRANGE(val, min, max) (min <= val && val <= max)

--- a/code/__DEFINES/hud.dm
+++ b/code/__DEFINES/hud.dm
@@ -77,7 +77,7 @@
 
 /proc/ui_hand_position(i)
 	// values based on old hand ui positions (CENTER:-/+16,SOUTH:5)
-	var/x_off = i % 2 ? 0 : -1
+	var/x_off = ISODD(i) ? 0 : -1
 	var/y_off = round((i-1) / 2)
 	return"CENTER+[x_off]:16,SOUTH+[y_off]:5"
 

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -293,7 +293,7 @@
 		return copytext(new_message, 1, length + 1)
 	if(delta == 1)
 		return new_message + " "
-	if(delta % 2)
+	if(ISODD(delta))
 		new_message = " " + new_message
 		delta--
 	var/spaces = add_lspace("",delta/2-1)

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -268,7 +268,7 @@
 	f = round(f)
 	f = max(low, f)
 	f = min(high, f)
-	if((f % 2) == 0) //Ensure the last digit is an odd number
+	if(ISEVEN(f)) //Ensure the last digit is an odd number
 		f += 1
 	return f
 

--- a/code/datums/components/footstep.dm
+++ b/code/datums/components/footstep.dm
@@ -61,7 +61,7 @@
 	if(steps >= 6)
 		steps = 0
 
-	if(steps % 2)
+	if(ISODD(steps))
 		return
 
 	if(steps != 0 && !has_gravity(LM, T)) // don't need to step as often when you hop around

--- a/code/game/objects/effects/spawners/airlock_spawner.dm
+++ b/code/game/objects/effects/spawners/airlock_spawner.dm
@@ -83,12 +83,12 @@ This spawner places pipe leading up to the interior door, you will need to finis
 	var/obj/machinery/access_button/the_button = spawn_button(T, is_this_an_interior_airlock ? interior_direction : exterior_direction, is_this_an_interior_airlock)
 	if(one_door_only == DOOR_NORMAL_PLACEMENT) //We only need one door, we are done
 		return
-	if(!(tiles_in_x_direction % 2) && (is_this_an_interior_airlock && north_or_south_interior || !is_this_an_interior_airlock && north_or_south_exterior)) //Handle extra airlock for aesthetics
+	if(ISEVEN(tiles_in_x_direction) && (is_this_an_interior_airlock && north_or_south_interior || !is_this_an_interior_airlock && north_or_south_exterior)) //Handle extra airlock for aesthetics
 		A = new door_type(get_step(T, EAST))
 		handle_door_stuff(A, is_this_an_interior_airlock)
 		if(one_door_only == DOOR_FLIPPED_PLACEMENT)
 			the_button.forceMove(get_step(the_button, EAST))
-	else if(!(tiles_in_y_direction % 2) && (is_this_an_interior_airlock && !north_or_south_interior || !is_this_an_interior_airlock && !north_or_south_exterior)) //Handle extra airlock for aesthetics
+	else if(ISEVEN(tiles_in_y_direction) && (is_this_an_interior_airlock && !north_or_south_interior || !is_this_an_interior_airlock && !north_or_south_exterior)) //Handle extra airlock for aesthetics
 		A = new door_type(get_step(T, NORTH))
 		handle_door_stuff(A, is_this_an_interior_airlock)
 		if(one_door_only == DOOR_FLIPPED_PLACEMENT)

--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -293,7 +293,7 @@ GLOBAL_LIST_EMPTY(safes)
 			for(var/i = 1 to ticks)
 				dial = WRAP(dial - 1, 0, 100)
 
-				var/invalid_turn = current_tumbler_index % 2 == 0 || current_tumbler_index > number_of_tumblers
+				var/invalid_turn = ISEVEN(current_tumbler_index) || current_tumbler_index > number_of_tumblers
 				if(invalid_turn) // The moment you turn the wrong way or go too far, the tumblers reset
 					current_tumbler_index = 1
 
@@ -313,7 +313,7 @@ GLOBAL_LIST_EMPTY(safes)
 			for(var/i = 1 to ticks)
 				dial = WRAP(dial + 1, 0, 100)
 
-				var/invalid_turn = current_tumbler_index % 2 != 0 || current_tumbler_index > number_of_tumblers
+				var/invalid_turn = ISODD(current_tumbler_index) || current_tumbler_index > number_of_tumblers
 				if(invalid_turn) // The moment you turn the wrong way or go too far, the tumblers reset
 					current_tumbler_index = 1
 

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -234,7 +234,7 @@ RESTRICT_TYPE(/datum/antagonist/traitor)
 			if(freq < 1451 || freq > 1459)
 				freqlist += freq
 			freq += 2
-			if((freq % 2) == 0)
+			if(ISEVEN(freq))
 				freq += 1
 		freq = pick(freqlist)
 

--- a/code/modules/mob/living/carbon/carbon_life.dm
+++ b/code/modules/mob/living/carbon/carbon_life.dm
@@ -46,7 +46,7 @@
 
 //Start of a breath chain, calls breathe()
 /mob/living/carbon/handle_breathing(times_fired)
-	if(times_fired % 2 == 1)
+	if(ISODD(times_fired))
 		var/datum/milla_safe/carbon_breathe/milla = new()
 		milla.invoke_async(src)
 	else

--- a/code/modules/procedural_mapping/mapGenerator.dm
+++ b/code/modules/procedural_mapping/mapGenerator.dm
@@ -44,7 +44,7 @@
 
 	//Even sphere correction engage
 	var/offByOneOffset = 1
-	if(bigZ % 2 == 0)
+	if(ISEVEN(bigZ))
 		offByOneOffset = 0
 
 	for(var/i = lilZ, i <= bigZ+offByOneOffset, i++)

--- a/code/modules/ruins/lavalandruin_code/puzzle.dm
+++ b/code/modules/ruins/lavalandruin_code/puzzle.dm
@@ -104,7 +104,7 @@
 			if(current_ordering[j] < checked_value)
 				swap_tally++
 
-	return swap_tally % 2 == 0
+	return ISEVEN(swap_tally)
 
 //swap two tiles in same row
 /obj/effect/sliding_puzzle/proc/make_solvable()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Ports https://github.com/BeeStation/BeeStation-Hornet/pull/10504

The tl;dr of it is that doing a modulo calculation to see if a number is odd/even is expensive, when you can just check the first bit for the same result. This also replaces all `mod 2` evaluations with the defines as there were some confusing usage of it. Some places make very frequent use of it.

## Why It's Good For The Game
Faster, makes me not go insane.

## Images of changes
![math](https://github.com/user-attachments/assets/1b7dad85-cb78-469b-9835-19081c3b8809)

## Testing
https://discord.com/channels/145533722026967040/727448459862343711/1334903958577348742
Ran a session and checked the files that had changes (i.e. mob atmos, safe cracking, footsteps, etc)

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog
NPFC

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
