### PR TITLE
Fixes a bug with tend wounds

### DIFF
--- a/code/modules/surgery/tending.dm
+++ b/code/modules/surgery/tending.dm
@@ -83,9 +83,6 @@
 	if(brute_damage_healed == 0 && burn_damage_healed == 0)
 		stack_trace("A healing surgery was given no healing values.")
 		return FALSE
-	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	if(affected.is_broken())
-		return FALSE
 
 	return (brute_damage_healed && target.get_damage_amount(BRUTE) || burn_damage_healed && target.get_damage_amount(BURN))
 

--- a/code/modules/surgery/tending.dm
+++ b/code/modules/surgery/tending.dm
@@ -112,7 +112,7 @@
 
 	if(!can_be_healed(user, target, target_zone))
 		to_chat(user, "<span class='notice'>It doesn't look like [target] has any more [damage_name_pretty].</span>")
-		return SURGERY_BEGINSTEP_SKIP
+		return SURGERY_STEP_CONTINUE
 
 	var/brute_healed = brute_damage_healed
 	var/burn_healed = burn_damage_healed


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes a bug with tend wounds surgeries that I didn't notice until it went in. You can now properly perform tend wounds.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Mechanics should work, sorry!
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
they did surgery on a vulp
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: tend wounds surgery should now work properly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
