### PR TITLE
fix lighting objects being moved from their turfs on shuttle move

### DIFF
--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -10,6 +10,10 @@
 	abstract_move(T1)
 	return 1
 
+/atom/movable/lighting_object/onShuttleMove(turf/oldT, turf/T1, rotation, mob/caller)
+	// lighting objects should not be moved from their parent turfs
+	return 0
+
 /obj/effect/landmark/shuttle_import/onShuttleMove()
 	// Used for marking where to preview/load shuttles
 	return 0


### PR DESCRIPTION
## What Does This PR Do
This PR fixes the "lighting object was qdeleted with a different loc then it is suppose to have" runtimes caused by making sure that lighting objects, which are always attached to a specific turf, are not considered for the purposes of shuttle moves.
## Why It's Good For The Game
Bugfix.
## Testing
Called mining shuttle, ensured no runtimes.

<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog
NPFC