### PR TITLE
Better atmos init

### DIFF
--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -1,8 +1,3 @@
-/turf/simulated/Initialize(mapload)
-	. = ..()
-	if(!blocks_air)
-		blind_set_air(get_initial_air())
-
 /turf/simulated/proc/get_initial_air()
 	var/datum/gas_mixture/air = new()
 	if(!blocks_air)
@@ -47,8 +42,12 @@
 		temperature -= heat/heat_capacity
 		sharer.temperature += heat/sharer.heat_capacity
 
-/turf/simulated/proc/update_visuals()
-	var/datum/gas_mixture/air = get_readonly_air()
+/turf/simulated/proc/update_visuals(use_initial_air = FALSE)
+	var/datum/gas_mixture/air
+	if(use_initial_air)
+		air = get_initial_air()
+	else
+		air = get_readonly_air()
 	var/new_overlay_type = tile_graphic(air)
 	if(new_overlay_type == atmos_overlay_type)
 		return
@@ -176,6 +175,10 @@
 	var/list/connectivity = private_unsafe_recalculate_atmos_connectivity()
 	var/list/air = list(oxygen, carbon_dioxide, nitrogen, toxins, sleeping_agent, agent_b, temperature)
 	milla_data = connectivity[1] + list(atmos_mode, SSmapping.environments[atmos_environment]) +  air + connectivity[2]
+
+/turf/simulated/Initialize_Atmos(milla_tick)
+	..()
+	update_visuals(TRUE)
 
 /turf/proc/recalculate_atmos_connectivity()
 	var/datum/milla_safe/recalculate_atmos_connectivity/milla = new()

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -104,6 +104,9 @@ GLOBAL_LIST_INIT(aalarm_modes, list(
 
 	var/report_danger_level = TRUE
 
+	/// Which MILLA tick were we initialized at?
+	var/init_tick
+
 /obj/machinery/alarm/monitor
 	report_danger_level = FALSE
 
@@ -232,6 +235,8 @@ GLOBAL_LIST_INIT(aalarm_modes, list(
 	if(!building)
 		first_run()
 
+	init_tick = SSair.milla_tick
+
 /obj/machinery/alarm/Destroy()
 	SStgui.close_uis(wires)
 	GLOB.air_alarms -= src
@@ -246,7 +251,7 @@ GLOBAL_LIST_INIT(aalarm_modes, list(
 	GLOB.air_alarm_repository.update_cache(src)
 
 /obj/machinery/alarm/process()
-	if((stat & (NOPOWER|BROKEN)) || shorted || buildstage != 2)
+	if((stat & (NOPOWER|BROKEN)) || shorted || buildstage != 2 || init_tick == SSair.milla_tick)
 		return
 
 	var/turf/simulated/location = loc


### PR DESCRIPTION
## What Does This PR Do
Removes an unnecessary `blind_set_air` on turf init.
Makes air alarms not fire until a MILLA tick has passed.
Makes roundstart N2O/plasma visible.

## Why It's Good For The Game
Correctness good, unnecessary work bad.

## Testing
Started game. Saw stuff in atmos tanks. Air alarms didn't panic about lack of air.
<hr>

### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

<hr>

## Changelog
:cl:
fix: The Shadow should no longer randomly have its fire alarms triggered.
fix: Roundstart N2O/plasma is now visible.
/:cl: