### PR TITLE
Gives guardians/holoparas lowlight vision

### DIFF
--- a/code/game/gamemodes/miniantags/guardian/guardian.dm
+++ b/code/game/gamemodes/miniantags/guardian/guardian.dm
@@ -12,6 +12,8 @@
 	icon_living = "magicOrange"
 	icon_dead = "magicOrange"
 	speed = 0
+	lighting_alpha = LIGHTING_PLANE_ALPHA_NV_TRAIT
+	see_in_dark = 2
 	mob_biotypes = NONE
 	a_intent = INTENT_HARM
 	can_change_intents = FALSE

--- a/code/game/gamemodes/miniantags/guardian/guardian.dm
+++ b/code/game/gamemodes/miniantags/guardian/guardian.dm
@@ -12,7 +12,7 @@
 	icon_living = "magicOrange"
 	icon_dead = "magicOrange"
 	speed = 0
-	lighting_alpha = LIGHTING_PLANE_ALPHA_NV_TRAIT
+	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
 	see_in_dark = 2
 	mob_biotypes = NONE
 	a_intent = INTENT_HARM


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Gives holoparas/guardians the same level of lowlight as humans, so they can see a tile around them in the dark
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
They have no lowlight at all currently, and its incredibly frustrating when your summoner /does/, so if they're in the dark, with NVGs or something, you're stuck looking at basically nothing as you using your light would also reveal your summonee. 
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
before:
![dreamseeker_tms6V954we](https://github.com/user-attachments/assets/1eabee58-e43a-48cc-90cf-33fa97343864)

after:
![image](https://github.com/user-attachments/assets/b4822129-999b-46d0-9757-027e464767cf)

human vision to compare:
![image](https://github.com/user-attachments/assets/82729f9b-4630-4eac-85db-c3f34d2f8a2c)

While the holopara can technically see more better, they can only see tiles the human can too, i believe theres an issue with how the darkness hud is applied to non carbons, im not sure.
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
see above
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
![Discord_qP6w0a1Z8m](https://github.com/user-attachments/assets/9348c845-9348-40fa-89bf-2522468e149a)

  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
tweak: Holoparasites/guardians now have very minor lowlight vision, comparable to standard humans. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
