### PR TITLE
Buff for Rubber Shot and Laser Shot Shells

### DIFF
--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -183,7 +183,7 @@
 	icon_state = "cshell"
 	projectile_type = /obj/item/projectile/bullet/pellet/rubber
 	pellets = 6
-	variance = 35
+	variance = 25
 	materials = list(MAT_METAL=4000)
 
 /obj/item/ammo_casing/shotgun/beanbag
@@ -267,7 +267,7 @@
 	icon_state = "lshell"
 	projectile_type = /obj/item/projectile/beam/scatter
 	pellets = 8
-	variance = 35
+	variance = 25
 	muzzle_flash_strength = MUZZLE_FLASH_STRENGTH_NORMAL
 	muzzle_flash_range = MUZZLE_FLASH_RANGE_NORMAL
 	muzzle_flash_color = LIGHT_COLOR_DARKRED


### PR DESCRIPTION
## What Does This PR Do
Partially reverts https://github.com/ParadiseSS13/Paradise/pull/21501 by reducing the shot spread on both rubber shot and laser shot.
## Why It's Good For The Game
With the direction antagonists have taken over the time since the original PR, security needs some buffs to compete.
## Testing
Spawned in a riot shotgun with rubber shot.
Observed the spread of the pellets.
<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
![Discord_B5nyupH08h](https://github.com/user-attachments/assets/2c8fdee8-2495-442f-bf29-20527e12ccff)
<hr>

## Changelog
:cl:
tweak: Tweaked the shot spread of Rubber shot and Laser shot
/:cl: