### PR TITLE
fix multi-tile airlocks not travelling with shuttles

### DIFF
--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -7,7 +7,7 @@
 		update_light()
 	if(rotation)
 		shuttleRotate(rotation)
-	forceMove(T1)
+	abstract_move(T1)
 	return 1
 
 /obj/effect/landmark/shuttle_import/onShuttleMove()


### PR DESCRIPTION
## What Does This PR Do
This PR fixes multi-tile airlocks not moving with shuttles they're installed on.
## Why It's Good For The Game
Fixes regression introduced by #26762.
## Testing
Travelled in whiteship, ensured that airlock moved with ship.
<hr>

### Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

<hr>

## Changelog

:cl:
fix: Multi-tile airlocks will not be left behind from shuttles when moving.
/:cl:
