### PR TITLE
Remove admin detector

### DIFF
--- a/code/datums/outfits/outfit_debug.dm
+++ b/code/datums/outfits/outfit_debug.dm
@@ -331,7 +331,6 @@
 	new /obj/item/clothing/gloves/fingerless/rapid/admin(src)
 	new /obj/item/clothing/under/misc/acj(src)
 	new /obj/item/clothing/suit/advanced_protective_suit(src)
-	new /obj/item/multitool/ai_detect/admin(src) // for giggles and shits
 	new /obj/item/adminfu_scroll(src)
 	new /obj/item/teleporter/admin(src)
 	new /obj/item/storage/belt/bluespace/admin(src) // god i love storage nesting

--- a/code/game/objects/items/tools/multitool.dm
+++ b/code/game/objects/items/tools/multitool.dm
@@ -158,24 +158,6 @@
 	user.dust()
 	return OBLITERATION
 
-/obj/item/multitool/ai_detect/admin
-	desc = "Used for pulsing wires to test which to cut. Not recommended by doctors. Has a strange tag that says 'Grief in Safety'" //What else should I say for a meme item?
-	track_delay = 5
-
-/obj/item/multitool/ai_detect/admin/Initialize(mapload)
-	. = ..()
-	ADD_TRAIT(src, TRAIT_SHOW_WIRE_INFO, ROUNDSTART_TRAIT)
-
-/obj/item/multitool/ai_detect/admin/multitool_detect()
-	var/turf/our_turf = get_turf(src)
-	for(var/mob/J in urange(rangewarning,our_turf))
-		if(check_rights(R_ADMIN, 0, J))
-			detect_state = PROXIMITY_NEAR
-			var/turf/detect_turf = get_turf(J)
-			if(get_dist(our_turf, detect_turf) < rangealert)
-				detect_state = PROXIMITY_ON_SCREEN
-				break
-
 /obj/item/multitool/cyborg
 	name = "multitool"
 	desc = "Optimised and stripped-down version of a regular multitool."


### PR DESCRIPTION
## What Does This PR Do
Removes the "admin detector" variant of the AI detector

## Why It's Good For The Game
It's a pointless item whose only possible use is for griefing. You'd need some kind of exploit to get one, but once you got it, you'd be able to make sure you were only breaking the rules while admins weren't watching.

## Testing
Compiled, spawned in with debug outfit, didn't have it.
<hr>

### Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

<hr>

## Changelog
NPFC