### PR TITLE
Adds the Chunky Fingers Trait to Boxing Gloves

### DIFF
--- a/code/modules/clothing/gloves/boxing_gloves.dm
+++ b/code/modules/clothing/gloves/boxing_gloves.dm
@@ -17,6 +17,7 @@
 	if(slot == ITEM_SLOT_GLOVES)
 		var/mob/living/carbon/human/H = user
 		style.teach(H, TRUE)
+		ADD_TRAIT(user, TRAIT_CHUNKYFINGERS, CLOTHING_TRAIT)
 
 /obj/item/clothing/gloves/boxing/dropped(mob/user)
 	..()
@@ -25,6 +26,7 @@
 	var/mob/living/carbon/human/H = user
 	if(H.get_item_by_slot(ITEM_SLOT_GLOVES) == src)
 		style.remove(H)
+		REMOVE_TRAIT(user, TRAIT_CHUNKYFINGERS, CLOTHING_TRAIT)
 
 /obj/item/clothing/gloves/boxing/green
 	icon_state = "boxinggreen"


### PR DESCRIPTION
## What Does This PR Do
Boxing gloves will now give you the chunky fingers trait when equipping the gloves. The trait will be removed when the user takes off the gloves.
## Why It's Good For The Game
Because boxing gloves shouldn't have the dexterity to do things like shoot guns. 
## Testing
Equipped boxing gloves. Checked to see if the Trait was applied.
Removed boxing gloves. Checked to see if the Trait was removed.
<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
![Discord_Zpdq3lPGZI](https://github.com/user-attachments/assets/73483b27-c602-4119-8058-2b3c120f101c)
<hr>

## Changelog
:cl:
tweak: Added chunky fingers trait to boxing gloves.
/:cl: