### PR TITLE
[LORE...sorta] Switches the L6's caliber to 7.62x51mm

### DIFF
--- a/_maps/map_files/generic/centcomm.dmm
+++ b/_maps/map_files/generic/centcomm.dmm
@@ -5925,10 +5925,10 @@
 /area/shuttle/syndicate)
 "ug" = (
 /obj/structure/rack,
-/obj/item/ammo_box/magazine/mm556x45,
-/obj/item/ammo_box/magazine/mm556x45,
-/obj/item/ammo_box/magazine/mm556x45,
-/obj/item/ammo_box/magazine/mm556x45,
+/obj/item/ammo_box/magazine/mm762x51,
+/obj/item/ammo_box/magazine/mm762x51,
+/obj/item/ammo_box/magazine/mm762x51,
+/obj/item/ammo_box/magazine/mm762x51,
 /obj/item/gun/projectile/automatic/l6_saw,
 /obj/item/gun/projectile/automatic/l6_saw{
 	pixel_x = 3;

--- a/code/datums/uplink_items/uplink_nuclear.dm
+++ b/code/datums/uplink_items/uplink_nuclear.dm
@@ -294,10 +294,10 @@
 	uplinktypes = list(UPLINK_TYPE_NUCLEAR, UPLINK_TYPE_SST)
 
 /datum/uplink_item/ammo/machinegun
-	name = "L6 SAW - 5.56x45mm Box Magazine"
-	desc = "A 50-round magazine of 5.56x45mm ammunition for use in the L6 SAW machine gun. By the time you need to use this, you'll already be on a pile of corpses."
+	name = "L6 SAW - 7.62x51mm Box Magazine"
+	desc = "A 50-round magazine of 7.62x51mm ammunition for use in the L6 SAW machine gun. By the time you need to use this, you'll already be on a pile of corpses."
 	reference = "762"
-	item = /obj/item/ammo_box/magazine/mm556x45
+	item = /obj/item/ammo_box/magazine/mm762x51
 	cost = 60
 	uplinktypes = list(UPLINK_TYPE_NUCLEAR, UPLINK_TYPE_SST)
 	surplus = 0

--- a/code/game/objects/structures/crates_lockers/closets/syndicate_lockers.dm
+++ b/code/game/objects/structures/crates_lockers/closets/syndicate_lockers.dm
@@ -48,7 +48,7 @@
 	desc = "It's a storage unit for an elite syndicate strike team's gear."
 
 /obj/structure/closet/syndicate/sst/populate_contents()
-	new /obj/item/ammo_box/magazine/mm556x45(src)
+	new /obj/item/ammo_box/magazine/mm762x51(src)
 	new /obj/item/gun/projectile/automatic/l6_saw(src)
 	new /obj/item/tank/internals/oxygen/red(src)
 	new /obj/item/storage/belt/military/sst(src)

--- a/code/modules/admin/verbs/striketeam_syndicate.dm
+++ b/code/modules/admin/verbs/striketeam_syndicate.dm
@@ -153,7 +153,7 @@ GLOBAL_VAR_INIT(sent_syndicate_strike_team, 0)
 		equip_to_slot_or_del(new /obj/item/tank/internals/oxygen/red(src), ITEM_SLOT_SUIT_STORE)
 		equip_to_slot_or_del(new /obj/item/clothing/shoes/magboots/elite(src), ITEM_SLOT_SHOES)
 		equip_to_slot_or_del(new /obj/item/gun/projectile/automatic/l6_saw(src), ITEM_SLOT_RIGHT_HAND)
-		equip_to_slot_or_del(new /obj/item/ammo_box/magazine/mm556x45(src), ITEM_SLOT_IN_BACKPACK)
+		equip_to_slot_or_del(new /obj/item/ammo_box/magazine/mm762x51(src), ITEM_SLOT_IN_BACKPACK)
 
 	var/obj/item/bio_chip/dust/D = new /obj/item/bio_chip/dust(src)
 	D.implant(src)

--- a/code/modules/projectiles/guns/projectile/saw.dm
+++ b/code/modules/projectiles/guns/projectile/saw.dm
@@ -1,12 +1,12 @@
 /obj/item/gun/projectile/automatic/l6_saw
 	name = "\improper L6 SAW"
-	desc = "A heavily modified 5.56 light machine gun, designated 'L6 SAW'. Has 'Aussec Armoury - 2531' engraved on the receiver below the designation."
+	desc = "A next-generation medium machine gun designed by Aussec Armory for CQB use aboard ships and stations. Chambered in 7.62x51mm Federal."
 	icon_state = "l6closed100"
 	item_state = "l6closedmag"
 	w_class = WEIGHT_CLASS_HUGE
 	slot_flags = 0
 	origin_tech = "combat=6;engineering=3;syndicate=6"
-	mag_type = /obj/item/ammo_box/magazine/mm556x45
+	mag_type = /obj/item/ammo_box/magazine/mm762x51
 	weapon_weight = WEAPON_HEAVY
 	fire_sound = 'sound/weapons/gunshots/gunshot_mg.ogg'
 	magin_sound = 'sound/weapons/gun_interactions/lmg_magin.ogg'
@@ -105,64 +105,64 @@
 
 //magazines//
 
-/obj/item/ammo_box/magazine/mm556x45
-	name = "box magazine (5.56x45mm)"
+/obj/item/ammo_box/magazine/mm762x51
+	name = "box magazine (7.62x51mm FMJ)"
 	icon_state = "a762"
 	origin_tech = "combat=2"
-	ammo_type = /obj/item/ammo_casing/mm556x45
-	caliber = "mm55645"
+	ammo_type = /obj/item/ammo_casing/mm762x51
+	caliber = "mm762x51"
 	max_ammo = 50
 	multi_sprite_step = 10
 
-/obj/item/ammo_box/magazine/mm556x45/bleeding
-	name = "box magazine (Bleeding 5.56x45mm)"
+/obj/item/ammo_box/magazine/mm762x51/bleeding
+	name = "box magazine (7.62x51mm Shredder)"
 	origin_tech = "combat=3"
-	ammo_type = /obj/item/ammo_casing/mm556x45/bleeding
+	ammo_type = /obj/item/ammo_casing/mm762x51/bleeding
 
-/obj/item/ammo_box/magazine/mm556x45/hollow
-	name = "box magazine (Hollow-Point 5.56x45mm)"
+/obj/item/ammo_box/magazine/mm762x51/hollow
+	name = "box magazine (7.62x51mm Hollowpoint)"
 	origin_tech = "combat=3"
-	ammo_type = /obj/item/ammo_casing/mm556x45/hollow
+	ammo_type = /obj/item/ammo_casing/mm762x51/hollow
 
-/obj/item/ammo_box/magazine/mm556x45/ap
-	name = "box magazine (Armor Penetrating 5.56x45mm)"
+/obj/item/ammo_box/magazine/mm762x51/ap
+	name = "box magazine (7.62x51mm Armor-Piercing)"
 	origin_tech = "combat=4"
-	ammo_type = /obj/item/ammo_casing/mm556x45/ap
+	ammo_type = /obj/item/ammo_casing/mm762x51/ap
 
-/obj/item/ammo_box/magazine/mm556x45/incen
-	name = "box magazine (Incendiary 5.56x45mm)"
+/obj/item/ammo_box/magazine/mm762x51/incen
+	name = "box magazine (7.62x51mm Incendiary)"
 	origin_tech = "combat=4"
-	ammo_type = /obj/item/ammo_casing/mm556x45/incen
+	ammo_type = /obj/item/ammo_casing/mm762x51/incen
 
 //casings//
 
-/obj/item/ammo_casing/mm556x45
-	name = "5.56x45mm round"
-	desc = "A 5.56x45mm rifle cartridge, commonly used in light machine guns."
+/obj/item/ammo_casing/mm762x51
+	name = "7.62x51mm round"
+	desc = "A 7.62x51mm full-metal jacket rifle cartridge, commonly used in general-purpose machine guns."
 	icon_state = "762-casing"
-	caliber = "mm55645"
+	caliber = "mm762x51"
 	projectile_type = /obj/item/projectile/bullet/saw
 	muzzle_flash_strength = MUZZLE_FLASH_STRENGTH_STRONG
 	muzzle_flash_range = MUZZLE_FLASH_RANGE_STRONG
 
-/obj/item/ammo_casing/mm556x45/bleeding
-	name = "5.56x45mm 'Shredder' round"
-	desc = "A 5.56x45mm 'Shredder' cartridge, with a heavily serrated tip intended to cause massive bleeding."
+/obj/item/ammo_casing/mm762x51/bleeding
+	name = "7.62x51mm 'Shredder' round"
+	desc = "A 7.62x51mm 'Shredder' cartridge, with a heavily serrated tip intended to cause massive bleeding."
 	icon_state = "762-casing"
 	projectile_type = /obj/item/projectile/bullet/saw/bleeding
 
-/obj/item/ammo_casing/mm556x45/hollow
-	name = "5.56x45mm hollow point round"
-	desc = "A 5.56x45mm rifle cartridge designed to cause more damage to unarmored targets."
+/obj/item/ammo_casing/mm762x51/hollow
+	name = "7.62x51mm hollow point round"
+	desc = "A 7.62x51mm rifle cartridge designed to cause more damage to unarmored targets."
 	projectile_type = /obj/item/projectile/bullet/saw/hollow
 
-/obj/item/ammo_casing/mm556x45/ap
-	name = "5.56x45mm armor piercing round"
-	desc = "A 5.56x45mm rifle cartridge with a hardened tungsten core to increase armor penetration."
+/obj/item/ammo_casing/mm762x51/ap
+	name = "7.62x51mm armor-piercing round"
+	desc = "A 7.62x51mm rifle cartridge with a hardened tungsten core to increase armor penetration."
 	projectile_type = /obj/item/projectile/bullet/saw/ap
 
-/obj/item/ammo_casing/mm556x45/incen
-	name = "5.56x45mm incendiary round"
-	desc = "A 5.56x45mm rifle cartridge with an incendiary chemical payload."
+/obj/item/ammo_casing/mm762x51/incen
+	name = "7.62x51mm incendiary round"
+	desc = "A 7.62x51mm rifle cartridge with an incendiary chemical payload."
 	projectile_type = /obj/item/projectile/bullet/saw/incen
 	muzzle_flash_color = LIGHT_COLOR_FIRE


### PR DESCRIPTION
## What Does This PR Do
Title. Also changes a few names and descriptions for readability.

Does not change any stats of the weapon or its ammunition.

## Why It's Good For The Game
The L6 being chambered in 5.56 didn't make much sense given its higher damage and relatively low magazine capacity. Also, the icon for the bullet it fires is literally called a 7.62 round already.

## Testing

- loaded in
- observed weapon and ammo
- fired weapon
- success

<hr>

### Declaration

- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  
<hr>

## Changelog

:cl:
tweak: Changed L6 to 7.62, changed a few descriptions and names.
/:cl:
