### PR TITLE
cerestation: add lattices under cargo shuttle beacon lights

### DIFF
--- a/_maps/map_files/stations/cerestation.dmm
+++ b/_maps/map_files/stations/cerestation.dmm
@@ -96226,6 +96226,7 @@
 /area/station/hallway/secondary/exit)
 "vuM" = (
 /obj/structure/marker_beacon/dock_marker,
+/obj/structure/lattice,
 /turf/space,
 /area/space/nearstation)
 "vuQ" = (


### PR DESCRIPTION
## What Does This PR Do
This PR adds lattices under the beacon lights used around the cargo and mining shuttles on Cerestation.
## Why It's Good For The Game
Much better looking.
## Images of changes
![2025_02_12__19_54_58__paradise dme  cerestation dmm  - StrongDMM](https://github.com/user-attachments/assets/5ea4b9fd-a4ec-4bbe-a9e8-5a5d046d6de2)
![2025_02_12__19_55_07__paradise dme  cerestation dmm  - StrongDMM](https://github.com/user-attachments/assets/8cd67602-8c0c-440f-b921-d8e3d2131271)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing

<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
tweak: Farragus: The beacons surrounding the cargo and mining shuttle docks are properly anchored with lattices.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
