### PR TITLE
Reduces Juggernaut laser resistance

### DIFF
--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -141,7 +141,7 @@
 /mob/living/simple_animal/hostile/construct/armoured/bullet_act(obj/item/projectile/P)
 	if(P.is_reflectable(REFLECTABILITY_ENERGY))
 		if(P.damage_type == BRUTE || P.damage_type == BURN)
-			adjustBruteLoss(P.damage * 0.6) // 21 hit with security laser gun
+			adjustBruteLoss(P.damage * 0.8) // ?? hit with security laser gun
 			P.on_hit(src)
 			return FALSE
 	return ..()

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -141,7 +141,7 @@
 /mob/living/simple_animal/hostile/construct/armoured/bullet_act(obj/item/projectile/P)
 	if(P.is_reflectable(REFLECTABILITY_ENERGY))
 		if(P.damage_type == BRUTE || P.damage_type == BURN)
-			adjustBruteLoss(P.damage * 0.8) // ?? hit with security laser gun
+			adjustBruteLoss(P.damage * 0.8) // 16 hit with security laser gun
 			P.on_hit(src)
 			return FALSE
 	return ..()


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Reduces the laser resistance of juggernauts from 0.6 x damage to 0.8 x damage. 
Shots to kill moved from 21 to 16.

## Why It's Good For The Game

Juggernauts are in a funny place. Melee is incredibly impractical with them and they're very very resistant to lasers, so their mere existence practically requires autorifles. But those autorifles are also very effective against the rest of cult, meaning that if sec orders autorifles early, cult can generally be stomped pretty easily.

Here's the range of problems I see:

**Sec orders Autorifles early to handle Juggs:**
Cult can be stomped very easy due to how powerful autorifles are, especially at countering Flag Robes (instant bone-breaks go brrt) and Mirror Shields.

**Sec doesn't immediately order Autorifles to handle Juggs:**
Juggs can pretty easily stomp sec by just rushing Brig, if Sec only has lasers they're really really bad at actually killing Juggs due to high melee resistance and good damage. Once sec is stomped, cult can run amok.

The goal of this PR is to reduce the immediate need to order autorifles against cult, preventing early cult stomps, by ensuring that sec isn't just immediately pulverized by juggs for not doing so. Ideally, this would result in sec ordering autorifles _as needed_, instead of simply being necessary if they don't want to be immediately stomped.

Shots to kill being 16 still places this above one full charge of a laser gun (12 shots), so Juggernauts aren't immediately squishy (especially considering not all shots will land), and WT's are still slightly better than Lasers (13 shots to kill instead of 16), but considering that's changing from a difference of 13 vs 21, it should be a lot closer and not _quite_ as necessary to instantly get ballistics for constructs.

## Testing

Spawned in, shot Jugg with lasers on a few different values of resistance, settled for *0.8 after discussion with Silverplate. Tried with WT to ensure this didn't change the damage for that, it remains at 13 shots. Fun fact - Constructs are invisible on non-cult rounds due to not having a specific cult to pull the icon from. Go figure.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

![image](https://github.com/user-attachments/assets/3f903309-b45d-449a-a022-35becdbd5b81)


## Changelog

:cl:
tweak: Juggernaut Constructs are now slightly less resistant to lasers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
