### PR TITLE
fix reagent containers not transferring into protolathes or circuit imprinters

### DIFF
--- a/code/modules/research/circuitprinter.dm
+++ b/code/modules/research/circuitprinter.dm
@@ -83,7 +83,7 @@ using metal and glass, it uses glass and reagents (usually sulfuric acis).
 		return ITEM_INTERACT_COMPLETE
 
 	if(used.is_open_container())
-		return ITEM_INTERACT_COMPLETE
+		return ITEM_INTERACT_SKIP_TO_AFTER_ATTACK
 
 	return ..()
 

--- a/code/modules/research/protolathe.dm
+++ b/code/modules/research/protolathe.dm
@@ -91,7 +91,7 @@ Note: Must be placed west/left of and R&D console to function.
 		return ITEM_INTERACT_COMPLETE
 
 	if(used.is_open_container())
-		return ITEM_INTERACT_COMPLETE
+		return ITEM_INTERACT_SKIP_TO_AFTER_ATTACK
 
 	return ..()
 

--- a/code/tests/attack_chain/test_attack_chain_machinery.dm
+++ b/code/tests/attack_chain/test_attack_chain_machinery.dm
@@ -158,3 +158,14 @@
 	player.retrieve(screwdriver)
 	player.click_on(firealarm_frame)
 	TEST_ASSERT_LAST_CHATLOG(player, "You close the panel")
+	player.put_away(screwdriver)
+
+	var/obj/protolathe = teleport_to_first(player, /obj/machinery/r_n_d/protolathe)
+	var/obj/item/reagent_containers/bottle = player.spawn_obj_in_hand(/obj/item/reagent_containers/glass/bottle/ammonia)
+	player.click_on(protolathe)
+	TEST_ASSERT_LAST_CHATLOG(player, "You transfer 10 units of the solution to Protolathe.")
+
+	var/obj/imprinter = teleport_to_first(player, /obj/machinery/r_n_d/circuit_imprinter)
+	bottle.amount_per_transfer_from_this = 5
+	player.click_on(imprinter)
+	TEST_ASSERT_LAST_CHATLOG(player, "You transfer 5 units of the solution to Circuit Imprinter.")


### PR DESCRIPTION
## What Does This PR Do
This PR fixes reagent containers not transferring reagents into protolathes or circuit imprinters.
## Why It's Good For The Game
Bugfix.
## Testing
New tests added to suite.
<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<hr>

## Changelog

:cl:
fix: Beakers and other containers properly transfer reagents to protolathes and circuit imprinters.
/:cl: