### PR TITLE
Fixes BSH stabilizers drawing more power than they should when requesting more mining power than can be stabilized

### DIFF
--- a/code/modules/station_goals/bluespace_tap.dm
+++ b/code/modules/station_goals/bluespace_tap.dm
@@ -1,3 +1,4 @@
+#define NEAREST_MW(power)((power) - (power) % (1 MW))
 //Station goal stuff goes here
 /datum/station_goal/bluespace_tap
 	name = "Bluespace Harvester"
@@ -273,36 +274,38 @@
 
 	// Round down to the nearest MW if above a MW
 	if(mining_power > 1 MW)
-		mining_power = mining_power - mining_power % (1 MW)
+		mining_power = NEAREST_MW(mining_power)
 
-	// Always try to use all available power for mining if emagged
+	// Always try to use all available power for mining if emagged and disable the stabilizers
 	if(emagged)
 		desired_mining_power = mining_power
+		stabilizer_power = 0
 
 	/*
 	* Stabilizers activate above 15MW of mining power
-	* Stabilizers consume up to 1MW for each 1MW of mining power, consuming less between 15 and 30MW of mining power
-	* If stabilizers have priority they will always consume enough power to stabilize the BSH, limiting mining
-	* Emagging disables stabilizers
+	* Stabilizers consume up to 1MW for each 1MW of mining power, consuming less between 15MW and 30MW of mining power
+	* If stabilizers have priority they will always consume enough power to stabilize the BSH, limiting mining power
 	*/
-	if(stabilizer_priority)
-		// stabilizer power is what we need to stabilize the current mining level, but no more than half the available power.
-		stabilizer_power = \
-		clamp(\
-		desired_mining_power - clamp(30 MW - desired_mining_power, 0, 15 MW), \
-		0, \
-		mining_power / 2) \
-		* (stabilizers && !emagged)
-	else
-		// stabilizer power is however much power we have left, but no more than we need to stabilize our desired mining power.
-		stabilizer_power = \
-		clamp(mining_power - desired_mining_power, \
-		0, \
-		desired_mining_power - clamp(30 MW - desired_mining_power, 0, 15 MW)) \
-		* (stabilizers && !emagged)
+	else if(stabilizers)
+		if(stabilizer_priority)
+			// Lowest between enough to stabilize our desired mining power and enough to stabilize the highest mining power we could sustain with our current power budget.
+			stabilizer_power =\
+			min(max(mining_power - max(NEAREST_MW(mining_power / 2), NEAREST_MW((mining_power + 30 MW) / 3)), 0), \
+			clamp(desired_mining_power - clamp((30 MW) - desired_mining_power, 0, 15 MW), 0, desired_mining_power / 2))
 
-	// Actual mining power is what the desired mining power we set, unless we don't have enough power to satisfty that.
-	mining_power = min(desired_mining_power, mining_power - stabilizer_power)
+			// Stabilizers take priority so we subtract them from the available total straight away
+			mining_power = mining_power - stabilizer_power
+		else
+			// stabilizer power is however much power we have left, but no more than we need to stabilize our desired mining power.
+			stabilizer_power = \
+			clamp(mining_power - desired_mining_power, \
+			0, \
+			desired_mining_power - clamp(30 MW - desired_mining_power, 0, 15 MW))
+	else
+		stabilizer_power = 0
+
+	// Now that we know our actual power budget we can finally set our mining power
+	mining_power = min(mining_power, desired_mining_power)
 
 	consume_direct_power(mining_power + stabilizer_power)
 
@@ -616,3 +619,4 @@
 
 #undef POINTS_PER_W
 #undef BASE_POINTS
+#undef NEAREST_MW


### PR DESCRIPTION


<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Stabilizers would draw enough energy to stabilize the desired mining power even when there wasn't enough power to reach it, leading to less power being available for mining. This would happen specifically when the actual mining power was under 30MW and the desired was both higher than it and higher than 15MW.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
bug fix
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Testing
- Input varying amounts of power into the BSH and input different mining power with stabilizer priority both on and off
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: BSH stabilizers no longer draw more power than they should when desired mining power is set too high
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
