### PR TITLE
Migrates `/obj/item/borg/stun` to the new attack chain.

### DIFF
--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -17,17 +17,17 @@ Keeping it in for adminabuse but the malf one is /obj/item/melee/baton/borg_stun
 
 /obj/item/borg/stun/attack(mob/living/target, mob/living/silicon/robot/user, params)
 	if(..())
-		return
+		return FINISH_ATTACK
 
 	if(ishuman(target))
 		var/mob/living/carbon/human/H = target
 		if(H.check_shields(src, 0, "[target]'s [name]", MELEE_ATTACK))
 			playsound(target, 'sound/weapons/genhit.ogg', 50, 1)
-			return FALSE
+			return FINISH_ATTACK
 
 	if(isrobot(user))
 		if(!user.cell.use(charge_cost))
-			return TRUE
+			return FINISH_ATTACK
 
 	user.do_attack_animation(target)
 	target.Weaken(10 SECONDS)

--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -12,25 +12,29 @@ Keeping it in for adminabuse but the malf one is /obj/item/melee/baton/borg_stun
 /obj/item/borg/stun
 	name = "electrically-charged arm"
 	icon_state = "elecarm_active"
+	new_attack_chain = TRUE
 	var/charge_cost = 30
 
-/obj/item/borg/stun/attack__legacy__attackchain(mob/living/M, mob/living/silicon/robot/user)
-	if(ishuman(M))
-		var/mob/living/carbon/human/H = M
-		if(H.check_shields(src, 0, "[M]'s [name]", MELEE_ATTACK))
-			playsound(M, 'sound/weapons/genhit.ogg', 50, 1)
-			return 0
+/obj/item/borg/stun/attack(mob/living/target, mob/living/silicon/robot/user, params)
+	if (..())
+		return
+
+	if(ishuman(target))
+		var/mob/living/carbon/human/H = target
+		if(H.check_shields(src, 0, "[target]'s [name]", MELEE_ATTACK))
+			playsound(target, 'sound/weapons/genhit.ogg', 50, 1)
+			return FALSE
 
 	if(isrobot(user))
 		if(!user.cell.use(charge_cost))
-			return
+			return TRUE
 
-	user.do_attack_animation(M)
-	M.Weaken(10 SECONDS)
-	M.apply_effect(STUTTER, 10 SECONDS)
+	user.do_attack_animation(target)
+	target.Weaken(10 SECONDS)
+	target.apply_effect(STUTTER, 10 SECONDS)
 
-	M.visible_message("<span class='danger'>[user] has prodded [M] with [src]!</span>", \
+	target.visible_message("<span class='danger'>[user] has prodded [target] with [src]!</span>", \
 					"<span class='userdanger'>[user] has prodded you with [src]!</span>")
 
 	playsound(loc, 'sound/weapons/egloves.ogg', 50, TRUE, -1)
-	add_attack_logs(user, M, "Stunned with [src] ([uppertext(user.a_intent)])")
+	add_attack_logs(user, target, "Stunned with [src] ([uppertext(user.a_intent)])")

--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -22,7 +22,7 @@ Keeping it in for adminabuse but the malf one is /obj/item/melee/baton/borg_stun
 	if(ishuman(target))
 		var/mob/living/carbon/human/H = target
 		if(H.check_shields(src, 0, "[target]'s [name]", MELEE_ATTACK))
-			playsound(target, 'sound/weapons/genhit.ogg', 50, 1)
+			playsound(target, 'sound/weapons/genhit.ogg', 50, TRUE)
 			return FINISH_ATTACK
 
 	if(isrobot(user))

--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -16,7 +16,7 @@ Keeping it in for adminabuse but the malf one is /obj/item/melee/baton/borg_stun
 	var/charge_cost = 30
 
 /obj/item/borg/stun/attack(mob/living/target, mob/living/silicon/robot/user, params)
-	if (..())
+	if(..())
 		return
 
 	if(ishuman(target))


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Title.

No player-facing changes.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Attack chain migration good.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Stunned some skrell with the stun arm, it functioned as before.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
