### PR TITLE
Adds 2 lavaland turfs to `keep_turfs` of ash accretion module

### DIFF
--- a/code/modules/mod/modules/modules_supply.dm
+++ b/code/modules/mod/modules/modules_supply.dm
@@ -328,8 +328,10 @@
 		keep_turfs = typecacheof(list(
 			/turf/simulated/floor/lava,
 			/turf/simulated/floor/indestructible/hierophant,
-			/turf/simulated/floor/indestructible/necropolis
-			))
+			/turf/simulated/floor/indestructible/necropolis,
+			/turf/simulated/floor/indestructible/boss,
+			/turf/simulated/floor/vault/lavaland_air,
+		))
 
 /obj/item/mod/module/ash_accretion/Destroy()
 	QDEL_NULL(armor_mod_2)


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

It's in the title. Adds 2 lavaland-exclusive turfs to the list of allowed turfs, so mining suit will not lose its ash while running on them.

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

Have you ever tried to solve a puzzle ruin while wearing mining modsuit? It's really annoying when each step you hear that recharge sound. Also puzzle area doesn't defend you from ash, so you should be able to keep the charge.

Also adds Legion's turfs from Necropolis. Yeah, there is not much of space, but.. it's more for the SS220, where we have a little bit more expanded Necropolis to explore. And its area isn't ashproof, so you should be able to keep the charge, otherwise you will suffer.

<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Spawned in, spawned these turfs, walked on them and didn't lose any charges of stored ash.

<!-- How did you test the PR, if at all? -->

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

NPFC

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
