### PR TITLE
Makes putting things in some things less likely to result in more things than anticipated

### DIFF
--- a/code/datums/spells/summonitem.dm
+++ b/code/datums/spells/summonitem.dm
@@ -76,9 +76,8 @@
 				if(ismob(item_to_retrieve.loc)) //If its on someone, properly drop it
 					var/mob/M = item_to_retrieve.loc
 
-					if(issilicon(M) || !M.drop_item_to_ground(item_to_retrieve)) //Items in silicons warp the whole silicon
+					if(issilicon(M) || !M.transfer_item_to(item_to_retrieve, target.loc)) //Items in silicons warp the whole silicon
 						M.visible_message("<span class='warning'>[M] suddenly disappears!</span>", "<span class='danger'>A force suddenly pulls you away!</span>")
-						M.forceMove(target.loc)
 						M.loc.visible_message("<span class='caution'>[M] suddenly appears!</span>")
 						item_to_retrieve = null
 						break

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -219,11 +219,10 @@ GLOBAL_VAR(bomb_set)
 		return ITEM_INTERACT_COMPLETE
 	if(istype(used, /obj/item/nuke_core/plutonium) && removal_stage == NUKE_CORE_FULLY_EXPOSED)
 		if(do_after(user, 2 SECONDS, target = src))
-			if(!user.drop_item_to_ground(used))
+			if(!user.transfer_item_to(used, src))
 				to_chat(user, "<span class='notice'>The [used] is stuck to your hand!</span>")
 				return
 			user.visible_message("<span class='notice'>[user] puts [used] back in [src].</span>", "<span class='notice'>You put [used] back in [src].</span>")
-			used.forceMove(src)
 			core = used
 			update_icon(UPDATE_OVERLAYS)
 

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -409,11 +409,10 @@
 			to_chat(user, "The headset can't hold another key!")
 			return
 
-		if(!user.drop_item_to_ground(key))
+		if(!user.transfer_item_to(key, src, FALSE, FALSE))
 			to_chat(user, "<span class='warning'>[key] is stuck to your hand, you can't insert it in [src].</span>")
 			return
 
-		key.forceMove(src)
 		if(!keyslot1)
 			keyslot1 = key
 		else

--- a/code/modules/clothing/suits/armor_suits.dm
+++ b/code/modules/clothing/suits/armor_suits.dm
@@ -54,9 +54,8 @@
 
 /obj/item/clothing/suit/armor/vest/security/attackby__legacy__attackchain(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/clothing/accessory/holobadge))
-		if(user.drop_item_to_ground(I))
+		if(user.transfer_item_to(I, src))
 			add_fingerprint(user)
-			I.forceMove(src)
 			attached_badge = I
 			var/datum/action/A = new /datum/action/item_action/remove_badge(src)
 			A.Grant(user)

--- a/code/modules/hydroponics/beekeeping/beebox.dm
+++ b/code/modules/hydroponics/beekeeping/beebox.dm
@@ -165,9 +165,8 @@
 			return
 
 		var/obj/item/queen_bee/qb = I
-		if(!user.drop_item_to_ground(qb))
+		if(!user.transfer_item_to(qb, src))
 			return
-		qb.queen.forceMove(src)
 		bees += qb.queen
 		queen_bee = qb.queen
 		qb.queen = null

--- a/code/modules/hydroponics/biogenerator.dm
+++ b/code/modules/hydroponics/biogenerator.dm
@@ -161,10 +161,9 @@
 		if(length(stored_plants) >= max_storable_plants)
 			to_chat(user, "<span class='warning'>[src] can't hold any more plants!</span>")
 			return ITEM_INTERACT_COMPLETE
-		if(!user.drop_item_to_ground(used))
+		if(!user.transfer_item_to(used, src))
 			return ITEM_INTERACT_COMPLETE
 
-		used.forceMove(src)
 		stored_plants += used
 		to_chat(user, "<span class='notice'>You put [used] in [src].</span>")
 		SStgui.update_uis(src)

--- a/code/modules/hydroponics/compost_bin.dm
+++ b/code/modules/hydroponics/compost_bin.dm
@@ -107,10 +107,9 @@
 		if(biomass >= biomass_capacity && potassium >= potassium_capacity)
 			to_chat(user, "<span class='warning'>[src] can't hold any more biomass, and its contents are saturated with potassium!</span>")
 			return ITEM_INTERACT_COMPLETE
-		if(!user.drop_item_to_ground(used))
+		if(!user.transfer_item_to(used, src))
 			return ITEM_INTERACT_COMPLETE
 
-		used.forceMove(src)
 		make_biomass(used)
 		to_chat(user, "<span class='notice'>You put [used] in [src].</span>")
 		SStgui.update_uis(src)

--- a/code/modules/newscaster/obj/newscaster.dm
+++ b/code/modules/newscaster/obj/newscaster.dm
@@ -386,9 +386,8 @@ GLOBAL_LIST_EMPTY(allNewscasters)
 				return
 			if(ishuman(usr))
 				var/obj/item/photo/P = usr.get_active_hand()
-				if(istype(P) && usr.drop_item_to_ground(P))
+				if(istype(P) && usr.transfer_item_to(P, src))
 					photo = P
-					P.forceMove(src)
 					usr.visible_message("<span class='notice'>[usr] inserts [P] into [src]'s photo slot.</span>",\
 										"<span class='notice'>You insert [P] into [src]'s photo slot.</span>")
 					playsound(loc, 'sound/machines/terminal_insert_disc.ogg', 30, TRUE)

--- a/code/modules/research/backup_console.dm
+++ b/code/modules/research/backup_console.dm
@@ -41,10 +41,9 @@
 /obj/machinery/computer/rnd_backup/item_interaction(mob/living/user, obj/item/used, list/modifiers)
 	if(istype(used, /obj/item/disk/rnd_backup_disk) && istype(user, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = user
-		if(!H.drop_item_to_ground(used))
+		if(!H.transfer_item_to(used, src))
 			return ITEM_INTERACT_COMPLETE
 
-		used.forceMove(src)
 		inserted_disk = used
 		to_chat(user, "<span class='notice'>You insert [used] into [src].</span>")
 		SStgui.update_uis(src)

--- a/code/modules/research/scientific_analyzer.dm
+++ b/code/modules/research/scientific_analyzer.dm
@@ -83,13 +83,12 @@ Note: Must be placed within 3 tiles of the R&D Console
 			to_chat(user, "<span class='warning'>You cannot deconstruct this item!</span>")
 			return ITEM_INTERACT_COMPLETE
 
-		if(!user.drop_item())
+		if(!user.transfer_item_to(used, src))
 			to_chat(user, "<span class='warning'>[used] is stuck to your hand, you cannot put it in [src]!</span>")
 			return ITEM_INTERACT_COMPLETE
 
 		busy = TRUE
 		loaded_item = used
-		used.loc = src
 		to_chat(user, "<span class='notice'>You add [used] to [src]!</span>")
 		SStgui.update_uis(linked_console)
 		flick("s_analyzer_la", src)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
The recent TG move manager results in funky behavior when items are dropped in zero-g. Putting an item in a machine using `drop_item_to_ground()` without gravity ends up attaching a `drift` component to the item. This will continue to fire even after the item is moved into the atom that is being transferred into. After it is moved, the item will be forced onto the turf of the target atom by a move loop fire without removing the target atom's references to the item. This causes duplication-like issues and weirdness. We need to go through `transfer_item_to()` instead.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
Bugs are bad!
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
I have only tested the science analyzer in zero-g. I have not tested the rest of these. Please do not merge this until they are tested.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
