### PR TITLE
Reduced dynamic budget at low player count

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -27,8 +27,7 @@ GLOBAL_LIST_EMPTY(dynamic_forced_rulesets)
 	to_chat(world, "<b>Possible Rulesets:</b> [english_list(possible_rulesets)]")
 
 /// Calculates the dynamic budget based on the number of players in the round
-/datum/game_mode/dynamic/proc/calculate_budget()
-	var/players = num_players()
+/datum/game_mode/dynamic/proc/calculate_budget(var/players)
 	switch(players)
 		if(0 to 4)
 			// Flat budget of 7
@@ -47,7 +46,7 @@ GLOBAL_LIST_EMPTY(dynamic_forced_rulesets)
 
 /datum/game_mode/dynamic/proc/allocate_ruleset_budget()
 	var/ruleset_budget = text2num(GLOB.dynamic_forced_rulesets["budget"] || pickweight(list("0" = 3, "1" = 8, "2" = 12, "3" = 3)))
-	antag_budget = calculate_budget()
+	antag_budget = calculate_budget(num_players())
 	log_dynamic("Allocated gamemode budget: [ruleset_budget]")
 	var/list/possible_rulesets = list()
 	for(var/datum/ruleset/ruleset as anything in subtypesof(/datum/ruleset))

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -27,7 +27,7 @@ GLOBAL_LIST_EMPTY(dynamic_forced_rulesets)
 	to_chat(world, "<b>Possible Rulesets:</b> [english_list(possible_rulesets)]")
 
 /// Calculates the dynamic budget based on the number of players in the round
-/datum/game_mode/dynamic/proc/calculate_budget(var/players)
+/datum/game_mode/dynamic/proc/calculate_budget(players)
 	switch(players)
 		if(0 to 4)
 			// Flat budget of 7

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -3,7 +3,7 @@ GLOBAL_LIST_EMPTY(dynamic_forced_rulesets)
 /datum/game_mode/dynamic
 	name = "Dynamic"
 	config_tag = "dynamic"
-	required_players = 10
+	required_players = 0
 	/// Non-implied rulesets in play
 	var/list/datum/ruleset/rulesets = list()
 	/// Implied rulesets that are in play
@@ -26,9 +26,28 @@ GLOBAL_LIST_EMPTY(dynamic_forced_rulesets)
 			possible_rulesets |= ruleset.implied_ruleset_type.name
 	to_chat(world, "<b>Possible Rulesets:</b> [english_list(possible_rulesets)]")
 
+/// Calculates the dynamic budget based on the number of players in the round
+/datum/game_mode/dynamic/proc/calculate_budget()
+	var/players = num_players()
+	switch(players)
+		if(0 to 4)
+			// Flat budget of 7
+			return 7
+		if(5 to 20)
+			// +0.5 budget each for players 5-20
+			// Cumulative total at 20 players: 15
+			return 7 + 0.5 * (players - 4)
+		if(21 to 30)
+			// +1.5 budget each for players 21 to 30
+			// Cumulative total at 30 players: 30
+			return 15 + 1.5 * (players - 20)
+		else
+			// +1 budget each for players 31+, so just player count.
+			return players
+
 /datum/game_mode/dynamic/proc/allocate_ruleset_budget()
 	var/ruleset_budget = text2num(GLOB.dynamic_forced_rulesets["budget"] || pickweight(list("0" = 3, "1" = 8, "2" = 12, "3" = 3)))
-	antag_budget = num_players()
+	antag_budget = calculate_budget()
 	log_dynamic("Allocated gamemode budget: [ruleset_budget]")
 	var/list/possible_rulesets = list()
 	for(var/datum/ruleset/ruleset as anything in subtypesof(/datum/ruleset))

--- a/code/tests/game_tests.dm
+++ b/code/tests/game_tests.dm
@@ -21,6 +21,7 @@
 #include "test_components.dm"
 #include "test_config_sanity.dm"
 #include "test_crafting_lists.dm"
