### PR TITLE
Changes Diagoras storefront maints corpse into remains and gibs

### DIFF
--- a/_maps/map_files/stations/emeraldstation.dmm
+++ b/_maps/map_files/stations/emeraldstation.dmm
@@ -21578,6 +21578,7 @@
 /obj/effect/spawner/random/blood/maybe,
 /obj/item/trash/spentcasing/shotgun,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/gibs,
 /turf/simulated/floor/plasteel{
 	icon_state = "redyellowfull"
 	},
@@ -41993,6 +41994,7 @@
 "iqK" = (
 /obj/effect/mapping_helpers/turfs/burn,
 /obj/item/trash/spentcasing/shotgun,
+/obj/effect/decal/cleanable/blood/gibs/body,
 /turf/simulated/floor/plating,
 /area/station/maintenance/dorms/port)
 "iqL" = (
@@ -45337,6 +45339,7 @@
 "iXG" = (
 /obj/item/trash/spentcasing/shotgun,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/gibs/body,
 /turf/simulated/floor/plasteel{
 	icon_state = "redyellowfull"
 	},

--- a/_maps/map_files/stations/emeraldstation.dmm
+++ b/_maps/map_files/stations/emeraldstation.dmm
@@ -24803,9 +24803,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
 "eYj" = (
-/obj/effect/mob_spawn/human/corpse/assistant,
 /obj/effect/spawner/random/blood/often,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human,
 /turf/simulated/floor/plasteel{
 	icon_state = "redyellowfull"
 	},


### PR DESCRIPTION

## What Does This PR Do

Removes the dead corpse from the Diagoras storefront butchery maint area and replaces it with skeletal remains and gibs.

## Why It's Good For The Game

Was supposedly causing too many false murder callouts for security and medbay. This should lessen that without jeapordizing the environmental storytelling.

## Testing

Map compiled and ran

<hr>

### Declaration

- [X] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
<hr>

## Changelog

:cl:
tweak: Replaced Emeraldstation storefront maint corpse with remains
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
