### PR TITLE
Spiderlings on move_manager

### DIFF
--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -111,8 +111,8 @@
 
 /obj/structure/spider/spiderling/Destroy()
 	STOP_PROCESSING(SSobj, src)
-	// Release possible ref if a walk is still being processed
-	walk_to(src, 0)
+	// Cancel our movement.
+	GLOB.move_manager.stop_looping(src)
 	entry_vent = null
 	if(amount_grown < 100)
 		new /obj/effect/decal/cleanable/spiderling_remains(get_turf(src))
@@ -175,7 +175,7 @@
 		for(var/obj/machinery/atmospherics/unary/vent_pump/v in view(7,src))
 			if(!v.welded)
 				entry_vent = v
-				walk_to(src, entry_vent, 1)
+				GLOB.move_manager.home_onto(src, entry_vent, 1, 10)
 				break
 	if(isturf(loc))
 		amount_grown += rand(0,2)
@@ -214,7 +214,7 @@
 		available_turfs += S
 	if(!length(available_turfs))
 		return FALSE
-	walk_to(src, pick(available_turfs))
+	GLOB.move_manager.home_onto(src, pick(available_turfs), 1, 10)
 	return TRUE
 
 /obj/structure/spider/spiderling/decompile_act(obj/item/matter_decompiler/C, mob/user)


### PR DESCRIPTION
## What Does This PR Do
Moves spiderlings from walk_to to move_manager.home_onto
Likely fixes #28223

## Why It's Good For The Game
Bugs bad
(Well, except the spiderlings themselves)

## Testing
Spawned a bunch of spiderlings in the garden, watched them scurry about.
It looks pretty funky without #28242, but it does work.
<hr>

### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

<hr>

## Changelog
:cl:
fix: Hopefully fixes spiderlings twitching like mad sometimes.
/:cl: