### PR TITLE
[LORE] Updates a bunch of manual summaries

### DIFF
--- a/code/game/objects/items/weapons/manuals.dm
+++ b/code/game/objects/items/weapons/manuals.dm
@@ -582,7 +582,7 @@
 	desc = "A small guidebook on how to operate a Ripley powerloader exosuit. It's filled with disclaimers and pre-signed waivers."
 	summary = "Standard operational practices and construction requirements for operation of the Ripley mk. 3 powerloader system."
 	icon_state ="book"
-	author = "Hephasteus Industries"
+	author = "Hephaestus Industries"
 	title = "APLU \"Ripley\" Construction and Operation Manual"
 
 	pages = list({"<html><meta charset='utf-8'>

--- a/code/game/objects/items/weapons/manuals.dm
+++ b/code/game/objects/items/weapons/manuals.dm
@@ -597,7 +597,7 @@
 				</head>
 				<body>
 				<center>
-				<b style='font-size: 12px;'>Hephasteus Industries - Forging the Tools of Tommorow </b>
+				<b style='font-size: 12px;'>Hephaestus Industries - Forging the Tools of Tomorrow</b>
 				<h1>Autonomous Power Loader Unit \"Ripley\"</h1>
 				</center>
 				<h2>Specifications:</h2>

--- a/code/game/objects/items/weapons/manuals.dm
+++ b/code/game/objects/items/weapons/manuals.dm
@@ -157,7 +157,7 @@
 
 /obj/item/book/manual/atmospipes
 	name = "Pipes and You: Getting To Know Your Scary Tools"
-	desc = "A plumber's guide on how to efficiently plumb and clean out old drone shells."
+	desc = "A plumber's guide on how to properly identify a pipe."
 	summary = "A handy encyclopedia on the many different flavors of pipe and device available to Atomspherics."
 	icon_state = "pipingbook"
 	author = "Maria Crash, Senior Atmospherics Technician"

--- a/code/game/objects/items/weapons/manuals.dm
+++ b/code/game/objects/items/weapons/manuals.dm
@@ -920,7 +920,7 @@
 /obj/item/book/manual/wiki/botanist
 	name = "The Station Botanist Handbook"
 	desc = "A handbook with instructions and tips for station botanists."
-	summary = "A quick reference guide to responsibilities and tasks of the station's Botany contingent."
+	summary = "A quick reference guide to the responsibilities and tasks of the station's Botany contingent."
 	icon_state ="bookHydroponicsBotanist"
 	author = "Nanotrasen"
 	title = "The Station Botanist Handbook"

--- a/code/game/objects/items/weapons/manuals.dm
+++ b/code/game/objects/items/weapons/manuals.dm
@@ -31,6 +31,7 @@
 /obj/item/book/manual/detective
 	name = "The Film Noir: Proper Procedures for Investigations"
 	desc = "A gumshoe's guide to find out whodunnit, howdunnit, and wheredunnit."
+	summary = "A how-to manual for basic forensic procedures and detective work."
 	icon_state ="bookDetective"
 	author = "Nanotrasen"
 	title = "The Film Noir: Proper Procedures for Investigations"
@@ -71,6 +72,7 @@
 /obj/item/book/manual/engineering_particle_accelerator
 	name = "Particle Accelerator User's Guide"
 	desc = "An engineer's guide to shooting relativistic particles out of a big gun."
+	summary = "A quick-assembly manual for the setup of high-intensity particle accelerator systems."
 	icon_state ="bookParticleAccelerator"
 	author = "Engineering Encyclopedia"
 	title = "Particle Accelerator User's Guide"
@@ -115,6 +117,7 @@
 /obj/item/book/manual/supermatter_engine
 	name = "Supermatter Engine Anomaly Reference"
 	desc = "An engineer's best tool for dealing with their worst frenemy: The Supermatter and its anomalous behavior."
+	summary = "A quick-reference booklet on Supermatter anomalies and their effects."
 	icon_state = "bookParticleAccelerator"
 	author = "Vroo-Looum-Kloo"
 	title = "Supermatter Engine Anomaly Reference"
@@ -155,6 +158,7 @@
 /obj/item/book/manual/atmospipes
 	name = "Pipes and You: Getting To Know Your Scary Tools"
 	desc = "A plumber's guide on how to efficiently plumb and clean out old drone shells."
+	summary = "A handy encyclopedia on the many different flavors of pipe and device available to Atomspherics."
 	icon_state = "pipingbook"
 	author = "Maria Crash, Senior Atmospherics Technician"
 	title = "Pipes and You: Getting To Know Your Scary Tools"
@@ -241,7 +245,8 @@
 
 /obj/item/book/manual/evaguide
 	name = "EVA Gear and You: Not Spending All Day Inside"
-	desc = "An enterprising explorer's expedition explainer. Helmet not included!"
+	desc = "An outdated guidebook outlining the ups and downs of various pieces of EVA gear. Considering it references hardsuits, it must be a decade old at the least."
+	summary = "A beginner's guide to the pros and cons of various suit classes."
 	icon_state = "evabook"
 	author = "Maria Crash, Senior Atmospherics Technician"
 	title = "EVA Gear and You: Not Spending All Day Inside"
@@ -302,6 +307,7 @@
 /obj/item/book/manual/engineering_singularity_safety
 	name = "Singularity Safety in Special Circumstances"
 	desc = "A sufficiently succinct suppliment to securing singularities."
+	summary = "An easily digestable field guide for singularity-related emergencies."
 	icon_state ="bookEngineeringSingularitySafety"
 	author = "Engineering Encyclopedia"
 	title = "Singularity Safety in Special Circumstances"
@@ -350,6 +356,7 @@
 /obj/item/book/manual/medical_cloning
 	name = "Introduction to Cloning"
 	desc = "A guide covering the basics of cloning."
+	summary = "A step-by-step guide to each part of the cloning process."
 	icon_state = "bookCloning"
 	author = "Bioarchitect for the Pillars of Creation" //this is a valid nian name, right?
 	title = "Introduction to Cloning"
@@ -426,6 +433,7 @@
 /obj/item/book/manual/zombie_manual
 	name = "Plague and You: Curing the Apocalypse"
 	desc = "A guide covering the basics of curing zombies."
+	summary = "A step-by-step guide to combatting each phase of the zombie virus."
 	icon_state = "bookCloning"
 	author = "Cleanses-The-Plague"
 	title = "Plague and You: Curing the Apocalypse"
@@ -571,9 +579,10 @@
 
 /obj/item/book/manual/ripley_build_and_repair
 	name = "APLU \"Ripley\" Construction and Operation Manual"
-	desc = "A guide from a little-known corporation on how to operate a heavy lifter mech. It's filled with disclaimers and pre-signed waivers."
+	desc = "A small guidebook on how to operate a Ripley powerloader exosuit. It's filled with disclaimers and pre-signed waivers."
+	summary = "Standard operational practices and construction requirements for operation of the Ripley mk. 3 powerloader system."
 	icon_state ="book"
-	author = "Weyland-Yutani Corp"
+	author = "Hephasteus Industries"
 	title = "APLU \"Ripley\" Construction and Operation Manual"
 
 	pages = list({"<html><meta charset='utf-8'>
@@ -588,7 +597,7 @@
 				</head>
 				<body>
 				<center>
-				<b style='font-size: 12px;'>Weyland-Yutani - Building Better Worlds</b>
+				<b style='font-size: 12px;'>Hephasteus Industries - Forging the Tools of Tommorow </b>
 				<h1>Autonomous Power Loader Unit \"Ripley\"</h1>
 				</center>
 				<h2>Specifications:</h2>
@@ -647,6 +656,7 @@
 /obj/item/book/manual/research_and_development
 	name = "Research and Development 101"
 	desc = "The mad scientist's second best friend, after coffee."
+	summary = "Construction & operational instructions for all standard Nanotrasen research machinery."
 	icon_state = "rdbook"
 	author = "Dr. L. Ight"
 	title = "Research and Development 101"
@@ -698,6 +708,7 @@
 /obj/item/book/manual/barman_recipes
 	name = "Barman Recipes"
 	desc = "A coffee-stained guide to mixing drinks."
+	summary = "A quick-access reference to several common alcoholic beverages."
 	icon_state = "barbook"
 	author = "Sir John Rose"
 	title = "Barman Recipes"
@@ -741,6 +752,7 @@
 /obj/item/book/manual/nuclear
 	name = "Fission Mailed: Nuclear Sabotage 101"
 	desc = "A blood-spattered book filled with block text, educating the reader on how to detonate nuclear bombs."
+	summary = "Reference material for the activation and detonation of nuclear devices. All material classified Level-1 PYTHON."
 	icon_state ="bookNuclear"
 	author = "Syndicate"
 	protected = TRUE
@@ -772,12 +784,13 @@
 			Good luck. Remember the order:<br>
 			<b>Disk, Code, Safety, Timer, Disk, RUN!</b><br>
 			Intelligence Analysts believe that normal Nanotrasen procedure is for the Captain to secure the nuclear authorisation disk.<br>
-			Good luck!
+			Speed and strength, operative.
 			</html>"})
 
 /obj/item/book/manual/hydroponics_pod_people
 	name = "The Human Harvest - From seed to market"
 	desc = "Blurry pictures of people coming out of pods are taped to the cover."
+	summary = "A handy-dandy guide to growing plant-people for fun and profit!"
 	icon_state ="bookHydroponicsPodPeople"
 	author = "Farmer John"
 	title = "The Human Harvest - From seed to market"
@@ -862,6 +875,7 @@
 /obj/item/book/manual/wiki/robotics_cyborgs
 	name = "Cyborgs for Dummies"
 	desc = "Precise instructions on how to construct your very own robotic friend."
+	summary = "Standard construction and maintenance procedures for Nanotrasen silicon units."
 	icon_state = "borgbook"
 	author = "XISC"
 	title = "Cyborgs for Dummies"
@@ -870,6 +884,7 @@
 /obj/item/book/manual/wiki/chef_recipes
 	name = "Chef Recipes"
 	desc = "Knives, Ovens, and You: A guide to cooking."
+	summary = "A comprehensive guide to the production of all manner of foods and drinks."
 	icon_state = "cook_book"
 	author = "Nanotrasen"
 	title = "Chef Recipes"
@@ -878,6 +893,7 @@
 /obj/item/book/manual/wiki/engineering_construction
 	name = "Station Repairs and Construction"
 	desc = "A guide on how to fix things without duct tape."
+	summary = "A comprehensive reference for the construction and maintenance of most on-station equipment."
 	icon_state ="bookEngineering"
 	author = "Engineering Encyclopedia"
 	title = "Station Repairs and Construction"
@@ -886,6 +902,7 @@
 /obj/item/book/manual/wiki/faxes
 	name = "Guide to Faxes"
 	desc = "Nanotrasen's own manual on how to write faxes."
+	summary = "A comprehensive reference on protocol for the writing and sending of faxes."
 	icon_state ="bookEngineering"
 	author = "Nanotrasen"
 	title = "Faxes and You!"
@@ -894,6 +911,7 @@
 /obj/item/book/manual/wiki/hydroponics
 	name = "General Hydroponics"
 	desc = "A guide outlining the principles of hydroponics."
+	summary = "A comprehensive reference on the identification and growth of various usable plants."
 	icon_state ="bookHydroponicsGeneral"
 	author = "Nanotrasen"
 	title = "General Hydroponics"
@@ -902,6 +920,7 @@
 /obj/item/book/manual/wiki/botanist
 	name = "The Station Botanist Handbook"
 	desc = "A handbook with instructions and tips for station botanists."
+	summary = "A quick reference guide to responsibilities and tasks of the station's Botany contingent."
 	icon_state ="bookHydroponicsBotanist"
 	author = "Nanotrasen"
 	title = "The Station Botanist Handbook"


### PR DESCRIPTION
## What Does This PR Do
Title. A bunch of manuals have summaries that are no longer copy-pasted. Also removes a mention of the literal, actual Weyland-Yutani corporation, which does not exist in lore.

## Why It's Good For The Game
Copy-pasted escriptions are bad. Word for word references to other media franchises are bad.

## Testing

- spawned books
- absorbed knowledge

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  
<hr>

## Changelog

:cl:
tweak: Added some proper manual summaries.
/:cl:
