### PR TITLE
Fix CQC slapper

### DIFF
--- a/code/game/objects/items/hand_item.dm
+++ b/code/game/objects/items/hand_item.dm
@@ -75,7 +75,7 @@
 	return ..()
 
 /obj/item/slapper/parry/proc/dropkey(mob/user)
-	if(user && user.get_active_hand() == src)
+	if(user?.get_active_hand() == src)
 		qdel(src)
 
 /obj/item/slapper/parry/Destroy()

--- a/code/game/objects/items/hand_item.dm
+++ b/code/game/objects/items/hand_item.dm
@@ -70,9 +70,13 @@
 	AddComponent(/datum/component/parry, _stamina_constant = 2, _stamina_coefficient = 0.5, _parryable_attack_types = NON_PROJECTILE_ATTACKS, _parry_cooldown = (4 / 3) SECONDS) //75% uptime
 	if(isliving(loc))
 		var/mob/owner = loc
-		RegisterSignal(owner, COMSIG_MOB_WILLINGLY_DROP, TYPE_PROC_REF(/datum, signal_qdel), override = TRUE)
-		RegisterSignal(owner, COMSIG_MOB_WEAPON_APPEARS, TYPE_PROC_REF(/datum, signal_qdel), override = TRUE)
+		RegisterSignal(owner, COMSIG_MOB_WILLINGLY_DROP, PROC_REF(dropkey), override = TRUE)
+		RegisterSignal(owner, COMSIG_MOB_WEAPON_APPEARS, PROC_REF(dropkey), override = TRUE)
 	return ..()
+
+/obj/item/slapper/parry/proc/dropkey(mob/user)
+	if(user && user.get_active_hand() == src)
+		qdel(src)
 
 /obj/item/slapper/parry/Destroy()
 	if(isliving(loc))


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes slapper getting qdel() on drop held item hotkey even when it's not in your active hand.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

Bug fix. You can now again perform combos like 3q3 without losing your ability to parry.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Local. Performed some combos, slapper never got deleted. Tried to drop slapper while in active hand by pressing Q, succeeded.

<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: CQC slapper won't anymore get deleted while performing combos like 3q3, 3q4 or dropping item from your other hand.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
