### PR TITLE
remove functional cult pylons from derelict2

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/derelict2.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/derelict2.dmm
@@ -85,7 +85,7 @@
 /turf/template_noop,
 /area/space/nearstation)
 "q" = (
-/obj/structure/cult/functional/pylon,
+/obj/structure/cult/pylon,
 /turf/simulated/floor/plasteel,
 /area/ruin/space/powered)
 "r" = (


### PR DESCRIPTION
## What Does This PR Do
This PR removes the functional cult pylons from derelict2.dmm.
## Why It's Good For The Game
On cult rounds these functional pylons will cause structural corruption, making it immediately obvious that it's a cult round.
## Testing
Visual inspection.

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
tweak: The Dinner For 2 ruin no longer uses actual cult pylons for decoration.
/:cl:
