### PR TITLE
Nerf Lavaland's bluespace spellblade

### DIFF
--- a/code/game/objects/items/weapons/melee/melee_misc.dm
+++ b/code/game/objects/items/weapons/melee/melee_misc.dm
@@ -525,6 +525,9 @@
 	target.Weaken(power)
 	COOLDOWN_START(src, enchant_cooldown, cooldown)
 
+/datum/enchantment/bluespace/on_apply_to_blade(obj/item/melee/spellblade/S)
+	cooldown /= S.power
+
 /datum/enchantment/time_slash
 	name = "temporal"
 	desc = "this blade will slice faster but weaker, and will curse the target, slashing them a few seconds after they have not been swinged at for each hit"


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Bluespace enchantment now takes into account blade's power to adjust its cooldown time, not only weaken time. This results in lavaland's spellblade being able to dash only each 5 seconds, instead of 2.5.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

The only difference between wizard's and bubblegum's bluespace spellblades is 2.5 DECIseconds of weaken(). You don't notice these 2 and a half of deciseconds at all. But we can just adjust cooldown depending on blade's power, and wow, wizard is 2x more effective at dashing! Incredible, thanks, i know.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Left one is wizard's, right one is miner's.
![image](https://github.com/user-attachments/assets/d8056418-fd28-421b-a451-3a407d9a8ea9)


<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
tweak: Bluespace spellblade's ability cooldown now depends on its power.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
