### PR TITLE
The Moon card makes flooring first before teleporting

### DIFF
--- a/code/game/gamemodes/wizard/magic_tarot.dm
+++ b/code/game/gamemodes/wizard/magic_tarot.dm
@@ -611,12 +611,7 @@
 			funny_ruin_list += ruin_landmark
 
 	if(length(funny_ruin_list))
-		var/turf/T = get_turf(pick(funny_ruin_list))
-		target.forceMove(T)
-		to_chat(target, "<span class='userdanger'>You are abruptly pulled through space!</span>")
-		T.ChangeTurf(/turf/simulated/floor/plating) //we give them plating so they are not trapped in a wall, and a pickaxe to avoid being trapped in a wall
-		new /obj/item/pickaxe/emergency(T)
-		target.update_parallax_contents()
+		teleport(target, get_turf(pick(funny_ruin_list)))
 		return
 	//We did not find a ruin on the same level. Well. I hope you have a space suit, but we'll go space ruins as they are mostly sorta kinda safer.
 	for(var/I in GLOB.ruin_landmarks)
@@ -626,14 +621,16 @@
 
 	if(!length(funny_ruin_list))
 		to_chat(target, "<span class='warning'>Huh. No space ruins? Well, this card is RUINED!</span>")
+		return
 
-	var/turf/T = get_turf(pick(funny_ruin_list))
-	target.forceMove(T)
+	teleport(target, get_turf(pick(funny_ruin_list)))
+
+/datum/tarot/the_moon/proc/teleport(mob/living/target, turf/teleport_location)
+	teleport_location.ChangeTurf(/turf/simulated/floor/plating) //we give them plating so they are not trapped in a wall or fall into lava/chasm, and a pickaxe to avoid being trapped in a wall
+	target.forceMove(teleport_location)
 	to_chat(target, "<span class='userdanger'>You are abruptly pulled through space!</span>")
-	T.ChangeTurf(/turf/simulated/floor/plating) //we give them plating so they are not trapped in a wall, and a pickaxe to avoid being trapped in a wall
-	new /obj/item/pickaxe/emergency(T)
+	new /obj/item/pickaxe/emergency(teleport_location)
 	target.update_parallax_contents()
-	return
 
 /datum/tarot/the_sun
 	name = "XIX - The Sun"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes The Moon's teleporting code into a separate proc, and changes the order of calls done (Make the floor _first_, then teleport the poor sap).

## Why It's Good For The Game
Fixes #28409

## Images of changes
![HALP](https://github.com/user-attachments/assets/99640809-fbf5-4053-bbe2-9d28ef79faa3)

## Testing
Limited the pool of ruins, and made one out of only chasms, then used a Moon card.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: The Moon will always place a floor at the intended location first before teleporting them
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
