### PR TITLE
Headrev sechud is now an implant

### DIFF
--- a/code/modules/antagonists/revolutionary/datum_headrev.dm
+++ b/code/modules/antagonists/revolutionary/datum_headrev.dm
@@ -46,9 +46,9 @@ RESTRICT_TYPE(/datum/antagonist/rev/head)
 		to_chat(revolutionary, "The flash in your [flashloc_name] will help you to persuade the crew to join your cause.")
 
 	if(give_hud)
-		var/obj/item/clothing/glasses/hud/security/chameleon/C = new(get_turf(revolutionary))
-		var/hudloc_name = revolutionary.equip_in_one_of_slots(C, slots)
-		to_chat(revolutionary, "The chameleon security HUD in your [hudloc_name] will help you keep track of who is mindshield-implanted, and unable to be recruited.")
+		var/obj/item/organ/internal/cyberimp/eyes/hud/security/hidden/O = new /obj/item/organ/internal/cyberimp/eyes/hud/security/hidden
+		O.insert(revolutionary)
+		to_chat(revolutionary, "The security HUD implant in your head will help you keep track of who is mindshield-implanted, and unable to be recruited.")
 
 	revolutionary.update_icons()
 	return flashloc_name

--- a/code/modules/surgery/organs/augments_eyes.dm
+++ b/code/modules/surgery/organs/augments_eyes.dm
@@ -61,6 +61,9 @@
 	HUD_type = DATA_HUD_SECURITY_ADVANCED
 	examine_extensions = list(EXAMINE_HUD_SECURITY_READ)
 
+/obj/item/organ/internal/cyberimp/eyes/hud/security/hidden
+	stealth_level = 4 // Only surgery or a body scanner with the highest tier of stock parts can detect this.
+
 /obj/item/organ/internal/cyberimp/eyes/hud/jani
 	name = "Janitor HUD implant"
 	desc = "These cybernetic eye implants will display a filth HUD over everything you see."


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->
Headrev sechud is now an implant instead of chameleon security sunglasses. They lose their flash protection. The implant cannot be seen on bodyscanners (unless they're tier 4, or they use surgery).

## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Getting your glasses checked is unfun, mindshielding should be the way to tell if theyre a headrev.

## Testing

<!-- How did you test the PR, if at all? -->
made myself a headrev, got the implant

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  
![image](https://github.com/user-attachments/assets/e7f267e4-03be-49d4-b63e-ec3933d2e570)

  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
tweak: Headrev sechud is now a hidden implant instead of chameleon security sunglasses. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
