### PR TITLE
[S] Fix unexpected behavior of the defibrillator when handing over the paddles.

### DIFF
--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -165,6 +165,14 @@
 		remove_paddles(user)
 		update_icon(UPDATE_OVERLAYS)
 
+/obj/item/defibrillator/on_mob_move(dir, mob/user)
+	if(paddles_on_defib)
+		return
+
+	if(paddles.loc != user)
+		remove_paddles(paddles.loc)
+
+
 /obj/item/defibrillator/item_action_slot_check(slot, mob/user)
 	if(slot == ITEM_SLOT_BACK)
 		return TRUE
@@ -370,6 +378,25 @@
 		loc = defib
 		defib.update_icon(UPDATE_OVERLAYS)
 		update_icon(UPDATE_ICON_STATE)
+
+/obj/item/shockpaddles/on_give(mob/living/carbon/giver, mob/living/carbon/receiver)
+
+	// This should be True, because action give calls drop() before this proc
+	if(defib.paddles_on_defib)
+		//Detach the paddles into the user's hands
+		defib.paddles.forceMove(receiver)
+		defib.paddles_on_defib = FALSE
+	else if(receiver.is_in_active_hand(defib.paddles))
+		//Remove from their hands and back onto the defib unit
+		defib.remove_paddles(receiver)
+
+	defib.update_icon(UPDATE_OVERLAYS)
+	update_icon(UPDATE_ICON_STATE)
+
+	// We call this to check if the receiver is outside the defib range
+	// Otherwise, it can be placed anywhere on the map
+	on_mob_move(null, receiver)
+
 
 /obj/item/shockpaddles/on_mob_move(dir, mob/user)
 	if(defib)


### PR DESCRIPTION
## What Does This PR Do
Fixes some unexpected behavior, that could lead to an abuse py players.

## Why It's Good For The Game
Bugs are bad! I squash them!

## Testing

Make sure problem is gone and tested everything on localhost with 2 clients.

<hr>

### Declaration
Got an approval from @DGamerL 
- [ ] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
fix: Fixed issues with the defibrillator that allowed it to be used beyond its intended limits.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
