### PR TITLE
Enlarges Emerald AI Sat's External Airlocks

### DIFF
--- a/_maps/map_files/stations/emeraldstation.dmm
+++ b/_maps/map_files/stations/emeraldstation.dmm
@@ -166576,7 +166576,7 @@ pbm
 pbm
 ltC
 rEk
-rEn
+rEk
 xnI
 rTJ
 aZS

--- a/_maps/map_files/stations/emeraldstation.dmm
+++ b/_maps/map_files/stations/emeraldstation.dmm
@@ -4384,7 +4384,11 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/west)
 "aVp" = (
-/obj/structure/closet/emcloset,
+/obj/machinery/atmospherics/portable/canister/air,
+/obj/machinery/atmospherics/unary/portables_connector,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -11867,6 +11871,10 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/sorting)
+"cqU" = (
+/obj/effect/spawner/airlock/e_to_w/long/square,
+/turf/simulated/wall/r_wall,
+/area/station/aisat/service)
 "cqY" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	name = "Portable Air Pump Connector"
@@ -15216,13 +15224,6 @@
 /turf/simulated/floor/engine,
 /area/station/engineering/engine)
 "dbn" = (
-/obj/effect/spawner/window/reinforced/grilled,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/structure/sign/securearea{
 	pixel_y = -32
 	},
@@ -28281,10 +28282,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
-"fFm" = (
-/obj/effect/mapping_helpers/airlock/access/all/science/minisat,
-/turf/simulated/floor/plating/airless,
-/area/station/aisat/hall)
 "fFA" = (
 /obj/structure/table,
 /obj/effect/spawner/random/maintenance,
@@ -33303,6 +33300,9 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plating/airless,
 /area/station/aisat/breakroom)
 "gFg" = (
@@ -34213,14 +34213,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/starboard)
-"gOC" = (
-/obj/effect/spawner/window/reinforced/grilled,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable,
-/turf/simulated/floor/plating/airless,
-/area/station/aisat/hall)
 "gOH" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/purple{
 	dir = 4
@@ -35039,19 +35031,6 @@
 	},
 /turf/simulated/floor/engine/n20,
 /area/station/engineering/atmos)
-"gXO" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "aisat_door_int";
-	locked = 1;
-	name = "MiniSat External Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
-/obj/effect/mapping_helpers/airlock/access/all/science/minisat,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/turret_protected/aisat/interior)
 "gXQ" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -35482,10 +35461,8 @@
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
 "hbJ" = (
-/obj/effect/spawner/window/reinforced/grilled,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
+/obj/effect/mapping_helpers/airlock/access/all/science/minisat,
 /turf/simulated/floor/plating/airless,
 /area/station/turret_protected/aisat/interior)
 "hbO" = (
@@ -40388,6 +40365,13 @@
 /obj/machinery/atmospherics/meter,
 /turf/simulated/floor/engine,
 /area/station/engineering/engine)
+"iak" = (
+/obj/effect/spawner/window/reinforced/grilled,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating/airless,
+/area/space/nearstation)
 "iaw" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -49962,6 +49946,14 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint)
