### PR TITLE
Removes Requirements for Printing WT-550 TTX

### DIFF
--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -196,7 +196,6 @@
 	name = "WT-550 PDW Uranium Ammo Box (4.6x30mm TX)"
 	desc = "A box of 20 uranium tipped rounds for the WT-550 PDW."
 	id = "box_oldsmg_tx"
-	req_tech = list("combat" = 3, "materials" = 2, "syndicate" = 3)
 	materials = list(MAT_METAL = 6000, MAT_SILVER = 600, MAT_URANIUM = 2000)
 	build_path = /obj/item/ammo_box/wt550/wttx
 	category = list("Weapons")


### PR DESCRIPTION
## What Does This PR Do
This is a revert of https://github.com/ParadiseSS13/Paradise/pull/25490, that added illegals to making the WT-550 Toxin Tips. 
## Why It's Good For The Game
Security needs some buffs overall and reverting this change is one of them.
## Testing
Checked to see if Toxin Tip rounds could be printed without illegals 3.
<hr>

### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
![Discord_gUQDSvwTjv](https://github.com/user-attachments/assets/b2a661f8-c07a-4ff5-93e4-11a1afaa294d)
![Discord_AQQdookzYf](https://github.com/user-attachments/assets/5e585d76-f203-43e7-95f3-866b30d6b222)
<hr>

## Changelog
:cl:
tweak: Removed the requirements for printing WT-550 TTX rounds.
/:cl: