### PR TITLE
Reduces taj/vulp darksight to 3 tiles again

### DIFF
--- a/code/modules/surgery/organs/subtypes/tajaran_organs.dm
+++ b/code/modules/surgery/organs/subtypes/tajaran_organs.dm
@@ -8,7 +8,7 @@
 	name = "tajaran eyeballs"
 	colourblind_matrix = MATRIX_TAJ_CBLIND //The colour matrix and darksight parameters that the mob will receive when they get the disability.
 	replace_colours = TRITANOPIA_COLOR_REPLACE
-	see_in_dark = 4
+	see_in_dark = 3
 
 /// Being the lesser form of Tajara, Farwas have an utterly incurable version of their colourblindness.
 /obj/item/organ/internal/eyes/tajaran/farwa

--- a/code/modules/surgery/organs/subtypes/vulpkanin_organs.dm
+++ b/code/modules/surgery/organs/subtypes/vulpkanin_organs.dm
@@ -8,7 +8,7 @@
 	icon = 'icons/obj/species_organs/vulpkanin.dmi'
 	colourblind_matrix = MATRIX_VULP_CBLIND //The colour matrix and darksight parameters that the mob will receive when they get the disability.
 	replace_colours = PROTANOPIA_COLOR_REPLACE
-	see_in_dark = 4
+	see_in_dark = 3
 
 /// Being the lesser form of Vulpkanin, Wolpins have an utterly incurable version of their colourblindness.
 /obj/item/organ/internal/eyes/vulpkanin/wolpin


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

Lowers taj/vulp darksight to 3 tiles again. 


## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Taj/vulp darksight was originally lowered to 3 in #20035 but was raised up to 4 in #20275 with the addition of a malus. 

This malus was removed in #23642 but darksight remained at 4.

Taj/vulps have very minor maluses, they should not be getting 4 darksight for what they currently have.

## Images of changes

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

#20035 Has pictures of what 3 darksight looks like. This is one extra tile over human eyes.

## Testing
It compiles.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
tweak: Taj/vulp darksight lowered to 3 again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
