### PR TITLE
Removes the Two Pull Request Limit

### DIFF
--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -58,11 +58,6 @@ made by people actually in-touch with the server atmosphere.
 
 ### PR Expectations
 
-Contributors may only have a maximum of **2** feature or balance Pull Requests
-open at any given time. Any additional Pull Requests beyond this limit will be
-closed at the discretion of the Headcoders. The Headcoders may grant an
-exemption to this limit on a case-by-case basis, as the need arises.
-
 All Pull Requests are expected to be tested prior to submission. If a submitted
 Pull Request fails to pass CI checks, the likelihood of it being merged will be
 significantly lower. If you can't take the time to compile/test your Pull


### PR DESCRIPTION
## What Does This PR Do
This removes the two pull request limit imposed on the code base.
## Why It's Good For The Game
As headcoders, we believe we are in a place where we currently do not need to have a limit on the number of pull requests open. It was implemented when a lot of changes were backlogged. The development team needed  time to rest and formulate a better strategy. 

At this time the same pre-approval limits still apply!
## Testing
Examined through Markdown viewer.
<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<hr>

## Changelog
NPFC