### PR TITLE
Fixes null spaced high value item runtime in TGUI antagonist menu

### DIFF
--- a/code/modules/admin/menus/antagonist_menu.dm
+++ b/code/modules/admin/menus/antagonist_menu.dm
@@ -101,7 +101,7 @@ RESTRICT_TYPE(/datum/ui_module/admin/antagonist_menu)
 		var/list/temp_list = list()
 		temp_list["name"] = target.name
 		temp_list["person"] = get(target, /mob/living)
-		temp_list["loc"] = target.loc.name
+		temp_list["loc"] = target.loc ? target.loc.name : "null"
 		temp_list["uid"] = target.UID()
 		var/turf/T = get_turf(target)
 		temp_list["admin_z"] = !T || is_admin_level(T.z)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
See title 
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game
See title
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing
I saw it work with my own eyes.
<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [ ] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
