### PR TITLE
Feature: Clown recycler, a new Cmag effect

### DIFF
--- a/code/datums/spells/banana_touch.dm
+++ b/code/datums/spells/banana_touch.dm
@@ -80,7 +80,7 @@
 	Stuttering(30 SECONDS)
 	do_jitter_animation(30 SECONDS)
 
-	var/obj/item/tank/internal_tank = src.internal
+	var/obj/item/tank/internal_tank = internal
 	var/obj/item/clothing/mask/gas/clown_hat/clown_mask = new()
 	var/obj/item/clothing/under/rank/civilian/clown/clown_suit = new()
 	var/obj/item/clothing/shoes/clown_shoes/clown_shoes = new()

--- a/code/datums/spells/banana_touch.dm
+++ b/code/datums/spells/banana_touch.dm
@@ -86,8 +86,3 @@
 	equip_to_slot_if_possible(new /obj/item/clothing/under/rank/civilian/clown, ITEM_SLOT_JUMPSUIT, TRUE, TRUE)
 	equip_to_slot_if_possible(new /obj/item/clothing/shoes/clown_shoes, ITEM_SLOT_SHOES, TRUE, TRUE)
 	equip_to_slot_if_possible(new /obj/item/clothing/mask/gas/clown_hat, ITEM_SLOT_MASK, TRUE, TRUE)
-
-	dna.SetSEState(GLOB.clumsyblock, TRUE, TRUE)
-	dna.SetSEState(GLOB.comicblock, TRUE, TRUE)
-	singlemutcheck(src, GLOB.clumsyblock, MUTCHK_FORCED)
-	singlemutcheck(src, GLOB.comicblock, MUTCHK_FORCED)

--- a/code/datums/spells/banana_touch.dm
+++ b/code/datums/spells/banana_touch.dm
@@ -80,9 +80,29 @@
 	Stuttering(30 SECONDS)
 	do_jitter_animation(30 SECONDS)
 
+	var/obj/item/tank/internal_tank = src.internal
+	var/obj/item/clothing/mask/gas/clown_hat/clown_mask = new()
+	var/obj/item/clothing/under/rank/civilian/clown/clown_suit = new()
+	var/obj/item/clothing/shoes/clown_shoes/clown_shoes = new()
+	clown_mask.flags |= DROPDEL
+	clown_suit.flags |= DROPDEL
+	clown_shoes.flags |= DROPDEL
+
 	drop_item_to_ground(shoes, force = TRUE)
 	drop_item_to_ground(wear_mask, force = TRUE)
 	drop_item_to_ground(w_uniform, force = TRUE)
-	equip_to_slot_if_possible(new /obj/item/clothing/under/rank/civilian/clown, ITEM_SLOT_JUMPSUIT, TRUE, TRUE)
-	equip_to_slot_if_possible(new /obj/item/clothing/shoes/clown_shoes, ITEM_SLOT_SHOES, TRUE, TRUE)
-	equip_to_slot_if_possible(new /obj/item/clothing/mask/gas/clown_hat, ITEM_SLOT_MASK, TRUE, TRUE)
+	if(isplasmaman(src))
+		drop_item_to_ground(head, force = TRUE)
+		var/obj/item/clothing/head/helmet/space/plasmaman/clown/clown_helmet = new()
+		clown_suit = new /obj/item/clothing/under/plasmaman/clown
+		clown_helmet.flags |= DROPDEL
+		clown_suit.flags |= DROPDEL
+		equip_to_slot_if_possible(clown_helmet, ITEM_SLOT_HEAD, TRUE, TRUE)
+	equip_to_slot_if_possible(clown_suit, ITEM_SLOT_JUMPSUIT, TRUE, TRUE)
+	equip_to_slot_if_possible(clown_shoes, ITEM_SLOT_SHOES, TRUE, TRUE)
+	equip_to_slot_if_possible(clown_mask, ITEM_SLOT_MASK, TRUE, TRUE)
+
+	// Re-equips the internal tank if present
+	equip_to_appropriate_slot(internal_tank)
+	src.internal = internal_tank
+

--- a/code/datums/spells/banana_touch.dm
+++ b/code/datums/spells/banana_touch.dm
@@ -83,9 +83,9 @@
 	drop_item_to_ground(shoes, force = TRUE)
 	drop_item_to_ground(wear_mask, force = TRUE)
 	drop_item_to_ground(w_uniform, force = TRUE)
-	equip_to_slot_if_possible(new /obj/item/clothing/under/rank/civilian/clown/nodrop, ITEM_SLOT_JUMPSUIT, TRUE, TRUE)
-	equip_to_slot_if_possible(new /obj/item/clothing/shoes/clown_shoes/nodrop, ITEM_SLOT_SHOES, TRUE, TRUE)
-	equip_to_slot_if_possible(new /obj/item/clothing/mask/gas/clown_hat/nodrop, ITEM_SLOT_MASK, TRUE, TRUE)
+	equip_to_slot_if_possible(new /obj/item/clothing/under/rank/civilian/clown, ITEM_SLOT_JUMPSUIT, TRUE, TRUE)
+	equip_to_slot_if_possible(new /obj/item/clothing/shoes/clown_shoes, ITEM_SLOT_SHOES, TRUE, TRUE)
+	equip_to_slot_if_possible(new /obj/item/clothing/mask/gas/clown_hat, ITEM_SLOT_MASK, TRUE, TRUE)
 
 	dna.SetSEState(GLOB.clumsyblock, TRUE, TRUE)
 	dna.SetSEState(GLOB.comicblock, TRUE, TRUE)

--- a/code/datums/spells/banana_touch.dm
+++ b/code/datums/spells/banana_touch.dm
@@ -72,3 +72,22 @@
 	if(!(iswizard(src) || (mind && mind.special_role == SPECIAL_ROLE_WIZARD_APPRENTICE))) //Mutations are permanent on non-wizards. Can still be removed by genetics fuckery but not mutadone.
 		dna.default_blocks.Add(GLOB.clumsyblock)
 		dna.default_blocks.Add(GLOB.comicblock)
+
+/// Like bananatouched, but intended to be used for funny one-off scenarios which aren't meant to permanently cripple someone's round.
+/mob/living/carbon/human/proc/bananatouched_harmless()
+	to_chat(src, "<font color='red' size='6'>HONK</font>")
+	Weaken(14 SECONDS)
+	Stuttering(30 SECONDS)
+	do_jitter_animation(30 SECONDS)
+
+	drop_item_to_ground(shoes, force = TRUE)
+	drop_item_to_ground(wear_mask, force = TRUE)
+	drop_item_to_ground(w_uniform, force = TRUE)
+	equip_to_slot_if_possible(new /obj/item/clothing/under/rank/civilian/clown/nodrop, ITEM_SLOT_JUMPSUIT, TRUE, TRUE)
+	equip_to_slot_if_possible(new /obj/item/clothing/shoes/clown_shoes/nodrop, ITEM_SLOT_SHOES, TRUE, TRUE)
+	equip_to_slot_if_possible(new /obj/item/clothing/mask/gas/clown_hat/nodrop, ITEM_SLOT_MASK, TRUE, TRUE)
+
+	dna.SetSEState(GLOB.clumsyblock, TRUE, TRUE)
+	dna.SetSEState(GLOB.comicblock, TRUE, TRUE)
+	singlemutcheck(src, GLOB.clumsyblock, MUTCHK_FORCED)
+	singlemutcheck(src, GLOB.comicblock, MUTCHK_FORCED)

--- a/code/datums/spells/banana_touch.dm
+++ b/code/datums/spells/banana_touch.dm
@@ -104,5 +104,5 @@
 
 	// Re-equips the internal tank if present
 	equip_to_appropriate_slot(internal_tank)
-	src.internal = internal_tank
+	internal = internal_tank
 

--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -190,7 +190,8 @@
 		playsound(loc, 'sound/machines/buzz-sigh.ogg', 50, 0)
 		return
 	var/mob/living/carbon/human/victim = L
-	victim.bananatouched_harmless()
+	playsound(src, 'sound/items/AirHorn.ogg', 100, TRUE, -1)
+	victim.bananatouched()
 
 /obj/machinery/recycler/proc/crush_living(mob/living/L)
 

--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -49,7 +49,10 @@
 	. = ..()
 	. += "<span class='notice'>The power light is [(stat & NOPOWER) ? "<b>off</b>" : "<b>on</b>"]."
 	. += "The operation light is [emergency_mode ? "<b>off</b>. [src] has detected a forbidden object with its sensors, and has shut down temporarily." : "<b>on</b>. [src] is active."]"
-	. += "The safety sensor light is [emagged ? "<b>off</b>!" : "<b>on</b>."]</span>"
+	if(HAS_TRAIT(src, TRAIT_CMAGGED))
+		. += "The safety sensor light is <font color=red>R</font><font color=green>G</font><font color=blue>B</font>.</span>"
+	else
+		. += "The safety sensor light is [emagged ? "<b>off</b>!" : "<b>on</b>."]</span>"
 	. += "The recycler current accepts items from [dir2text(eat_dir)]."
 
 /obj/machinery/recycler/power_change()