+"jRR" = (
+/obj/effect/spawner/window/reinforced/grilled,
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/aisat/breakroom)
 "jRV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -51801,11 +51793,10 @@
 /turf/simulated/floor/engine,
 /area/station/science/misc_lab)
 "kmm" = (
-/obj/effect/spawner/window/reinforced/grilled,
-/obj/structure/cable,
-/obj/effect/spawner/airlock,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
+/obj/effect/mapping_helpers/airlock/access/all/science/minisat,
 /turf/simulated/floor/plating/airless,
-/area/station/aisat/hall)
+/area/station/aisat/breakroom)
 "kmq" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -51855,9 +51846,6 @@
 "kmM" = (
 /obj/structure/cable{
 	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -57343,6 +57331,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/aisat/breakroom)
@@ -69657,9 +69648,6 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/station/medical/virology)
-"nSe" = (
-/turf/simulated/floor/plating/airless,
-/area/station/aisat/hall)
 "nSu" = (
 /obj/structure/chair/stool,
 /obj/machinery/camera{
@@ -74683,11 +74671,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos/asteroid_filtering)
-"oPU" = (
-/obj/effect/spawner/window/reinforced/grilled,
-/obj/structure/cable,
-/turf/simulated/floor/plating/airless,
-/area/station/aisat/hall)
 "oQa" = (
 /obj/effect/spawner/random/maintenance,
 /obj/effect/decal/cleanable/dirt,
@@ -75395,16 +75378,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/ne)
-"oWC" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "aisat_door_ext";
-	locked = 1;
-	name = "MiniSat External Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
-/obj/effect/mapping_helpers/airlock/access/all/science/minisat,
-/turf/simulated/floor/plating,
-/area/station/turret_protected/aisat/interior)
 "oWG" = (
 /obj/structure/sink/kitchen/old{
 	dir = 4;
@@ -77986,15 +77959,6 @@
 	icon_state = "redyellowfull"
 	},
 /area/station/maintenance/dorms/port)
-"pwO" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/access_button{
-	autolink_id = "aisat_btn_ext";
-	pixel_x = 25;
-	pixel_y = 25
-	},
-/turf/space,
-/area/space/nearstation)
 "pwP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -84694,21 +84658,6 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/medbay)
-"qQL" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4;
-	autolink_id = "aisat_vent"
-	},
-/obj/machinery/airlock_controller/air_cycler{
-	pixel_y = 25;
-	vent_link_id = "aisat_vent";
-	ext_door_link_id = "aisat_door_ext";
-	int_door_link_id = "aisat_door_int";
-	ext_button_link_id = "aisat_btn_ext";
-	int_button_link_id = "aisat_btn_int"
-	},
-/turf/simulated/floor/plating,
-/area/station/turret_protected/aisat/interior)
 "qQM" = (
 /obj/effect/decal/cleanable/confetti,
 /obj/effect/decal/cleanable/dirt,
@@ -85088,9 +85037,6 @@
 /area/station/maintenance/aft)
 "qVp" = (
 /obj/effect/spawner/window/reinforced/grilled,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -88614,6 +88560,23 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/station/public/storage/emergency)
+"rEk" = (
+/obj/effect/spawner/window/reinforced/grilled,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable,
+/turf/simulated/floor/plating/airless,
+/area/station/aisat/breakroom)
+"rEn" = (
+/obj/effect/spawner/window/reinforced/grilled,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/simulated/floor/plating/airless,
+/area/station/aisat/breakroom)
 "rEo" = (
 /obj/machinery/door/poddoor/shutters{
 	id_tag = "mechbay_outer";
@@ -93708,9 +93671,6 @@
 "sBE" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
 	icon_state = "1-4"
 	},
 /obj/structure/cable,
@@ -98025,12 +97985,11 @@
 	},
 /area/station/engineering/break_room)
 "tsv" = (
-/obj/machinery/atmospherics/portable/canister/air,
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -103139,6 +103098,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 6
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -104571,9 +104531,6 @@
 /turf/simulated/floor/wood,
 /area/station/command/office/blueshield)
 "uIx" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plating,
 /area/station/turret_protected/aisat/interior)
 "uIz" = (
@@ -109557,6 +109514,9 @@
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 8
 	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -111102,6 +111062,16 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/vault)
+"vXI" = (
+/obj/effect/spawner/window/reinforced/grilled,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/turret_protected/aisat/interior)
 "vXQ" = (
 /obj/effect/mapping_helpers/turfs/rust/maybe,
 /turf/simulated/wall,
@@ -111532,6 +111502,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/turf_decal/stripes/corner,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -117288,6 +117259,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/station/supply/lobby)
+"xnI" = (
+/obj/effect/spawner/window/reinforced/grilled,
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/spawner/airlock/long/square/wide,
+/turf/simulated/floor/plating/airless,
+/area/station/aisat/breakroom)
 "xnJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -120886,13 +120866,9 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/west)
 "xZA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10
