### PR TITLE
Adds tiny fans to all emergency shuttles

### DIFF
--- a/_maps/map_files/shuttles/emergency_bar.dmm
+++ b/_maps/map_files/shuttles/emergency_bar.dmm
@@ -161,6 +161,7 @@
 	id_tag = "s_docking_airlock";
 	name = "Shuttle Hatch"
 	},
+/obj/structure/fans/tiny,
 /turf/simulated/floor/plating,
 /area/shuttle/escape)
 "aJ" = (
@@ -240,6 +241,7 @@
 	id_tag = "s_docking_airlock";
 	name = "Shuttle Hatch"
 	},
+/obj/structure/fans/tiny,
 /turf/simulated/floor/plating,
 /area/shuttle/escape)
 "aU" = (

--- a/_maps/map_files/shuttles/emergency_clown.dmm
+++ b/_maps/map_files/shuttles/emergency_clown.dmm
@@ -183,6 +183,7 @@
 	id_tag = "s_docking_airlock";
 	name = "Shuttle Hatch"
 	},
+/obj/structure/fans/tiny,
 /turf/simulated/floor/plating,
 /area/shuttle/escape)
 "aQ" = (
@@ -225,6 +226,7 @@
 	id_tag = "s_docking_airlock";
 	name = "Shuttle Hatch"
 	},
+/obj/structure/fans/tiny,
 /turf/simulated/floor/plating,
 /area/shuttle/escape)
 "aU" = (
@@ -258,6 +260,7 @@
 	id_tag = "s_docking_airlock";
 	name = "Shuttle Hatch"
 	},
+/obj/structure/fans/tiny,
 /turf/simulated/floor/noslip,
 /area/shuttle/escape)
 "bb" = (

--- a/_maps/map_files/shuttles/emergency_cramped.dmm
+++ b/_maps/map_files/shuttles/emergency_cramped.dmm
@@ -36,6 +36,7 @@
 	id_tag = "s_docking_airlock";
 	name = "Shuttle Hatch"
 	},
+/obj/structure/fans/tiny,
 /turf/simulated/floor/plating,
 /area/shuttle/escape)
 "m" = (
@@ -75,6 +76,7 @@
 	name = "Secure Transport Vessel 5";
 	timid = 1
 	},
+/obj/structure/fans/tiny,
 /turf/simulated/floor/plating,
 /area/shuttle/escape)
 "r" = (

--- a/_maps/map_files/shuttles/emergency_cyb.dmm
+++ b/_maps/map_files/shuttles/emergency_cyb.dmm
@@ -406,6 +406,7 @@
 	id_tag = "s_docking_airlock";
 	name = "Shuttle Hatch"
 	},
+/obj/structure/fans/tiny,
 /turf/simulated/floor/plating,
 /area/shuttle/escape)
 "bp" = (
@@ -500,6 +501,7 @@
 	timid = 1;
 	width = 29
 	},
+/obj/structure/fans/tiny,
 /turf/simulated/floor/plating,
 /area/shuttle/escape)
 "bE" = (
@@ -768,9 +770,7 @@
 /obj/machinery/door/airlock/medical/glass{
 	name = "Escape Shuttle Infirmary"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "cm" = (

--- a/_maps/map_files/shuttles/emergency_dept.dmm
+++ b/_maps/map_files/shuttles/emergency_dept.dmm
@@ -444,6 +444,7 @@
 	id_tag = "s_docking_airlock";
 	name = "Shuttle Hatch"
 	},
+/obj/structure/fans/tiny,
 /turf/simulated/floor/plasteel,
 /area/shuttle/escape)
 "bp" = (

--- a/_maps/map_files/shuttles/emergency_jungle.dmm
+++ b/_maps/map_files/shuttles/emergency_jungle.dmm
@@ -277,6 +277,7 @@
 	id_tag = "s_docking_airlock";
 	name = "Shuttle Hatch"
 	},
+/obj/structure/fans/tiny,
 /turf/simulated/floor/mineral/plastitanium/red/brig{
 	icon_state = "wood"
 	},
@@ -814,13 +815,6 @@
 /obj/structure/barricade/wooden,
 /turf/simulated/floor/grass,
 /area/shuttle/escape)
-"Mb" = (
-/obj/machinery/door/airlock/wood{
-	id_tag = "s_docking_airlock";
-	name = "Shuttle Hatch"
-	},
-/turf/simulated/floor/grass,
-/area/shuttle/escape)
 "NA" = (
 /obj/structure/flora/junglebush/large,
 /turf/simulated/floor/grass,
@@ -886,9 +880,9 @@ ac
 ac
 ac
 ab
-Mb
+bi
 ab
-Mb
+bi
 ab
 ab
 ac

--- a/_maps/map_files/shuttles/emergency_meta.dmm
+++ b/_maps/map_files/shuttles/emergency_meta.dmm
@@ -15,6 +15,7 @@
 	name = "Emergency Shuttle Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/structure/fans/tiny,
 /turf/simulated/floor/plating,
 /area/shuttle/escape)
 "ah" = (
@@ -26,6 +27,7 @@
 	id_tag = "s_docking_airlock";
 	name = "Emergency Shuttle Airlock"
 	},
+/obj/structure/fans/tiny,
 /turf/simulated/floor/plating,
 /area/shuttle/escape)
 "am" = (
@@ -789,6 +791,7 @@
 	id_tag = "s_docking_airlock";
 	name = "Emergency Shuttle Airlock"
 	},
+/obj/structure/fans/tiny,
 /turf/simulated/floor/plating,
 /area/shuttle/escape)
 "FM" = (
@@ -798,6 +801,13 @@
 /area/shuttle/escape)
 "Rk" = (
 /turf/simulated/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"SW" = (
+/obj/machinery/door/airlock/external{
+	name = "Emergency Recovery Airlock"
+	},
+/obj/structure/fans/tiny,
+/turf/simulated/floor/plating,
 /area/shuttle/escape)
 
 (1,1,1) = {"
@@ -878,7 +888,7 @@ bp
 bp
 bp
 bp
-bq
+SW
 "}
 (6,1,1) = {"
 ac
@@ -894,7 +904,7 @@ bq
 ab
 bp
 bp
-bq
+SW
 "}
 (7,1,1) = {"
 ac

--- a/_maps/map_files/shuttles/emergency_narnar.dmm
+++ b/_maps/map_files/shuttles/emergency_narnar.dmm
@@ -344,6 +344,11 @@
 /obj/structure/shuttle/engine/propulsion,
 /turf/simulated/floor/plating/airless,
 /area/shuttle/escape)
+"vX" = (
+/obj/machinery/door/airlock/cult/friendly,
+/obj/structure/fans/tiny,
+/turf/simulated/floor/engine/cult,
+/area/shuttle/escape)
 
 (1,1,1) = {"
 aa
@@ -355,7 +360,7 @@ aa
 ab
 ab
 ab
-ar
+vX
 ab
 aE
 ab
@@ -363,9 +368,9 @@ ac
 ac
 ac
 ab
-ar
+vX
 ab
-ar
+vX
 ac
 ab
 ab

--- a/_maps/map_files/shuttles/emergency_old.dmm
+++ b/_maps/map_files/shuttles/emergency_old.dmm
@@ -42,6 +42,7 @@
 	id_tag = "s_docking_airlock";
 	name = "Shuttle Hatch"
 	},
+/obj/structure/fans/tiny,
 /turf/simulated/floor/plating,
 /area/shuttle/escape)
 "al" = (
@@ -208,6 +209,7 @@
 	id_tag = "s_docking_airlock";
 	name = "Shuttle Hatch"
 	},
+/obj/structure/fans/tiny,
 /turf/simulated/floor/plating,
 /area/shuttle/escape)
 "aX" = (

--- a/_maps/map_files/shuttles/emergency_shadow.dmm
+++ b/_maps/map_files/shuttles/emergency_shadow.dmm
@@ -873,6 +873,7 @@
 	height = 13;
 	shuttle_speed_factor = 2
 	},
+/obj/structure/fans/tiny,
 /turf/simulated/floor/pod/dark,
 /area/shuttle/escape)
 "Kf" = (
@@ -982,6 +983,7 @@
 /area/shuttle/escape)
 "PX" = (
 /obj/machinery/door/airlock/hatch,
+/obj/structure/fans/tiny,
 /turf/simulated/floor/pod/dark,
 /area/shuttle/escape)
 "Qj" = (


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR adds tiny fans to emergency shuttles that don't already have them.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
With switching over to MILLA, emergency shuttles tend to lose air in seconds if departures is spaced or has other atmospheric issues. Tiny fans fix this by preventing the shuttle from spacing almost immediately if an airlock is opened to a breached area.
 <!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Compiled, looked at all the tiny fans in the airlocks.
Opened airlocks to space, tiny fans kept the shuttle pressurized with nice breathable air.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
tweak: Added tiny fans to all emergency shuttles.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
