### PR TITLE
Refactors how revenants spawn

### DIFF
--- a/code/game/gamemodes/miniantags/revenant/revenant.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant.dm
@@ -133,13 +133,14 @@
 /mob/living/simple_animal/revenant/Initialize(mapload)
 	. = ..()
 	if(!mapload)
-		var/built_name = ""
+		var/list/built_name = list()
 		built_name += pick(strings(REVENANT_NAME_FILE, "spirit_type"))
 		built_name += " of "
 		built_name += pick(strings(REVENANT_NAME_FILE, "adjective"))
 		built_name += pick(strings(REVENANT_NAME_FILE, "theme"))
-		name = built_name
-		real_name = built_name
+		var/combined_name = built_name.Join("")
+		name = combined_name
+		real_name = combined_name
 
 	flags_2 |= RAD_NO_CONTAMINATE_2
 	remove_from_all_data_huds()
@@ -147,7 +148,7 @@
 	RegisterSignal(src, COMSIG_BODY_TRANSFER_TO, PROC_REF(make_revenant_antagonist))
 
 /mob/living/simple_animal/revenant/proc/make_revenant_antagonist(revenant)
-	SIGNAL_HANDLER
+	SIGNAL_HANDLER // COMSIG_BODY_TRANSFER_TO
 	mind.assigned_role = SPECIAL_ROLE_REVENANT
 	mind.special_role = SPECIAL_ROLE_REVENANT
 	giveObjectivesandGoals()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Refactors the spawning of revenants, so they dont wait 15 seconds to give spells and abilities when you spawn
Mostly copied from how pulse demon spawns

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
It waiting how it did was seemingly for if admins manually spawned a revenant? which is a decent idea in theory, but im unsure as to why an admin would be manually spawning a revenant to give to ghosts, over using the event manager. 
it waiting an entire 15 seconds has confused me personally multiple times when i've rolled it, so i can imagine it'd confuse others too
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
Forced a revenant event, got the spells and objectives.
Manually spawned a revenant, got spells, didn't get objectives, however this is consistent with all the other midrounds(excluding humanoids) that have objectives so im counting it as working as intended:tm:
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
tweak: Revenants no longer wait for 15 seconds to give the ghost their abilities and objectives.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