-	},
-/obj/machinery/access_button{
-	autolink_id = "aisat_btn_int";
-	pixel_x = -25;
-	pixel_y = 25
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -165529,10 +165505,10 @@ aZS
 aZS
 aZS
 aZS
-aZS
-aZS
-aZS
-aZS
+tHM
+tHM
+tHM
+tHM
 aOV
 fBo
 xap
@@ -165787,10 +165763,10 @@ tHM
 tHM
 tHM
 tHM
-tHM
-pwO
-tHM
-aOV
+iak
+rdB
+rdB
+cqU
 jcR
 nCP
 ayj
@@ -166044,8 +166020,8 @@ aZS
 aZS
 aZS
 aZS
-hbJ
-oWC
+vXI
+uIx
 hbJ
 aOV
 ppC
@@ -166302,7 +166278,7 @@ jnP
 aZS
 jnP
 jzu
-qQL
+uIx
 uIx
 iLL
 iLL
@@ -166559,7 +166535,7 @@ jnP
 aZS
 fSu
 jwT
-gXO
+uIx
 dbn
 iLL
 bfT
@@ -166599,12 +166575,12 @@ eGH
 pbm
 pbm
 ltC
+rEk
+rEn
+xnI
 rTJ
-rdB
-rdB
-rdB
 aZS
-jnP
+aZS
 jnP
 jnP
 jnP
@@ -166856,12 +166832,12 @@ qbx
 sOv
 wcz
 qVp
-gOC
+amA
 kmm
+ycO
 pYU
 pYU
 aZS
-jnP
 jnP
 jnP
 jnP
@@ -167113,12 +167089,12 @@ hKF
 aTO
 uvj
 amA
-fFm
-nSe
+amA
+amA
+amA
 rdB
 rdB
 aZS
-jnP
 jnP
 jnP
 fNb
@@ -167370,12 +167346,12 @@ hBj
 wlP
 vJx
 sBE
-gOC
-oPU
+amA
+amA
+pLm
 jST
 jST
 aZS
-jnP
 jnP
 jnP
 jnP
@@ -167627,12 +167603,12 @@ eGH
 aTO
 rZL
 gFd
+rEn
+rEn
+jRR
 rTJ
-rdB
-rdB
-rdB
 aZS
-jnP
+aZS
 jnP
 jnP
 jnP

--- a/_maps/map_files/stations/emeraldstation.dmm
+++ b/_maps/map_files/stations/emeraldstation.dmm
@@ -55972,11 +55972,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
 "lfY" = (
+/obj/machinery/power/apc/directional/west,
+/obj/structure/cable,
 /obj/structure/chair/sofa/corp/left{
 	dir = 4
 	},
-/obj/machinery/power/apc/directional/west,
-/obj/structure/cable,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -88565,15 +88565,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/cable,
-/turf/simulated/floor/plating/airless,
-/area/station/aisat/breakroom)
-"rEn" = (
-/obj/effect/spawner/window/reinforced/grilled,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable,
 /obj/structure/cable,
 /turf/simulated/floor/plating/airless,
 /area/station/aisat/breakroom)
@@ -167603,8 +167594,8 @@ eGH
 aTO
 rZL
 gFd
-rEn
-rEn
+rEk
+rEk
 jRR
 rTJ
 aZS


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Replaces the upper handmade Emerald AI sat external airlock with a 2x2, and the lower airlock with a 3x2.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Replacing handcrafted airlocks with map helpers improves maintainability and standardizes airlocks in general.

Larger airlocks are easier to use than 1x1s.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://github.com/user-attachments/assets/a7f1be5d-431a-40cd-8db4-3740ab32c26d)
![image](https://github.com/user-attachments/assets/aca4a9e1-1308-4463-9a38-c343c21f6d88)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
Inspected and used both airlocks.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
tweak: The fore external airlock on the emerald AI sat is now 2x2.
tweak: The aft external airlock on the emerald AI sat is now 3x2.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
