### PR TITLE
Puppet test activate_self wrapper and negative any_chatlog check

### DIFF
--- a/code/tests/_game_test.dm
+++ b/code/tests/_game_test.dm
@@ -19,6 +19,8 @@ GLOBAL_LIST_EMPTY(game_test_chats)
 
 #define TEST_ASSERT_ANY_CHATLOG(puppet, text) if(!puppet.any_chatlog_has_text(text))  { return Fail("Expected `[text]` in any chatlog but got [jointext(puppet.get_chatlogs(), "\n")]", __FILE__, __LINE__) }
 
+#define TEST_ASSERT_NOT_CHATLOG(puppet, text) if(puppet.any_chatlog_has_text(text))  { return Fail("Didn't expect `[text]` in any chatlog but got [jointext(puppet.get_chatlogs(), "\n")]", __FILE__, __LINE__) }
+
 /// Asserts that the two parameters passed are equal, fails otherwise
 /// Optionally allows an additional message in the case of a failure
 #define TEST_ASSERT_EQUAL(a, b, message) do { \

--- a/code/tests/_game_test_puppeteer.dm
+++ b/code/tests/_game_test_puppeteer.dm
@@ -48,6 +48,16 @@
 
 	origin_test.Fail("could not spawn obj [obj_type] near [src]")
 
+/datum/test_puppeteer/proc/use_item_in_hand()
+	var/obj/item/item = puppet.get_active_hand()
+	if(!item)
+		origin_test.Fail("could not find obj in [puppet] active hand", __FILE__, __LINE__)
+		return
+
+	item.activate_self(puppet)
+	puppet.next_click = world.time
+	puppet.next_move = world.time
+
 /datum/test_puppeteer/proc/click_on(target, params)
 	var/datum/test_puppeteer/puppet_target = target
 	if(istype(puppet_target))

--- a/code/tests/_game_test_puppeteer.dm
+++ b/code/tests/_game_test_puppeteer.dm
@@ -51,12 +51,12 @@
 /datum/test_puppeteer/proc/use_item_in_hand()
 	var/obj/item/item = puppet.get_active_hand()
 	if(!item)
-		origin_test.Fail("could not find obj in [puppet] active hand", __FILE__, __LINE__)
 		return
 
 	item.activate_self(puppet)
 	puppet.next_click = world.time
 	puppet.next_move = world.time
+	return TRUE
 
 /datum/test_puppeteer/proc/click_on(target, params)
 	var/datum/test_puppeteer/puppet_target = target


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds an activate_self wrapper and a negative check for any_chatlog for game tests,

Taking suggestions for their naming cause I suck at it!
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Could wind up useful for game tests
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
Negative any_chatlog check
![Code_i9kYhWjWIa](https://github.com/user-attachments/assets/7ac35656-a466-43f1-8937-0dfd04c339a3)

failed activate_self check
![image](https://github.com/user-attachments/assets/9150c043-b36e-4bba-a59a-816c049af1b3)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
checked that they run and that they fail.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog
NPFC
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
