### PR TITLE
Adds a mindshield to the Head of Personnel.

### DIFF
--- a/code/game/gamemodes/dynamic/antag_rulesets.dm
+++ b/code/game/gamemodes/dynamic/antag_rulesets.dm
@@ -33,8 +33,8 @@
 		"Nanotrasen Career Trainer",
 		"Nanotrasen Navy Officer",
 		"Special Operations Officer",
-		"Trans-Solar Federation General"
-        "Head of Personnel"
+		"Trans-Solar Federation General",
+        "Head of Personnel",
 	)
 	/// Applies the mind roll to assigned_role, preventing them from rolling a normal job. Good for wizards and nuclear operatives.
 	var/assign_job_role = FALSE

--- a/code/game/gamemodes/dynamic/antag_rulesets.dm
+++ b/code/game/gamemodes/dynamic/antag_rulesets.dm
@@ -34,6 +34,7 @@
 		"Nanotrasen Navy Officer",
 		"Special Operations Officer",
 		"Trans-Solar Federation General"
+        "Head of Personnel"
 	)
 	/// Applies the mind roll to assigned_role, preventing them from rolling a normal job. Good for wizards and nuclear operatives.
 	var/assign_job_role = FALSE

--- a/code/game/jobs/job/supervisor.dm
+++ b/code/game/jobs/job/supervisor.dm
@@ -122,7 +122,7 @@
 		/obj/item/melee/classic_baton/telescopic = 1
 	)
 
-	bio_chips = list()
+	bio_chips = list(/obj/item/bio_chip/mindshield)
 
 /datum/job/nanotrasenrep
 	title = "Nanotrasen Representative"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

This PR adds a mindshield to the Head of Personnel.

## Why It's Good For The Game

This PR is a less extreme version of https://github.com/ParadiseSS13/Paradise/pull/28173 which removed ALL command from being eligible to roll roundstart. But I don't think that it's fair. Most command antag complaints have been towards HoP antag, which is yeah, antag on easy mode, and RD with the reactive armor, but that's not the scope of this PR. There are barely any complaints about CE, QM, CMO antags. And ICly, to mindshield the next in line for command + AA makes a lot of sense for NT. Most of the command antag fishing is done on HoP.

## Images of changes

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing

Loaded in as HoP. Put on sec huds. Saw that I have a mindshield.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
 I don´t know if THAT counts, but the ´no command antag´ PR was approved. This is just a less extreme version of that.
<hr>

## Changelog

:cl:
add: A mindshield to the HoP.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
