### PR TITLE
Kill some jerks

### DIFF
--- a/code/controllers/subsystem/movement/movement_types.dm
+++ b/code/controllers/subsystem/movement/movement_types.dm
@@ -135,7 +135,10 @@
 	if(flags & MOVEMENT_LOOP_IGNORE_GLIDE)
 		return
 
-	moving.set_glide_size(MOVEMENT_ADJUSTED_GLIDE_SIZE(delay, visual_delay))
+	var/glide_multiplier = visual_delay
+	if(IS_DIR_DIAGONAL(get_dir(old_loc, moving.loc)) && !(moving.appearance_flags & LONG_GLIDE))
+		glide_multiplier *= sqrt(2)
+	moving.set_glide_size(MOVEMENT_ADJUSTED_GLIDE_SIZE(delay, glide_multiplier))
 
 ///Handles the actual move, overriden by children
 ///Returns FALSE if nothing happen, TRUE otherwise

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -418,9 +418,18 @@
 	return TRUE
 
 /// Called when src is being moved to a target turf because another movable (puller) is moving around.
-/atom/movable/proc/move_from_pull(atom/movable/puller, turf/target_turf, glide_size_override)
+/atom/movable/proc/move_from_pull(atom/movable/puller, turf/target_turf, puller_glide_size)
 	moving_from_pull = puller
-	Move(target_turf, get_dir(src, target_turf), glide_size_override)
+	var/new_glide_size = puller_glide_size
+	var/pull_dir = get_dir(src, target_turf)
+	// Adjust diagonal pulls for LONG_GLIDE differences.
+	if(IS_DIR_DIAGONAL(pull_dir))
+		if((puller.appearance_flags & LONG_GLIDE) && !(appearance_flags & LONG_GLIDE))
+			new_glide_size *= sqrt(2)
+		if(!(puller.appearance_flags & LONG_GLIDE) && (appearance_flags & LONG_GLIDE))
+			new_glide_size /= sqrt(2)
+	set_glide_size(new_glide_size)
+	Move(target_turf, pull_dir)
 	moving_from_pull = null
 
 // Make sure you know what you're doing if you call this

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -613,30 +613,12 @@
 	if(restrained() || HAS_TRAIT(src, TRAIT_CANNOT_PULL))
 		stop_pulling()
 
-	var/turf/old_loc = loc
 	. = ..()
 	if(.)
 		step_count++
-		pull_pulled(old_loc, pullee, glide_size_override)
 
 	if(s_active && !(s_active in contents) && get_turf(s_active) != get_turf(src))	//check !( s_active in contents) first so we hopefully don't have to call get_turf() so much.
 		s_active.close(src)
-
-/mob/living/proc/pull_pulled(turf/dest, atom/movable/pullee, glide_size_override)
-	if(pulling && pulling == pullee) // we were pulling a thing and didn't lose it during our move.
-		if(pulling.anchored)
-			stop_pulling()
-			return
-
-		var/pull_dir = get_dir(src, pulling)
-		if(get_dist(src, pulling) > 1 || (moving_diagonally != SECOND_DIAG_STEP && ((pull_dir - 1) & pull_dir))) // puller and pullee more than one tile away or in diagonal position
-			if(isliving(pulling))
-				var/mob/living/M = pulling
-				if(IS_HORIZONTAL(M) && !M.buckled && (prob(M.getBruteLoss() * 200 / M.maxHealth))) // So once you reach 50 brute damage you hit 100% chance to leave a blood trail for every tile you're pulled
-					M.makeTrail(dest)
-			pulling.Move(dest, get_dir(pulling, dest), glide_size_override) // the pullee tries to reach our previous position
-			if(pulling && get_dist(src, pulling) > 1) // the pullee couldn't keep up
-				stop_pulling()
 
 /mob/living/proc/makeTrail(turf/turf_to_trail_on)
 	if(!has_gravity(src))

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -142,8 +142,16 @@
 		if(!isalienhunter(mob)) // i hate grab code
 			add_delay += 7
 
-	var/new_glide_size = DELAY_TO_GLIDE_SIZE(add_delay * ((NSCOMPONENT(direct) && EWCOMPONENT(direct)) ? sqrt(2) : 1))
-	mob.set_glide_size(new_glide_size) // set it now in case of pulled objects
+	var/diagonal_factor = 1
+	if(IS_DIR_DIAGONAL(direct))
+		// For some reason, LONG_GLIDE mobs need to slow down here, but other mobs need to speed up.
+		// I'd expect one or the other to change, not both.
+		// If you can figure out why, please update this comment.
+		if(mob.appearance_flags & LONG_GLIDE)
+			diagonal_factor = sqrt(2)
+		else
+			diagonal_factor = 1 / sqrt(2)
+	mob.set_glide_size(DELAY_TO_GLIDE_SIZE(add_delay * diagonal_factor)) // set it now in case of pulled objects
 
 	//If the move was recent, count using old_move_delay
 	//We want fractional behavior and all
@@ -179,22 +187,28 @@
 
 	. = ..()
 
+	var/new_glide_size = 0
+	// Only adjust for diagonal movement if the move was *actually* diagonal
 	if(mob.loc == new_loc)
+		// Similar to the glide size calculation above, LONG_GLIDE mobs need to slow down and other mobs speed up.
+		// Unline before, we also want to calculate the new movement delay, which is increased for LONG_GLIDE mobs, and unchanged for other mobs.
 		mob.last_movement = world.time
-		if(IS_DIR_DIAGONAL(direct))
-			// only incur the extra delay if the move was *actually* diagonal
-			// There would be a bit of visual jank if we try to walk diagonally next to a wall
-			// and the move ends up being cardinal, rather than diagonal,
-			// but that's better than it being jank on every *successful* diagonal move.
+		if(IS_DIR_DIAGONAL(direct) && (mob.appearance_flags & LONG_GLIDE))
 			add_delay *= sqrt(2)
 
-	var/after_glide = 0
-	if(visual_delay)
-		after_glide = visual_delay
-	else
-		after_glide = DELAY_TO_GLIDE_SIZE(add_delay)
+		if(visual_delay)
+			new_glide_size = visual_delay
+		else
+			new_glide_size = DELAY_TO_GLIDE_SIZE(add_delay)
 
-	mob.set_glide_size(after_glide)
+		if(IS_DIR_DIAGONAL(direct) && !(mob.appearance_flags & LONG_GLIDE))
+			new_glide_size *= sqrt(2)
+
+		mob.set_glide_size(new_glide_size)
+	else if(visual_delay)
+		mob.set_glide_size(visual_delay)
+	else
+		mob.set_glide_size(DELAY_TO_GLIDE_SIZE(add_delay))
 
 	move_delay += add_delay
 


### PR DESCRIPTION
## What Does This PR Do
Removes a bunch of jerky movement from diagonals surrounding LONG_GLIDE, see changelog.

## Why It's Good For The Game
Everybody hates jerks. Especially visual ones.

## Testing
Pulled a human with a human.
Pulled a crab with a human.
Pulled a human with a crab.
Pulled a crab with a crab.
Tossed an item next to me in space so it drifted slowly.
<hr>

### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

<hr>

## Changelog

:cl:
fix: Atoms without LONG_GLIDE (most things that aren't humanoid) no longer jerk around when pulled by mobs with LONG_GLIDE or while drifting diagonally in space.
fix: Mobs without LONG_GLIDE no longer have a jerky camera when moving diagonally.
fix: Mobs with LONG_GLIDE no longer jerk around when pulled by mobs without LONG_GLIDE.
/:cl: