### PR TITLE
Vended items land on the vendor again

### DIFF
--- a/code/game/machinery/vendors/vending.dm
+++ b/code/game/machinery/vendors/vending.dm
@@ -904,7 +904,9 @@
 /obj/machinery/economy/vending/proc/do_vend(datum/data/vending_product/R, mob/user, put_in_hands = TRUE)
 	var/vended = R.vend(loc)
 	if(put_in_hands && isliving(user) && istype(vended, /obj/item) && Adjacent(user))
-		user.put_in_hands(vended)
+		// Try the active hand first, then the inactive hand, and leave it here if both fail
+		if(!user.put_in_active_hand(vended))
+			user.put_in_inactive_hand(vended)
 	return vended
 
 /* Example override for do_vend proc:


### PR DESCRIPTION
## What Does This PR Do
Vended items land on the vendor again, rather than falling to the floor under the user.

## Why It's Good For The Game
No hiding items under me, please.

## Testing
Vended three items with left hand active. First in left hand, second in right hand, third on the vendor.
Vended three items with right hand active. First in right hand, second in left hand, third on the vendor.
<hr>

### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

<hr>

## Changelog
:cl:
fix: Vending an item with your hands full will leave it on the vendor, rather than the floor under you.
/:cl: