### PR TITLE
Fixes Cyborg Gripper Disposal Bin Interaction

### DIFF
--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -124,7 +124,20 @@
 
 // attack by item places it in to disposal
 /obj/machinery/disposal/item_interaction(mob/living/user, obj/item/used, list/modifiers)
-	if(stat & BROKEN || !user || used.flags & ABSTRACT)
+	if(stat & BROKEN || !user)
+		return ITEM_INTERACT_COMPLETE
+
+	// Borg gripper check here because it is an `ABSTRACT` item.
+	if(istype(used, /obj/item/gripper))
+		var/obj/item/gripper/gripper = used
+		if(!gripper.gripped_item)
+			to_chat(user, "<span class='warning'>There's nothing in your gripper to throw away!</span>")
+			return ITEM_INTERACT_COMPLETE
+
+		// Gripper will cancel the attack and call `item_interaction()` with the held item.
+		return ..()
+
+	if(used.flags & ABSTRACT)
 		return ITEM_INTERACT_COMPLETE
 
 	if(user.a_intent != INTENT_HELP)
@@ -153,22 +166,6 @@
 			S.update_icon() // For content-sensitive icons
 			update()
 			return ITEM_INTERACT_COMPLETE
-
-	// Borg using their gripper to throw stuff away.
-	if(istype(used, /obj/item/gripper))
-		var/obj/item/gripper/gripper = used
-		// Gripper is empty.
-		if(!gripper.gripped_item)
-			to_chat(user, "<span class='warning'>There's nothing in your gripper to throw away!</span>")
-			return ITEM_INTERACT_COMPLETE
-
-		gripper.gripped_item.forceMove(src)
-		user.visible_message(
-			"<span class='notice'>[user] places [gripper.gripped_item] into the disposal unit.</span>",
-			"<span class='notice'>You place [gripper.gripped_item] into the disposal unit.</span>",
-			"<span class='notice'>You hear someone dropping something into a disposal unit.</span>"
-		)
-		return ITEM_INTERACT_COMPLETE
 
 	// Someone has a mob in a grab.
 	var/obj/item/grab/G = used


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Cyborg grippers can drop stuff into disposals again.

Removes some now-redundant code.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Bug fix good.
Removing duplicated code bad (thank you new attack chain).
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Dropped stuff into disposals with gripper.
Tried to drop empty gripper.

<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: Cyborg gripper can drop stuff into disposals again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
