### PR TITLE
Add Pump Up to the list of stims in Haloperidol and Nanocalcium

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -1330,7 +1330,7 @@
 	color = "#FFDCFF"
 	taste_description = "stability"
 	harmless = FALSE
-	var/list/drug_list = list("crank", "methamphetamine", "space_drugs", "synaptizine", "psilocybin", "ephedrine", "epinephrine", "stimulants", "stimulative_agent", "bath_salts", "lsd", "thc", "mephedrone")
+	var/list/drug_list = list("crank", "methamphetamine", "space_drugs", "synaptizine", "psilocybin", "ephedrine", "epinephrine", "stimulants", "stimulative_agent", "bath_salts", "lsd", "thc", "mephedrone", "pump_up")
 	goal_difficulty = REAGENT_GOAL_NORMAL
 
 /datum/reagent/medicine/haloperidol/on_mob_life(mob/living/M)

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -1589,7 +1589,7 @@
 	harmless = FALSE
 	taste_description = "2 minutes of suffering"
 	process_flags = ORGANIC | SYNTHETIC
-	var/list/stimulant_list = list("methamphetamine", "crank", "bath_salts", "stimulative_agent", "stimulants", "mephedrone", "ultralube", "surge", "surge_plus", "combatlube")
+	var/list/stimulant_list = list("methamphetamine", "crank", "bath_salts", "stimulative_agent", "stimulants", "mephedrone", "ultralube", "surge", "surge_plus", "combatlube", "pump_up")
 
 /datum/reagent/medicine/nanocalcium/on_mob_life(mob/living/carbon/human/M)
 	var/update_flags = STATUS_UPDATE_NONE


### PR DESCRIPTION
## What Does This PR Do

Adds Pump Up to the list of stimulants that Haloperidol purges and the list of stimulants that nanocalcium checks for.

## Why It's Good For The Game

Fixing oversights is a good thing.

## Testing

Put 50u of Pump Up in a human, shot at the human with a tranquiliser dart shell, saw Pump Up being removed as Haloperidol normally does for stimulants.

Put 40u of Pump Up in a Drask, used a nanocalcium injector, once the generous purging phase ended toxin damage as expected for stimulants began to occur, this caused the death of the Drask.

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
<hr>

## Changelog

:cl:
fix: Fixed the oversight of Pump Up not being purged by Haloperidol.
fix: Fixed the oversight of Pump Up not being among the stimulants that Nanocalcium checks for.
/:cl:
