### PR TITLE
fix mapmanip script and add docs/gitignore for generated maps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,6 @@ rustlibs_panic.txt
 
 # mkdocs output.
 site
+
+# mapmanip-generated DMM files
+_maps/map_files/**/*.mapmanipout.dmm

--- a/docs/mapping/submaps.md
+++ b/docs/mapping/submaps.md
@@ -95,6 +95,16 @@ even whole layouts, making it so a map looks different every time it is visited.
 
     ![](./images/mapmanip_results.png)
 
+    Mapmanip can also generate permutations of your map at the command line, by
+    running:
+
+    ```sh
+    .\tools\rustlib_tools\mapmanip.ps1
+    ```
+
+    This will create a version of every map that has submaps and save them with
+    the suffix `mapmanipout.dmm`, wherever the original map is located.
+
 ## Areas and Turfs
 
 Areas and turfs, and specifically their "noop" types, have special meaning in

--- a/tools/rustlibs_tools/mapmanip.ps1
+++ b/tools/rustlibs_tools/mapmanip.ps1
@@ -31,7 +31,7 @@ $BapiDllFunction = "all_mapmanip_configs_execute_ffi"
 $BapiExecutionTime = Measure-Command {
 	# `rundll` runs a function from a dll
 	# the very sad limitation is that it does not give any output from that function
-	rundll32.exe $BapiPath, $BapiDllFunction
+	rundll32.exe $BapiPath $BapiDllFunction
 }
 
 # done


### PR DESCRIPTION
## What Does This PR Do
This PR makes a fix to the powershell script used to generate mapmanip output from outside of the game, adds documentation referring to it, and adds a pattern to gitignore to ignore the generated map output.
## Why It's Good For The Game
Tooling cleanup, helps mappers.
## Testing
Ran powershell script to ensure that map generation outside of the game worked, ensured that new map files were not marked as new to git.
<hr>

### Declaration
- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<hr>

## Changelog
NPFC