@@ -77,9 +80,23 @@
 	if(default_unfasten_wrench(user, I, time = 6 SECONDS))
 		return TRUE
 
-
+/obj/machinery/recycler/cmag_act(mob/user)
+	if(emagged)
+		to_chat(user, "<span class='warning'>The board is completely fried.</span>")
+		return
+	if(!HAS_TRAIT(src, TRAIT_CMAGGED))
+		ADD_TRAIT(src, TRAIT_CMAGGED, CLOWN_EMAG)
+		if(emergency_mode)
+			emergency_mode = FALSE
+			update_icon(UPDATE_ICON_STATE)
+		playsound(src, "sparks", 75, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
+		to_chat(user, "<span class='notice'>You use the jestographic sequencer on [src].</span>")
+		return TRUE
 
 /obj/machinery/recycler/emag_act(mob/user)
+	if(HAS_TRAIT(src, TRAIT_CMAGGED))
+		to_chat(user, "<span class='warning'>The access panel is coated in yellow ooze...</span>")
+		return
 	if(!emagged)
 		emagged = TRUE
 		if(emergency_mode)
@@ -127,6 +144,8 @@
 		else if(isliving(AM))
 			if(emagged)
 				crush_living(AM)
+			else if(HAS_TRAIT(src, TRAIT_CMAGGED))
+				bananafication(AM)
 			else
 				emergency_stop(AM)
 		else if(isitem(AM))
@@ -164,6 +183,14 @@
 	playsound(loc, 'sound/machines/ping.ogg', 50, 0)
 	emergency_mode = FALSE
 	update_icon(UPDATE_ICON_STATE)
+
+/obj/machinery/recycler/proc/bananafication(mob/living/L)
+	L.loc = loc
+	if(!iscarbon(L))
+		playsound(loc, 'sound/machines/buzz-sigh.ogg', 50, 0)
+		return
+	var/mob/living/carbon/human/victim = L
+	victim.bananatouched_harmless()
 
 /obj/machinery/recycler/proc/crush_living(mob/living/L)
 

--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -83,7 +83,7 @@
 /obj/machinery/recycler/cmag_act(mob/user)
 	if(emagged)
 		to_chat(user, "<span class='warning'>The board is completely fried.</span>")
-		return
+		return FALSE
 	if(!HAS_TRAIT(src, TRAIT_CMAGGED))
 		ADD_TRAIT(src, TRAIT_CMAGGED, CLOWN_EMAG)
 		if(emergency_mode)
@@ -96,7 +96,7 @@
 /obj/machinery/recycler/emag_act(mob/user)
 	if(HAS_TRAIT(src, TRAIT_CMAGGED))
 		to_chat(user, "<span class='warning'>The access panel is coated in yellow ooze...</span>")
-		return
+		return FALSE
 	if(!emagged)
 		emagged = TRUE
 		if(emergency_mode)

--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -191,7 +191,7 @@
 		return
 	var/mob/living/carbon/human/victim = L
 	playsound(src, 'sound/items/AirHorn.ogg', 100, TRUE, -1)
-	victim.bananatouched()
+	victim.bananatouched_harmless()
 
 /obj/machinery/recycler/proc/crush_living(mob/living/L)
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds a cmag effect to the recycler, which utilizes a variant of the `banantouched()` proc called `bananatouched_harmless()`
Made a new proc, alternative to `bananatouched()` called `bananatouched_harmless()`. It's identical in idea, but omits some of the more round crippling effects that the original proc has.
Added dropdel variants of the clown clothes, which will be used to equip the recycled clown.
Recycler emag and cmag are now mutually exclusive. You cannot cmag an emagged recycler and vice versa.

Process goes, cmag recycler, someone falls in, they get stripped off their uniform, shoes, mask and if plasmaman, helmet. Their original belongings drop under the recycler (where they won't be deleted). They get equipped with enough dropdel clown clothing that they won't burn up or look naked. If they have internals, their tank will snap into the best available slot and turn itself on.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Because funi. Also, more possible uses for the cmag. Kinda fit's the goofy sorta stuff a cmag would do.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
https://github.com/user-attachments/assets/b26b54c4-b155-4fdb-b8a4-aab04734f8b8

![dreamseeker_tRaqqPYZCT](https://github.com/user-attachments/assets/845c622c-3f9f-49be-9ace-644b79e6f5b7)



<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Emagged it and tried cmagging it.
Cmagged it and tried emagging it.
Went through while it's cmagged.
Went through with a modsuit while it's cmagged.
Went through it as a plasmaman with an internals tank. The internals tank snapped onto me immediately.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
add: recycler can now be cmagged, dressing people who fall into it like a clown.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
