### PR TITLE
Fixes heartbeat warnings when stacking deployments

### DIFF
--- a/code/datums/tgs_event_handler.dm
+++ b/code/datums/tgs_event_handler.dm
@@ -13,6 +13,9 @@ GLOBAL_VAR_INIT(slower_restart, FALSE)
 	receive_health_checks = TRUE
 
 /datum/tgs_event_handler/impl/HandleEvent(event_code, ...)
+	// Do this for any TGS event receieved as deployments dont proc the heartbeat event
+	SSheartbeat.last_heartbeat = REALTIMEOFDAY
+
 	switch(event_code)
 		if(TGS_EVENT_REBOOT_MODE_CHANGE)
 			var/list/reboot_mode_lookup = list ("[TGS_REBOOT_MODE_NORMAL]" = "be normal", "[TGS_REBOOT_MODE_SHUTDOWN]" = "shutdown the server", "[TGS_REBOOT_MODE_RESTART]" = "hard restart the server")
@@ -50,7 +53,7 @@ GLOBAL_VAR_INIT(slower_restart, FALSE)
 				deltimer(reattach_timer)
 				reattach_timer = null
 		if(TGS_EVENT_HEALTH_CHECK)
-			SSheartbeat.last_heartbeat = REALTIMEOFDAY
+			return // does no extra behaviour
 
 /datum/tgs_event_handler/impl/proc/LateOnReattach()
 	server_announce_adminonly("\[Warning] TGS hasn't notified us of it coming back for a full minute! Is there a problem?")


### PR DESCRIPTION
## What Does This PR Do
Currently, if you do many TGS deployments quickly, TGS doesnt send the heartbeat event to not overload DD.

Unfortunately, our health check SS doesnt care.
![image](https://github.com/user-attachments/assets/59b8eecd-81b5-4518-99b1-0f1c280e8246)

This PR makes it so any TGS event counts as communication, since, well, it is, and uses that to track.

## Why It's Good For The Game
False warnings that make me get out of bed are bad.

## Images of changes
N/A

## Testing
I didnt even bother compiling this, but I am upfront about that.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

<hr>

## Changelog
NPFC