### PR TITLE
Add a hologram flag check for hand tele portals

### DIFF
--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -550,6 +550,7 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 /obj/effect/overlay/holo_pad_hologram
 	var/mob/living/Impersonation
 	var/datum/holocall/HC
+	flags_2 = HOLOGRAM_2
 
 /obj/effect/overlay/holo_pad_hologram/Destroy()
 	Impersonation = null

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -68,7 +68,7 @@
 	return
 
 /obj/effect/portal/proc/on_atom_entered(datum/source, atom/movable/entered, old_loc)
-	if(isobserver(entered))
+	if(isobserver(entered) || entered.flags_2 & HOLOGRAM_2)
 		return
 
 	if(target && (get_turf(old_loc) == get_turf(target)))


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Adds a `HOLOGRAM_2` flag check for hand tele portals, and adds the flag to the holocall hologram.

## Why It's Good For The Game
Fixes #27527

## Images of changes
![Holo](https://github.com/user-attachments/assets/34507d24-eac0-4e10-bb8d-3db9415249d3)

## Testing
Took a call, and then used a hand tele and had the caller go through the portal

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: Holograms do not destabilize hand tele portals anymore
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