+#include "test_dynamic_budget.dm"
 #include "test_elements.dm"
 #include "test_emotes.dm"
 #include "test_init_sanity.dm"

--- a/code/tests/test_dynamic_budget.dm
+++ b/code/tests/test_dynamic_budget.dm
@@ -12,4 +12,4 @@
 	TEST_ASSERT_EQUAL(dynamic.calculate_budget(30), 30, "Midpop budget incorrect.")
 
 	TEST_ASSERT_EQUAL(dynamic.calculate_budget(31), 31, "Highpop budget incorrect.")
-	TEST_ASSERT_EQUAL(dynamic.calculate_budget(100),1001, "Highpop budget incorrect.")
+	TEST_ASSERT_EQUAL(dynamic.calculate_budget(100), 100, "Highpop budget incorrect.")

--- a/code/tests/test_dynamic_budget.dm
+++ b/code/tests/test_dynamic_budget.dm
@@ -1,0 +1,15 @@
+/datum/game_test/dynamic_budget/Run()
+	var/datum/game_mode/dynamic/dynamic = new()
+
+	// If calculate_budgets updates, and these need to change to match, the pattern is to put an assert at the beginning and end of each distinct range of players (with 100 here standing in for a non-existent upper limit).
+	TEST_ASSERT_EQUAL(dynamic.calculate_budget(0), 7, "Flat budget incorrect.")
+	TEST_ASSERT_EQUAL(dynamic.calculate_budget(4), 7, "Flat budget incorrect.")
+
+	TEST_ASSERT_EQUAL(dynamic.calculate_budget(5), 7.5, "Lowpop budget incorrect.")
+	TEST_ASSERT_EQUAL(dynamic.calculate_budget(20), 15, "Lowpop budget incorrect.")
+
+	TEST_ASSERT_EQUAL(dynamic.calculate_budget(21), 16.5, "Midpop budget incorrect.")
+	TEST_ASSERT_EQUAL(dynamic.calculate_budget(30), 30, "Midpop budget incorrect.")
+
+	TEST_ASSERT_EQUAL(dynamic.calculate_budget(31), 31, "Highpop budget incorrect.")
+	TEST_ASSERT_EQUAL(dynamic.calculate_budget(100),1001, "Highpop budget incorrect.")


### PR DESCRIPTION
## What Does This PR Do
Makes dynamic usable below 10 players.
Scales back dynamic budget below 30 players. Previously, it was always 1 per player. Now:
* Flat budget of 7
* +0 budget each for players 1-4
* +0.5 budget each for players 5-20 (cumulative total 15)
* +1.5 budget each for players 21-30 (cumulative total 30)
* +1 budget each for players 31+

**Breakpoints:**
* 7 always: 1 tot
* 10 @ 10 players: 1 tot/cling/vamp/flayer
* 14 @ 18 players: 2 tots
* 17 @ 22 players: 1 tot, 1 cling/vamp/flayer
* 21 @ 24 players: 2 clings/vamps/flayers OR 3 tots
* 24 @ 26 players: 2 tots, 1 cling/vamp/flayer OR 2 clings/vamps/flayers OR 3 tots
* 27 @ 28 players: 1 tot, 2 clings/vamps/flayers OR 3 tots
* 28 @ 29 players: 1 tot, 2 clings/vamps/flayers OR 4 tots 
* 30+ players: as before

## Why It's Good For The Game
Lowpop antagonists are pretty brutal. This scales them back a bit, so that the crew has a better chance.

Also, dynamic includes extended, so having a min of 10 meant <10 players forced autotot.

## Testing
code/tests/test_dynamic_budget.dm
<hr>

### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

![image](https://github.com/user-attachments/assets/d244ecc6-0ccd-4566-ab48-f0d037a13cd1)
<hr>

## Changelog
:cl:
tweak: Dynamic can now roll below 10 players.
tweak: Dynamic budget has been reduced below 30 players, with a minimum of 7 (one traitor).
/:cl: