### PR TITLE
Added fire suits to seed vault

### DIFF
--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
@@ -473,6 +473,14 @@
 /obj/item/tank/internals/emergency_oxygen/engi,
 /turf/simulated/floor/plasteel/freezer,
 /area/ruin/powered/seedvault)
+"ZO" = (
+/obj/structure/closet/firecloset/full,
+/obj/item/clothing/suit/fire/firefighter,
+/obj/item/clothing/head/hardhat/red,
+/obj/item/tank/internals/oxygen/red,
+/obj/item/clothing/mask/gas,
+/turf/simulated/floor/plasteel/freezer,
+/area/ruin/powered/seedvault)
 "ZQ" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/disks_plantgene,
@@ -1166,11 +1174,11 @@ aa
 aa
 aa
 yZ
-al
-yc
+yZ
+yZ
 xe
-eI
-OL
+Wu
+vt
 vt
 vt
 vt
@@ -1196,8 +1204,8 @@ yZ
 yZ
 no
 no
-Lg
-nt
+ZO
+ZO
 vt
 DQ
 nt


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes: #26542

Removed the redundant trash chute and replaces it with two fire suit lockers in the lavaland seed vault. Each locker has an extra set of equipment in it for the possible 4 diona that can spawn there. This will allow a means for the diona to leave the seed vault without burning up

## Why It's Good For The Game

should be possible to complete diona objectives, which require you to go out into lavaland

## Images of changes

![image](https://github.com/user-attachments/assets/5eb2b353-a2c1-4f9c-928c-6bb3c85e2e82)

## Testing

code compiled, simple map change

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
tweak: Added firesuits to seed vault
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
