### PR TITLE
Adds Mosin bullets to the autolathe

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -810,6 +810,14 @@
 	build_path = /obj/item/ammo_box/foambox/sniper/riot
 	category = list("hacked", "Security")
 
+/datum/design/a762
+	name = "7.62 round"
+	id = "762a"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 250)
+	build_path = /obj/item/ammo_casing/a762
+	category = list("hacked", "Security")
+
 /datum/design/b357
 	name = "Ammo Box (.357)"
 	id = "b357"

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -814,7 +814,7 @@
 	name = "7.62 round"
 	id = "762a"
 	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 250)
+	materials = list(MAT_METAL = 10000)
 	build_path = /obj/item/ammo_casing/a762
 	category = list("hacked", "Security")
 


### PR DESCRIPTION
## What Does This PR Do

Allows a rather rare but fun-to-use weapon to have some viability in the hands of whoever wishes to requisition one from space by adding it's bullets to the autolathe. Must be hacked to access, costs 10,000 metal per cartridge.


## Why It's Good For The Game

Adds some more variety to the game, but at an exuberant price. The damage output is on par with common lasers / ballistic weapons due to their long ammo cycling periods and subsequently longer reloads. This can indirectly open an avenue for explorers to healthily communicate with security on a common interest. 

## Images of changes

![Screenshot 2025-02-12 122630](https://github.com/user-attachments/assets/49bd6f4c-0194-4bb1-b406-d76ef59d17f5)

## Testing

hacked an autolathe, printed some boolets. 

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

![Screenshot 2025-02-17 175441](https://github.com/user-attachments/assets/a15ac232-a6da-46bb-bda7-e5d256751972)

 
<hr>

## Changelog

:cl:
add: Added 7.62 bullets to the autolathe

/:cl:
