### PR TITLE
Fix sluggish AI/camera eye movement

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -217,7 +217,7 @@
 /atom/movable/proc/set_loc(T, teleported=0)
 	var/old_loc = loc
 	loc = T
-	Moved(old_loc, get_dir(old_loc, loc))
+	Moved(old_loc, get_dir(old_loc, loc), null, null, FALSE)
 
 
 /**

--- a/code/modules/mob/camera/eye.dm
+++ b/code/modules/mob/camera/eye.dm
@@ -96,7 +96,7 @@
 /mob/camera/eye/set_loc(T)
 	if(user)
 		T = get_turf(T)
-		loc = T
+		..(T)
 		update_visibility()
 		refresh_visible_icon()
 

--- a/code/modules/mob/camera/eye.dm
+++ b/code/modules/mob/camera/eye.dm
@@ -96,7 +96,7 @@
 /mob/camera/eye/set_loc(T)
 	if(user)
 		T = get_turf(T)
-		..(T)
+		loc = T
 		update_visibility()
 		refresh_visible_icon()
 


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes #28326

With #27698, a default-TRUE `momentum_change` parameter was added to each call to `/atom/movable/proc/Moved()`. With #25078, a callback to `Moved()` was kept in the `set_loc` proc, which is exclusively used in camera eye movement, but its call signature was not updated to match the new function signature. This caused camera eyes to undergo a newtonian move every movement, which is the reason for the sluggishness seen in #28326. The missing parameters have been added to the `Moved` call in `/atom/movable/proc/set_loc`, which removed said sluggishness.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Sluggish movement is uncomfortable.

## Testing

I logged in as an AI and moved around with low and high acceleration, and noted the sluggishness in camera eye movement was gone.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl: Ascio
fix: Fixed sluggish AI/camera eye movement
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
