### PR TITLE
Fixes a runtime in PDA gas scanner code

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -774,9 +774,6 @@ SLIME SCANNER
 				message += "<span class='notice'>Volume: [round(volume)] Liters</span>" // don't want to change the order volume appears in, suck it
 
 	else// Sum mixtures then present
-		if(!total_moles)
-			message += "<span class='notice'>[target] is empty!</span>"
-			message += "<span class='notice'>Volume: [round(volume)] Liters</span>" // don't want to change the order volume appears in, suck it
 		for(var/datum/gas_mixture/air as anything in airs)
 			if(isnull(air))
 				continue

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -750,7 +750,9 @@ SLIME SCANNER
 			volume = air.return_volume() //could just do mixture.volume... but safety, I guess?
 			heat_capacity = air.heat_capacity()
 			thermal_energy = air.thermal_energy()
-
+			if(!total_moles)
+				message += "<span class='notice'>[target] is empty!</span>"
+				message += "<span class='notice'>Volume: [round(volume)] Liters</span>" // don't want to change the order volume appears in, suck it
 			if(total_moles)
 				message += "<span class='notice'>Total: [round(total_moles, 0.01)] moles</span>"
 				if(air.oxygen() && (milla_turf_details || air.oxygen() / total_moles > 0.01))
@@ -775,17 +777,20 @@ SLIME SCANNER
 				message += "<span class='notice'>Volume: [round(volume)] Liters</span>" // don't want to change the order volume appears in, suck it
 
 	else// Sum mixtures then present
+		if(!total_moles)
+			message += "<span class='notice'>[target] is empty!</span>"
+			message += "<span class='notice'>Volume: [round(volume)] Liters</span>" // don't want to change the order volume appears in, suck it
 		for(var/datum/gas_mixture/air as anything in airs)
-			total_moles += air.total_moles()
-			volume += air.return_volume()
-			heat_capacity += air.heat_capacity()
-			thermal_energy += air.thermal_energy()
-			oxygen += air.oxygen()
-			nitrogen += air.nitrogen()
-			toxins += air.toxins()
-			carbon_dioxide += air.carbon_dioxide()
-			sleeping_agent += air.sleeping_agent()
-			agent_b += air.agent_b()
+			total_moles += air?.total_moles()
+			volume += air?.return_volume()
+			heat_capacity += air?.heat_capacity()
+			thermal_energy += air?.thermal_energy()
+			oxygen += air?.oxygen()
+			nitrogen += air?.nitrogen()
+			toxins += air?.toxins()
+			carbon_dioxide += air?.carbon_dioxide()
+			sleeping_agent += air?.sleeping_agent()
+			agent_b += air?.agent_b()
 
 		var/temperature = heat_capacity ? thermal_energy / heat_capacity : 0
 		pressure = volume ? total_moles * R_IDEAL_GAS_EQUATION * temperature / volume : 0

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -781,16 +781,18 @@ SLIME SCANNER
 			message += "<span class='notice'>[target] is empty!</span>"
 			message += "<span class='notice'>Volume: [round(volume)] Liters</span>" // don't want to change the order volume appears in, suck it
 		for(var/datum/gas_mixture/air as anything in airs)
-			total_moles += air?.total_moles()
-			volume += air?.return_volume()
-			heat_capacity += air?.heat_capacity()
-			thermal_energy += air?.thermal_energy()
-			oxygen += air?.oxygen()
-			nitrogen += air?.nitrogen()
-			toxins += air?.toxins()
-			carbon_dioxide += air?.carbon_dioxide()
-			sleeping_agent += air?.sleeping_agent()
-			agent_b += air?.agent_b()
+			if(isnull(air))
+				continue
+			total_moles += air.total_moles()
+			volume += air.return_volume()
+			heat_capacity += air.heat_capacity()
+			thermal_energy += air.thermal_energy()
+			oxygen += air.oxygen()
+			nitrogen += air.nitrogen()
+			toxins += air.toxins()
+			carbon_dioxide += air.carbon_dioxide()
+			sleeping_agent += air.sleeping_agent()
+			agent_b += air.agent_b()
 
 		var/temperature = heat_capacity ? thermal_energy / heat_capacity : 0
 		pressure = volume ? total_moles * R_IDEAL_GAS_EQUATION * temperature / volume : 0

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -750,9 +750,6 @@ SLIME SCANNER
 			volume = air.return_volume() //could just do mixture.volume... but safety, I guess?
 			heat_capacity = air.heat_capacity()
 			thermal_energy = air.thermal_energy()
-			if(!total_moles)
-				message += "<span class='notice'>[target] is empty!</span>"
-				message += "<span class='notice'>Volume: [round(volume)] Liters</span>" // don't want to change the order volume appears in, suck it
 			if(total_moles)
 				message += "<span class='notice'>Total: [round(total_moles, 0.01)] moles</span>"
 				if(air.oxygen() && (milla_turf_details || air.oxygen() / total_moles > 0.01))


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes a null value runtime in PDA atmos scanner code
## Why It's Good For The Game
Runtime bad

## Testing
Compiles, now gives a readout when scanning empty pipes

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: PDA atmos scanners no longer runtime when scanning empty devices.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
