### PR TITLE
fix engiborgs not being able to insert/remove lights from sockets

### DIFF
--- a/code/modules/power/lights.dm
+++ b/code/modules/power/lights.dm
@@ -593,6 +593,13 @@
 // attack with item - insert light (if right type), otherwise try to break the light
 
 /obj/machinery/light/item_interaction(mob/living/user, obj/item/used, list/modifiers)
+	var/obj/item/gripper/gripper = used
+	if(istype(gripper) && gripper.engineering_machine_interaction)
+		if(gripper.gripped_item)
+			return item_interaction(user, gripper.gripped_item, modifiers)
+		else
+			return ..()
+
 	user.changeNext_move(CLICK_CD_MELEE) // This is an ugly hack and I hate it forever
 	//Light replacer code
 	if(istype(used, /obj/item/lightreplacer))


### PR DESCRIPTION
## What Does This PR Do
This PR fixes issues with engiborgs attempting to use grippers to remove/insert lights from sockets.
## Why It's Good For The Game
Bugfix.
## Testing
Removed and reinserted bulb from socket as engiborg. Switched to medborg. Ensured I could not remove/insert light bulbs.
<hr>

### Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<hr>

## Changelog
:cl:
fix: Engineering borgs can now properly insert and remove light bulbs from sockets.
/:cl:
