### PR TITLE
No VV/proccall click runtime

### DIFF
--- a/code/modules/admin/verbs/modifyvariables.dm
+++ b/code/modules/admin/verbs/modifyvariables.dm
@@ -607,8 +607,7 @@ GLOBAL_PROTECT(VVmaint_only)
 
 /client/proc/prompt_for_atom_click(prompt = "Click something!")
 	to_chat(src, "<span class='notice big'>[prompt]</span>")
-	var/datum/click_intercept/pick_atom/picker = new()
-	click_intercept = picker
+	var/datum/click_intercept/pick_atom/picker = new(src)
 	while(isnull(picker.picked))
 		if(isnull(src) || click_intercept != picker)
 			return null


### PR DESCRIPTION
## What Does This PR Do
Fixes a runtime when using VV/proccall's new "click an atom" feature.

## Why It's Good For The Game
Runtimes bad.

## Testing
Made a die rainbow glow. No runtime.
<hr>

### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

<hr>

## Changelog
NPFC